### PR TITLE
Add a `toString` function for addresses, integers, and fixed-point numbers

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -819,6 +819,26 @@ func (v IntValue) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return IntValue{res}
 }
 
+func (v IntValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (IntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // Int8Value
 
 type Int8Value int8
@@ -1012,6 +1032,26 @@ func (v Int8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o := other.(Int8Value)
 	return v >> o
+}
+
+func (v Int8Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Int8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // Int16Value
@@ -1209,6 +1249,26 @@ func (v Int16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return v >> o
 }
 
+func (v Int16Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Int16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // Int32Value
 
 type Int32Value int32
@@ -1404,6 +1464,26 @@ func (v Int32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return v >> o
 }
 
+func (v Int32Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Int32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // Int64Value
 
 type Int64Value int64
@@ -1596,6 +1676,26 @@ func (v Int64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o := other.(Int64Value)
 	return v >> o
+}
+
+func (v Int64Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Int64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // Int128Value
@@ -1850,6 +1950,26 @@ func (v Int128Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	}
 	res.Rsh(v.BigInt, uint(o.BigInt.Uint64()))
 	return Int128Value{res}
+}
+
+func (v Int128Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Int128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // Int256Value
@@ -2107,6 +2227,26 @@ func (v Int256Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return Int256Value{res}
 }
 
+func (v Int256Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Int256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // UIntValue
 
 type UIntValue struct {
@@ -2308,6 +2448,26 @@ func (v UIntValue) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return UIntValue{res}
 }
 
+func (v UIntValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UIntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // UInt8Value
 
 type UInt8Value uint8
@@ -2471,6 +2631,26 @@ func (v UInt8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return v >> o
 }
 
+func (v UInt8Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UInt8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // UInt16Value
 
 type UInt16Value uint16
@@ -2630,6 +2810,26 @@ func (v UInt16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o := other.(UInt16Value)
 	return v >> o
+}
+
+func (v UInt16Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UInt16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // UInt32Value
@@ -2793,6 +2993,26 @@ func (v UInt32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o := other.(UInt32Value)
 	return v >> o
+}
+
+func (v UInt32Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UInt32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // UInt64Value
@@ -2959,6 +3179,26 @@ func (v UInt64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o := other.(UInt64Value)
 	return v >> o
+}
+
+func (v UInt64Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UInt64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // UInt128Value
@@ -3186,6 +3426,26 @@ func (v UInt128Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return UInt128Value{res}
 }
 
+func (v UInt128Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UInt128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // UInt256Value
 
 type UInt256Value struct {
@@ -3411,6 +3671,26 @@ func (v UInt256Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return UInt256Value{res}
 }
 
+func (v UInt256Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UInt256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // Word8Value
 
 type Word8Value uint8
@@ -3535,6 +3815,26 @@ func (v Word8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return v >> o
 }
 
+func (v Word8Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Word8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // Word16Value
 
 type Word16Value uint16
@@ -3655,6 +3955,26 @@ func (v Word16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Word16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o := other.(Word16Value)
 	return v >> o
+}
+
+func (v Word16Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Word16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // Word32Value
@@ -3781,6 +4101,26 @@ func (v Word32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	return v >> o
 }
 
+func (v Word32Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Word32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // Word64Value
 
 type Word64Value uint64
@@ -3903,6 +4243,26 @@ func (v Word64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Word64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o := other.(Word64Value)
 	return v >> o
+}
+
+func (v Word64Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Word64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // Fix64Value
@@ -4130,6 +4490,26 @@ func ConvertFix64(value Value, interpreter *Interpreter) Value {
 	}
 }
 
+func (v Fix64Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (Fix64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 // UFix64Value
 
 type UFix64Value uint64
@@ -4345,6 +4725,26 @@ func ConvertUFix64(value Value, interpreter *Interpreter) Value {
 			value,
 		))
 	}
+}
+
+func (v UFix64Value) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (UFix64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // CompositeValue
@@ -5333,6 +5733,26 @@ func (v AddressValue) Hex() string {
 
 func (v AddressValue) ToAddress() common.Address {
 	return common.Address(v)
+}
+
+func (v AddressValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) trampoline.Trampoline {
+				result := NewStringValue(v.String())
+				return trampoline.Done{Result: result}
+			},
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (AddressValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
 }
 
 // AccountValue

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -248,6 +248,28 @@ var toStringFunctionType = &FunctionType{
 	),
 }
 
+var typeBuiltinFunctionTypes = map[TypeID]map[string]*FunctionType{}
+
+func init() {
+	for _, ty := range append(
+		AllNumberTypes[:],
+		&NumberType{},
+		&SignedNumberType{},
+		&FixedPointType{},
+		&SignedFixedPointType{},
+		&IntegerType{},
+		&SignedIntegerType{},
+		&AddressType{},
+	) {
+		functionTypes, ok := typeBuiltinFunctionTypes[ty.ID()]
+		if !ok {
+			functionTypes = map[string]*FunctionType{}
+			typeBuiltinFunctionTypes[ty.ID()] = functionTypes
+		}
+		functionTypes[ToStringFunctionName] = toStringFunctionType
+	}
+}
+
 // AnyType represents the top type of all types.
 // NOTE: This type is only used internally and not available in programs.
 type AnyType struct{}
@@ -970,17 +992,15 @@ func (*NumberType) CanHaveMembers() bool {
 }
 
 func (t *NumberType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // SignedNumberType represents the super-type of all signed number types
@@ -1042,17 +1062,15 @@ func (*SignedNumberType) CanHaveMembers() bool {
 }
 
 func (t *SignedNumberType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // IntegerRangedType
@@ -1129,17 +1147,15 @@ func (*IntegerType) CanHaveMembers() bool {
 }
 
 func (t *IntegerType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // SignedIntegerType represents the super-type of all signed integer types
@@ -1201,17 +1217,15 @@ func (*SignedIntegerType) CanHaveMembers() bool {
 }
 
 func (t *SignedIntegerType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // IntType represents the arbitrary-precision integer type `Int`
@@ -1273,17 +1287,15 @@ func (*IntType) CanHaveMembers() bool {
 }
 
 func (t *IntType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Int8Type represents the 8-bit signed integer type `Int8`
@@ -1349,17 +1361,15 @@ func (*Int8Type) CanHaveMembers() bool {
 }
 
 func (t *Int8Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Int16Type represents the 16-bit signed integer type `Int16`
@@ -1424,17 +1434,15 @@ func (*Int16Type) CanHaveMembers() bool {
 }
 
 func (t *Int16Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Int32Type represents the 32-bit signed integer type `Int32`
@@ -1499,17 +1507,15 @@ func (*Int32Type) CanHaveMembers() bool {
 }
 
 func (t *Int32Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Int64Type represents the 64-bit signed integer type `Int64`
@@ -1574,17 +1580,15 @@ func (*Int64Type) CanHaveMembers() bool {
 }
 
 func (t *Int64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Int128Type represents the 128-bit signed integer type `Int128`
@@ -1661,17 +1665,15 @@ func (*Int128Type) CanHaveMembers() bool {
 }
 
 func (t *Int128Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Int256Type represents the 256-bit signed integer type `Int256`
@@ -1748,17 +1750,15 @@ func (*Int256Type) CanHaveMembers() bool {
 }
 
 func (t *Int256Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UIntType represents the arbitrary-precision unsigned integer type `UInt`
@@ -1822,17 +1822,15 @@ func (*UIntType) CanHaveMembers() bool {
 }
 
 func (t *UIntType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UInt8Type represents the 8-bit unsigned integer type `UInt8`
@@ -1898,17 +1896,15 @@ func (*UInt8Type) CanHaveMembers() bool {
 }
 
 func (t *UInt8Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UInt16Type represents the 16-bit unsigned integer type `UInt16`
@@ -1974,17 +1970,15 @@ func (*UInt16Type) CanHaveMembers() bool {
 }
 
 func (t *UInt16Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UInt32Type represents the 32-bit unsigned integer type `UInt32`
@@ -2050,17 +2044,15 @@ func (*UInt32Type) CanHaveMembers() bool {
 }
 
 func (t *UInt32Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UInt64Type represents the 64-bit unsigned integer type `UInt64`
@@ -2126,17 +2118,15 @@ func (*UInt64Type) CanHaveMembers() bool {
 }
 
 func (t *UInt64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UInt128Type represents the 128-bit unsigned integer type `UInt128`
@@ -2208,17 +2198,15 @@ func (*UInt128Type) CanHaveMembers() bool {
 }
 
 func (t *UInt128Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UInt256Type represents the 256-bit unsigned integer type `UInt256`
@@ -2290,17 +2278,15 @@ func (*UInt256Type) CanHaveMembers() bool {
 }
 
 func (t *UInt256Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Word8Type represents the 8-bit unsigned integer type `Word8`
@@ -2366,17 +2352,15 @@ func (*Word8Type) CanHaveMembers() bool {
 }
 
 func (t *Word8Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Word16Type represents the 16-bit unsigned integer type `Word16`
@@ -2442,17 +2426,15 @@ func (*Word16Type) CanHaveMembers() bool {
 }
 
 func (t *Word16Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Word32Type represents the 32-bit unsigned integer type `Word32`
@@ -2518,17 +2500,15 @@ func (*Word32Type) CanHaveMembers() bool {
 }
 
 func (t *Word32Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // Word64Type represents the 64-bit unsigned integer type `Word64`
@@ -2594,17 +2574,15 @@ func (*Word64Type) CanHaveMembers() bool {
 }
 
 func (t *Word64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // FixedPointType represents the super-type of all fixed-point types
@@ -2666,17 +2644,15 @@ func (*FixedPointType) CanHaveMembers() bool {
 }
 
 func (t *FixedPointType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // SignedFixedPointType represents the super-type of all signed fixed-point types
@@ -2738,17 +2714,15 @@ func (*SignedFixedPointType) CanHaveMembers() bool {
 }
 
 func (t *SignedFixedPointType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 const Fix64Scale uint = 8
@@ -2842,17 +2816,15 @@ func (*Fix64Type) CanHaveMembers() bool {
 }
 
 func (t *Fix64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
@@ -2939,17 +2911,15 @@ func (*UFix64Type) CanHaveMembers() bool {
 }
 
 func (t *UFix64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // ArrayType
@@ -5101,17 +5071,15 @@ func (*AddressType) CanHaveMembers() bool {
 }
 
 func (t *AddressType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
-	newFunction := func(functionType *FunctionType) *Member {
-		return NewPublicFunctionMember(t, identifier, functionType)
-	}
-
-	switch identifier {
-	case ToStringFunctionName:
-		return newFunction(toStringFunctionType)
-
-	default:
+	builtinFunctionTypes, ok := typeBuiltinFunctionTypes[t.ID()]
+	if !ok {
 		return nil
 	}
+	functionType, ok := builtinFunctionTypes[identifier]
+	if !ok {
+		return nil
+	}
+	return NewPublicFunctionMember(t, identifier, functionType)
 }
 
 // IsSubType determines if the given subtype is a subtype

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -238,6 +238,16 @@ func NewTypeAnnotation(ty Type) *TypeAnnotation {
 	}
 }
 
+// toString
+
+const ToStringFunctionName = "toString"
+
+var toStringFunctionType = &FunctionType{
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&StringType{},
+	),
+}
+
 // AnyType represents the top type of all types.
 // NOTE: This type is only used internally and not available in programs.
 type AnyType struct{}
@@ -955,6 +965,24 @@ func (t *NumberType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*NumberType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *NumberType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // SignedNumberType represents the super-type of all signed number types
 type SignedNumberType struct{}
 
@@ -1007,6 +1035,24 @@ func (*SignedNumberType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err err
 
 func (t *SignedNumberType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*SignedNumberType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *SignedNumberType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // IntegerRangedType
@@ -1078,6 +1124,24 @@ func (t *IntegerType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*IntegerType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *IntegerType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // SignedIntegerType represents the super-type of all signed integer types
 type SignedIntegerType struct{}
 
@@ -1132,6 +1196,24 @@ func (t *SignedIntegerType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*SignedIntegerType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *SignedIntegerType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // IntType represents the arbitrary-precision integer type `Int`
 type IntType struct{}
 
@@ -1184,6 +1266,24 @@ func (*IntType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ as
 
 func (t *IntType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*IntType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *IntType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // Int8Type represents the 8-bit signed integer type `Int8`
@@ -1244,6 +1344,24 @@ func (t *Int8Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*Int8Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Int8Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // Int16Type represents the 16-bit signed integer type `Int16`
 type Int16Type struct{}
 
@@ -1299,6 +1417,24 @@ func (*Int16Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ 
 
 func (t *Int16Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*Int16Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Int16Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // Int32Type represents the 32-bit signed integer type `Int32`
@@ -1358,6 +1494,24 @@ func (t *Int32Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*Int32Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Int32Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // Int64Type represents the 64-bit signed integer type `Int64`
 type Int64Type struct{}
 
@@ -1413,6 +1567,24 @@ func (*Int64Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ 
 
 func (t *Int64Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*Int64Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Int64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // Int128Type represents the 128-bit signed integer type `Int128`
@@ -1484,6 +1656,24 @@ func (t *Int128Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*Int128Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Int128Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // Int256Type represents the 256-bit signed integer type `Int256`
 type Int256Type struct{}
 
@@ -1553,6 +1743,24 @@ func (t *Int256Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*Int256Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Int256Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // UIntType represents the arbitrary-precision unsigned integer type `UInt`
 type UIntType struct{}
 
@@ -1607,6 +1815,24 @@ func (*UIntType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ a
 
 func (t *UIntType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*UIntType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UIntType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // UInt8Type represents the 8-bit unsigned integer type `UInt8`
@@ -1667,6 +1893,24 @@ func (t *UInt8Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*UInt8Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UInt8Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // UInt16Type represents the 16-bit unsigned integer type `UInt16`
 // which checks for overflow and underflow
 type UInt16Type struct{}
@@ -1723,6 +1967,24 @@ func (*UInt16Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _
 
 func (t *UInt16Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*UInt16Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UInt16Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // UInt32Type represents the 32-bit unsigned integer type `UInt32`
@@ -1783,6 +2045,24 @@ func (t *UInt32Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*UInt32Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UInt32Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // UInt64Type represents the 64-bit unsigned integer type `UInt64`
 // which checks for overflow and underflow
 type UInt64Type struct{}
@@ -1839,6 +2119,24 @@ func (*UInt64Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _
 
 func (t *UInt64Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*UInt64Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UInt64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // UInt128Type represents the 128-bit unsigned integer type `UInt128`
@@ -1905,6 +2203,24 @@ func (t *UInt128Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*UInt128Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UInt128Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // UInt256Type represents the 256-bit unsigned integer type `UInt256`
 // which checks for overflow and underflow
 type UInt256Type struct{}
@@ -1969,6 +2285,24 @@ func (t *UInt256Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*UInt256Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UInt256Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // Word8Type represents the 8-bit unsigned integer type `Word8`
 // which does NOT check for overflow and underflow
 type Word8Type struct{}
@@ -2025,6 +2359,24 @@ func (*Word8Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ 
 
 func (t *Word8Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*Word8Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Word8Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // Word16Type represents the 16-bit unsigned integer type `Word16`
@@ -2085,6 +2437,24 @@ func (t *Word16Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*Word16Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Word16Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // Word32Type represents the 32-bit unsigned integer type `Word32`
 // which does NOT check for overflow and underflow
 type Word32Type struct{}
@@ -2141,6 +2511,24 @@ func (*Word32Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _
 
 func (t *Word32Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*Word32Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Word32Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // Word64Type represents the 64-bit unsigned integer type `Word64`
@@ -2201,6 +2589,24 @@ func (t *Word64Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*Word64Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Word64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // FixedPointType represents the super-type of all fixed-point types
 type FixedPointType struct{}
 
@@ -2255,6 +2661,24 @@ func (t *FixedPointType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*FixedPointType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *FixedPointType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // SignedFixedPointType represents the super-type of all signed fixed-point types
 type SignedFixedPointType struct{}
 
@@ -2307,6 +2731,24 @@ func (*SignedFixedPointType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err
 
 func (t *SignedFixedPointType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*SignedFixedPointType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *SignedFixedPointType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 const Fix64Scale uint = 8
@@ -2395,6 +2837,24 @@ func (t *Fix64Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
 }
 
+func (*Fix64Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *Fix64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
+}
+
 // UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
 // which has a scale of 1E9, and checks for overflow and underflow
 type UFix64Type struct{}
@@ -2472,6 +2932,24 @@ func (*UFix64Type) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _
 
 func (t *UFix64Type) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*UFix64Type) CanHaveMembers() bool {
+	return true
+}
+
+func (t *UFix64Type) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // ArrayType
@@ -4616,6 +5094,24 @@ func (*AddressType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), 
 
 func (t *AddressType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+func (*AddressType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *AddressType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newFunction := func(functionType *FunctionType) *Member {
+		return NewPublicFunctionMember(t, identifier, functionType)
+	}
+
+	switch identifier {
+	case ToStringFunctionName:
+		return newFunction(toStringFunctionType)
+
+	default:
+		return nil
+	}
 }
 
 // IsSubType determines if the given subtype is a subtype

--- a/runtime/tests/checker/tostring_test.go
+++ b/runtime/tests/checker/tostring_test.go
@@ -1,0 +1,50 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package checker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestCheckToString(t *testing.T) {
+
+	for _, ty := range allIntegerTypesAndAddressType {
+		// Test non-optional and optional type
+
+		t.Run(ty.String(), func(t *testing.T) {
+
+			_, err := ParseAndCheck(t,
+				fmt.Sprintf(
+					`
+                      let x: %s = 0x1
+                      let y = x.toString()
+                    `,
+					ty,
+				),
+			)
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/runtime/tests/interpreter/tostring_test.go
+++ b/runtime/tests/interpreter/tostring_test.go
@@ -1,0 +1,89 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+func TestInterpretToString(t *testing.T) {
+
+	for _, ty := range sema.AllIntegerTypes {
+
+		t.Run(ty.String(), func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      let x: %s = 42
+                      let y = x.toString()
+                    `,
+					ty,
+				),
+			)
+
+			assert.Equal(t,
+				interpreter.NewStringValue("42"),
+				inter.Globals["y"].Value,
+			)
+		})
+	}
+
+	t.Run("Address", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t,
+			`
+              let x: Address = 0x42
+              let y = x.toString()
+            `,
+		)
+
+		assert.Equal(t,
+			interpreter.NewStringValue("0x42"),
+			inter.Globals["y"].Value,
+		)
+	})
+
+	for _, ty := range sema.AllFixedPointTypes {
+
+		t.Run(ty.String(), func(t *testing.T) {
+
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+                      let x: %s = 12.34
+                      let y = x.toString()
+                    `,
+					ty,
+				),
+			)
+
+			assert.Equal(t,
+				interpreter.NewStringValue("12.34000000"),
+				inter.Globals["y"].Value,
+			)
+		})
+	}
+}


### PR DESCRIPTION
Until we can properly model inheritance we have to duplicate the definitions