### PR TITLE
Improve access modifier checks

### DIFF
--- a/runtime/ast/access.go
+++ b/runtime/ast/access.go
@@ -41,12 +41,21 @@ func (a Access) IsLessPermissiveThan(otherAccess Access) bool {
 	return a < otherAccess
 }
 
-var Accesses = []Access{
+// TODO: remove.
+//   only used by tests which are not updated yet
+//   to include contract and account access
+
+var BasicAccesses = []Access{
 	AccessNotSpecified,
 	AccessPrivate,
 	AccessPublic,
 	AccessPublicSettable,
 }
+
+var AllAccesses = append(BasicAccesses[:],
+	AccessContract,
+	AccessAccount,
+)
 
 func (a Access) Keyword() string {
 	switch a {

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -297,7 +297,7 @@ func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclar
 		interfaceType,
 		declaration.Members.Fields,
 		declaration.Members.Functions,
-		false,
+		ContainerKindInterface,
 	)
 
 	interfaceType.Members = members

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -249,7 +249,7 @@ func (checker *Checker) declareTransactionDeclaration(declaration *ast.Transacti
 		transactionType,
 		declaration.Fields,
 		nil,
-		true,
+		ContainerKindComposite,
 	)
 
 	checker.memberOrigins[transactionType] = origins

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2040,3 +2040,39 @@ func (checker *Checker) ValueActivationDepth() int {
 func (checker *Checker) TypeActivationDepth() int {
 	return checker.typeActivations.Depth()
 }
+
+func (checker *Checker) effectiveMemberAccess(access ast.Access, containerKind ContainerKind) ast.Access {
+	switch containerKind {
+	case ContainerKindComposite:
+		return checker.effectiveCompositeMemberAccess(access)
+	case ContainerKindInterface:
+		return checker.effectiveInterfaceMemberAccess(access)
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (checker *Checker) effectiveInterfaceMemberAccess(access ast.Access) ast.Access {
+	if access == ast.AccessNotSpecified {
+		return ast.AccessPublic
+	} else {
+		return access
+	}
+}
+
+func (checker *Checker) effectiveCompositeMemberAccess(access ast.Access) ast.Access {
+	if access != ast.AccessNotSpecified {
+		return access
+	}
+
+	switch checker.accessCheckMode {
+	case AccessCheckModeStrict, AccessCheckModeNotSpecifiedRestricted:
+		return ast.AccessPrivate
+
+	case AccessCheckModeNotSpecifiedUnrestricted, AccessCheckModeNone:
+		return ast.AccessPublic
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -135,9 +135,7 @@ func TestCheckAccessModifierCompositeFunctionDeclaration(t *testing.T) {
 				if expectSuccess {
 					assert.NoError(t, err)
 				} else {
-					errs := ExpectCheckerErrors(t, err, 1)
-
-					assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+					expectInvalidAccessModifierError(t, err)
 				}
 			})
 		}
@@ -278,9 +276,7 @@ func TestCheckAccessModifierCompositeConstantFieldDeclaration(t *testing.T) {
 					if expectSuccess(isInterface) {
 						assert.NoError(t, err)
 					} else {
-						errs := ExpectCheckerErrors(t, err, 1)
-
-						assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+						expectInvalidAccessModifierError(t, err)
 					}
 				})
 			}
@@ -328,9 +324,7 @@ func TestCheckAccessModifierCompositeVariableFieldDeclaration(t *testing.T) {
 					// private fields in interfaces are invalid
 
 					if isInterface && access == ast.AccessPrivate {
-						errs := ExpectCheckerErrors(t, err, 1)
-
-						assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+						expectInvalidAccessModifierError(t, err)
 					} else {
 						assert.NoError(t, err)
 					}
@@ -367,9 +361,7 @@ func TestCheckAccessModifierGlobalFunctionDeclaration(t *testing.T) {
 			if expectSuccess {
 				assert.NoError(t, err)
 			} else {
-				errs := ExpectCheckerErrors(t, err, 1)
-
-				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				expectInvalidAccessModifierError(t, err)
 			}
 		})
 	}
@@ -402,9 +394,7 @@ func TestCheckAccessModifierGlobalVariableDeclaration(t *testing.T) {
 			if expectSuccess {
 				assert.NoError(t, err)
 			} else {
-				errs := ExpectCheckerErrors(t, err, 1)
-
-				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				expectInvalidAccessModifierError(t, err)
 			}
 		})
 	}
@@ -437,9 +427,7 @@ func TestCheckAccessModifierGlobalConstantDeclaration(t *testing.T) {
 			if expectSuccess {
 				assert.NoError(t, err)
 			} else {
-				errs := ExpectCheckerErrors(t, err, 1)
-
-				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				expectInvalidAccessModifierError(t, err)
 			}
 		})
 	}
@@ -483,9 +471,7 @@ func TestCheckAccessModifierLocalVariableDeclaration(t *testing.T) {
 				if expectSuccess {
 					assert.NoError(t, err)
 				} else {
-					errs := ExpectCheckerErrors(t, err, 1)
-
-					assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+					expectInvalidAccessModifierError(t, err)
 				}
 			})
 		}
@@ -522,9 +508,7 @@ func TestCheckAccessModifierLocalOptionalBinding(t *testing.T) {
 			if expectSuccess {
 				assert.NoError(t, err)
 			} else {
-				errs := ExpectCheckerErrors(t, err, 1)
-
-				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				expectInvalidAccessModifierError(t, err)
 			}
 		})
 	}
@@ -559,21 +543,13 @@ func TestCheckAccessModifierLocalFunctionDeclaration(t *testing.T) {
 			if expectSuccess {
 				assert.NoError(t, err)
 			} else {
-				errs := ExpectCheckerErrors(t, err, 1)
-
-				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				expectInvalidAccessModifierError(t, err)
 			}
 		})
 	}
 }
 
 func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
-
-	expectInvalidAccessModifierError := func(t *testing.T, err error) {
-		errs := ExpectCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
-	}
 
 	expectMissingAccessModifierError := func(t *testing.T, err error) {
 		errs := ExpectCheckerErrors(t, err, 1)
@@ -1971,9 +1947,7 @@ func TestCheckContractNestedDeclarationPrivateAccess(t *testing.T) {
           let num = Outer.num
         `)
 
-		errs := ExpectCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.InvalidAccessError{}, errs[0])
+		expectInvalidAccessError(t, err)
 	})
 }
 
@@ -2262,9 +2236,7 @@ func TestCheckInvalidRestrictiveAccessModifier(t *testing.T) {
 					),
 				)
 
-				errs := ExpectCheckerErrors(t, err, 1)
-
-				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				expectInvalidAccessModifierError(t, err)
 			})
 
 			t.Run("interface", func(t *testing.T) {
@@ -2281,9 +2253,7 @@ func TestCheckInvalidRestrictiveAccessModifier(t *testing.T) {
 					),
 				)
 
-				errs := ExpectCheckerErrors(t, err, 1)
-
-				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				expectInvalidAccessModifierError(t, err)
 			})
 		})
 	}

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -42,6 +42,12 @@ func expectConformanceError(t *testing.T, err error) {
 	assert.IsType(t, &sema.ConformanceError{}, errs[0])
 }
 
+func expectInvalidAccessModifierError(t *testing.T, err error) {
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+}
+
 func expectInvalidAccessError(t *testing.T, err error) {
 	errs := ExpectCheckerErrors(t, err, 1)
 
@@ -65,6 +71,13 @@ func expectConformanceAndInvalidAccessErrors(t *testing.T, err error) {
 	errs := ExpectCheckerErrors(t, err, 2)
 
 	assert.IsType(t, &sema.ConformanceError{}, errs[0])
+	assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
+}
+
+func expectInvalidAccessModifierAndInvalidAccessErrors(t *testing.T, err error) {
+	errs := ExpectCheckerErrors(t, err, 2)
+
+	assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
 	assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
 }
 
@@ -95,47 +108,112 @@ func TestCheckAccessModifierCompositeFunctionDeclaration(t *testing.T) {
 			ast.AccessPublicSettable: false,
 		}
 
-		require.Len(t, tests, len(ast.Accesses))
+		require.Len(t, tests, len(ast.BasicAccesses))
 
 		for access, expectSuccess := range tests {
-			for _, isInterface := range []bool{true, false} {
 
-				interfaceKeyword := ""
-				body := ""
-				if isInterface {
-					interfaceKeyword = "interface"
+			testName := fmt.Sprintf(
+				"%s/%s",
+				compositeKind.Keyword(),
+				access.Keyword(),
+			)
+
+			t.Run(testName, func(t *testing.T) {
+
+				_, err := ParseAndCheck(t,
+					fmt.Sprintf(
+						`
+                          %[1]s Test {
+                              %[2]s fun test() {}
+                          }
+	                    `,
+						compositeKind.Keyword(),
+						access.Keyword(),
+					),
+				)
+
+				if expectSuccess {
+					assert.NoError(t, err)
 				} else {
-					body = "{}"
-				}
+					errs := ExpectCheckerErrors(t, err, 1)
 
-				testName := fmt.Sprintf("%s %s/%s",
+					assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				}
+			})
+		}
+	}
+}
+
+func TestCheckAccessModifierInterfaceFunctionDeclaration(t *testing.T) {
+
+	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]error{
+		sema.AccessCheckModeStrict: {
+			ast.AccessNotSpecified:   &sema.MissingAccessModifierError{},
+			ast.AccessPrivate:        &sema.InvalidAccessModifierError{},
+			ast.AccessPublic:         nil,
+			ast.AccessPublicSettable: &sema.InvalidAccessModifierError{},
+		},
+		sema.AccessCheckModeNotSpecifiedRestricted: {
+			ast.AccessNotSpecified:   nil,
+			ast.AccessPrivate:        &sema.InvalidAccessModifierError{},
+			ast.AccessPublic:         nil,
+			ast.AccessPublicSettable: &sema.InvalidAccessModifierError{},
+		},
+		sema.AccessCheckModeNotSpecifiedUnrestricted: {
+			ast.AccessNotSpecified:   nil,
+			ast.AccessPrivate:        &sema.InvalidAccessModifierError{},
+			ast.AccessPublic:         nil,
+			ast.AccessPublicSettable: &sema.InvalidAccessModifierError{},
+		},
+		sema.AccessCheckModeNone: {
+			ast.AccessNotSpecified:   nil,
+			ast.AccessPrivate:        &sema.InvalidAccessModifierError{},
+			ast.AccessPublic:         nil,
+			ast.AccessPublicSettable: &sema.InvalidAccessModifierError{},
+		},
+	}
+
+	require.Len(t, checkModeTests, len(sema.AccessCheckModes))
+
+	for checkMode, tests := range checkModeTests {
+		require.Len(t, tests, len(ast.BasicAccesses))
+
+		for access, expectedErr := range tests {
+
+			for _, compositeKind := range common.CompositeKindsWithBody {
+
+				testName := fmt.Sprintf(
+					"%s/%s interface/%s",
+					checkMode,
 					compositeKind.Keyword(),
-					interfaceKeyword,
 					access.Keyword(),
 				)
 
 				t.Run(testName, func(t *testing.T) {
 
-					_, err := ParseAndCheck(t,
+					_, err := ParseAndCheckWithOptions(t,
 						fmt.Sprintf(
 							`
-                              %[1]s %[2]s Test {
-                                  %[3]s fun test() %[4]s
+                              pub %[1]s interface Test {
+                                  %[2]s fun test()
                               }
 	                        `,
 							compositeKind.Keyword(),
-							interfaceKeyword,
 							access.Keyword(),
-							body,
 						),
+						ParseAndCheckOptions{
+							Options: []sema.Option{
+								sema.WithAccessCheckMode(checkMode),
+							},
+						},
 					)
 
-					if expectSuccess {
+					if expectedErr == nil {
 						assert.NoError(t, err)
 					} else {
 						errs := ExpectCheckerErrors(t, err, 1)
 
-						assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+						assert.IsType(t, expectedErr, errs[0])
 					}
 				})
 			}
@@ -145,14 +223,22 @@ func TestCheckAccessModifierCompositeFunctionDeclaration(t *testing.T) {
 
 func TestCheckAccessModifierCompositeConstantFieldDeclaration(t *testing.T) {
 
-	tests := map[ast.Access]bool{
-		ast.AccessNotSpecified:   true,
-		ast.AccessPrivate:        true,
-		ast.AccessPublic:         true,
-		ast.AccessPublicSettable: false,
+	tests := map[ast.Access]func(isInterface bool) bool{
+		ast.AccessNotSpecified: func(_ bool) bool {
+			return true
+		},
+		ast.AccessPrivate: func(isInterface bool) bool {
+			return !isInterface
+		},
+		ast.AccessPublic: func(_ bool) bool {
+			return true
+		},
+		ast.AccessPublicSettable: func(_ bool) bool {
+			return false
+		},
 	}
 
-	require.Len(t, tests, len(ast.Accesses))
+	require.Len(t, tests, len(ast.BasicAccesses))
 
 	for access, expectSuccess := range tests {
 		for _, compositeKind := range common.CompositeKindsWithBody {
@@ -189,7 +275,7 @@ func TestCheckAccessModifierCompositeConstantFieldDeclaration(t *testing.T) {
 						),
 					)
 
-					if expectSuccess {
+					if expectSuccess(isInterface) {
 						assert.NoError(t, err)
 					} else {
 						errs := ExpectCheckerErrors(t, err, 1)
@@ -204,7 +290,7 @@ func TestCheckAccessModifierCompositeConstantFieldDeclaration(t *testing.T) {
 
 func TestCheckAccessModifierCompositeVariableFieldDeclaration(t *testing.T) {
 
-	for _, access := range ast.Accesses {
+	for _, access := range ast.BasicAccesses {
 		for _, compositeKind := range common.CompositeKindsWithBody {
 			for _, isInterface := range []bool{true, false} {
 
@@ -239,7 +325,15 @@ func TestCheckAccessModifierCompositeVariableFieldDeclaration(t *testing.T) {
 						),
 					)
 
-					assert.NoError(t, err)
+					// private fields in interfaces are invalid
+
+					if isInterface && access == ast.AccessPrivate {
+						errs := ExpectCheckerErrors(t, err, 1)
+
+						assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+					} else {
+						assert.NoError(t, err)
+					}
 				})
 			}
 		}
@@ -255,7 +349,7 @@ func TestCheckAccessModifierGlobalFunctionDeclaration(t *testing.T) {
 		ast.AccessPublicSettable: false,
 	}
 
-	require.Len(t, tests, len(ast.Accesses))
+	require.Len(t, tests, len(ast.BasicAccesses))
 
 	for access, expectSuccess := range tests {
 
@@ -290,7 +384,7 @@ func TestCheckAccessModifierGlobalVariableDeclaration(t *testing.T) {
 		ast.AccessPublicSettable: true,
 	}
 
-	require.Len(t, tests, len(ast.Accesses))
+	require.Len(t, tests, len(ast.BasicAccesses))
 
 	for access, expectSuccess := range tests {
 
@@ -325,7 +419,7 @@ func TestCheckAccessModifierGlobalConstantDeclaration(t *testing.T) {
 		ast.AccessPublicSettable: false,
 	}
 
-	require.Len(t, tests, len(ast.Accesses))
+	require.Len(t, tests, len(ast.BasicAccesses))
 
 	for access, expectSuccess := range tests {
 
@@ -360,7 +454,7 @@ func TestCheckAccessModifierLocalVariableDeclaration(t *testing.T) {
 		ast.AccessPublicSettable: false,
 	}
 
-	require.Len(t, tests, len(ast.Accesses))
+	require.Len(t, tests, len(ast.BasicAccesses))
 
 	for _, variableKind := range ast.VariableKinds {
 
@@ -407,7 +501,7 @@ func TestCheckAccessModifierLocalOptionalBinding(t *testing.T) {
 		ast.AccessPublicSettable: false,
 	}
 
-	require.Len(t, tests, len(ast.Accesses))
+	require.Len(t, tests, len(ast.BasicAccesses))
 
 	for access, expectSuccess := range tests {
 
@@ -445,7 +539,7 @@ func TestCheckAccessModifierLocalFunctionDeclaration(t *testing.T) {
 		ast.AccessPublicSettable: false,
 	}
 
-	require.Len(t, tests, len(ast.Accesses))
+	require.Len(t, tests, len(ast.BasicAccesses))
 
 	for access, expectSuccess := range tests {
 
@@ -517,7 +611,7 @@ func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
 	require.Len(t, checkModeTests, len(sema.AccessCheckModes))
 
 	for checkMode, tests := range checkModeTests {
-		require.Len(t, tests, len(ast.Accesses))
+		require.Len(t, tests, len(ast.BasicAccesses))
 
 		for access, check := range tests {
 			for _, compositeKind := range common.AllCompositeKinds {
@@ -715,7 +809,7 @@ func TestCheckAccessCompositeFunction(t *testing.T) {
 		require.Len(t, checkModeTests, len(sema.AccessCheckModes))
 
 		for checkMode, checkModeTests := range checkModeTests {
-			require.Len(t, checkModeTests, len(ast.Accesses))
+			require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 			for access, check := range checkModeTests {
 
@@ -793,25 +887,25 @@ func TestCheckAccessInterfaceFunction(t *testing.T) {
 		checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 			sema.AccessCheckModeStrict: {
 				ast.AccessNotSpecified:   nil,
-				ast.AccessPrivate:        expectConformanceAndInvalidAccessErrors,
+				ast.AccessPrivate:        expectInvalidAccessModifierAndInvalidAccessErrors,
 				ast.AccessPublic:         expectSuccess,
 				ast.AccessPublicSettable: nil,
 			},
 			sema.AccessCheckModeNotSpecifiedRestricted: {
-				ast.AccessNotSpecified:   expectInvalidAccessError,
-				ast.AccessPrivate:        expectConformanceAndInvalidAccessErrors,
+				ast.AccessNotSpecified:   expectConformanceAndInvalidAccessErrors,
+				ast.AccessPrivate:        expectInvalidAccessModifierAndInvalidAccessErrors,
 				ast.AccessPublic:         expectSuccess,
 				ast.AccessPublicSettable: nil,
 			},
 			sema.AccessCheckModeNotSpecifiedUnrestricted: {
 				ast.AccessNotSpecified:   expectSuccess,
-				ast.AccessPrivate:        expectConformanceAndInvalidAccessErrors,
+				ast.AccessPrivate:        expectInvalidAccessModifierAndInvalidAccessErrors,
 				ast.AccessPublic:         expectSuccess,
 				ast.AccessPublicSettable: nil,
 			},
 			sema.AccessCheckModeNone: {
 				ast.AccessNotSpecified:   expectSuccess,
-				ast.AccessPrivate:        expectConformanceError,
+				ast.AccessPrivate:        expectInvalidAccessModifierError,
 				ast.AccessPublic:         expectSuccess,
 				ast.AccessPublicSettable: nil,
 			},
@@ -820,7 +914,7 @@ func TestCheckAccessInterfaceFunction(t *testing.T) {
 		require.Len(t, checkModeTests, len(sema.AccessCheckModes))
 
 		for checkMode, checkModeTests := range checkModeTests {
-			require.Len(t, checkModeTests, len(ast.Accesses))
+			require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 			for access, check := range checkModeTests {
 
@@ -932,7 +1026,7 @@ func TestCheckAccessCompositeFieldRead(t *testing.T) {
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 		for checkMode, checkModeTests := range checkModeTests {
-			require.Len(t, checkModeTests, len(ast.Accesses))
+			require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 			for access, check := range checkModeTests {
 
@@ -1013,25 +1107,25 @@ func TestCheckAccessInterfaceFieldRead(t *testing.T) {
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 		sema.AccessCheckModeStrict: {
 			ast.AccessNotSpecified:   nil,
-			ast.AccessPrivate:        expectConformanceAndInvalidAccessErrors,
+			ast.AccessPrivate:        expectInvalidAccessModifierAndInvalidAccessErrors,
 			ast.AccessPublic:         expectSuccess,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNotSpecifiedRestricted: {
-			ast.AccessNotSpecified:   expectInvalidAccessError,
-			ast.AccessPrivate:        expectConformanceAndInvalidAccessErrors,
+			ast.AccessNotSpecified:   expectConformanceAndInvalidAccessErrors,
+			ast.AccessPrivate:        expectInvalidAccessModifierAndInvalidAccessErrors,
 			ast.AccessPublic:         expectSuccess,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNotSpecifiedUnrestricted: {
 			ast.AccessNotSpecified:   expectSuccess,
-			ast.AccessPrivate:        expectConformanceAndInvalidAccessErrors,
+			ast.AccessPrivate:        expectInvalidAccessModifierAndInvalidAccessErrors,
 			ast.AccessPublic:         expectSuccess,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNone: {
 			ast.AccessNotSpecified:   expectSuccess,
-			ast.AccessPrivate:        expectConformanceError,
+			ast.AccessPrivate:        expectInvalidAccessModifierError,
 			ast.AccessPublic:         expectSuccess,
 			ast.AccessPublicSettable: expectSuccess,
 		},
@@ -1041,7 +1135,7 @@ func TestCheckAccessInterfaceFieldRead(t *testing.T) {
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 		for checkMode, checkModeTests := range checkModeTests {
-			require.Len(t, checkModeTests, len(ast.Accesses))
+			require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 			for access, check := range checkModeTests {
 
@@ -1158,7 +1252,7 @@ func TestCheckAccessCompositeFieldAssignmentAndSwap(t *testing.T) {
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 		for checkMode, checkModeTests := range checkModeTests {
-			require.Len(t, checkModeTests, len(ast.Accesses))
+			require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 			for access, check := range checkModeTests {
 
@@ -1251,28 +1345,38 @@ func TestCheckAccessInterfaceFieldWrite(t *testing.T) {
 		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[4])
 	}
 
+	expectInvalidAccessModifierAndAccessErrors := func(t *testing.T, err error) {
+		errs := ExpectCheckerErrors(t, err, 5)
+
+		assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+		assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
+		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[2])
+		assert.IsType(t, &sema.InvalidAccessError{}, errs[3])
+		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[4])
+	}
+
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 		sema.AccessCheckModeStrict: {
 			ast.AccessNotSpecified:   nil,
-			ast.AccessPrivate:        expectConformanceAndAccessErrors,
+			ast.AccessPrivate:        expectInvalidAccessModifierAndAccessErrors,
 			ast.AccessPublic:         expectTwoInvalidAssignmentAccessErrors,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNotSpecifiedRestricted: {
-			ast.AccessNotSpecified:   expectTwoAccessErrors,
-			ast.AccessPrivate:        expectConformanceAndAccessErrors,
+			ast.AccessNotSpecified:   expectConformanceAndAccessErrors,
+			ast.AccessPrivate:        expectInvalidAccessModifierAndAccessErrors,
 			ast.AccessPublic:         expectTwoInvalidAssignmentAccessErrors,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNotSpecifiedUnrestricted: {
 			ast.AccessNotSpecified:   expectSuccess,
-			ast.AccessPrivate:        expectConformanceAndAccessErrors,
+			ast.AccessPrivate:        expectInvalidAccessModifierAndAccessErrors,
 			ast.AccessPublic:         expectTwoInvalidAssignmentAccessErrors,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNone: {
 			ast.AccessNotSpecified:   expectSuccess,
-			ast.AccessPrivate:        expectConformanceError,
+			ast.AccessPrivate:        expectInvalidAccessModifierError,
 			ast.AccessPublic:         expectSuccess,
 			ast.AccessPublicSettable: expectSuccess,
 		},
@@ -1282,7 +1386,7 @@ func TestCheckAccessInterfaceFieldWrite(t *testing.T) {
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 		for checkMode, checkModeTests := range checkModeTests {
-			require.Len(t, checkModeTests, len(ast.Accesses))
+			require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 			for access, check := range checkModeTests {
 
@@ -1402,7 +1506,7 @@ func TestCheckAccessCompositeFieldVariableDeclarationWithSecondValue(t *testing.
 	require.Len(t, checkModeTests, len(sema.AccessCheckModes))
 
 	for checkMode, checkModeTests := range checkModeTests {
-		require.Len(t, checkModeTests, len(ast.Accesses))
+		require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 		for access, check := range checkModeTests {
 
@@ -1464,10 +1568,10 @@ func TestCheckAccessCompositeFieldVariableDeclarationWithSecondValue(t *testing.
 
 func TestCheckAccessInterfaceFieldVariableDeclarationWithSecondValue(t *testing.T) {
 
-	expectConformanceAndInvalidAccessAndAssignmentAccessErrors := func(t *testing.T, err error) {
+	expectPrivateAccessErrors := func(t *testing.T, err error) {
 		errs := ExpectCheckerErrors(t, err, 3)
 
-		assert.IsType(t, &sema.ConformanceError{}, errs[0])
+		assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
 		assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
 		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[2])
 	}
@@ -1475,25 +1579,31 @@ func TestCheckAccessInterfaceFieldVariableDeclarationWithSecondValue(t *testing.
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 		sema.AccessCheckModeStrict: {
 			ast.AccessNotSpecified:   nil,
-			ast.AccessPrivate:        expectConformanceAndInvalidAccessAndAssignmentAccessErrors,
+			ast.AccessPrivate:        expectPrivateAccessErrors,
 			ast.AccessPublic:         expectInvalidAssignmentAccessError,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNotSpecifiedRestricted: {
-			ast.AccessNotSpecified:   expectAccessErrors,
-			ast.AccessPrivate:        expectConformanceAndInvalidAccessAndAssignmentAccessErrors,
+			ast.AccessNotSpecified: func(t *testing.T, err error) {
+				errs := ExpectCheckerErrors(t, err, 3)
+
+				assert.IsType(t, &sema.ConformanceError{}, errs[0])
+				assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
+				assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[2])
+			},
+			ast.AccessPrivate:        expectPrivateAccessErrors,
 			ast.AccessPublic:         expectInvalidAssignmentAccessError,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNotSpecifiedUnrestricted: {
 			ast.AccessNotSpecified:   expectSuccess,
-			ast.AccessPrivate:        expectConformanceAndInvalidAccessAndAssignmentAccessErrors,
+			ast.AccessPrivate:        expectPrivateAccessErrors,
 			ast.AccessPublic:         expectInvalidAssignmentAccessError,
 			ast.AccessPublicSettable: expectSuccess,
 		},
 		sema.AccessCheckModeNone: {
 			ast.AccessNotSpecified:   expectSuccess,
-			ast.AccessPrivate:        expectConformanceError,
+			ast.AccessPrivate:        expectInvalidAccessModifierError,
 			ast.AccessPublic:         expectSuccess,
 			ast.AccessPublicSettable: expectSuccess,
 		},
@@ -1502,7 +1612,7 @@ func TestCheckAccessInterfaceFieldVariableDeclarationWithSecondValue(t *testing.
 	require.Len(t, checkModeTests, len(sema.AccessCheckModes))
 
 	for checkMode, checkModeTests := range checkModeTests {
-		require.Len(t, checkModeTests, len(ast.Accesses))
+		require.Len(t, checkModeTests, len(ast.BasicAccesses))
 
 		for access, check := range checkModeTests {
 
@@ -2047,6 +2157,134 @@ func TestCheckAccessOtherContractInnerStructInterfaceField(t *testing.T) {
 			} else {
 				require.Error(t, err)
 			}
+		})
+	}
+}
+
+func TestCheckRestrictiveAccessModifier(t *testing.T) {
+
+	for _, access := range ast.AllAccesses {
+
+		if access <= ast.AccessPrivate {
+			continue
+		}
+
+		t.Run(access.Keyword(), func(t *testing.T) {
+
+			t.Run("type requirement", func(t *testing.T) {
+
+				_, err := ParseAndCheck(t,
+					fmt.Sprintf(
+						`
+                          pub contract interface CI {
+
+                              pub resource R {
+
+                                  %[1]s var x: Int
+                              }
+                          }
+
+                          pub contract C: CI {
+
+                              pub resource R {
+
+                                  %[1]s var x: Int
+
+                                  init () {
+                                      self.x = 0
+                                  }
+                              }
+                          }
+                        `,
+						access.Keyword(),
+					),
+				)
+
+				require.NoError(t, err)
+			})
+
+			t.Run("interface", func(t *testing.T) {
+
+				_, err := ParseAndCheck(t,
+					fmt.Sprintf(
+						`
+                          pub resource interface RI {
+
+                              %[1]s var x: Int
+                          }
+
+                          pub resource R: RI {
+
+                              %[1]s var x: Int
+
+                              init () {
+                                  self.x = 0
+                              }
+                          }
+                        `,
+						access.Keyword(),
+					),
+				)
+
+				require.NoError(t, err)
+			})
+
+		})
+	}
+}
+
+func TestCheckInvalidRestrictiveAccessModifier(t *testing.T) {
+
+	for _, access := range ast.AllAccesses {
+
+		if access == ast.AccessNotSpecified ||
+			access > ast.AccessPrivate {
+
+			continue
+		}
+
+		t.Run(access.Keyword(), func(t *testing.T) {
+
+			t.Run("type requirement", func(t *testing.T) {
+
+				_, err := ParseAndCheck(t,
+					fmt.Sprintf(
+						`
+                          pub contract interface CI {
+
+                              pub resource R {
+
+                                  %[1]s var x: Int
+                              }
+                          }
+                        `,
+						access.Keyword(),
+					),
+				)
+
+				errs := ExpectCheckerErrors(t, err, 1)
+
+				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+			})
+
+			t.Run("interface", func(t *testing.T) {
+
+				_, err := ParseAndCheck(t,
+					fmt.Sprintf(
+						`
+                          pub resource interface RI {
+
+                              %[1]s var x: Int
+                          }
+                        `,
+						access.Keyword(),
+					),
+				)
+
+				errs := ExpectCheckerErrors(t, err, 1)
+
+				assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+			})
 		})
 	}
 }

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -131,9 +131,7 @@ func TestCheckInvalidFunctionAccess(t *testing.T) {
        pub(set) fun test() {}
     `)
 
-	errs := ExpectCheckerErrors(t, err, 1)
-
-	assert.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+	expectInvalidAccessModifierError(t, err)
 }
 
 func TestCheckReturnWithoutExpression(t *testing.T) {

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -6832,7 +6832,7 @@ func TestParseAccessModifiers(t *testing.T) {
 	}
 
 	for _, declaration := range declarations {
-		for _, access := range Accesses {
+		for _, access := range BasicAccesses {
 			testName := fmt.Sprintf("%s/%s", declaration.name, access)
 			t.Run(testName, func(t *testing.T) {
 				program := fmt.Sprintf(declaration.code, access.Keyword())


### PR DESCRIPTION
Closes #41

## Description

- Report a separate error when an interface member is private, instead of just failing the conformance check. There was no bug in the checking here, this improves UX
- Check the *effective* access when checking conformance, not just the explicit access: If a composite does not specify an access modifier for a member, the access check mode must be used to determine how it will be effectively seen
- Fix error notes
- Report conformance error member mismatches as error notes:
  ```
  error: resource `Example.R` does not conform to resource type requirement `C.R`
   --> test.cdc:8:23
    |
  8 |           pub resource R {
    |                        ^
    |
  9 |               access(self) var x: Int
    |                                - mismatch here
  ```

