### PR TITLE
Use latest version of SDK

### DIFF
--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/mattn/go-isatty v0.0.12
-	github.com/onflow/cadence v0.0.0-20200417232004-d4a1bfe50192
-	github.com/onflow/flow-go-sdk v0.1.0-alpha.4
+	github.com/onflow/cadence v0.0.0-20200419043649-1294714a718e
+	github.com/onflow/flow-go-sdk v0.1.0-alpha.4.0.20200419173622-28e70e024a9b
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20191222043438-96c4efab7ee2
 	google.golang.org/grpc v1.28.1
 )

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -69,8 +69,6 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/dapperlabs/cadence v0.0.0-20200321002116-1f8e9f246c35/go.mod h1:WgzAWRd7gcxi6dfJmEdeTArtQVGOr48oLxLW4adsztk=
-github.com/dapperlabs/cadence v0.0.0-20200401151421-7c78a2da20a6 h1:DEGjcmLodBrPU2GVH9y2cC24Xl8TXFvF5I7rAoFruaw=
-github.com/dapperlabs/cadence v0.0.0-20200401151421-7c78a2da20a6/go.mod h1:WgzAWRd7gcxi6dfJmEdeTArtQVGOr48oLxLW4adsztk=
 github.com/dapperlabs/flow-go v0.3.2-0.20200331201607-7630da6300eb h1:frXI+a1fVVdBVi8EBtXAE+B+7Am+gx3zkR9k7Dc0Sc0=
 github.com/dapperlabs/flow-go v0.3.2-0.20200331201607-7630da6300eb/go.mod h1:5NklyvZPL3TTVWanzC5/onFpP/94jakEhnAX2Dmlvj0=
 github.com/dapperlabs/flow-go/crypto v0.3.2-0.20200312195452-df4550a863b7/go.mod h1:6UyHoekg86OJnzTz9hp3Ubzp2ZkrDMFg2krGbVEiloU=
@@ -359,10 +357,8 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/onflow/flow-go-sdk v0.0.0-20200418000618-c361886aa450 h1:hkYkIIPh1d7j8SUueaPUjCiZL74JD4EZNxIFlahkp5o=
-github.com/onflow/flow-go-sdk v0.0.0-20200418000618-c361886aa450/go.mod h1:A0UomCK2j17EPD9MX5vGQya1Wqa5JMXdcZFHZCU5tPM=
-github.com/onflow/flow-go-sdk v0.1.0-alpha.4 h1:hlLO25eX2aR4NP5g7xsu0fUZ05YQQNC0uXnWt3UozyA=
-github.com/onflow/flow-go-sdk v0.1.0-alpha.4/go.mod h1:A0UomCK2j17EPD9MX5vGQya1Wqa5JMXdcZFHZCU5tPM=
+github.com/onflow/flow-go-sdk v0.1.0-alpha.4.0.20200419173622-28e70e024a9b h1:FU7m4YAPuB/D3hpL6X+UiA1SY2HsIK1Q/uILEiS9sHI=
+github.com/onflow/flow-go-sdk v0.1.0-alpha.4.0.20200419173622-28e70e024a9b/go.mod h1:ShDIXTamSNy2SJqrpewFEM4v+vpBy/pUWiNjPrhIPaw=
 github.com/onflow/flow/protobuf/go/flow v0.1.3 h1:xT/wjpc0CyGo6Jldn3H+5Y2G42tp+TE2Jg2BNA9x/mk=
 github.com/onflow/flow/protobuf/go/flow v0.1.3/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Use the latest version of the SDK that [uses Cadence from the onflow GitHub org](https://github.com/onflow/flow-go-sdk/pull/3)