### PR TITLE
Remove unnecessary check for transaction prepare parameter types

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -108,20 +108,6 @@ func (e InvalidTransactionAuthorizerCountError) Error() string {
 	)
 }
 
-// InvalidTransactionPrepareParameterError
-
-type InvalidTransactionPrepareParameterError struct {
-	Actual sema.Type
-}
-
-func (e InvalidTransactionPrepareParameterError) Error() string {
-	return fmt.Sprintf(
-		"invalid prepare statement parameter: expected `%s`, got `%s`",
-		&sema.AuthAccountType{},
-		e.Actual,
-	)
-}
-
 // InvalidTransactionArgumentError
 
 type InvalidTransactionArgumentError struct {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -246,17 +246,6 @@ func (r *interpreterRuntime) ExecuteTransaction(
 		)
 	}
 
-	// check all prepare argument types are `AuthAccount`
-
-	for _, parameter := range transactionType.PrepareParameters {
-		parameterType := parameter.TypeAnnotation.Type
-		if !parameterType.Equal(&sema.AuthAccountType{}) {
-			return newError(InvalidTransactionPrepareParameterError{
-				Actual: parameterType,
-			})
-		}
-	}
-
 	_, err = r.interpret(
 		runtimeInterface,
 		runtimeStorage,


### PR DESCRIPTION
I missed this in the review of #45:

Transactions' prepare block parameter types are already checked statically, so there's no need to do this in the runtime:
https://github.com/onflow/cadence/blob/dc1a633f4064deb65d0ef0e0e17d77b9f1b668b2/runtime/sema/check_transaction_declaration.go#L196-L217

Also, I checked and verified that we already check transaction parameter types to not be resources:
https://github.com/onflow/cadence/blob/dc1a633f4064deb65d0ef0e0e17d77b9f1b668b2/runtime/sema/check_transaction_declaration.go#L80-L106
