### PR TITLE
Reset the resource return info when checking a function

### DIFF
--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -108,6 +108,14 @@ func (checker *Checker) checkFunction(
 		checker.checkTypeAnnotation(functionType.ReturnTypeAnnotation, returnTypeAnnotation)
 	}
 
+	// Reset the returning state and restore it when leaving
+
+	returned := checker.resources.Returns
+	checker.resources.Returns = false
+	defer func() {
+		checker.resources.Returns = returned
+	}()
+
 	// NOTE: Always declare the function parameters, even if the function body is empty.
 	// For example, event declarations have an initializer with an empty body,
 	// but their parameters (e.g. duplication) needs to still be checked.

--- a/runtime/tests/examples/examples.go
+++ b/runtime/tests/examples/examples.go
@@ -65,6 +65,7 @@ const ExampleFungibleTokenContract = `
                 self.balance = self.balance + exampleVault.balance
                 destroy exampleVault
             } else {
+               destroy vault
                panic("deposited vault is not an ExampleToken.Vault")
             }
          }


### PR DESCRIPTION
Closes dapperlabs/flow-go#3407
Depends on #30

## Description

The resource invalidation info is global, but contains one flag for the return status of the function. We've set this correctly, but forgot to reset it for each function. This caused functions to influence the return info of other functions, and therefore also the resource invalidation checks, leading to the missing resource loss error. 