### PR TITLE
Implement naive metering

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -92,3 +92,16 @@ func (e InvalidTransactionParameterTypeError) Error() string {
 		e.Actual,
 	)
 }
+
+// ComputationLimitExceededError
+
+type ComputationLimitExceededError struct {
+	Limit uint64
+}
+
+func (e ComputationLimitExceededError) Error() string {
+	return fmt.Sprintf(
+		"computation limited exceeded: %d",
+		e.Limit,
+	)
+}

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -41,14 +41,12 @@ type Interface interface {
 	Log(string)
 	// EmitEvent is called when an event is emitted by the runtime.
 	EmitEvent(Event)
-}
-
-type InterfaceV2 interface {
-	Interface
 	// ValueExists returns true if the given key exists in the storage, controlled and owned by the given accounts.
 	ValueExists(owner, controller, key []byte) (exists bool, err error)
 	// GenerateUUID is called to generate a UUID.
 	GenerateUUID() uint64
+	// GetComputationLimit returns the computation limit. A value <= 0 means there is no limit
+	GetComputationLimit() uint64
 }
 
 type EmptyRuntimeInterface struct{}
@@ -98,5 +96,9 @@ func (i *EmptyRuntimeInterface) Log(message string) {}
 func (i *EmptyRuntimeInterface) EmitEvent(event Event) {}
 
 func (i *EmptyRuntimeInterface) GenerateUUID() uint64 {
+	return 0
+}
+
+func (i *EmptyRuntimeInterface) GetComputationLimit() uint64 {
 	return 0
 }

--- a/runtime/interpreter/statement_trampoline.go
+++ b/runtime/interpreter/statement_trampoline.go
@@ -23,8 +23,9 @@ import (
 )
 
 type StatementTrampoline struct {
-	F    func() trampoline.Trampoline
-	Line int
+	F           func() trampoline.Trampoline
+	Interpreter *Interpreter
+	Line        int
 }
 
 func (m StatementTrampoline) Resume() interface{} {

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -68,21 +68,10 @@ func (s *interpreterRuntimeStorage) valueExists(
 	}
 
 	// Cache miss: Ask interface
-
-	var exists bool
-	if runtimeInterfaceV2, ok := s.runtimeInterface.(InterfaceV2); ok {
-		var err error
-		// TODO: fix controller
-		exists, err = runtimeInterfaceV2.ValueExists([]byte(storageIdentifier), []byte{}, []byte(key))
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		value, err := s.runtimeInterface.GetValue([]byte(storageIdentifier), []byte{}, []byte(key))
-		if err != nil {
-			panic(err)
-		}
-		exists = len(value) > 0
+	// TODO: fix controller
+	exists, err := s.runtimeInterface.ValueExists([]byte(storageIdentifier), []byte{}, []byte(key))
+	if err != nil {
+		panic(err)
 	}
 
 	if !exists {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -76,6 +76,7 @@ type testRuntimeInterface struct {
 	log                func(string)
 	emitEvent          func(Event)
 	generateUUID       func() uint64
+	computationLimit   uint64
 }
 
 func (i *testRuntimeInterface) ResolveImport(location Location) ([]byte, error) {
@@ -134,6 +135,10 @@ func (i *testRuntimeInterface) GenerateUUID() uint64 {
 		return 0
 	}
 	return i.generateUUID()
+}
+
+func (i *testRuntimeInterface) GetComputationLimit() uint64 {
+	return i.computationLimit
 }
 
 func TestRuntimeImport(t *testing.T) {
@@ -2708,4 +2713,94 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 		},
 		loggedMessages,
 	)
+}
+
+func TestRuntimeComputationLimit(t *testing.T) {
+
+	const computationLimit = 5
+
+	type test struct {
+		name string
+		code string
+		ok   bool
+	}
+
+	tests := []test{
+		{
+			name: "Infinite while loop",
+			code: `
+              while true {}
+            `,
+			ok: false,
+		},
+		{
+			name: "Limited while loop",
+			code: `
+              var i = 0
+              while i < 5 {
+                  i = i + 1
+              }
+            `,
+			ok: false,
+		},
+		{
+			name: "Too many for-in loop iterations",
+			code: `
+              for i in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] {}
+            `,
+			ok: false,
+		},
+		{
+			name: "Some for-in loop iterations",
+			code: `
+              for i in [1, 2, 3, 4] {}
+            `,
+			ok: true,
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+
+			script := []byte(
+				fmt.Sprintf(
+					`
+                      transaction {
+                          prepare() {
+                              %s
+                          }
+                      }
+                    `,
+					test.code,
+				),
+			)
+
+			runtime := NewInterpreterRuntime()
+
+			runtimeInterface := &testRuntimeInterface{
+				getSigningAccounts: func() []Address {
+					return nil
+				},
+				computationLimit: computationLimit,
+			}
+
+			err := runtime.ExecuteTransaction(script, runtimeInterface, utils.TestLocation)
+			if test.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+
+				require.IsType(t, Error{}, err)
+				err = err.(Error).Unwrap()
+
+				assert.Equal(t,
+					ComputationLimitExceededError{
+						Limit: computationLimit,
+					},
+					err,
+				)
+			}
+		})
+	}
 }

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -1,0 +1,124 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestInterpretMetering(t *testing.T) {
+
+	checkerImported, err := ParseAndCheck(t, `
+      pub fun a() {
+          true
+          true
+      }
+    `)
+	require.NoError(t, err)
+
+	checkerImporting, err := ParseAndCheckWithOptions(t,
+		`
+          import a from "imported"
+
+          fun b() {
+              true
+              true
+              a()
+              true
+              true
+          }
+
+          fun c() {
+              true
+              true
+              b()
+              true
+              true
+          }
+        `,
+		ParseAndCheckOptions{
+			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
+				return checkerImported.Program, nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	type occurrence struct {
+		interpreterID int
+		line          int
+	}
+
+	var occurrences []occurrence
+	var nextInterpreterID int
+	interpreterIDs := map[*interpreter.Interpreter]int{}
+
+	inter, err := interpreter.NewInterpreter(
+		checkerImporting,
+		interpreter.WithOnStatementHandler(
+			func(statement *interpreter.Statement) {
+				inter := statement.Interpreter
+
+				id, ok := interpreterIDs[inter]
+				if !ok {
+					id = nextInterpreterID
+					nextInterpreterID++
+					interpreterIDs[inter] = id
+				}
+
+				occurrences = append(occurrences, occurrence{
+					interpreterID: id,
+					line:          statement.Line,
+				})
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	err = inter.Interpret()
+	require.NoError(t, err)
+
+	_, err = inter.Invoke("c")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]occurrence{
+			{0, 13},
+			{0, 14},
+			{0, 15},
+			{0, 5},
+			{0, 6},
+			{0, 7},
+			{1, 3},
+			{1, 4},
+			{0, 8},
+			{0, 9},
+			{0, 16},
+			{0, 17},
+		},
+		occurrences,
+	)
+}


### PR DESCRIPTION
Closes dapperlabs/flow-go#3329

## Description

Add a `GetComputationLimit` function to `runtime.Interface`. 
If it returns a value > 0, count statements, loop iterations, and function invocations and abort interpretation when the limit is reached.