### PR TITLE
Defer resource dictionary values

### DIFF
--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -163,17 +163,17 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	// Dictionary keys should be written to separate storage keys
 
 	insertTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         let c = signer.borrow<&Test.C>(from: /storage/c)!
-	         c.rs["a"] <-! Test.createR(1)
-	         c.rs["b"] <-! Test.createR(2)
-	     }
-	  }
-	`)
+         prepare(signer: AuthAccount) {
+             let c = signer.borrow<&Test.C>(from: /storage/c)!
+             c.rs["a"] <-! Test.createR(1)
+             c.rs["b"] <-! Test.createR(2)
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	err = runtime.ExecuteTransaction(insertTx, nil, runtimeInterface, utils.TestLocation)
@@ -200,17 +200,17 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	// Reading a single key should only load that key once
 
 	readTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+         prepare(signer: AuthAccount) {
+             let c = signer.borrow<&Test.C>(from: /storage/c)!
              log(c.rs["b"]?.value)
              log(c.rs["b"]?.value)
-	     }
-	  }
-	`)
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	loggedMessages = nil
@@ -239,18 +239,18 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	// the single, associated storage key
 
 	updateTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+         prepare(signer: AuthAccount) {
+             let c = signer.borrow<&Test.C>(from: /storage/c)!
              c.rs["b"]?.increment()
 
              log(c.rs["b"]?.value)
-	     }
-	  }
-	`)
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	loggedMessages = nil
@@ -291,19 +291,19 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	// Replace the key with a different resource
 
 	replaceTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+         prepare(signer: AuthAccount) {
+             let c = signer.borrow<&Test.C>(from: /storage/c)!
              log(c.rs["b"]?.value)
              let existing <- c.rs["b"] <- Test.createR(4)
              destroy existing
              log(c.rs["b"]?.value)
-	     }
-	  }
-	`)
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	loggedMessages = nil
@@ -344,19 +344,19 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	// Remove the key
 
 	removeTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+         prepare(signer: AuthAccount) {
+             let c = signer.borrow<&Test.C>(from: /storage/c)!
              log(c.rs["b"]?.value)
              let existing <- c.rs["b"] <- nil
              destroy existing
              log(c.rs["b"]?.value)
-	     }
-	  }
-	`)
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	loggedMessages = nil
@@ -418,12 +418,12 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	// Replace the collection
 
 	destroyTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         if let c <- signer.load<@Test.C>(from: /storage/c) {
+         prepare(signer: AuthAccount) {
+             if let c <- signer.load<@Test.C>(from: /storage/c) {
                  // important: read "a", so the value is in the dictionary value,
                  // but the deferred storage key must still be removed
                  log(c.rs["a"]?.value)
@@ -431,11 +431,11 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
              }
 
              let c2 <- Test.createC()
-	         c2.rs["x"] <-! Test.createR(10)
+             c2.rs["x"] <-! Test.createR(10)
              signer.save(<-c2, to: /storage/c)
-	     }
-	  }
-	`)
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	loggedMessages = nil
@@ -630,19 +630,19 @@ func TestRuntimeStorageDeferredResourceDictionaryValuesNested(t *testing.T) {
 	// Dictionary keys should be written to separate storage keys
 
 	insertTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+         prepare(signer: AuthAccount) {
+             let c = signer.borrow<&Test.C>(from: /storage/c)!
              let c2 <- Test.createC2()
              c2.rs["a"] <-! Test.createR(1)
              c2.rs["b"] <-! Test.createR(2)
-	         c.c2s["x"] <-! c2
-	     }
-	  }
-	`)
+             c.c2s["x"] <-! c2
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	err = runtime.ExecuteTransaction(insertTx, nil, runtimeInterface, utils.TestLocation)
@@ -672,17 +672,17 @@ func TestRuntimeStorageDeferredResourceDictionaryValuesNested(t *testing.T) {
 	// Reading a single key should only load that key once
 
 	readTx := []byte(`
-	  import Test from 0xCADE
+      import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+         prepare(signer: AuthAccount) {
+             let c = signer.borrow<&Test.C>(from: /storage/c)!
              // TODO: use nested optional chaining
              log(c.c2s["x"]?.value(key: "b"))
-	     }
-	  }
-	`)
+         }
+      }
+    `)
 
 	clearReadsAndWrites()
 	loggedMessages = nil
@@ -778,7 +778,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValuesTransfer(t *testing.T) {
           prepare(signer1: AuthAccount, signer2: AuthAccount) {
               let c <- Test.createC()
               c.rs["a"] <-! Test.createR(1)
-	          c.rs["b"] <-! Test.createR(2)
+              c.rs["b"] <-! Test.createR(2)
               signer1.save(<-c, to: /storage/c)
           }
        }
@@ -881,17 +881,17 @@ func TestRuntimeStorageDeferredResourceDictionaryValuesTransfer(t *testing.T) {
 	// Transfer
 
 	transferTx := []byte(`
-	 import Test from 0x1
+     import Test from 0x1
 
-	 transaction {
+     transaction {
 
-	    prepare(signer1: AuthAccount, signer2: AuthAccount) {
-	        let c <- signer1.load<@Test.C>(from: /storage/c) ?? panic("missing C")
+        prepare(signer1: AuthAccount, signer2: AuthAccount) {
+            let c <- signer1.load<@Test.C>(from: /storage/c) ?? panic("missing C")
             c.rs["x"] <-! Test.createR(42)
-	        signer2.save(<-c, to: /storage/c2)
-	    }
-	 }
-	`)
+            signer2.save(<-c, to: /storage/c2)
+        }
+     }
+    `)
 
 	clearReadsAndWrites()
 	loggedMessages = nil

--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -1,0 +1,713 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
+
+	runtime := NewInterpreterRuntime()
+
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
+
+	contract := []byte(`
+      pub contract Test {
+
+          pub resource R {
+
+              pub var value: Int
+
+              init(_ value: Int) {
+                  self.value = value
+              }
+
+              pub fun increment() {
+                  self.value = self.value + 1
+              }
+          }
+
+          pub fun createR(_ value: Int): @R {
+              return <-create R(value)
+          }
+
+          pub resource C {
+
+              pub let rs: @{String: R}
+
+              init() {
+                  self.rs <- {}
+              }
+
+              destroy() {
+                  destroy self.rs
+              }
+          }
+
+          pub fun createC(): @C {
+              return <-create C()
+          }
+      }
+    `)
+
+	deploy := []byte(fmt.Sprintf(
+		`
+          transaction {
+
+              prepare(signer: AuthAccount) {
+                  signer.setCode(%s)
+              }
+          }
+        `,
+		ArrayValueFromBytes(contract).String(),
+	))
+
+	setupTx := []byte(`
+      import Test from 0xCADE
+
+       transaction {
+
+          prepare(signer: AuthAccount) {
+              signer.save(<-Test.createC(), to: /storage/c)
+          }
+       }
+    `)
+
+	var accountCode []byte
+	var events []cadence.Event
+	var loggedMessages []string
+	var reads []testRead
+	var writes []testWrite
+
+	onRead := func(controller, owner, key, value []byte) {
+		reads = append(reads, testRead{
+			controller,
+			owner,
+			key,
+		})
+	}
+
+	onWrite := func(controller, owner, key, value []byte) {
+		writes = append(writes, testWrite{
+			controller,
+			owner,
+			key,
+			value,
+		})
+	}
+
+	clearReadsAndWrites := func() {
+		writes = nil
+		reads = nil
+	}
+
+	runtimeInterface := &testRuntimeInterface{
+		resolveImport: func(_ Location) (bytes []byte, err error) {
+			return accountCode, nil
+		},
+		storage: newTestStorage(onRead, onWrite),
+		getSigningAccounts: func() []Address {
+			return []Address{common.BytesToAddress(addressValue.Bytes())}
+		},
+		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+			accountCode = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) {
+			events = append(events, event)
+		},
+		log: func(message string) {
+			loggedMessages = append(loggedMessages, message)
+		},
+	}
+
+	clearReadsAndWrites()
+	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.NotNil(t, accountCode)
+
+	assert.Len(t, writes, 1)
+
+	clearReadsAndWrites()
+	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Len(t, writes, 1)
+
+	// Dictionary keys should be written to separate storage keys
+
+	insertTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+	         c.rs["a"] <-! Test.createR(1)
+	         c.rs["b"] <-! Test.createR(2)
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	err = runtime.ExecuteTransaction(insertTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	cStorageKey := []byte("storage\x1fc")
+	aStorageKey := []byte("storage\x1fc\x1frs\x1fv\x1fa")
+	bStorageKey := []byte("storage\x1fc\x1frs\x1fv\x1fb")
+
+	// writes can be out of order
+	assert.ElementsMatch(t,
+		[][]byte{
+			cStorageKey,
+			aStorageKey,
+			bStorageKey,
+		},
+		[][]byte{
+			writes[0].key,
+			writes[1].key,
+			writes[2].key,
+		},
+	)
+
+	// Reading a single key should only load that key once
+
+	readTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+             log(c.rs["b"]?.value)
+             log(c.rs["b"]?.value)
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"2", "2"}, loggedMessages)
+
+	assert.Len(t, writes, 0)
+	require.Len(t, reads, 3)
+	assert.Equal(t,
+		[]byte(contractKey),
+		reads[0].key,
+	)
+	assert.Equal(t,
+		cStorageKey,
+		reads[1].key,
+	)
+	assert.Equal(t,
+		bStorageKey,
+		reads[2].key,
+	)
+
+	// Updating a value of a single key should only update
+	// the single, associated storage key
+
+	updateTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+             c.rs["b"]?.increment()
+
+             log(c.rs["b"]?.value)
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(updateTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"3"}, loggedMessages)
+
+	// TODO: optimize: only value has changed, dictionary itself did not
+
+	// writes can be out of order
+	assert.ElementsMatch(t,
+		[][]byte{
+			cStorageKey,
+			bStorageKey,
+		},
+		[][]byte{
+			writes[0].key,
+			writes[1].key,
+		},
+	)
+
+	require.Len(t, reads, 3)
+	assert.Equal(t,
+		[]byte(contractKey),
+		reads[0].key,
+	)
+	assert.Equal(t,
+		cStorageKey,
+		reads[1].key,
+	)
+	assert.Equal(t,
+		bStorageKey,
+		reads[2].key,
+	)
+
+	// Replace the key with a different resource
+
+	replaceTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+             log(c.rs["b"]?.value)
+             let existing <- c.rs["b"] <- Test.createR(4)
+             destroy existing
+             log(c.rs["b"]?.value)
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(replaceTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"3", "4"}, loggedMessages)
+
+	// TODO: optimize: only value has changed, dictionary itself did not
+
+	// writes can be out of order
+	assert.ElementsMatch(t,
+		[][]byte{
+			cStorageKey,
+			bStorageKey,
+		},
+		[][]byte{
+			writes[0].key,
+			writes[1].key,
+		},
+	)
+
+	require.Len(t, reads, 3)
+	assert.Equal(t,
+		[]byte(contractKey),
+		reads[0].key,
+	)
+	assert.Equal(t,
+		cStorageKey,
+		reads[1].key,
+	)
+	assert.Equal(t,
+		bStorageKey,
+		reads[2].key,
+	)
+
+	// Remove the key
+
+	removeTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+             log(c.rs["b"]?.value)
+             let existing <- c.rs["b"] <- nil
+             destroy existing
+             log(c.rs["b"]?.value)
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(removeTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"4", "nil"}, loggedMessages)
+
+	// TODO: optimize: only value has changed, dictionary itself did not
+
+	// writes can be out of order
+	assert.ElementsMatch(t,
+		[][]byte{
+			cStorageKey,
+			bStorageKey,
+		},
+		[][]byte{
+			writes[0].key,
+			writes[1].key,
+		},
+	)
+
+	require.Len(t, reads, 3)
+	assert.Equal(t,
+		[]byte(contractKey),
+		reads[0].key,
+	)
+	assert.Equal(t,
+		cStorageKey,
+		reads[1].key,
+	)
+	assert.Equal(t,
+		bStorageKey,
+		reads[2].key,
+	)
+
+	// Read the deleted key
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"nil", "nil"}, loggedMessages)
+
+	assert.Len(t, writes, 0)
+	require.Len(t, reads, 2)
+	assert.Equal(t,
+		[]byte(contractKey),
+		reads[0].key,
+	)
+	assert.Equal(t,
+		cStorageKey,
+		reads[1].key,
+	)
+
+	// Replace the collection
+
+	destroyTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         if let c <- signer.load<@Test.C>(from: /storage/c) {
+                 // important: read "a", so the value is in the dictionary value,
+                 // but the deferred storage key must still be removed
+                 log(c.rs["a"]?.value)
+                 destroy c
+             }
+
+             let c2 <- Test.createC()
+	         c2.rs["x"] <-! Test.createR(10)
+             signer.save(<-c2, to: /storage/c)
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(destroyTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"1"}, loggedMessages)
+
+	xStorageKey := []byte("storage\x1fc\x1frs\x1fv\x1fx")
+
+	// writes can be out of order
+	assert.ElementsMatch(t,
+		[][]byte{
+			cStorageKey,
+			aStorageKey,
+			xStorageKey,
+		},
+		[][]byte{
+			writes[0].key,
+			writes[1].key,
+			writes[2].key,
+		},
+	)
+
+	require.Len(t, reads, 3)
+	assert.Equal(t,
+		[]byte(contractKey),
+		reads[0].key,
+	)
+	assert.Equal(t,
+		cStorageKey,
+		reads[1].key,
+	)
+	assert.Equal(t,
+		aStorageKey,
+		reads[2].key,
+	)
+}
+
+func TestRuntimeStorageDeferredResourceDictionaryValuesNested(t *testing.T) {
+
+	runtime := NewInterpreterRuntime()
+
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
+
+	contract := []byte(`
+      pub contract Test {
+
+          pub resource R {
+
+              pub var value: Int
+
+              init(_ value: Int) {
+                  self.value = value
+              }
+
+              pub fun increment() {
+                  self.value = self.value + 1
+              }
+          }
+
+          pub fun createR(_ value: Int): @R {
+              return <-create R(value)
+          }
+
+          pub resource C2 {
+
+              pub let rs: @{String: R}
+
+              init() {
+                  self.rs <- {}
+              }
+
+              pub fun value(key: String): Int? {
+                  return self.rs[key]?.value
+              }
+
+              destroy() {
+                  destroy self.rs
+              }
+          }
+
+          pub fun createC2(): @C2 {
+              return <-create C2()
+          }
+
+          pub resource C {
+
+              pub let c2s: @{String: C2}
+
+              init() {
+                  self.c2s <- {}
+              }
+
+              destroy() {
+                  destroy self.c2s
+              }
+          }
+
+          pub fun createC(): @C {
+              return <-create C()
+          }
+      }
+    `)
+
+	deploy := []byte(fmt.Sprintf(
+		`
+          transaction {
+
+              prepare(signer: AuthAccount) {
+                  signer.setCode(%s)
+              }
+          }
+        `,
+		ArrayValueFromBytes(contract).String(),
+	))
+
+	setupTx := []byte(`
+      import Test from 0xCADE
+
+       transaction {
+
+          prepare(signer: AuthAccount) {
+              signer.save(<-Test.createC(), to: /storage/c)
+          }
+       }
+    `)
+
+	var accountCode []byte
+	var events []cadence.Event
+	var loggedMessages []string
+	var reads []testRead
+	var writes []testWrite
+
+	onRead := func(controller, owner, key, value []byte) {
+		reads = append(reads, testRead{
+			controller,
+			owner,
+			key,
+		})
+	}
+
+	onWrite := func(controller, owner, key, value []byte) {
+		writes = append(writes, testWrite{
+			controller,
+			owner,
+			key,
+			value,
+		})
+	}
+
+	clearReadsAndWrites := func() {
+		writes = nil
+		reads = nil
+	}
+
+	runtimeInterface := &testRuntimeInterface{
+		resolveImport: func(_ Location) (bytes []byte, err error) {
+			return accountCode, nil
+		},
+		storage: newTestStorage(onRead, onWrite),
+		getSigningAccounts: func() []Address {
+			return []Address{common.BytesToAddress(addressValue.Bytes())}
+		},
+		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+			accountCode = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) {
+			events = append(events, event)
+		},
+		log: func(message string) {
+			loggedMessages = append(loggedMessages, message)
+		},
+	}
+
+	clearReadsAndWrites()
+	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.NotNil(t, accountCode)
+
+	assert.Len(t, writes, 1)
+
+	clearReadsAndWrites()
+	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Len(t, writes, 1)
+
+	// Dictionary keys should be written to separate storage keys
+
+	insertTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+             let c2 <- Test.createC2()
+             c2.rs["a"] <-! Test.createR(1)
+             c2.rs["b"] <-! Test.createR(2)
+	         c.c2s["x"] <-! c2
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	err = runtime.ExecuteTransaction(insertTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	cStorageKey := []byte("storage\x1fc")
+	xStorageKey := []byte("storage\x1fc\x1fc2s\x1fv\x1fx")
+	aStorageKey := []byte("storage\x1fc\x1fc2s\x1fv\x1fx\x1frs\x1fv\x1fa")
+	bStorageKey := []byte("storage\x1fc\x1fc2s\x1fv\x1fx\x1frs\x1fv\x1fb")
+
+	// writes can be out of order
+	assert.ElementsMatch(t,
+		[][]byte{
+			cStorageKey,
+			xStorageKey,
+			aStorageKey,
+			bStorageKey,
+		},
+		[][]byte{
+			writes[0].key,
+			writes[1].key,
+			writes[2].key,
+			writes[3].key,
+		},
+	)
+
+	// Reading a single key should only load that key once
+
+	readTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	     prepare(signer: AuthAccount) {
+	         let c = signer.borrow<&Test.C>(from: /storage/c)!
+             // TODO: use nested optional chaining
+             log(c.c2s["x"]?.value(key: "b"))
+	     }
+	  }
+	`)
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"2"}, loggedMessages)
+
+	assert.Len(t, writes, 0)
+	require.Len(t, reads, 4)
+	assert.Equal(t,
+		[]byte(contractKey),
+		reads[0].key,
+	)
+	assert.Equal(t,
+		cStorageKey,
+		reads[1].key,
+	)
+	assert.Equal(t,
+		xStorageKey,
+		reads[2].key,
+	)
+	assert.Equal(t,
+		bStorageKey,
+		reads[3].key,
+	)
+}

--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -711,3 +711,209 @@ func TestRuntimeStorageDeferredResourceDictionaryValuesNested(t *testing.T) {
 		reads[3].key,
 	)
 }
+
+func TestRuntimeStorageDeferredResourceDictionaryValuesTransfer(t *testing.T) {
+
+	signer1 := common.BytesToAddress([]byte{0x1})
+	signer2 := common.BytesToAddress([]byte{0x2})
+
+	runtime := NewInterpreterRuntime()
+
+	contract := []byte(`
+      pub contract Test {
+
+          pub resource R {
+
+              pub var value: Int
+
+              init(_ value: Int) {
+                  self.value = value
+              }
+
+              pub fun increment() {
+                  self.value = self.value + 1
+              }
+          }
+
+          pub fun createR(_ value: Int): @R {
+              return <-create R(value)
+          }
+
+          pub resource C {
+
+              pub let rs: @{String: R}
+
+              init() {
+                  self.rs <- {}
+              }
+
+              destroy() {
+                  destroy self.rs
+              }
+          }
+
+          pub fun createC(): @C {
+              return <-create C()
+          }
+      }
+    `)
+
+	deploy := []byte(fmt.Sprintf(
+		`
+          transaction {
+
+              prepare(signer1: AuthAccount, signer2: AuthAccount) {
+                  signer1.setCode(%s)
+              }
+          }
+        `,
+		ArrayValueFromBytes(contract).String(),
+	))
+
+	setupTx := []byte(`
+      import Test from 0x1
+
+       transaction {
+
+          prepare(signer1: AuthAccount, signer2: AuthAccount) {
+              let c <- Test.createC()
+              c.rs["a"] <-! Test.createR(1)
+	          c.rs["b"] <-! Test.createR(2)
+              signer1.save(<-c, to: /storage/c)
+          }
+       }
+    `)
+
+	var accountCode []byte
+	var events []cadence.Event
+	var loggedMessages []string
+	var reads []testRead
+	var writes []testWrite
+
+	onRead := func(controller, owner, key, value []byte) {
+		reads = append(reads, testRead{
+			controller,
+			owner,
+			key,
+		})
+	}
+
+	onWrite := func(controller, owner, key, value []byte) {
+		writes = append(writes, testWrite{
+			controller,
+			owner,
+			key,
+			value,
+		})
+	}
+
+	clearReadsAndWrites := func() {
+		writes = nil
+		reads = nil
+	}
+
+	indexWrites := func() (indexedWrites map[string]map[string][]byte) {
+		indexedWrites = map[string]map[string][]byte{}
+		for _, write := range writes {
+			values, ok := indexedWrites[string(write.controller)]
+			if !ok {
+				values = map[string][]byte{}
+				indexedWrites[string(write.controller)] = values
+			}
+			values[string(write.key)] = write.value
+		}
+		return
+	}
+
+	runtimeInterface := &testRuntimeInterface{
+		resolveImport: func(_ Location) (bytes []byte, err error) {
+			return accountCode, nil
+		},
+		storage: newTestStorage(onRead, onWrite),
+		getSigningAccounts: func() []Address {
+			return []Address{
+				signer1,
+				signer2,
+			}
+		},
+		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+			accountCode = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) {
+			events = append(events, event)
+		},
+		log: func(message string) {
+			loggedMessages = append(loggedMessages, message)
+		},
+	}
+
+	clearReadsAndWrites()
+	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	assert.NotNil(t, accountCode)
+
+	assert.Len(t, writes, 1)
+
+	clearReadsAndWrites()
+	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	cStorageKey := []byte("storage\x1fc")
+	aStorageKey := []byte("storage\x1fc\x1frs\x1fv\x1fa")
+	bStorageKey := []byte("storage\x1fc\x1frs\x1fv\x1fb")
+
+	// writes can be out of order
+	assert.ElementsMatch(t,
+		[][]byte{
+			cStorageKey,
+			aStorageKey,
+			bStorageKey,
+		},
+		[][]byte{
+			writes[0].key,
+			writes[1].key,
+			writes[2].key,
+		},
+	)
+
+	// Transfer
+
+	transferTx := []byte(`
+	 import Test from 0x1
+
+	 transaction {
+
+	    prepare(signer1: AuthAccount, signer2: AuthAccount) {
+	        let c <- signer1.load<@Test.C>(from: /storage/c) ?? panic("missing C")
+            c.rs["x"] <-! Test.createR(42)
+	        signer2.save(<-c, to: /storage/c2)
+	    }
+	 }
+	`)
+
+	clearReadsAndWrites()
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(transferTx, nil, runtimeInterface, utils.TestLocation)
+	require.NoError(t, err)
+
+	require.Len(t, writes, 7)
+
+	indexedWrites := indexWrites()
+
+	cStorageKey2 := []byte("storage\x1fc2")
+	aStorageKey2 := []byte("storage\x1fc2\x1frs\x1fv\x1fa")
+	bStorageKey2 := []byte("storage\x1fc2\x1frs\x1fv\x1fb")
+	xStorageKey2 := []byte("storage\x1fc2\x1frs\x1fv\x1fx")
+
+	assert.Empty(t, indexedWrites[string(signer1[:])][string(cStorageKey)])
+	assert.Empty(t, indexedWrites[string(signer1[:])][string(aStorageKey)])
+	assert.Empty(t, indexedWrites[string(signer1[:])][string(bStorageKey)])
+
+	assert.NotEmpty(t, indexedWrites[string(signer2[:])][string(cStorageKey2)])
+	assert.NotEmpty(t, indexedWrites[string(signer2[:])][string(aStorageKey2)])
+	assert.NotEmpty(t, indexedWrites[string(signer2[:])][string(bStorageKey2)])
+	assert.NotEmpty(t, indexedWrites[string(signer2[:])][string(xStorageKey2)])
+}

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -267,9 +267,13 @@ func (d *Decoder) decodeDictionary(v interface{}, path []string) (*DictionaryVal
 	var deferred map[string]string
 	var deferredOwner *common.Address
 
+	// Are the values in the dictionary deferred, i.e. are they encoded
+	// separately and stored in separate storage keys?
+
 	isDeferred := countMismatch && entryCount == 0
 
 	if isDeferred {
+
 		deferred = make(map[string]string, keyCount)
 		entries = map[string]Value{}
 		deferredOwner = d.owner

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -25,6 +25,10 @@ type Decoder struct {
 // Decode returns a value decoded from its CBOR-encoded representation,
 // for the given owner (can be `nil`).
 //
+// The given path is used to identify values in the object graph.
+// For example, path elements are appended for array elements (the index),
+// dictionary values (the key), and composites (the field name).
+//
 func DecodeValue(b []byte, owner *common.Address, path []string) (Value, error) {
 	reader := bytes.NewReader(b)
 

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -215,6 +215,17 @@ type Encoder struct {
 
 // EncodeValue returns the CBOR-encoded representation of the given value.
 //
+// The given path is used to identify values in the object graph.
+// For example, path elements are appended for array elements (the index),
+// dictionary values (the key), and composites (the field name).
+//
+// The deferred flag determines if child values should be deferred,
+// i.e. should not be encoded into the result,
+// but e.g. be eventually written to separate storage keys.
+// If true, the deferrals result will contain the values
+// which have not been encoded, and which values need to be moved
+// from a previous storage key to another storage key.
+//
 func EncodeValue(value Value, path []string, deferred bool) (
 	encoded []byte,
 	deferrals *EncodingDeferrals,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -116,6 +116,7 @@ type StorageReadHandlerFunc func(
 	inter *Interpreter,
 	storageAddress common.Address,
 	key string,
+	deferred bool,
 ) OptionalValue
 
 // StorageWriteHandlerFunc is a function that handles storage writes.
@@ -3353,8 +3354,8 @@ func (interpreter *Interpreter) storedValueExists(storageAddress common.Address,
 	return interpreter.storageExistenceHandler(interpreter, storageAddress, key)
 }
 
-func (interpreter *Interpreter) readStored(storageAddress common.Address, key string) OptionalValue {
-	return interpreter.storageReadHandler(interpreter, storageAddress, key)
+func (interpreter *Interpreter) readStored(storageAddress common.Address, key string, deferred bool) OptionalValue {
+	return interpreter.storageReadHandler(interpreter, storageAddress, key, deferred)
 }
 
 func (interpreter *Interpreter) writeStored(storageAddress common.Address, key string, value OptionalValue) {
@@ -3665,7 +3666,7 @@ func (interpreter *Interpreter) authAccountReadFunction(addressValue AddressValu
 			common.PathDomainStorage,
 		)
 
-		value := interpreter.readStored(address, key)
+		value := interpreter.readStored(address, key, false)
 
 		switch value := value.(type) {
 		case NilValue:
@@ -3720,7 +3721,7 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 			common.PathDomainStorage,
 		)
 
-		value := interpreter.readStored(address, key)
+		value := interpreter.readStored(address, key, false)
 
 		switch value := value.(type) {
 		case NilValue:
@@ -3840,7 +3841,7 @@ func (interpreter *Interpreter) authAccountGetLinkTargetFunction(addressValue Ad
 			common.PathDomainPublic,
 		)
 
-		value := interpreter.readStored(address, capabilityKey)
+		value := interpreter.readStored(address, capabilityKey, false)
 
 		switch value := value.(type) {
 		case NilValue:
@@ -3976,7 +3977,7 @@ func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
 			seenKeys[key] = struct{}{}
 		}
 
-		value := interpreter.readStored(address, key)
+		value := interpreter.readStored(address, key, false)
 
 		switch value := value.(type) {
 		case NilValue:

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -585,8 +585,8 @@ func (r *interpreterRuntime) storageInterpreterOptions(runtimeStorage *interpret
 			},
 		),
 		interpreter.WithStorageReadHandler(
-			func(_ *interpreter.Interpreter, address common.Address, key string) interpreter.OptionalValue {
-				return runtimeStorage.readValue(string(address[:]), key)
+			func(_ *interpreter.Interpreter, address common.Address, key string, deferred bool) interpreter.OptionalValue {
+				return runtimeStorage.readValue(string(address[:]), key, deferred)
 			},
 		),
 		interpreter.WithStorageWriteHandler(
@@ -1057,6 +1057,7 @@ func (r *interpreterRuntime) loadContract(
 	storedValue := runtimeStorage.readValue(
 		string(address[:]),
 		contractKey,
+		false,
 	)
 	switch typedValue := storedValue.(type) {
 	case *interpreter.SomeValue:

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -581,17 +581,17 @@ func (r *interpreterRuntime) storageInterpreterOptions(runtimeStorage *interpret
 	return []interpreter.Option{
 		interpreter.WithStorageExistenceHandler(
 			func(_ *interpreter.Interpreter, address common.Address, key string) bool {
-				return runtimeStorage.valueExists(string(address[:]), key)
+				return runtimeStorage.valueExists(address, key)
 			},
 		),
 		interpreter.WithStorageReadHandler(
 			func(_ *interpreter.Interpreter, address common.Address, key string, deferred bool) interpreter.OptionalValue {
-				return runtimeStorage.readValue(string(address[:]), key, deferred)
+				return runtimeStorage.readValue(address, key, deferred)
 			},
 		),
 		interpreter.WithStorageWriteHandler(
 			func(_ *interpreter.Interpreter, address common.Address, key string, value interpreter.OptionalValue) {
-				runtimeStorage.writeValue(string(address[:]), key, value)
+				runtimeStorage.writeValue(address, key, value)
 			},
 		),
 	}
@@ -1043,7 +1043,7 @@ func (r *interpreterRuntime) writeContract(
 	contractValue interpreter.OptionalValue,
 ) {
 	runtimeStorage.writeValue(
-		string(addressValue[:]),
+		addressValue.ToAddress(),
 		contractKey,
 		contractValue,
 	)
@@ -1055,7 +1055,7 @@ func (r *interpreterRuntime) loadContract(
 ) *interpreter.CompositeValue {
 	address := compositeType.Location.(AddressLocation).ToAddress()
 	storedValue := runtimeStorage.readValue(
-		string(address[:]),
+		address,
 		contractKey,
 		false,
 	)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3694,15 +3694,15 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	assert.Len(t, writes, 2)
 
 	readTx := []byte(`
-	 import Test from 0xCADE
+     import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
-	         log(signer.borrow<&Test.R>(from: /storage/r)!.test)
-	     }
-	  }
-	`)
+         prepare(signer: AuthAccount) {
+             log(signer.borrow<&Test.R>(from: /storage/r)!.test)
+         }
+      }
+    `)
 
 	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, utils.TestLocation)
 	require.NoError(t, err)
@@ -3710,16 +3710,16 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	assert.Len(t, writes, 2)
 
 	writeTx := []byte(`
-	 import Test from 0xCADE
+     import Test from 0xCADE
 
-	  transaction {
+      transaction {
 
-	     prepare(signer: AuthAccount) {
+         prepare(signer: AuthAccount) {
              let r = signer.borrow<&Test.R>(from: /storage/r)!
-	         r.test = 2
-	     }
-	  }
-	`)
+             r.test = 2
+         }
+      }
+    `)
 
 	err = runtime.ExecuteTransaction(writeTx, nil, runtimeInterface, utils.TestLocation)
 	require.NoError(t, err)

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -99,7 +99,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		}
 	}
 
-	storageGetter := func(_ *interpreter.Interpreter, _ common.Address, key string) interpreter.OptionalValue {
+	storageGetter := func(_ *interpreter.Interpreter, _ common.Address, key string, deferred bool) interpreter.OptionalValue {
 		value := storedValues[key]
 		if value == nil {
 			return interpreter.NilValue{}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7367,10 +7367,10 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 		encoded, _, err := interpreter.EncodeValue(test, path, false)
 		require.NoError(t, err)
 
-		decoder, err := interpreter.NewDecoder(bytes.NewReader(encoded))
+		decoder, err := interpreter.NewDecoder(bytes.NewReader(encoded), owner)
 		require.NoError(t, err)
 
-		decoded, err := decoder.Decode(owner, path)
+		decoded, err := decoder.Decode(path)
 		require.NoError(t, err)
 
 		test.SetModified(false)


### PR DESCRIPTION
Closes dapperlabs/flow-go#3682

When all values of a dictionary are resources, store the values under separate storage keys. When the dictionary is accessed, lazily load the values from storage.