### PR TITLE
New Parser: Fix infix, add prefix

### DIFF
--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -19,6 +19,7 @@
 package lexer
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 
@@ -58,6 +59,15 @@ func Lex(input string) []Token {
 }
 
 func (l *lexer) run(state stateFn) {
+	defer func() {
+		if r := recover(); r != nil {
+			err, ok := r.(error)
+			if !ok {
+				err = fmt.Errorf("lexer: %v", r)
+			}
+			l.emitError(err)
+		}
+	}()
 	for state != nil {
 		state = state(l)
 	}
@@ -177,4 +187,10 @@ func (l *lexer) scanSpace() {
 	// lookahead is already lexed.
 	// parse more, if any
 	l.acceptZeroOrMore(" \t\n")
+}
+
+func (l *lexer) mustOne(r rune) {
+	if !l.acceptOne(r) {
+		panic(fmt.Errorf("expected character: %#U", r))
+	}
 }

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -19,6 +19,7 @@
 package lexer
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -269,6 +270,92 @@ func TestLex(t *testing.T) {
 				},
 			},
 			Lex("1 \n  2\n"),
+		)
+	})
+
+	t.Run("nil-coalesce", func(t *testing.T) {
+		assert.Equal(t,
+			[]Token{
+				{
+					Type:  TokenNumber,
+					Value: "1",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+					},
+				},
+				{
+					Type:  TokenSpace,
+					Value: " ",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+					},
+				},
+				{
+					Type: TokenOperatorNilCoalesce,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+						EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+				},
+				{
+					Type:  TokenSpace,
+					Value: " ",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+						EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
+					},
+				},
+				{
+					Type:  TokenNumber,
+					Value: "2",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
+						EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
+					},
+				},
+				{
+					Type: TokenEOF,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
+						EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
+					},
+				},
+			},
+			Lex("1 ?? 2"),
+		)
+	})
+
+	t.Run("invalid nil-coalesce", func(t *testing.T) {
+		assert.Equal(t,
+			[]Token{
+				{
+					Type:  TokenNumber,
+					Value: "1",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+					},
+				},
+				{
+					Type:  TokenSpace,
+					Value: " ",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+					},
+				},
+				{
+					Type:  TokenError,
+					Value: errors.New("expected character: U+003F '?'"),
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+						EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+					},
+				},
+			},
+			Lex("1 ?X"),
 		)
 	})
 }

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -42,6 +42,9 @@ func rootState(l *lexer) stateFn {
 		l.emitType(TokenOperatorMul)
 	case '%':
 		l.emitType(TokenOperatorDiv)
+	case '?':
+		l.mustOne('?')
+		l.emitType(TokenOperatorNilCoalesce)
 	case '(':
 		l.emitType(TokenParenOpen)
 	case ')':

--- a/runtime/parser2/lexer/tokentype.go
+++ b/runtime/parser2/lexer/tokentype.go
@@ -33,6 +33,7 @@ const (
 	TokenOperatorMinus
 	TokenOperatorMul
 	TokenOperatorDiv
+	TokenOperatorNilCoalesce
 	TokenParenOpen
 	TokenParenClose
 	TokenBraceOpen

--- a/runtime/parser2/lexer/tokentype_string.go
+++ b/runtime/parser2/lexer/tokentype_string.go
@@ -16,17 +16,18 @@ func _() {
 	_ = x[TokenOperatorMinus-5]
 	_ = x[TokenOperatorMul-6]
 	_ = x[TokenOperatorDiv-7]
-	_ = x[TokenParenOpen-8]
-	_ = x[TokenParenClose-9]
-	_ = x[TokenBraceOpen-10]
-	_ = x[TokenBraceClose-11]
-	_ = x[TokenBracketOpen-12]
-	_ = x[TokenBracketClose-13]
+	_ = x[TokenOperatorNilCoalesce-8]
+	_ = x[TokenParenOpen-9]
+	_ = x[TokenParenClose-10]
+	_ = x[TokenBraceOpen-11]
+	_ = x[TokenBraceClose-12]
+	_ = x[TokenBracketOpen-13]
+	_ = x[TokenBracketClose-14]
 }
 
-const _TokenType_name = "ErrorEOFSpaceNumberOperatorPlusOperatorMinusOperatorMulOperatorDivParenOpenParenCloseBraceOpenBraceCloseBracketOpenBracketClose"
+const _TokenType_name = "ErrorEOFSpaceNumberOperatorPlusOperatorMinusOperatorMulOperatorDivOperatorNilCoalesceParenOpenParenCloseBraceOpenBraceCloseBracketOpenBracketClose"
 
-var _TokenType_index = [...]uint8{0, 5, 8, 13, 19, 31, 44, 55, 66, 75, 85, 94, 104, 115, 127}
+var _TokenType_index = [...]uint8{0, 5, 8, 13, 19, 31, 44, 55, 66, 85, 94, 104, 113, 123, 134, 146}
 
 func (i TokenType) String() string {
 	if i >= TokenType(len(_TokenType_index)-1) {

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -19,7 +19,6 @@
 package parser2
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/cadence/runtime/ast"
@@ -31,7 +30,6 @@ type parser struct {
 	current lexer.Token
 	pos     int
 	errors  []error
-	atEnd   bool
 }
 
 func Parse(input string) (ast.Expression, []error) {
@@ -56,10 +54,6 @@ func (p *parser) report(err error) {
 
 func (p *parser) next() {
 	p.pos++
-	p.atEnd = p.pos >= len(p.tokens)
-	if p.atEnd {
-		p.report(errors.New("unexpected end of expression"))
-	}
 	p.current = p.tokens[p.pos]
 }
 

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -68,4 +68,91 @@ func TestParseExpression(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("repeated infix, same operator, left associative", func(t *testing.T) {
+		result, errors := Parse("1 + 2 + 3")
+		require.Empty(t, errors)
+
+		assert.Equal(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationPlus,
+				Left: &ast.BinaryExpression{
+					Operation: ast.OperationPlus,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(2),
+						Base:  10,
+					},
+				},
+				Right: &ast.IntegerExpression{
+					Value: big.NewInt(3),
+					Base:  10,
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("repeated infix, same operator, right associative", func(t *testing.T) {
+		result, errors := Parse("1 ?? 2 ?? 3")
+		require.Empty(t, errors)
+
+		assert.Equal(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationNilCoalesce,
+				Left: &ast.IntegerExpression{
+					Value: big.NewInt(1),
+					Base:  10,
+				},
+				Right: &ast.BinaryExpression{
+					Operation: ast.OperationNilCoalesce,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(2),
+						Base:  10,
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(3),
+						Base:  10,
+					},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("mixed infix and prefix", func(t *testing.T) {
+		result, errors := Parse("1 +- 2 ++ 3")
+		require.Empty(t, errors)
+
+		assert.Equal(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationPlus,
+				Left: &ast.BinaryExpression{
+					Operation: ast.OperationPlus,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+					},
+					Right: &ast.UnaryExpression{
+						Operation: ast.OperationMinus,
+						Expression: &ast.IntegerExpression{
+							Value: big.NewInt(2),
+							Base:  10,
+						},
+					},
+				},
+				Right: &ast.UnaryExpression{
+					Operation: ast.OperationPlus,
+					Expression: &ast.IntegerExpression{
+						Value: big.NewInt(3),
+						Base:  10,
+					},
+				},
+			},
+			result,
+		)
+	})
 }


### PR DESCRIPTION
Work towards dapperlabs/flow-go#2193

- Fix infix operators: don't cache current token, as null denotation might affect current token
  (https://github.com/onflow/cadence/pull/65/files#diff-dc3156241c5da3fc88bf5e2220db331aL152-R238)
- Add support for prefix operators