### PR TITLE
New Parser: Add reference expression

### DIFF
--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -115,9 +115,6 @@ func parseVariableDeclaration(p *parser) *ast.VariableDeclaration {
 	p.skipSpaceAndComments(true)
 
 	value := parseExpression(p, lowestBindingPower)
-	if value == nil {
-		panic(fmt.Errorf("expected initial value for variable"))
-	}
 
 	// TODO: second transfer and value
 

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -885,22 +885,34 @@ func TestParseBlockComment(t *testing.T) {
 
 	t.Run("nested comment, nothing else", func(t *testing.T) {
 
-		result, errs := ParseExpression(" /* test  foo/* bar  */ asd*/ ")
+		result, errs := ParseExpression(" /* test  foo/* bar  */ asd*/ true")
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			&ast.BoolExpression{
+				Value: true,
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 30, Offset: 30},
+					EndPos:   ast.Position{Line: 1, Column: 33, Offset: 33},
+				},
+			},
 			result,
 		)
 	})
 
 	t.Run("two comments", func(t *testing.T) {
 
-		result, errs := ParseExpression(" /*test  foo*/ /* bar  */ ")
+		result, errs := ParseExpression(" /*test  foo*/ /* bar  */ true")
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			&ast.BoolExpression{
+				Value: true,
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 26, Offset: 26},
+					EndPos:   ast.Position{Line: 1, Column: 29, Offset: 29},
+				},
+			},
 			result,
 		)
 	})
@@ -975,4 +987,29 @@ func BenchmarkParseArray(b *testing.B) {
 			_, _, _ = oldParser.ParseExpression(lit)
 		}
 	})
+}
+
+func TestParseReference(t *testing.T) {
+
+	result, errs := ParseExpression("& t as T")
+	require.Empty(t, errs)
+
+	utils.AssertEqualWithDiff(t,
+		&ast.ReferenceExpression{
+			Expression: &ast.IdentifierExpression{
+				Identifier: ast.Identifier{
+					Identifier: "t",
+					Pos:        ast.Position{Line: 1, Column: 2, Offset: 2},
+				},
+			},
+			Type: &ast.NominalType{
+				Identifier: ast.Identifier{
+					Identifier: "T",
+					Pos:        ast.Position{Line: 1, Column: 7, Offset: 7},
+				},
+			},
+			StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+		},
+		result,
+	)
 }

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -37,6 +37,7 @@ const keywordNil = "nil"
 const keywordLet = "let"
 const keywordVar = "var"
 const keywordFun = "fun"
+const keywordAs = "as"
 
 const lowestBindingPower = 0
 

--- a/runtime/parser2/statement.go
+++ b/runtime/parser2/statement.go
@@ -19,8 +19,6 @@
 package parser2
 
 import (
-	"fmt"
-
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/parser2/lexer"
 )
@@ -74,13 +72,9 @@ func parseStatement(p *parser) ast.Statement {
 	}
 
 	expression := parseExpression(p, lowestBindingPower)
-	if expression != nil {
-		return &ast.ExpressionStatement{
-			Expression: expression,
-		}
+	return &ast.ExpressionStatement{
+		Expression: expression,
 	}
-
-	return nil
 }
 
 func parseReturnStatement(p *parser) *ast.ReturnStatement {
@@ -90,9 +84,12 @@ func parseReturnStatement(p *parser) *ast.ReturnStatement {
 	sawNewLine := p.skipSpaceAndComments(false)
 
 	var expression ast.Expression
-	if !sawNewLine {
-		expression = parseExpression(p, lowestBindingPower)
-		if expression != nil {
+	switch p.current.Type {
+	case lexer.TokenEOF, lexer.TokenSemicolon:
+		break
+	default:
+		if !sawNewLine {
+			expression = parseExpression(p, lowestBindingPower)
 			endPosition = expression.EndPosition()
 		}
 	}
@@ -133,14 +130,8 @@ func parseIfStatement(p *parser) *ast.IfStatement {
 		p.next()
 
 		expression := parseExpression(p, lowestBindingPower)
-		if expression == nil {
-			panic(fmt.Errorf("expected test expression"))
-		}
 
 		thenBlock := parseBlock(p)
-		if thenBlock == nil {
-			panic(fmt.Errorf("expected block for then branch"))
-		}
 
 		var elseBlock *ast.Block
 
@@ -155,9 +146,6 @@ func parseIfStatement(p *parser) *ast.IfStatement {
 				parseNested = true
 			} else {
 				elseBlock = parseBlock(p)
-				if elseBlock == nil {
-					panic(fmt.Errorf("expected block for else branch"))
-				}
 			}
 		}
 
@@ -197,14 +185,8 @@ func parseWhileStatement(p *parser) *ast.WhileStatement {
 	p.next()
 
 	expression := parseExpression(p, lowestBindingPower)
-	if expression == nil {
-		panic(fmt.Errorf("expected test expression"))
-	}
 
 	block := parseBlock(p)
-	if block == nil {
-		panic(fmt.Errorf("expected block for then branch"))
-	}
 
 	return &ast.WhileStatement{
 		Test:     expression,

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -474,9 +474,6 @@ func parseType(p *parser, rightBindingPower int) ast.Type {
 	p.next()
 
 	left := applyTypeNullDenotation(p, t)
-	if left == nil {
-		return nil
-	}
 
 	for rightBindingPower < typeLeftBindingPowers[p.current.Type] {
 		t = p.current
@@ -510,7 +507,7 @@ func applyTypeNullDenotation(p *parser, token lexer.Token) ast.Type {
 	tokenType := token.Type
 	nullDenotation, ok := typeNullDenotations[tokenType]
 	if !ok {
-		return nil
+		panic(fmt.Errorf("missing type null denotation for token %q", token.Type))
 	}
 	return nullDenotation(p, token)
 }
@@ -518,7 +515,7 @@ func applyTypeNullDenotation(p *parser, token lexer.Token) ast.Type {
 func applyTypeLeftDenotation(p *parser, token lexer.Token, left ast.Type) ast.Type {
 	leftDenotation, ok := typeLeftDenotations[token.Type]
 	if !ok {
-		panic(fmt.Errorf("missing left denotation for token %q", token.Type))
+		panic(fmt.Errorf("missing type left denotation for token %q", token.Type))
 	}
 	return leftDenotation(p, token, left)
 }


### PR DESCRIPTION
Work towards dapperlabs/flow-go#2193

Also improve expression and block parsing: Instead of returning `nil`, panic if no null denotation, i.e. no expression, can be found. It used to be that way, but when I added return statements I thought this "optionality" is required, though it is not. I fixed the return statement and removed all the unnecessary checks for the parsed expression/block to be nil.