### PR TITLE
Avoid unnecessary writes by tracking modifications

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -296,10 +296,11 @@ func importCompositeValue(
 		fields[fieldType.Identifier] = importValue(fieldValue)
 	}
 
-	return &interpreter.CompositeValue{
-		Location: ast.LocationFromTypeID(typeID),
-		Kind:     kind,
-		TypeID:   sema.TypeID(typeID),
-		Fields:   fields,
-	}
+	return interpreter.NewCompositeValue(
+		ast.LocationFromTypeID(typeID),
+		sema.TypeID(typeID),
+		kind,
+		fields,
+		nil,
+	)
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -204,8 +204,9 @@ func (d *Decoder) decodeArray(v []interface{}, owner *common.Address) (*ArrayVal
 	}
 
 	return &ArrayValue{
-		Values: values,
-		Owner:  owner,
+		Values:   values,
+		Owner:    owner,
+		modified: true,
 	}, nil
 }
 
@@ -248,9 +249,10 @@ func (d *Decoder) decodeDictionary(v interface{}, owner *common.Address) (*Dicti
 	}
 
 	return &DictionaryValue{
-		Keys:    keys,
-		Entries: entries,
-		Owner:   owner,
+		Keys:     keys,
+		Entries:  entries,
+		Owner:    owner,
+		modified: true,
 	}, nil
 }
 
@@ -352,13 +354,7 @@ func (d *Decoder) decodeComposite(v interface{}, owner *common.Address) (*Compos
 		fields[nameString] = decodedValue
 	}
 
-	return &CompositeValue{
-		Location: location,
-		TypeID:   typeID,
-		Kind:     kind,
-		Fields:   fields,
-		Owner:    owner,
-	}, nil
+	return NewCompositeValue(location, typeID, kind, fields, owner), nil
 }
 
 func (d *Decoder) decodeBig(v interface{}) (*big.Int, error) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -699,7 +699,7 @@ func (d *Decoder) decodeSome(v interface{}, owner *common.Address) (*SomeValue, 
 	}, nil
 }
 
-func (d *Decoder) decodeStorageReference(v interface{}, owner *common.Address) (*StorageReferenceValue, error) {
+func (d *Decoder) decodeStorageReference(v interface{}, _ *common.Address) (*StorageReferenceValue, error) {
 	encoded, ok := v.(map[interface{}]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid storage reference encoding: %T", v)
@@ -726,7 +726,6 @@ func (d *Decoder) decodeStorageReference(v interface{}, owner *common.Address) (
 		Authorized:           authorized,
 		TargetStorageAddress: targetStorageAddress,
 		TargetKey:            targetKey,
-		Owner:                owner,
 	}, nil
 }
 

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -74,7 +74,7 @@ func (d *Decoder) decodeValue(v interface{}, owner *common.Address) (Value, erro
 		return BoolValue(v), nil
 
 	case string:
-		return NewStringValue(v), nil
+		return d.decodeString(v), nil
 
 	case nil:
 		return NilValue{}, nil
@@ -193,6 +193,12 @@ func (d *Decoder) decodeValue(v interface{}, owner *common.Address) (Value, erro
 	}
 }
 
+func (d *Decoder) decodeString(v string) Value {
+	value := NewStringValue(v)
+	value.modified = false
+	return value
+}
+
 func (d *Decoder) decodeArray(v []interface{}, owner *common.Address) (*ArrayValue, error) {
 	values := make([]Value, len(v))
 	for i, value := range v {
@@ -206,7 +212,7 @@ func (d *Decoder) decodeArray(v []interface{}, owner *common.Address) (*ArrayVal
 	return &ArrayValue{
 		Values:   values,
 		Owner:    owner,
-		modified: true,
+		modified: false,
 	}, nil
 }
 
@@ -252,7 +258,7 @@ func (d *Decoder) decodeDictionary(v interface{}, owner *common.Address) (*Dicti
 		Keys:     keys,
 		Entries:  entries,
 		Owner:    owner,
-		modified: true,
+		modified: false,
 	}, nil
 }
 
@@ -354,7 +360,9 @@ func (d *Decoder) decodeComposite(v interface{}, owner *common.Address) (*Compos
 		fields[nameString] = decodedValue
 	}
 
-	return NewCompositeValue(location, typeID, kind, fields, owner), nil
+	compositeValue := NewCompositeValue(location, typeID, kind, fields, owner)
+	compositeValue.modified = false
+	return compositeValue, nil
 }
 
 func (d *Decoder) decodeBig(v interface{}) (*big.Int, error) {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -203,7 +203,7 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 					NewStringValue("test"), NewArrayValueUnownedNonCopying(),
 					BoolValue(true), BoolValue(false),
 					NewStringValue("foo"), NewStringValue("bar"),
-				),
+				).Copy(),
 				encoded: []byte{
 					// tag
 					0xd8, cborTagDictionaryValue,

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -258,12 +258,13 @@ func TestEncodeDecodeComposite(t *testing.T) {
 	t.Run("empty structure, string location", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: &CompositeValue{
-					TypeID:   "S.test.TestStruct",
-					Kind:     common.CompositeKindStructure,
-					Fields:   map[string]Value{},
-					Location: utils.TestLocation,
-				},
+				value: NewCompositeValue(
+					utils.TestLocation,
+					"S.test.TestStruct",
+					common.CompositeKindStructure,
+					map[string]Value{},
+					nil,
+				),
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -302,15 +303,16 @@ func TestEncodeDecodeComposite(t *testing.T) {
 	t.Run("non-empty resource", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: &CompositeValue{
-					TypeID: "S.test.TestResource",
-					Kind:   common.CompositeKindResource,
-					Fields: map[string]Value{
+				value: NewCompositeValue(
+					utils.TestLocation,
+					"S.test.TestResource",
+					common.CompositeKindResource,
+					map[string]Value{
 						"true":   BoolValue(true),
 						"string": NewStringValue("test"),
 					},
-					Location: utils.TestLocation,
-				},
+					nil,
+				),
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -361,12 +363,13 @@ func TestEncodeDecodeComposite(t *testing.T) {
 	t.Run("empty, address location", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: &CompositeValue{
-					TypeID:   "A.0x1.TestStruct",
-					Kind:     common.CompositeKindStructure,
-					Fields:   map[string]Value{},
-					Location: ast.AddressLocation{0x1},
-				},
+				value: NewCompositeValue(
+					ast.AddressLocation{0x1},
+					"A.0x1.TestStruct",
+					common.CompositeKindStructure,
+					map[string]Value{},
+					nil,
+				),
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -82,8 +82,12 @@ func (InterpretedFunctionValue) GetOwner() *common.Address {
 	return nil
 }
 
-func (InterpretedFunctionValue) SetOwner(owner *common.Address) {
+func (InterpretedFunctionValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
+}
+
+func (InterpretedFunctionValue) Modified() bool {
+	return false
 }
 
 func (InterpretedFunctionValue) isFunctionValue() {}
@@ -129,8 +133,12 @@ func (HostFunctionValue) GetOwner() *common.Address {
 	return nil
 }
 
-func (HostFunctionValue) SetOwner(owner *common.Address) {
+func (HostFunctionValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
+}
+
+func (HostFunctionValue) Modified() bool {
+	return false
 }
 
 func (HostFunctionValue) isFunctionValue() {}
@@ -139,7 +147,7 @@ func (f HostFunctionValue) Invoke(invocation Invocation) Trampoline {
 	return f.Function(invocation)
 }
 
-func (f HostFunctionValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
+func (f HostFunctionValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
 	return f.Members[name]
 }
 
@@ -173,8 +181,12 @@ func (BoundFunctionValue) GetOwner() *common.Address {
 	return nil
 }
 
-func (BoundFunctionValue) SetOwner(owner *common.Address) {
+func (BoundFunctionValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
+}
+
+func (BoundFunctionValue) Modified() bool {
+	return false
 }
 
 func (BoundFunctionValue) isFunctionValue() {}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2457,7 +2457,8 @@ func (interpreter *Interpreter) declareCompositeValue(
 				Functions:      functions,
 				Destructor:     destructorFunction,
 				// NOTE: new value has no owner
-				Owner: nil,
+				Owner:    nil,
+				modified: true,
 			}
 
 			invocation.Self = value
@@ -3148,6 +3149,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 	self := &CompositeValue{
 		Location: interpreter.Checker.Location,
 		Fields:   map[string]Value{},
+		modified: true,
 	}
 
 	transactionFunction := NewHostFunctionValue(

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3749,8 +3749,6 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 				Authorized:           referenceType.Authorized,
 				TargetStorageAddress: address,
 				TargetKey:            key,
-				// NOTE: new value has no owner
-				Owner: nil,
 			}
 
 			return Done{Result: NewSomeValueOwningNonCopying(reference)}
@@ -3913,8 +3911,6 @@ func (interpreter *Interpreter) capabilityBorrowFunction(addressValue AddressVal
 			Authorized:           authorized,
 			TargetStorageAddress: address,
 			TargetKey:            targetStorageKey,
-			// NOTE: new value has no owner
-			Owner: nil,
 		}
 
 		return Done{Result: NewSomeValueOwningNonCopying(reference)}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -376,6 +376,8 @@ func (v *ArrayValue) GetOwner() *common.Address {
 }
 
 func (v *ArrayValue) SetOwner(owner *common.Address) {
+	v.modified = true
+
 	if v.Owner == owner {
 		return
 	}
@@ -4467,6 +4469,8 @@ func (v *CompositeValue) GetOwner() *common.Address {
 }
 
 func (v *CompositeValue) SetOwner(owner *common.Address) {
+	v.modified = true
+
 	if v.Owner == owner {
 		return
 	}
@@ -4685,6 +4689,8 @@ func (v *DictionaryValue) GetOwner() *common.Address {
 }
 
 func (v *DictionaryValue) SetOwner(owner *common.Address) {
+	v.modified = true
+
 	if v.Owner == owner {
 		return
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -322,6 +322,10 @@ func (*StringValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 	panic(errors.NewUnreachableError())
 }
 
+func (v *StringValue) SetModified(modified bool) {
+	v.modified = false
+}
+
 // ArrayValue
 
 type ArrayValue struct {
@@ -584,6 +588,10 @@ func (v *ArrayValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Valu
 
 func (v *ArrayValue) Count() int {
 	return len(v.Values)
+}
+
+func (v *ArrayValue) SetModified(modified bool) {
+	v.modified = modified
 }
 
 // NumberValue
@@ -4913,6 +4921,10 @@ func (v *DictionaryValue) Insert(keyValue Value, value Value) (existingValue Val
 	}
 
 	return existingValue
+}
+
+func (v *DictionaryValue) SetModified(modified bool) {
+	v.modified = modified
 }
 
 type DictionaryEntryValues struct {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -236,10 +236,13 @@ func (v *StringValue) Get(_ *Interpreter, _ LocationRange, key Value) Value {
 }
 
 func (v *StringValue) Set(_ *Interpreter, _ LocationRange, key Value, value Value) {
-	v.modified = true
+	index := key.(NumberValue).ToInt()
+	char := value.(*StringValue)
+	v.SetIndex(index, char)
+}
 
-	i := key.(NumberValue).ToInt()
-	char := value.(*StringValue).Str
+func (v *StringValue) SetIndex(index int, char *StringValue) {
+	v.modified = true
 
 	str := v.Str
 
@@ -247,7 +250,7 @@ func (v *StringValue) Set(_ *Interpreter, _ LocationRange, key Value, value Valu
 	graphemes := uniseg.NewGraphemes(str)
 	graphemes.Next()
 
-	for j := 0; j < i; j++ {
+	for j := 0; j < index; j++ {
 		graphemes.Next()
 	}
 
@@ -256,7 +259,7 @@ func (v *StringValue) Set(_ *Interpreter, _ LocationRange, key Value, value Valu
 	var sb strings.Builder
 
 	sb.WriteString(str[:start])
-	sb.WriteString(char)
+	sb.WriteString(char.Str)
 	sb.WriteString(str[end:])
 
 	v.Str = sb.String()
@@ -416,12 +419,14 @@ func (v *ArrayValue) Get(_ *Interpreter, _ LocationRange, key Value) Value {
 }
 
 func (v *ArrayValue) Set(_ *Interpreter, _ LocationRange, key Value, value Value) {
+	index := key.(NumberValue).ToInt()
+	v.SetIndex(index, value)
+}
+
+func (v *ArrayValue) SetIndex(index int, value Value) {
 	v.modified = true
-
 	value.SetOwner(v.Owner)
-
-	integerKey := key.(NumberValue).ToInt()
-	v.Values[integerKey] = value
+	v.Values[index] = value
 }
 
 func (v *ArrayValue) String() string {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4383,6 +4383,7 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, locationRange Locatio
 
 	return tramp.Then(func(_ interface{}) {
 		v.destroyed = true
+		v.modified = true
 	})
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -376,8 +376,6 @@ func (v *ArrayValue) GetOwner() *common.Address {
 }
 
 func (v *ArrayValue) SetOwner(owner *common.Address) {
-	v.modified = true
-
 	if v.Owner == owner {
 		return
 	}
@@ -4469,8 +4467,6 @@ func (v *CompositeValue) GetOwner() *common.Address {
 }
 
 func (v *CompositeValue) SetOwner(owner *common.Address) {
-	v.modified = true
-
 	if v.Owner == owner {
 		return
 	}
@@ -4689,8 +4685,6 @@ func (v *DictionaryValue) GetOwner() *common.Address {
 }
 
 func (v *DictionaryValue) SetOwner(owner *common.Address) {
-	v.modified = true
-
 	if v.Owner == owner {
 		return
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4804,7 +4804,6 @@ type StorageReferenceValue struct {
 	Authorized           bool
 	TargetStorageAddress common.Address
 	TargetKey            string
-	Owner                *common.Address
 }
 
 func (*StorageReferenceValue) IsValue() {}
@@ -4828,17 +4827,17 @@ func (v *StorageReferenceValue) Copy() Value {
 		Authorized:           v.Authorized,
 		TargetStorageAddress: v.TargetStorageAddress,
 		TargetKey:            v.TargetKey,
-		// NOTE: new value has no owner
-		Owner: nil,
 	}
 }
 
 func (v *StorageReferenceValue) GetOwner() *common.Address {
-	return v.Owner
+	// value is never owned
+	return nil
 }
 
-func (v *StorageReferenceValue) SetOwner(owner *common.Address) {
-	v.Owner = owner
+func (v *StorageReferenceValue) SetOwner(_ *common.Address) {
+	// NO-OP: value cannot be owned
+}
 }
 
 func (v *StorageReferenceValue) referencedValue(interpreter *Interpreter) *Value {

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -28,13 +28,13 @@ import (
 )
 
 func newTestCompositeValue(owner common.Address) *CompositeValue {
-	return &CompositeValue{
-		Location: utils.TestLocation,
-		TypeID:   "Test",
-		Kind:     common.CompositeKindStructure,
-		Fields:   map[string]Value{},
-		Owner:    &owner,
-	}
+	return NewCompositeValue(
+		utils.TestLocation,
+		"Test",
+		common.CompositeKindStructure,
+		map[string]Value{},
+		&owner,
+	)
 }
 
 func TestOwnerNewArray(t *testing.T) {

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -278,45 +278,6 @@ func TestSetOwnerSomeCopy(t *testing.T) {
 	assert.Equal(t, &newOwner, value.GetOwner())
 }
 
-func TestSetOwnerReference(t *testing.T) {
-	oldOwner := common.Address{0x1}
-	newOwner := common.Address{0x2}
-	targetAddress := common.Address{0x3}
-
-	reference := &StorageReferenceValue{
-		TargetStorageAddress: targetAddress,
-		TargetKey:            "Test",
-		Owner:                &oldOwner,
-	}
-
-	assert.Equal(t, &oldOwner, reference.GetOwner())
-
-	reference.SetOwner(&newOwner)
-
-	assert.Equal(t, &newOwner, reference.GetOwner())
-}
-
-func TestSetOwnerReferenceCopy(t *testing.T) {
-	oldOwner := common.Address{0x1}
-	newOwner := common.Address{0x2}
-	targetAddress := common.Address{0x3}
-
-	reference := &StorageReferenceValue{
-		TargetStorageAddress: targetAddress,
-		TargetKey:            "Test",
-		Owner:                &oldOwner,
-	}
-
-	assert.Equal(t, &oldOwner, reference.GetOwner())
-
-	reference.SetOwner(&newOwner)
-
-	referenceCopy := reference.Copy().(*StorageReferenceValue)
-
-	assert.Nil(t, referenceCopy.GetOwner())
-	assert.Equal(t, &newOwner, reference.GetOwner())
-}
-
 func TestOwnerNewComposite(t *testing.T) {
 	oldOwner := common.Address{0x1}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1235,6 +1235,10 @@ func (BlockValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
+func (BlockValue) Modified() bool {
+	return false
+}
+
 func (v BlockValue) GetMember(_ *interpreter.Interpreter, _ interpreter.LocationRange, name string) interpreter.Value {
 	switch name {
 	case "height":

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -32,6 +32,8 @@ type storageKey struct {
 }
 
 type cacheEntry struct {
+	// true indicates that the value definitely must be written, independent of the value.
+	// false indicates that the value may has to be written if the value is modified.
 	mustWrite bool
 	value     interpreter.Value
 }
@@ -202,7 +204,7 @@ func (s *interpreterRuntimeStorage) writeCached() {
 
 	for fullKey, entry := range s.cache {
 
-		if !entry.mustWrite && (entry.value == nil || !entry.value.Modified()) {
+		if !entry.mustWrite && entry.value != nil && !entry.value.Modified() {
 			continue
 		}
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -1228,7 +1228,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 
 						expectedValue := interpreter.NewDictionaryValueUnownedNonCopying(
 							interpreter.NewStringValue("test"), interpreter.NewIntValueFromInt64(42),
-						)
+						).Copy()
 
 						assert.Equal(t,
 							expectedValue,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7396,7 +7396,7 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 			),
 		)
 
-		test := inter.Globals["test"].Value
+		test := inter.Globals["test"].Value.(*interpreter.DictionaryValue)
 
 		owner := &common.Address{
 			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -7418,6 +7418,13 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 
 		decoded, err := decoder.Decode(owner)
 		require.NoError(t, err)
+
+		test.SetModified(false)
+		test.Keys.SetModified(false)
+		for _, key := range test.Keys.Values {
+			stringKey := key.(*interpreter.StringValue)
+			stringKey.SetModified(false)
+		}
 
 		require.Equal(t, test, decoded)
 	}


### PR DESCRIPTION
Work towards dapperlabs/flow-go#2884

Track modifications and only write values that are new or modified.
Also, storage references don't need an owner.