### PR TITLE
Fix number conversion

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1749,7 +1749,22 @@ func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerEx
 func (interpreter *Interpreter) VisitFixedPointExpression(expression *ast.FixedPointExpression) ast.Repr {
 	// TODO: adjust once/if we support more fixed point types
 	value := interpreter.convertToFixedPointBigInt(expression, sema.Fix64Scale)
-	return Done{Result: Fix64Value(value.Int64())}
+
+	// Return a
+	// Fix64: If the value is negative or in the range of Fix64,
+	// UFix64: otherwise.
+
+	var result Value
+
+	if expression.Negative ||
+		expression.UnsignedInteger.Cmp(sema.Fix64TypeMaxIntBig) <= 0 {
+
+		result = Fix64Value(value.Int64())
+	} else {
+		result = UFix64Value(value.Uint64())
+	}
+
+	return Done{Result: result}
 }
 
 func (interpreter *Interpreter) convertToFixedPointBigInt(expression *ast.FixedPointExpression, scale uint) *big.Int {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1750,15 +1750,9 @@ func (interpreter *Interpreter) VisitFixedPointExpression(expression *ast.FixedP
 	// TODO: adjust once/if we support more fixed point types
 	value := interpreter.convertToFixedPointBigInt(expression, sema.Fix64Scale)
 
-	// Return a
-	// Fix64: If the value is negative or in the range of Fix64,
-	// UFix64: otherwise.
-
 	var result Value
 
-	if expression.Negative ||
-		expression.UnsignedInteger.Cmp(sema.Fix64TypeMaxIntBig) <= 0 {
-
+	if expression.Negative {
 		result = Fix64Value(value.Int64())
 	} else {
 		result = UFix64Value(value.Uint64())

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -828,7 +828,7 @@ func (v Int8Value) Mod(other NumberValue) NumberValue {
 	o := other.(Int8Value)
 	// INT33-C
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -998,7 +998,7 @@ func (v Int16Value) Mod(other NumberValue) NumberValue {
 	o := other.(Int16Value)
 	// INT33-C
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -1168,7 +1168,7 @@ func (v Int32Value) Mod(other NumberValue) NumberValue {
 	o := other.(Int32Value)
 	// INT33-C
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -1342,7 +1342,7 @@ func (v Int64Value) Mod(other NumberValue) NumberValue {
 	o := other.(Int64Value)
 	// INT33-C
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -2073,7 +2073,7 @@ func (v UInt8Value) Minus(other NumberValue) NumberValue {
 func (v UInt8Value) Mod(other NumberValue) NumberValue {
 	o := other.(UInt8Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -2089,7 +2089,7 @@ func (v UInt8Value) Mul(other NumberValue) NumberValue {
 func (v UInt8Value) Div(other NumberValue) NumberValue {
 	o := other.(UInt8Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }
@@ -2209,7 +2209,7 @@ func (v UInt16Value) Minus(other NumberValue) NumberValue {
 func (v UInt16Value) Mod(other NumberValue) NumberValue {
 	o := other.(UInt16Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -2225,7 +2225,7 @@ func (v UInt16Value) Mul(other NumberValue) NumberValue {
 func (v UInt16Value) Div(other NumberValue) NumberValue {
 	o := other.(UInt16Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }
@@ -2347,7 +2347,7 @@ func (v UInt32Value) Minus(other NumberValue) NumberValue {
 func (v UInt32Value) Mod(other NumberValue) NumberValue {
 	o := other.(UInt32Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -2363,7 +2363,7 @@ func (v UInt32Value) Mul(other NumberValue) NumberValue {
 func (v UInt32Value) Div(other NumberValue) NumberValue {
 	o := other.(UInt32Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }
@@ -2490,7 +2490,7 @@ func (v UInt64Value) Minus(other NumberValue) NumberValue {
 func (v UInt64Value) Mod(other NumberValue) NumberValue {
 	o := other.(UInt64Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -2506,7 +2506,7 @@ func (v UInt64Value) Mul(other NumberValue) NumberValue {
 func (v UInt64Value) Div(other NumberValue) NumberValue {
 	o := other.(UInt64Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }
@@ -2972,7 +2972,7 @@ func (v Word8Value) Minus(other NumberValue) NumberValue {
 func (v Word8Value) Mod(other NumberValue) NumberValue {
 	o := other.(Word8Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -2984,7 +2984,7 @@ func (v Word8Value) Mul(other NumberValue) NumberValue {
 func (v Word8Value) Div(other NumberValue) NumberValue {
 	o := other.(Word8Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }
@@ -3069,7 +3069,7 @@ func (v Word16Value) Minus(other NumberValue) NumberValue {
 func (v Word16Value) Mod(other NumberValue) NumberValue {
 	o := other.(Word16Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -3081,7 +3081,7 @@ func (v Word16Value) Mul(other NumberValue) NumberValue {
 func (v Word16Value) Div(other NumberValue) NumberValue {
 	o := other.(Word16Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }
@@ -3168,7 +3168,7 @@ func (v Word32Value) Minus(other NumberValue) NumberValue {
 func (v Word32Value) Mod(other NumberValue) NumberValue {
 	o := other.(Word32Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -3180,7 +3180,7 @@ func (v Word32Value) Mul(other NumberValue) NumberValue {
 func (v Word32Value) Div(other NumberValue) NumberValue {
 	o := other.(Word32Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }
@@ -3267,7 +3267,7 @@ func (v Word64Value) Minus(other NumberValue) NumberValue {
 func (v Word64Value) Mod(other NumberValue) NumberValue {
 	o := other.(Word64Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v % o
 }
@@ -3279,7 +3279,7 @@ func (v Word64Value) Mul(other NumberValue) NumberValue {
 func (v Word64Value) Div(other NumberValue) NumberValue {
 	o := other.(Word64Value)
 	if o == 0 {
-		panic(&DivisionByZeroError{})
+		panic(DivisionByZeroError{})
 	}
 	return v / o
 }

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -142,7 +142,7 @@ func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatem
 		)
 	}
 
-	// Ensure that a self-standing expression can be converted to it's own type.
+	// Ensure that a self-standing expression can be converted to its own type.
 	//
 	// For example, the expression might be a fixed-point expression,
 	// which is inferred to have type Fix64, and the check ensures the literal

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -160,9 +160,16 @@ func (checker *Checker) VisitIntegerExpression(_ *ast.IntegerExpression) ast.Rep
 	return &IntType{}
 }
 
-func (checker *Checker) VisitFixedPointExpression(_ *ast.FixedPointExpression) ast.Repr {
+func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpression) ast.Repr {
 	// TODO: adjust once/if we support more fixed point types
-	return &Fix64Type{}
+
+	if expression.Negative ||
+		expression.UnsignedInteger.IsInt64() {
+
+		return &Fix64Type{}
+	}
+
+	return &UFix64Type{}
 }
 
 func (checker *Checker) VisitStringExpression(_ *ast.StringExpression) ast.Repr {

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -179,13 +179,11 @@ func (checker *Checker) VisitIntegerExpression(_ *ast.IntegerExpression) ast.Rep
 func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpression) ast.Repr {
 	// TODO: adjust once/if we support more fixed point types
 
-	if expression.Negative ||
-		expression.UnsignedInteger.IsInt64() {
-
+	if expression.Negative {
 		return &Fix64Type{}
+	} else {
+		return &UFix64Type{}
 	}
-
-	return &UFix64Type{}
 }
 
 func (checker *Checker) VisitStringExpression(_ *ast.StringExpression) ast.Repr {

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -130,16 +130,32 @@ func (checker *Checker) checkResourceVariableCapturingInFunction(variable *Varia
 }
 
 func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatement) ast.Repr {
-	result := statement.Expression.Accept(checker)
+	expression := statement.Expression
 
-	if ty, ok := result.(Type); ok &&
-		ty.IsResourceType() {
+	ty := expression.Accept(checker).(Type)
 
+	if ty.IsResourceType() {
 		checker.report(
 			&ResourceLossError{
-				Range: ast.NewRangeFromPositioned(statement.Expression),
+				Range: ast.NewRangeFromPositioned(expression),
 			},
 		)
+	}
+
+	// Ensure that a self-standing expression can be converted to it's own type.
+	//
+	// For example, the expression might be a fixed-point expression,
+	// which is inferred to have type Fix64, and the check ensures the literal
+	// fits into the type's range.
+	//
+	// This check is already performed for e.g. variable declarations
+	// and function function arguments.
+	//
+	// It might seem odd that the target type is the value type,
+	// but this is exactly the case for an expression that is a separate statement.
+
+	if !ty.IsInvalidType() {
+		checker.checkTypeCompatibility(expression, ty, ty)
 	}
 
 	return nil

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2579,17 +2579,24 @@ func (*UFix64Type) ContainsFirstLevelInterfaceType() bool {
 	return false
 }
 
-var UFix64TypeMinInt = big.NewInt(0)
-var UFix64TypeMaxInt = big.NewInt(0).SetUint64(math.MaxUint64 / uint64(Fix64Factor))
-var UFix64TypeMinFractional = big.NewInt(0)
-var UFix64TypeMaxFractional = big.NewInt(0).SetUint64(math.MaxUint64 % uint64(Fix64Factor))
+const UFix64TypeMinInt = 0
+const UFix64TypeMaxInt = math.MaxUint64 / uint64(Fix64Factor)
+
+var UFix64TypeMinIntBig = big.NewInt(0).SetUint64(UFix64TypeMinInt)
+var UFix64TypeMaxIntBig = big.NewInt(0).SetUint64(UFix64TypeMaxInt)
+
+const UFix64TypeMinFractional = 0
+const UFix64TypeMaxFractional = math.MaxUint64 % uint64(Fix64Factor)
+
+var UFix64TypeMinFractionalBig = big.NewInt(0).SetUint64(UFix64TypeMinFractional)
+var UFix64TypeMaxFractionalBig = big.NewInt(0).SetUint64(UFix64TypeMaxFractional)
 
 func (*UFix64Type) MinInt() *big.Int {
-	return UFix64TypeMinInt
+	return UFix64TypeMinIntBig
 }
 
 func (*UFix64Type) MaxInt() *big.Int {
-	return UFix64TypeMaxInt
+	return UFix64TypeMaxIntBig
 }
 
 func (*UFix64Type) Scale() uint {
@@ -2597,11 +2604,11 @@ func (*UFix64Type) Scale() uint {
 }
 
 func (*UFix64Type) MinFractional() *big.Int {
-	return UFix64TypeMinFractional
+	return UFix64TypeMinFractionalBig
 }
 
 func (*UFix64Type) MaxFractional() *big.Int {
-	return UFix64TypeMaxFractional
+	return UFix64TypeMaxFractionalBig
 }
 
 func (*UFix64Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -90,8 +90,9 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 			},
 			tests: []operationTest{
 				{&sema.IntType{}, "1", "2", nil},
-				{&sema.Fix64Type{}, "1.2", "3.4", nil},
-				{&sema.Fix64Type{}, "1.2", "3", []error{
+				{&sema.UFix64Type{}, "1.2", "3.4", nil},
+				{&sema.Fix64Type{}, "-1.2", "-3.4", nil},
+				{&sema.UFix64Type{}, "1.2", "3", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
 				{&sema.IntType{}, "1", "2.3", []error{
@@ -111,7 +112,7 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.Fix64Type{}, "1.2", "true", []error{
+				{&sema.UFix64Type{}, "1.2", "true", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -1,0 +1,479 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
+
+	inter := parseCheckAndInterpret(t, `
+      let x = -0.42
+    `)
+
+	assert.Equal(t,
+		interpreter.Fix64Value(-42000000),
+		inter.Globals["x"].Value,
+	)
+}
+
+func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
+
+	tests := map[string]interpreter.Value{
+		// Fix*
+		"Fix64": interpreter.Fix64Value(123000000),
+		// UFix*
+		"UFix64": interpreter.UFix64Value(123000000),
+	}
+
+	for _, fixedPointType := range sema.AllFixedPointTypes {
+		if _, ok := tests[fixedPointType.String()]; !ok {
+			panic(fmt.Sprintf("broken test: missing %s", fixedPointType))
+		}
+	}
+
+	for fixedPointType, value := range tests {
+
+		t.Run(fixedPointType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      let x: %[1]s = 1.23
+                      let y = %[1]s(0.42) + %[1]s(0.81)
+                      let z = y == x
+                    `,
+					fixedPointType,
+				),
+			)
+
+			assert.Equal(t,
+				value,
+				inter.Globals["x"].Value,
+			)
+
+			assert.Equal(t,
+				value,
+				inter.Globals["y"].Value,
+			)
+
+			assert.Equal(t,
+				interpreter.BoolValue(true),
+				inter.Globals["z"].Value,
+			)
+
+		})
+	}
+}
+
+var testFixedPointValues = map[string]interpreter.Value{
+	"Fix64":  interpreter.Fix64Value(50 * sema.Fix64Factor),
+	"UFix64": interpreter.UFix64Value(50 * sema.Fix64Factor),
+}
+
+func init() {
+	for _, fixedPointType := range sema.AllFixedPointTypes {
+		if _, ok := testFixedPointValues[fixedPointType.String()]; !ok {
+			panic(fmt.Sprintf("broken test: missing fixed-point type: %s", fixedPointType))
+		}
+	}
+}
+
+func TestInterpretFixedPointConversions(t *testing.T) {
+
+	// check conversion to integer types
+
+	for fixedPointType, fixedPointValue := range testFixedPointValues {
+
+		for integerType, integerValue := range testIntegerTypesAndValues {
+
+			testName := fmt.Sprintf("valid %s to %s", fixedPointType, integerType)
+
+			t.Run(testName, func(t *testing.T) {
+
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+                          let x: %[1]s = 50.0
+                          let y = %[2]s(x)
+                        `,
+						fixedPointType,
+						integerType,
+					),
+				)
+
+				assert.Equal(t,
+					fixedPointValue,
+					inter.Globals["x"].Value,
+				)
+
+				assert.Equal(t,
+					integerValue,
+					inter.Globals["y"].Value,
+				)
+			})
+		}
+	}
+
+	t.Run("valid UFix64 to UFix64", func(t *testing.T) {
+
+		for _, value := range []uint64{
+			50,
+			sema.UFix64TypeMinInt,
+			sema.UFix64TypeMaxInt,
+		} {
+
+			t.Run(fmt.Sprint(value), func(t *testing.T) {
+
+				code := fmt.Sprintf(
+					`
+                          let x: UFix64 = %d.0
+                          let y = UFix64(x)
+                        `,
+					value,
+				)
+
+				inter := parseCheckAndInterpret(t, code)
+
+				expected := interpreter.UFix64Value(value * sema.Fix64Factor)
+
+				assert.Equal(t,
+					expected,
+					inter.Globals["x"].Value,
+				)
+
+				assert.Equal(t,
+					expected,
+					inter.Globals["y"].Value,
+				)
+			})
+		}
+	})
+
+	t.Run("valid Fix64 to Fix64", func(t *testing.T) {
+
+		for _, value := range []int64{
+			-50,
+			50,
+			sema.Fix64TypeMinInt,
+			sema.Fix64TypeMaxInt,
+		} {
+
+			t.Run(fmt.Sprint(value), func(t *testing.T) {
+
+				code := fmt.Sprintf(
+					`
+                          let x: Fix64 = %d.0
+                          let y = Fix64(x)
+                        `,
+					value,
+				)
+
+				inter := parseCheckAndInterpret(t, code)
+
+				expected := interpreter.Fix64Value(value * sema.Fix64Factor)
+
+				assert.Equal(t,
+					expected,
+					inter.Globals["x"].Value,
+				)
+
+				assert.Equal(t,
+					expected,
+					inter.Globals["y"].Value,
+				)
+			})
+		}
+	})
+
+	t.Run("valid Fix64 to UFix64", func(t *testing.T) {
+
+		for _, value := range []int64{0, 50, sema.Fix64TypeMaxInt} {
+
+			t.Run(fmt.Sprint(value), func(t *testing.T) {
+
+				code := fmt.Sprintf(
+					`
+                          let x: Fix64 = %d.0
+                          let y = UFix64(x)
+                        `,
+					value,
+				)
+
+				inter := parseCheckAndInterpret(t, code)
+
+				assert.Equal(t,
+					interpreter.Fix64Value(value*sema.Fix64Factor),
+					inter.Globals["x"].Value,
+				)
+
+				assert.Equal(t,
+					interpreter.UFix64Value(value*sema.Fix64Factor),
+					inter.Globals["y"].Value,
+				)
+			})
+		}
+	})
+
+	t.Run("valid UFix64 to Fix64", func(t *testing.T) {
+
+		for _, value := range []int64{0, 50, sema.Fix64TypeMaxInt} {
+
+			t.Run(fmt.Sprint(value), func(t *testing.T) {
+
+				code := fmt.Sprintf(
+					`
+                          let x: UFix64 = %d.0
+                          let y = Fix64(x)
+                        `,
+					value,
+				)
+
+				inter := parseCheckAndInterpret(t, code)
+
+				assert.Equal(t,
+					interpreter.UFix64Value(value*sema.Fix64Factor),
+					inter.Globals["x"].Value,
+				)
+
+				assert.Equal(t,
+					interpreter.Fix64Value(value*sema.Fix64Factor),
+					inter.Globals["y"].Value,
+				)
+			})
+		}
+	})
+
+	t.Run("invalid negative Fix64 to UFix64", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t, `
+		  fun test(): UFix64 {
+		      let x: Fix64 = -1.0
+		      return UFix64(x)
+		  }
+		`)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+
+		assert.IsType(t, interpreter.UnderflowError{}, err)
+	})
+
+	t.Run("invalid UFix64 > max Fix64 int to Fix64", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t,
+			fmt.Sprintf(
+				`
+		          fun test(): Fix64 {
+		              let x: UFix64 = %d.0
+		              return Fix64(x)
+		          }
+		        `,
+				sema.Fix64TypeMaxInt+1,
+			),
+		)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+
+		assert.IsType(t, interpreter.OverflowError{}, err)
+	})
+
+	t.Run("invalid negative integer to UFix64", func(t *testing.T) {
+
+		for _, integerType := range sema.AllSignedIntegerTypes {
+
+			t.Run(integerType.String(), func(t *testing.T) {
+
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+	                     fun test(): UFix64 {
+	                         let x: %s = -1
+	                         return UFix64(x)
+	                     }
+	                   `,
+						integerType,
+					),
+				)
+
+				_, err := inter.Invoke("test")
+				require.Error(t, err)
+
+				assert.IsType(t, interpreter.UnderflowError{}, err)
+			})
+		}
+	})
+
+	t.Run("invalid big integer (>uint64) to UFix64", func(t *testing.T) {
+
+		bigIntegerTypes := []sema.Type{
+			&sema.Word64Type{},
+			&sema.UInt64Type{},
+			&sema.UInt128Type{},
+			&sema.UInt256Type{},
+			&sema.Int256Type{},
+			&sema.Int128Type{},
+		}
+
+		for _, integerType := range bigIntegerTypes {
+
+			t.Run(integerType.String(), func(t *testing.T) {
+
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+	                     fun test(): UFix64 {
+	                         let x: %s = %d
+	                         return UFix64(x)
+	                     }
+	                   `,
+						integerType,
+						sema.UFix64TypeMaxInt+1,
+					),
+				)
+
+				_, err := inter.Invoke("test")
+				require.Error(t, err)
+
+				assert.IsType(t, interpreter.OverflowError{}, err)
+			})
+		}
+	})
+
+	t.Run("invalid integer > UFix64 max int to UFix64", func(t *testing.T) {
+
+		const testedValue = sema.UFix64TypeMaxInt + 1
+		testValueBig := big.NewInt(0).SetUint64(testedValue)
+
+		for _, integerType := range sema.AllIntegerTypes {
+
+			// Only test for integer types that can hold testedValue
+
+			maxInt := integerType.(sema.IntegerRangedType).MaxInt()
+			if maxInt != nil && maxInt.Cmp(testValueBig) < 0 {
+				continue
+			}
+
+			t.Run(integerType.String(), func(t *testing.T) {
+
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+	                     fun test(): UFix64 {
+	                         let x: %s = %d
+	                         return UFix64(x)
+	                     }
+	                   `,
+						integerType,
+						testedValue,
+					),
+				)
+
+				_, err := inter.Invoke("test")
+				require.Error(t, err)
+
+				assert.IsType(t, interpreter.OverflowError{}, err)
+			})
+		}
+	})
+
+	t.Run("invalid integer > Fix64 max int to Fix64", func(t *testing.T) {
+
+		const testedValue = sema.Fix64TypeMaxInt + 1
+		testValueBig := big.NewInt(0).SetUint64(testedValue)
+
+		for _, integerType := range sema.AllIntegerTypes {
+
+			// Only test for integer types that can hold testedValue
+
+			maxInt := integerType.(sema.IntegerRangedType).MaxInt()
+			if maxInt != nil && maxInt.Cmp(testValueBig) < 0 {
+				continue
+			}
+
+			t.Run(integerType.String(), func(t *testing.T) {
+
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+	                     fun test(): Fix64 {
+	                         let x: %s = %d
+	                         return Fix64(x)
+	                     }
+	                   `,
+						integerType,
+						testedValue,
+					),
+				)
+
+				_, err := inter.Invoke("test")
+				require.Error(t, err)
+
+				assert.IsType(t, interpreter.OverflowError{}, err)
+			})
+		}
+	})
+
+	t.Run("invalid integer < Fix64 min int to Fix64", func(t *testing.T) {
+
+		const testedValue = sema.Fix64TypeMinInt - 1
+		testValueBig := big.NewInt(testedValue)
+
+		for _, integerType := range sema.AllSignedIntegerTypes {
+
+			// Only test for integer types that can hold testedValue
+
+			minInt := integerType.(sema.IntegerRangedType).MinInt()
+			if minInt != nil && minInt.Cmp(testValueBig) > 0 {
+				continue
+			}
+
+			t.Run(integerType.String(), func(t *testing.T) {
+
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+	                     fun test(): Fix64 {
+	                         let x: %s = %d
+	                         return Fix64(x)
+	                     }
+	                   `,
+						integerType,
+						testedValue,
+					),
+				)
+
+				_, err := inter.Invoke("test")
+				require.Error(t, err)
+
+				assert.IsType(t, interpreter.UnderflowError{}, err)
+			})
+		}
+	})
+}

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -1,0 +1,348 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+var testIntegerTypesAndValues = map[string]interpreter.Value{
+	// Int*
+	"Int":    interpreter.NewIntValueFromInt64(50),
+	"Int8":   interpreter.Int8Value(50),
+	"Int16":  interpreter.Int16Value(50),
+	"Int32":  interpreter.Int32Value(50),
+	"Int64":  interpreter.Int64Value(50),
+	"Int128": interpreter.NewInt128ValueFromInt64(50),
+	"Int256": interpreter.NewInt256ValueFromInt64(50),
+	// UInt*
+	"UInt":    interpreter.NewUIntValueFromUint64(50),
+	"UInt8":   interpreter.UInt8Value(50),
+	"UInt16":  interpreter.UInt16Value(50),
+	"UInt32":  interpreter.UInt32Value(50),
+	"UInt64":  interpreter.UInt64Value(50),
+	"UInt128": interpreter.NewUInt128ValueFromInt64(50),
+	"UInt256": interpreter.NewUInt256ValueFromInt64(50),
+	// Word*
+	"Word8":  interpreter.Word8Value(50),
+	"Word16": interpreter.Word16Value(50),
+	"Word32": interpreter.Word32Value(50),
+	"Word64": interpreter.Word64Value(50),
+}
+
+func init() {
+	for _, integerType := range sema.AllIntegerTypes {
+		if _, ok := testIntegerTypesAndValues[integerType.String()]; !ok {
+			panic(fmt.Sprintf("broken test: missing %s", integerType))
+		}
+	}
+}
+
+func TestInterpretIntegerConversions(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      let x: %[1]s = 50
+                      let y = %[1]s(40) + %[1]s(10)
+                      let z = y == x
+                    `,
+					integerType,
+				),
+			)
+
+			assert.Equal(t,
+				value,
+				inter.Globals["x"].Value,
+			)
+
+			assert.Equal(t,
+				value,
+				inter.Globals["y"].Value,
+			)
+
+			assert.Equal(t,
+				interpreter.BoolValue(true),
+				inter.Globals["z"].Value,
+			)
+
+		})
+	}
+}
+
+func TestInterpretAddressConversion(t *testing.T) {
+
+	inter := parseCheckAndInterpret(t, `
+      let x: Address = 0x1
+      let y = Address(0x2)
+    `)
+
+	assert.Equal(t,
+		interpreter.AddressValue{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+		},
+		inter.Globals["x"].Value,
+	)
+
+	assert.Equal(t,
+		interpreter.AddressValue{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
+		},
+		inter.Globals["y"].Value,
+	)
+}
+
+func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      let x: %s = 50
+                    `,
+					integerType,
+				),
+			)
+
+			assert.Equal(t,
+				value,
+				inter.Globals["x"].Value,
+			)
+
+		})
+	}
+}
+
+func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                        let x: %s? = 50
+                    `,
+					integerType,
+				),
+			)
+
+			assert.Equal(t,
+				interpreter.NewSomeValueOwningNonCopying(value),
+				inter.Globals["x"].Value,
+			)
+		})
+	}
+}
+
+func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      var x: %s = 50
+                      fun test() {
+                          x = x + x
+                      }
+                    `,
+					integerType,
+				),
+			)
+
+			assert.Equal(t,
+				value,
+				inter.Globals["x"].Value,
+			)
+
+			_, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			numberValue := value.(interpreter.NumberValue)
+			assert.Equal(t,
+				numberValue.Plus(numberValue),
+				inter.Globals["x"].Value,
+			)
+		})
+	}
+}
+
+func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      var x: %s? = 50
+                      fun test() {
+                          x = 100
+                      }
+                    `,
+					integerType,
+				),
+			)
+
+			assert.Equal(t,
+				interpreter.NewSomeValueOwningNonCopying(value),
+				inter.Globals["x"].Value,
+			)
+
+			_, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			numberValue := value.(interpreter.NumberValue)
+
+			assert.Equal(t,
+				interpreter.NewSomeValueOwningNonCopying(
+					numberValue.Plus(numberValue),
+				),
+				inter.Globals["x"].Value,
+			)
+		})
+	}
+}
+
+func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      fun test(_ x: %[1]s): %[1]s {
+                          return x
+                      }
+                      let x = test(50)
+                    `,
+					integerType,
+				),
+			)
+
+			assert.Equal(t,
+				value,
+				inter.Globals["x"].Value,
+			)
+		})
+	}
+}
+
+func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                        fun test(_ x: %[1]s?): %[1]s? {
+                            return x
+                        }
+                        let x = test(50)
+                    `,
+					integerType,
+				),
+			)
+
+			assert.Equal(t,
+				interpreter.NewSomeValueOwningNonCopying(value),
+				inter.Globals["x"].Value,
+			)
+		})
+	}
+}
+
+func TestInterpretIntegerLiteralTypeConversionInReturn(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      fun test(): %s {
+                          return 50
+                      }
+                    `,
+					integerType,
+				),
+			)
+
+			result, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			assert.Equal(t,
+				value,
+				result,
+			)
+		})
+	}
+}
+
+func TestInterpretIntegerLiteralTypeConversionInReturnOptional(t *testing.T) {
+
+	for integerType, value := range testIntegerTypesAndValues {
+
+		t.Run(integerType, func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      fun test(): %s? {
+                          return 50
+                      }
+                    `,
+					integerType,
+				),
+			)
+
+			result, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			assert.Equal(t,
+				interpreter.NewSomeValueOwningNonCopying(value),
+				result,
+			)
+		})
+	}
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4705,150 +4705,6 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 	}
 }
 
-func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        let x: Int8 = 1
-    `)
-
-	assert.Equal(t,
-		interpreter.Int8Value(1),
-		inter.Globals["x"].Value,
-	)
-}
-
-func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        let x: Int8? = 1
-    `)
-
-	assert.Equal(t,
-		interpreter.NewSomeValueOwningNonCopying(
-			interpreter.Int8Value(1),
-		),
-		inter.Globals["x"].Value,
-	)
-}
-
-func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        var x: Int8 = 1
-        fun test() {
-            x = 2
-        }
-    `)
-
-	assert.Equal(t,
-		interpreter.Int8Value(1),
-		inter.Globals["x"].Value,
-	)
-
-	_, err := inter.Invoke("test")
-	require.NoError(t, err)
-
-	assert.Equal(t,
-		interpreter.Int8Value(2),
-		inter.Globals["x"].Value,
-	)
-}
-
-func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        var x: Int8? = 1
-        fun test() {
-            x = 2
-        }
-    `)
-
-	assert.Equal(t,
-		interpreter.NewSomeValueOwningNonCopying(
-			interpreter.Int8Value(1),
-		),
-		inter.Globals["x"].Value,
-	)
-
-	_, err := inter.Invoke("test")
-	require.NoError(t, err)
-
-	assert.Equal(t,
-		interpreter.NewSomeValueOwningNonCopying(
-			interpreter.Int8Value(2),
-		),
-		inter.Globals["x"].Value,
-	)
-}
-
-func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        fun test(_ x: Int8): Int8 {
-            return x
-        }
-        let x = test(1)
-    `)
-
-	assert.Equal(t,
-		interpreter.Int8Value(1),
-		inter.Globals["x"].Value,
-	)
-}
-
-func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        fun test(_ x: Int8?): Int8? {
-            return x
-        }
-        let x = test(1)
-    `)
-
-	assert.Equal(t,
-		interpreter.NewSomeValueOwningNonCopying(
-			interpreter.Int8Value(1),
-		),
-		inter.Globals["x"].Value,
-	)
-}
-
-func TestInterpretIntegerLiteralTypeConversionInReturn(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        fun test(): Int8 {
-            return 1
-        }
-    `)
-
-	value, err := inter.Invoke("test")
-	require.NoError(t, err)
-
-	assert.Equal(t,
-		interpreter.Int8Value(1),
-		value,
-	)
-}
-
-func TestInterpretIntegerLiteralTypeConversionInReturnOptional(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-        fun test(): Int8? {
-            return 1
-        }
-    `)
-
-	value, err := inter.Invoke("test")
-	require.NoError(t, err)
-
-	assert.Equal(t,
-		interpreter.NewSomeValueOwningNonCopying(
-			interpreter.Int8Value(1),
-		),
-		value,
-	)
-}
-
 func TestInterpretIndirectDestroy(t *testing.T) {
 
 	inter := parseCheckAndInterpret(t, `
@@ -5915,155 +5771,6 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 	)
 }
 
-func TestInterpretIntegerConversions(t *testing.T) {
-
-	tests := map[string]interpreter.Value{
-		// Int*
-		"Int":    interpreter.NewIntValueFromInt64(100),
-		"Int8":   interpreter.Int8Value(100),
-		"Int16":  interpreter.Int16Value(100),
-		"Int32":  interpreter.Int32Value(100),
-		"Int64":  interpreter.Int64Value(100),
-		"Int128": interpreter.NewInt128ValueFromInt64(100),
-		"Int256": interpreter.NewInt256ValueFromInt64(100),
-		// UInt*
-		"UInt":    interpreter.NewUIntValueFromUint64(100),
-		"UInt8":   interpreter.UInt8Value(100),
-		"UInt16":  interpreter.UInt16Value(100),
-		"UInt32":  interpreter.UInt32Value(100),
-		"UInt64":  interpreter.UInt64Value(100),
-		"UInt128": interpreter.NewUInt128ValueFromInt64(100),
-		"UInt256": interpreter.NewUInt256ValueFromInt64(100),
-		// Word*
-		"Word8":  interpreter.Word8Value(100),
-		"Word16": interpreter.Word16Value(100),
-		"Word32": interpreter.Word32Value(100),
-		"Word64": interpreter.Word64Value(100),
-	}
-
-	for _, integerType := range sema.AllIntegerTypes {
-		if _, ok := tests[integerType.String()]; !ok {
-			panic(fmt.Sprintf("broken test: missing %s", integerType))
-		}
-	}
-
-	for integerType, value := range tests {
-
-		t.Run(integerType, func(t *testing.T) {
-
-			inter := parseCheckAndInterpret(t,
-				fmt.Sprintf(
-					`
-                      let x: %[1]s = 100
-                      let y = %[1]s(90) + %[1]s(10)
-                      let z = y == x
-                    `,
-					integerType,
-				),
-			)
-
-			assert.Equal(t,
-				value,
-				inter.Globals["x"].Value,
-			)
-
-			assert.Equal(t,
-				value,
-				inter.Globals["y"].Value,
-			)
-
-			assert.Equal(t,
-				interpreter.BoolValue(true),
-				inter.Globals["z"].Value,
-			)
-
-		})
-	}
-}
-
-func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-      let x = -0.42
-    `)
-
-	assert.Equal(t,
-		interpreter.Fix64Value(-42000000),
-		inter.Globals["x"].Value,
-	)
-}
-
-func TestInterpretFixedPointConversions(t *testing.T) {
-
-	tests := map[string]interpreter.Value{
-		// Fix*
-		"Fix64": interpreter.Fix64Value(123000000),
-		// UFix*
-		"UFix64": interpreter.UFix64Value(123000000),
-	}
-
-	for _, fixedPointType := range sema.AllFixedPointTypes {
-		if _, ok := tests[fixedPointType.String()]; !ok {
-			panic(fmt.Sprintf("broken test: missing %s", fixedPointType))
-		}
-	}
-
-	for fixedPointType, value := range tests {
-
-		t.Run(fixedPointType, func(t *testing.T) {
-
-			inter := parseCheckAndInterpret(t,
-				fmt.Sprintf(
-					`
-                      let x: %[1]s = 1.23
-                      let y = %[1]s(0.42) + %[1]s(0.81)
-                      let z = y == x
-                    `,
-					fixedPointType,
-				),
-			)
-
-			assert.Equal(t,
-				value,
-				inter.Globals["x"].Value,
-			)
-
-			assert.Equal(t,
-				value,
-				inter.Globals["y"].Value,
-			)
-
-			assert.Equal(t,
-				interpreter.BoolValue(true),
-				inter.Globals["z"].Value,
-			)
-
-		})
-	}
-}
-
-func TestInterpretAddressConversion(t *testing.T) {
-
-	inter := parseCheckAndInterpret(t, `
-      let x: Address = 0x1
-      let y = Address(0x2)
-    `)
-
-	assert.Equal(t,
-		interpreter.AddressValue{
-			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
-		},
-		inter.Globals["x"].Value,
-	)
-
-	assert.Equal(t,
-		interpreter.AddressValue{
-			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
-		},
-		inter.Globals["y"].Value,
-	)
-}
-
 func TestInterpretCastingIntLiteralToInt8(t *testing.T) {
 
 	inter := parseCheckAndInterpret(t, `
@@ -6976,12 +6683,12 @@ func TestInterpretFix64(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		interpreter.Fix64Value(78_900_123_010),
+		interpreter.UFix64Value(78_900_123_010),
 		inter.Globals["a"].Value,
 	)
 
 	assert.Equal(t,
-		interpreter.Fix64Value(123_405_600_000),
+		interpreter.UFix64Value(123_405_600_000),
 		inter.Globals["b"].Value,
 	)
 
@@ -6995,7 +6702,7 @@ func TestInterpretFix64Mul(t *testing.T) {
 
 	inter := parseCheckAndInterpret(t,
 		`
-          let a = 1.1 * -1.1
+          let a = Fix64(1.1) * -1.1
         `,
 	)
 
@@ -7662,81 +7369,6 @@ func TestInterpretCountDigits256(t *testing.T) {
 					expected,
 					inter.Globals[variableName].Value,
 				)
-			}
-		})
-	}
-}
-
-func TestInterpretFixedPointToIntegerConversions(t *testing.T) {
-
-	fixedPointValues := map[string]interpreter.Value{
-		"Fix64":  interpreter.Fix64Value(100 * sema.Fix64Factor),
-		"UFix64": interpreter.UFix64Value(100 * sema.Fix64Factor),
-	}
-
-	for _, fixedPointType := range sema.AllFixedPointTypes {
-		if _, ok := fixedPointValues[fixedPointType.String()]; !ok {
-			panic(fmt.Sprintf("broken test: missing fixed-point type: %s", fixedPointType))
-		}
-	}
-
-	integerValues := map[string]interpreter.Value{
-		// Int*
-		"Int":    interpreter.NewIntValueFromInt64(100),
-		"Int8":   interpreter.Int8Value(100),
-		"Int16":  interpreter.Int16Value(100),
-		"Int32":  interpreter.Int32Value(100),
-		"Int64":  interpreter.Int64Value(100),
-		"Int128": interpreter.NewInt128ValueFromInt64(100),
-		"Int256": interpreter.NewInt256ValueFromInt64(100),
-		// UInt*
-		"UInt":    interpreter.NewUIntValueFromUint64(100),
-		"UInt8":   interpreter.UInt8Value(100),
-		"UInt16":  interpreter.UInt16Value(100),
-		"UInt32":  interpreter.UInt32Value(100),
-		"UInt64":  interpreter.UInt64Value(100),
-		"UInt128": interpreter.NewUInt128ValueFromInt64(100),
-		"UInt256": interpreter.NewUInt256ValueFromInt64(100),
-		// Word*
-		"Word8":  interpreter.Word8Value(100),
-		"Word16": interpreter.Word16Value(100),
-		"Word32": interpreter.Word32Value(100),
-		"Word64": interpreter.Word64Value(100),
-	}
-
-	for _, integerType := range sema.AllIntegerTypes {
-		if _, ok := integerValues[integerType.String()]; !ok {
-			panic(fmt.Sprintf("broken test: missing integer type: %s", integerType))
-		}
-	}
-
-	for fixedPointType, fixedPointValue := range fixedPointValues {
-		t.Run(fixedPointType, func(t *testing.T) {
-
-			for integerType, integerValue := range integerValues {
-				t.Run(integerType, func(t *testing.T) {
-
-					inter := parseCheckAndInterpret(t,
-						fmt.Sprintf(
-							`
-                          let x: %[1]s = 100.0
-                          let y = %[2]s(x)
-                        `,
-							fixedPointType,
-							integerType,
-						),
-					)
-
-					assert.Equal(t,
-						fixedPointValue,
-						inter.Globals["x"].Value,
-					)
-
-					assert.Equal(t,
-						integerValue,
-						inter.Globals["y"].Value,
-					)
-				})
 			}
 		})
 	}


### PR DESCRIPTION
Closes dapperlabs/flow-go#2141

## Description

- Infer negative fixed-point literals to `Fix64`, and `UFix64` otherwise
- Check type compatibility of expression statements: 
  For example, an expression statement might be a fixed-point literal, 
  e.g. in the REPL, which might be inferred to `Fix64` or `UFix64`,
  but might exceed the valid range of the type
- Fix the conversion of numbers to `[U]Fix64`: Properly check integer ranges, handle "big" number values (values >`math.Max[u]int64`)
- Move integer and fixed-point interpreter tests to separate files 