### PR TITLE
New Parser: Fix end positions of tokens, add position info to expressions

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -463,7 +463,7 @@ func (e *ConditionalExpression) EndPosition() Position {
 type UnaryExpression struct {
 	Operation  Operation
 	Expression Expression
-	Range
+	StartPos   Position
 }
 
 func (*UnaryExpression) isExpression() {}
@@ -483,6 +483,14 @@ func (e *UnaryExpression) String() string {
 		"%s%s",
 		e.Operation.Symbol(), e.Expression,
 	)
+}
+
+func (e *UnaryExpression) StartPosition() Position {
+	return e.StartPos
+}
+
+func (e *UnaryExpression) EndPosition() Position {
+	return e.Expression.EndPosition()
 }
 
 // BinaryExpression

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1751,10 +1751,7 @@ func (interpreter *Interpreter) VisitUnaryExpression(expression *ast.UnaryExpres
 			panic(&unsupportedOperation{
 				kind:      common.OperationKindUnary,
 				operation: expression.Operation,
-				Range: ast.Range{
-					StartPos: expression.StartPos,
-					EndPos:   expression.EndPos,
-				},
+				Range:     ast.NewRangeFromPositioned(expression),
 			})
 		})
 }

--- a/runtime/parser/program_visitor.go
+++ b/runtime/parser/program_visitor.go
@@ -1519,15 +1519,11 @@ func (v *ProgramVisitor) VisitUnaryExpression(ctx *UnaryExpressionContext) inter
 	operation := ctx.UnaryOp(0).Accept(v).(ast.Operation)
 
 	startPosition := PositionFromToken(ctx.GetStart())
-	endPosition := expression.EndPosition()
 
 	return &ast.UnaryExpression{
 		Operation:  operation,
 		Expression: expression,
-		Range: ast.Range{
-			StartPos: startPosition,
-			EndPos:   endPosition,
-		},
+		StartPos:   startPosition,
 	}
 }
 

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -49,7 +49,7 @@ func TestLex(t *testing.T) {
 						Value: "0",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
@@ -74,7 +74,7 @@ func TestLex(t *testing.T) {
 						Value: "01",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
 						},
 					},
 					{
@@ -100,7 +100,7 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
@@ -108,7 +108,7 @@ func TestLex(t *testing.T) {
 						Value: "01",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
 						},
 					},
 					{
@@ -116,7 +116,7 @@ func TestLex(t *testing.T) {
 						Value: "\t  ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
-							EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
+							EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
 						},
 					},
 					{
@@ -124,7 +124,7 @@ func TestLex(t *testing.T) {
 						Value: "10",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
-							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+							EndPos:   ast.Position{Line: 1, Column: 7, Offset: 7},
 						},
 					},
 					{
@@ -148,7 +148,7 @@ func TestLex(t *testing.T) {
 						Type: TokenParenOpen,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
@@ -156,7 +156,7 @@ func TestLex(t *testing.T) {
 						Value: "2",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
 						},
 					},
 					{
@@ -164,14 +164,14 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
 						},
 					},
 					{
 						Type: TokenPlus,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
-							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
 						},
 					},
 					{
@@ -179,7 +179,7 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
-							EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
 						},
 					},
 					{
@@ -187,14 +187,14 @@ func TestLex(t *testing.T) {
 						Value: "3",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
-							EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
+							EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
 						},
 					},
 					{
 						Type: TokenParenClose,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
-							EndPos:   ast.Position{Line: 1, Column: 7, Offset: 7},
+							EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
 						},
 					},
 					{
@@ -202,14 +202,14 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 7, Offset: 7},
-							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+							EndPos:   ast.Position{Line: 1, Column: 7, Offset: 7},
 						},
 					},
 					{
 						Type: TokenStar,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
-							EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
+							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
 						},
 					},
 					{
@@ -217,7 +217,7 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 9, Offset: 9},
-							EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
+							EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
 						},
 					},
 					{
@@ -225,7 +225,7 @@ func TestLex(t *testing.T) {
 						Value: "4",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 10, Offset: 10},
-							EndPos:   ast.Position{Line: 1, Column: 11, Offset: 11},
+							EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
 						},
 					},
 					{
@@ -249,7 +249,7 @@ func TestLex(t *testing.T) {
 						Type: TokenParenOpen,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
@@ -257,7 +257,7 @@ func TestLex(t *testing.T) {
 						Value: "2",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
 						},
 					},
 					{
@@ -265,14 +265,14 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
 						},
 					},
 					{
 						Type: TokenMinus,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
-							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
 						},
 					},
 					{
@@ -280,7 +280,7 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
-							EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
 						},
 					},
 					{
@@ -288,14 +288,14 @@ func TestLex(t *testing.T) {
 						Value: "3",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
-							EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
+							EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
 						},
 					},
 					{
 						Type: TokenParenClose,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
-							EndPos:   ast.Position{Line: 1, Column: 7, Offset: 7},
+							EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
 						},
 					},
 					{
@@ -303,14 +303,14 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 7, Offset: 7},
-							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+							EndPos:   ast.Position{Line: 1, Column: 7, Offset: 7},
 						},
 					},
 					{
 						Type: TokenSlash,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
-							EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
+							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
 						},
 					},
 					{
@@ -318,7 +318,7 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 9, Offset: 9},
-							EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
+							EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
 						},
 					},
 					{
@@ -326,7 +326,7 @@ func TestLex(t *testing.T) {
 						Value: "4",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 10, Offset: 10},
-							EndPos:   ast.Position{Line: 1, Column: 11, Offset: 11},
+							EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
 						},
 					},
 					{
@@ -351,7 +351,7 @@ func TestLex(t *testing.T) {
 						Value: "1",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
@@ -359,7 +359,7 @@ func TestLex(t *testing.T) {
 						Value: " \n  ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 2, Column: 2, Offset: 5},
+							EndPos:   ast.Position{Line: 2, Column: 1, Offset: 4},
 						},
 					},
 					{
@@ -367,7 +367,7 @@ func TestLex(t *testing.T) {
 						Value: "2",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 2, Column: 2, Offset: 5},
-							EndPos:   ast.Position{Line: 2, Column: 3, Offset: 6},
+							EndPos:   ast.Position{Line: 2, Column: 2, Offset: 5},
 						},
 					},
 					{
@@ -375,7 +375,7 @@ func TestLex(t *testing.T) {
 						Value: "\n",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 2, Column: 3, Offset: 6},
-							EndPos:   ast.Position{Line: 3, Column: 0, Offset: 7},
+							EndPos:   ast.Position{Line: 2, Column: 3, Offset: 6},
 						},
 					},
 					{
@@ -400,7 +400,7 @@ func TestLex(t *testing.T) {
 						Value: "1",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
@@ -408,14 +408,14 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
 						},
 					},
 					{
 						Type: TokenNilCoalesce,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
 						},
 					},
 					{
@@ -423,7 +423,7 @@ func TestLex(t *testing.T) {
 						Value: " ",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
-							EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
 						},
 					},
 					{
@@ -431,7 +431,7 @@ func TestLex(t *testing.T) {
 						Value: "2",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
-							EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
+							EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
 						},
 					},
 					{
@@ -456,7 +456,7 @@ func TestLex(t *testing.T) {
 						Value: "test",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
 						},
 					},
 					{
@@ -481,7 +481,7 @@ func TestLex(t *testing.T) {
 						Value: "_test_123",
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
+							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
 						},
 					},
 					{
@@ -505,21 +505,21 @@ func TestLex(t *testing.T) {
 						Type: TokenColon,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
 						Type: TokenComma,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
 						},
 					},
 					{
 						Type: TokenQuestionMark,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
 						},
 					},
 					{
@@ -543,21 +543,21 @@ func TestLex(t *testing.T) {
 						Type: TokenBracketOpen,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
 						Type: TokenBraceClose,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
 						},
 					},
 					{
 						Type: TokenBracketClose,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
 						},
 					},
 
@@ -565,7 +565,7 @@ func TestLex(t *testing.T) {
 						Type: TokenBraceOpen,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
-							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
 						},
 					},
 					{
@@ -589,21 +589,21 @@ func TestLex(t *testing.T) {
 						Type: TokenLess,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
 						},
 					},
 					{
 						Type: TokenGreater,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
 						},
 					},
 					{
 						Type: TokenLeftArrow,
 						Range: ast.Range{
 							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
 						},
 					},
 					{

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -22,39 +22,49 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestParseExpression(t *testing.T) {
-
-	expectedSimpleExpression := &ast.BinaryExpression{
-		Operation: ast.OperationPlus,
-		Left: &ast.IntegerExpression{
-			Value: big.NewInt(1),
-			Base:  10,
-		},
-		Right: &ast.BinaryExpression{
-			Operation: ast.OperationMul,
-			Left: &ast.IntegerExpression{
-				Value: big.NewInt(2),
-				Base:  10,
-			},
-			Right: &ast.IntegerExpression{
-				Value: big.NewInt(3),
-				Base:  10,
-			},
-		},
-	}
 
 	t.Run("simple, no spaces", func(t *testing.T) {
 		result, errors := Parse("1+2*3")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
-			expectedSimpleExpression,
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationPlus,
+				Left: &ast.IntegerExpression{
+					Value: big.NewInt(1),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+						EndPos:   ast.Position{Offset: 0, Line: 1, Column: 0},
+					},
+				},
+				Right: &ast.BinaryExpression{
+					Operation: ast.OperationMul,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(2),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+							EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+						},
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(3),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+							EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+						},
+					},
+				},
+			},
 			result,
 		)
 	})
@@ -63,8 +73,37 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("  1   +   2  *   3 ")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
-			expectedSimpleExpression,
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationPlus,
+				Left: &ast.IntegerExpression{
+					Value: big.NewInt(1),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+						EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+					},
+				},
+				Right: &ast.BinaryExpression{
+					Operation: ast.OperationMul,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(2),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 10, Line: 1, Column: 10},
+							EndPos:   ast.Position{Offset: 10, Line: 1, Column: 10},
+						},
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(3),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 17, Line: 1, Column: 17},
+							EndPos:   ast.Position{Offset: 17, Line: 1, Column: 17},
+						},
+					},
+				},
+			},
 			result,
 		)
 	})
@@ -73,7 +112,7 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("1 + 2 + 3")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationPlus,
 				Left: &ast.BinaryExpression{
@@ -81,15 +120,27 @@ func TestParseExpression(t *testing.T) {
 					Left: &ast.IntegerExpression{
 						Value: big.NewInt(1),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 0, Line: 1, Column: 0},
+						},
 					},
 					Right: &ast.IntegerExpression{
 						Value: big.NewInt(2),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+							EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+						},
 					},
 				},
 				Right: &ast.IntegerExpression{
 					Value: big.NewInt(3),
 					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 8, Line: 1, Column: 8},
+						EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},
+					},
 				},
 			},
 			result,
@@ -100,22 +151,34 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("1 ?? 2 ?? 3")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationNilCoalesce,
 				Left: &ast.IntegerExpression{
 					Value: big.NewInt(1),
 					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+						EndPos:   ast.Position{Offset: 0, Line: 1, Column: 0},
+					},
 				},
 				Right: &ast.BinaryExpression{
 					Operation: ast.OperationNilCoalesce,
 					Left: &ast.IntegerExpression{
 						Value: big.NewInt(2),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 5, Line: 1, Column: 5},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
 					},
 					Right: &ast.IntegerExpression{
 						Value: big.NewInt(3),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 10, Line: 1, Column: 10},
+							EndPos:   ast.Position{Offset: 10, Line: 1, Column: 10},
+						},
 					},
 				},
 			},
@@ -127,7 +190,7 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("1 +- 2 ++ 3")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationPlus,
 				Left: &ast.BinaryExpression{
@@ -135,13 +198,22 @@ func TestParseExpression(t *testing.T) {
 					Left: &ast.IntegerExpression{
 						Value: big.NewInt(1),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 0, Line: 1, Column: 0},
+						},
 					},
 					Right: &ast.UnaryExpression{
 						Operation: ast.OperationMinus,
 						Expression: &ast.IntegerExpression{
 							Value: big.NewInt(2),
 							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 5, Line: 1, Column: 5},
+								EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+							},
 						},
+						StartPos: ast.Position{Offset: 3, Line: 1, Column: 3},
 					},
 				},
 				Right: &ast.UnaryExpression{
@@ -149,7 +221,12 @@ func TestParseExpression(t *testing.T) {
 					Expression: &ast.IntegerExpression{
 						Value: big.NewInt(3),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 10, Line: 1, Column: 10},
+							EndPos:   ast.Position{Offset: 10, Line: 1, Column: 10},
+						},
 					},
+					StartPos: ast.Position{Offset: 8, Line: 1, Column: 8},
 				},
 			},
 			result,
@@ -160,7 +237,7 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("(1 + 2) * 3")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationMul,
 				Left: &ast.BinaryExpression{
@@ -168,15 +245,27 @@ func TestParseExpression(t *testing.T) {
 					Left: &ast.IntegerExpression{
 						Value: big.NewInt(1),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 1, Line: 1, Column: 1},
+							EndPos:   ast.Position{Offset: 1, Line: 1, Column: 1},
+						},
 					},
 					Right: &ast.IntegerExpression{
 						Value: big.NewInt(2),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 5, Line: 1, Column: 5},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
 					},
 				},
 				Right: &ast.IntegerExpression{
 					Value: big.NewInt(3),
 					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 10, Line: 1, Column: 10},
+						EndPos:   ast.Position{Offset: 10, Line: 1, Column: 10},
+					},
 				},
 			},
 			result,
@@ -187,7 +276,7 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("1 < 2 > 3")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationGreater,
 				Left: &ast.BinaryExpression{
@@ -195,15 +284,27 @@ func TestParseExpression(t *testing.T) {
 					Left: &ast.IntegerExpression{
 						Value: big.NewInt(1),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 0, Line: 1, Column: 0},
+						},
 					},
 					Right: &ast.IntegerExpression{
 						Value: big.NewInt(2),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+							EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+						},
 					},
 				},
 				Right: &ast.IntegerExpression{
 					Value: big.NewInt(3),
 					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 8, Line: 1, Column: 8},
+						EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},
+					},
 				},
 			},
 			result,
@@ -214,32 +315,56 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("[ 1,2 + 3, 4  ,  5 ]")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.ArrayExpression{
 				Values: []ast.Expression{
 					&ast.IntegerExpression{
 						Value: big.NewInt(1),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+							EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+						},
 					},
 					&ast.BinaryExpression{
 						Operation: ast.OperationPlus,
 						Left: &ast.IntegerExpression{
 							Value: big.NewInt(2),
 							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+								EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+							},
 						},
 						Right: &ast.IntegerExpression{
 							Value: big.NewInt(3),
 							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 8, Line: 1, Column: 8},
+								EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},
+							},
 						},
 					},
 					&ast.IntegerExpression{
 						Value: big.NewInt(4),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 11, Line: 1, Column: 11},
+							EndPos:   ast.Position{Offset: 11, Line: 1, Column: 11},
+						},
 					},
 					&ast.IntegerExpression{
 						Value: big.NewInt(5),
 						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 17, Line: 1, Column: 17},
+							EndPos:   ast.Position{Offset: 17, Line: 1, Column: 17},
+						},
 					},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+					EndPos:   ast.Position{Offset: 19, Line: 1, Column: 19},
 				},
 			},
 			result,
@@ -250,23 +375,35 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("{ 1:2 + 3, 4  :  5 }")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.DictionaryExpression{
 				Entries: []ast.Entry{
 					{
 						Key: &ast.IntegerExpression{
 							Value: big.NewInt(1),
 							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+								EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+							},
 						},
 						Value: &ast.BinaryExpression{
 							Operation: ast.OperationPlus,
 							Left: &ast.IntegerExpression{
 								Value: big.NewInt(2),
 								Base:  10,
+								Range: ast.Range{
+									StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+									EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+								},
 							},
 							Right: &ast.IntegerExpression{
 								Value: big.NewInt(3),
 								Base:  10,
+								Range: ast.Range{
+									StartPos: ast.Position{Offset: 8, Line: 1, Column: 8},
+									EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},
+								},
 							},
 						},
 					},
@@ -274,12 +411,24 @@ func TestParseExpression(t *testing.T) {
 						Key: &ast.IntegerExpression{
 							Value: big.NewInt(4),
 							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 11, Line: 1, Column: 11},
+								EndPos:   ast.Position{Offset: 11, Line: 1, Column: 11},
+							},
 						},
 						Value: &ast.IntegerExpression{
 							Value: big.NewInt(5),
 							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 17, Line: 1, Column: 17},
+								EndPos:   ast.Position{Offset: 17, Line: 1, Column: 17},
+							},
 						},
 					},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+					EndPos:   ast.Position{Offset: 19, Line: 1, Column: 19},
 				},
 			},
 			result,
@@ -290,17 +439,22 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("a + 3")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationPlus,
 				Left: &ast.IdentifierExpression{
 					Identifier: ast.Identifier{
 						Identifier: "a",
+						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
 				Right: &ast.IntegerExpression{
 					Value: big.NewInt(3),
 					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+						EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+					},
 				},
 			},
 			result,
@@ -311,10 +465,17 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("/foo/bar")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.PathExpression{
-				Domain:     ast.Identifier{Identifier: "foo"},
-				Identifier: ast.Identifier{Identifier: "bar"},
+				Domain: ast.Identifier{
+					Identifier: "foo",
+					Pos:        ast.Position{Offset: 1, Line: 1, Column: 1},
+				},
+				Identifier: ast.Identifier{
+					Identifier: "bar",
+					Pos:        ast.Position{Offset: 5, Line: 1, Column: 5},
+				},
+				StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
 			},
 			result,
 		)
@@ -324,32 +485,37 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("a ? b : c ? d : e")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.ConditionalExpression{
 				Test: &ast.IdentifierExpression{
 					Identifier: ast.Identifier{
 						Identifier: "a",
+						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
 				Then: &ast.IdentifierExpression{
 					Identifier: ast.Identifier{
 						Identifier: "b",
+						Pos:        ast.Position{Offset: 4, Line: 1, Column: 4},
 					},
 				},
 				Else: &ast.ConditionalExpression{
 					Test: &ast.IdentifierExpression{
 						Identifier: ast.Identifier{
 							Identifier: "c",
+							Pos:        ast.Position{Offset: 8, Line: 1, Column: 8},
 						},
 					},
 					Then: &ast.IdentifierExpression{
 						Identifier: ast.Identifier{
 							Identifier: "d",
+							Pos:        ast.Position{Offset: 12, Line: 1, Column: 12},
 						},
 					},
 					Else: &ast.IdentifierExpression{
 						Identifier: ast.Identifier{
 							Identifier: "e",
+							Pos:        ast.Position{Offset: 16, Line: 1, Column: 16},
 						},
 					},
 				},
@@ -362,32 +528,42 @@ func TestParseExpression(t *testing.T) {
 		result, errors := Parse("true + false")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationPlus,
 				Left: &ast.BoolExpression{
 					Value: true,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+						EndPos:   ast.Position{Offset: 3, Line: 1, Column: 3},
+					},
 				},
 				Right: &ast.BoolExpression{
 					Value: false,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 7, Line: 1, Column: 7},
+						EndPos:   ast.Position{Offset: 11, Line: 1, Column: 11},
+					},
 				},
 			},
 			result,
 		)
 	})
 
-	t.Run("move operator", func(t *testing.T) {
+	t.Run("move operator, nested", func(t *testing.T) {
 		result, errors := Parse("(<-x)")
 		require.Empty(t, errors)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.UnaryExpression{
 				Operation: ast.OperationMove,
 				Expression: &ast.IdentifierExpression{
 					Identifier: ast.Identifier{
 						Identifier: "x",
+						Pos:        ast.Position{Offset: 3, Line: 1, Column: 3},
 					},
 				},
+				StartPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 			},
 			result,
 		)

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -692,10 +692,7 @@ func TestParseUnaryExpression(t *testing.T) {
 					Pos:        Position{Offset: 17, Line: 2, Column: 16},
 				},
 			},
-			Range: Range{
-				StartPos: Position{Offset: 16, Line: 2, Column: 15},
-				EndPos:   Position{Offset: 19, Line: 2, Column: 18},
-			},
+			StartPos: Position{Offset: 16, Line: 2, Column: 15},
 		},
 		StartPos: Position{Offset: 6, Line: 2, Column: 5},
 	}
@@ -5390,10 +5387,7 @@ func TestParseMoveOperator(t *testing.T) {
 								Pos:        Position{Offset: 21, Line: 2, Column: 20},
 							},
 						},
-						Range: Range{
-							StartPos: Position{Offset: 19, Line: 2, Column: 18},
-							EndPos:   Position{Offset: 21, Line: 2, Column: 20},
-						},
+						StartPos: Position{Offset: 19, Line: 2, Column: 18},
 					},
 				},
 			},
@@ -7900,10 +7894,7 @@ func TestParsePreconditionWithUnaryNegation(t *testing.T) {
 								EndPos:   Position{Offset: 78, Line: 5, Column: 19},
 							},
 						},
-						Range: Range{
-							StartPos: Position{Offset: 73, Line: 5, Column: 14},
-							EndPos:   Position{Offset: 78, Line: 5, Column: 19},
-						},
+						StartPos: Position{Offset: 73, Line: 5, Column: 14},
 					},
 					Message: &StringExpression{
 						Value: "two",


### PR DESCRIPTION
Work towards dapperlabs/flow-go#2193

- Fix the end positions of tokens: Just like in the current parser, tokens' end position is inclusive.
- Add position information to the existing expressions
