### PR TITLE
Recover external panics

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -25,6 +25,10 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 )
 
+const BlockHashLength = 32
+
+type BlockHash [BlockHashLength]byte
+
 type Interface interface {
 	// ResolveImport resolves an import of a program.
 	ResolveImport(Location) ([]byte, error)
@@ -42,8 +46,6 @@ type Interface interface {
 	AddAccountKey(address Address, publicKey []byte) error
 	// RemoveAccountKey removes a key from an account by index.
 	RemoveAccountKey(address Address, index int) (publicKey []byte, err error)
-	// CheckCode checks the validity of the code.
-	CheckCode(address Address, code []byte) (err error)
 	// UpdateAccountCode updates the code associated with an account.
 	UpdateAccountCode(address Address, code []byte, checkPermission bool) (err error)
 	// GetSigningAccounts returns the signing accounts.
@@ -59,11 +61,11 @@ type Interface interface {
 	// GetComputationLimit returns the computation limit. A value <= 0 means there is no limit
 	GetComputationLimit() uint64
 	// DecodeArgument decodes a transaction argument against the given type.
-	DecodeArgument(b []byte, t cadence.Type) (cadence.Value, error)
+	DecodeArgument(argument []byte, argumentType cadence.Type) (cadence.Value, error)
 	// GetCurrentBlockHeight returns the current block height.
 	GetCurrentBlockHeight() uint64
 	// GetBlockAtHeight returns the block at the given height.
-	GetBlockAtHeight(height uint64) (hash [32]byte, timestamp int64, exists bool)
+	GetBlockAtHeight(height uint64) (hash BlockHash, timestamp int64, exists bool)
 }
 
 type Metrics interface {
@@ -112,10 +114,6 @@ func (i *EmptyRuntimeInterface) RemoveAccountKey(_ Address, _ int) (publicKey []
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) CheckCode(_ Address, _ []byte) error {
-	return nil
-}
-
 func (i *EmptyRuntimeInterface) UpdateAccountCode(_ Address, _ []byte, _ bool) error {
 	return nil
 }
@@ -144,6 +142,6 @@ func (i *EmptyRuntimeInterface) GetCurrentBlockHeight() uint64 {
 	return 0
 }
 
-func (i *EmptyRuntimeInterface) GetBlockAtHeight(height uint64) (hash [32]byte, timestamp int64, exists bool) {
+func (i *EmptyRuntimeInterface) GetBlockAtHeight(_ uint64) (hash BlockHash, timestamp int64, exists bool) {
 	return
 }

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -43,6 +43,17 @@ func (e *unsupportedOperation) Error() string {
 	)
 }
 
+// ExternalError is an error that occurred externally.
+// It contains the recovered value.
+//
+type ExternalError struct {
+	Recovered interface{}
+}
+
+func (e ExternalError) Error() string {
+	return fmt.Sprint(e.Recovered)
+}
+
 // NotDeclaredError
 
 type NotDeclaredError struct {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -816,16 +816,15 @@ func (interpreter *Interpreter) InvokeTransaction(index int, arguments ...Value)
 
 func recoverErrors(onError func(error)) {
 	if r := recover(); r != nil {
-		var ok bool
-		// don't recover Go errors
-		goErr, ok := r.(goRuntime.Error)
-		if ok {
-			panic(goErr)
-		}
-
-		err, ok := r.(error)
-		if !ok {
-			err = fmt.Errorf("%v", r)
+		var err error
+		switch r := r.(type) {
+		case goRuntime.Error, ExternalError:
+			// Don't recover Go's or external panics
+			panic(r)
+		case error:
+			err = r
+		default:
+			err = fmt.Errorf("%s", r)
 		}
 
 		onError(err)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -315,7 +315,9 @@ func wrapPanic(f func()) {
 				panic(goErr)
 			}
 
-			panic(interpreter.ExternalError{r})
+			panic(interpreter.ExternalError{
+				Recovered: r,
+			})
 		}
 	}()
 	f()

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -75,8 +75,13 @@ func (s *interpreterRuntimeStorage) valueExists(
 	}
 
 	// Cache miss: Ask interface
-	// TODO: fix controller
-	exists, err := s.runtimeInterface.ValueExists([]byte(storageIdentifier), []byte{}, []byte(key))
+
+	var exists bool
+	var err error
+	wrapPanic(func() {
+		// TODO: fix controller
+		exists, err = s.runtimeInterface.ValueExists([]byte(storageIdentifier), []byte{}, []byte(key))
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -122,8 +127,12 @@ func (s *interpreterRuntimeStorage) readValue(
 	// Cache miss: Load and deserialize the stored value (if any)
 	// through the runtime interface
 
-	// TODO: fix controller
-	storedData, err := s.runtimeInterface.GetValue([]byte(storageIdentifier), []byte{}, []byte(key))
+	var storedData []byte
+	var err error
+	wrapPanic(func() {
+		// TODO: fix controller
+		storedData, err = s.runtimeInterface.GetValue([]byte(storageIdentifier), []byte{}, []byte(key))
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -225,13 +234,16 @@ func (s *interpreterRuntimeStorage) writeCached() {
 			}
 		}
 
-		// TODO: fix controller
-		err := s.runtimeInterface.SetValue(
-			[]byte(fullKey.storageIdentifier),
-			[]byte{},
-			[]byte(fullKey.key),
-			newData,
-		)
+		var err error
+		wrapPanic(func() {
+			// TODO: fix controller
+			err = s.runtimeInterface.SetValue(
+				[]byte(fullKey.storageIdentifier),
+				[]byte{},
+				[]byte(fullKey.key),
+				newData,
+			)
+		})
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
The interpreter recovers all panics except for Go's own errors and returns them as error values.

However, the interpreter is also making calls to "external" components, in particular the `runtime.Interface` functions.

Recover panics from those external calls and re-panic them, so they can be handled by what is calling into the interpreter.
