### PR TITLE
Update interpreter.Invoke functions to accept Value instead of interface{}

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3199,7 +3199,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 			switch expression.Operation {
 			case ast.OperationFailableCast, ast.OperationForceCast:
 				dynamicType := value.DynamicType(interpreter)
-				isSubType := interpreter.IsSubType(dynamicType, expectedType)
+				isSubType := IsSubType(dynamicType, expectedType)
 
 				switch expression.Operation {
 				case ast.OperationFailableCast:
@@ -3377,7 +3377,7 @@ func (interpreter *Interpreter) newConverterFunction(converter ValueConverter) F
 // - PublicAccount
 // - Block
 
-func (interpreter *Interpreter) IsSubType(subType DynamicType, superType sema.Type) bool {
+func IsSubType(subType DynamicType, superType sema.Type) bool {
 	switch typedSubType := subType.(type) {
 	case VoidDynamicType:
 		switch superType.(type) {
@@ -3439,7 +3439,7 @@ func (interpreter *Interpreter) IsSubType(subType DynamicType, superType sema.Ty
 		}
 
 		for _, elementType := range typedSubType.ElementTypes {
-			if !interpreter.IsSubType(elementType, superTypeElementType) {
+			if !IsSubType(elementType, superTypeElementType) {
 				return false
 			}
 		}
@@ -3451,8 +3451,8 @@ func (interpreter *Interpreter) IsSubType(subType DynamicType, superType sema.Ty
 		switch typedSuperType := superType.(type) {
 		case *sema.DictionaryType:
 			for _, entryTypes := range typedSubType.EntryTypes {
-				if !interpreter.IsSubType(entryTypes.KeyType, typedSuperType.KeyType) ||
-					!interpreter.IsSubType(entryTypes.ValueType, typedSuperType.ValueType) {
+				if !IsSubType(entryTypes.KeyType, typedSuperType.KeyType) ||
+					!IsSubType(entryTypes.ValueType, typedSuperType.ValueType) {
 
 					return false
 				}
@@ -3479,7 +3479,7 @@ func (interpreter *Interpreter) IsSubType(subType DynamicType, superType sema.Ty
 	case SomeDynamicType:
 		switch typedSuperType := superType.(type) {
 		case *sema.OptionalType:
-			return interpreter.IsSubType(typedSubType.InnerType, typedSuperType.Type)
+			return IsSubType(typedSubType.InnerType, typedSuperType.Type)
 
 		case *sema.AnyStructType, *sema.AnyResourceType:
 			return true
@@ -3495,7 +3495,7 @@ func (interpreter *Interpreter) IsSubType(subType DynamicType, superType sema.Ty
 
 		case *sema.ReferenceType:
 			if typedSubType.Authorized() {
-				return interpreter.IsSubType(typedSubType.InnerType(), typedSuperType.Type)
+				return IsSubType(typedSubType.InnerType(), typedSuperType.Type)
 			} else {
 				// NOTE: Allowing all casts for casting unauthorized references is intentional:
 				// all invalid cases have already been rejected statically
@@ -3635,7 +3635,7 @@ func (interpreter *Interpreter) authAccountReadFunction(addressValue AddressValu
 			}
 
 			dynamicType := value.Value.DynamicType(interpreter)
-			if !interpreter.IsSubType(dynamicType, ty) {
+			if !IsSubType(dynamicType, ty) {
 				return Done{Result: NilValue{}}
 			}
 
@@ -3692,7 +3692,7 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 			referenceType := ty.(*sema.ReferenceType)
 
 			dynamicType := value.Value.DynamicType(interpreter)
-			if !interpreter.IsSubType(dynamicType, referenceType.Type) {
+			if !IsSubType(dynamicType, referenceType.Type) {
 				return Done{Result: NilValue{}}
 			}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4354,60 +4354,6 @@ type DictionaryEntryValues struct {
 	Value Value
 }
 
-// ToValue converts a Go value into an interpreter value
-func ToValue(value interface{}) (Value, error) {
-	// TODO: support more types
-	switch value := value.(type) {
-	case *big.Int:
-		return IntValue{value}, nil
-	case int:
-		return NewIntValueFromInt64(int64(value)), nil
-	case int8:
-		return Int8Value(value), nil
-	case int16:
-		return Int16Value(value), nil
-	case int32:
-		return Int32Value(value), nil
-	case int64:
-		return Int64Value(value), nil
-	case uint8:
-		return UInt8Value(value), nil
-	case uint16:
-		return UInt16Value(value), nil
-	case uint32:
-		return UInt32Value(value), nil
-	case uint64:
-		return UInt64Value(value), nil
-	case bool:
-		return BoolValue(value), nil
-	case string:
-		return NewStringValue(value), nil
-	case nil:
-		return NilValue{}, nil
-	}
-
-	return nil, fmt.Errorf("cannot convert Go value to value: %#+v", value)
-}
-
-func ToValues(inputs []interface{}) ([]Value, error) {
-	var newValues []Value
-	for _, argument := range inputs {
-		value, ok := argument.(Value)
-		if !ok {
-			var err error
-			value, err = ToValue(argument)
-			if err != nil {
-				return nil, err
-			}
-		}
-		newValues = append(
-			newValues,
-			value,
-		)
-	}
-	return newValues, nil
-}
-
 // OptionalValue
 
 type OptionalValue interface {

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -22,32 +22,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
-
-func TestToExpression(t *testing.T) {
-
-	testValue := func(expected Value) func(actual Value, err error) {
-		return func(actual Value, err error) {
-			require.NoError(t, err)
-			assert.Equal(t, expected, actual)
-		}
-	}
-
-	testValue(Int8Value(1))(ToValue(int8(1)))
-	testValue(Int16Value(2))(ToValue(int16(2)))
-	testValue(Int32Value(3))(ToValue(int32(3)))
-	testValue(Int64Value(4))(ToValue(int64(4)))
-	testValue(UInt8Value(1))(ToValue(uint8(1)))
-	testValue(UInt16Value(2))(ToValue(uint16(2)))
-	testValue(UInt32Value(3))(ToValue(uint32(3)))
-	testValue(UInt64Value(4))(ToValue(uint64(4)))
-	testValue(BoolValue(true))(ToValue(true))
-	testValue(BoolValue(false))(ToValue(false))
-}
 
 func newTestCompositeValue(owner common.Address) *CompositeValue {
 	return &CompositeValue{

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -237,7 +237,7 @@ func (r *interpreterRuntime) ExecuteTransaction(
 		}
 	}
 
-	signingAccounts := make([]interface{}, signingAccountsCount)
+	signingAccounts := make([]interpreter.Value, signingAccountsCount)
 
 	for i, address := range signingAccountAddresses {
 		signingAccounts[i] = r.newAuthAccountValue(

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -47,7 +47,11 @@ func TestAssert(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	_, err = inter.Invoke("assert", false, "oops")
+	_, err = inter.Invoke(
+		"assert",
+		interpreter.BoolValue(false),
+		interpreter.NewStringValue("oops"),
+	)
 	assert.Equal(t,
 		AssertionError{
 			Message:       "oops",
@@ -56,7 +60,7 @@ func TestAssert(t *testing.T) {
 		err,
 	)
 
-	_, err = inter.Invoke("assert", false)
+	_, err = inter.Invoke("assert", interpreter.BoolValue(false))
 	assert.Equal(t,
 		AssertionError{
 			Message:       "",
@@ -64,10 +68,14 @@ func TestAssert(t *testing.T) {
 		},
 		err)
 
-	_, err = inter.Invoke("assert", true, "oops")
+	_, err = inter.Invoke(
+		"assert",
+		interpreter.BoolValue(true),
+		interpreter.NewStringValue("oops"),
+	)
 	assert.NoError(t, err)
 
-	_, err = inter.Invoke("assert", true)
+	_, err = inter.Invoke("assert", interpreter.BoolValue(true))
 	assert.NoError(t, err)
 }
 
@@ -86,7 +94,7 @@ func TestPanic(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	_, err = inter.Invoke("panic", "oops")
+	_, err = inter.Invoke("panic", interpreter.NewStringValue("oops"))
 	assert.Equal(t,
 		PanicError{
 			Message:       "oops",

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -264,7 +264,7 @@ func TestInterpretFunctionSideEffects(t *testing.T) {
        }
     `)
 
-	newValue := big.NewInt(42)
+	newValue := interpreter.NewIntValueFromInt64(42)
 
 	value, err := inter.Invoke("test", newValue)
 	require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestInterpretFunctionSideEffects(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		interpreter.NewIntValueFromBigInt(newValue),
+		newValue,
 		inter.Globals["value"].Value,
 	)
 }
@@ -414,21 +414,18 @@ func TestInterpretParameters(t *testing.T) {
        }
     `)
 
-	value, err := inter.Invoke("returnA", big.NewInt(24), big.NewInt(42))
+	a := interpreter.NewIntValueFromInt64(24)
+	b := interpreter.NewIntValueFromInt64(42)
+
+	value, err := inter.Invoke("returnA", a, b)
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromInt64(24),
-		value,
-	)
+	assert.Equal(t, a, value)
 
-	value, err = inter.Invoke("returnB", big.NewInt(24), big.NewInt(42))
+	value, err = inter.Invoke("returnB", a, b)
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromInt64(42),
-		value,
-	)
+	assert.Equal(t, b, value)
 }
 
 func TestInterpretArrayIndexing(t *testing.T) {
@@ -1415,7 +1412,10 @@ func TestInterpretRecursionFib(t *testing.T) {
        }
    `)
 
-	value, err := inter.Invoke("fib", big.NewInt(14))
+	value, err := inter.Invoke(
+		"fib",
+		interpreter.NewIntValueFromInt64(14),
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -1436,7 +1436,10 @@ func TestInterpretRecursionFactorial(t *testing.T) {
         }
    `)
 
-	value, err := inter.Invoke("factorial", big.NewInt(5))
+	value, err := inter.Invoke(
+		"factorial",
+		interpreter.NewIntValueFromInt64(5),
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -1818,15 +1821,12 @@ func TestInterpretStructureDeclarationWithField(t *testing.T) {
       }
     `)
 
-	newValue := big.NewInt(42)
+	newValue := interpreter.NewIntValueFromInt64(42)
 
 	value, err := inter.Invoke("test", newValue)
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromBigInt(newValue),
-		value,
-	)
+	assert.Equal(t, newValue, value)
 }
 
 func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
@@ -1846,7 +1846,7 @@ func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
       }
     `)
 
-	newValue := big.NewInt(42)
+	newValue := interpreter.NewIntValueFromInt64(42)
 
 	value, err := inter.Invoke("test", newValue)
 	require.NoError(t, err)
@@ -1856,10 +1856,7 @@ func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
 		value,
 	)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromBigInt(newValue),
-		inter.Globals["value"].Value,
-	)
+	assert.Equal(t, newValue, inter.Globals["value"].Value)
 }
 
 func TestInterpretStructureFunctionCall(t *testing.T) {
@@ -1998,17 +1995,17 @@ func TestInterpretFunctionPreCondition(t *testing.T) {
       }
     `)
 
-	_, err := inter.Invoke("test", big.NewInt(42))
+	_, err := inter.Invoke(
+		"test",
+		interpreter.NewIntValueFromInt64(42),
+	)
 	assert.IsType(t, &interpreter.ConditionError{}, err)
 
-	zero := big.NewInt(0)
+	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromBigInt(zero),
-		value,
-	)
+	assert.Equal(t, zero, value)
 }
 
 func TestInterpretFunctionPostCondition(t *testing.T) {
@@ -2023,17 +2020,17 @@ func TestInterpretFunctionPostCondition(t *testing.T) {
       }
     `)
 
-	_, err := inter.Invoke("test", big.NewInt(42))
+	_, err := inter.Invoke(
+		"test",
+		interpreter.NewIntValueFromInt64(42),
+	)
 	assert.IsType(t, &interpreter.ConditionError{}, err)
 
-	zero := big.NewInt(0)
+	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromBigInt(zero),
-		value,
-	)
+	assert.Equal(t, zero, value)
 }
 
 func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
@@ -2047,17 +2044,17 @@ func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
       }
     `)
 
-	_, err := inter.Invoke("test", big.NewInt(42))
+	_, err := inter.Invoke(
+		"test",
+		interpreter.NewIntValueFromInt64(42),
+	)
 	assert.IsType(t, &interpreter.ConditionError{}, err)
 
-	zero := big.NewInt(0)
+	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromBigInt(zero),
-		value,
-	)
+	assert.Equal(t, zero, value)
 }
 
 func TestInterpretFunctionWithoutResultAndPostConditionWithResult(t *testing.T) {
@@ -2169,7 +2166,10 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
       }
     `)
 
-	_, err := inter.Invoke("test", big.NewInt(42))
+	_, err := inter.Invoke(
+		"test",
+		interpreter.NewIntValueFromInt64(42),
+	)
 	assert.IsType(t, &interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
@@ -2177,14 +2177,11 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 		err.(*interpreter.ConditionError).Message,
 	)
 
-	zero := big.NewInt(0)
+	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		interpreter.NewIntValueFromBigInt(zero),
-		value,
-	)
+	assert.Equal(t, zero, value)
 }
 
 func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
@@ -2199,7 +2196,10 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
       }
     `)
 
-	_, err := inter.Invoke("test", big.NewInt(42))
+	_, err := inter.Invoke(
+		"test",
+		interpreter.NewIntValueFromInt64(42),
+	)
 	assert.IsType(t, &interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
@@ -2207,7 +2207,7 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 		err.(*interpreter.ConditionError).Message,
 	)
 
-	zero := big.NewInt(0)
+	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
@@ -2228,7 +2228,7 @@ func TestInterpretFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
       }
     `)
 
-	_, err := inter.Invoke("test", "parameter value")
+	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
 	assert.IsType(t, &interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
@@ -2248,7 +2248,7 @@ func TestInterpretFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
       }
     `)
 
-	_, err := inter.Invoke("test", "parameter value")
+	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
 	assert.IsType(t, &interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
@@ -2538,7 +2538,7 @@ func TestInterpretMutuallyRecursiveFunctions(t *testing.T) {
       }
     `)
 
-	four := big.NewInt(4)
+	four := interpreter.NewIntValueFromInt64(4)
 
 	value, err := inter.Invoke("isEven", four)
 	require.NoError(t, err)
@@ -2629,7 +2629,10 @@ func TestInterpretOptionalParameterInvokedExternal(t *testing.T) {
       }
     `)
 
-	value, err := inter.Invoke("test", big.NewInt(2))
+	value, err := inter.Invoke(
+		"test",
+		interpreter.NewIntValueFromInt64(2),
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -2675,7 +2678,7 @@ func TestInterpretOptionalReturn(t *testing.T) {
       }
     `)
 
-	value, err := inter.Invoke("test", big.NewInt(2))
+	value, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3253,7 +3256,10 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
     `)
 
 	t.Run("2", func(t *testing.T) {
-		value, err := inter.Invoke("test", big.NewInt(2))
+		value, err := inter.Invoke(
+			"test",
+			interpreter.NewIntValueFromInt64(2),
+		)
 		require.NoError(t, err)
 		assert.Equal(t,
 			interpreter.NewIntValueFromInt64(2),
@@ -3266,7 +3272,7 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 	})
 
 	t.Run("nil", func(t *testing.T) {
-		value, err := inter.Invoke("test", nil)
+		value, err := inter.Invoke("test", interpreter.NilValue{})
 		require.NoError(t, err)
 		assert.Equal(t,
 			interpreter.NewIntValueFromInt64(0),
@@ -3295,7 +3301,10 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
     `)
 
 	t.Run("2", func(t *testing.T) {
-		value, err := inter.Invoke("test", big.NewInt(2))
+		value, err := inter.Invoke(
+			"test",
+			interpreter.NewIntValueFromInt64(2),
+		)
 		require.NoError(t, err)
 		assert.Equal(t,
 			interpreter.NewIntValueFromInt64(2),
@@ -3308,7 +3317,7 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 	})
 
 	t.Run("nil", func(t *testing.T) {
-		value, err := inter.Invoke("test", nil)
+		value, err := inter.Invoke("test", interpreter.NilValue{})
 		require.NoError(t, err)
 		assert.Equal(t,
 			interpreter.NewIntValueFromInt64(0),
@@ -3339,7 +3348,10 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
     `)
 
 	t.Run("2", func(t *testing.T) {
-		value, err := inter.Invoke("test", big.NewInt(2))
+		value, err := inter.Invoke(
+			"test",
+			interpreter.NewIntValueFromInt64(2),
+		)
 		require.NoError(t, err)
 		assert.Equal(t,
 			interpreter.NewSomeValueOwningNonCopying(
@@ -3354,7 +3366,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 	})
 
 	t.Run("nil", func(t *testing.T) {
-		value, err := inter.Invoke("test", nil)
+		value, err := inter.Invoke("test", interpreter.NilValue{})
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -3387,7 +3399,10 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
     `)
 
 	t.Run("2", func(t *testing.T) {
-		value, err := inter.Invoke("test", big.NewInt(2))
+		value, err := inter.Invoke(
+			"test",
+			interpreter.NewIntValueFromInt64(2),
+		)
 		require.NoError(t, err)
 		assert.Equal(t,
 			interpreter.NewSomeValueOwningNonCopying(
@@ -3403,7 +3418,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 	})
 
 	t.Run("nil", func(t *testing.T) {
-		value, err := inter.Invoke("test", nil)
+		value, err := inter.Invoke("test", interpreter.NilValue{})
 		require.NoError(t, err)
 		assert.Equal(t,
 			interpreter.NewSomeValueOwningNonCopying(
@@ -3674,10 +3689,10 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 				},
 			)
 
-			_, err := inter.Invoke("callTest", big.NewInt(0))
+			_, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(0))
 			assert.IsType(t, &interpreter.ConditionError{}, err)
 
-			value, err := inter.Invoke("callTest", big.NewInt(1))
+			value, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(1))
 			require.NoError(t, err)
 
 			assert.Equal(t,
@@ -3685,7 +3700,7 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 				value,
 			)
 
-			_, err = inter.Invoke("callTest", big.NewInt(2))
+			_, err = inter.Invoke("callTest", interpreter.NewIntValueFromInt64(2))
 			assert.IsType(t,
 				&interpreter.ConditionError{},
 				err,
@@ -3801,7 +3816,7 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 						err = inter.Interpret()
 						require.NoError(t, err)
 
-						_, err = inter.Invoke("test", big.NewInt(value))
+						_, err = inter.Invoke("test", interpreter.NewIntValueFromInt64(value))
 						check(err)
 					}
 				})
@@ -3857,7 +3872,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	)
 
 	t.Run("-1", func(t *testing.T) {
-		_, err := inter.Invoke("test", big.NewInt(-1))
+		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(-1))
 		require.IsType(t,
 			&interpreter.ConditionError{},
 			err,
@@ -3870,7 +3885,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	})
 
 	t.Run("0", func(t *testing.T) {
-		_, err := inter.Invoke("test", big.NewInt(0))
+		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(0))
 		assert.IsType(t,
 			&interpreter.ConditionError{},
 			err,
@@ -3879,7 +3894,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	})
 
 	t.Run("1", func(t *testing.T) {
-		value, err := inter.Invoke("test", big.NewInt(1))
+		value, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
 		require.NoError(t, err)
 
 		assert.IsType(t,
@@ -3889,7 +3904,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	})
 
 	t.Run("2", func(t *testing.T) {
-		_, err := inter.Invoke("test", big.NewInt(2))
+		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
 		assert.IsType(t,
 			&interpreter.ConditionError{},
 			err,

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -253,8 +253,12 @@ func TestInterpretTransactions(t *testing.T) {
           }
         `)
 
-		transactionArguments := []interface{}{1, true}
-		prepareArguments := []interface{}{
+		transactionArguments := []interpreter.Value{
+			interpreter.NewIntValueFromInt64(1),
+			interpreter.BoolValue(true),
+		}
+
+		prepareArguments := []interpreter.Value{
 			interpreter.NewAuthAccountValue(
 				interpreter.AddressValue{},
 				panicFunction,


### PR DESCRIPTION
Woork towards https://github.com/dapperlabs/flow-go/issues/3286

## Description

In order to support transaction arguments, the interpreter needs to accept all valid value types as inputs. To accomplish this, I updated the `Invoke` functions to accept arguments as `interpreter.Value` rather than `interface{}`. Combined with the new `runtime.importValue` function, we can import and prepare values before passing them into the interpreter.