### PR TITLE
Fix flow.AccountCodeUpdated event

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -673,6 +673,18 @@ func (r *interpreterRuntime) emitAccountEvent(
 		Fields: eventFields,
 	}
 
+	actualLen := len(eventFields)
+	expectedLen := len(eventType.ConstructorParameters)
+
+	if actualLen != expectedLen {
+		panic(fmt.Errorf(
+			"event emission value mismatch: event %s: expected %d, got %d",
+			eventType.QualifiedString(),
+			expectedLen,
+			actualLen,
+		))
+	}
+
 	runtimeInterface.EmitEvent(exportEvent(eventValue))
 }
 

--- a/runtime/stdlib/flow_builtin.go
+++ b/runtime/stdlib/flow_builtin.go
@@ -249,7 +249,6 @@ var AccountCodeUpdatedEventType = newFlowEventType(
 	"AccountCodeUpdated",
 	AccountEventAddressParameter,
 	AccountEventCodeHashParameter,
-	AccountEventPublicKeyParameter,
 	AccountEventContractsParameter,
 )
 


### PR DESCRIPTION
The `flow.AccountCodeUpdated` with the correct values, but the type was incorrect, so decoding failed.

Remove the superfluous parameter from the type.