### PR TITLE
Support caching of program ASTs

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -19,8 +19,6 @@
 package runtime
 
 import (
-	"errors"
-
 	"github.com/onflow/cadence/runtime/ast"
 )
 
@@ -67,7 +65,7 @@ func (i *EmptyRuntimeInterface) ResolveImport(location Location) ([]byte, error)
 	return nil, nil
 }
 func (i *EmptyRuntimeInterface) GetCachedProgram(location Location) (*ast.Program, error) {
-	return nil, errors.New("cache not implemented")
+	return nil, nil
 }
 
 func (i *EmptyRuntimeInterface) CacheProgram(location Location, program *ast.Program) error {

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -64,6 +64,7 @@ type EmptyRuntimeInterface struct{}
 func (i *EmptyRuntimeInterface) ResolveImport(location Location) ([]byte, error) {
 	return nil, nil
 }
+
 func (i *EmptyRuntimeInterface) GetCachedProgram(location Location) (*ast.Program, error) {
 	return nil, nil
 }

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -18,9 +18,19 @@
 
 package runtime
 
+import (
+	"errors"
+
+	"github.com/onflow/cadence/runtime/ast"
+)
+
 type Interface interface {
 	// ResolveImport resolves an import of a program.
 	ResolveImport(Location) ([]byte, error)
+	// GetCachedProgram attempts to get a parsed program from a cache.
+	GetCachedProgram(Location) (*ast.Program, error)
+	// CacheProgram adds a parsed program to a cache.
+	CacheProgram(Location, *ast.Program) error
 	// GetValue gets a value for the given key in the storage, controlled and owned by the given accounts.
 	GetValue(owner, controller, key []byte) (value []byte, err error)
 	// SetValue sets a value for the given key in the storage, controlled and owned by the given accounts.
@@ -55,6 +65,13 @@ type EmptyRuntimeInterface struct{}
 
 func (i *EmptyRuntimeInterface) ResolveImport(location Location) ([]byte, error) {
 	return nil, nil
+}
+func (i *EmptyRuntimeInterface) GetCachedProgram(location Location) (*ast.Program, error) {
+	return nil, errors.New("cache not implemented")
+}
+
+func (i *EmptyRuntimeInterface) CacheProgram(location Location, program *ast.Program) error {
+	return nil
 }
 
 func (i *EmptyRuntimeInterface) ValueExists(controller, owner, key []byte) (exists bool, err error) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -281,6 +281,10 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 	// If the program has not been previously cached, proceed to parse the program.
 	program, err := runtimeInterface.GetCachedProgram(location)
 	if err != nil {
+		return nil, err
+	}
+
+	if program == nil {
 		program, err = r.parse(code)
 		if err != nil {
 			return nil, err

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -192,14 +192,23 @@ func TestRuntimeImport(t *testing.T) {
 }
 
 func TestRuntimeProgramCache(t *testing.T) {
-	var cacheHitSuccess bool
+
 	programCache := map[ast.LocationID]*ast.Program{}
+	cacheHits := make(map[ast.LocationID]bool)
+
+	importedScript := []byte(`
+	transaction {
+		prepare() {}
+		execute {}
+	}
+	`)
+	importedScriptLocation := ast.StringLocation("imported")
 
 	runtime := NewInterpreterRuntime()
 	runtimeInterface := &testRuntimeInterface{
 		getCachedProgram: func(location ast.Location) (*ast.Program, error) {
 			program, found := programCache[location.ID()]
-			cacheHitSuccess = found
+			cacheHits[location.ID()] = found
 			if !found {
 				return nil, nil
 			}
@@ -209,29 +218,84 @@ func TestRuntimeProgramCache(t *testing.T) {
 			programCache[location.ID()] = program
 			return nil
 		},
+		resolveImport: func(location Location) ([]byte, error) {
+			fmt.Println(location.ID())
+			switch location {
+			case importedScriptLocation:
+				return importedScript, nil
+			default:
+				return nil, fmt.Errorf("unknown import location: %s", location)
+			}
+		},
 	}
 
-	scriptLocation := ast.StringLocation("test-location")
+	t.Run("empty cache, cache miss", func(t *testing.T) {
 
-	script := []byte(`
-      transaction {
-        prepare() {}
-        execute {}
-      }
-	`)
+		script := []byte(`
+		import "imported"
 
-	// Initial call, should parse script, store result in cache.
-	err := runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
-	assert.NoError(t, err)
-	cachedProgram, exists := programCache[scriptLocation.ID()]
-	assert.True(t, exists)
-	assert.False(t, cacheHitSuccess)
-	assert.NotNil(t, cachedProgram)
+		transaction {
+			prepare() {}
+			execute {}
+		}
+		`)
+		scriptLocation := ast.StringLocation("placeholder")
 
-	// Call a second time to hit the cache
-	err = runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
-	assert.NoError(t, err)
-	assert.True(t, cacheHitSuccess)
+		// Initial call, should parse script, store result in cache.
+		err := runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
+		assert.NoError(t, err)
+
+		// Program was added to cache.
+		cachedProgram, exists := programCache[scriptLocation.ID()]
+		assert.True(t, exists)
+		assert.NotNil(t, cachedProgram)
+
+		// Script was not in cache.
+		assert.False(t, cacheHits[scriptLocation.ID()])
+	})
+
+	t.Run("program previously parsed, cache hit", func(t *testing.T) {
+
+		script := []byte(`
+		import "imported"
+
+		transaction {
+			prepare() {}
+			execute {}
+		}
+		`)
+		scriptLocation := ast.StringLocation("placeholder")
+
+		// Call a second time to hit the cache
+		err := runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
+		assert.NoError(t, err)
+
+		// Script was in cache.
+		assert.True(t, cacheHits[scriptLocation.ID()])
+	})
+
+	t.Run("imported program previously parsed, cache hit", func(t *testing.T) {
+
+		script := []byte(`
+		import "imported"
+
+		transaction {
+			prepare() {}
+			execute {}
+		}
+		`)
+		scriptLocation := ast.StringLocation("placeholder")
+
+		// Call a second time to hit the cache
+		err := runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
+		assert.NoError(t, err)
+
+		// Script was in cache.
+		assert.True(t, cacheHits[scriptLocation.ID()])
+		// Import was in cache.
+		assert.True(t, cacheHits[importedScriptLocation.ID()])
+	})
+
 }
 
 func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -219,7 +219,6 @@ func TestRuntimeProgramCache(t *testing.T) {
 			return nil
 		},
 		resolveImport: func(location Location) ([]byte, error) {
-			fmt.Println(location.ID())
 			switch location {
 			case importedScriptLocation:
 				return importedScript, nil


### PR DESCRIPTION
Closes https://github.com/dapperlabs/flow-go/issues/3401.

## Description

Provide `runtime.Interface` methods to support caching the program AST of parsed programs. This should expedite loading of previously parsed programs (by skipping the parse phase). An error returned from `GetCachedProgram` (a non-fatal error) will result in the input program being parsed.