### PR TITLE
Improve REPL

### DIFF
--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -19,6 +19,8 @@
 package interpreter
 
 import (
+	"fmt"
+
 	"github.com/raviqqe/hamt"
 
 	"github.com/onflow/cadence/runtime/ast"
@@ -61,6 +63,10 @@ type InterpretedFunctionValue struct {
 	PostConditions   ast.Conditions
 }
 
+func (f InterpretedFunctionValue) String() string {
+	return fmt.Sprintf("Function%s", f.Type.String())
+}
+
 func (InterpretedFunctionValue) IsValue() {}
 
 func (InterpretedFunctionValue) DynamicType(_ *Interpreter) DynamicType {
@@ -93,6 +99,11 @@ type HostFunction func(invocation Invocation) Trampoline
 type HostFunctionValue struct {
 	Function HostFunction
 	Members  map[string]Value
+}
+
+func (f HostFunctionValue) String() string {
+	// TODO: include type
+	return "Function(...)"
 }
 
 func NewHostFunctionValue(
@@ -141,6 +152,10 @@ func (f HostFunctionValue) SetMember(_ *Interpreter, _ LocationRange, _ string, 
 type BoundFunctionValue struct {
 	Function FunctionValue
 	Self     *CompositeValue
+}
+
+func (f BoundFunctionValue) String() string {
+	return fmt.Sprint(f.Function)
 }
 
 func (BoundFunctionValue) IsValue() {}

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -19,6 +19,8 @@
 package runtime
 
 import (
+	"sort"
+
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -152,7 +154,11 @@ func (r *REPL) Accept(code string) (inputIsComplete bool) {
 	return
 }
 
-func (r *REPL) Suggestions() (result []struct{ Name, Description string }) {
+type REPLSuggestion struct {
+	Name, Description string
+}
+
+func (r *REPL) Suggestions() (result []REPLSuggestion) {
 	names := map[string]string{}
 
 	for name, variable := range r.checker.GlobalValues {
@@ -163,11 +169,17 @@ func (r *REPL) Suggestions() (result []struct{ Name, Description string }) {
 	}
 
 	for name, description := range names {
-		result = append(result, struct{ Name, Description string }{
+		result = append(result, REPLSuggestion{
 			Name:        name,
 			Description: description,
 		})
 	}
+
+	sort.Slice(result, func(i, j int) bool {
+		a := result[i]
+		b := result[j]
+		return a.Name < b.Name
+	})
 
 	return
 }


### PR DESCRIPTION
- Add a string representation for function values by implementing `fmt.Stringer`.
  - Old:
    ```
    1> fun foo() {}
    2> foo
    {0xc00010e300 0xc0002cb400 ((): Void) {{25 {0 [<nil> {UInt 0xc00019ad00} <nil> <nil> {Int64 0xc00019aa90} <nil> {UInt256 0xc0...
    ```
  - New:
    ```
    1> fun foo() {}
    2> foo
    Function((): Void)
    ```
- Make REPL suggestions stable. The suggestions are regenerated on navigation of the suggestion menu and the ordering was not deterministic, so suggestions "jumped around"