### PR TITLE
Fix type requirements

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2357,8 +2357,8 @@ func (interpreter *Interpreter) declareCompositeValue(
 	// in reverse order: first the conformances, then the type requirements;
 	// each conformances and type requirements in reverse order as well.
 
-	for i := len(compositeType.Conformances) - 1; i >= 0; i-- {
-		conformance := compositeType.Conformances[i]
+	for i := len(compositeType.ExplicitInterfaceConformances) - 1; i >= 0; i-- {
+		conformance := compositeType.ExplicitInterfaceConformances[i]
 
 		wrapFunctions(interpreter.typeCodes.interfaceCodes[conformance.ID()])
 	}

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -195,7 +195,7 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 
 						return IsSubType(typedInnerSubType, restrictedSuperType) &&
 							typedSuperType.RestrictionSet().
-								IsSubsetOf(typedInnerSubType.ConformanceSet())
+								IsSubsetOf(typedInnerSubType.ExplicitInterfaceConformanceSet())
 					}
 				}
 
@@ -216,7 +216,7 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 
 						return IsSubType(typedInnerSubType, restrictedSuperType) &&
 							typedSuperType.RestrictionSet().
-								IsSubsetOf(typedInnerSubType.ConformanceSet())
+								IsSubsetOf(typedInnerSubType.ExplicitInterfaceConformanceSet())
 					}
 				}
 
@@ -239,7 +239,7 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 
 						return IsSubType(typedInnerSubType, restrictedSuperType) &&
 							typedSuperType.RestrictionSet().
-								IsSubsetOf(typedInnerSubType.ConformanceSet())
+								IsSubsetOf(typedInnerSubType.ExplicitInterfaceConformanceSet())
 					}
 				}
 
@@ -278,7 +278,7 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 
 				return IsSubType(typedSubType, typedSuperType.Type) &&
 					typedSuperType.RestrictionSet().
-						IsSubsetOf(typedSubType.ConformanceSet())
+						IsSubsetOf(typedSubType.ExplicitInterfaceConformanceSet())
 
 			default:
 

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -135,7 +135,7 @@ func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDecl
 
 	checkMissingMembers := kind != ContainerKindInterface
 
-	for i, interfaceType := range compositeType.Conformances {
+	for i, interfaceType := range compositeType.ExplicitInterfaceConformances {
 		interfaceNominalType := declaration.Conformances[i]
 
 		checker.checkCompositeConformance(
@@ -463,8 +463,8 @@ func (checker *Checker) declareCompositeMembersAndValue(
 
 		// Resolve conformances
 
-		conformances := checker.conformances(declaration, compositeType)
-		compositeType.Conformances = conformances
+		conformances := checker.explicitInterfaceConformances(declaration, compositeType)
+		compositeType.ExplicitInterfaceConformances = conformances
 
 		// NOTE: determine initializer parameter types while nested types are in scope,
 		// and after declaring nested types as the initializer may use nested type in parameters
@@ -605,7 +605,10 @@ func (checker *Checker) initializerParameters(initializers []*ast.SpecialFunctio
 	return parameters
 }
 
-func (checker *Checker) conformances(declaration *ast.CompositeDeclaration, compositeType *CompositeType) []*InterfaceType {
+func (checker *Checker) explicitInterfaceConformances(
+	declaration *ast.CompositeDeclaration,
+	compositeType *CompositeType,
+) []*InterfaceType {
 
 	var interfaceTypes []*InterfaceType
 	seenConformances := map[string]bool{}
@@ -799,7 +802,7 @@ func (checker *Checker) memberSatisfied(compositeMember, interfaceMember *Member
 			interfaceMemberFunctionType := interfaceMemberType.(*FunctionType)
 			compositeMemberFunctionType := compositeMemberType.(*FunctionType)
 
-			// TODO: subtype?
+			// TODO: parameters may be supertype, return type may be subtype
 			if !compositeMemberFunctionType.EqualIncludingArgumentLabels(interfaceMemberFunctionType) {
 				return false
 			}
@@ -902,9 +905,9 @@ func (checker *Checker) checkTypeRequirement(
 	// Check that the composite declaration declares at least the conformances
 	// that the type requirement stated
 
-	for _, requiredConformance := range requiredCompositeType.Conformances {
+	for _, requiredConformance := range requiredCompositeType.ExplicitInterfaceConformances {
 		found := false
-		for _, conformance := range declaredCompositeType.Conformances {
+		for _, conformance := range declaredCompositeType.ExplicitInterfaceConformances {
 			if conformance == requiredConformance {
 				found = true
 				break
@@ -924,12 +927,12 @@ func (checker *Checker) checkTypeRequirement(
 	// Check the conformance of the composite to the type requirement
 	// like a top-level composite declaration to an interface type
 
-	interfaceType := requiredCompositeType.InterfaceType()
+	requiredInterfaceType := requiredCompositeType.InterfaceType()
 
 	checker.checkCompositeConformance(
 		compositeDeclaration,
 		declaredCompositeType,
-		interfaceType,
+		requiredInterfaceType,
 		compositeDeclaration.Identifier,
 		compositeConformanceCheckOptions{
 			checkMissingMembers:            true,

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1054,17 +1054,13 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 
 		// Prepare a set of all the conformances
 
-		allConformances := compositeType.AllConformances()
-		conformancesSet := make(map[*InterfaceType]bool, len(allConformances))
-		for _, conformance := range allConformances {
-			conformancesSet[conformance] = true
-		}
+		conformances := compositeType.ExplicitInterfaceConformanceSet()
 
 		for _, restriction := range restrictions {
 			// The restriction must be an explicit or implicit conformance
 			// of the composite (restricted type)
 
-			if !conformancesSet[restriction] {
+			if !conformances.Includes(restriction) {
 				checker.report(
 					&InvalidNonConformanceRestrictionError{
 						Type:  restriction,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3722,7 +3722,7 @@ func (t *CompositeType) Equal(other Type) bool {
 	}
 
 	return otherStructure.Kind == t.Kind &&
-		otherStructure.Identifier == t.Identifier
+		otherStructure.ID() == t.ID()
 }
 
 func (t *CompositeType) CanHaveMembers() bool {
@@ -4316,7 +4316,7 @@ func (t *InterfaceType) Equal(other Type) bool {
 	}
 
 	return otherInterface.CompositeKind == t.CompositeKind &&
-		otherInterface.Identifier == t.Identifier
+		otherInterface.ID() == t.ID()
 }
 
 func (t *InterfaceType) CanHaveMembers() bool {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3780,12 +3780,6 @@ func (t *CompositeType) TypeRequirements() []*CompositeType {
 	return typeRequirements
 }
 
-func (t *CompositeType) AllConformances() []*InterfaceType {
-	// TODO: also return conformances' conformances recursively
-	//   once interface can have conformances
-	return t.Conformances
-}
-
 func (*CompositeType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {
 	// TODO:
 	return false

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3739,8 +3739,26 @@ func (t *CompositeType) CanHaveMembers() bool {
 	return true
 }
 
-func (t *CompositeType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	return t.Members[identifier]
+func (t *CompositeType) GetMember(identifier string, accessRange ast.Range, report func(error)) *Member {
+	member := t.Members[identifier]
+	if member != nil {
+		return member
+	}
+
+	// Check conformances.
+	// If this composite type results from a normal composite declaration,
+	// it must have members declared for all interfaces it conforms to.
+	// However, if this composite type is a type requirement,
+	// it acts like an interface and does not have to declare members.
+
+	for conformance := range t.ExplicitInterfaceConformanceSet() {
+		member = conformance.GetMember(identifier, accessRange, report)
+		if member != nil {
+			return member
+		}
+	}
+
+	return nil
 }
 
 func (t *CompositeType) IsResourceType() bool {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3664,6 +3664,7 @@ type CompositeType struct {
 	// an internal set of field `ExplicitInterfaceConformances`
 	explicitInterfaceConformanceSet     InterfaceSet
 	ExplicitInterfaceConformances       []*InterfaceType
+	ImplicitTypeRequirementConformances []*CompositeType
 	Members                             map[string]*Member
 	// TODO: add support for overloaded initializers
 	ConstructorParameters []*Parameter
@@ -3684,6 +3685,10 @@ func (t *CompositeType) ExplicitInterfaceConformanceSet() InterfaceSet {
 
 	return t.explicitInterfaceConformanceSet
 }
+
+func (t *CompositeType) AddImplicitTypeRequirementConformance(typeRequirement *CompositeType) {
+	t.ImplicitTypeRequirementConformances =
+		append(t.ImplicitTypeRequirementConformances, typeRequirement)
 }
 
 func init() {
@@ -5244,7 +5249,8 @@ func IsSubType(subType Type, superType Type) bool {
 		// NOTE: type equality case (composite type `T` is subtype of composite type `U`)
 		// is already handled at beginning of function
 
-		if typedSubType, ok := subType.(*RestrictedType); ok {
+		switch typedSubType := subType.(type) {
+		case *RestrictedType:
 
 			// A restricted type `T{Us}`
 			// is a subtype of an unrestricted type `V`:
@@ -5260,6 +5266,16 @@ func IsSubType(subType Type, superType Type) bool {
 				// The owner may freely unrestrict.
 
 				return restrictedSubType == typedSuperType
+			}
+
+		case *CompositeType:
+			// The supertype composite type might be a type requirement.
+			// Check if the subtype composite type implicitly conforms to it.
+
+			for _, conformance := range typedSubType.ImplicitTypeRequirementConformances {
+				if conformance == typedSuperType {
+					return true
+				}
 			}
 		}
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3658,27 +3658,32 @@ func numberFunctionArgumentExpressionsChecker(numberType Type) func(*Checker, []
 // CompositeType
 
 type CompositeType struct {
-	Location     ast.Location
-	Identifier   string
-	Kind         common.CompositeKind
-	Conformances []*InterfaceType
-	// an internal set of field `Conformances`
-	conformanceSet InterfaceSet
-	Members        map[string]*Member
+	Location   ast.Location
+	Identifier string
+	Kind       common.CompositeKind
+	// an internal set of field `ExplicitInterfaceConformances`
+	explicitInterfaceConformanceSet     InterfaceSet
+	ExplicitInterfaceConformances       []*InterfaceType
+	Members                             map[string]*Member
 	// TODO: add support for overloaded initializers
 	ConstructorParameters []*Parameter
 	nestedTypes           map[string]Type
 	ContainerType         Type
 }
 
-func (t *CompositeType) ConformanceSet() InterfaceSet {
-	if t.conformanceSet == nil {
-		t.conformanceSet = make(InterfaceSet, len(t.Conformances))
-		for _, conformance := range t.Conformances {
-			t.conformanceSet[conformance] = struct{}{}
+func (t *CompositeType) ExplicitInterfaceConformanceSet() InterfaceSet {
+	if t.explicitInterfaceConformanceSet == nil {
+		// TODO: also include conformances' conformances recursively
+		//   once interface can have conformances
+
+		t.explicitInterfaceConformanceSet = make(InterfaceSet, len(t.ExplicitInterfaceConformances))
+		for _, conformance := range t.ExplicitInterfaceConformances {
+			t.explicitInterfaceConformanceSet.Add(conformance)
 		}
 	}
-	return t.conformanceSet
+
+	return t.explicitInterfaceConformanceSet
+}
 }
 
 func init() {
@@ -3766,7 +3771,7 @@ func (t *CompositeType) TypeRequirements() []*CompositeType {
 	var typeRequirements []*CompositeType
 
 	if containerComposite, ok := t.ContainerType.(*CompositeType); ok {
-		for _, conformance := range containerComposite.Conformances {
+		for _, conformance := range containerComposite.ExplicitInterfaceConformances {
 			ty := conformance.nestedTypes[t.Identifier]
 			typeRequirement, ok := ty.(*CompositeType)
 			if !ok {
@@ -4961,7 +4966,7 @@ func IsSubType(subType Type, superType Type) bool {
 					// TODO: once interfaces can conform to interfaces, include
 					return IsSubType(typedInnerSubType, restrictedSuperType) &&
 						typedInnerSuperType.RestrictionSet().
-							IsSubsetOf(typedInnerSubType.ConformanceSet())
+							IsSubsetOf(typedInnerSubType.ExplicitInterfaceConformanceSet())
 
 				case *AnyResourceType, *AnyStructType, *AnyType:
 					// An unauthorized reference to an unrestricted type `&T`
@@ -5156,7 +5161,7 @@ func IsSubType(subType Type, superType Type) bool {
 					// TODO: once interfaces can conform to interfaces, include
 					return IsSubType(restrictedSubtype, restrictedSuperType) &&
 						typedSuperType.RestrictionSet().
-							IsSubsetOf(restrictedSubtype.ConformanceSet())
+							IsSubsetOf(restrictedSubtype.ExplicitInterfaceConformanceSet())
 				}
 
 			case *AnyResourceType:
@@ -5191,7 +5196,7 @@ func IsSubType(subType Type, superType Type) bool {
 
 				return IsSubType(typedSubType, typedSuperType.Type) &&
 					typedSuperType.RestrictionSet().
-						IsSubsetOf(typedSubType.ConformanceSet())
+						IsSubsetOf(typedSubType.ExplicitInterfaceConformanceSet())
 			}
 
 		default:
@@ -5280,7 +5285,7 @@ func IsSubType(subType Type, superType Type) bool {
 			}
 
 			// TODO: once interfaces can conform to interfaces, include
-			if _, ok := typedSubType.ConformanceSet()[typedSuperType]; ok {
+			if _, ok := typedSubType.ExplicitInterfaceConformanceSet()[typedSuperType]; ok {
 				return true
 			}
 
@@ -5470,6 +5475,15 @@ func (s InterfaceSet) IsSubsetOf(other InterfaceSet) bool {
 	}
 
 	return true
+}
+
+func (s InterfaceSet) Includes(interfaceType *InterfaceType) bool {
+	_, ok := s[interfaceType]
+	return ok
+}
+
+func (s InterfaceSet) Add(interfaceType *InterfaceType) {
+	s[interfaceType] = struct{}{}
 }
 
 // RestrictedType

--- a/runtime/tests/checker/conformance_test.go
+++ b/runtime/tests/checker/conformance_test.go
@@ -19,6 +19,7 @@
 package checker
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,4 +45,201 @@ func TestCheckInvalidEventTypeRequirementConformance(t *testing.T) {
 	errs := ExpectCheckerErrors(t, err, 1)
 
 	require.IsType(t, &sema.ConformanceError{}, errs[0])
+}
+
+func TestCheckTypeRequirementConformance(t *testing.T) {
+
+	type test struct {
+		name            string
+		preparationCode string
+		interfaceCode   string
+		conformanceCode string
+		valid           bool
+	}
+
+	tests := []test{
+		{
+			"Both empty",
+			``,
+			`pub struct S {}`,
+			`pub struct S {}`,
+			true,
+		},
+		{
+			"Conformance with additional function",
+			``,
+			`
+              pub struct S {}
+            `,
+			`
+              pub struct S {
+                  fun foo() {}
+              }
+            `,
+			true,
+		},
+		{
+			"Conformance with missing function",
+			``,
+			`
+              pub struct S {}
+            `,
+			`
+              pub struct S {
+                  fun foo() {}
+              }
+            `,
+			true,
+		},
+		{
+			"Conformance with missing function",
+			``,
+			`
+              pub struct S {}
+            `,
+			`
+              pub struct S {
+                  fun foo() {}
+              }
+            `,
+			true,
+		},
+		{
+			"Conformance with same name, same parameter type, but different argument label",
+			``,
+			`
+              pub struct S {
+                  fun foo(x: Int)
+              }
+            `,
+			`
+              pub struct S {
+                  fun foo(y: Int) {}
+              }
+            `,
+			false,
+		},
+		{
+			"Conformance with same name, same argument label, but different parameter type",
+			``,
+			`
+              pub struct S {
+                  fun foo(x: Int)
+              }
+            `,
+			`
+              pub struct S {
+                  fun foo(x: String) {}
+              }
+            `,
+			false,
+		},
+		{
+			"Conformance with same name, same argument label, same parameter type, different parameter name",
+			``,
+			`
+              pub struct S {
+                  fun foo(x y: String)
+              }
+            `,
+			`
+              pub struct S {
+                  fun foo(x z: String) {}
+              }
+            `,
+			true,
+		},
+		{
+			"Conformance with more specific parameter type",
+			`
+                pub struct interface I {}
+                pub struct T: I {}
+            `,
+			`
+              pub struct S {
+                  fun foo(bar: {I})
+              }
+            `,
+			`
+              pub struct S {
+                  fun foo(bar: T) {}
+              }
+            `,
+			false,
+		},
+		{
+			"Conformance with same nested parameter type",
+			`
+                pub contract X {
+                    struct Bar {}
+                }
+            `,
+			`
+              pub struct S {
+                  fun foo(bar: X.Bar)
+              }
+            `,
+			`
+              pub struct S {
+                  fun foo(bar: X.Bar) {}
+              }
+            `,
+			true,
+		},
+		{
+			"Conformance with different nested parameter type",
+			`
+                pub contract X {
+                    struct Bar {}
+                }
+
+                pub contract Y {
+                    struct Bar {}
+                }
+            `,
+			`
+              pub struct S {
+                  fun foo(bar: X.Bar)
+              }
+            `,
+			`
+              pub struct S {
+                  fun foo(bar: Y.Bar) {}
+              }
+            `,
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			_, err := ParseAndCheck(t,
+				fmt.Sprintf(
+					`
+                      %s
+
+                      pub contract interface CI {
+                          %s
+                      }
+
+                      pub contract C: CI {
+                          %s
+                      }
+                    `,
+					test.preparationCode,
+					test.interfaceCode,
+					test.conformanceCode,
+				),
+			)
+
+			if test.valid {
+				require.NoError(t, err)
+			} else {
+				errs := ExpectCheckerErrors(t, err, 1)
+
+				require.IsType(t, &sema.ConformanceError{}, errs[0])
+			}
+		})
+	}
 }

--- a/runtime/tests/checker/conformance_test.go
+++ b/runtime/tests/checker/conformance_test.go
@@ -82,27 +82,14 @@ func TestCheckTypeRequirementConformance(t *testing.T) {
 			"Conformance with missing function",
 			``,
 			`
-              pub struct S {}
-            `,
-			`
               pub struct S {
-                  fun foo() {}
+                  fun foo()
               }
             `,
-			true,
-		},
-		{
-			"Conformance with missing function",
-			``,
 			`
               pub struct S {}
             `,
-			`
-              pub struct S {
-                  fun foo() {}
-              }
-            `,
-			true,
+			false,
 		},
 		{
 			"Conformance with same name, same parameter type, but different argument label",

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -500,6 +500,8 @@ func TestCheckInvalidInterfaceConformanceUndeclared(t *testing.T) {
 				errs := ExpectCheckerErrors(t, err, 1)
 
 				assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			} else {
+				require.NoError(t, err)
 			}
 
 			require.NotNil(t, checker)

--- a/runtime/tests/examples/examples.go
+++ b/runtime/tests/examples/examples.go
@@ -1,0 +1,81 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package examples
+
+const FungibleTokenContractInterface = `
+  pub contract interface FungibleToken {
+
+      pub resource interface Provider {
+
+          pub fun withdraw(amount: Int): @Vault
+      }
+
+      pub resource interface Receiver {
+
+          pub fun deposit(vault: @Vault)
+      }
+
+      pub resource Vault: Provider, Receiver {
+
+          pub balance: Int
+
+          init(balance: Int)
+      }
+
+      pub fun absorb(vault: @Vault)
+
+      pub fun sprout(balance: Int): @Vault
+  }
+`
+
+const ExampleFungibleTokenContract = `
+  pub contract ExampleToken: FungibleToken {
+
+     pub resource Vault: FungibleToken.Receiver, FungibleToken.Provider {
+
+         pub var balance: Int
+
+         init(balance: Int) {
+             self.balance = balance
+         }
+
+         pub fun withdraw(amount: Int): @FungibleToken.Vault {
+             self.balance = self.balance - amount
+             return <-create Vault(balance: amount)
+         }
+
+         pub fun deposit(vault: @FungibleToken.Vault) {
+            if let exampleVault <- vault as? @Vault {
+                self.balance = self.balance + exampleVault.balance
+                destroy exampleVault
+            } else {
+               panic("deposited vault is not an ExampleToken.Vault")
+            }
+         }
+     }
+
+     pub fun absorb(vault: @FungibleToken.Vault) {
+         destroy vault
+     }
+
+     pub fun sprout(balance: Int): @FungibleToken.Vault {
+         return <-create Vault(balance: balance)
+     }
+  }
+`

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7660,3 +7660,30 @@ func TestInterpretCountDigits256(t *testing.T) {
 		})
 	}
 }
+
+func TestInterpretFailableCastingCompositeTypeConfusion(t *testing.T) {
+
+	inter := parseCheckAndInterpretWithOptions(t,
+		`
+          contract A {
+              struct S {}
+          }
+
+          contract B {
+              struct S {}
+          }
+
+          let s = A.S() as? B.S
+        `,
+		ParseCheckAndInterpretOptions{
+			Options: []interpreter.Option{
+				makeContractValueHandler(nil, nil, nil),
+			},
+		},
+	)
+
+	assert.Equal(t,
+		interpreter.NilValue{},
+		inter.Globals["s"].Value,
+	)
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/examples"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 	"github.com/onflow/cadence/runtime/trampoline"
 )
@@ -6408,88 +6409,51 @@ func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
 	)
 }
 
-const fungibleTokenContract = `
-  pub contract interface FungibleToken {
-
-      pub resource interface Provider {
-
-          pub fun withdraw(amount: Int): @Vault
-      }
-
-      pub resource interface Receiver {
-
-          pub fun deposit(vault: @Vault)
-      }
-
-      pub resource Vault: Provider, Receiver {
-
-          pub balance: Int
-
-          init(balance: Int)
-      }
-
-      pub fun absorb(vault: @Vault)
-
-      pub fun sprout(balance: Int): @Vault
-  }
-
-  pub contract ExampleToken: FungibleToken {
-
-     pub resource Vault: FungibleToken.Receiver, FungibleToken.Provider {
-
-         pub var balance: Int
-
-         init(balance: Int) {
-             self.balance = balance
-         }
-
-         pub fun withdraw(amount: Int): @Vault {
-             self.balance = self.balance - amount
-             return <-create Vault(balance: amount)
-         }
-
-         pub fun deposit(vault: @Vault) {
-            self.balance = self.balance + vault.balance
-            destroy vault
-         }
-     }
-
-     pub fun absorb(vault: @Vault) {
-         destroy vault
-     }
-
-     pub fun sprout(balance: Int): @Vault {
-         return <-create Vault(balance: balance)
-     }
-  }
-`
-
 func TestInterpretFungibleTokenContract(t *testing.T) {
 
-	code := fungibleTokenContract + "\n" + `
+	code := strings.Join(
+		[]string{
+			examples.FungibleTokenContractInterface,
+			examples.ExampleFungibleTokenContract,
+			`
+              pub fun test(): [Int; 2] {
 
-      pub fun test(): [Int; 2] {
+                  let publisher <- ExampleToken.sprout(balance: 100)
+                  let receiver <- ExampleToken.sprout(balance: 0)
 
-          let publisher <- ExampleToken.sprout(balance: 100)
-          let receiver <- ExampleToken.sprout(balance: 0)
+                  let withdrawn <- publisher.withdraw(amount: 60)
+                  receiver.deposit(vault: <-withdrawn)
 
-          let withdrawn <- publisher.withdraw(amount: 60)
-          receiver.deposit(vault: <-withdrawn)
+                  let publisherBalance = publisher.balance
+                  let receiverBalance = receiver.balance
 
-          let publisherBalance = publisher.balance
-          let receiverBalance = receiver.balance
+                  destroy publisher
+                  destroy receiver
 
-          destroy publisher
-          destroy receiver
+                  return [publisherBalance, receiverBalance]
+              }
+            `,
+		},
+		"\n",
+	)
 
-          return [publisherBalance, receiverBalance]
-      }
-    `
+	standardLibraryFunctions :=
+		stdlib.StandardLibraryFunctions{
+			stdlib.PanicFunction,
+		}
+
+	valueDeclarations := standardLibraryFunctions.ToValueDeclarations()
+	predefinedValues := standardLibraryFunctions.ToValues()
+
 	inter := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
 			Options: []interpreter.Option{
+				interpreter.WithPredefinedValues(predefinedValues),
 				makeContractValueHandler(nil, nil, nil),
+			},
+			CheckerOptions: []sema.Option{
+				sema.WithPredeclaredValues(valueDeclarations),
 			},
 		},
 	)


### PR DESCRIPTION
Closes dapperlabs/flow-go#3177

## Description

Type requirements were broken in several ways. 

Interfaces and composites can be nested for a while now; however the equality check was not updated to consider nesting and location. This lead to implementations of type requirements being able to use more restrictive types or even other types. 

This made the example fungible contract pass, even though it should not. For example, the `deposit` method in the `ExampleToken` implementation specified a more restrictive type `ExampleToken.Vault` instead of the required `FungibleToken.Vault`. 

As failable casting in the interpreter uses the subtyping function of the checker, this also erroneously enabled type confusion: Any type named "Vault" could be casted to e.g. `FungibleToken.Vault` or `ExampleToken.Vault`.

Fixing the equality methods for interface and composite types fixed these bugs, but also uncovered that currently composites conforming to type requirements (e.g. `ExampleToken.Vault` to `FungibleToken.Vault`) were not actually subtypes – the bug above allowed the subtyping to succeed.

Fix the missing subtyping relation by recording composite types' implicit conformances to type requirements in the composite type, just like explicit conformances to interfaces, and add a subtyping rule between composite types that consideres these implicit type requirements conformances.

This is likely hard to be reviewed, but this is a very important bugfix and a review needs to be thorough. I'm more than happy to go over it step by step in a call.