### PR TITLE
Support member exprs in new parser

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -363,6 +363,7 @@ func init() {
 	definePathExpression()
 	defineConditionalExpression()
 	defineReferenceExpression()
+	defineMemberExpression()
 
 	setExprNullDenotation(lexer.TokenEOF, func(parser *parser, token lexer.Token) ast.Expression {
 		panic("expected expression")
@@ -556,6 +557,21 @@ func defineReferenceExpression() {
 				Expression: expression,
 				Type:       ty,
 				StartPos:   token.StartPos,
+			}
+		},
+	)
+}
+
+func defineMemberExpression() {
+	setExprLeftBindingPower(lexer.TokenDot, 140)
+	setExprLeftDenotation(
+		lexer.TokenDot,
+		func(p *parser, token lexer.Token, left ast.Expression) ast.Expression {
+			p.skipSpaceAndComments(true)
+			identifierToken := p.mustOne(lexer.TokenIdentifier)
+			return &ast.MemberExpression{
+				Expression: left,
+				Identifier: tokenToIdentifier(identifierToken),
 			}
 		},
 	)

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -568,10 +568,10 @@ func defineMemberExpression() {
 		lexer.TokenDot,
 		func(p *parser, token lexer.Token, left ast.Expression) ast.Expression {
 			p.skipSpaceAndComments(true)
-			identifierToken := p.mustOne(lexer.TokenIdentifier)
+			identifier := mustIdentifier(p)
 			return &ast.MemberExpression{
 				Expression: left,
-				Identifier: tokenToIdentifier(identifierToken),
+				Identifier: identifier,
 			}
 		},
 	)

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -563,7 +563,7 @@ func defineReferenceExpression() {
 }
 
 func defineMemberExpression() {
-	setExprLeftBindingPower(lexer.TokenDot, 140)
+	setExprLeftBindingPower(lexer.TokenDot, 150)
 	setExprLeftDenotation(
 		lexer.TokenDot,
 		func(p *parser, token lexer.Token, left ast.Expression) ast.Expression {

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -1131,6 +1131,77 @@ func TestInvocation(t *testing.T) {
 	})
 }
 
+func TestMemberExpression(t *testing.T) {
+	t.Run("member", func(t *testing.T) {
+		result, errors := ParseExpression("f.n")
+		require.Empty(t, errors)
+		assert.Equal(t,
+			&ast.MemberExpression{
+				Expression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "f",
+						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
+					},
+				},
+				Identifier: ast.Identifier{
+					Identifier: "n",
+					Pos:        ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
+			},
+			result,
+		)
+	})
+	t.Run("member, whitespace", func(t *testing.T) {
+		result, errors := ParseExpression("f .n")
+		require.Empty(t, errors)
+		assert.Equal(t,
+			&ast.MemberExpression{
+				Expression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "f",
+						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
+					},
+				},
+				Identifier: ast.Identifier{
+					Identifier: "n",
+					Pos:        ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
+			},
+			result,
+		)
+	})
+	t.Run("member, precedence", func(t *testing.T) {
+		result, errors := ParseExpression("3 * f.n")
+		require.Empty(t, errors)
+		assert.Equal(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationMul,
+				Left: &ast.IntegerExpression{
+					Value: big.NewInt(3),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+						EndPos:   ast.Position{Offset: 0, Line: 1, Column: 0},
+					},
+				},
+				Right: &ast.MemberExpression{
+					Expression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "f",
+							Pos:        ast.Position{Offset: 4, Line: 1, Column: 4},
+						},
+					},
+					Identifier: ast.Identifier{
+						Identifier: "n",
+						Pos:        ast.Position{Offset: 6, Line: 1, Column: 6},
+					},
+				},
+			},
+			result,
+		)
+	})
+}
+
 func TestParseBlockComment(t *testing.T) {
 
 	t.Run("nested comment, nothing else", func(t *testing.T) {


### PR DESCRIPTION
Work towards dapperlabs/flow-go#2193.

Handle member expressions, minding precedence. Includes test cases.

If you can think of other potentially relevant test cases let me know! Would be good to test with force unwrap when we have that one merged.