### PR TITLE
Report elapsed durations instead of start and end timestamp 

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -63,11 +63,11 @@ type Interface interface {
 }
 
 type Metrics interface {
-	ProgramParsed(start, end time.Time)
-	ProgramChecked(start, end time.Time)
-	ProgramInterpreted(start, end time.Time)
-	ValueEncoded(start, end time.Time)
-	ValueDecoded(start, end time.Time)
+	ProgramParsed(duration time.Duration)
+	ProgramChecked(duration time.Duration)
+	ProgramInterpreted(duration time.Duration)
+	ValueEncoded(duration time.Duration)
+	ValueDecoded(duration time.Duration)
 }
 
 type EmptyRuntimeInterface struct{}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -91,7 +91,7 @@ func validTopLevelDeclarations(location ast.Location) []common.DeclarationKind {
 func reportMetric(
 	f func(),
 	runtimeInterface Interface,
-	report func(metrics Metrics, start, end time.Time),
+	report func(Metrics, time.Duration),
 ) {
 	metrics, ok := runtimeInterface.(Metrics)
 	if !ok {
@@ -101,9 +101,9 @@ func reportMetric(
 
 	start := time.Now()
 	f()
-	end := time.Now()
+	elapsed := time.Since(start)
 
-	report(metrics, start, end)
+	report(metrics, elapsed)
 }
 
 const contractKey = "contract"
@@ -188,8 +188,8 @@ func (r *interpreterRuntime) interpret(
 			result, err = f(inter)
 		},
 		runtimeInterface,
-		func(metrics Metrics, start, end time.Time) {
-			metrics.ProgramInterpreted(start, end)
+		func(metrics Metrics, duration time.Duration) {
+			metrics.ProgramInterpreted(duration)
 		},
 	)
 
@@ -392,8 +392,8 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 			err = checker.Check()
 		},
 		runtimeInterface,
-		func(metrics Metrics, start, end time.Time) {
-			metrics.ProgramChecked(start, end)
+		func(metrics Metrics, duration time.Duration) {
+			metrics.ProgramChecked(duration)
 		},
 	)
 	if err != nil {
@@ -634,8 +634,8 @@ func (r *interpreterRuntime) parse(script []byte, runtimeInterface Interface) (p
 			program, _, err = parser.ParseProgram(string(script))
 		},
 		runtimeInterface,
-		func(metrics Metrics, start, end time.Time) {
-			metrics.ProgramParsed(start, end)
+		func(metrics Metrics, duration time.Duration) {
+			metrics.ProgramParsed(duration)
 		},
 	)
 

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -132,8 +132,8 @@ func (s *interpreterRuntimeStorage) readValue(
 			storedValue, err = interpreter.DecodeValue(storedData, &address)
 		},
 		s.runtimeInterface,
-		func(metrics Metrics, start, end time.Time) {
-			metrics.ValueDecoded(start, end)
+		func(metrics Metrics, duration time.Duration) {
+			metrics.ValueDecoded(duration)
 		},
 	)
 	if err != nil {
@@ -188,8 +188,8 @@ func (s *interpreterRuntimeStorage) writeCached() {
 					newData, err = interpreter.EncodeValue(value)
 				},
 				s.runtimeInterface,
-				func(metrics Metrics, start, end time.Time) {
-					metrics.ValueEncoded(start, end)
+				func(metrics Metrics, duration time.Duration) {
+					metrics.ValueEncoded(duration)
 				},
 			)
 			if err != nil {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -86,11 +86,11 @@ type testRuntimeInterface struct {
 	generateUUID       func() uint64
 	computationLimit   uint64
 	decodeArgument     func(b []byte, t cadence.Type) (cadence.Value, error)
-	programParsed      func(start, end time.Time)
-	programChecked     func(start, end time.Time)
-	programInterpreted func(start, end time.Time)
-	valueEncoded       func(start, end time.Time)
-	valueDecoded       func(start, end time.Time)
+	programParsed      func(duration time.Duration)
+	programChecked     func(duration time.Duration)
+	programInterpreted func(duration time.Duration)
+	valueEncoded       func(duration time.Duration)
+	valueDecoded       func(duration time.Duration)
 }
 
 func (i *testRuntimeInterface) ResolveImport(location Location) ([]byte, error) {
@@ -173,39 +173,39 @@ func (i *testRuntimeInterface) DecodeArgument(b []byte, t cadence.Type) (cadence
 	return i.decodeArgument(b, t)
 }
 
-func (i *testRuntimeInterface) ProgramParsed(start, end time.Time) {
+func (i *testRuntimeInterface) ProgramParsed(duration time.Duration) {
 	if i.programParsed == nil {
 		return
 	}
-	i.programParsed(start, end)
+	i.programParsed(duration)
 }
 
-func (i *testRuntimeInterface) ProgramChecked(start, end time.Time) {
+func (i *testRuntimeInterface) ProgramChecked(duration time.Duration) {
 	if i.programChecked == nil {
 		return
 	}
-	i.programChecked(start, end)
+	i.programChecked(duration)
 }
 
-func (i *testRuntimeInterface) ProgramInterpreted(start, end time.Time) {
+func (i *testRuntimeInterface) ProgramInterpreted(duration time.Duration) {
 	if i.programInterpreted == nil {
 		return
 	}
-	i.programInterpreted(start, end)
+	i.programInterpreted(duration)
 }
 
-func (i *testRuntimeInterface) ValueEncoded(start, end time.Time) {
+func (i *testRuntimeInterface) ValueEncoded(duration time.Duration) {
 	if i.valueEncoded == nil {
 		return
 	}
-	i.valueEncoded(start, end)
+	i.valueEncoded(duration)
 }
 
-func (i *testRuntimeInterface) ValueDecoded(start, end time.Time) {
+func (i *testRuntimeInterface) ValueDecoded(duration time.Duration) {
 	if i.valueDecoded == nil {
 		return
 	}
-	i.valueDecoded(start, end)
+	i.valueDecoded(duration)
 }
 
 func TestRuntimeImport(t *testing.T) {
@@ -3341,19 +3341,19 @@ func TestRuntimeMetrics(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{{42}}
 		},
-		programParsed: func(start, end time.Time) {
+		programParsed: func(duration time.Duration) {
 			programParsedReports++
 		},
-		programChecked: func(start, end time.Time) {
+		programChecked: func(duration time.Duration) {
 			programCheckedReports++
 		},
-		programInterpreted: func(start, end time.Time) {
+		programInterpreted: func(duration time.Duration) {
 			programInterpretedReports++
 		},
-		valueEncoded: func(start, end time.Time) {
+		valueEncoded: func(duration time.Duration) {
 			valueEncodedReports++
 		},
-		valueDecoded: func(start, end time.Time) {
+		valueDecoded: func(duration time.Duration) {
 			valueDecodedReports++
 		},
 	}


### PR DESCRIPTION
This reverts commit 9d185258dd2a4e7e3cc844c39dd418cb59125a8b.
