### PR TITLE
Prevent resource loss in equality binary expression

### DIFF
--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -207,6 +207,9 @@ func (checker *Checker) checkBinaryExpressionEquality(
 		)
 	}
 
+	checker.checkUnusedExpressionResourceLoss(leftType, expression.Left)
+	checker.checkUnusedExpressionResourceLoss(rightType, expression.Right)
+
 	return
 }
 

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -199,7 +199,7 @@ func (checker *Checker) visitIndexExpression(
 		isAssignment,
 	)
 
-	checker.checkAccessResourceLoss(elementType, targetExpression)
+	checker.checkUnusedExpressionResourceLoss(elementType, targetExpression)
 
 	return elementType
 }

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -79,7 +79,7 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (member *M
 		expressionType = accessedExpression.Accept(checker).(Type)
 	}()
 
-	checker.checkAccessResourceLoss(expressionType, accessedExpression)
+	checker.checkUnusedExpressionResourceLoss(expressionType, accessedExpression)
 
 	// If the the access is to a member of `self` and a resource,
 	// its use must be recorded/checked, so that it isn't used after it was invalidated

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1505,20 +1505,24 @@ func (checker *Checker) checkWithInitializedMembers(
 	return check()
 }
 
-// checkAccessResourceLoss checks for a resource loss caused by an expression which is accessed
-// (indexed or member). This is basically any expression that does not have an identifier
-// as its "base" expression.
+// checkUnusedExpressionResourceLoss checks for a resource loss caused by an expression
+// which has a resource type, but will not be used after its evaluation,
+// i.e. implicitly dropped at this point.
 //
 // For example, function invocations, array literals, or dictionary literals will cause a resource loss
 // if the expression is accessed immediately: e.g.
 //   - `returnResource()[0]`
-//   - `[<-create R(), <-create R()][0]`,
-//   - `{"resource": <-create R()}.length`
+//   - `[<-create R(), <-create R()][0]`
+//   - in an equality binary expression: `f() != nil`
 //
-// Safe expressions are identifier expressions, an indexing expression into a safe expression,
+// Basically any expression that does not have an identifier as its "base" expression
+// will cause the resource to be lost.
+//
+// Safe expressions are identifier expressions,
+// an indexing expression into a safe expression,
 // or a member access on a safe expression.
 //
-func (checker *Checker) checkAccessResourceLoss(expressionType Type, expression ast.Expression) {
+func (checker *Checker) checkUnusedExpressionResourceLoss(expressionType Type, expression ast.Expression) {
 	if !expressionType.IsResourceType() {
 		return
 	}

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -1166,6 +1166,7 @@ func TestCheckResourceCreationInContracts(t *testing.T) {
 }
 
 func TestCheckInvalidResourceLoss(t *testing.T) {
+
 	t.Run("UnassignedResource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -1262,6 +1263,38 @@ func TestCheckInvalidResourceLoss(t *testing.T) {
 
 		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
 		assert.IsType(t, &sema.InvalidNestedResourceMoveError{}, errs[1])
+	})
+
+	t.Run("ImmediateComparisonOptionalNil", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            resource Foo {}
+
+            pub fun foo(): @Foo? {
+                return <- create Foo()
+            }
+
+            pub let isNil = foo() == nil
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("ImmediateComparisonArray", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            resource Foo {}
+
+            let empty: @[Foo] <- []
+            let isEmpty = [<- create Foo()] == empty
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidBinaryOperandsError{}, errs[0])
+		assert.IsType(t, &sema.ResourceLossError{}, errs[1])
 	})
 }
 


### PR DESCRIPTION
This was already applied in the old repo: https://github.com/dapperlabs/cadence/pull/64