### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,24 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
         go-version: '1.13.10'
-    - run: make ci
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - run: make test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - run: make test
+    - run: |
+        make test
+        make tidy
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,3 @@ lint:
 .PHONY: tidy
 tidy:
 	go mod tidy; git diff --exit-code
-
-.PHONY: ci
-ci: install-tools tidy lint test


### PR DESCRIPTION
- Instead of sequentially running linting and tests, split them into separate jobs.
- Enable caching for the test job, so dependencies don't have to be refetched on every run
- Use golangci-lint's own action, which is supposedly faster than downloading and running the binary, plus it reports linting errors as PR comments