### PR TITLE
Runtime Values: Add ToRuntimeValue function

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -44,6 +44,108 @@ func ConvertEvent(event Event) cadence.Event {
 	return cadence.NewEvent(fields).WithType(ConvertType(event.Type).(cadence.EventType))
 }
 
+// ToRuntimeValue converts a Cadence value to a runtime value.
+func ToRuntimeValue(value cadence.Value) Value {
+	switch v := value.(type) {
+	case cadence.Void:
+		return Value{Value: interpreter.VoidValue{}}
+	case cadence.Optional:
+		if v.Value == nil {
+			return Value{Value: interpreter.NilValue{}}
+		}
+
+		innerValue := ToRuntimeValue(v.Value).Value
+		value := interpreter.NewSomeValueOwningNonCopying(innerValue)
+
+		return Value{Value: value}
+	case cadence.Bool:
+		return Value{Value: interpreter.BoolValue(v)}
+	case cadence.String:
+		return Value{Value: interpreter.NewStringValue(string(v))}
+	case cadence.Bytes:
+		return Value{Value: interpreter.ByteSliceToByteArrayValue(v)}
+	case cadence.Address:
+		return Value{Value: interpreter.NewAddressValueFromBytes(v.Bytes())}
+	case cadence.Int:
+		return Value{Value: interpreter.NewIntValueFromBigInt(v.Big())}
+	case cadence.Int8:
+		return Value{Value: interpreter.Int8Value(v)}
+	case cadence.Int16:
+		return Value{Value: interpreter.Int16Value(v)}
+	case cadence.Int32:
+		return Value{Value: interpreter.Int32Value(v)}
+	case cadence.Int64:
+		return Value{Value: interpreter.Int64Value(v)}
+	case cadence.Int128:
+		return Value{Value: interpreter.NewInt128ValueFromBigInt(v.Big())}
+	case cadence.Int256:
+		return Value{Value: interpreter.NewInt256ValueFromBigInt(v.Big())}
+	case cadence.UInt:
+		return Value{Value: interpreter.NewUIntValueFromBigInt(v.Big())}
+	case cadence.UInt8:
+		return Value{Value: interpreter.UInt8Value(v)}
+	case cadence.UInt16:
+		return Value{Value: interpreter.UInt16Value(v)}
+	case cadence.UInt32:
+		return Value{Value: interpreter.UInt32Value(v)}
+	case cadence.UInt64:
+		return Value{Value: interpreter.UInt64Value(v)}
+	case cadence.UInt128:
+		return Value{Value: interpreter.NewUInt128ValueFromBigInt(v.Big())}
+	case cadence.UInt256:
+		return Value{Value: interpreter.NewUInt256ValueFromBigInt(v.Big())}
+	case cadence.Word8:
+		return Value{Value: interpreter.Word8Value(v)}
+	case cadence.Word16:
+		return Value{Value: interpreter.Word16Value(v)}
+	case cadence.Word32:
+		return Value{Value: interpreter.Word32Value(v)}
+	case cadence.Word64:
+		return Value{Value: interpreter.Word64Value(v)}
+	case cadence.Fix64:
+		return Value{Value: interpreter.Fix64Value(v)}
+	case cadence.UFix64:
+		return Value{Value: interpreter.UFix64Value(v)}
+	case cadence.Array:
+		values := make([]interpreter.Value, len(v.Values))
+
+		for i, elem := range v.Values {
+			values[i] = ToRuntimeValue(elem).Value
+		}
+
+		return Value{Value: interpreter.NewArrayValueUnownedNonCopying(values...)}
+	case cadence.Dictionary:
+		keysAndValues := make([]interpreter.Value, len(v.Pairs)*2)
+
+		for i, pair := range v.Pairs {
+			keysAndValues[i*2] = ToRuntimeValue(pair.Key).Value
+			keysAndValues[i*2+1] = ToRuntimeValue(pair.Value).Value
+		}
+
+		return Value{Value: interpreter.NewDictionaryValueUnownedNonCopying(keysAndValues...)}
+	case cadence.Struct:
+		return compositeToRuntimeValue(v.StructType.Fields, v.Fields)
+	case cadence.Resource:
+		return compositeToRuntimeValue(v.ResourceType.Fields, v.Fields)
+	case cadence.Event:
+		return compositeToRuntimeValue(v.EventType.Fields, v.Fields)
+	}
+
+	panic(fmt.Sprintf("cannot convert value of type %T", value))
+}
+
+func compositeToRuntimeValue(fieldTypes []cadence.Field, fieldValues []cadence.Value) Value {
+	fields := make(map[string]interpreter.Value, len(fieldTypes))
+
+	for i := 0; i < len(fieldTypes) && i < len(fieldValues); i++ {
+		fieldType := fieldTypes[i]
+		fieldValue := fieldValues[i]
+		fields[fieldType.Identifier] = ToRuntimeValue(fieldValue).Value
+	}
+
+	return Value{Value: &interpreter.CompositeValue{Fields: fields}}
+}
+
 func convertValue(value interpreter.Value, inter *interpreter.Interpreter) cadence.Value {
 	switch v := value.(type) {
 	case interpreter.VoidValue:

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -31,9 +31,10 @@ import (
 )
 
 var convertTests = []struct {
-	label    string
-	value    interpreter.Value
-	expected cadence.Value
+	label       string
+	value       interpreter.Value
+	expected    cadence.Value
+	skipReverse bool
 }{
 	{
 		label:    "Void",
@@ -41,9 +42,10 @@ var convertTests = []struct {
 		expected: cadence.NewVoid(),
 	},
 	{
-		label:    "Nil",
-		value:    interpreter.NilValue{},
-		expected: cadence.NewOptional(nil),
+		label:       "Nil",
+		value:       interpreter.NilValue{},
+		expected:    cadence.NewOptional(nil),
+		skipReverse: true,
 	},
 	{
 		label:    "SomeValue",
@@ -195,6 +197,11 @@ func TestConvertValue(t *testing.T) {
 		t.Run(tt.label, func(t *testing.T) {
 			actual := convertValue(tt.value, nil)
 			assert.Equal(t, tt.expected, actual)
+
+			if !tt.skipReverse {
+				original := ToRuntimeValue(actual)
+				assert.Equal(t, tt.value, original.Value)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**Part 2 of 3**

This PR adds a `runtime.ToRuntimeValue` function that converts a `cadence.Value` type to a `runtime.Value` type.

This PR copies the same logic as this PR, but instead keeps value conversion inside the `runtime` package: https://github.com/onflow/cadence/pull/29 