### PR TITLE
Add an explanation for access modifier errors

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1656,6 +1656,8 @@ func (checker *Checker) ResetErrors() {
 	checker.errors = nil
 }
 
+const invalidTypeDeclarationAccessModifierExplanation = "type declarations must be public for now"
+
 func (checker *Checker) checkDeclarationAccessModifier(
 	access ast.Access,
 	declarationKind common.DeclarationKind,
@@ -1668,6 +1670,7 @@ func (checker *Checker) checkDeclarationAccessModifier(
 			checker.report(
 				&InvalidAccessModifierError{
 					Access:          access,
+					Explanation:     "local declarations may not have an access modifier",
 					DeclarationKind: declarationKind,
 					Pos:             startPos,
 				},
@@ -1683,9 +1686,18 @@ func (checker *Checker) checkDeclarationAccessModifier(
 			// and type declarations must be public for now
 
 			if isConstant || isTypeDeclaration {
+				var explanation string
+				switch {
+				case isConstant:
+					explanation = "constants can never be set"
+				case isTypeDeclaration:
+					explanation = invalidTypeDeclarationAccessModifierExplanation
+				}
+
 				checker.report(
 					&InvalidAccessModifierError{
 						Access:          access,
+						Explanation:     explanation,
 						DeclarationKind: declarationKind,
 						Pos:             startPos,
 					},
@@ -1700,6 +1712,7 @@ func (checker *Checker) checkDeclarationAccessModifier(
 				checker.report(
 					&InvalidAccessModifierError{
 						Access:          access,
+						Explanation:     invalidTypeDeclarationAccessModifierExplanation,
 						DeclarationKind: declarationKind,
 						Pos:             startPos,
 					},
@@ -1715,6 +1728,7 @@ func (checker *Checker) checkDeclarationAccessModifier(
 				checker.report(
 					&InvalidAccessModifierError{
 						Access:          access,
+						Explanation:     invalidTypeDeclarationAccessModifierExplanation,
 						DeclarationKind: declarationKind,
 						Pos:             startPos,
 					},
@@ -1731,6 +1745,7 @@ func (checker *Checker) checkDeclarationAccessModifier(
 				checker.report(
 					&MissingAccessModifierError{
 						DeclarationKind: declarationKind,
+						Explanation:     invalidTypeDeclarationAccessModifierExplanation,
 						Pos:             startPos,
 					},
 				)
@@ -2016,4 +2031,12 @@ func (checker *Checker) checkTypeAnnotation(typeAnnotation *TypeAnnotation, pos 
 			},
 		)
 	}
+}
+
+func (checker *Checker) ValueActivationDepth() int {
+	return checker.valueActivations.Depth()
+}
+
+func (checker *Checker) TypeActivationDepth() int {
+	return checker.typeActivations.Depth()
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1656,7 +1656,7 @@ func (checker *Checker) ResetErrors() {
 	checker.errors = nil
 }
 
-const invalidTypeDeclarationAccessModifierExplanation = "type declarations must be public for now"
+const invalidTypeDeclarationAccessModifierExplanation = "type declarations must be public"
 
 func (checker *Checker) checkDeclarationAccessModifier(
 	access ast.Access,

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -471,15 +471,22 @@ func (*ControlStatementError) isSemanticError() {}
 
 type InvalidAccessModifierError struct {
 	DeclarationKind common.DeclarationKind
+	Explanation     string
 	Access          ast.Access
 	Pos             ast.Position
 }
 
 func (e *InvalidAccessModifierError) Error() string {
+	var explanation string
+	if e.Explanation != "" {
+		explanation = fmt.Sprintf(". %s", e.Explanation)
+	}
+
 	return fmt.Sprintf(
-		"invalid access modifier for %s: `%s`",
+		"invalid access modifier for %s: `%s`%s",
 		e.DeclarationKind.Name(),
 		e.Access.Keyword(),
+		explanation,
 	)
 }
 
@@ -498,13 +505,20 @@ func (e *InvalidAccessModifierError) EndPosition() ast.Position {
 
 type MissingAccessModifierError struct {
 	DeclarationKind common.DeclarationKind
+	Explanation     string
 	Pos             ast.Position
 }
 
 func (e *MissingAccessModifierError) Error() string {
+	var explanation string
+	if e.Explanation != "" {
+		explanation = fmt.Sprintf(". %s", e.Explanation)
+	}
+
 	return fmt.Sprintf(
-		"missing access modifier for %s",
+		"missing access modifier for %s%s",
 		e.DeclarationKind.Name(),
+		explanation,
 	)
 }
 


### PR DESCRIPTION
## Description

Currently, error messages for incorrect or missing access modifiers do not explain why the modifier is wrong, just that it is wrong.

For example, when using the access modifier `access(contract)` for a nested struct in a contract, the error message is:

> invalid access modifier for structure: `access(contract)`

This PR adds an optional explanation to such errors. 

The above example is now reported as:
  
> invalid access modifier for structure: `access(contract)`. type declarations must be public for now
