### PR TITLE
Implement modulo for [U]Fix64, fix modulo with negative operands

### DIFF
--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -3148,7 +3148,46 @@ func TestDivFix64(t *testing.T) {
 	})
 }
 
-func TestDivUFix64(t *testing.T) {
+func TestModFix64(t *testing.T) {
+
+	tests := []struct {
+		a, b  Int64Value
+		valid bool
+	}{
+		{0, 0, false},
+		{1, 0, false},
+		{2, 0, false},
+		{-1, 0, false},
+
+		{0, 1, true},
+		{1, 1, true},
+		{2, 1, true},
+		{-1, 1, true},
+
+		{0, 2, true},
+		{1, 2, true},
+		{2, 2, true},
+		{-1, 2, true},
+
+		{0, -1, true},
+		{1, -1, true},
+		{2, -1, true},
+		{-1, -1, true},
+	}
+
+	for _, test := range tests {
+		f := func() {
+			test.a.Mod(test.b)
+		}
+		if test.valid {
+			assert.NotPanics(t, f)
+		} else {
+			assert.Panics(t, f)
+		}
+	}
+}
+
+func TestDivModUFix64(t *testing.T) {
 
 	tests := []struct {
 		a, b  uint64
@@ -3175,16 +3214,26 @@ func TestDivUFix64(t *testing.T) {
 
 	for _, test := range tests {
 
-		f := func() {
-			a := NewUFix64ValueWithInteger(test.a)
-			b := NewUFix64ValueWithInteger(test.b)
-			a.Div(b)
-		}
+		for _, f := range []func(a, b UFix64Value){
+			func(a, b UFix64Value) {
+				a.Div(b)
+			},
+			func(a, b UFix64Value) {
+				a.Mod(b)
+			},
+		} {
 
-		if test.valid {
-			assert.NotPanics(t, f)
-		} else {
-			assert.Panics(t, f)
+			f := func() {
+				a := NewUFix64ValueWithInteger(test.a)
+				b := NewUFix64ValueWithInteger(test.b)
+				f(a, b)
+			}
+
+			if test.valid {
+				assert.NotPanics(t, f)
+			} else {
+				assert.Panics(t, f)
+			}
 		}
 	}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -657,7 +657,7 @@ func (v IntValue) Mod(other NumberValue) NumberValue {
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
 	}
-	res.Mod(v.BigInt, o.BigInt)
+	res.Rem(v.BigInt, o.BigInt)
 	return IntValue{res}
 }
 
@@ -1638,7 +1638,7 @@ func (v Int128Value) Mod(other NumberValue) NumberValue {
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
 	}
-	res.Mod(v.BigInt, o.BigInt)
+	res.Rem(v.BigInt, o.BigInt)
 	return Int128Value{res}
 }
 
@@ -1889,7 +1889,7 @@ func (v Int256Value) Mod(other NumberValue) NumberValue {
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
 	}
-	res.Mod(v.BigInt, o.BigInt)
+	res.Rem(v.BigInt, o.BigInt)
 	return Int256Value{res}
 }
 
@@ -2123,7 +2123,7 @@ func (v UIntValue) Mod(other NumberValue) NumberValue {
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
 	}
-	res.Mod(v.BigInt, o.BigInt)
+	res.Rem(v.BigInt, o.BigInt)
 	return UIntValue{res}
 }
 
@@ -2956,7 +2956,7 @@ func (v UInt128Value) Mod(other NumberValue) NumberValue {
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
 	}
-	res.Mod(v.BigInt, o.BigInt)
+	res.Rem(v.BigInt, o.BigInt)
 	return UInt128Value{res}
 }
 
@@ -3177,7 +3177,7 @@ func (v UInt256Value) Mod(other NumberValue) NumberValue {
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
 	}
-	res.Mod(v.BigInt, o.BigInt)
+	res.Rem(v.BigInt, o.BigInt)
 	return UInt256Value{res}
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -3929,8 +3929,11 @@ func (v Fix64Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) Mod(other NumberValue) NumberValue {
-	// TODO:
-	panic("TODO")
+	o := other.(Fix64Value)
+	// v - int(v/o) * o
+	quotient := v.Div(o).(Fix64Value)
+	truncatedQuotient := (int64(quotient) / sema.Fix64Factor) * sema.Fix64Factor
+	return v.Minus(Fix64Value(truncatedQuotient).Mul(o))
 }
 
 func (v Fix64Value) Less(other NumberValue) BoolValue {
@@ -4132,8 +4135,11 @@ func (v UFix64Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) Mod(other NumberValue) NumberValue {
-	// TODO:
-	panic("TODO")
+	o := other.(UFix64Value)
+	// v - int(v/o) * o
+	quotient := v.Div(o).(UFix64Value)
+	truncatedQuotient := (uint64(quotient) / sema.Fix64Factor) * sema.Fix64Factor
+	return v.Minus(UFix64Value(truncatedQuotient).Mul(o))
 }
 
 func (v UFix64Value) Less(other NumberValue) BoolValue {


### PR DESCRIPTION
Closes dapperlabs/flow-go#3071
Fixes #33

## Description

- Implement modulo for `[U]Fix64`
- Ensure that all modulo for all signed integer and fixed-point types behaves the same way: the sign of the dividend is used

