### PR TITLE
Parallelize tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PATH := $(PATH):$(GOPATH)/bin
 .PHONY: test
 test:
 	# test all packages
-	GO111MODULE=on go test $(if $(JSON_OUTPUT),-json,) ./...
+	GO111MODULE=on go test $(if $(JSON_OUTPUT),-json,) -parallel 8 ./...
 
 .PHONY: install-tools
 install-tools:

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -40,10 +40,16 @@ type encodeTest struct {
 }
 
 func TestEncodeVoid(t *testing.T) {
+
+	t.Parallel()
+
 	testEncode(t, cadence.NewVoid(), `{"type":"Void"}`)
 }
 
 func TestEncodeOptional(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Nil",
@@ -59,6 +65,9 @@ func TestEncodeOptional(t *testing.T) {
 }
 
 func TestEncodeBool(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"True",
@@ -74,6 +83,9 @@ func TestEncodeBool(t *testing.T) {
 }
 
 func TestEncodeString(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Empty",
@@ -89,6 +101,9 @@ func TestEncodeString(t *testing.T) {
 }
 
 func TestEncodeAddress(t *testing.T) {
+
+	t.Parallel()
+
 	testEncode(
 		t,
 		cadence.BytesToAddress([]byte{1, 2, 3, 4, 5}),
@@ -97,6 +112,9 @@ func TestEncodeAddress(t *testing.T) {
 }
 
 func TestEncodeInt(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Negative",
@@ -127,6 +145,9 @@ func TestEncodeInt(t *testing.T) {
 }
 
 func TestEncodeInt8(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -147,6 +168,9 @@ func TestEncodeInt8(t *testing.T) {
 }
 
 func TestEncodeInt16(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -167,6 +191,9 @@ func TestEncodeInt16(t *testing.T) {
 }
 
 func TestEncodeInt32(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -187,6 +214,9 @@ func TestEncodeInt32(t *testing.T) {
 }
 
 func TestEncodeInt64(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -207,6 +237,9 @@ func TestEncodeInt64(t *testing.T) {
 }
 
 func TestEncodeInt128(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -227,6 +260,9 @@ func TestEncodeInt128(t *testing.T) {
 }
 
 func TestEncodeInt256(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -247,6 +283,9 @@ func TestEncodeInt256(t *testing.T) {
 }
 
 func TestEncodeUInt(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -267,6 +306,9 @@ func TestEncodeUInt(t *testing.T) {
 }
 
 func TestEncodeUInt8(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -282,6 +324,9 @@ func TestEncodeUInt8(t *testing.T) {
 }
 
 func TestEncodeUInt16(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -297,6 +342,9 @@ func TestEncodeUInt16(t *testing.T) {
 }
 
 func TestEncodeUInt32(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -312,6 +360,9 @@ func TestEncodeUInt32(t *testing.T) {
 }
 
 func TestEncodeUInt64(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -327,6 +378,9 @@ func TestEncodeUInt64(t *testing.T) {
 }
 
 func TestEncodeUInt128(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -342,6 +396,9 @@ func TestEncodeUInt128(t *testing.T) {
 }
 
 func TestEncodeUInt256(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -357,6 +414,9 @@ func TestEncodeUInt256(t *testing.T) {
 }
 
 func TestEncodeWord8(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -372,6 +432,9 @@ func TestEncodeWord8(t *testing.T) {
 }
 
 func TestEncodeWord16(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -387,6 +450,9 @@ func TestEncodeWord16(t *testing.T) {
 }
 
 func TestEncodeWord32(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -402,6 +468,9 @@ func TestEncodeWord32(t *testing.T) {
 }
 
 func TestEncodeWord64(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -417,6 +486,9 @@ func TestEncodeWord64(t *testing.T) {
 }
 
 func TestEncodeFix64(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -442,6 +514,9 @@ func TestEncodeFix64(t *testing.T) {
 }
 
 func TestEncodeUFix64(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -462,6 +537,9 @@ func TestEncodeUFix64(t *testing.T) {
 }
 
 func TestEncodeArray(t *testing.T) {
+
+	t.Parallel()
+
 	emptyArray := encodeTest{
 		"Empty",
 		cadence.NewArray([]cadence.Value{}),
@@ -502,6 +580,9 @@ func TestEncodeArray(t *testing.T) {
 }
 
 func TestEncodeDictionary(t *testing.T) {
+
+	t.Parallel()
+
 	simpleDict := encodeTest{
 		"Simple",
 		cadence.NewDictionary([]cadence.KeyValuePair{
@@ -588,6 +669,9 @@ func TestEncodeDictionary(t *testing.T) {
 }
 
 func TestEncodeResource(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) resource Foo {
             access(all) let bar: Int
@@ -610,6 +694,9 @@ func TestEncodeResource(t *testing.T) {
 }
 
 func TestEncodeNestedResource(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) resource Bar {
             access(all) let x: Int
@@ -644,6 +731,9 @@ func TestEncodeNestedResource(t *testing.T) {
 }
 
 func TestEncodeStruct(t *testing.T) {
+
+	t.Parallel()
+
 	simpleStructType := cadence.StructType{
 		TypeID:     "test.FooStruct",
 		Identifier: "FooStruct",
@@ -704,6 +794,9 @@ func TestEncodeStruct(t *testing.T) {
 }
 
 func TestEncodeEvent(t *testing.T) {
+
+	t.Parallel()
+
 	simpleEventType := cadence.EventType{
 		TypeID:     "test.FooEvent",
 		Identifier: "FooEvent",

--- a/encoding/xdr/encoding_test.go
+++ b/encoding/xdr/encoding_test.go
@@ -38,10 +38,16 @@ type encodeTest struct {
 }
 
 func TestEncodeVoid(t *testing.T) {
+
+	t.Parallel()
+
 	testEncode(t, cadence.VoidType{}, cadence.Void{})
 }
 
 func TestEncodeString(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Empty",
@@ -57,6 +63,9 @@ func TestEncodeString(t *testing.T) {
 }
 
 func TestEncodeOptional(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Nil",
@@ -72,6 +81,9 @@ func TestEncodeOptional(t *testing.T) {
 }
 
 func TestEncodeBool(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"True",
@@ -87,6 +99,9 @@ func TestEncodeBool(t *testing.T) {
 }
 
 func TestEncodeBytes(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Empty",
@@ -102,10 +117,16 @@ func TestEncodeBytes(t *testing.T) {
 }
 
 func TestEncodeAddress(t *testing.T) {
+
+	t.Parallel()
+
 	testEncode(t, cadence.AddressType{}, cadence.NewAddress([common.AddressLength]byte{1, 2, 3, 4, 5}))
 }
 
 func TestEncodeInt(t *testing.T) {
+
+	t.Parallel()
+
 	x := new(big.Int).SetUint64(math.MaxUint64)
 	x = x.Mul(x, big.NewInt(2))
 
@@ -136,6 +157,9 @@ func TestEncodeInt(t *testing.T) {
 }
 
 func TestEncodeInt8(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -156,6 +180,9 @@ func TestEncodeInt8(t *testing.T) {
 }
 
 func TestEncodeInt16(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -176,6 +203,9 @@ func TestEncodeInt16(t *testing.T) {
 }
 
 func TestEncodeInt32(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -196,6 +226,9 @@ func TestEncodeInt32(t *testing.T) {
 }
 
 func TestEncodeInt64(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Min",
@@ -216,6 +249,9 @@ func TestEncodeInt64(t *testing.T) {
 }
 
 func TestEncodeUInt8(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -231,6 +267,9 @@ func TestEncodeUInt8(t *testing.T) {
 }
 
 func TestEncodeUInt16(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -246,6 +285,9 @@ func TestEncodeUInt16(t *testing.T) {
 }
 
 func TestEncodeUInt32(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -261,6 +303,9 @@ func TestEncodeUInt32(t *testing.T) {
 }
 
 func TestEncodeUInt64(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Zero",
@@ -276,6 +321,9 @@ func TestEncodeUInt64(t *testing.T) {
 }
 
 func TestEncodeVariableSizedArray(t *testing.T) {
+
+	t.Parallel()
+
 	emptyArray := encodeTest{
 		"Empty",
 		cadence.VariableSizedArrayType{
@@ -325,6 +373,9 @@ func TestEncodeVariableSizedArray(t *testing.T) {
 }
 
 func TestEncodeConstantSizedArray(t *testing.T) {
+
+	t.Parallel()
+
 	testAllEncode(t, []encodeTest{
 		{
 			"Empty",
@@ -350,6 +401,9 @@ func TestEncodeConstantSizedArray(t *testing.T) {
 }
 
 func TestEncodeDictionary(t *testing.T) {
+
+	t.Parallel()
+
 	simpleDict := encodeTest{
 		"Simple",
 		cadence.DictionaryType{
@@ -451,6 +505,9 @@ func TestEncodeDictionary(t *testing.T) {
 }
 
 func TestEncodeResource(t *testing.T) {
+
+	t.Parallel()
+
 	simpleResource := encodeTest{
 		"Simple",
 		fooResourceType,
@@ -554,6 +611,9 @@ func TestEncodeResource(t *testing.T) {
 }
 
 func TestEncodeEvent(t *testing.T) {
+
+	t.Parallel()
+
 	simpleEventType := cadence.EventType{
 		Fields: []cadence.Field{
 			{

--- a/runtime/activations/activations_test.go
+++ b/runtime/activations/activations_test.go
@@ -25,6 +25,9 @@ import (
 )
 
 func TestActivations(t *testing.T) {
+
+	t.Parallel()
+
 	activations := &Activations{}
 
 	activations.Set("a", 1)

--- a/runtime/ast/expression_extractor_test.go
+++ b/runtime/ast/expression_extractor_test.go
@@ -51,6 +51,8 @@ func (testIntExtractor) ExtractInteger(
 
 func TestExpressionExtractorBinaryExpressionNothingExtracted(t *testing.T) {
 
+	t.Parallel()
+
 	expression := &BinaryExpression{
 		Operation: OperationEqual,
 		Left: &IdentifierExpression{
@@ -85,6 +87,8 @@ func TestExpressionExtractorBinaryExpressionNothingExtracted(t *testing.T) {
 }
 
 func TestExpressionExtractorBinaryExpressionIntegerExtracted(t *testing.T) {
+
+	t.Parallel()
 
 	expression := &BinaryExpression{
 		Operation: OperationEqual,

--- a/runtime/ast/program_test.go
+++ b/runtime/ast/program_test.go
@@ -28,6 +28,8 @@ import (
 
 func TestProgram_ResolveImports(t *testing.T) {
 
+	t.Parallel()
+
 	makeImportingProgram := func(imported string) *Program {
 		return &Program{
 			Declarations: []Declaration{
@@ -71,6 +73,8 @@ func TestProgram_ResolveImports(t *testing.T) {
 }
 
 func TestProgram_ResolveImportsCycle(t *testing.T) {
+
+	t.Parallel()
 
 	makeImportingProgram := func(imported string) *Program {
 		return &Program{

--- a/runtime/common/interface_entry/interface_entry_test.go
+++ b/runtime/common/interface_entry/interface_entry_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestInterfaceEntry(t *testing.T) {
+
+	t.Parallel()
+
 	type X struct{}
 	x := X{}
 

--- a/runtime/common/intervalst/intervalst_test.go
+++ b/runtime/common/intervalst/intervalst_test.go
@@ -57,6 +57,8 @@ func (l lineAndColumn) Compare(other Position) int {
 
 func TestIntervalST(t *testing.T) {
 
+	t.Parallel()
+
 	st := &IntervalST{}
 
 	st.Put(
@@ -137,6 +139,8 @@ func TestIntervalST(t *testing.T) {
 }
 
 func TestIntervalST2(t *testing.T) {
+
+	t.Parallel()
 
 	intervals := []Interval{
 		{

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -193,6 +193,9 @@ var exportTests = []struct {
 }
 
 func TestExportValue(t *testing.T) {
+
+	t.Parallel()
+
 	for _, tt := range exportTests {
 		t.Run(tt.label, func(t *testing.T) {
 			actual := exportValueWithInterpreter(tt.value, nil)
@@ -207,6 +210,9 @@ func TestExportValue(t *testing.T) {
 }
 
 func TestExportIntegerValuesFromScript(t *testing.T) {
+
+	t.Parallel()
+
 	for _, integerType := range sema.AllIntegerTypes {
 
 		script := fmt.Sprintf(
@@ -225,6 +231,9 @@ func TestExportIntegerValuesFromScript(t *testing.T) {
 }
 
 func TestExportFixedPointValuesFromScript(t *testing.T) {
+
+	t.Parallel()
+
 	for _, fixedPointType := range sema.AllFixedPointTypes {
 		script := fmt.Sprintf(
 			`
@@ -242,6 +251,9 @@ func TestExportFixedPointValuesFromScript(t *testing.T) {
 }
 
 func TestExportDictionaryValue(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("Empty", func(t *testing.T) {
 		script := `
             access(all) fun main(): {String: Int} {
@@ -282,6 +294,9 @@ func TestExportDictionaryValue(t *testing.T) {
 }
 
 func TestExportAddressValue(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) fun main(): Address {
             return 0x42
@@ -297,6 +312,9 @@ func TestExportAddressValue(t *testing.T) {
 }
 
 func TestExportStructValue(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) struct Foo {
             access(all) let bar: Int
@@ -318,6 +336,9 @@ func TestExportStructValue(t *testing.T) {
 }
 
 func TestExportResourceValue(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) resource Foo {
             access(all) let bar: Int
@@ -343,6 +364,9 @@ func TestExportResourceValue(t *testing.T) {
 }
 
 func TestExportResourceArrayValue(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) resource Foo {
             access(all) let bar: Int
@@ -373,6 +397,9 @@ func TestExportResourceArrayValue(t *testing.T) {
 }
 
 func TestExportResourceDictionaryValue(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) resource Foo {
             access(all) let bar: Int
@@ -412,6 +439,9 @@ func TestExportResourceDictionaryValue(t *testing.T) {
 }
 
 func TestExportNestedResourceValueFromScript(t *testing.T) {
+
+	t.Parallel()
+
 	barResourceType := cadence.ResourceType{
 		TypeID:     "test.Bar",
 		Identifier: "Bar",
@@ -481,6 +511,9 @@ func TestExportNestedResourceValueFromScript(t *testing.T) {
 }
 
 func TestExportEventValue(t *testing.T) {
+
+	t.Parallel()
+
 	script := `
         access(all) event Foo(bar: Int)
 

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestByteArrayValueToByteSlice(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("invalid", func(t *testing.T) {
 
 		largeBigInt, ok := new(big.Int).SetString("1000000000000000000000000000000000000000000000", 10)
@@ -46,6 +48,8 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 }
 
 func TestByteValueToByte(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("invalid", func(t *testing.T) {
 

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestDivModUInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt8Value
 		valid bool
@@ -98,6 +100,8 @@ func TestDivModUInt8(t *testing.T) {
 }
 
 func TestDivModUInt16(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt16Value
@@ -169,6 +173,8 @@ func TestDivModUInt16(t *testing.T) {
 
 func TestDivModUInt32(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt32Value
 		valid bool
@@ -238,6 +244,8 @@ func TestDivModUInt32(t *testing.T) {
 }
 
 func TestDivModUInt64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt64Value
@@ -398,6 +406,8 @@ func TestDivModUInt64(t *testing.T) {
 }
 
 func TestDivModUInt128(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: hex values are integer values, not bit patterns!
 
@@ -560,6 +570,8 @@ func TestDivModUInt128(t *testing.T) {
 }
 
 func TestDivModUInt256(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: hex values are integer values, not bit patterns!
 
@@ -1229,6 +1241,8 @@ func TestDivModUInt256(t *testing.T) {
 
 func TestDivInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int8Value
 		valid bool
@@ -1291,6 +1305,8 @@ func TestDivInt8(t *testing.T) {
 
 func TestModInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int8Value
 		valid bool
@@ -1351,6 +1367,8 @@ func TestModInt8(t *testing.T) {
 }
 
 func TestDivInt16(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int16Value
@@ -1414,6 +1432,8 @@ func TestDivInt16(t *testing.T) {
 
 func TestModInt16(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int16Value
 		valid bool
@@ -1474,6 +1494,8 @@ func TestModInt16(t *testing.T) {
 }
 
 func TestDivInt32(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int32Value
@@ -1537,6 +1559,8 @@ func TestDivInt32(t *testing.T) {
 
 func TestModInt32(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int32Value
 		valid bool
@@ -1597,6 +1621,8 @@ func TestModInt32(t *testing.T) {
 }
 
 func TestDivInt64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int64Value
@@ -1750,6 +1776,8 @@ func TestDivInt64(t *testing.T) {
 
 func TestModInt64(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int64Value
 		valid bool
@@ -1901,6 +1929,8 @@ func TestModInt64(t *testing.T) {
 
 func TestDivModInt(t *testing.T) {
 
+	t.Parallel()
+
 	for _, f := range []func(a, b IntValue){
 		func(a, b IntValue) {
 			a.Div(b)
@@ -1916,6 +1946,8 @@ func TestDivModInt(t *testing.T) {
 }
 
 func TestDivInt128(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int128Value
@@ -2027,6 +2059,8 @@ func TestDivInt128(t *testing.T) {
 
 func TestModInt128(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int128Value
 		valid bool
@@ -2135,6 +2169,8 @@ func TestModInt128(t *testing.T) {
 }
 
 func TestDivInt256(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int256Value
@@ -2588,6 +2624,8 @@ func TestDivInt256(t *testing.T) {
 
 func TestModInt256(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int256Value
 		valid bool
@@ -3039,6 +3077,8 @@ func TestModInt256(t *testing.T) {
 
 func TestReciprocalFix64(t *testing.T) {
 
+	t.Parallel()
+
 	assert.PanicsWithValue(t,
 		DivisionByZeroError{},
 		func() {
@@ -3064,6 +3104,8 @@ func TestReciprocalFix64(t *testing.T) {
 
 func TestReciprocalUFix64(t *testing.T) {
 
+	t.Parallel()
+
 	assert.PanicsWithValue(t,
 		DivisionByZeroError{},
 		func() {
@@ -3088,6 +3130,8 @@ func TestReciprocalUFix64(t *testing.T) {
 }
 
 func TestDivFix64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  int64
@@ -3151,6 +3195,8 @@ func TestDivFix64(t *testing.T) {
 
 func TestModFix64(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int64Value
 		valid bool
@@ -3189,6 +3235,8 @@ func TestModFix64(t *testing.T) {
 }
 
 func TestDivModUFix64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  uint64
@@ -3254,6 +3302,8 @@ func TestDivModUFix64(t *testing.T) {
 // when an operand is negative
 //
 func TestNegativeMod(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("integer", func(t *testing.T) {
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -57,6 +57,9 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 }
 
 func TestEncodeDecodeNilValue(t *testing.T) {
+
+	t.Parallel()
+
 	testEncodeDecode(t,
 		encodeDecodeTest{
 			value: NilValue{},
@@ -69,6 +72,9 @@ func TestEncodeDecodeNilValue(t *testing.T) {
 }
 
 func TestEncodeDecodeVoidValue(t *testing.T) {
+
+	t.Parallel()
+
 	testEncodeDecode(t,
 		encodeDecodeTest{
 			value: VoidValue{},
@@ -83,6 +89,8 @@ func TestEncodeDecodeVoidValue(t *testing.T) {
 }
 
 func TestEncodeDecodeBool(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("false", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -110,6 +118,8 @@ func TestEncodeDecodeBool(t *testing.T) {
 }
 
 func TestEncodeDecodeString(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
 		expected := NewStringValue("")
@@ -144,6 +154,8 @@ func TestEncodeDecodeString(t *testing.T) {
 }
 
 func TestEncodeDecodeArray(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
 		expected := NewArrayValueUnownedNonCopying()
@@ -188,6 +200,8 @@ func TestEncodeDecodeArray(t *testing.T) {
 }
 
 func TestEncodeDecodeDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
 		expected := NewDictionaryValueUnownedNonCopying()
@@ -290,6 +304,8 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 }
 
 func TestEncodeDecodeComposite(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("empty structure, string location", func(t *testing.T) {
 		expected := NewCompositeValue(
@@ -491,6 +507,8 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 func TestEncodeDecodeIntValue(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -560,6 +578,8 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 }
 
 func TestEncodeDecodeInt8Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -668,6 +688,8 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 
 func TestEncodeDecodeInt16Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -774,6 +796,8 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 }
 
 func TestEncodeDecodeInt32Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -882,6 +906,8 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 
 func TestEncodeDecodeInt64Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -988,6 +1014,8 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 }
 
 func TestEncodeDecodeInt128Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -1126,6 +1154,8 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 }
 
 func TestEncodeDecodeInt256Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -1274,6 +1304,8 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 
 func TestEncodeDecodeUIntValue(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -1344,6 +1376,8 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 }
 
 func TestEncodeDecodeUInt8Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -1422,6 +1456,8 @@ func TestEncodeDecodeUInt8Value(t *testing.T) {
 
 func TestEncodeDecodeUInt16Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -1498,6 +1534,8 @@ func TestEncodeDecodeUInt16Value(t *testing.T) {
 }
 
 func TestEncodeDecodeUInt32Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -1576,6 +1614,8 @@ func TestEncodeDecodeUInt32Value(t *testing.T) {
 
 func TestEncodeDecodeUInt64Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -1637,6 +1677,8 @@ func TestEncodeDecodeUInt64Value(t *testing.T) {
 }
 
 func TestEncodeDecodeUInt128Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -1743,6 +1785,8 @@ func TestEncodeDecodeUInt128Value(t *testing.T) {
 
 func TestEncodeDecodeUInt256Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -1837,6 +1881,8 @@ func TestEncodeDecodeUInt256Value(t *testing.T) {
 
 func TestEncodeDecodeWord8Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -1914,6 +1960,8 @@ func TestEncodeDecodeWord8Value(t *testing.T) {
 
 func TestEncodeDecodeWord16Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -1975,6 +2023,8 @@ func TestEncodeDecodeWord16Value(t *testing.T) {
 }
 
 func TestEncodeDecodeWord32Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -2038,6 +2088,8 @@ func TestEncodeDecodeWord32Value(t *testing.T) {
 
 func TestEncodeDecodeWord64Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -2084,6 +2136,8 @@ func TestEncodeDecodeWord64Value(t *testing.T) {
 }
 
 func TestEncodeDecodeSomeValue(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("nil", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -2140,6 +2194,8 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 }
 
 func TestEncodeDecodeFix64Value(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -2249,6 +2305,8 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 
 func TestEncodeDecodeUFix64Value(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("zero", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -2310,6 +2368,8 @@ func TestEncodeDecodeUFix64Value(t *testing.T) {
 }
 
 func TestEncodeDecodeStorageReferenceValue(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("not-authorized", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -2381,6 +2441,8 @@ func TestEncodeDecodeStorageReferenceValue(t *testing.T) {
 }
 
 func TestEncodeDecodeAddressValue(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -2475,6 +2537,8 @@ var publicPathValue = PathValue{
 
 func TestEncodeDecodePathValue(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("private", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -2525,6 +2589,8 @@ func TestEncodeDecodePathValue(t *testing.T) {
 }
 
 func TestEncodeDecodeCapabilityValue(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("private path", func(t *testing.T) {
 		testEncodeDecode(t,
@@ -2610,6 +2676,8 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 }
 
 func TestEncodeDecodeLinkValue(t *testing.T) {
+
+	t.Parallel()
 
 	expectedLinkEncodingPrefix := []byte{
 		// tag

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -31,6 +31,8 @@ import (
 
 func TestInterpreterOptionalBoxing(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := sema.NewChecker(nil, utils.TestLocation)
 	require.NoError(t, err)
 
@@ -103,6 +105,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 }
 
 func TestInterpreterBoxing(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := sema.NewChecker(nil, utils.TestLocation)
 	require.NoError(t, err)

--- a/runtime/interpreter/minus_test.go
+++ b/runtime/interpreter/minus_test.go
@@ -26,6 +26,8 @@ import (
 
 func TestMinusUInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt8Value
 		valid bool
@@ -134,6 +136,8 @@ func TestMinusUInt8(t *testing.T) {
 }
 
 func TestMinusUInt16(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt16Value
@@ -244,6 +248,8 @@ func TestMinusUInt16(t *testing.T) {
 
 func TestMinusUInt32(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt32Value
 		valid bool
@@ -352,6 +358,8 @@ func TestMinusUInt32(t *testing.T) {
 }
 
 func TestMinusUInt64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt64Value
@@ -678,6 +686,8 @@ func TestMinusUInt64(t *testing.T) {
 
 func TestMinusUInt128(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: hex values are integer values, not bit patterns!
 
 	tests := []struct {
@@ -788,6 +798,8 @@ func TestMinusUInt128(t *testing.T) {
 }
 
 func TestMinusUInt256(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: hex values are integer values, not bit patterns!
 
@@ -1242,6 +1254,8 @@ func TestMinusUInt256(t *testing.T) {
 
 func TestMinusInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int8Value
 		valid bool
@@ -1352,6 +1366,8 @@ func TestMinusInt8(t *testing.T) {
 
 func TestMinusInt16(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int16Value
 		valid bool
@@ -1461,6 +1477,8 @@ func TestMinusInt16(t *testing.T) {
 
 func TestMinusInt32(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int32Value
 		valid bool
@@ -1569,6 +1587,8 @@ func TestMinusInt32(t *testing.T) {
 }
 
 func TestMinusInt64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int64Value
@@ -1895,6 +1915,8 @@ func TestMinusInt64(t *testing.T) {
 
 func TestMinusInt128(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: hex values are integer values, not bit patterns!
 
 	tests := []struct {
@@ -2005,6 +2027,8 @@ func TestMinusInt128(t *testing.T) {
 }
 
 func TestMinusInt256(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: hex values are integer values, not bit patterns!
 
@@ -2458,6 +2482,8 @@ func TestMinusInt256(t *testing.T) {
 }
 
 func TestMinusUInt(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  uint64

--- a/runtime/interpreter/mul_test.go
+++ b/runtime/interpreter/mul_test.go
@@ -26,6 +26,8 @@ import (
 
 func TestMulUInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt8Value
 		valid bool
@@ -169,6 +171,8 @@ func TestMulUInt8(t *testing.T) {
 }
 
 func TestMulUInt16(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt16Value
@@ -314,6 +318,8 @@ func TestMulUInt16(t *testing.T) {
 
 func TestMulUInt32(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt32Value
 		valid bool
@@ -458,6 +464,8 @@ func TestMulUInt32(t *testing.T) {
 }
 
 func TestMulUInt64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt64Value
@@ -614,6 +622,8 @@ func TestMulUInt64(t *testing.T) {
 
 func TestMulUInt128(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: hex values are integer values, not bit patterns!
 
 	tests := []struct {
@@ -769,6 +779,8 @@ func TestMulUInt128(t *testing.T) {
 }
 
 func TestMulUInt256(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: hex values are integer values, not bit patterns!
 
@@ -1436,6 +1448,8 @@ func TestMulUInt256(t *testing.T) {
 
 func TestMulInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int8Value
 		valid bool
@@ -1613,6 +1627,8 @@ func TestMulInt8(t *testing.T) {
 }
 
 func TestMulInt16(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int16Value
@@ -1799,6 +1815,8 @@ func TestMulInt16(t *testing.T) {
 
 func TestMulInt32(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int32Value
 		valid bool
@@ -1968,6 +1986,8 @@ func TestMulInt32(t *testing.T) {
 
 func TestMulInt64(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int64Value
 		valid bool
@@ -2123,6 +2143,8 @@ func TestMulInt64(t *testing.T) {
 
 func TestMulInt128(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: hex values are integer values, not bit patterns!
 
 	tests := []struct {
@@ -2277,6 +2299,8 @@ func TestMulInt128(t *testing.T) {
 }
 
 func TestMulInt256(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: hex values are integer values, not bit patterns!
 

--- a/runtime/interpreter/negate_test.go
+++ b/runtime/interpreter/negate_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestNegate(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("Int8", func(t *testing.T) {
 		assert.Panics(t, func() {
 			Int8Value(math.MinInt8).Negate()

--- a/runtime/interpreter/plus_test.go
+++ b/runtime/interpreter/plus_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestPlusUInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt8Value
 		valid bool
@@ -140,6 +142,8 @@ func TestPlusUInt8(t *testing.T) {
 
 func TestPlusUInt16(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  UInt16Value
 		valid bool
@@ -248,6 +252,8 @@ func TestPlusUInt16(t *testing.T) {
 }
 
 func TestPlusUInt32(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt32Value
@@ -358,6 +364,8 @@ func TestPlusUInt32(t *testing.T) {
 }
 
 func TestPlusUInt64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt64Value
@@ -698,6 +706,8 @@ func uint128(v string) UInt128Value {
 
 func TestPlusUInt128(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: hex values are integer values, not bit patterns!
 
 	tests := []struct {
@@ -823,6 +833,8 @@ func uint256(v string) UInt256Value {
 }
 
 func TestPlusUInt256(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  UInt256Value
@@ -1276,6 +1288,8 @@ func TestPlusUInt256(t *testing.T) {
 
 func TestPlusInt8(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int8Value
 		valid bool
@@ -1385,6 +1399,8 @@ func TestPlusInt8(t *testing.T) {
 }
 
 func TestPlusInt16(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int16Value
@@ -1496,6 +1512,8 @@ func TestPlusInt16(t *testing.T) {
 
 func TestPlusInt32(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		a, b  Int32Value
 		valid bool
@@ -1605,6 +1623,8 @@ func TestPlusInt32(t *testing.T) {
 }
 
 func TestPlusInt64(t *testing.T) {
+
+	t.Parallel()
 
 	tests := []struct {
 		a, b  Int64Value
@@ -1955,6 +1975,8 @@ func int128(v string) Int128Value {
 
 func TestPlusInt128(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: hex values are integer values, not bit patterns!
 
 	tests := []struct {
@@ -2079,6 +2101,8 @@ func int256(v string) Int256Value {
 }
 
 func TestPlusInt256(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: hex values are integer values, not bit patterns!
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -38,6 +38,9 @@ func newTestCompositeValue(owner common.Address) *CompositeValue {
 }
 
 func TestOwnerNewArray(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 
 	value := newTestCompositeValue(oldOwner)
@@ -51,6 +54,9 @@ func TestOwnerNewArray(t *testing.T) {
 }
 
 func TestSetOwnerArray(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -65,6 +71,9 @@ func TestSetOwnerArray(t *testing.T) {
 }
 
 func TestSetOwnerArrayCopy(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -83,6 +92,9 @@ func TestSetOwnerArrayCopy(t *testing.T) {
 }
 
 func TestSetOwnerArraySetIndex(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -104,6 +116,9 @@ func TestSetOwnerArraySetIndex(t *testing.T) {
 }
 
 func TestSetOwnerArrayAppend(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -122,6 +137,9 @@ func TestSetOwnerArrayAppend(t *testing.T) {
 }
 
 func TestSetOwnerArrayInsert(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -140,6 +158,9 @@ func TestSetOwnerArrayInsert(t *testing.T) {
 }
 
 func TestOwnerNewDictionary(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 
 	keyValue := NewStringValue("test")
@@ -155,6 +176,9 @@ func TestOwnerNewDictionary(t *testing.T) {
 }
 
 func TestSetOwnerDictionary(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -170,6 +194,9 @@ func TestSetOwnerDictionary(t *testing.T) {
 }
 
 func TestSetOwnerDictionaryCopy(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -188,6 +215,9 @@ func TestSetOwnerDictionaryCopy(t *testing.T) {
 }
 
 func TestSetOwnerDictionarySetIndex(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -212,6 +242,9 @@ func TestSetOwnerDictionarySetIndex(t *testing.T) {
 }
 
 func TestSetOwnerDictionaryInsert(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -231,6 +264,9 @@ func TestSetOwnerDictionaryInsert(t *testing.T) {
 }
 
 func TestOwnerNewSome(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 
 	value := newTestCompositeValue(oldOwner)
@@ -244,6 +280,9 @@ func TestOwnerNewSome(t *testing.T) {
 }
 
 func TestSetOwnerSome(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -260,6 +299,9 @@ func TestSetOwnerSome(t *testing.T) {
 }
 
 func TestSetOwnerSomeCopy(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -279,6 +321,9 @@ func TestSetOwnerSomeCopy(t *testing.T) {
 }
 
 func TestOwnerNewComposite(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 
 	composite := newTestCompositeValue(oldOwner)
@@ -287,6 +332,9 @@ func TestOwnerNewComposite(t *testing.T) {
 }
 
 func TestSetOwnerComposite(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 
@@ -304,6 +352,9 @@ func TestSetOwnerComposite(t *testing.T) {
 }
 
 func TestSetOwnerCompositeCopy(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 
 	value := newTestCompositeValue(oldOwner)
@@ -322,6 +373,9 @@ func TestSetOwnerCompositeCopy(t *testing.T) {
 }
 
 func TestSetOwnerCompositeSetMember(t *testing.T) {
+
+	t.Parallel()
+
 	oldOwner := common.Address{0x1}
 	newOwner := common.Address{0x2}
 

--- a/runtime/parser/parse_test.go
+++ b/runtime/parser/parse_test.go
@@ -26,6 +26,8 @@ import (
 
 func TestParseIncomplete(t *testing.T) {
 
+	t.Parallel()
+
 	program, inputIsComplete, err := ParseProgram("struct X")
 
 	assert.Nil(t, program)

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestParseVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("var, no type annotation, copy, one value", func(t *testing.T) {
 		result, errs := ParseStatements("var x = 1")
 		require.Empty(t, errs)
@@ -164,6 +166,8 @@ func TestParseVariableDeclaration(t *testing.T) {
 }
 
 func TestParseParameterList(t *testing.T) {
+
+	t.Parallel()
 
 	parse := func(input string) (interface{}, []error) {
 		return Parse(
@@ -341,6 +345,8 @@ func TestParseParameterList(t *testing.T) {
 }
 
 func TestParseFunctionDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("without return type", func(t *testing.T) {
 		result, errs := ParseStatements("fun foo () { }")

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -33,6 +33,9 @@ func TestParseVariableDeclaration(t *testing.T) {
 	t.Parallel()
 
 	t.Run("var, no type annotation, copy, one value", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("var x = 1")
 		require.Empty(t, errs)
 
@@ -64,6 +67,9 @@ func TestParseVariableDeclaration(t *testing.T) {
 	})
 
 	t.Run("let, no type annotation, copy, one value", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("let x = 1")
 		require.Empty(t, errs)
 
@@ -95,6 +101,9 @@ func TestParseVariableDeclaration(t *testing.T) {
 	})
 
 	t.Run("let, no type annotation, move, one value", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("let x <- 1")
 		require.Empty(t, errs)
 
@@ -126,6 +135,9 @@ func TestParseVariableDeclaration(t *testing.T) {
 	})
 
 	t.Run("let, resource type annotation, move, one value", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("let r2: @R <- r")
 		require.Empty(t, errs)
 
@@ -179,6 +191,9 @@ func TestParseParameterList(t *testing.T) {
 	}
 
 	t.Run("empty", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := parse("()")
 		require.Empty(t, errs)
 
@@ -194,6 +209,9 @@ func TestParseParameterList(t *testing.T) {
 	})
 
 	t.Run("space", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := parse(" (   )")
 		require.Empty(t, errs)
 
@@ -209,6 +227,9 @@ func TestParseParameterList(t *testing.T) {
 	})
 
 	t.Run("one, without argument label", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := parse("( a : Int )")
 		require.Empty(t, errs)
 
@@ -247,6 +268,9 @@ func TestParseParameterList(t *testing.T) {
 	})
 
 	t.Run("one, with argument label", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := parse("( a b : Int )")
 		require.Empty(t, errs)
 
@@ -285,6 +309,9 @@ func TestParseParameterList(t *testing.T) {
 	})
 
 	t.Run("two, with and without argument label", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := parse("( a b : Int , c : Int )")
 		require.Empty(t, errs)
 
@@ -349,6 +376,9 @@ func TestParseFunctionDeclaration(t *testing.T) {
 	t.Parallel()
 
 	t.Run("without return type", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("fun foo () { }")
 		require.Empty(t, errs)
 
@@ -392,6 +422,9 @@ func TestParseFunctionDeclaration(t *testing.T) {
 	})
 
 	t.Run("with return type", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("fun foo (): X { }")
 		require.Empty(t, errs)
 

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -42,6 +42,9 @@ func TestParseSimpleInfixExpression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no spaces", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("1+2*3")
 		require.Empty(t, errs)
 
@@ -81,6 +84,9 @@ func TestParseSimpleInfixExpression(t *testing.T) {
 	})
 
 	t.Run("with spaces", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("  1   +   2  *   3 ")
 		require.Empty(t, errs)
 
@@ -120,6 +126,9 @@ func TestParseSimpleInfixExpression(t *testing.T) {
 	})
 
 	t.Run("repeated infix, same operator, left associative", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("1 + 2 + 3")
 		require.Empty(t, errs)
 
@@ -159,6 +168,9 @@ func TestParseSimpleInfixExpression(t *testing.T) {
 	})
 
 	t.Run("repeated infix, same operator, right associative", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("1 ?? 2 ?? 3")
 		require.Empty(t, errs)
 
@@ -203,6 +215,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("mixed infix and prefix", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("1 +- 2 ++ 3")
 		require.Empty(t, errs)
 
@@ -246,6 +261,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 	})
 
 	t.Run("nested expression", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("(1 + 2) * 3")
 		require.Empty(t, errs)
 
@@ -285,6 +303,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 	})
 
 	t.Run("less and greater", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("1 < 2 > 3")
 		require.Empty(t, errs)
 
@@ -324,6 +345,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 	})
 
 	t.Run("conditional", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("a ? b : c ? d : e")
 		require.Empty(t, errs)
 
@@ -367,6 +391,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 	})
 
 	t.Run("boolean expressions", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("true + false")
 		require.Empty(t, errs)
 
@@ -393,6 +420,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 	})
 
 	t.Run("move operator, nested", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("(<-x)")
 		require.Empty(t, errs)
 
@@ -418,6 +448,9 @@ func TestParseArrayExpression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("array expression", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("[ 1,2 + 3, 4  ,  5 ]")
 		require.Empty(t, errs)
 
@@ -483,6 +516,9 @@ func TestParseDictionaryExpression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("dictionary expression", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("{ 1:2 + 3, 4  :  5 }")
 		require.Empty(t, errs)
 
@@ -552,6 +588,9 @@ func TestParseIdentifier(t *testing.T) {
 	t.Parallel()
 
 	t.Run("identifier in addition", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("a + 3")
 		require.Empty(t, errs)
 
@@ -606,6 +645,9 @@ func TestParseString(t *testing.T) {
 	t.Parallel()
 
 	t.Run("valid, empty", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("\"\"")
 		assert.Empty(t, errs)
 
@@ -622,6 +664,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, empty, missing end at end of file", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("\"")
 		assert.Equal(t,
 			[]error{
@@ -643,6 +688,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, empty, missing end at end of line", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("\"\n")
 		assert.Equal(t,
 			[]error{
@@ -664,6 +712,8 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, non-empty, missing end at end of file", func(t *testing.T) {
+
+		t.Parallel()
 		result, errs := ParseExpression("\"t")
 		assert.Equal(t,
 			[]error{
@@ -685,6 +735,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, non-empty, missing end at end of line", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("\"t\n")
 		assert.Equal(t,
 			[]error{
@@ -706,6 +759,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, non-empty, missing escape character", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("\"\\")
 		assert.Equal(t,
 			[]error{
@@ -728,6 +784,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("valid, with escapes", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`"te\tst\"te\u{1F3CE}\u{FE0F}xt"`)
 		assert.Empty(t, errs)
 
@@ -744,6 +803,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, unknown escape character", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`"te\Xst"`)
 		assert.Equal(t,
 			[]error{
@@ -765,6 +827,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, missing '{' after Unicode escape character", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`"te\u`)
 		assert.Equal(t,
 			[]error{
@@ -787,6 +852,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, invalid character after Unicode escape character", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`"te\us`)
 		assert.Equal(t,
 			[]error{
@@ -809,6 +877,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, missing '}' after Unicode escape sequence digits", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`"te\u{`)
 		assert.Equal(t,
 			[]error{
@@ -831,6 +902,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("valid, empty Unicode escape sequence", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`"te\u{}"`)
 		assert.Empty(t, errs)
 
@@ -847,6 +921,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("valid, non-empty Unicode escape sequence", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(
 			`"te\u{73}t ` +
 				`\u{4A}J\u{4a}J ` +
@@ -871,6 +948,9 @@ func TestParseString(t *testing.T) {
 	})
 
 	t.Run("invalid, non-empty Unicode escape sequence", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`"te\u{X}st"`)
 		assert.Equal(t,
 			[]error{
@@ -897,6 +977,9 @@ func TestInvocation(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no arguments", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f()")
 		require.Empty(t, errs)
 
@@ -916,6 +999,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("no arguments, with whitespace", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f ()")
 		require.Empty(t, errs)
 
@@ -935,6 +1021,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("no arguments, with whitespace within params", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f ( )")
 		require.Empty(t, errs)
 
@@ -954,6 +1043,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("with arguments", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f(1)")
 		require.Empty(t, errs)
 
@@ -985,6 +1077,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("with arguments, multiple", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f(1,2)")
 		require.Empty(t, errs)
 
@@ -1027,6 +1122,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("invalid: no arguments, multiple commas", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseExpression("f(,,)")
 		require.Equal(t,
 			[]error{
@@ -1040,6 +1138,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("invalid: with argument, multiple commas", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseExpression("f(1,,)")
 		require.Equal(t,
 			[]error{
@@ -1053,6 +1154,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("invalid: with multiple argument, no commas", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseExpression("f(1 2)")
 		require.Equal(t,
 			[]error{
@@ -1066,6 +1170,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("with arguments, nested", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f(1,g(2))")
 		require.Empty(t, errs)
 
@@ -1122,6 +1229,9 @@ func TestInvocation(t *testing.T) {
 	})
 
 	t.Run("with arguments, nested, string", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f(1,g(\"test\"))")
 		require.Empty(t, errs)
 
@@ -1182,6 +1292,9 @@ func TestMemberExpression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("identifier, no space", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f.n")
 		require.Empty(t, errs)
 
@@ -1203,6 +1316,9 @@ func TestMemberExpression(t *testing.T) {
 	})
 
 	t.Run("whitespace between", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f .n")
 		require.Empty(t, errs)
 
@@ -1224,6 +1340,9 @@ func TestMemberExpression(t *testing.T) {
 	})
 
 	t.Run("precedence", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("3 * f.n")
 		require.Empty(t, errs)
 
@@ -1256,6 +1375,9 @@ func TestMemberExpression(t *testing.T) {
 	})
 
 	t.Run("identifier, optional", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("f?.n")
 		require.Empty(t, errs)
 
@@ -1284,6 +1406,8 @@ func TestParseBlockComment(t *testing.T) {
 
 	t.Run("nested comment, nothing else", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(" /* test  foo/* bar  */ asd*/ true")
 		require.Empty(t, errs)
 
@@ -1301,6 +1425,8 @@ func TestParseBlockComment(t *testing.T) {
 
 	t.Run("two comments", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(" /*test  foo*/ /* bar  */ true")
 		require.Empty(t, errs)
 
@@ -1317,6 +1443,8 @@ func TestParseBlockComment(t *testing.T) {
 	})
 
 	t.Run("in infix", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(" 1/*test  foo*/+/* bar  */ 2  ")
 		require.Empty(t, errs)
@@ -1421,6 +1549,8 @@ func TestParseCasts(t *testing.T) {
 
 	t.Run("non-failable", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(" t as T")
 		require.Empty(t, errs)
 
@@ -1448,6 +1578,8 @@ func TestParseCasts(t *testing.T) {
 	})
 
 	t.Run("failable", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(" t as? T")
 		require.Empty(t, errs)
@@ -1477,6 +1609,8 @@ func TestParseCasts(t *testing.T) {
 	})
 
 	t.Run("force", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(" t as! T")
 		require.Empty(t, errs)
@@ -1511,6 +1645,9 @@ func TestParseForceExpression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("identifier", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("t!")
 		require.Empty(t, errs)
 		utils.AssertEqualWithDiff(t,
@@ -1528,6 +1665,9 @@ func TestParseForceExpression(t *testing.T) {
 	})
 
 	t.Run("with whitespace", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(" t ! ")
 		require.Empty(t, errs)
 		utils.AssertEqualWithDiff(t,
@@ -1545,6 +1685,9 @@ func TestParseForceExpression(t *testing.T) {
 	})
 
 	t.Run("precedence, force unwrap before move", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("<-t!")
 		require.Empty(t, errs)
 		utils.AssertEqualWithDiff(t,
@@ -1566,6 +1709,9 @@ func TestParseForceExpression(t *testing.T) {
 	})
 
 	t.Run("precedence", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("10 *  t!")
 		require.Empty(t, errs)
 		utils.AssertEqualWithDiff(t,
@@ -1598,6 +1744,9 @@ func TestParseCreate(t *testing.T) {
 	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("create T()")
 		require.Empty(t, errs)
 
@@ -1639,6 +1788,9 @@ func TestParseDestroy(t *testing.T) {
 	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("destroy t")
 		require.Empty(t, errs)
 
@@ -1693,6 +1845,9 @@ func TestParseFunctionExpression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("without return type", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("fun () { }")
 		require.Empty(t, errs)
 
@@ -1730,6 +1885,9 @@ func TestParseFunctionExpression(t *testing.T) {
 	})
 
 	t.Run("with return type", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression("fun (): X { }")
 		require.Empty(t, errs)
 
@@ -1772,6 +1930,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("binary prefix, missing trailing digits", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0b`)
 		require.Equal(t,
 			[]error{
@@ -1803,6 +1963,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("binary", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`0b101010`)
 		require.Empty(t, errs)
@@ -1840,6 +2002,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("binary with underscores", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0b101010_101010`)
 		require.Empty(t, errs)
 
@@ -1857,6 +2021,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("binary with leading underscore", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`0b_101010_101010`)
 		require.Equal(t,
@@ -1889,6 +2055,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("binary with trailing underscore", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0b101010_101010_`)
 		require.Equal(t,
 			[]error{
@@ -1919,6 +2087,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("octal prefix, missing trailing digits", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`0o`)
 		require.Equal(t,
@@ -1952,6 +2122,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("octal", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0o32`)
 		require.Empty(t, errs)
 
@@ -1970,6 +2142,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("octal with underscores", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0o32_45`)
 		require.Empty(t, errs)
 
@@ -1987,6 +2161,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("octal with leading underscore", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`0o_32_45`)
 		require.Equal(t,
@@ -2019,6 +2195,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("octal with leading underscore", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0o32_45_`)
 		require.Equal(t,
 			[]error{
@@ -2050,6 +2228,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("decimal", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`1234567890`)
 		require.Empty(t, errs)
 
@@ -2068,6 +2248,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("decimal with underscores", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`1_234_567_890`)
 		require.Empty(t, errs)
 
@@ -2085,6 +2267,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("decimal with trailing underscore", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`1_234_567_890_`)
 		require.Equal(t,
@@ -2116,6 +2300,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("hexadecimal prefix, missing trailing digits", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`0x`)
 		require.Equal(t,
@@ -2149,6 +2335,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("hexadecimal", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0xf2`)
 		require.Empty(t, errs)
 
@@ -2167,6 +2355,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("hexadecimal with underscores", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0xf2_09`)
 		require.Empty(t, errs)
 
@@ -2184,6 +2374,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("hexadecimal with leading underscore", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`0x_f2_09`)
 		require.Equal(t,
@@ -2216,6 +2408,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("hexadecimal with trailing underscore", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0xf2_09_`)
 		require.Equal(t,
 			[]error{
@@ -2247,6 +2441,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("0", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`0`)
 		require.Empty(t, errs)
 
@@ -2264,6 +2460,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("01", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression(`01`)
 		require.Empty(t, errs)
@@ -2283,6 +2481,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("09", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression(`09`)
 		require.Empty(t, errs)
 
@@ -2301,6 +2501,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Run("leading zeros", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression("00123")
 		require.Empty(t, errs)
 
@@ -2318,6 +2520,9 @@ func TestParseIntegerLiterals(t *testing.T) {
 	})
 
 	t.Run("invalid prefix", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseExpression(`0z123`)
 		require.Equal(t,
 			[]error{
@@ -2355,6 +2560,8 @@ func TestParseFixedPoint(t *testing.T) {
 
 	t.Run("with underscores", func(t *testing.T) {
 
+		t.Parallel()
+
 		result, errs := ParseExpression("1234_5678_90.0009_8765_4321")
 		require.Empty(t, errs)
 
@@ -2374,6 +2581,8 @@ func TestParseFixedPoint(t *testing.T) {
 	})
 
 	t.Run("leading zero", func(t *testing.T) {
+
+		t.Parallel()
 
 		result, errs := ParseExpression("0.1")
 		require.Empty(t, errs)

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -39,6 +39,8 @@ import (
 
 func TestParseSimpleInfixExpression(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("no spaces", func(t *testing.T) {
 		result, errs := ParseExpression("1+2*3")
 		require.Empty(t, errs)
@@ -197,6 +199,8 @@ func TestParseSimpleInfixExpression(t *testing.T) {
 }
 
 func TestParseAdvancedExpression(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("mixed infix and prefix", func(t *testing.T) {
 		result, errs := ParseExpression("1 +- 2 ++ 3")
@@ -411,6 +415,8 @@ func TestParseAdvancedExpression(t *testing.T) {
 
 func TestParseArrayExpression(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("array expression", func(t *testing.T) {
 		result, errs := ParseExpression("[ 1,2 + 3, 4  ,  5 ]")
 		require.Empty(t, errs)
@@ -473,6 +479,8 @@ func TestParseArrayExpression(t *testing.T) {
 }
 
 func TestParseDictionaryExpression(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("dictionary expression", func(t *testing.T) {
 		result, errs := ParseExpression("{ 1:2 + 3, 4  :  5 }")
@@ -541,6 +549,8 @@ func TestParseDictionaryExpression(t *testing.T) {
 
 func TestParseIdentifier(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("identifier in addition", func(t *testing.T) {
 		result, errs := ParseExpression("a + 3")
 		require.Empty(t, errs)
@@ -570,6 +580,8 @@ func TestParseIdentifier(t *testing.T) {
 
 func TestParsePath(t *testing.T) {
 
+	t.Parallel()
+
 	result, errs := ParseExpression("/foo/bar")
 	require.Empty(t, errs)
 
@@ -590,6 +602,8 @@ func TestParsePath(t *testing.T) {
 }
 
 func TestParseString(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("valid, empty", func(t *testing.T) {
 		result, errs := ParseExpression("\"\"")
@@ -880,6 +894,8 @@ func TestParseString(t *testing.T) {
 
 func TestInvocation(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("no arguments", func(t *testing.T) {
 		result, errs := ParseExpression("f()")
 		require.Empty(t, errs)
@@ -1163,6 +1179,8 @@ func TestInvocation(t *testing.T) {
 
 func TestMemberExpression(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("identifier, no space", func(t *testing.T) {
 		result, errs := ParseExpression("f.n")
 		require.Empty(t, errs)
@@ -1261,6 +1279,8 @@ func TestMemberExpression(t *testing.T) {
 }
 
 func TestParseBlockComment(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("nested comment, nothing else", func(t *testing.T) {
 
@@ -1370,6 +1390,8 @@ func BenchmarkParseArray(b *testing.B) {
 
 func TestParseReference(t *testing.T) {
 
+	t.Parallel()
+
 	result, errs := ParseExpression("& t as T")
 	require.Empty(t, errs)
 
@@ -1394,6 +1416,8 @@ func TestParseReference(t *testing.T) {
 }
 
 func TestParseCasts(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("non-failable", func(t *testing.T) {
 
@@ -1484,6 +1508,8 @@ func TestParseCasts(t *testing.T) {
 
 func TestParseForceExpression(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("identifier", func(t *testing.T) {
 		result, errs := ParseExpression("t!")
 		require.Empty(t, errs)
@@ -1569,6 +1595,8 @@ func TestParseForceExpression(t *testing.T) {
 
 func TestParseCreate(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("simple", func(t *testing.T) {
 		result, errs := ParseExpression("create T()")
 		require.Empty(t, errs)
@@ -1592,6 +1620,9 @@ func TestParseCreate(t *testing.T) {
 }
 
 func TestParseNil(t *testing.T) {
+
+	t.Parallel()
+
 	result, errs := ParseExpression(" nil")
 	require.Empty(t, errs)
 
@@ -1604,6 +1635,8 @@ func TestParseNil(t *testing.T) {
 }
 
 func TestParseDestroy(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
 		result, errs := ParseExpression("destroy t")
@@ -1625,6 +1658,9 @@ func TestParseDestroy(t *testing.T) {
 }
 
 func TestParseLineComment(t *testing.T) {
+
+	t.Parallel()
+
 	result, errs := ParseExpression(" //// // this is a comment\n 1 / 2")
 	require.Empty(t, errs)
 
@@ -1653,6 +1689,8 @@ func TestParseLineComment(t *testing.T) {
 }
 
 func TestParseFunctionExpression(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("without return type", func(t *testing.T) {
 		result, errs := ParseExpression("fun () { }")
@@ -1729,6 +1767,8 @@ func TestParseFunctionExpression(t *testing.T) {
 }
 
 func TestParseIntegerLiterals(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("binary prefix, missing trailing digits", func(t *testing.T) {
 
@@ -2310,6 +2350,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 }
 
 func TestParseFixedPoint(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("with underscores", func(t *testing.T) {
 

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -47,6 +47,8 @@ func testLex(t *testing.T, input string, expected []Token) {
 
 func TestLexBasic(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("two numbers separated by whitespace", func(t *testing.T) {
 		testLex(t,
 			" 01\t  10",
@@ -595,6 +597,8 @@ func TestLexBasic(t *testing.T) {
 
 func TestLexString(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("valid, empty", func(t *testing.T) {
 		testLex(t,
 			`""`,
@@ -852,6 +856,8 @@ func TestLexString(t *testing.T) {
 
 func TestLexBlockComment(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("nested 1", func(t *testing.T) {
 		testLex(t,
 			`/*  // *X /* \\*  */`,
@@ -981,6 +987,8 @@ func TestLexBlockComment(t *testing.T) {
 }
 
 func TestLexIntegerLiterals(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("binary prefix, missing trailing digits", func(t *testing.T) {
 		testLex(t,
@@ -1577,6 +1585,8 @@ func TestLexIntegerLiterals(t *testing.T) {
 
 func TestLexFixedPoint(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("with underscores", func(t *testing.T) {
 		testLex(t,
 			"1234_5678_90.0009_8765_4321",
@@ -1625,6 +1635,8 @@ func TestLexFixedPoint(t *testing.T) {
 }
 
 func TestLexLineComment(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("no newline", func(t *testing.T) {
 

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -40,6 +40,9 @@ func withTokens(tokenChan chan Token, fn func([]Token)) {
 }
 
 func testLex(t *testing.T, input string, expected []Token) {
+
+	t.Parallel()
+
 	withTokens(Lex(input), func(tokens []Token) {
 		assert.Equal(t, expected, tokens)
 	})

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestParseReturnStatement(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("no expression", func(t *testing.T) {
 		result, errs := ParseStatements("return")
 		require.Empty(t, errs)
@@ -128,6 +130,8 @@ func TestParseReturnStatement(t *testing.T) {
 }
 
 func TestParseIfStatement(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("only empty then", func(t *testing.T) {
 		result, errs := ParseStatements("if true { }")
@@ -499,6 +503,8 @@ func TestParseIfStatement(t *testing.T) {
 
 func TestParseWhileStatement(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("empty block", func(t *testing.T) {
 		result, errs := ParseStatements("while true { }")
 		require.Empty(t, errs)
@@ -529,6 +535,8 @@ func TestParseWhileStatement(t *testing.T) {
 }
 
 func TestParseAssignmentStatement(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("copy", func(t *testing.T) {
 		result, errs := ParseStatements(" x = 1")
@@ -626,6 +634,8 @@ func TestParseAssignmentStatement(t *testing.T) {
 
 func TestParseSwapStatement(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("simple", func(t *testing.T) {
 		result, errs := ParseStatements(" x <-> y")
 		require.Empty(t, errs)
@@ -653,6 +663,8 @@ func TestParseSwapStatement(t *testing.T) {
 }
 
 func TestParseForStatement(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("empty block", func(t *testing.T) {
 		result, errs := ParseStatements("for x in y { }")
@@ -687,6 +699,8 @@ func TestParseForStatement(t *testing.T) {
 }
 
 func TestParseEmit(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
 		result, errs := ParseStatements("emit T()")

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -33,6 +33,9 @@ func TestParseReturnStatement(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no expression", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("return")
 		require.Empty(t, errs)
 
@@ -50,6 +53,9 @@ func TestParseReturnStatement(t *testing.T) {
 	})
 
 	t.Run("expression on same line", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("return 1")
 		require.Empty(t, errs)
 
@@ -75,6 +81,9 @@ func TestParseReturnStatement(t *testing.T) {
 	})
 
 	t.Run("expression on next line, no semicolon", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("return \n1")
 		require.Empty(t, errs)
 
@@ -102,6 +111,9 @@ func TestParseReturnStatement(t *testing.T) {
 	})
 
 	t.Run("expression on next line, semicolon", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("return ;\n1")
 		require.Empty(t, errs)
 
@@ -134,6 +146,9 @@ func TestParseIfStatement(t *testing.T) {
 	t.Parallel()
 
 	t.Run("only empty then", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("if true { }")
 		require.Empty(t, errs)
 
@@ -162,6 +177,9 @@ func TestParseIfStatement(t *testing.T) {
 	})
 
 	t.Run("only then, two statements on one line", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("if true { 1 ; 2 }")
 		require.Empty(t, errs)
 
@@ -211,6 +229,9 @@ func TestParseIfStatement(t *testing.T) {
 	})
 
 	t.Run("only then, two statements on multiple lines", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("if true { 1 \n 2 }")
 		require.Empty(t, errs)
 
@@ -260,6 +281,9 @@ func TestParseIfStatement(t *testing.T) {
 	})
 
 	t.Run("with else", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("if true { 1 } else { 2 }")
 		require.Empty(t, errs)
 
@@ -317,6 +341,9 @@ func TestParseIfStatement(t *testing.T) {
 	})
 
 	t.Run("with else if and else, no space", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("if true{1}else if true {2} else{3}")
 		require.Empty(t, errs)
 
@@ -410,6 +437,9 @@ func TestParseIfStatement(t *testing.T) {
 	})
 
 	t.Run("if-var", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("if var x = 1 { }")
 		require.Empty(t, errs)
 
@@ -455,6 +485,9 @@ func TestParseIfStatement(t *testing.T) {
 	})
 
 	t.Run("if-let", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("if let x = 1 { }")
 		require.Empty(t, errs)
 
@@ -506,6 +539,9 @@ func TestParseWhileStatement(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty block", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("while true { }")
 		require.Empty(t, errs)
 
@@ -539,6 +575,9 @@ func TestParseAssignmentStatement(t *testing.T) {
 	t.Parallel()
 
 	t.Run("copy", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements(" x = 1")
 		require.Empty(t, errs)
 
@@ -570,6 +609,9 @@ func TestParseAssignmentStatement(t *testing.T) {
 	})
 
 	t.Run("move", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements(" x <- 1")
 		require.Empty(t, errs)
 
@@ -601,6 +643,9 @@ func TestParseAssignmentStatement(t *testing.T) {
 	})
 
 	t.Run("move", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements(" x <-! 1")
 		require.Empty(t, errs)
 
@@ -637,6 +682,9 @@ func TestParseSwapStatement(t *testing.T) {
 	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements(" x <-> y")
 		require.Empty(t, errs)
 
@@ -667,6 +715,9 @@ func TestParseForStatement(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty block", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("for x in y { }")
 		require.Empty(t, errs)
 
@@ -703,6 +754,9 @@ func TestParseEmit(t *testing.T) {
 	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseStatements("emit T()")
 		require.Empty(t, errs)
 

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -34,6 +34,9 @@ func TestParseNominalType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("Int")
 		require.Empty(t, errs)
 
@@ -49,6 +52,9 @@ func TestParseNominalType(t *testing.T) {
 	})
 
 	t.Run("nested", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("Foo.Bar")
 		require.Empty(t, errs)
 
@@ -75,6 +81,9 @@ func TestParseArrayType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("variable", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("[Int]")
 		require.Empty(t, errs)
 
@@ -96,6 +105,9 @@ func TestParseArrayType(t *testing.T) {
 	})
 
 	t.Run("constant", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("[Int ; 2 ]")
 		require.Empty(t, errs)
 
@@ -131,6 +143,9 @@ func TestParseOptionalType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nominal", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("Int?")
 		require.Empty(t, errs)
 
@@ -149,6 +164,9 @@ func TestParseOptionalType(t *testing.T) {
 	})
 
 	t.Run("double", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("Int??")
 		require.Empty(t, errs)
 
@@ -170,6 +188,9 @@ func TestParseOptionalType(t *testing.T) {
 	})
 
 	t.Run("triple", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("Int???")
 		require.Empty(t, errs)
 
@@ -199,6 +220,9 @@ func TestParseReferenceType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("unauthorized, nominal", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("&Int")
 		require.Empty(t, errs)
 
@@ -218,6 +242,9 @@ func TestParseReferenceType(t *testing.T) {
 	})
 
 	t.Run("authorized, nominal", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("auth &Int")
 		require.Empty(t, errs)
 
@@ -242,6 +269,9 @@ func TestParseOptionalReferenceType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("unauthorized", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("&Int?")
 		require.Empty(t, errs)
 
@@ -269,6 +299,9 @@ func TestParseRestrictedType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("with restricted type, no restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("T{}")
 		require.Empty(t, errs)
 
@@ -291,6 +324,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("with restricted type, one restriction", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("T{U}")
 		require.Empty(t, errs)
 
@@ -320,6 +356,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("with restricted type, two restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("T{ U , V }")
 		require.Empty(t, errs)
 
@@ -355,6 +394,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("without restricted type, no restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("{}")
 		require.Empty(t, errs)
 
@@ -370,6 +412,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("without restricted type, one restriction", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("{ T }")
 		require.Empty(t, errs)
 
@@ -393,6 +438,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, missing type after comma", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{ T , }")
 		require.Equal(t,
 			[]error{
@@ -403,6 +451,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, type without comma", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{ T U }")
 		require.Equal(t,
 			[]error{
@@ -413,6 +464,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, colon", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{ T , U : V }")
 		require.Equal(t,
 			[]error{
@@ -423,6 +477,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: with restricted type, colon", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("T{ T , U : V }")
 		require.Equal(t,
 			[]error{
@@ -433,6 +490,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, first is non-nominal", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{[T]}")
 		require.Equal(t,
 			[]error{
@@ -443,6 +503,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: with restricted type, first is non-nominal", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("T{[U]}")
 		require.Equal(t,
 			[]error{
@@ -453,6 +516,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, second is non-nominal", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{T, [U]}")
 		require.Equal(t,
 			[]error{
@@ -463,6 +529,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: with restricted type, second is non-nominal", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("T{U, [V]}")
 		require.Equal(t,
 			[]error{
@@ -473,6 +542,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, missing end", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{")
 		require.Equal(t,
 			[]error{
@@ -483,6 +555,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: with restricted type, missing end", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("T{")
 		require.Equal(t,
 			[]error{
@@ -493,6 +568,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, missing end after type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{U")
 		require.Equal(t,
 			[]error{
@@ -503,6 +581,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: with restricted type, missing end after type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("T{U")
 		require.Equal(t,
 			[]error{
@@ -513,6 +594,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, missing end after comma", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{U,")
 		require.Equal(t,
 			[]error{
@@ -523,6 +607,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: with restricted type, missing end after comma", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("T{U,")
 		require.Equal(t,
 			[]error{
@@ -533,6 +620,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: without restricted type, just comma", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{,}")
 		require.Equal(t,
 			[]error{
@@ -543,6 +633,9 @@ func TestParseRestrictedType(t *testing.T) {
 	})
 
 	t.Run("invalid: with restricted type, just comma", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("T{,}")
 		require.Equal(t,
 			[]error{
@@ -558,6 +651,9 @@ func TestParseDictionaryType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("{T: U}")
 		require.Empty(t, errs)
 
@@ -585,6 +681,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, missing value type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{T:}")
 		require.Equal(t,
 			[]error{
@@ -595,6 +694,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, missing key and value type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{:}")
 		require.Equal(t,
 			[]error{
@@ -605,6 +707,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, missing key type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{:U}")
 		require.Equal(t,
 			[]error{
@@ -615,6 +720,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, unexpected comma after value type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{T:U,}")
 		require.Equal(t,
 			[]error{
@@ -625,6 +733,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, unexpected colon after value type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{T:U:}")
 		require.Equal(t,
 			[]error{
@@ -635,6 +746,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, unexpected colon after colon", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{T::U}")
 		require.Equal(t,
 			[]error{
@@ -645,6 +759,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, missing value type after colon", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{T:")
 		require.Equal(t,
 			[]error{
@@ -655,6 +772,9 @@ func TestParseDictionaryType(t *testing.T) {
 	})
 
 	t.Run("invalid, missing end after key type  and value type", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, errs := ParseType("{T:U")
 		require.Equal(t,
 			[]error{
@@ -671,6 +791,9 @@ func TestParseFunctionType(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no parameters, Void return type", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("(():Void)")
 		require.Empty(t, errs)
 
@@ -697,6 +820,9 @@ func TestParseFunctionType(t *testing.T) {
 	})
 
 	t.Run("three parameters, Int return type", func(t *testing.T) {
+
+		t.Parallel()
+
 		result, errs := ParseType("( ( String , Bool , @R ) : Int)")
 		require.Empty(t, errs)
 

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -31,6 +31,8 @@ import (
 
 func TestParseNominalType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("simple", func(t *testing.T) {
 		result, errs := ParseType("Int")
 		require.Empty(t, errs)
@@ -69,6 +71,8 @@ func TestParseNominalType(t *testing.T) {
 }
 
 func TestParseArrayType(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("variable", func(t *testing.T) {
 		result, errs := ParseType("[Int]")
@@ -123,6 +127,8 @@ func TestParseArrayType(t *testing.T) {
 }
 
 func TestParseOptionalType(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("nominal", func(t *testing.T) {
 		result, errs := ParseType("Int?")
@@ -190,6 +196,8 @@ func TestParseOptionalType(t *testing.T) {
 
 func TestParseReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("unauthorized, nominal", func(t *testing.T) {
 		result, errs := ParseType("&Int")
 		require.Empty(t, errs)
@@ -231,6 +239,8 @@ func TestParseReferenceType(t *testing.T) {
 
 func TestParseOptionalReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("unauthorized", func(t *testing.T) {
 		result, errs := ParseType("&Int?")
 		require.Empty(t, errs)
@@ -255,6 +265,8 @@ func TestParseOptionalReferenceType(t *testing.T) {
 }
 
 func TestParseRestrictedType(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("with restricted type, no restrictions", func(t *testing.T) {
 		result, errs := ParseType("T{}")
@@ -543,6 +555,8 @@ func TestParseRestrictedType(t *testing.T) {
 
 func TestParseDictionaryType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("valid", func(t *testing.T) {
 		result, errs := ParseType("{T: U}")
 		require.Empty(t, errs)
@@ -653,6 +667,8 @@ func TestParseDictionaryType(t *testing.T) {
 }
 
 func TestParseFunctionType(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("no parameters, Void return type", func(t *testing.T) {
 		result, errs := ParseType("(():Void)")

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -234,6 +234,8 @@ func (i *testRuntimeInterface) GetBlockAtHeight(height uint64) (hash BlockHash, 
 
 func TestRuntimeImport(t *testing.T) {
 
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	importedScript := []byte(`
@@ -272,6 +274,8 @@ func TestRuntimeImport(t *testing.T) {
 }
 
 func TestRuntimeProgramCache(t *testing.T) {
+
+	t.Parallel()
 
 	programCache := map[ast.LocationID]*ast.Program{}
 	cacheHits := make(map[ast.LocationID]bool)
@@ -377,6 +381,9 @@ func TestRuntimeProgramCache(t *testing.T) {
 }
 
 func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -397,6 +404,9 @@ func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
 }
 
 func TestRuntimeTransactionWithAccount(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -427,6 +437,9 @@ func TestRuntimeTransactionWithAccount(t *testing.T) {
 }
 
 func TestRuntimeTransactionWithArguments(t *testing.T) {
+
+	t.Parallel()
+
 	var tests = []struct {
 		label        string
 		script       string
@@ -722,6 +735,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 }
 
 func TestRuntimeProgramWithNoTransaction(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -738,6 +754,9 @@ func TestRuntimeProgramWithNoTransaction(t *testing.T) {
 }
 
 func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -759,6 +778,8 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
 }
 
 func TestRuntimeStorage(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[string]string{
 		"resource": `
@@ -872,6 +893,9 @@ func TestRuntimeStorage(t *testing.T) {
 }
 
 func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	container := []byte(`
@@ -964,6 +988,9 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 // of a stored resource declared in an imported program
 //
 func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	deepThought := []byte(`
@@ -1034,6 +1061,9 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 // of a stored resource declared in an imported program
 //
 func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported := []byte(`
@@ -1106,6 +1136,9 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 // See https://github.com/dapperlabs/flow-go/issues/838
 //
 func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported := []byte(`
@@ -1169,6 +1202,9 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
 }
 
 func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported := []byte(`
@@ -1236,6 +1272,9 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 }
 
 func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported := []byte(`
@@ -1304,6 +1343,9 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 }
 
 func TestRuntimeResourceContractWithInterface(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported1 := []byte(`
@@ -1386,6 +1428,9 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 }
 
 func TestParseAndCheckProgram(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("ValidProgram", func(t *testing.T) {
 		runtime := NewInterpreterRuntime()
 
@@ -1418,6 +1463,9 @@ func TestParseAndCheckProgram(t *testing.T) {
 }
 
 func TestRuntimeSyntaxError(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -1437,6 +1485,9 @@ func TestRuntimeSyntaxError(t *testing.T) {
 }
 
 func TestRuntimeStorageChanges(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported := []byte(`
@@ -1507,6 +1558,9 @@ func TestRuntimeStorageChanges(t *testing.T) {
 }
 
 func TestRuntimeAccountAddress(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -1537,6 +1591,9 @@ func TestRuntimeAccountAddress(t *testing.T) {
 }
 
 func TestRuntimePublicAccountAddress(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -1567,6 +1624,9 @@ func TestRuntimePublicAccountAddress(t *testing.T) {
 }
 
 func TestRuntimeAccountPublishAndAccess(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported := []byte(`
@@ -1640,6 +1700,9 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 }
 
 func TestRuntimeTransactionWithUpdateAccountCodeEmpty(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -1677,6 +1740,9 @@ func TestRuntimeTransactionWithUpdateAccountCodeEmpty(t *testing.T) {
 }
 
 func TestRuntimeTransactionWithCreateAccountEmpty(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -1714,6 +1780,9 @@ func TestRuntimeTransactionWithCreateAccountEmpty(t *testing.T) {
 }
 
 func TestRuntimeCyclicImport(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported := []byte(`
@@ -1762,6 +1831,8 @@ func ArrayValueFromBytes(bytes []byte) *interpreter.ArrayValue {
 }
 
 func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
+
+	t.Parallel()
 
 	expectSuccess := func(t *testing.T, err error, accountCode []byte, events []cadence.Event, expectedEventType cadence.Type) {
 		require.NoError(t, err)
@@ -1990,6 +2061,8 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 func TestRuntimeContractAccount(t *testing.T) {
 
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	addressValue := cadence.NewAddress([common.AddressLength]byte{
@@ -2083,6 +2156,9 @@ func TestRuntimeContractAccount(t *testing.T) {
 }
 
 func TestRuntimeContractNestedResource(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	addressValue := Address{
@@ -2258,6 +2334,8 @@ pub contract FungibleToken {
 
 func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	address1Value := Address{
@@ -2362,6 +2440,8 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 
 func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	address1Value := Address{
@@ -2465,6 +2545,8 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 }
 
 func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
+
+	t.Parallel()
 
 	runtime := NewInterpreterRuntime()
 
@@ -2625,6 +2707,9 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 }
 
 func TestRuntimeBlock(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -2676,6 +2761,8 @@ func TestRuntimeBlock(t *testing.T) {
 
 func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("transaction with function", func(t *testing.T) {
 		runtime := NewInterpreterRuntime()
 
@@ -2723,6 +2810,8 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 }
 
 func TestRuntimeStoreIntegerTypes(t *testing.T) {
+
+	t.Parallel()
 
 	runtime := NewInterpreterRuntime()
 
@@ -2795,6 +2884,8 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 }
 
 func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
+
+	t.Parallel()
 
 	runtime := NewInterpreterRuntime()
 
@@ -2932,6 +3023,8 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 }
 
 func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
+
+	t.Parallel()
 
 	runtime := NewInterpreterRuntime()
 
@@ -3088,6 +3181,8 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 
 func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	address := Address{
@@ -3243,6 +3338,8 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 
 func TestRuntimeComputationLimit(t *testing.T) {
 
+	t.Parallel()
+
 	const computationLimit = 5
 
 	type test struct {
@@ -3332,6 +3429,9 @@ func TestRuntimeComputationLimit(t *testing.T) {
 }
 
 func TestRuntimeMetrics(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	imported1Location := StringLocation("imported1")
@@ -3484,6 +3584,8 @@ func TestRuntimeMetrics(t *testing.T) {
 
 func TestRuntimeContractWriteback(t *testing.T) {
 
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	addressValue := cadence.NewAddress([common.AddressLength]byte{
@@ -3592,6 +3694,8 @@ func TestRuntimeContractWriteback(t *testing.T) {
 }
 
 func TestRuntimeStorageWriteback(t *testing.T) {
+
+	t.Parallel()
 
 	runtime := NewInterpreterRuntime()
 
@@ -3726,6 +3830,9 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 }
 
 func TestRuntimeExternalError(t *testing.T) {
+
+	t.Parallel()
+
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`

--- a/runtime/sema/before_extractor_test.go
+++ b/runtime/sema/before_extractor_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestBeforeExtractor(t *testing.T) {
 
+	t.Parallel()
+
 	expression, inputIsComplete, err := parser.ParseExpression(`
         before(x + before(y)) + z
     `)

--- a/runtime/sema/checker_test.go
+++ b/runtime/sema/checker_test.go
@@ -28,6 +28,8 @@ import (
 
 func TestOptionalSubtyping(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("Int? <: Int?", func(t *testing.T) {
 		assert.True(t,
 			IsSubType(
@@ -57,6 +59,8 @@ func TestOptionalSubtyping(t *testing.T) {
 }
 
 func TestCompositeType_ID(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("composite in composite", func(t *testing.T) {
 
@@ -99,6 +103,8 @@ func TestCompositeType_ID(t *testing.T) {
 
 func TestInterfaceType_ID(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("interface in composite", func(t *testing.T) {
 
 		interfaceInComposite :=
@@ -139,6 +145,8 @@ func TestInterfaceType_ID(t *testing.T) {
 }
 
 func TestFunctionSubtyping(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("((Int): Void) <: ((AnyStruct): Void)", func(t *testing.T) {
 		assert.False(t,

--- a/runtime/sema/resources_test.go
+++ b/runtime/sema/resources_test.go
@@ -27,6 +27,9 @@ import (
 )
 
 func TestResources_Add(t *testing.T) {
+
+	t.Parallel()
+
 	resources := &Resources{}
 
 	varX := &Variable{
@@ -127,6 +130,8 @@ func TestResources_Add(t *testing.T) {
 
 func TestResourceResources_FirstRest(t *testing.T) {
 
+	t.Parallel()
+
 	resources := &Resources{}
 
 	varX := &Variable{
@@ -194,6 +199,8 @@ func TestResourceResources_FirstRest(t *testing.T) {
 }
 
 func TestResources_MergeBranches(t *testing.T) {
+
+	t.Parallel()
 
 	resourcesThen := &Resources{}
 	resourcesElse := &Resources{}

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestConstantSizedType_String(t *testing.T) {
 
+	t.Parallel()
+
 	ty := &ConstantSizedType{
 		Type: &VariableSizedType{Type: &IntType{}},
 		Size: 2,
@@ -41,6 +43,8 @@ func TestConstantSizedType_String(t *testing.T) {
 }
 
 func TestConstantSizedType_String_OfFunctionType(t *testing.T) {
+
+	t.Parallel()
 
 	ty := &ConstantSizedType{
 		Type: &FunctionType{
@@ -64,6 +68,8 @@ func TestConstantSizedType_String_OfFunctionType(t *testing.T) {
 
 func TestVariableSizedType_String(t *testing.T) {
 
+	t.Parallel()
+
 	ty := &VariableSizedType{
 		Type: &ConstantSizedType{
 			Type: &IntType{},
@@ -78,6 +84,8 @@ func TestVariableSizedType_String(t *testing.T) {
 }
 
 func TestVariableSizedType_String_OfFunctionType(t *testing.T) {
+
+	t.Parallel()
 
 	ty := &VariableSizedType{
 		Type: &FunctionType{
@@ -100,6 +108,8 @@ func TestVariableSizedType_String_OfFunctionType(t *testing.T) {
 
 func TestIsResourceType_AnyStructNestedInArray(t *testing.T) {
 
+	t.Parallel()
+
 	ty := &VariableSizedType{
 		Type: &AnyStructType{},
 	}
@@ -109,6 +119,8 @@ func TestIsResourceType_AnyStructNestedInArray(t *testing.T) {
 
 func TestIsResourceType_AnyResourceNestedInArray(t *testing.T) {
 
+	t.Parallel()
+
 	ty := &VariableSizedType{
 		Type: &AnyResourceType{},
 	}
@@ -117,6 +129,8 @@ func TestIsResourceType_AnyResourceNestedInArray(t *testing.T) {
 }
 
 func TestIsResourceType_ResourceNestedInArray(t *testing.T) {
+
+	t.Parallel()
 
 	ty := &VariableSizedType{
 		Type: &CompositeType{
@@ -128,6 +142,8 @@ func TestIsResourceType_ResourceNestedInArray(t *testing.T) {
 }
 
 func TestIsResourceType_ResourceNestedInDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	ty := &DictionaryType{
 		KeyType: &StringType{},
@@ -143,6 +159,8 @@ func TestIsResourceType_ResourceNestedInDictionary(t *testing.T) {
 
 func TestIsResourceType_StructNestedInDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	ty := &DictionaryType{
 		KeyType: &StringType{},
 		ValueType: &VariableSizedType{
@@ -156,6 +174,8 @@ func TestIsResourceType_StructNestedInDictionary(t *testing.T) {
 }
 
 func TestRestrictedType_StringAndID(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("base type and restriction", func(t *testing.T) {
 		interfaceType := &InterfaceType{
@@ -239,6 +259,8 @@ func TestRestrictedType_StringAndID(t *testing.T) {
 }
 
 func TestRestrictedType_Equals(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("same base type and more restrictions", func(t *testing.T) {
 
@@ -382,6 +404,8 @@ func TestRestrictedType_Equals(t *testing.T) {
 
 func TestRestrictedType_GetMember(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("forbid undeclared members", func(t *testing.T) {
 		resourceType := &CompositeType{
 			Kind:       common.CompositeKindResource,
@@ -441,6 +465,8 @@ func TestRestrictedType_GetMember(t *testing.T) {
 }
 
 func TestBeforeType_Strings(t *testing.T) {
+
+	t.Parallel()
 
 	expected := "(<T: AnyStruct>(_ value: T): T)"
 

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestAssert(t *testing.T) {
 
+	t.Parallel()
+
 	program := &ast.Program{}
 
 	checker, err := sema.NewChecker(
@@ -80,6 +82,8 @@ func TestAssert(t *testing.T) {
 }
 
 func TestPanic(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := sema.NewChecker(
 		&ast.Program{},

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -93,6 +93,8 @@ func expectTwoAccessErrors(t *testing.T, err error) {
 
 func TestCheckAccessModifierCompositeFunctionDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
 		tests := map[ast.Access]bool{
@@ -137,6 +139,8 @@ func TestCheckAccessModifierCompositeFunctionDeclaration(t *testing.T) {
 }
 
 func TestCheckAccessModifierInterfaceFunctionDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]error{
 		sema.AccessCheckModeStrict: {
@@ -215,6 +219,8 @@ func TestCheckAccessModifierInterfaceFunctionDeclaration(t *testing.T) {
 
 func TestCheckAccessModifierCompositeConstantFieldDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	tests := map[ast.Access]func(isInterface bool) bool{
 		ast.AccessNotSpecified: func(_ bool) bool {
 			return true
@@ -280,6 +286,8 @@ func TestCheckAccessModifierCompositeConstantFieldDeclaration(t *testing.T) {
 
 func TestCheckAccessModifierCompositeVariableFieldDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, access := range ast.BasicAccesses {
 		for _, compositeKind := range common.CompositeKindsWithBody {
 			for _, isInterface := range []bool{true, false} {
@@ -330,6 +338,8 @@ func TestCheckAccessModifierCompositeVariableFieldDeclaration(t *testing.T) {
 
 func TestCheckAccessModifierGlobalFunctionDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	tests := map[ast.Access]bool{
 		ast.AccessNotSpecified:   true,
 		ast.AccessPrivate:        true,
@@ -362,6 +372,8 @@ func TestCheckAccessModifierGlobalFunctionDeclaration(t *testing.T) {
 }
 
 func TestCheckAccessModifierGlobalVariableDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[ast.Access]bool{
 		ast.AccessNotSpecified:   true,
@@ -396,6 +408,8 @@ func TestCheckAccessModifierGlobalVariableDeclaration(t *testing.T) {
 
 func TestCheckAccessModifierGlobalConstantDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	tests := map[ast.Access]bool{
 		ast.AccessNotSpecified:   true,
 		ast.AccessPrivate:        true,
@@ -428,6 +442,8 @@ func TestCheckAccessModifierGlobalConstantDeclaration(t *testing.T) {
 }
 
 func TestCheckAccessModifierLocalVariableDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[ast.Access]bool{
 		ast.AccessNotSpecified:   true,
@@ -474,6 +490,8 @@ func TestCheckAccessModifierLocalVariableDeclaration(t *testing.T) {
 
 func TestCheckAccessModifierLocalOptionalBinding(t *testing.T) {
 
+	t.Parallel()
+
 	tests := map[ast.Access]bool{
 		ast.AccessNotSpecified:   true,
 		ast.AccessPrivate:        false,
@@ -510,6 +528,8 @@ func TestCheckAccessModifierLocalOptionalBinding(t *testing.T) {
 
 func TestCheckAccessModifierLocalFunctionDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	tests := map[ast.Access]bool{
 		ast.AccessNotSpecified:   true,
 		ast.AccessPrivate:        false,
@@ -544,6 +564,8 @@ func TestCheckAccessModifierLocalFunctionDeclaration(t *testing.T) {
 }
 
 func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	expectMissingAccessModifierError := func(t *testing.T, err error) {
 		errs := ExpectCheckerErrors(t, err, 1)
@@ -636,6 +658,8 @@ func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
 }
 
 func TestCheckAccessImportGlobalValue(t *testing.T) {
+
+	t.Parallel()
 
 	checkModeTests := map[sema.AccessCheckMode]func(*testing.T, error){
 		sema.AccessCheckModeStrict: func(t *testing.T, err error) {
@@ -747,6 +771,8 @@ func TestCheckAccessImportGlobalValue(t *testing.T) {
 
 func TestCheckAccessCompositeFunction(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
 		checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
@@ -851,6 +877,8 @@ func TestCheckAccessCompositeFunction(t *testing.T) {
 }
 
 func TestCheckAccessInterfaceFunction(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -965,6 +993,8 @@ func TestCheckAccessInterfaceFunction(t *testing.T) {
 
 func TestCheckAccessCompositeFieldRead(t *testing.T) {
 
+	t.Parallel()
+
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 		sema.AccessCheckModeStrict: {
 			ast.AccessNotSpecified:   nil,
@@ -1073,6 +1103,8 @@ func TestCheckAccessCompositeFieldRead(t *testing.T) {
 }
 
 func TestCheckAccessInterfaceFieldRead(t *testing.T) {
+
+	t.Parallel()
 
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 		sema.AccessCheckModeStrict: {
@@ -1191,6 +1223,8 @@ func TestCheckAccessInterfaceFieldRead(t *testing.T) {
 
 func TestCheckAccessCompositeFieldAssignmentAndSwap(t *testing.T) {
 
+	t.Parallel()
+
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 		sema.AccessCheckModeStrict: {
 			ast.AccessNotSpecified:   nil,
@@ -1304,6 +1338,8 @@ func TestCheckAccessCompositeFieldAssignmentAndSwap(t *testing.T) {
 }
 
 func TestCheckAccessInterfaceFieldWrite(t *testing.T) {
+
+	t.Parallel()
 
 	expectConformanceAndAccessErrors := func(t *testing.T, err error) {
 		errs := ExpectCheckerErrors(t, err, 5)
@@ -1446,6 +1482,8 @@ func TestCheckAccessInterfaceFieldWrite(t *testing.T) {
 
 func TestCheckAccessCompositeFieldVariableDeclarationWithSecondValue(t *testing.T) {
 
+	t.Parallel()
+
 	checkModeTests := map[sema.AccessCheckMode]map[ast.Access]func(*testing.T, error){
 		sema.AccessCheckModeStrict: {
 			ast.AccessNotSpecified:   nil,
@@ -1537,6 +1575,8 @@ func TestCheckAccessCompositeFieldVariableDeclarationWithSecondValue(t *testing.
 }
 
 func TestCheckAccessInterfaceFieldVariableDeclarationWithSecondValue(t *testing.T) {
+
+	t.Parallel()
 
 	expectPrivateAccessErrors := func(t *testing.T, err error) {
 		errs := ExpectCheckerErrors(t, err, 3)
@@ -1647,6 +1687,8 @@ func TestCheckAccessInterfaceFieldVariableDeclarationWithSecondValue(t *testing.
 }
 
 func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
+
+	t.Parallel()
 
 	worstCase := func(t *testing.T, err error) {
 		errs := ExpectCheckerErrors(t, err, 8)
@@ -1852,6 +1894,8 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
 
 func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: only parse, don't check imported program.
 	// will be checked by checker checking importing program
 
@@ -1914,6 +1958,8 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
 
 func TestCheckContractNestedDeclarationPrivateAccess(t *testing.T) {
 
+	t.Parallel()
+
 	const contract = `
 	  contract Outer {
 		  priv let num: Int
@@ -1946,6 +1992,8 @@ func TestCheckContractNestedDeclarationPrivateAccess(t *testing.T) {
 }
 
 func TestCheckAccessSameContractInnerStructField(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[ast.Access]bool{
 		ast.AccessPrivate:  false,
@@ -1989,6 +2037,8 @@ func TestCheckAccessSameContractInnerStructField(t *testing.T) {
 }
 
 func TestCheckAccessSameContractInnerStructInterfaceField(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[ast.Access]bool{
 		ast.AccessPrivate:  false,
@@ -2037,6 +2087,8 @@ func TestCheckAccessSameContractInnerStructInterfaceField(t *testing.T) {
 
 func TestCheckAccessOtherContractInnerStructField(t *testing.T) {
 
+	t.Parallel()
+
 	tests := map[ast.Access]bool{
 		ast.AccessPrivate:  false,
 		ast.AccessContract: false,
@@ -2081,6 +2133,8 @@ func TestCheckAccessOtherContractInnerStructField(t *testing.T) {
 }
 
 func TestCheckAccessOtherContractInnerStructInterfaceField(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[ast.Access]bool{
 		ast.AccessPrivate:  false,
@@ -2130,6 +2184,8 @@ func TestCheckAccessOtherContractInnerStructInterfaceField(t *testing.T) {
 }
 
 func TestCheckRestrictiveAccessModifier(t *testing.T) {
+
+	t.Parallel()
 
 	for _, access := range ast.AllAccesses {
 
@@ -2202,6 +2258,8 @@ func TestCheckRestrictiveAccessModifier(t *testing.T) {
 }
 
 func TestCheckInvalidRestrictiveAccessModifier(t *testing.T) {
+
+	t.Parallel()
 
 	for _, access := range ast.AllAccesses {
 

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -56,6 +56,8 @@ func ParseAndCheckAccount(t *testing.T, code string) (*sema.Checker, error) {
 
 func TestCheckAccount(t *testing.T) {
 
+	t.Parallel()
+
 	for _, domain := range common.AllPathDomainsByIdentifier {
 
 		// NOTE: all domains are statically valid at the moment

--- a/runtime/tests/checker/any_test.go
+++ b/runtime/tests/checker/any_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestCheckAnyStruct(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let a: AnyStruct = 1
       let b: AnyStruct = true
@@ -38,6 +40,8 @@ func TestCheckAnyStruct(t *testing.T) {
 }
 
 func TestCheckInvalidAnyStructResourceType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}
@@ -54,6 +58,8 @@ func TestCheckInvalidAnyStructResourceType(t *testing.T) {
 
 func TestCheckAnyResource(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
 
@@ -65,6 +71,8 @@ func TestCheckAnyResource(t *testing.T) {
 }
 
 func TestCheckInvalidAnyResourceNonResourceType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -35,6 +35,8 @@ import (
 
 func TestCheckDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let z = {"a": 1, "b": 2}
 	`)
@@ -44,6 +46,8 @@ func TestCheckDictionary(t *testing.T) {
 
 func TestCheckDictionaryType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let z: {String: Int} = {"a": 1, "b": 2}
 	`)
@@ -52,6 +56,8 @@ func TestCheckDictionaryType(t *testing.T) {
 }
 
 func TestCheckInvalidDictionaryTypeKey(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let z: {Int: Int} = {"a": 1, "b": 2}
@@ -64,6 +70,8 @@ func TestCheckInvalidDictionaryTypeKey(t *testing.T) {
 
 func TestCheckInvalidDictionaryTypeValue(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let z: {String: String} = {"a": 1, "b": 2}
 	`)
@@ -74,6 +82,8 @@ func TestCheckInvalidDictionaryTypeValue(t *testing.T) {
 }
 
 func TestCheckInvalidDictionaryTypeSwapped(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let z: {Int: String} = {"a": 1, "b": 2}
@@ -86,6 +96,8 @@ func TestCheckInvalidDictionaryTypeSwapped(t *testing.T) {
 
 func TestCheckInvalidDictionaryKeys(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let z = {"a": 1, true: 2}
 	`)
@@ -97,6 +109,8 @@ func TestCheckInvalidDictionaryKeys(t *testing.T) {
 
 func TestCheckInvalidDictionaryValues(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let z = {"a": 1, "b": true}
 	`)
@@ -107,6 +121,8 @@ func TestCheckInvalidDictionaryValues(t *testing.T) {
 }
 
 func TestCheckDictionaryIndexingString(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
       let x = {"abc": 1, "def": 2}
@@ -123,6 +139,8 @@ func TestCheckDictionaryIndexingString(t *testing.T) {
 
 func TestCheckDictionaryIndexingBool(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x = {true: 1, false: 2}
       let y = x[true]
@@ -132,6 +150,8 @@ func TestCheckDictionaryIndexingBool(t *testing.T) {
 }
 
 func TestCheckInvalidDictionaryIndexing(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x = {"abc": 1, "def": 2}
@@ -145,6 +165,8 @@ func TestCheckInvalidDictionaryIndexing(t *testing.T) {
 
 func TestCheckDictionaryIndexingAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let x = {"abc": 1, "def": 2}
@@ -156,6 +178,8 @@ func TestCheckDictionaryIndexingAssignment(t *testing.T) {
 }
 
 func TestCheckInvalidDictionaryIndexingAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -171,6 +195,8 @@ func TestCheckInvalidDictionaryIndexingAssignment(t *testing.T) {
 
 func TestCheckDictionaryRemove(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let x = {"abc": 1, "def": 2}
@@ -182,6 +208,8 @@ func TestCheckDictionaryRemove(t *testing.T) {
 }
 
 func TestCheckInvalidDictionaryRemove(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -197,6 +225,8 @@ func TestCheckInvalidDictionaryRemove(t *testing.T) {
 
 func TestCheckDictionaryInsert(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let x = {"abc": 1, "def": 2}
@@ -208,6 +238,8 @@ func TestCheckDictionaryInsert(t *testing.T) {
 }
 
 func TestCheckInvalidDictionaryInsert(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -223,6 +255,8 @@ func TestCheckInvalidDictionaryInsert(t *testing.T) {
 
 func TestCheckDictionaryKeys(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
         let keys = {"abc": 1, "def": 2}.keys
     `)
@@ -236,6 +270,8 @@ func TestCheckDictionaryKeys(t *testing.T) {
 }
 
 func TestCheckDictionaryValues(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
         let values = {"abc": 1, "def": 2}.values
@@ -251,6 +287,8 @@ func TestCheckDictionaryValues(t *testing.T) {
 
 func TestCheckLength(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x = "cafe\u{301}".length
       let y = [1, 2, 3].length
@@ -260,6 +298,8 @@ func TestCheckLength(t *testing.T) {
 }
 
 func TestCheckArrayAppend(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
@@ -273,6 +313,8 @@ func TestCheckArrayAppend(t *testing.T) {
 }
 
 func TestCheckInvalidArrayAppend(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
@@ -289,6 +331,8 @@ func TestCheckInvalidArrayAppend(t *testing.T) {
 
 func TestCheckArrayAppendBound(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
           let x = [1, 2, 3]
@@ -302,6 +346,8 @@ func TestCheckArrayAppendBound(t *testing.T) {
 }
 
 func TestCheckInvalidArrayAppendToConstantSize(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int; 3] {
@@ -318,6 +364,8 @@ func TestCheckInvalidArrayAppendToConstantSize(t *testing.T) {
 
 func TestCheckArrayConcat(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 	  fun test(): [Int] {
 	 	  let a = [1, 2]
@@ -331,6 +379,8 @@ func TestCheckArrayConcat(t *testing.T) {
 }
 
 func TestCheckInvalidArrayConcat(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
@@ -348,6 +398,8 @@ func TestCheckInvalidArrayConcat(t *testing.T) {
 
 func TestCheckInvalidArrayConcatOfConstantSized(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 	  fun test(): [Int] {
 	 	  let a: [Int; 2] = [1, 2]
@@ -364,6 +416,8 @@ func TestCheckInvalidArrayConcatOfConstantSized(t *testing.T) {
 
 func TestCheckArrayConcatBound(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
 		  let a = [1, 2]
@@ -378,6 +432,8 @@ func TestCheckArrayConcatBound(t *testing.T) {
 
 func TestCheckArrayInsert(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
           let x = [1, 2, 3]
@@ -390,6 +446,8 @@ func TestCheckArrayInsert(t *testing.T) {
 }
 
 func TestCheckInvalidArrayInsert(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
@@ -406,6 +464,8 @@ func TestCheckInvalidArrayInsert(t *testing.T) {
 
 func TestCheckInvalidArrayInsertIntoConstantSized(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int; 3] {
           let x: [Int; 3] = [1, 2, 3]
@@ -421,6 +481,8 @@ func TestCheckInvalidArrayInsertIntoConstantSized(t *testing.T) {
 
 func TestCheckArrayRemove(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
           let x = [1, 2, 3]
@@ -433,6 +495,8 @@ func TestCheckArrayRemove(t *testing.T) {
 }
 
 func TestCheckInvalidArrayRemove(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
@@ -449,6 +513,8 @@ func TestCheckInvalidArrayRemove(t *testing.T) {
 
 func TestCheckInvalidArrayRemoveFromConstantSized(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int; 3] {
           let x: [Int; 3] = [1, 2, 3]
@@ -464,6 +530,8 @@ func TestCheckInvalidArrayRemoveFromConstantSized(t *testing.T) {
 
 func TestCheckArrayRemoveFirst(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
           let x = [1, 2, 3]
@@ -476,6 +544,8 @@ func TestCheckArrayRemoveFirst(t *testing.T) {
 }
 
 func TestCheckInvalidArrayRemoveFirst(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
@@ -492,6 +562,8 @@ func TestCheckInvalidArrayRemoveFirst(t *testing.T) {
 
 func TestCheckInvalidArrayRemoveFirstFromConstantSized(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int; 3] {
           let x: [Int; 3] = [1, 2, 3]
@@ -507,6 +579,8 @@ func TestCheckInvalidArrayRemoveFirstFromConstantSized(t *testing.T) {
 
 func TestCheckArrayRemoveLast(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): [Int] {
           let x = [1, 2, 3]
@@ -519,6 +593,8 @@ func TestCheckArrayRemoveLast(t *testing.T) {
 }
 
 func TestCheckInvalidArrayRemoveLastFromConstantSized(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): [Int; 3] {
@@ -535,6 +611,8 @@ func TestCheckInvalidArrayRemoveLastFromConstantSized(t *testing.T) {
 
 func TestCheckArrayContains(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Bool {
           let x = [1, 2, 3]
@@ -546,6 +624,8 @@ func TestCheckArrayContains(t *testing.T) {
 }
 
 func TestCheckInvalidArrayContains(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): Bool {
@@ -561,6 +641,8 @@ func TestCheckInvalidArrayContains(t *testing.T) {
 
 func TestCheckInvalidArrayContainsNotEquatable(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Bool {
           let z = [[1], [2], [3]]
@@ -575,6 +657,8 @@ func TestCheckInvalidArrayContainsNotEquatable(t *testing.T) {
 
 func TestCheckEmptyArray(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let xs: [Int] = []
 	`)
@@ -583,6 +667,8 @@ func TestCheckEmptyArray(t *testing.T) {
 }
 
 func TestCheckEmptyArrayCall(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun foo(xs: [Int]) {
@@ -595,6 +681,8 @@ func TestCheckEmptyArrayCall(t *testing.T) {
 
 func TestCheckEmptyDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let xs: {String: Int} = {}
 	`)
@@ -603,6 +691,8 @@ func TestCheckEmptyDictionary(t *testing.T) {
 }
 
 func TestCheckEmptyDictionaryCall(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun foo(xs: {String: Int}) {
@@ -614,6 +704,8 @@ func TestCheckEmptyDictionaryCall(t *testing.T) {
 }
 
 func TestCheckArraySubtyping(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 
@@ -656,6 +748,8 @@ func TestCheckArraySubtyping(t *testing.T) {
 
 func TestCheckInvalidArraySubtyping(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let xs: [Bool] = []
       let ys: [Int] = xs
@@ -667,6 +761,8 @@ func TestCheckInvalidArraySubtyping(t *testing.T) {
 }
 
 func TestCheckDictionarySubtyping(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 
@@ -707,6 +803,8 @@ func TestCheckDictionarySubtyping(t *testing.T) {
 
 func TestCheckInvalidDictionarySubtyping(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let xs: {String: Bool} = {}
       let ys: {String: Int} = xs
@@ -719,6 +817,8 @@ func TestCheckInvalidDictionarySubtyping(t *testing.T) {
 
 func TestCheckInvalidArrayElements(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let z = [0, true]
 	`)
@@ -730,6 +830,8 @@ func TestCheckInvalidArrayElements(t *testing.T) {
 
 func TestCheckConstantSizedArrayDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x: [Int; 3] = [1, 2, 3]
     `)
@@ -738,6 +840,8 @@ func TestCheckConstantSizedArrayDeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidConstantSizedArrayDeclarationCountMismatchTooMany(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x: [Int; 2] = [1, 2, 3]
@@ -750,6 +854,8 @@ func TestCheckInvalidConstantSizedArrayDeclarationCountMismatchTooMany(t *testin
 }
 
 func TestCheckInvalidConstantSizedArrayDeclarationOutOfRangeSize(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("negative", func(t *testing.T) {
 
@@ -786,6 +892,8 @@ func TestCheckInvalidConstantSizedArrayDeclarationOutOfRangeSize(t *testing.T) {
 
 func TestCheckInvalidConstantSizedArrayDeclarationBase(t *testing.T) {
 
+	t.Parallel()
+
 	for _, size := range []string{"0x42", "0b1010", "0o10"} {
 
 		t.Run(size, func(t *testing.T) {
@@ -809,6 +917,8 @@ func TestCheckInvalidConstantSizedArrayDeclarationBase(t *testing.T) {
 }
 
 func TestCheckDictionaryKeyTypesExpressions(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[string]string{
 		"String":    `"abc"`,

--- a/runtime/tests/checker/assert_test.go
+++ b/runtime/tests/checker/assert_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckAssertWithoutMessage(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheckWithOptions(t,
 		`
             pub fun test() {
@@ -51,6 +53,8 @@ func TestCheckAssertWithoutMessage(t *testing.T) {
 }
 
 func TestCheckAssertWithMessage(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheckWithOptions(t,
 		`

--- a/runtime/tests/checker/assignment_test.go
+++ b/runtime/tests/checker/assignment_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckInvalidUnknownDeclarationAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           x = 2
@@ -42,6 +44,8 @@ func TestCheckInvalidUnknownDeclarationAssignment(t *testing.T) {
 }
 
 func TestCheckInvalidConstantAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -57,6 +61,8 @@ func TestCheckInvalidConstantAssignment(t *testing.T) {
 
 func TestCheckAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           var x = 2
@@ -68,6 +74,8 @@ func TestCheckAssignment(t *testing.T) {
 }
 
 func TestCheckInvalidGlobalConstantAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x = 2
@@ -84,6 +92,8 @@ func TestCheckInvalidGlobalConstantAssignment(t *testing.T) {
 
 func TestCheckGlobalVariableAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       var x = 2
 
@@ -98,6 +108,8 @@ func TestCheckGlobalVariableAssignment(t *testing.T) {
 
 func TestCheckInvalidAssignmentToParameter(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: Int8) {
            x = 2
@@ -110,6 +122,8 @@ func TestCheckInvalidAssignmentToParameter(t *testing.T) {
 }
 
 func TestCheckInvalidAssignmentTargetExpression(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun f() {}

--- a/runtime/tests/checker/boolean_test.go
+++ b/runtime/tests/checker/boolean_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckBoolean(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
         let x = true
     `)

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestCheckCapability(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("type annotation", func(t *testing.T) {
 
 		checker, err := ParseAndCheckWithPanic(t, `

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -31,6 +31,8 @@ import (
 
 func TestCheckCastingIntLiteralToIntegerType(t *testing.T) {
 
+	t.Parallel()
+
 	for _, integerType := range sema.AllIntegerTypes {
 
 		t.Run(integerType.String(), func(t *testing.T) {
@@ -58,6 +60,8 @@ func TestCheckCastingIntLiteralToIntegerType(t *testing.T) {
 
 func TestCheckInvalidCastingIntLiteralToString(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x = 1 as String
     `)
@@ -68,6 +72,8 @@ func TestCheckInvalidCastingIntLiteralToString(t *testing.T) {
 }
 
 func TestCheckCastingIntLiteralToAnyStruct(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
       let x = 1 as AnyStruct
@@ -84,6 +90,8 @@ func TestCheckCastingIntLiteralToAnyStruct(t *testing.T) {
 }
 
 func TestCheckCastingResourceToAnyResource(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
       resource R {}
@@ -102,6 +110,8 @@ func TestCheckCastingResourceToAnyResource(t *testing.T) {
 
 func TestCheckCastingArrayLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun zipOf3(a: [AnyStruct; 3], b: [Int; 3]): [[AnyStruct; 2]; 3] {
           return [
@@ -116,6 +126,8 @@ func TestCheckCastingArrayLiteral(t *testing.T) {
 }
 
 func TestCheckCastResourceType(t *testing.T) {
+
+	t.Parallel()
 
 	// Supertype: Restricted type
 
@@ -1265,6 +1277,8 @@ func TestCheckCastResourceType(t *testing.T) {
 
 func TestCheckCastStructType(t *testing.T) {
 
+	t.Parallel()
+
 	// Supertype: Restricted type
 
 	t.Run("restricted type -> restricted type: fewer restrictions", func(t *testing.T) {
@@ -2245,6 +2259,8 @@ func TestCheckCastStructType(t *testing.T) {
 
 func TestCheckReferenceTypeSubTyping(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		for _, ty := range []string{
@@ -2355,6 +2371,8 @@ func TestCheckReferenceTypeSubTyping(t *testing.T) {
 }
 
 func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
+
+	t.Parallel()
 
 	// Supertype: Restricted type
 
@@ -3442,6 +3460,8 @@ func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
 
 func TestCheckCastAuthorizedStructReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	// Supertype: Restricted type
 
 	t.Run("restricted type -> restricted type: fewer restrictions", func(t *testing.T) {
@@ -4503,6 +4523,8 @@ func TestCheckCastAuthorizedStructReferenceType(t *testing.T) {
 
 func TestCheckCastUnauthorizedResourceReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	for name, op := range map[string]string{
 		"static":  "as",
 		"dynamic": "as?",
@@ -5151,6 +5173,8 @@ func TestCheckCastUnauthorizedResourceReferenceType(t *testing.T) {
 }
 
 func TestCheckCastUnauthorizedStructReferenceType(t *testing.T) {
+
+	t.Parallel()
 
 	for name, op := range map[string]string{
 		"static":  "as",

--- a/runtime/tests/checker/character_test.go
+++ b/runtime/tests/checker/character_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckCharacterLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
         let a: Character = "a"
     `)
@@ -43,6 +45,8 @@ func TestCheckCharacterLiteral(t *testing.T) {
 }
 
 func TestCheckInvalidCharacterLiteral(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
         let a: Character = "abc"

--- a/runtime/tests/checker/composite_test.go
+++ b/runtime/tests/checker/composite_test.go
@@ -34,6 +34,8 @@ import (
 
 func TestCheckInvalidCompositeRedeclaringType(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -65,6 +67,8 @@ func TestCheckInvalidCompositeRedeclaringType(t *testing.T) {
 
 func TestCheckComposite(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -95,6 +99,8 @@ func TestCheckComposite(t *testing.T) {
 
 func TestCheckInitializerName(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -115,6 +121,8 @@ func TestCheckInitializerName(t *testing.T) {
 }
 
 func TestCheckDestructor(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -147,6 +155,8 @@ func TestCheckDestructor(t *testing.T) {
 }
 
 func TestCheckInvalidUnknownSpecialFunction(t *testing.T) {
+
+	t.Parallel()
 
 	interfacePossibilities := []bool{true, false}
 
@@ -183,6 +193,8 @@ func TestCheckInvalidUnknownSpecialFunction(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeFieldNames(t *testing.T) {
+
+	t.Parallel()
 
 	interfacePossibilities := []bool{true, false}
 
@@ -230,6 +242,8 @@ func TestCheckInvalidCompositeFieldNames(t *testing.T) {
 
 func TestCheckInvalidCompositeFunctionNames(t *testing.T) {
 
+	t.Parallel()
+
 	interfacePossibilities := []bool{true, false}
 
 	for _, kind := range common.CompositeKindsWithBody {
@@ -273,6 +287,8 @@ func TestCheckInvalidCompositeFunctionNames(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeRedeclaringFields(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 
@@ -321,6 +337,8 @@ func TestCheckInvalidCompositeRedeclaringFields(t *testing.T) {
 
 func TestCheckInvalidCompositeRedeclaringFunctions(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -344,6 +362,8 @@ func TestCheckInvalidCompositeRedeclaringFunctions(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeRedeclaringFieldsAndFunctions(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -369,6 +389,8 @@ func TestCheckInvalidCompositeRedeclaringFieldsAndFunctions(t *testing.T) {
 }
 
 func TestCheckCompositeFieldsAndFunctions(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -396,6 +418,8 @@ func TestCheckCompositeFieldsAndFunctions(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeFieldType(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -435,6 +459,8 @@ func TestCheckInvalidCompositeFieldType(t *testing.T) {
 
 func TestCheckInvalidCompositeInitializerParameterType(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -458,6 +484,8 @@ func TestCheckInvalidCompositeInitializerParameterType(t *testing.T) {
 
 func TestCheckInvalidCompositeInitializerParameters(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -480,6 +508,8 @@ func TestCheckInvalidCompositeInitializerParameters(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeSpecialFunction(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -519,6 +549,8 @@ func TestCheckInvalidCompositeSpecialFunction(t *testing.T) {
 
 func TestCheckInvalidCompositeFunction(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -541,6 +573,8 @@ func TestCheckInvalidCompositeFunction(t *testing.T) {
 }
 
 func TestCheckCompositeInitializerSelfUse(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -580,6 +614,8 @@ func TestCheckCompositeInitializerSelfUse(t *testing.T) {
 
 func TestCheckCompositeFunctionSelfUse(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -615,6 +651,8 @@ func TestCheckCompositeFunctionSelfUse(t *testing.T) {
 
 func TestCheckInvalidCompositeMissingInitializer(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -638,6 +676,8 @@ func TestCheckInvalidCompositeMissingInitializer(t *testing.T) {
 
 func TestCheckInvalidResourceMissingDestructor(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        resource Test {
            let test: @Test
@@ -653,6 +693,8 @@ func TestCheckInvalidResourceMissingDestructor(t *testing.T) {
 }
 
 func TestCheckResourceWithDestructor(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        resource Test {
@@ -672,6 +714,8 @@ func TestCheckResourceWithDestructor(t *testing.T) {
 }
 
 func TestCheckInvalidResourceFieldWithMissingResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	interfacePossibilities := []bool{true, false}
 
@@ -734,6 +778,8 @@ func TestCheckInvalidResourceFieldWithMissingResourceAnnotation(t *testing.T) {
 
 func TestCheckCompositeFieldAccess(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -762,6 +808,8 @@ func TestCheckCompositeFieldAccess(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeFieldAccess(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -809,6 +857,8 @@ func TestCheckInvalidCompositeFieldAccess(t *testing.T) {
 }
 
 func TestCheckCompositeFieldAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -864,6 +914,8 @@ func TestCheckCompositeFieldAssignment(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeSelfAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[common.CompositeKind]func(error){
 		common.CompositeKindStructure: func(err error) {
@@ -921,6 +973,8 @@ func TestCheckInvalidCompositeSelfAssignment(t *testing.T) {
 
 func TestCheckInvalidCompositeFieldAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -960,6 +1014,8 @@ func TestCheckInvalidCompositeFieldAssignment(t *testing.T) {
 
 func TestCheckInvalidCompositeFieldAssignmentWrongType(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -991,6 +1047,8 @@ func TestCheckInvalidCompositeFieldAssignmentWrongType(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeFieldConstantAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1025,6 +1083,8 @@ func TestCheckInvalidCompositeFieldConstantAssignment(t *testing.T) {
 
 func TestCheckCompositeFunctionCall(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1049,6 +1109,8 @@ func TestCheckCompositeFunctionCall(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeFunctionCall(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1076,6 +1138,8 @@ func TestCheckInvalidCompositeFunctionCall(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeFunctionAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1109,6 +1173,8 @@ func TestCheckInvalidCompositeFunctionAssignment(t *testing.T) {
 }
 
 func TestCheckCompositeInstantiation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -1152,6 +1218,8 @@ func TestCheckCompositeInstantiation(t *testing.T) {
 
 func TestCheckInvalidSameCompositeRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1184,6 +1252,8 @@ func TestCheckInvalidSameCompositeRedeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidDifferentCompositeRedeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	for _, firstKind := range common.AllCompositeKinds {
 		for _, secondKind := range common.AllCompositeKinds {
@@ -1239,6 +1309,8 @@ func TestCheckInvalidDifferentCompositeRedeclaration(t *testing.T) {
 
 func TestCheckInvalidForwardReference(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x = y
       let y = x
@@ -1250,6 +1322,9 @@ func TestCheckInvalidForwardReference(t *testing.T) {
 }
 
 func TestCheckInvalidIncompatibleSameCompositeTypes(t *testing.T) {
+
+	t.Parallel()
+
 	// tests that composite typing is nominal, not structural,
 	// and composite kind is considered
 
@@ -1302,6 +1377,8 @@ func TestCheckInvalidIncompatibleSameCompositeTypes(t *testing.T) {
 
 func TestCheckInvalidCompositeFunctionWithSelfParameter(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1325,6 +1402,8 @@ func TestCheckInvalidCompositeFunctionWithSelfParameter(t *testing.T) {
 
 func TestCheckInvalidCompositeInitializerWithSelfParameter(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1347,6 +1426,8 @@ func TestCheckInvalidCompositeInitializerWithSelfParameter(t *testing.T) {
 }
 
 func TestCheckCompositeInitializesConstant(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -1388,6 +1469,8 @@ func TestCheckCompositeInitializesConstant(t *testing.T) {
 
 func TestCheckCompositeInitializerWithArgumentLabel(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
 		if compositeKind == common.CompositeKindContract {
@@ -1419,6 +1502,8 @@ func TestCheckCompositeInitializerWithArgumentLabel(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeInitializerCallWithMissingArgumentLabel(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -1453,6 +1538,8 @@ func TestCheckInvalidCompositeInitializerCallWithMissingArgumentLabel(t *testing
 }
 
 func TestCheckCompositeFunctionWithArgumentLabel(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -1495,6 +1582,8 @@ func TestCheckCompositeFunctionWithArgumentLabel(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeFunctionCallWithMissingArgumentLabel(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -1539,6 +1628,8 @@ func TestCheckInvalidCompositeFunctionCallWithMissingArgumentLabel(t *testing.T)
 }
 
 func TestCheckCompositeConstructorUseInInitializerAndFunction(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -1612,6 +1703,8 @@ func TestCheckCompositeConstructorUseInInitializerAndFunction(t *testing.T) {
 
 func TestCheckInvalidCompositeFieldMissingVariableKind(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1638,6 +1731,8 @@ func TestCheckInvalidCompositeFieldMissingVariableKind(t *testing.T) {
 }
 
 func TestCheckCompositeFunction(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1684,6 +1779,8 @@ func TestCheckCompositeFunction(t *testing.T) {
 
 func TestCheckCompositeReferenceBeforeDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
 		if compositeKind == common.CompositeKindContract {
@@ -1722,6 +1819,8 @@ func TestCheckCompositeReferenceBeforeDeclaration(t *testing.T) {
 
 func TestCheckInvalidDestructorParameters(t *testing.T) {
 
+	t.Parallel()
+
 	interfacePossibilities := []bool{true, false}
 
 	for _, isInterface := range interfacePossibilities {
@@ -1759,6 +1858,8 @@ func TestCheckInvalidDestructorParameters(t *testing.T) {
 
 func TestCheckInvalidResourceWithDestructorMissingFieldInvalidation(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        resource Test {
            let test: @Test
@@ -1785,6 +1886,8 @@ func TestCheckInvalidResourceWithDestructorMissingFieldInvalidation(t *testing.T
 
 func TestCheckInvalidResourceWithDestructorMissingFieldInvalidationFirstFieldNonResource(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        resource Test {
            let a: Int
@@ -1805,6 +1908,8 @@ func TestCheckInvalidResourceWithDestructorMissingFieldInvalidationFirstFieldNon
 }
 
 func TestCheckInvalidResourceWithDestructorMissingDefinitiveFieldInvalidation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        resource Test {
@@ -1829,6 +1934,8 @@ func TestCheckInvalidResourceWithDestructorMissingDefinitiveFieldInvalidation(t 
 
 func TestCheckResourceWithDestructorAndStructField(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        struct S {}
 
@@ -1847,6 +1954,8 @@ func TestCheckResourceWithDestructorAndStructField(t *testing.T) {
 }
 
 func TestCheckInvalidResourceDestructorMoveInvalidation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        resource Test {
@@ -1874,6 +1983,8 @@ func TestCheckInvalidResourceDestructorMoveInvalidation(t *testing.T) {
 
 func TestCheckInvalidResourceDestructorRepeatedDestruction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        resource Test {
            let test: @Test
@@ -1895,6 +2006,8 @@ func TestCheckInvalidResourceDestructorRepeatedDestruction(t *testing.T) {
 }
 
 func TestCheckInvalidResourceDestructorCapturing(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        var duplicate: ((): @Test)? = nil
@@ -1921,6 +2034,8 @@ func TestCheckInvalidResourceDestructorCapturing(t *testing.T) {
 
 func TestCheckInvalidStructureFunctionWithMissingBody(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         struct Test {
             pub fun getFoo(): Int
@@ -1934,6 +2049,8 @@ func TestCheckInvalidStructureFunctionWithMissingBody(t *testing.T) {
 
 func TestCheckInvalidStructureInitializerWithMissingBody(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         struct Test {
             init()
@@ -1946,6 +2063,8 @@ func TestCheckInvalidStructureInitializerWithMissingBody(t *testing.T) {
 }
 
 func TestCheckMutualTypeUseTopLevel(t *testing.T) {
+
+	t.Parallel()
 
 	interfacePossibilities := []bool{true, false}
 

--- a/runtime/tests/checker/conditional_test.go
+++ b/runtime/tests/checker/conditional_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckConditionalExpressionTest(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let x = true ? 1 : 2
@@ -40,6 +42,8 @@ func TestCheckConditionalExpressionTest(t *testing.T) {
 }
 
 func TestCheckInvalidConditionalExpressionTest(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -53,6 +57,8 @@ func TestCheckInvalidConditionalExpressionTest(t *testing.T) {
 }
 
 func TestCheckInvalidConditionalExpressionElse(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -69,6 +75,8 @@ func TestCheckInvalidConditionalExpressionElse(t *testing.T) {
 
 func TestCheckInvalidConditionalExpressionTypes(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let x = true ? 2 : false
@@ -82,6 +90,8 @@ func TestCheckInvalidConditionalExpressionTypes(t *testing.T) {
 
 // TODO: return common super type for conditional
 func TestCheckInvalidAnyConditional(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x: AnyStruct = true

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckFunctionConditions(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: Int) {
           pre {
@@ -45,6 +47,8 @@ func TestCheckFunctionConditions(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionPreConditionReference(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: Int) {
@@ -74,6 +78,8 @@ func TestCheckInvalidFunctionPreConditionReference(t *testing.T) {
 
 func TestCheckInvalidFunctionNonBoolCondition(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: Int) {
           pre {
@@ -93,6 +99,8 @@ func TestCheckInvalidFunctionNonBoolCondition(t *testing.T) {
 
 func TestCheckFunctionPostConditionWithBefore(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
       fun test(x: Int) {
           post {
@@ -109,6 +117,8 @@ func TestCheckFunctionPostConditionWithBefore(t *testing.T) {
 
 func TestCheckFunctionPostConditionWithBeforeNotDeclaredUse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           post {
@@ -123,6 +133,8 @@ func TestCheckFunctionPostConditionWithBeforeNotDeclaredUse(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionPostConditionWithBeforeAndNoArgument(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: Int) {
@@ -139,6 +151,8 @@ func TestCheckInvalidFunctionPostConditionWithBeforeAndNoArgument(t *testing.T) 
 }
 
 func TestCheckInvalidFunctionPreConditionWithBefore(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: Int) {
@@ -159,6 +173,8 @@ func TestCheckInvalidFunctionPreConditionWithBefore(t *testing.T) {
 
 func TestCheckInvalidFunctionWithBeforeVariableAndPostConditionWithBefore(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: Int) {
           post {
@@ -175,6 +191,8 @@ func TestCheckInvalidFunctionWithBeforeVariableAndPostConditionWithBefore(t *tes
 
 func TestCheckFunctionWithBeforeVariable(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: Int) {
           let before = 0
@@ -185,6 +203,8 @@ func TestCheckFunctionWithBeforeVariable(t *testing.T) {
 }
 
 func TestCheckFunctionPostCondition(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: Int): Int {
@@ -200,6 +220,8 @@ func TestCheckFunctionPostCondition(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionPreConditionWithResult(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
@@ -221,6 +243,8 @@ func TestCheckInvalidFunctionPreConditionWithResult(t *testing.T) {
 
 func TestCheckInvalidFunctionPostConditionWithResultWrongType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
           post {
@@ -237,6 +261,8 @@ func TestCheckInvalidFunctionPostConditionWithResultWrongType(t *testing.T) {
 
 func TestCheckFunctionPostConditionWithResult(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
           post {
@@ -250,6 +276,8 @@ func TestCheckFunctionPostConditionWithResult(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionPostConditionWithResult(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -270,6 +298,8 @@ func TestCheckInvalidFunctionPostConditionWithResult(t *testing.T) {
 
 func TestCheckFunctionWithoutReturnTypeAndLocalResultAndPostConditionWithResult(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           post {
@@ -284,6 +314,8 @@ func TestCheckFunctionWithoutReturnTypeAndLocalResultAndPostConditionWithResult(
 
 func TestCheckFunctionWithoutReturnTypeAndResultParameterAndPostConditionWithResult(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(result: Int) {
           post {
@@ -296,6 +328,8 @@ func TestCheckFunctionWithoutReturnTypeAndResultParameterAndPostConditionWithRes
 }
 
 func TestCheckInvalidFunctionWithReturnTypeAndLocalResultAndPostConditionWithResult(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
@@ -314,6 +348,8 @@ func TestCheckInvalidFunctionWithReturnTypeAndLocalResultAndPostConditionWithRes
 
 func TestCheckInvalidFunctionWithReturnTypeAndResultParameterAndPostConditionWithResult(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(result: Int): Int {
           post {
@@ -330,6 +366,8 @@ func TestCheckInvalidFunctionWithReturnTypeAndResultParameterAndPostConditionWit
 
 func TestCheckInvalidFunctionPostConditionWithFunction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           post {
@@ -345,6 +383,8 @@ func TestCheckInvalidFunctionPostConditionWithFunction(t *testing.T) {
 
 func TestCheckFunctionPostConditionWithMessageUsingStringLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           post {
@@ -357,6 +397,8 @@ func TestCheckFunctionPostConditionWithMessageUsingStringLiteral(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionPostConditionWithMessageUsingBooleanLiteral(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -373,6 +415,8 @@ func TestCheckInvalidFunctionPostConditionWithMessageUsingBooleanLiteral(t *test
 
 func TestCheckFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): String {
           post {
@@ -387,6 +431,8 @@ func TestCheckFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 
 func TestCheckFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: String) {
           post {
@@ -399,6 +445,8 @@ func TestCheckFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
 }
 
 func TestCheckFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: String) {

--- a/runtime/tests/checker/conformance_test.go
+++ b/runtime/tests/checker/conformance_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckInvalidEventTypeRequirementConformance(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       pub contract interface CI {
 
@@ -48,6 +50,8 @@ func TestCheckInvalidEventTypeRequirementConformance(t *testing.T) {
 }
 
 func TestCheckTypeRequirementConformance(t *testing.T) {
+
+	t.Parallel()
 
 	type test struct {
 		name            string

--- a/runtime/tests/checker/contract_test.go
+++ b/runtime/tests/checker/contract_test.go
@@ -33,6 +33,8 @@ import (
 
 func TestCheckInvalidContractAccountField(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract Test {
           let account: AuthAccount
@@ -50,6 +52,8 @@ func TestCheckInvalidContractAccountField(t *testing.T) {
 
 func TestCheckInvalidContractInterfaceAccountField(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract interface Test {
           let account: AuthAccount
@@ -62,6 +66,8 @@ func TestCheckInvalidContractInterfaceAccountField(t *testing.T) {
 }
 
 func TestCheckInvalidContractAccountFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       contract Test {
@@ -76,6 +82,8 @@ func TestCheckInvalidContractAccountFunction(t *testing.T) {
 
 func TestCheckInvalidContractInterfaceAccountFunction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract interface Test {
           fun account()
@@ -88,6 +96,8 @@ func TestCheckInvalidContractInterfaceAccountFunction(t *testing.T) {
 }
 
 func TestCheckContractAccountFieldUse(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       contract Test {
@@ -103,6 +113,8 @@ func TestCheckContractAccountFieldUse(t *testing.T) {
 
 func TestCheckContractInterfaceAccountFieldUse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract interface Test {
 
@@ -116,6 +128,8 @@ func TestCheckContractInterfaceAccountFieldUse(t *testing.T) {
 }
 
 func TestCheckInvalidContractAccountFieldInitialization(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       contract Test {
@@ -133,6 +147,8 @@ func TestCheckInvalidContractAccountFieldInitialization(t *testing.T) {
 
 func TestCheckInvalidContractAccountFieldAccess(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract Test {}
 
@@ -145,6 +161,8 @@ func TestCheckInvalidContractAccountFieldAccess(t *testing.T) {
 }
 
 func TestCheckContractAccountFieldUseInitialized(t *testing.T) {
+
+	t.Parallel()
 
 	code := `
       contract Test {
@@ -169,6 +187,8 @@ func TestCheckContractAccountFieldUseInitialized(t *testing.T) {
 }
 
 func TestCheckInvalidContractMoveToFunction(t *testing.T) {
+
+	t.Parallel()
 
 	for _, name := range []string{"self", "C"} {
 
@@ -199,6 +219,8 @@ func TestCheckInvalidContractMoveToFunction(t *testing.T) {
 
 func TestCheckInvalidContractMoveInVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, name := range []string{"self", "C"} {
 
 		t.Run(name, func(t *testing.T) {
@@ -225,6 +247,8 @@ func TestCheckInvalidContractMoveInVariableDeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidContractMoveReturnFromFunction(t *testing.T) {
+
+	t.Parallel()
 
 	for _, name := range []string{"self", "C"} {
 
@@ -253,6 +277,8 @@ func TestCheckInvalidContractMoveReturnFromFunction(t *testing.T) {
 
 func TestCheckInvalidContractMoveIntoArrayLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	for _, name := range []string{"self", "C"} {
 
 		t.Run(name, func(t *testing.T) {
@@ -280,6 +306,8 @@ func TestCheckInvalidContractMoveIntoArrayLiteral(t *testing.T) {
 
 func TestCheckInvalidContractMoveIntoDictionaryLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	for _, name := range []string{"self", "C"} {
 
 		t.Run(name, func(t *testing.T) {
@@ -306,6 +334,8 @@ func TestCheckInvalidContractMoveIntoDictionaryLiteral(t *testing.T) {
 }
 
 func TestCheckContractNestedDeclarationOrderOutsideInside(t *testing.T) {
+
+	t.Parallel()
 
 	for _, isInterface := range []bool{true, false} {
 
@@ -367,6 +397,8 @@ func TestCheckContractNestedDeclarationOrderOutsideInside(t *testing.T) {
 
 func TestCheckContractNestedDeclarationOrderInsideOutside(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract C {
 
@@ -389,6 +421,8 @@ func TestCheckContractNestedDeclarationOrderInsideOutside(t *testing.T) {
 // - Mutually using sibling types
 //
 func TestCheckContractNestedDeclarationsComplex(t *testing.T) {
+
+	t.Parallel()
 
 	interfacePossibilities := []bool{true, false}
 
@@ -608,6 +642,8 @@ func TestCheckContractNestedDeclarationsComplex(t *testing.T) {
 }
 
 func TestCheckInvalidContractNestedTypeShadowing(t *testing.T) {
+
+	t.Parallel()
 
 	type test struct {
 		name        string

--- a/runtime/tests/checker/declaration_test.go
+++ b/runtime/tests/checker/declaration_test.go
@@ -33,6 +33,8 @@ import (
 
 func TestCheckConstantAndVariableDeclarations(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
         let x = 1
         var y = 1
@@ -53,6 +55,8 @@ func TestCheckConstantAndVariableDeclarations(t *testing.T) {
 
 func TestCheckInvalidGlobalConstantRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         fun x() {}
 
@@ -66,6 +70,8 @@ func TestCheckInvalidGlobalConstantRedeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidGlobalFunctionRedeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
         let x = true
@@ -81,6 +87,8 @@ func TestCheckInvalidGlobalFunctionRedeclaration(t *testing.T) {
 
 func TestCheckInvalidLocalRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         fun test() {
             let x = true
@@ -94,6 +102,8 @@ func TestCheckInvalidLocalRedeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidLocalFunctionRedeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
         fun test() {
@@ -111,6 +121,8 @@ func TestCheckInvalidLocalFunctionRedeclaration(t *testing.T) {
 
 func TestCheckInvalidUnknownDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        fun test() {
            return x
@@ -125,6 +137,8 @@ func TestCheckInvalidUnknownDeclaration(t *testing.T) {
 
 func TestCheckInvalidUnknownDeclarationInGlobal(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        let x = y
     `)
@@ -135,6 +149,8 @@ func TestCheckInvalidUnknownDeclarationInGlobal(t *testing.T) {
 }
 
 func TestCheckInvalidUnknownDeclarationInGlobalAndUnknownType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        let x: X = y
@@ -165,6 +181,8 @@ func TestCheckInvalidUnknownDeclarationInGlobalAndUnknownType(t *testing.T) {
 
 func TestCheckInvalidUnknownDeclarationCallInGlobal(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        let x = y()
     `)
@@ -175,6 +193,8 @@ func TestCheckInvalidUnknownDeclarationCallInGlobal(t *testing.T) {
 }
 
 func TestCheckInvalidRedeclarations(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(a: Int, a: Int) {
@@ -191,6 +211,8 @@ func TestCheckInvalidRedeclarations(t *testing.T) {
 
 func TestCheckInvalidConstantValue(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x: Bool = 1
     `)
@@ -201,6 +223,8 @@ func TestCheckInvalidConstantValue(t *testing.T) {
 }
 
 func TestCheckInvalidUse(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -215,6 +239,8 @@ func TestCheckInvalidUse(t *testing.T) {
 
 func TestCheckInvalidVariableDeclarationSecondValueNotDeclared(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        var y = 2
        let z = y = x
@@ -228,6 +254,8 @@ func TestCheckInvalidVariableDeclarationSecondValueNotDeclared(t *testing.T) {
 
 func TestCheckInvalidVariableDeclarationSecondValueCopyTransfers(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        var x = 1
        var y = 2
@@ -240,6 +268,8 @@ func TestCheckInvalidVariableDeclarationSecondValueCopyTransfers(t *testing.T) {
 }
 
 func TestCheckInvalidVariableDeclarationSecondValueNotTarget(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -256,6 +286,8 @@ func TestCheckInvalidVariableDeclarationSecondValueNotTarget(t *testing.T) {
 
 func TestCheckInvalidVariableDeclarationSecondValueCopyTransferSecond(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource R {}
 
@@ -270,6 +302,8 @@ func TestCheckInvalidVariableDeclarationSecondValueCopyTransferSecond(t *testing
 }
 
 func TestCheckInvalidVariableDeclarationSecondValueCopyTransferFirst(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      resource R {}
@@ -286,6 +320,8 @@ func TestCheckInvalidVariableDeclarationSecondValueCopyTransferFirst(t *testing.
 
 func TestCheckInvalidVariableDeclarationSecondValueConstant(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource R {}
 
@@ -300,6 +336,8 @@ func TestCheckInvalidVariableDeclarationSecondValueConstant(t *testing.T) {
 }
 
 func TestCheckInvalidVariableDeclarationSecondValueTypeMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      resource X {}
@@ -317,6 +355,8 @@ func TestCheckInvalidVariableDeclarationSecondValueTypeMismatch(t *testing.T) {
 
 func TestCheckInvalidVariableDeclarationSecondValueUseAfterInvalidation(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource R {}
 
@@ -333,6 +373,8 @@ func TestCheckInvalidVariableDeclarationSecondValueUseAfterInvalidation(t *testi
 }
 
 func TestCheckVariableDeclarationSecondValue(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
      resource R {}
@@ -368,6 +410,8 @@ func TestCheckVariableDeclarationSecondValue(t *testing.T) {
 }
 
 func TestCheckVariableDeclarationSecondValueDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
      resource R {}
@@ -406,6 +450,8 @@ func TestCheckVariableDeclarationSecondValueDictionary(t *testing.T) {
 
 func TestCheckVariableDeclarationSecondValueNil(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource R {}
 
@@ -421,6 +467,8 @@ func TestCheckVariableDeclarationSecondValueNil(t *testing.T) {
 }
 
 func TestCheckTopLevelContractRestriction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheckWithOptions(t,
 		`
@@ -444,6 +492,8 @@ func TestCheckTopLevelContractRestriction(t *testing.T) {
 }
 
 func TestCheckInvalidTopLevelContractRestriction(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[string]string{
 		"resource":           `resource Test {}`,
@@ -484,6 +534,8 @@ func TestCheckInvalidTopLevelContractRestriction(t *testing.T) {
 }
 
 func TestCheckInvalidLocalDeclarations(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[string]string{
 		"transaction": `transaction { execute {} }`,

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -37,6 +37,8 @@ var dynamicCastingOperations = []ast.Operation{
 
 func TestCheckDynamicCastingAnyStruct(t *testing.T) {
 
+	t.Parallel()
+
 	for _, operation := range dynamicCastingOperations {
 
 		t.Run(operation.Symbol(), func(t *testing.T) {
@@ -83,6 +85,8 @@ func TestCheckDynamicCastingAnyStruct(t *testing.T) {
 }
 
 func TestCheckDynamicCastingAnyResource(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -174,6 +178,8 @@ func TestCheckDynamicCastingAnyResource(t *testing.T) {
 
 func TestCheckDynamicCastingNumber(t *testing.T) {
 
+	t.Parallel()
+
 	type test struct {
 		ty    sema.Type
 		value string
@@ -260,6 +266,8 @@ func TestCheckDynamicCastingNumber(t *testing.T) {
 
 func TestCheckDynamicCastingVoid(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.AnyStructType{},
 		&sema.VoidType{},
@@ -324,6 +332,8 @@ func TestCheckDynamicCastingVoid(t *testing.T) {
 
 func TestCheckDynamicCastingString(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.AnyStructType{},
 		&sema.StringType{},
@@ -384,6 +394,8 @@ func TestCheckDynamicCastingString(t *testing.T) {
 }
 
 func TestCheckDynamicCastingBool(t *testing.T) {
+
+	t.Parallel()
 
 	types := []sema.Type{
 		&sema.AnyStructType{},
@@ -446,6 +458,8 @@ func TestCheckDynamicCastingBool(t *testing.T) {
 
 func TestCheckDynamicCastingAddress(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.AnyStructType{},
 		&sema.AddressType{},
@@ -507,6 +521,8 @@ func TestCheckDynamicCastingAddress(t *testing.T) {
 }
 
 func TestCheckDynamicCastingStruct(t *testing.T) {
+
+	t.Parallel()
 
 	types := []string{
 		"AnyStruct",
@@ -593,6 +609,8 @@ func TestCheckDynamicCastingStruct(t *testing.T) {
 }
 
 func TestCheckDynamicCastingResource(t *testing.T) {
+
+	t.Parallel()
 
 	types := []string{
 		"AnyResource",
@@ -708,6 +726,8 @@ func TestCheckDynamicCastingResource(t *testing.T) {
 
 func TestCheckDynamicCastingStructInterface(t *testing.T) {
 
+	t.Parallel()
+
 	types := []string{
 		"AnyStruct",
 		"S",
@@ -798,6 +818,8 @@ func TestCheckDynamicCastingStructInterface(t *testing.T) {
 }
 
 func TestCheckDynamicCastingResourceInterface(t *testing.T) {
+
+	t.Parallel()
 
 	types := []string{
 		"AnyResource",
@@ -988,6 +1010,8 @@ func TestCheckDynamicCastingResourceInterface(t *testing.T) {
 
 func TestCheckDynamicCastingSome(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.OptionalType{Type: &sema.IntType{}},
 		&sema.OptionalType{Type: &sema.AnyStructType{}},
@@ -1048,6 +1072,8 @@ func TestCheckDynamicCastingSome(t *testing.T) {
 
 func TestCheckDynamicCastingArray(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.VariableSizedType{Type: &sema.IntType{}},
 		&sema.VariableSizedType{Type: &sema.AnyStructType{}},
@@ -1107,6 +1133,8 @@ func TestCheckDynamicCastingArray(t *testing.T) {
 }
 
 func TestCheckDynamicCastingDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	types := []sema.Type{
 		&sema.DictionaryType{

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -35,6 +35,8 @@ import (
 
 func TestCheckEventDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("ValidEvent", func(t *testing.T) {
 		checker, err := ParseAndCheck(t, `
             event Transfer(to: Int, from: Int)
@@ -182,6 +184,8 @@ func TestCheckEventDeclaration(t *testing.T) {
 }
 
 func TestCheckEmitEvent(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("ValidEvent", func(t *testing.T) {
 		_, err := ParseAndCheck(t, `

--- a/runtime/tests/checker/fixedpoint_test.go
+++ b/runtime/tests/checker/fixedpoint_test.go
@@ -34,6 +34,8 @@ import (
 
 func TestCheckFixedPointLiteralTypeConversionInVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range sema.AllFixedPointTypes {
 		// Test non-optional and optional type
 
@@ -65,6 +67,8 @@ func TestCheckFixedPointLiteralTypeConversionInVariableDeclaration(t *testing.T)
 }
 
 func TestCheckFixedPointLiteralTypeConversionInAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range sema.AllFixedPointTypes {
 		// Test non-optional and optional type
@@ -99,6 +103,8 @@ func TestCheckFixedPointLiteralTypeConversionInAssignment(t *testing.T) {
 }
 
 func TestCheckFixedPointLiteralRanges(t *testing.T) {
+
+	t.Parallel()
 
 	inferredType := func(t *testing.T, literal string) sema.Type {
 
@@ -468,6 +474,8 @@ func TestCheckFixedPointLiteralRanges(t *testing.T) {
 //
 func TestCheckInvalidFixedPointLiteralWithNeverReturnType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         fun test(): Never {
             return 1.2
@@ -480,6 +488,8 @@ func TestCheckInvalidFixedPointLiteralWithNeverReturnType(t *testing.T) {
 }
 
 func TestCheckFixedPointLiteralTypeConversionInFunctionCallArgument(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range sema.AllFixedPointTypes {
 		// Test non-optional and optional type
@@ -508,6 +518,8 @@ func TestCheckFixedPointLiteralTypeConversionInFunctionCallArgument(t *testing.T
 
 func TestCheckFixedPointLiteralTypeConversionInReturn(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range sema.AllFixedPointTypes {
 		// Test non-optional and optional type
 
@@ -535,6 +547,8 @@ func TestCheckFixedPointLiteralTypeConversionInReturn(t *testing.T) {
 
 func TestCheckSignedFixedPointNegate(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range sema.AllSignedFixedPointTypes {
 		name := ty.String()
 
@@ -555,6 +569,8 @@ func TestCheckSignedFixedPointNegate(t *testing.T) {
 }
 
 func TestCheckInvalidUnsignedFixedPointNegate(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range sema.AllUnsignedFixedPointTypes {
 
@@ -578,6 +594,8 @@ func TestCheckInvalidUnsignedFixedPointNegate(t *testing.T) {
 
 func TestCheckInvalidNegativeZeroUnsignedFixedPoint(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range sema.AllUnsignedFixedPointTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
@@ -598,6 +616,8 @@ func TestCheckInvalidNegativeZeroUnsignedFixedPoint(t *testing.T) {
 }
 
 func TestCheckFixedPointLiteralScales(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range sema.AllFixedPointTypes {
 		t.Run(ty.String(), func(t *testing.T) {

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestCheckForVariableSized(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let xs: [Int] = [1, 2, 3]
@@ -42,6 +44,8 @@ func TestCheckForVariableSized(t *testing.T) {
 }
 
 func TestCheckForConstantSized(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -57,6 +61,8 @@ func TestCheckForConstantSized(t *testing.T) {
 
 func TestCheckForEmpty(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           for x in [] {}
@@ -67,6 +73,8 @@ func TestCheckForEmpty(t *testing.T) {
 }
 
 func TestCheckInvalidForValueNonArray(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -80,6 +88,8 @@ func TestCheckInvalidForValueNonArray(t *testing.T) {
 }
 
 func TestCheckInvalidForValueResource(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}
@@ -98,6 +108,8 @@ func TestCheckInvalidForValueResource(t *testing.T) {
 
 func TestCheckInvalidForBlock(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           for x in [1, 2, 3] { y }
@@ -111,6 +123,8 @@ func TestCheckInvalidForBlock(t *testing.T) {
 
 func TestCheckForBreakStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        fun test() {
            for x in [1, 2, 3] {
@@ -123,6 +137,8 @@ func TestCheckForBreakStatement(t *testing.T) {
 }
 
 func TestCheckInvalidForBreakStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        fun test() {
@@ -141,6 +157,8 @@ func TestCheckInvalidForBreakStatement(t *testing.T) {
 
 func TestCheckForContinueStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        fun test() {
            for x in [1, 2, 3] {
@@ -153,6 +171,8 @@ func TestCheckForContinueStatement(t *testing.T) {
 }
 
 func TestCheckInvalidForContinueStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        fun test() {

--- a/runtime/tests/checker/force_test.go
+++ b/runtime/tests/checker/force_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckForce(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("valid", func(t *testing.T) {
 
 		checker, err := ParseAndCheck(t, `

--- a/runtime/tests/checker/function_expression_test.go
+++ b/runtime/tests/checker/function_expression_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckInvalidFunctionExpressionReturnValue(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let test = fun (): Int {
           return true
@@ -42,6 +44,8 @@ func TestCheckInvalidFunctionExpressionReturnValue(t *testing.T) {
 }
 
 func TestCheckFunctionExpressionsAndScope(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        let x = 10

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckReferenceInFunction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           test
@@ -41,6 +43,8 @@ func TestCheckReferenceInFunction(t *testing.T) {
 
 func TestCheckParameterNameWithFunctionName(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(test: Int) {
           test
@@ -51,6 +55,8 @@ func TestCheckParameterNameWithFunctionName(t *testing.T) {
 }
 
 func TestCheckMutuallyRecursiveFunctions(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun isEven(_ n: Int): Bool {
@@ -73,6 +79,8 @@ func TestCheckMutuallyRecursiveFunctions(t *testing.T) {
 
 func TestCheckMutuallyRecursiveScoping(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun f(): Int {
          return g()
@@ -91,6 +99,8 @@ func TestCheckMutuallyRecursiveScoping(t *testing.T) {
 
 func TestCheckInvalidFunctionDeclarations(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           fun foo() {}
@@ -105,6 +115,8 @@ func TestCheckInvalidFunctionDeclarations(t *testing.T) {
 
 func TestCheckInvalidFunctionRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun foo() {
           fun foo() {}
@@ -118,6 +130,8 @@ func TestCheckInvalidFunctionRedeclaration(t *testing.T) {
 
 func TestCheckFunctionAccess(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        pub fun test() {}
     `)
@@ -127,6 +141,8 @@ func TestCheckFunctionAccess(t *testing.T) {
 
 func TestCheckInvalidFunctionAccess(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        pub(set) fun test() {}
     `)
@@ -135,6 +151,8 @@ func TestCheckInvalidFunctionAccess(t *testing.T) {
 }
 
 func TestCheckReturnWithoutExpression(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        fun returnNothing() {
@@ -147,6 +165,8 @@ func TestCheckReturnWithoutExpression(t *testing.T) {
 
 func TestCheckAnyReturnType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun foo(): AnyStruct {
           return foo
@@ -157,6 +177,8 @@ func TestCheckAnyReturnType(t *testing.T) {
 }
 
 func TestCheckInvalidParameterTypes(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: X, y: Y) {}
@@ -172,6 +194,8 @@ func TestCheckInvalidParameterTypes(t *testing.T) {
 
 func TestCheckInvalidParameterNameRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(a: Int, a: Int) {}
     `)
@@ -183,6 +207,8 @@ func TestCheckInvalidParameterNameRedeclaration(t *testing.T) {
 
 func TestCheckParameterRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(a: Int) {
           let a = 1
@@ -193,6 +219,8 @@ func TestCheckParameterRedeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidParameterAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(a: Int) {
@@ -207,6 +235,8 @@ func TestCheckInvalidParameterAssignment(t *testing.T) {
 
 func TestCheckInvalidArgumentLabelRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x a: Int, x b: Int) {}
     `)
@@ -218,6 +248,8 @@ func TestCheckInvalidArgumentLabelRedeclaration(t *testing.T) {
 
 func TestCheckArgumentLabelRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(_ a: Int, _ b: Int) {}
     `)
@@ -226,6 +258,8 @@ func TestCheckArgumentLabelRedeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionDeclarationReturnValue(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
@@ -239,6 +273,8 @@ func TestCheckInvalidFunctionDeclarationReturnValue(t *testing.T) {
 }
 
 func TestCheckInvalidResourceCapturingThroughVariable(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource Kitty {}
@@ -260,6 +296,8 @@ func TestCheckInvalidResourceCapturingThroughVariable(t *testing.T) {
 
 func TestCheckInvalidResourceCapturingThroughParameter(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource Kitty {}
 
@@ -278,6 +316,8 @@ func TestCheckInvalidResourceCapturingThroughParameter(t *testing.T) {
 }
 
 func TestCheckInvalidSelfResourceCapturing(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource Kitty {
@@ -299,6 +339,9 @@ func TestCheckInvalidSelfResourceCapturing(t *testing.T) {
 }
 
 func TestCheckInvalidResourceCapturingJustMemberAccess(t *testing.T) {
+
+	t.Parallel()
+
 	// Resource capturing even just for read access (e.g. reading a member) is invalid
 
 	_, err := ParseAndCheck(t, `

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -52,6 +52,8 @@ func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.
 
 func TestCheckGenericFunction(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("valid: no type parameters, no type arguments, no parameters, no arguments, no return type", func(t *testing.T) {
 
 		for _, variant := range []string{"", "<>"} {
@@ -826,6 +828,8 @@ func TestCheckGenericFunction(t *testing.T) {
 
 // https://github.com/dapperlabs/flow-go/issues/3275
 func TestCheckGenericFunctionIsInvalid(t *testing.T) {
+
+	t.Parallel()
 
 	typeParameter := &sema.TypeParameter{
 		Name:      "T",

--- a/runtime/tests/checker/if_test.go
+++ b/runtime/tests/checker/if_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckIfStatementTest(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           if true {}
@@ -40,6 +42,8 @@ func TestCheckIfStatementTest(t *testing.T) {
 }
 
 func TestCheckIfStatementScoping(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -57,6 +61,8 @@ func TestCheckIfStatementScoping(t *testing.T) {
 
 func TestCheckInvalidIfStatementTest(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           if 1 {}
@@ -69,6 +75,8 @@ func TestCheckInvalidIfStatementTest(t *testing.T) {
 }
 
 func TestCheckInvalidIfStatementElse(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -85,6 +93,8 @@ func TestCheckInvalidIfStatementElse(t *testing.T) {
 
 func TestCheckIfStatementTestWithDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: Int?): Int {
           if var y = x {
@@ -99,6 +109,8 @@ func TestCheckIfStatementTestWithDeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidIfStatementTestWithDeclarationReferenceInElse(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: Int?) {
@@ -117,6 +129,8 @@ func TestCheckInvalidIfStatementTestWithDeclarationReferenceInElse(t *testing.T)
 
 func TestCheckIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      fun test(x: Int??): Int? {
          if var y = x {
@@ -132,6 +146,8 @@ func TestCheckIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 
 func TestCheckIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      fun test(x: Int??): Int? {
          if var y: Int? = x {
@@ -146,6 +162,8 @@ func TestCheckIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotation(t 
 }
 
 func TestCheckInvalidIfStatementTestWithDeclarationNonOptional(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      fun test(x: Int) {
@@ -163,6 +181,8 @@ func TestCheckInvalidIfStatementTestWithDeclarationNonOptional(t *testing.T) {
 }
 
 func TestCheckInvalidIfStatementTestWithDeclarationSameType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(x: Int?): Int? {

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -35,6 +35,8 @@ import (
 
 func TestCheckInvalidImport(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        import "unknown"
     `)
@@ -45,6 +47,8 @@ func TestCheckInvalidImport(t *testing.T) {
 }
 
 func TestCheckInvalidRepeatedImport(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheckWithOptions(t,
 		`
@@ -64,6 +68,8 @@ func TestCheckInvalidRepeatedImport(t *testing.T) {
 }
 
 func TestCheckImportAll(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
       pub fun answer(): Int {
@@ -91,6 +97,8 @@ func TestCheckImportAll(t *testing.T) {
 
 func TestCheckInvalidImportUnexported(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
        pub let x = 1
     `)
@@ -116,6 +124,8 @@ func TestCheckInvalidImportUnexported(t *testing.T) {
 }
 
 func TestCheckImportSome(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
       pub fun answer(): Int {
@@ -145,6 +155,8 @@ func TestCheckImportSome(t *testing.T) {
 
 func TestCheckInvalidImportedError(t *testing.T) {
 
+	t.Parallel()
+
 	// NOTE: only parse, don't check imported program.
 	// will be checked by checker checking importing program
 
@@ -171,6 +183,8 @@ func TestCheckInvalidImportedError(t *testing.T) {
 }
 
 func TestCheckImportTypes(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -246,6 +260,8 @@ func TestCheckImportTypes(t *testing.T) {
 }
 
 func TestCheckInvalidImportCycle(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: only parse, don't check imported program.
 	// will be checked by checker checking importing program

--- a/runtime/tests/checker/indexing_test.go
+++ b/runtime/tests/checker/indexing_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckArrayIndexingWithInteger(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let z = [0, 3]
@@ -42,6 +44,8 @@ func TestCheckArrayIndexingWithInteger(t *testing.T) {
 
 func TestCheckNestedArrayIndexingWithInteger(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let z = [[0, 1], [2, 3]]
@@ -53,6 +57,8 @@ func TestCheckNestedArrayIndexingWithInteger(t *testing.T) {
 }
 
 func TestCheckInvalidArrayIndexingWithBool(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -68,6 +74,8 @@ func TestCheckInvalidArrayIndexingWithBool(t *testing.T) {
 
 func TestCheckInvalidArrayIndexingIntoBool(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
           return true[0]
@@ -81,6 +89,8 @@ func TestCheckInvalidArrayIndexingIntoBool(t *testing.T) {
 
 func TestCheckInvalidArrayIndexingIntoInteger(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
           return 2[0]
@@ -93,6 +103,8 @@ func TestCheckInvalidArrayIndexingIntoInteger(t *testing.T) {
 }
 
 func TestCheckInvalidArrayIndexingAssignmentWithBool(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -108,6 +120,8 @@ func TestCheckInvalidArrayIndexingAssignmentWithBool(t *testing.T) {
 
 func TestCheckArrayIndexingAssignmentWithInteger(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let z = [0, 3]
@@ -119,6 +133,8 @@ func TestCheckArrayIndexingAssignmentWithInteger(t *testing.T) {
 }
 
 func TestCheckInvalidArrayIndexingAssignmentWithWrongType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -134,6 +150,8 @@ func TestCheckInvalidArrayIndexingAssignmentWithWrongType(t *testing.T) {
 
 func TestCheckInvalidStringIndexingWithBool(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let z = "abc"
@@ -148,6 +166,8 @@ func TestCheckInvalidStringIndexingWithBool(t *testing.T) {
 
 func TestCheckInvalidUnknownDeclarationIndexing(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           x[0]
@@ -160,6 +180,8 @@ func TestCheckInvalidUnknownDeclarationIndexing(t *testing.T) {
 }
 
 func TestCheckInvalidUnknownDeclarationIndexingAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {

--- a/runtime/tests/checker/initialization_test.go
+++ b/runtime/tests/checker/initialization_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestCheckInvalidFieldInitializationEmptyInitializer(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct Test {
           var foo: Int
@@ -49,6 +51,8 @@ func TestCheckInvalidFieldInitializationEmptyInitializer(t *testing.T) {
 
 func TestCheckFieldInitializationFromArgument(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        struct Test {
            var foo: Int
@@ -63,6 +67,8 @@ func TestCheckFieldInitializationFromArgument(t *testing.T) {
 }
 
 func TestCheckFieldInitializationWithFunctionCallAfterAllFieldsInitialized(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       struct Test {
@@ -81,6 +87,8 @@ func TestCheckFieldInitializationWithFunctionCallAfterAllFieldsInitialized(t *te
 }
 
 func TestCheckInvalidFieldInitializationWithFunctionCallBeforeAllFieldsInitialized(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       struct Test {
@@ -101,6 +109,8 @@ func TestCheckInvalidFieldInitializationWithFunctionCallBeforeAllFieldsInitializ
 }
 
 func TestCheckInvalidFieldInitializationWithUseBeforeAllFieldsInitialized(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       struct Test {
@@ -124,6 +134,8 @@ func TestCheckInvalidFieldInitializationWithUseBeforeAllFieldsInitialized(t *tes
 
 func TestCheckConstantFieldInitialization(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct Test {
           let foo: Int
@@ -138,6 +150,8 @@ func TestCheckConstantFieldInitialization(t *testing.T) {
 }
 
 func TestCheckInvalidRepeatedConstantFieldInitialization(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       struct Test {
@@ -156,6 +170,9 @@ func TestCheckInvalidRepeatedConstantFieldInitialization(t *testing.T) {
 }
 
 func TestCheckFieldInitializationInIfStatement(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("ValidIfStatement", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -197,6 +214,8 @@ func TestCheckFieldInitializationInIfStatement(t *testing.T) {
 
 func TestCheckFieldInitializationInWhileStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         struct Test {
             var foo: Int
@@ -215,6 +234,9 @@ func TestCheckFieldInitializationInWhileStatement(t *testing.T) {
 }
 
 func TestCheckFieldInitializationFromField(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("FromInitializedField", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -253,6 +275,9 @@ func TestCheckFieldInitializationFromField(t *testing.T) {
 }
 
 func TestCheckFieldInitializationUsages(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("InitializedUsage", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -383,6 +408,8 @@ func TestCheckFieldInitializationUsages(t *testing.T) {
 
 func TestCheckFieldInitializationWithReturn(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("Direct", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -445,6 +472,8 @@ func TestCheckFieldInitializationWithReturn(t *testing.T) {
 
 func TestCheckFieldInitializationWithPotentialNeverCallInElse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheckWithPanic(
 		t,
 		`
@@ -467,6 +496,8 @@ func TestCheckFieldInitializationWithPotentialNeverCallInElse(t *testing.T) {
 
 func TestCheckFieldInitializationWithPotentialNeverCallInNilCoalescing(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheckWithPanic(t,
 		`
           struct Test {
@@ -483,6 +514,8 @@ func TestCheckFieldInitializationWithPotentialNeverCallInNilCoalescing(t *testin
 }
 
 func TestCheckInvalidFieldInitializationWithUseOfUninitializedInPrecondition(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       struct Test {

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -37,6 +37,8 @@ var allIntegerTypesAndAddressType = append(
 
 func TestCheckIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range allIntegerTypesAndAddressType {
 		// Test non-optional and optional type
 
@@ -68,6 +70,8 @@ func TestCheckIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {
 }
 
 func TestCheckIntegerLiteralTypeConversionInAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range allIntegerTypesAndAddressType {
 		// Test non-optional and optional type
@@ -102,6 +106,8 @@ func TestCheckIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 }
 
 func TestCheckIntegerLiteralRanges(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range allIntegerTypesAndAddressType {
 		t.Run(ty.String(), func(t *testing.T) {
@@ -213,6 +219,8 @@ func TestCheckIntegerLiteralRanges(t *testing.T) {
 
 func TestCheckInvalidIntegerLiteralValues(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range allIntegerTypesAndAddressType {
 
 		min := ty.(sema.IntegerRangedType).MinInt()
@@ -295,6 +303,8 @@ func TestCheckInvalidIntegerLiteralValues(t *testing.T) {
 //
 func TestCheckInvalidIntegerLiteralWithNeverReturnType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         fun test(): Never {
             return 1
@@ -307,6 +317,8 @@ func TestCheckInvalidIntegerLiteralWithNeverReturnType(t *testing.T) {
 }
 
 func TestCheckIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range allIntegerTypesAndAddressType {
 		// Test non-optional and optional type
@@ -335,6 +347,8 @@ func TestCheckIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.T) {
 
 func TestCheckIntegerLiteralTypeConversionInReturn(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range allIntegerTypesAndAddressType {
 		// Test non-optional and optional type
 
@@ -362,6 +376,8 @@ func TestCheckIntegerLiteralTypeConversionInReturn(t *testing.T) {
 
 func TestCheckInvalidAddressDecimal(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
         let a: Address = 1
         let b = Address(2)
@@ -374,6 +390,8 @@ func TestCheckInvalidAddressDecimal(t *testing.T) {
 }
 
 func TestCheckSignedIntegerNegate(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range sema.AllSignedIntegerTypes {
 		name := ty.String()
@@ -394,6 +412,8 @@ func TestCheckSignedIntegerNegate(t *testing.T) {
 }
 
 func TestCheckInvalidUnsignedIntegerNegate(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range sema.AllUnsignedIntegerTypes {
 		name := ty.String()
@@ -416,6 +436,8 @@ func TestCheckInvalidUnsignedIntegerNegate(t *testing.T) {
 }
 
 func TestCheckInvalidIntegerConversionFunctionWithoutArgs(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range allIntegerTypesAndAddressType {
 
@@ -440,6 +462,8 @@ func TestCheckInvalidIntegerConversionFunctionWithoutArgs(t *testing.T) {
 
 func TestCheckFixedPointToIntegerConversion(t *testing.T) {
 
+	t.Parallel()
+
 	for _, ty := range sema.AllIntegerTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
@@ -459,6 +483,8 @@ func TestCheckFixedPointToIntegerConversion(t *testing.T) {
 }
 
 func TestCheckIntegerLiteralArguments(t *testing.T) {
+
+	t.Parallel()
 
 	for _, ty := range sema.AllIntegerTypes {
 

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -42,6 +42,8 @@ func constructorArguments(compositeKind common.CompositeKind) string {
 
 func TestCheckInvalidLocalInterface(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		if !kind.SupportsInterfaces() {
@@ -76,6 +78,8 @@ func TestCheckInvalidLocalInterface(t *testing.T) {
 
 func TestCheckInterfaceWithFunction(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -97,6 +101,8 @@ func TestCheckInterfaceWithFunction(t *testing.T) {
 }
 
 func TestCheckInterfaceWithFunctionImplementationAndConditions(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -124,6 +130,8 @@ func TestCheckInterfaceWithFunctionImplementationAndConditions(t *testing.T) {
 
 func TestCheckInvalidInterfaceWithFunctionImplementation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -148,6 +156,8 @@ func TestCheckInvalidInterfaceWithFunctionImplementation(t *testing.T) {
 }
 
 func TestCheckInvalidInterfaceWithFunctionImplementationNoConditions(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -174,6 +184,8 @@ func TestCheckInvalidInterfaceWithFunctionImplementationNoConditions(t *testing.
 
 func TestCheckInterfaceWithInitializer(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -194,6 +206,8 @@ func TestCheckInterfaceWithInitializer(t *testing.T) {
 }
 
 func TestCheckInvalidInterfaceWithInitializerImplementation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -220,6 +234,8 @@ func TestCheckInvalidInterfaceWithInitializerImplementation(t *testing.T) {
 
 func TestCheckInterfaceWithInitializerImplementationAndConditions(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -244,6 +260,8 @@ func TestCheckInterfaceWithInitializerImplementationAndConditions(t *testing.T) 
 }
 
 func TestCheckInterfaceUse(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 
@@ -281,6 +299,8 @@ func TestCheckInterfaceUse(t *testing.T) {
 }
 
 func TestCheckInterfaceConformanceNoRequirements(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -329,6 +349,8 @@ func TestCheckInterfaceConformanceNoRequirements(t *testing.T) {
 }
 
 func TestCheckInvalidInterfaceConformanceIncompatibleCompositeKinds(t *testing.T) {
+
+	t.Parallel()
 
 	for _, firstKind := range common.AllCompositeKinds {
 
@@ -431,6 +453,8 @@ func TestCheckInvalidInterfaceConformanceIncompatibleCompositeKinds(t *testing.T
 
 func TestCheckInvalidInterfaceConformanceUndeclared(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		if !compositeKind.SupportsInterfaces() {
@@ -494,6 +518,8 @@ func TestCheckInvalidInterfaceConformanceUndeclared(t *testing.T) {
 
 func TestCheckInvalidCompositeInterfaceConformanceNonInterface(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		if !kind.SupportsInterfaces() {
@@ -525,6 +551,8 @@ func TestCheckInvalidCompositeInterfaceConformanceNonInterface(t *testing.T) {
 }
 
 func TestCheckInterfaceFieldUse(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -571,6 +599,8 @@ func TestCheckInterfaceFieldUse(t *testing.T) {
 
 func TestCheckInvalidInterfaceUndeclaredFieldUse(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
 		if compositeKind == common.CompositeKindContract {
@@ -615,6 +645,8 @@ func TestCheckInvalidInterfaceUndeclaredFieldUse(t *testing.T) {
 }
 
 func TestCheckInterfaceFunctionUse(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -668,6 +700,8 @@ func TestCheckInterfaceFunctionUse(t *testing.T) {
 
 func TestCheckInvalidInterfaceUndeclaredFunctionUse(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
 		if compositeKind == common.CompositeKindContract {
@@ -711,6 +745,8 @@ func TestCheckInvalidInterfaceUndeclaredFunctionUse(t *testing.T) {
 
 func TestCheckInvalidInterfaceConformanceInitializerExplicitMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -738,6 +774,8 @@ func TestCheckInvalidInterfaceConformanceInitializerExplicitMismatch(t *testing.
 
 func TestCheckInvalidInterfaceConformanceInitializerImplicitMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -764,6 +802,8 @@ func TestCheckInvalidInterfaceConformanceInitializerImplicitMismatch(t *testing.
 
 func TestCheckInvalidInterfaceConformanceMissingFunction(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -788,6 +828,8 @@ func TestCheckInvalidInterfaceConformanceMissingFunction(t *testing.T) {
 }
 
 func TestCheckInvalidInterfaceConformanceFunctionMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -818,6 +860,8 @@ func TestCheckInvalidInterfaceConformanceFunctionMismatch(t *testing.T) {
 
 func TestCheckInvalidInterfaceConformanceFunctionPrivateAccessModifier(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -846,6 +890,8 @@ func TestCheckInvalidInterfaceConformanceFunctionPrivateAccessModifier(t *testin
 }
 
 func TestCheckInvalidInterfaceConformanceMissingField(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 
@@ -892,6 +938,8 @@ func TestCheckInvalidInterfaceConformanceMissingField(t *testing.T) {
 
 func TestCheckInvalidInterfaceConformanceFieldTypeMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -921,6 +969,8 @@ func TestCheckInvalidInterfaceConformanceFieldTypeMismatch(t *testing.T) {
 }
 
 func TestCheckInvalidInterfaceConformanceFieldPrivateAccessModifier(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -953,6 +1003,8 @@ func TestCheckInvalidInterfaceConformanceFieldPrivateAccessModifier(t *testing.T
 
 func TestCheckInvalidInterfaceConformanceFieldMismatchAccessModifierMoreRestrictive(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -984,6 +1036,8 @@ func TestCheckInvalidInterfaceConformanceFieldMismatchAccessModifierMoreRestrict
 
 func TestCheckInvalidInterfaceConformanceFunctionMismatchAccessModifierMoreRestrictive(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1010,6 +1064,8 @@ func TestCheckInvalidInterfaceConformanceFunctionMismatchAccessModifierMoreRestr
 }
 
 func TestCheckInterfaceConformanceFieldMorePermissiveAccessModifier(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1040,6 +1096,8 @@ func TestCheckInterfaceConformanceFieldMorePermissiveAccessModifier(t *testing.T
 
 func TestCheckInvalidInterfaceConformanceKindFieldFunctionMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1068,6 +1126,8 @@ func TestCheckInvalidInterfaceConformanceKindFieldFunctionMismatch(t *testing.T)
 }
 
 func TestCheckInvalidInterfaceConformanceKindFunctionFieldMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1100,6 +1160,8 @@ func TestCheckInvalidInterfaceConformanceKindFunctionFieldMismatch(t *testing.T)
 
 func TestCheckInvalidInterfaceConformanceFieldKindLetVarMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1130,6 +1192,8 @@ func TestCheckInvalidInterfaceConformanceFieldKindLetVarMismatch(t *testing.T) {
 }
 
 func TestCheckInvalidInterfaceConformanceFieldKindVarLetMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1162,6 +1226,8 @@ func TestCheckInvalidInterfaceConformanceFieldKindVarLetMismatch(t *testing.T) {
 
 func TestCheckInterfaceConformanceFunctionArgumentLabelMatch(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -1186,6 +1252,8 @@ func TestCheckInterfaceConformanceFunctionArgumentLabelMatch(t *testing.T) {
 }
 
 func TestCheckInvalidInterfaceConformanceFunctionArgumentLabelMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
@@ -1213,6 +1281,8 @@ func TestCheckInvalidInterfaceConformanceFunctionArgumentLabelMismatch(t *testin
 }
 
 func TestCheckInvalidInterfaceConformanceRepetition(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 
@@ -1250,6 +1320,8 @@ func TestCheckInvalidInterfaceConformanceRepetition(t *testing.T) {
 
 func TestCheckInvalidInterfaceTypeAsValue(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		if !kind.SupportsInterfaces() {
@@ -1283,6 +1355,8 @@ func TestCheckInvalidInterfaceTypeAsValue(t *testing.T) {
 }
 
 func TestCheckInterfaceWithFieldHavingStructType(t *testing.T) {
+
+	t.Parallel()
 
 	for _, firstKind := range common.CompositeKindsWithBody {
 		for _, secondKind := range common.CompositeKindsWithBody {
@@ -1336,6 +1410,8 @@ func TestCheckInterfaceWithFieldHavingStructType(t *testing.T) {
 
 func TestCheckInterfaceWithFunctionHavingStructType(t *testing.T) {
 
+	t.Parallel()
+
 	for _, firstKind := range common.CompositeKindsWithBody {
 		for _, secondKind := range common.CompositeKindsWithBody {
 
@@ -1370,6 +1446,8 @@ func TestCheckInterfaceWithFunctionHavingStructType(t *testing.T) {
 
 func TestCheckInterfaceUseCompositeInInitializer(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct Foo {}
 
@@ -1382,6 +1460,8 @@ func TestCheckInterfaceUseCompositeInInitializer(t *testing.T) {
 }
 
 func TestCheckInterfaceSelfUse(t *testing.T) {
+
+	t.Parallel()
 
 	declarationKinds := []common.DeclarationKind{
 		common.DeclarationKindInitializer,
@@ -1433,6 +1513,8 @@ func TestCheckInterfaceSelfUse(t *testing.T) {
 
 func TestCheckInvalidContractInterfaceConformanceMissingTypeRequirement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           contract interface Test {
@@ -1451,6 +1533,8 @@ func TestCheckInvalidContractInterfaceConformanceMissingTypeRequirement(t *testi
 }
 
 func TestCheckInvalidContractInterfaceConformanceTypeRequirementKindMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -1472,6 +1556,8 @@ func TestCheckInvalidContractInterfaceConformanceTypeRequirementKindMismatch(t *
 
 func TestCheckInvalidContractInterfaceConformanceTypeRequirementMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
          contract interface Test {
@@ -1492,6 +1578,8 @@ func TestCheckInvalidContractInterfaceConformanceTypeRequirementMismatch(t *test
 
 func TestCheckContractInterfaceTypeRequirement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           contract interface Test {
@@ -1506,6 +1594,8 @@ func TestCheckContractInterfaceTypeRequirement(t *testing.T) {
 }
 
 func TestCheckInvalidContractInterfaceTypeRequirementFunctionImplementation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -1525,6 +1615,8 @@ func TestCheckInvalidContractInterfaceTypeRequirementFunctionImplementation(t *t
 }
 
 func TestCheckInvalidContractInterfaceTypeRequirementMissingFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -1549,6 +1641,8 @@ func TestCheckInvalidContractInterfaceTypeRequirementMissingFunction(t *testing.
 
 func TestCheckContractInterfaceTypeRequirementWithFunction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           contract interface Test {
@@ -1572,6 +1666,8 @@ func TestCheckContractInterfaceTypeRequirementWithFunction(t *testing.T) {
 
 func TestCheckContractInterfaceTypeRequirementConformanceMissingMembers(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           contract interface Test {
@@ -1592,6 +1688,8 @@ func TestCheckContractInterfaceTypeRequirementConformanceMissingMembers(t *testi
 }
 
 func TestCheckInvalidContractInterfaceTypeRequirementConformance(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -1615,6 +1713,8 @@ func TestCheckInvalidContractInterfaceTypeRequirementConformance(t *testing.T) {
 }
 
 func TestCheckInvalidContractInterfaceTypeRequirementConformanceMissingFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -1642,6 +1742,8 @@ func TestCheckInvalidContractInterfaceTypeRequirementConformanceMissingFunction(
 }
 
 func TestCheckInvalidContractInterfaceTypeRequirementMissingConformance(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -1673,6 +1775,8 @@ func TestCheckInvalidContractInterfaceTypeRequirementMissingConformance(t *testi
 
 func TestCheckContractInterfaceTypeRequirementImplementation(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           struct interface OtherInterface {}
@@ -1702,6 +1806,8 @@ func TestCheckContractInterfaceTypeRequirementImplementation(t *testing.T) {
 
 func TestCheckContractInterfaceFungibleToken(t *testing.T) {
 
+	t.Parallel()
+
 	const code = examples.FungibleTokenContractInterface
 	_, err := ParseAndCheck(t, code)
 
@@ -1711,6 +1817,8 @@ func TestCheckContractInterfaceFungibleToken(t *testing.T) {
 }
 
 func TestCheckContractInterfaceFungibleTokenConformance(t *testing.T) {
+
+	t.Parallel()
 
 	code := examples.FungibleTokenContractInterface + "\n" + examples.ExampleFungibleTokenContract
 
@@ -1722,6 +1830,8 @@ func TestCheckContractInterfaceFungibleTokenConformance(t *testing.T) {
 }
 
 func TestCheckContractInterfaceFungibleTokenUse(t *testing.T) {
+
+	t.Parallel()
 
 	code := examples.FungibleTokenContractInterface + "\n" +
 		examples.ExampleFungibleTokenContract + "\n" + `

--- a/runtime/tests/checker/invalid_test.go
+++ b/runtime/tests/checker/invalid_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestCheckSpuriousIdentifierAssignmentInvalidValueTypeMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           fun test() {
@@ -44,6 +46,8 @@ func TestCheckSpuriousIdentifierAssignmentInvalidValueTypeMismatch(t *testing.T)
 }
 
 func TestCheckSpuriousIdentifierAssignmentInvalidTargetTypeMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -61,6 +65,8 @@ func TestCheckSpuriousIdentifierAssignmentInvalidTargetTypeMismatch(t *testing.T
 
 func TestCheckSpuriousIndexAssignmentInvalidValueTypeMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           fun test() {
@@ -77,6 +83,8 @@ func TestCheckSpuriousIndexAssignmentInvalidValueTypeMismatch(t *testing.T) {
 
 func TestCheckSpuriousIndexAssignmentInvalidElementTypeMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           fun test() {
@@ -92,6 +100,8 @@ func TestCheckSpuriousIndexAssignmentInvalidElementTypeMismatch(t *testing.T) {
 }
 
 func TestCheckSpuriousMemberAssignmentInvalidValueTypeMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -111,6 +121,8 @@ func TestCheckSpuriousMemberAssignmentInvalidValueTypeMismatch(t *testing.T) {
 
 func TestCheckSpuriousMemberAssignmentInvalidMemberTypeMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
          struct X {
@@ -129,6 +141,8 @@ func TestCheckSpuriousMemberAssignmentInvalidMemberTypeMismatch(t *testing.T) {
 
 func TestCheckSpuriousReturnWithInvalidValueTypeMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           fun test(): Int {
@@ -143,6 +157,8 @@ func TestCheckSpuriousReturnWithInvalidValueTypeMismatch(t *testing.T) {
 }
 
 func TestCheckSpuriousReturnWithInvalidReturnTypeMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -159,6 +175,8 @@ func TestCheckSpuriousReturnWithInvalidReturnTypeMismatch(t *testing.T) {
 
 func TestCheckSpuriousCastWithInvalidTargetTypeMismatch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
           let y = 1 as X
@@ -171,6 +189,8 @@ func TestCheckSpuriousCastWithInvalidTargetTypeMismatch(t *testing.T) {
 }
 
 func TestCheckSpuriousCastWithInvalidValueTypeMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -31,6 +31,8 @@ import (
 
 func TestCheckInvalidFunctionCallWithTooFewArguments(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
           return x
@@ -48,6 +50,8 @@ func TestCheckInvalidFunctionCallWithTooFewArguments(t *testing.T) {
 
 func TestCheckFunctionCallWithArgumentLabel(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
           return x
@@ -63,6 +67,8 @@ func TestCheckFunctionCallWithArgumentLabel(t *testing.T) {
 
 func TestCheckFunctionCallWithoutArgumentLabel(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun f(_ x: Int): Int {
           return x
@@ -77,6 +83,8 @@ func TestCheckFunctionCallWithoutArgumentLabel(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionCallWithNotRequiredArgumentLabel(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun f(_ x: Int): Int {
@@ -95,6 +103,8 @@ func TestCheckInvalidFunctionCallWithNotRequiredArgumentLabel(t *testing.T) {
 
 func TestCheckIndirectFunctionCallWithoutArgumentLabel(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
           return x
@@ -110,6 +120,8 @@ func TestCheckIndirectFunctionCallWithoutArgumentLabel(t *testing.T) {
 }
 
 func TestCheckFunctionCallMissingArgumentLabel(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
@@ -128,6 +140,8 @@ func TestCheckFunctionCallMissingArgumentLabel(t *testing.T) {
 
 func TestCheckFunctionCallIncorrectArgumentLabel(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
           return x
@@ -144,6 +158,8 @@ func TestCheckFunctionCallIncorrectArgumentLabel(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionCallWithTooManyArguments(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
@@ -164,6 +180,8 @@ func TestCheckInvalidFunctionCallWithTooManyArguments(t *testing.T) {
 
 func TestCheckInvalidFunctionCallOfBool(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
           return true()
@@ -177,6 +195,8 @@ func TestCheckInvalidFunctionCallOfBool(t *testing.T) {
 
 func TestCheckInvalidFunctionCallOfInteger(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Int {
           return 2()
@@ -189,6 +209,8 @@ func TestCheckInvalidFunctionCallOfInteger(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionCallWithWrongType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
@@ -206,6 +228,8 @@ func TestCheckInvalidFunctionCallWithWrongType(t *testing.T) {
 }
 
 func TestCheckInvalidFunctionCallWithWrongTypeAndMissingArgumentLabel(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun f(x: Int): Int {
@@ -226,6 +250,8 @@ func TestCheckInvalidFunctionCallWithWrongTypeAndMissingArgumentLabel(t *testing
 
 func TestCheckInvocationOfFunctionFromStructFunction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun f(x: Int) {}
 
@@ -239,6 +265,8 @@ func TestCheckInvocationOfFunctionFromStructFunction(t *testing.T) {
 }
 
 func TestCheckInvalidStructFunctionInvocation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
 
@@ -255,6 +283,8 @@ func TestCheckInvalidStructFunctionInvocation(t *testing.T) {
 
 func TestCheckInvocationOfFunctionFromStructFunctionWithSameName(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun x(y: Int) {}
 
@@ -270,6 +300,8 @@ func TestCheckInvocationOfFunctionFromStructFunctionWithSameName(t *testing.T) {
 
 func TestCheckIntricateIntegerBinaryExpression(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x: Int8 = 100
       let y = (Int8(90) + Int8(10)) == x
@@ -278,6 +310,8 @@ func TestCheckIntricateIntegerBinaryExpression(t *testing.T) {
 }
 
 func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheckWithOptions(t,
 		`

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckOptionalChainingNonOptionalFieldRead(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
       struct Test {
           let x: Int
@@ -53,6 +55,8 @@ func TestCheckOptionalChainingNonOptionalFieldRead(t *testing.T) {
 
 func TestCheckOptionalChainingOptionalFieldRead(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
       struct Test {
           let x: Int?
@@ -75,6 +79,8 @@ func TestCheckOptionalChainingOptionalFieldRead(t *testing.T) {
 }
 
 func TestCheckOptionalChainingFunctionRead(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
       struct Test {
@@ -104,6 +110,8 @@ func TestCheckOptionalChainingFunctionRead(t *testing.T) {
 
 func TestCheckOptionalChainingFunctionCall(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
       struct Test {
           fun x(): Int {
@@ -126,6 +134,8 @@ func TestCheckOptionalChainingFunctionCall(t *testing.T) {
 
 func TestCheckInvalidOptionalChainingNonOptional(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct Test {
           let x: Int
@@ -145,6 +155,8 @@ func TestCheckInvalidOptionalChainingNonOptional(t *testing.T) {
 }
 
 func TestCheckInvalidOptionalChainingFieldAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       struct Test {

--- a/runtime/tests/checker/nesting_test.go
+++ b/runtime/tests/checker/nesting_test.go
@@ -31,6 +31,9 @@ import (
 )
 
 func TestCheckCompositeDeclarationNesting(t *testing.T) {
+
+	t.Parallel()
+
 	interfacePossibilities := []bool{true, false}
 
 	for _, outerComposite := range common.CompositeKindsWithBody {
@@ -104,6 +107,8 @@ func TestCheckCompositeDeclarationNesting(t *testing.T) {
 
 func TestCheckCompositeDeclarationNestedStructUse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract Test {
 
@@ -121,6 +126,8 @@ func TestCheckCompositeDeclarationNestedStructUse(t *testing.T) {
 }
 
 func TestCheckCompositeDeclarationNestedStructInterfaceUse(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       contract Test {
@@ -146,6 +153,8 @@ func TestCheckCompositeDeclarationNestedStructInterfaceUse(t *testing.T) {
 
 func TestCheckCompositeDeclarationNestedTypeScopingInsideNestedOuter(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract Test {
 
@@ -163,6 +172,8 @@ func TestCheckCompositeDeclarationNestedTypeScopingInsideNestedOuter(t *testing.
 
 func TestCheckCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract Test {
 
@@ -178,6 +189,8 @@ func TestCheckCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeDeclarationNestedTypeScopingAfterInner(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       contract Test {
@@ -196,6 +209,8 @@ func TestCheckInvalidCompositeDeclarationNestedTypeScopingAfterInner(t *testing.
 
 func TestCheckInvalidCompositeDeclarationNestedDuplicateNames(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract Test {
 
@@ -212,6 +227,8 @@ func TestCheckInvalidCompositeDeclarationNestedDuplicateNames(t *testing.T) {
 
 func TestCheckCompositeDeclarationNestedConstructorAndType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       contract Test {
 
@@ -225,6 +242,8 @@ func TestCheckCompositeDeclarationNestedConstructorAndType(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeDeclarationNestedType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       contract Test {
@@ -241,6 +260,8 @@ func TestCheckInvalidCompositeDeclarationNestedType(t *testing.T) {
 }
 
 func TestCheckInvalidNestedType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x: Int.X = 1

--- a/runtime/tests/checker/never_test.go
+++ b/runtime/tests/checker/never_test.go
@@ -26,6 +26,8 @@ import (
 
 func TestCheckNever(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheckWithPanic(t,
 		`
             pub fun test(): Int {

--- a/runtime/tests/checker/nil_coalescing_test.go
+++ b/runtime/tests/checker/nil_coalescing_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckNilCoalescingNilIntToOptional(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let one = 1
       let none: Int? = nil
@@ -40,6 +42,8 @@ func TestCheckNilCoalescingNilIntToOptional(t *testing.T) {
 }
 
 func TestCheckNilCoalescingNilIntToOptionals(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let one = 1
@@ -52,6 +56,8 @@ func TestCheckNilCoalescingNilIntToOptionals(t *testing.T) {
 
 func TestCheckNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let one = 1
       let x: Int? = nil ?? one
@@ -61,6 +67,8 @@ func TestCheckNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 }
 
 func TestCheckInvalidNilCoalescingMismatch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x: Int? = nil ?? false
@@ -73,6 +81,8 @@ func TestCheckInvalidNilCoalescingMismatch(t *testing.T) {
 
 func TestCheckNilCoalescingRightSubtype(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x: Int? = nil ?? nil
     `)
@@ -81,6 +91,8 @@ func TestCheckNilCoalescingRightSubtype(t *testing.T) {
 }
 
 func TestCheckNilCoalescingNilInt(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let one = 1
@@ -92,6 +104,8 @@ func TestCheckNilCoalescingNilInt(t *testing.T) {
 }
 
 func TestCheckInvalidNilCoalescingOptionalsInt(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let one = 1
@@ -106,6 +120,8 @@ func TestCheckInvalidNilCoalescingOptionalsInt(t *testing.T) {
 
 func TestCheckNilCoalescingNilLiteralInt(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let one = 1
      let x: Int = nil ?? one
@@ -115,6 +131,8 @@ func TestCheckNilCoalescingNilLiteralInt(t *testing.T) {
 }
 
 func TestCheckInvalidNilCoalescingMismatchNonOptional(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      let x: Int = nil ?? false
@@ -127,6 +145,8 @@ func TestCheckInvalidNilCoalescingMismatchNonOptional(t *testing.T) {
 
 func TestCheckInvalidNilCoalescingRightSubtype(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let x: Int = nil ?? nil
    `)
@@ -137,6 +157,8 @@ func TestCheckInvalidNilCoalescingRightSubtype(t *testing.T) {
 }
 
 func TestCheckInvalidNilCoalescingNonMatchingTypes(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x: Int? = 1
@@ -150,6 +172,8 @@ func TestCheckInvalidNilCoalescingNonMatchingTypes(t *testing.T) {
 
 func TestCheckNilCoalescingAny(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let x: AnyStruct? = 1
      let y = x ?? false
@@ -159,6 +183,8 @@ func TestCheckNilCoalescingAny(t *testing.T) {
 }
 
 func TestCheckNilCoalescingOptionalRightHandSide(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
      let x: Int? = 1
@@ -173,6 +199,8 @@ func TestCheckNilCoalescingOptionalRightHandSide(t *testing.T) {
 
 func TestCheckNilCoalescingBothOptional(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
      let x: Int?? = 1
      let y: Int? = 2
@@ -185,6 +213,8 @@ func TestCheckNilCoalescingBothOptional(t *testing.T) {
 }
 
 func TestCheckNilCoalescingWithNever(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheckWithPanic(t,
 		`

--- a/runtime/tests/checker/occurrences_test.go
+++ b/runtime/tests/checker/occurrences_test.go
@@ -34,6 +34,8 @@ import (
 
 func TestCheckOccurrencesVariableDeclarations(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
         let x = 1
         var y = x
@@ -85,6 +87,8 @@ nextMatcher:
 }
 
 func TestCheckOccurrencesFunction(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
 		fun f1(paramX: Int, paramY: Bool) {
@@ -216,6 +220,8 @@ nextMatcher:
 }
 
 func TestCheckOccurrencesStructAndInterface(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
 		struct interface I1 {}

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -33,6 +33,8 @@ import (
 
 func TestCheckInvalidUnaryBooleanNegationOfInteger(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let a = !1
 	`)
@@ -44,6 +46,8 @@ func TestCheckInvalidUnaryBooleanNegationOfInteger(t *testing.T) {
 
 func TestCheckUnaryBooleanNegation(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let a = !true
 	`)
@@ -52,6 +56,8 @@ func TestCheckUnaryBooleanNegation(t *testing.T) {
 }
 
 func TestCheckInvalidUnaryIntegerNegationOfBoolean(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let a = -true
@@ -63,6 +69,8 @@ func TestCheckInvalidUnaryIntegerNegationOfBoolean(t *testing.T) {
 }
 
 func TestCheckUnaryIntegerNegation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let a = -1
@@ -83,6 +91,9 @@ type operationTests struct {
 }
 
 func TestCheckIntegerBinaryOperations(t *testing.T) {
+
+	t.Parallel()
+
 	allOperationTests := []operationTests{
 		{
 			operations: []ast.Operation{
@@ -280,6 +291,8 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeEquality(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 

--- a/runtime/tests/checker/optional_test.go
+++ b/runtime/tests/checker/optional_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestCheckOptional(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x: Int? = 1
     `)
@@ -40,6 +42,8 @@ func TestCheckOptional(t *testing.T) {
 }
 
 func TestCheckInvalidOptional(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x: Int? = false
@@ -52,6 +56,8 @@ func TestCheckInvalidOptional(t *testing.T) {
 
 func TestCheckOptionalNesting(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x: Int?? = 1
     `)
@@ -60,6 +66,8 @@ func TestCheckOptionalNesting(t *testing.T) {
 }
 
 func TestCheckNil(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      let x: Int? = nil
@@ -70,6 +78,8 @@ func TestCheckNil(t *testing.T) {
 
 func TestCheckOptionalNestingNil(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let x: Int?? = nil
    `)
@@ -78,6 +88,8 @@ func TestCheckOptionalNestingNil(t *testing.T) {
 }
 
 func TestCheckNilReturnValue(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      fun test(): Int?? {
@@ -90,6 +102,8 @@ func TestCheckNilReturnValue(t *testing.T) {
 
 func TestCheckInvalidNonOptionalNil(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let x: Int = nil
     `)
@@ -101,6 +115,8 @@ func TestCheckInvalidNonOptionalNil(t *testing.T) {
 
 func TestCheckNilsComparison(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let x = nil == nil
    `)
@@ -109,6 +125,8 @@ func TestCheckNilsComparison(t *testing.T) {
 }
 
 func TestCheckOptionalNilComparison(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      let x: Int? = 1
@@ -120,6 +138,8 @@ func TestCheckOptionalNilComparison(t *testing.T) {
 
 func TestCheckNonOptionalNilComparison(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let x: Int = 1
      let y = x == nil
@@ -129,6 +149,8 @@ func TestCheckNonOptionalNilComparison(t *testing.T) {
 }
 
 func TestCheckNonOptionalNilComparisonSwapped(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      let x: Int = 1
@@ -141,6 +163,8 @@ func TestCheckNonOptionalNilComparisonSwapped(t *testing.T) {
 
 func TestCheckOptionalNilComparisonSwapped(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let x: Int? = 1
      let y = nil == x
@@ -150,6 +174,8 @@ func TestCheckOptionalNilComparisonSwapped(t *testing.T) {
 }
 
 func TestCheckNestedOptionalNilComparisonSwapped(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      let x: Int?? = 1
@@ -161,6 +187,8 @@ func TestCheckNestedOptionalNilComparisonSwapped(t *testing.T) {
 
 func TestCheckNestedOptionalComparison(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      let x: Int? = nil
      let y: Int?? = nil
@@ -171,6 +199,8 @@ func TestCheckNestedOptionalComparison(t *testing.T) {
 }
 
 func TestCheckInvalidNestedOptionalComparison(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      let x: Int? = nil
@@ -184,6 +214,8 @@ func TestCheckInvalidNestedOptionalComparison(t *testing.T) {
 }
 
 func TestCheckCompositeNilEquality(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -230,6 +262,8 @@ func TestCheckCompositeNilEquality(t *testing.T) {
 }
 
 func TestCheckInvalidCompositeNilEquality(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -287,6 +321,8 @@ func TestCheckInvalidCompositeNilEquality(t *testing.T) {
 
 func TestCheckInvalidNonOptionalReturn(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(x: Int?): Int {
           return x
@@ -299,6 +335,8 @@ func TestCheckInvalidNonOptionalReturn(t *testing.T) {
 }
 
 func TestCheckInvalidOptionalIntegerConversion(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let x: Int8? = 1

--- a/runtime/tests/checker/overloading_test.go
+++ b/runtime/tests/checker/overloading_test.go
@@ -31,6 +31,8 @@ import (
 
 func TestCheckInvalidCompositeInitializerOverloading(t *testing.T) {
 
+	t.Parallel()
+
 	interfacePossibilities := []bool{true, false}
 
 	for _, kind := range common.CompositeKindsWithBody {
@@ -74,6 +76,8 @@ func TestCheckInvalidCompositeInitializerOverloading(t *testing.T) {
 }
 
 func TestCheckInvalidResourceDestructorOverloading(t *testing.T) {
+
+	t.Parallel()
 
 	interfacePossibilities := []bool{true, false}
 

--- a/runtime/tests/checker/path_test.go
+++ b/runtime/tests/checker/path_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestCheckPath(t *testing.T) {
 
+	t.Parallel()
+
 	for _, domain := range common.AllPathDomainsByIdentifier {
 
 		t.Run(fmt.Sprintf("valid: %s", domain.Name()), func(t *testing.T) {

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestCheckReferenceTypeOuter(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -56,6 +58,8 @@ func TestCheckReferenceTypeOuter(t *testing.T) {
 }
 
 func TestCheckReferenceTypeInner(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -83,6 +87,8 @@ func TestCheckReferenceTypeInner(t *testing.T) {
 
 func TestCheckNestedReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -108,6 +114,8 @@ func TestCheckNestedReferenceType(t *testing.T) {
 
 func TestCheckInvalidReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(t: &T) {}
     `)
@@ -119,6 +127,8 @@ func TestCheckInvalidReferenceType(t *testing.T) {
 }
 
 func TestCheckReferenceExpressionWithCompositeResultType(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -171,6 +181,8 @@ func TestCheckReferenceExpressionWithCompositeResultType(t *testing.T) {
 
 func TestCheckReferenceExpressionWithInterfaceResultType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -204,6 +216,8 @@ func TestCheckReferenceExpressionWithInterfaceResultType(t *testing.T) {
 
 func TestCheckReferenceExpressionWithRestrictedAnyResultType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -232,6 +246,8 @@ func TestCheckReferenceExpressionWithRestrictedAnyResultType(t *testing.T) {
 }
 
 func TestCheckInvalidReferenceExpressionType(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -263,6 +279,8 @@ func TestCheckInvalidReferenceExpressionType(t *testing.T) {
 }
 
 func TestCheckInvalidReferenceExpressionTypeMismatchStructResource(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("struct / resource", func(t *testing.T) {
 
@@ -297,6 +315,8 @@ func TestCheckInvalidReferenceExpressionTypeMismatchStructResource(t *testing.T)
 
 func TestCheckInvalidReferenceExpressionDifferentStructs(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct S {}
       struct T {}
@@ -312,6 +332,8 @@ func TestCheckInvalidReferenceExpressionDifferentStructs(t *testing.T) {
 
 func TestCheckInvalidReferenceExpressionTypeMismatchDifferentResources(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
       resource T {}
@@ -326,6 +348,8 @@ func TestCheckInvalidReferenceExpressionTypeMismatchDifferentResources(t *testin
 }
 
 func TestCheckReference(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("struct variable", func(t *testing.T) {
 
@@ -365,6 +389,8 @@ func TestCheckReference(t *testing.T) {
 }
 
 func TestCheckReferenceUse(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -428,6 +454,8 @@ func TestCheckReferenceUse(t *testing.T) {
 
 func TestCheckReferenceUseArray(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -490,6 +518,8 @@ func TestCheckReferenceUseArray(t *testing.T) {
 
 func TestCheckReferenceIndexingIfReferencedIndexable(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -529,6 +559,8 @@ func TestCheckReferenceIndexingIfReferencedIndexable(t *testing.T) {
 
 func TestCheckInvalidReferenceResourceLoss(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
 
@@ -546,6 +578,8 @@ func TestCheckInvalidReferenceResourceLoss(t *testing.T) {
 }
 
 func TestCheckInvalidReferenceIndexingIfReferencedNotIndexable(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -586,6 +620,8 @@ func TestCheckInvalidReferenceIndexingIfReferencedNotIndexable(t *testing.T) {
 }
 
 func TestCheckResourceInterfaceReferenceFunctionCall(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -635,6 +671,8 @@ func TestCheckResourceInterfaceReferenceFunctionCall(t *testing.T) {
 
 func TestCheckInvalidResourceInterfaceReferenceFunctionCall(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -682,6 +720,8 @@ func TestCheckInvalidResourceInterfaceReferenceFunctionCall(t *testing.T) {
 }
 
 func TestCheckReferenceExpressionReferenceType(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range []common.CompositeKind{
 		common.CompositeKindResource,
@@ -736,6 +776,8 @@ func TestCheckReferenceExpressionReferenceType(t *testing.T) {
 
 func TestCheckReferenceExpressionOfOptional(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -769,6 +811,8 @@ func TestCheckReferenceExpressionOfOptional(t *testing.T) {
 
 func TestCheckInvalidReferenceExpressionNonReferenceAmbiguous(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let y = &x as {}
     `)
@@ -781,6 +825,8 @@ func TestCheckInvalidReferenceExpressionNonReferenceAmbiguous(t *testing.T) {
 
 func TestCheckInvalidReferenceExpressionNonReferenceAnyResource(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       let y = &x as AnyResource{}
     `)
@@ -792,6 +838,8 @@ func TestCheckInvalidReferenceExpressionNonReferenceAnyResource(t *testing.T) {
 }
 
 func TestCheckInvalidReferenceExpressionNonReferenceAnyStruct(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       let y = &x as AnyStruct{}

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -34,6 +34,8 @@ import (
 
 func TestCheckFailableCastingWithResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -84,6 +86,8 @@ func TestCheckFailableCastingWithResourceAnnotation(t *testing.T) {
 
 func TestCheckFunctionDeclarationParameterWithResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -129,6 +133,8 @@ func TestCheckFunctionDeclarationParameterWithResourceAnnotation(t *testing.T) {
 
 func TestCheckFunctionDeclarationParameterWithoutResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -173,6 +179,8 @@ func TestCheckFunctionDeclarationParameterWithoutResourceAnnotation(t *testing.T
 }
 
 func TestCheckFunctionDeclarationReturnTypeWithResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -231,6 +239,8 @@ func TestCheckFunctionDeclarationReturnTypeWithResourceAnnotation(t *testing.T) 
 
 func TestCheckFunctionDeclarationReturnTypeWithoutResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		if compositeKind == common.CompositeKindContract {
@@ -283,6 +293,8 @@ func TestCheckFunctionDeclarationReturnTypeWithoutResourceAnnotation(t *testing.
 }
 
 func TestCheckVariableDeclarationWithResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -338,6 +350,8 @@ func TestCheckVariableDeclarationWithResourceAnnotation(t *testing.T) {
 
 func TestCheckVariableDeclarationWithoutResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		if compositeKind == common.CompositeKindContract {
@@ -390,6 +404,8 @@ func TestCheckVariableDeclarationWithoutResourceAnnotation(t *testing.T) {
 }
 
 func TestCheckFieldDeclarationWithResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 
@@ -453,6 +469,9 @@ func TestCheckFieldDeclarationWithResourceAnnotation(t *testing.T) {
 }
 
 func TestCheckFieldDeclarationWithoutResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
+
 	for _, kind := range common.CompositeKindsWithBody {
 		t.Run(kind.Keyword(), func(t *testing.T) {
 
@@ -511,6 +530,8 @@ func TestCheckFieldDeclarationWithoutResourceAnnotation(t *testing.T) {
 
 func TestCheckFunctionExpressionParameterWithResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -555,6 +576,8 @@ func TestCheckFunctionExpressionParameterWithResourceAnnotation(t *testing.T) {
 }
 
 func TestCheckFunctionExpressionParameterWithoutResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.AllCompositeKinds {
 
@@ -601,6 +624,8 @@ func TestCheckFunctionExpressionParameterWithoutResourceAnnotation(t *testing.T)
 }
 
 func TestCheckFunctionExpressionReturnTypeWithResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -658,6 +683,8 @@ func TestCheckFunctionExpressionReturnTypeWithResourceAnnotation(t *testing.T) {
 
 func TestCheckFunctionExpressionReturnTypeWithoutResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		if compositeKind == common.CompositeKindContract {
@@ -713,6 +740,8 @@ func TestCheckFunctionExpressionReturnTypeWithoutResourceAnnotation(t *testing.T
 
 func TestCheckFunctionTypeParameterWithResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -760,6 +789,8 @@ func TestCheckFunctionTypeParameterWithResourceAnnotation(t *testing.T) {
 // NOTE: variable type instead of function parameter
 func TestCheckFunctionTypeParameterWithoutResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, kind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -805,6 +836,8 @@ func TestCheckFunctionTypeParameterWithoutResourceAnnotation(t *testing.T) {
 }
 
 func TestCheckFunctionTypeReturnTypeWithResourceAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -864,6 +897,8 @@ func TestCheckFunctionTypeReturnTypeWithResourceAnnotation(t *testing.T) {
 
 func TestCheckFunctionTypeReturnTypeWithoutResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		if compositeKind == common.CompositeKindContract {
@@ -920,6 +955,8 @@ func TestCheckFunctionTypeReturnTypeWithoutResourceAnnotation(t *testing.T) {
 
 func TestCheckFailableCastingWithoutResourceAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		body := "{}"
@@ -970,6 +1007,8 @@ func TestCheckFailableCastingWithoutResourceAnnotation(t *testing.T) {
 
 func TestCheckUnaryMove(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -989,6 +1028,8 @@ func TestCheckUnaryMove(t *testing.T) {
 
 func TestCheckImmediateDestroy(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1001,6 +1042,8 @@ func TestCheckImmediateDestroy(t *testing.T) {
 }
 
 func TestCheckIndirectDestroy(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1016,6 +1059,8 @@ func TestCheckIndirectDestroy(t *testing.T) {
 
 func TestCheckInvalidResourceCreationWithoutCreate(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1029,6 +1074,8 @@ func TestCheckInvalidResourceCreationWithoutCreate(t *testing.T) {
 }
 
 func TestCheckInvalidDestroy(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       struct X {}
@@ -1045,6 +1092,8 @@ func TestCheckInvalidDestroy(t *testing.T) {
 
 func TestCheckUnaryCreateAndDestroy(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1058,6 +1107,8 @@ func TestCheckUnaryCreateAndDestroy(t *testing.T) {
 }
 
 func TestCheckUnaryCreateAndDestroyWithInitializer(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -1077,6 +1128,8 @@ func TestCheckUnaryCreateAndDestroyWithInitializer(t *testing.T) {
 }
 
 func TestCheckInvalidUnaryCreateAndDestroyWithWrongInitializerArguments(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -1100,6 +1153,8 @@ func TestCheckInvalidUnaryCreateAndDestroyWithWrongInitializerArguments(t *testi
 
 func TestCheckInvalidUnaryCreateStruct(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct X {}
 
@@ -1114,6 +1169,8 @@ func TestCheckInvalidUnaryCreateStruct(t *testing.T) {
 }
 
 func TestCheckInvalidCreateImportedResource(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
       pub resource R {}
@@ -1142,6 +1199,8 @@ func TestCheckInvalidCreateImportedResource(t *testing.T) {
 }
 
 func TestCheckResourceCreationInContracts(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("in sibling contract", func(t *testing.T) {
 
@@ -1184,6 +1243,8 @@ func TestCheckResourceCreationInContracts(t *testing.T) {
 }
 
 func TestCheckInvalidResourceLoss(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("UnassignedResource", func(t *testing.T) {
 
@@ -1318,6 +1379,8 @@ func TestCheckInvalidResourceLoss(t *testing.T) {
 
 func TestCheckResourceReturn(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1330,6 +1393,8 @@ func TestCheckResourceReturn(t *testing.T) {
 }
 
 func TestCheckInvalidResourceReturnMissingMove(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1345,6 +1410,8 @@ func TestCheckInvalidResourceReturnMissingMove(t *testing.T) {
 }
 
 func TestCheckInvalidResourceReturnMissingMoveInvalidReturnType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1362,6 +1429,8 @@ func TestCheckInvalidResourceReturnMissingMoveInvalidReturnType(t *testing.T) {
 
 func TestCheckInvalidNonResourceReturnWithMove(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct X {}
 
@@ -1376,6 +1445,8 @@ func TestCheckInvalidNonResourceReturnWithMove(t *testing.T) {
 }
 
 func TestCheckResourceArgument(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1393,6 +1464,8 @@ func TestCheckResourceArgument(t *testing.T) {
 }
 
 func TestCheckInvalidResourceArgumentMissingMove(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1413,6 +1486,8 @@ func TestCheckInvalidResourceArgumentMissingMove(t *testing.T) {
 
 func TestCheckInvalidResourceArgumentMissingMoveInvalidParameterType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1431,6 +1506,8 @@ func TestCheckInvalidResourceArgumentMissingMoveInvalidParameterType(t *testing.
 
 func TestCheckInvalidNonResourceArgumentWithMove(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct X {}
 
@@ -1448,6 +1525,8 @@ func TestCheckInvalidNonResourceArgumentWithMove(t *testing.T) {
 
 func TestCheckResourceVariableDeclarationTransfer(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1459,6 +1538,8 @@ func TestCheckResourceVariableDeclarationTransfer(t *testing.T) {
 }
 
 func TestCheckInvalidResourceVariableDeclarationIncorrectTransfer(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1475,6 +1556,8 @@ func TestCheckInvalidResourceVariableDeclarationIncorrectTransfer(t *testing.T) 
 
 func TestCheckInvalidNonResourceVariableDeclarationMoveTransfer(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct X {}
 
@@ -1488,6 +1571,8 @@ func TestCheckInvalidNonResourceVariableDeclarationMoveTransfer(t *testing.T) {
 }
 
 func TestCheckInvalidResourceAssignmentTransfer(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1506,6 +1591,8 @@ func TestCheckInvalidResourceAssignmentTransfer(t *testing.T) {
 }
 
 func TestCheckInvalidResourceAssignmentIncorrectTransfer(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1526,6 +1613,8 @@ func TestCheckInvalidResourceAssignmentIncorrectTransfer(t *testing.T) {
 
 func TestCheckInvalidNonResourceAssignmentMoveTransfer(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct X {}
 
@@ -1542,6 +1631,8 @@ func TestCheckInvalidNonResourceAssignmentMoveTransfer(t *testing.T) {
 }
 
 func TestCheckResourceAssignmentForceTransfer(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("new to nil", func(t *testing.T) {
 
@@ -1626,6 +1717,8 @@ func TestCheckResourceAssignmentForceTransfer(t *testing.T) {
 
 func TestCheckInvalidResourceLossThroughVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1640,6 +1733,8 @@ func TestCheckInvalidResourceLossThroughVariableDeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidResourceLossThroughVariableDeclarationAfterCreation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1656,6 +1751,8 @@ func TestCheckInvalidResourceLossThroughVariableDeclarationAfterCreation(t *test
 }
 
 func TestCheckInvalidResourceLossThroughAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1675,6 +1772,8 @@ func TestCheckInvalidResourceLossThroughAssignment(t *testing.T) {
 
 func TestCheckResourceMoveThroughReturn(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1688,6 +1787,8 @@ func TestCheckResourceMoveThroughReturn(t *testing.T) {
 }
 
 func TestCheckResourceMoveThroughArgumentPassing(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1706,6 +1807,8 @@ func TestCheckResourceMoveThroughArgumentPassing(t *testing.T) {
 }
 
 func TestCheckInvalidResourceUseAfterMoveToFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1727,6 +1830,8 @@ func TestCheckInvalidResourceUseAfterMoveToFunction(t *testing.T) {
 }
 
 func TestCheckInvalidResourceUseAfterMoveToVariable(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1750,6 +1855,8 @@ func TestCheckInvalidResourceUseAfterMoveToVariable(t *testing.T) {
 }
 
 func TestCheckInvalidResourceFieldUseAfterMoveToVariable(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -1777,6 +1884,8 @@ func TestCheckInvalidResourceFieldUseAfterMoveToVariable(t *testing.T) {
 
 func TestCheckResourceUseAfterMoveInIfStatementThenBranch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1800,6 +1909,8 @@ func TestCheckResourceUseAfterMoveInIfStatementThenBranch(t *testing.T) {
 
 func TestCheckResourceUseInIfStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1821,6 +1932,8 @@ func TestCheckResourceUseInIfStatement(t *testing.T) {
 }
 
 func TestCheckResourceUseInNestedIfStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1847,6 +1960,8 @@ func TestCheckResourceUseInNestedIfStatement(t *testing.T) {
 ////
 
 func TestCheckInvalidResourceUseAfterIfStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1889,6 +2004,8 @@ func TestCheckInvalidResourceUseAfterIfStatement(t *testing.T) {
 
 func TestCheckInvalidResourceLossAfterDestroyInIfStatementThenBranch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1906,6 +2023,8 @@ func TestCheckInvalidResourceLossAfterDestroyInIfStatementThenBranch(t *testing.
 }
 
 func TestCheckInvalidResourceLossAndUseAfterDestroyInIfStatementThenBranch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -1932,6 +2051,8 @@ func TestCheckInvalidResourceLossAndUseAfterDestroyInIfStatementThenBranch(t *te
 
 func TestCheckResourceMoveIntoArray(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1943,6 +2064,8 @@ func TestCheckResourceMoveIntoArray(t *testing.T) {
 }
 
 func TestCheckInvalidResourceMoveIntoArrayMissingMoveOperation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1958,6 +2081,8 @@ func TestCheckInvalidResourceMoveIntoArrayMissingMoveOperation(t *testing.T) {
 
 func TestCheckInvalidNonResourceMoveIntoArray(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct X {}
 
@@ -1971,6 +2096,8 @@ func TestCheckInvalidNonResourceMoveIntoArray(t *testing.T) {
 }
 
 func TestCheckInvalidUseAfterResourceMoveIntoArray(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -1986,6 +2113,8 @@ func TestCheckInvalidUseAfterResourceMoveIntoArray(t *testing.T) {
 
 func TestCheckResourceMoveIntoDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -1997,6 +2126,8 @@ func TestCheckResourceMoveIntoDictionary(t *testing.T) {
 }
 
 func TestCheckInvalidResourceMoveIntoDictionaryMissingMoveOperation(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2012,6 +2143,8 @@ func TestCheckInvalidResourceMoveIntoDictionaryMissingMoveOperation(t *testing.T
 
 func TestCheckInvalidNonResourceMoveIntoDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       struct X {}
 
@@ -2025,6 +2158,8 @@ func TestCheckInvalidNonResourceMoveIntoDictionary(t *testing.T) {
 }
 
 func TestCheckInvalidUseAfterResourceMoveIntoDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2043,6 +2178,8 @@ func TestCheckInvalidUseAfterResourceMoveIntoDictionary(t *testing.T) {
 
 func TestCheckInvalidUseAfterResourceMoveIntoDictionaryAsKey(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2057,6 +2194,8 @@ func TestCheckInvalidUseAfterResourceMoveIntoDictionaryAsKey(t *testing.T) {
 }
 
 func TestCheckInvalidResourceUseAfterMoveInWhileStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2077,6 +2216,8 @@ func TestCheckInvalidResourceUseAfterMoveInWhileStatement(t *testing.T) {
 }
 
 func TestCheckResourceUseInWhileStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -2099,6 +2240,8 @@ func TestCheckResourceUseInWhileStatement(t *testing.T) {
 }
 
 func TestCheckInvalidResourceUseInWhileStatementAfterDestroy(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -2127,6 +2270,8 @@ func TestCheckInvalidResourceUseInWhileStatementAfterDestroy(t *testing.T) {
 
 func TestCheckInvalidResourceUseInWhileStatementAfterDestroyAndLoss(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2145,6 +2290,8 @@ func TestCheckInvalidResourceUseInWhileStatementAfterDestroyAndLoss(t *testing.T
 }
 
 func TestCheckInvalidResourceUseInNestedWhileStatementAfterDestroyAndLoss1(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -2174,6 +2321,8 @@ func TestCheckInvalidResourceUseInNestedWhileStatementAfterDestroyAndLoss1(t *te
 
 func TestCheckInvalidResourceUseInNestedWhileStatementAfterDestroyAndLoss2(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {
           let id: Int
@@ -2202,6 +2351,8 @@ func TestCheckInvalidResourceUseInNestedWhileStatementAfterDestroyAndLoss2(t *te
 
 func TestCheckResourceUseInNestedWhileStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {
           let id: Int
@@ -2226,6 +2377,8 @@ func TestCheckResourceUseInNestedWhileStatement(t *testing.T) {
 
 func TestCheckInvalidResourceLossThroughReturn(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2243,6 +2396,8 @@ func TestCheckInvalidResourceLossThroughReturn(t *testing.T) {
 }
 
 func TestCheckInvalidResourceLossThroughReturnInIfStatementThrenBranch(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2262,6 +2417,8 @@ func TestCheckInvalidResourceLossThroughReturnInIfStatementThrenBranch(t *testin
 }
 
 func TestCheckInvalidResourceLossThroughReturnInIfStatementBranches(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2290,6 +2447,8 @@ func TestCheckInvalidResourceLossThroughReturnInIfStatementBranches(t *testing.T
 
 func TestCheckResourceWithMoveAndReturnInIfStatementThenAndDestroyInElse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2313,6 +2472,8 @@ func TestCheckResourceWithMoveAndReturnInIfStatementThenAndDestroyInElse(t *test
 
 func TestCheckResourceWithMoveAndReturnInIfStatementThenBranch(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2334,6 +2495,9 @@ func TestCheckResourceWithMoveAndReturnInIfStatementThenBranch(t *testing.T) {
 }
 
 func TestCheckResourceNesting(t *testing.T) {
+
+	t.Parallel()
+
 	interfacePossibilities := []bool{true, false}
 
 	for _, innerCompositeKind := range common.AllCompositeKinds {
@@ -2493,6 +2657,8 @@ func testResourceNesting(
 
 func TestCheckContractResourceField(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
 
@@ -2509,6 +2675,8 @@ func TestCheckContractResourceField(t *testing.T) {
 }
 
 func TestCheckInvalidContractResourceFieldMove(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}
@@ -2537,6 +2705,8 @@ func TestCheckInvalidContractResourceFieldMove(t *testing.T) {
 //
 func TestCheckResourceInterfaceConformance(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource interface X {
           fun test()
@@ -2555,6 +2725,8 @@ func TestCheckResourceInterfaceConformance(t *testing.T) {
 //
 func TestCheckInvalidResourceInterfaceConformance(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource interface X {
           fun test()
@@ -2572,6 +2744,8 @@ func TestCheckInvalidResourceInterfaceConformance(t *testing.T) {
 // can not be used as a type
 //
 func TestCheckInvalidResourceInterfaceUseAsType(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource interface I {}
@@ -2592,6 +2766,8 @@ func TestCheckInvalidResourceInterfaceUseAsType(t *testing.T) {
 //
 func TestCheckResourceInterfaceUseAsType(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource interface I {}
 
@@ -2604,6 +2780,8 @@ func TestCheckResourceInterfaceUseAsType(t *testing.T) {
 }
 
 func TestCheckResourceArrayIndexing(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource Foo {
@@ -2626,6 +2804,8 @@ func TestCheckResourceArrayIndexing(t *testing.T) {
 }
 
 func TestCheckInvalidResourceLossReturnResourceAndMemberAccess(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {
@@ -2652,6 +2832,8 @@ func TestCheckInvalidResourceLossReturnResourceAndMemberAccess(t *testing.T) {
 
 func TestCheckInvalidResourceLossAfterMoveThroughArrayIndexing(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2671,6 +2853,8 @@ func TestCheckInvalidResourceLossAfterMoveThroughArrayIndexing(t *testing.T) {
 }
 
 func TestCheckInvalidResourceLossThroughFunctionResultAccess(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource Foo {
@@ -2700,6 +2884,8 @@ func TestCheckInvalidResourceLossThroughFunctionResultAccess(t *testing.T) {
 //
 func TestCheckAnyResourceDestruction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource interface I {}
 
@@ -2722,6 +2908,8 @@ func TestCheckAnyResourceDestruction(t *testing.T) {
 // a variable declaration. This would partially invalidate the containing resource
 //
 func TestCheckInvalidResourceFieldMoveThroughVariableDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource Foo {}
@@ -2761,6 +2949,8 @@ func TestCheckInvalidResourceFieldMoveThroughVariableDeclaration(t *testing.T) {
 //
 func TestCheckInvalidResourceFieldMoveThroughParameter(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource Foo {}
 
@@ -2798,6 +2988,8 @@ func TestCheckInvalidResourceFieldMoveThroughParameter(t *testing.T) {
 
 func TestCheckInvalidResourceFieldMoveSelf(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource Y {}
 
@@ -2830,6 +3022,8 @@ func TestCheckInvalidResourceFieldMoveSelf(t *testing.T) {
 
 func TestCheckInvalidResourceFieldUseAfterDestroy(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource Y {}
 
@@ -2855,6 +3049,8 @@ func TestCheckInvalidResourceFieldUseAfterDestroy(t *testing.T) {
 
 func TestCheckResourceArrayAppend(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2869,6 +3065,8 @@ func TestCheckResourceArrayAppend(t *testing.T) {
 }
 
 func TestCheckResourceArrayInsert(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2885,6 +3083,8 @@ func TestCheckResourceArrayInsert(t *testing.T) {
 
 func TestCheckResourceArrayRemove(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2900,6 +3100,8 @@ func TestCheckResourceArrayRemove(t *testing.T) {
 }
 
 func TestCheckInvalidResourceArrayRemoveResourceLoss(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2918,6 +3120,8 @@ func TestCheckInvalidResourceArrayRemoveResourceLoss(t *testing.T) {
 
 func TestCheckResourceArrayRemoveFirst(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2934,6 +3138,8 @@ func TestCheckResourceArrayRemoveFirst(t *testing.T) {
 
 func TestCheckResourceArrayRemoveLast(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2949,6 +3155,8 @@ func TestCheckResourceArrayRemoveLast(t *testing.T) {
 }
 
 func TestCheckInvalidResourceArrayContains(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -2968,6 +3176,8 @@ func TestCheckInvalidResourceArrayContains(t *testing.T) {
 
 func TestCheckResourceArrayLength(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -2983,6 +3193,8 @@ func TestCheckResourceArrayLength(t *testing.T) {
 }
 
 func TestCheckInvalidResourceArrayConcat(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -3003,6 +3215,8 @@ func TestCheckInvalidResourceArrayConcat(t *testing.T) {
 
 func TestCheckResourceDictionaryRemove(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -3018,6 +3232,8 @@ func TestCheckResourceDictionaryRemove(t *testing.T) {
 }
 
 func TestCheckInvalidResourceDictionaryRemoveResourceLoss(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -3036,6 +3252,8 @@ func TestCheckInvalidResourceDictionaryRemoveResourceLoss(t *testing.T) {
 
 func TestCheckResourceDictionaryInsert(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -3051,6 +3269,8 @@ func TestCheckResourceDictionaryInsert(t *testing.T) {
 }
 
 func TestCheckInvalidResourceDictionaryInsertResourceLoss(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -3069,6 +3289,8 @@ func TestCheckInvalidResourceDictionaryInsertResourceLoss(t *testing.T) {
 
 func TestCheckResourceDictionaryLength(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -3084,6 +3306,8 @@ func TestCheckResourceDictionaryLength(t *testing.T) {
 }
 
 func TestCheckInvalidResourceDictionaryKeys(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -3105,6 +3329,8 @@ func TestCheckInvalidResourceDictionaryKeys(t *testing.T) {
 
 func TestCheckInvalidResourceDictionaryValues(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -3123,6 +3349,8 @@ func TestCheckInvalidResourceDictionaryValues(t *testing.T) {
 }
 
 func TestCheckInvalidResourceLossAfterMoveThroughDictionaryIndexing(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -3144,6 +3372,8 @@ func TestCheckInvalidResourceLossAfterMoveThroughDictionaryIndexing(t *testing.T
 
 func TestCheckInvalidResourceSwap(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -3160,6 +3390,8 @@ func TestCheckInvalidResourceSwap(t *testing.T) {
 }
 
 func TestCheckInvalidResourceConstantResourceFieldSwap(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource Foo {}
@@ -3193,6 +3425,8 @@ func TestCheckInvalidResourceConstantResourceFieldSwap(t *testing.T) {
 
 func TestCheckResourceVariableResourceFieldSwap(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource Foo {}
 
@@ -3222,6 +3456,8 @@ func TestCheckResourceVariableResourceFieldSwap(t *testing.T) {
 }
 
 func TestCheckInvalidResourceFieldDestroy(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      resource Foo {}
@@ -3254,6 +3490,8 @@ func TestCheckInvalidResourceFieldDestroy(t *testing.T) {
 }
 
 func TestCheckResourceParameterInInterfaceNoResourceLossError(t *testing.T) {
+
+	t.Parallel()
 
 	declarationKinds := []common.DeclarationKind{
 		common.DeclarationKindInitializer,
@@ -3311,6 +3549,8 @@ func TestCheckResourceParameterInInterfaceNoResourceLossError(t *testing.T) {
 
 func TestCheckResourceFieldUseAndDestruction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource interface RI {}
 
@@ -3341,6 +3581,8 @@ func TestCheckResourceFieldUseAndDestruction(t *testing.T) {
 
 func TestCheckInvalidResourceMethodBinding(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
 
@@ -3359,6 +3601,8 @@ func TestCheckInvalidResourceMethodBinding(t *testing.T) {
 
 func TestCheckInvalidResourceMethodCall(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
 
@@ -3373,6 +3617,8 @@ func TestCheckInvalidResourceMethodCall(t *testing.T) {
 }
 
 func TestCheckResourceOptionalBinding(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}
@@ -3391,6 +3637,8 @@ func TestCheckResourceOptionalBinding(t *testing.T) {
 }
 
 func TestCheckInvalidResourceOptionalBindingResourceLossInThen(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}
@@ -3412,6 +3660,8 @@ func TestCheckInvalidResourceOptionalBindingResourceLossInThen(t *testing.T) {
 
 func TestCheckInvalidResourceOptionalBindingResourceLossInElse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
 
@@ -3431,6 +3681,8 @@ func TestCheckInvalidResourceOptionalBindingResourceLossInElse(t *testing.T) {
 }
 
 func TestCheckInvalidResourceOptionalBindingResourceUseAfterInvalidationInThen(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}
@@ -3452,6 +3704,8 @@ func TestCheckInvalidResourceOptionalBindingResourceUseAfterInvalidationInThen(t
 }
 
 func TestCheckInvalidResourceOptionalBindingResourceUseAfterInvalidationAfterBranches(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource R {}
@@ -3478,6 +3732,8 @@ func TestCheckInvalidResourceOptionalBindingResourceUseAfterInvalidationAfterBra
 
 func TestCheckResourceOptionalBindingFailableCast(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
          resource interface RI {}
@@ -3498,6 +3754,8 @@ func TestCheckResourceOptionalBindingFailableCast(t *testing.T) {
 }
 
 func TestCheckInvalidResourceOptionalBindingFailableCastResourceUseAfterInvalidationInThen(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t,
 		`
@@ -3523,6 +3781,8 @@ func TestCheckInvalidResourceOptionalBindingFailableCastResourceUseAfterInvalida
 
 func TestCheckInvalidResourceOptionalBindingFailableCastResourceUseAfterInvalidationAfterBranches(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t,
 		`
          resource interface RI {}
@@ -3545,6 +3805,8 @@ func TestCheckInvalidResourceOptionalBindingFailableCastResourceUseAfterInvalida
 
 func TestCheckInvalidResourceOptionalBindingFailableCastResourceLossMissingElse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource interface RI {}
 
@@ -3564,6 +3826,8 @@ func TestCheckInvalidResourceOptionalBindingFailableCastResourceLossMissingElse(
 }
 
 func TestCheckInvalidResourceOptionalBindingFailableCastResourceUseAfterInvalidationAfterThen(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource interface RI {}
@@ -3585,6 +3849,8 @@ func TestCheckInvalidResourceOptionalBindingFailableCastResourceUseAfterInvalida
 }
 
 func TestCheckInvalidResourceOptionalBindingFailableCastMissingElse(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("top-level resource interface to resource", func(t *testing.T) {
 
@@ -3631,6 +3897,8 @@ func TestCheckInvalidResourceOptionalBindingFailableCastMissingElse(t *testing.T
 
 func TestCheckInvalidResourceFailableCastOutsideOptionalBinding(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource interface RI {}
 
@@ -3650,6 +3918,8 @@ func TestCheckInvalidResourceFailableCastOutsideOptionalBinding(t *testing.T) {
 
 func TestCheckInvalidUnaryMoveAndCopyTransfer(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource R {}
 
@@ -3665,6 +3935,8 @@ func TestCheckInvalidUnaryMoveAndCopyTransfer(t *testing.T) {
 }
 
 func TestCheckInvalidResourceSelfMoveToFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
 
@@ -3687,6 +3959,8 @@ func TestCheckInvalidResourceSelfMoveToFunction(t *testing.T) {
 
 func TestCheckInvalidResourceSelfMoveInVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
       resource X {
@@ -3705,6 +3979,8 @@ func TestCheckInvalidResourceSelfMoveInVariableDeclaration(t *testing.T) {
 
 func TestCheckInvalidResourceSelfDestruction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
       resource X {
@@ -3721,6 +3997,8 @@ func TestCheckInvalidResourceSelfDestruction(t *testing.T) {
 }
 
 func TestCheckInvalidResourceSelfMoveReturnFromFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
 
@@ -3739,6 +4017,8 @@ func TestCheckInvalidResourceSelfMoveReturnFromFunction(t *testing.T) {
 
 func TestCheckInvalidResourceSelfMoveIntoArrayLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
       resource X {
@@ -3756,6 +4036,8 @@ func TestCheckInvalidResourceSelfMoveIntoArrayLiteral(t *testing.T) {
 
 func TestCheckInvalidResourceSelfMoveIntoDictionaryLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
       resource X {
@@ -3772,6 +4054,8 @@ func TestCheckInvalidResourceSelfMoveIntoDictionaryLiteral(t *testing.T) {
 }
 
 func TestCheckInvalidResourceSelfMoveSwap(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
 
@@ -3793,6 +4077,8 @@ func TestCheckInvalidResourceSelfMoveSwap(t *testing.T) {
 
 func TestCheckResourceCreationAndInvalidationInLoop(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
       resource X {}
@@ -3812,6 +4098,8 @@ func TestCheckResourceCreationAndInvalidationInLoop(t *testing.T) {
 
 func TestCheckInvalidResourceOwnerField(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource Test {
           let owner: PublicAccount
@@ -3829,6 +4117,8 @@ func TestCheckInvalidResourceOwnerField(t *testing.T) {
 
 func TestCheckInvalidResourceInterfaceOwnerField(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource interface Test {
          let owner: PublicAccount
@@ -3841,6 +4131,8 @@ func TestCheckInvalidResourceInterfaceOwnerField(t *testing.T) {
 }
 
 func TestCheckInvalidResourceOwnerFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      resource Test {
@@ -3855,6 +4147,8 @@ func TestCheckInvalidResourceOwnerFunction(t *testing.T) {
 
 func TestCheckInvalidResourceInterfaceOwnerFunction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource interface Test {
          fun owner()
@@ -3867,6 +4161,8 @@ func TestCheckInvalidResourceInterfaceOwnerFunction(t *testing.T) {
 }
 
 func TestCheckResourceOwnerFieldUse(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      resource Test {
@@ -3882,6 +4178,8 @@ func TestCheckResourceOwnerFieldUse(t *testing.T) {
 
 func TestCheckResourceInterfaceOwnerFieldUse(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
      resource interface Test {
 
@@ -3895,6 +4193,8 @@ func TestCheckResourceInterfaceOwnerFieldUse(t *testing.T) {
 }
 
 func TestCheckInvalidResourceOwnerFieldInitialization(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
      resource Test {
@@ -3911,6 +4211,8 @@ func TestCheckInvalidResourceOwnerFieldInitialization(t *testing.T) {
 }
 
 func TestCheckInvalidResourceInterfaceType(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("direct", func(t *testing.T) {
 		_, err := ParseAndCheck(t, `
@@ -3945,6 +4247,8 @@ func TestCheckInvalidResourceInterfaceType(t *testing.T) {
 
 func TestCheckRestrictedAnyResourceType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("direct", func(t *testing.T) {
 		_, err := ParseAndCheck(t, `
           resource interface RI {}
@@ -3972,6 +4276,8 @@ func TestCheckRestrictedAnyResourceType(t *testing.T) {
 
 func TestCheckInvalidOptionalResourceNilCoalescingResourceLoss(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheckWithPanic(t, `
 
       resource R {}
@@ -3989,6 +4295,8 @@ func TestCheckInvalidOptionalResourceNilCoalescingResourceLoss(t *testing.T) {
 
 func TestCheckOptionalResourceCoalescingAndReturn(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheckWithPanic(t, `
 
       resource R {}
@@ -4003,6 +4311,8 @@ func TestCheckOptionalResourceCoalescingAndReturn(t *testing.T) {
 }
 
 func TestCheckInvalidOptionalResourceCoalescingRightSide(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheckWithPanic(t, `
 
@@ -4028,6 +4338,8 @@ func TestCheckInvalidOptionalResourceCoalescingRightSide(t *testing.T) {
 // does not influence another function's return information.
 //
 func TestCheckInvalidResourceLossInNestedContractResource(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheckWithPanic(t, `
 

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckRestrictedType(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource: no restrictions", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -267,6 +269,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 func TestCheckRestrictedTypeMemberAccess(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("no restrictions: resource", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -485,6 +489,8 @@ func TestCheckRestrictedTypeMemberAccess(t *testing.T) {
 }
 
 func TestCheckRestrictedTypeSubtyping(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource type to restricted type with same type, no restriction", func(t *testing.T) {
 
@@ -784,6 +790,8 @@ func TestCheckRestrictedTypeSubtyping(t *testing.T) {
 }
 
 func TestCheckRestrictedTypeNoType(t *testing.T) {
+
+	t.Parallel()
 
 	const resourceTypes = `
       resource interface I1 {}

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestCheckInvalidReturnValue(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        fun test() {
            return 1
@@ -45,6 +47,8 @@ func TestCheckInvalidReturnValue(t *testing.T) {
 
 func TestCheckMissingReturnStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): Int {}
     `)
@@ -55,6 +59,8 @@ func TestCheckMissingReturnStatement(t *testing.T) {
 }
 
 func TestCheckMissingReturnStatementInterfaceFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
         struct interface Test {
@@ -70,6 +76,8 @@ func TestCheckMissingReturnStatementInterfaceFunction(t *testing.T) {
 }
 
 func TestCheckInvalidMissingReturnStatementStructFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
         struct Test {
@@ -124,6 +132,9 @@ func testExits(t *testing.T, tests []exitTest) {
 }
 
 func TestCheckReturnStatementExits(t *testing.T) {
+
+	t.Parallel()
+
 	testExits(
 		t, []exitTest{
 			{
@@ -139,6 +150,9 @@ func TestCheckReturnStatementExits(t *testing.T) {
 }
 
 func TestCheckIfStatementExits(t *testing.T) {
+
+	t.Parallel()
+
 	testExits(
 		t,
 		[]exitTest{
@@ -214,6 +228,9 @@ func TestCheckIfStatementExits(t *testing.T) {
 }
 
 func TestCheckWhileStatementExits(t *testing.T) {
+
+	t.Parallel()
+
 	testExits(
 		t,
 		[]exitTest{
@@ -297,6 +314,9 @@ func TestCheckWhileStatementExits(t *testing.T) {
 }
 
 func TestCheckNeverInvocationExits(t *testing.T) {
+
+	t.Parallel()
+
 	valueDeclarations := stdlib.StandardLibraryFunctions{
 		stdlib.PanicFunction,
 	}.ToValueDeclarations()
@@ -348,6 +368,9 @@ func TestCheckNeverInvocationExits(t *testing.T) {
 // nested inside another function does not influence the containing function
 //
 func TestCheckNestedFunctionExits(t *testing.T) {
+
+	t.Parallel()
+
 	testExits(
 		t,
 		[]exitTest{

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckCharacter(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
         let x: Character = "x"
 	`)
@@ -43,6 +45,8 @@ func TestCheckCharacter(t *testing.T) {
 }
 
 func TestCheckCharacterUnicodeScalar(t *testing.T) {
+
+	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
         let x: Character = "\u{1F1FA}\u{1F1F8}"
@@ -58,6 +62,8 @@ func TestCheckCharacterUnicodeScalar(t *testing.T) {
 
 func TestCheckString(t *testing.T) {
 
+	t.Parallel()
+
 	checker, err := ParseAndCheck(t, `
         let x = "x"
 	`)
@@ -72,6 +78,8 @@ func TestCheckString(t *testing.T) {
 
 func TestCheckStringConcat(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 	  fun test(): String {
 	 	  let a = "abc"
@@ -85,6 +93,8 @@ func TestCheckStringConcat(t *testing.T) {
 }
 
 func TestCheckInvalidStringConcat(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): String {
@@ -102,6 +112,8 @@ func TestCheckInvalidStringConcat(t *testing.T) {
 
 func TestCheckStringConcatBound(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test(): String {
 		  let a = "abc"
@@ -116,6 +128,8 @@ func TestCheckStringConcatBound(t *testing.T) {
 
 func TestCheckStringSlice(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 	  fun test(): String {
 	 	  let a = "abcdef"
@@ -127,6 +141,9 @@ func TestCheckStringSlice(t *testing.T) {
 }
 
 func TestCheckInvalidStringSlice(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("MissingBothArgumentLabels", func(t *testing.T) {
 
 		_, err := ParseAndCheck(t, `
@@ -167,6 +184,8 @@ func TestCheckInvalidStringSlice(t *testing.T) {
 }
 
 func TestCheckStringSliceBound(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test(): String {
@@ -210,6 +229,8 @@ func TestCheckStringSliceBound(t *testing.T) {
 
 func TestCheckStringIndexing(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           let z = "abc"
@@ -221,6 +242,8 @@ func TestCheckStringIndexing(t *testing.T) {
 }
 
 func TestCheckStringIndexingAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -234,6 +257,8 @@ func TestCheckStringIndexingAssignment(t *testing.T) {
 }
 
 func TestCheckStringIndexingAssignmentWithCharacterLiteral(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {

--- a/runtime/tests/checker/swap_test.go
+++ b/runtime/tests/checker/swap_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestCheckInvalidUnknownDeclarationSwap(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           var x = 1
@@ -43,6 +45,8 @@ func TestCheckInvalidUnknownDeclarationSwap(t *testing.T) {
 }
 
 func TestCheckInvalidLeftConstantSwap(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -59,6 +63,8 @@ func TestCheckInvalidLeftConstantSwap(t *testing.T) {
 
 func TestCheckInvalidRightConstantSwap(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           var x = 2
@@ -74,6 +80,8 @@ func TestCheckInvalidRightConstantSwap(t *testing.T) {
 
 func TestCheckSwap(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           var x = 2
@@ -86,6 +94,8 @@ func TestCheckSwap(t *testing.T) {
 }
 
 func TestCheckInvalidTypesSwap(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -102,6 +112,8 @@ func TestCheckInvalidTypesSwap(t *testing.T) {
 
 func TestCheckInvalidTypesSwap2(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           var x = "2"
@@ -116,6 +128,8 @@ func TestCheckInvalidTypesSwap2(t *testing.T) {
 }
 
 func TestCheckInvalidSwapTargetExpressionLeft(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -135,6 +149,8 @@ func TestCheckInvalidSwapTargetExpressionLeft(t *testing.T) {
 
 func TestCheckInvalidSwapTargetExpressionRight(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           var x = 1
@@ -152,6 +168,8 @@ func TestCheckInvalidSwapTargetExpressionRight(t *testing.T) {
 }
 
 func TestCheckInvalidSwapTargetExpressions(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -171,6 +189,8 @@ func TestCheckInvalidSwapTargetExpressions(t *testing.T) {
 
 func TestCheckSwapOptional(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           var x: Int? = 2
@@ -183,6 +203,8 @@ func TestCheckSwapOptional(t *testing.T) {
 }
 
 func TestCheckSwapResourceArrayElementAndVariable(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -201,6 +223,8 @@ func TestCheckSwapResourceArrayElementAndVariable(t *testing.T) {
 
 func TestCheckSwapResourceArrayElements(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -215,6 +239,8 @@ func TestCheckSwapResourceArrayElements(t *testing.T) {
 }
 
 func TestCheckSwapResourceFields(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}
@@ -247,6 +273,8 @@ func TestCheckSwapResourceFields(t *testing.T) {
 // to swap fields which are constant (`let`)
 //
 func TestCheckInvalidSwapConstantResourceFields(t *testing.T) {
+
+	t.Parallel()
 
 	for i := 0; i < 2; i++ {
 
@@ -312,6 +340,8 @@ func TestCheckInvalidSwapConstantResourceFields(t *testing.T) {
 
 func TestCheckSwapResourceDictionaryElement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       resource X {}
 
@@ -328,6 +358,8 @@ func TestCheckSwapResourceDictionaryElement(t *testing.T) {
 }
 
 func TestCheckInvalidSwapResourceDictionaryElement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       resource X {}

--- a/runtime/tests/checker/transactions_test.go
+++ b/runtime/tests/checker/transactions_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestCheckTransactions(t *testing.T) {
 
+	t.Parallel()
+
 	type test struct {
 		name   string
 		code   string
@@ -371,6 +373,9 @@ func TestCheckTransactions(t *testing.T) {
 }
 
 func TestCheckTransactionExecuteScope(t *testing.T) {
+
+	t.Parallel()
+
 	// non-global variable declarations do not require access modifiers
 	// execute block should be treated like function block
 
@@ -396,6 +401,8 @@ func TestCheckTransactionExecuteScope(t *testing.T) {
 
 func TestCheckInvalidTransactionSelfMoveToFunction(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
       transaction {
@@ -415,6 +422,8 @@ func TestCheckInvalidTransactionSelfMoveToFunction(t *testing.T) {
 
 func TestCheckInvalidTransactionSelfMoveInVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
      transaction {
@@ -431,6 +440,8 @@ func TestCheckInvalidTransactionSelfMoveInVariableDeclaration(t *testing.T) {
 }
 
 func TestCheckInvalidTransactionSelfMoveReturnFromFunction(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
 
@@ -449,6 +460,8 @@ func TestCheckInvalidTransactionSelfMoveReturnFromFunction(t *testing.T) {
 
 func TestCheckInvalidTransactionSelfMoveIntoArrayLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
 
      transaction {
@@ -465,6 +478,8 @@ func TestCheckInvalidTransactionSelfMoveIntoArrayLiteral(t *testing.T) {
 }
 
 func TestCheckInvalidTransactionSelfMoveIntoDictionaryLiteral(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
 

--- a/runtime/tests/checker/while_test.go
+++ b/runtime/tests/checker/while_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestCheckInvalidWhileTest(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           while 1 {}
@@ -42,6 +44,8 @@ func TestCheckInvalidWhileTest(t *testing.T) {
 
 func TestCheckWhileTest(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
       fun test() {
           while true {}
@@ -52,6 +56,8 @@ func TestCheckWhileTest(t *testing.T) {
 }
 
 func TestCheckInvalidWhileBlock(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
       fun test() {
@@ -66,6 +72,8 @@ func TestCheckInvalidWhileBlock(t *testing.T) {
 
 func TestCheckWhileBreakStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        fun test() {
            while true {
@@ -78,6 +86,8 @@ func TestCheckWhileBreakStatement(t *testing.T) {
 }
 
 func TestCheckInvalidWhileBreakStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        fun test() {
@@ -96,6 +106,8 @@ func TestCheckInvalidWhileBreakStatement(t *testing.T) {
 
 func TestCheckWhileContinueStatement(t *testing.T) {
 
+	t.Parallel()
+
 	_, err := ParseAndCheck(t, `
        fun test() {
            while true {
@@ -108,6 +120,8 @@ func TestCheckWhileContinueStatement(t *testing.T) {
 }
 
 func TestCheckInvalidWhileContinueStatement(t *testing.T) {
+
+	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
        fun test() {

--- a/runtime/tests/fuzz/crashers_test.go
+++ b/runtime/tests/fuzz/crashers_test.go
@@ -33,6 +33,8 @@ const crashersDir = "../../../crashers"
 
 func TestCrashers(t *testing.T) {
 
+	t.Parallel()
+
 	f, err := os.Open(crashersDir)
 	if err != nil {
 		t.Skip()

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -127,6 +127,8 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 
 func TestInterpretAuthAccountSave(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		t.Run("valid", func(t *testing.T) {
@@ -293,6 +295,8 @@ func TestInterpretAuthAccountSave(t *testing.T) {
 }
 
 func TestInterpretAuthAccountLoad(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -519,6 +523,8 @@ func TestInterpretAuthAccountLoad(t *testing.T) {
 
 func TestInterpretAuthAccountCopy(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("valid", func(t *testing.T) {
 
 		const code = `
@@ -636,6 +642,8 @@ func TestInterpretAuthAccountCopy(t *testing.T) {
 }
 
 func TestInterpretAuthAccountBorrow(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -901,6 +909,8 @@ func TestInterpretAuthAccountBorrow(t *testing.T) {
 }
 
 func TestInterpretAuthAccountLink(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 
@@ -1168,6 +1178,8 @@ func TestInterpretAuthAccountLink(t *testing.T) {
 
 func TestInterpretAuthAccountUnlink(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		for _, capabilityDomain := range []common.PathDomain{
@@ -1334,6 +1346,8 @@ func TestInterpretAuthAccountUnlink(t *testing.T) {
 }
 
 func TestInterpretAccountGetLinkTarget(t *testing.T) {
+
+	t.Parallel()
 
 	for _, auth := range []bool{true, false} {
 
@@ -1527,6 +1541,8 @@ func TestInterpretAccountGetLinkTarget(t *testing.T) {
 }
 
 func TestInterpretAccountGetCapability(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[bool][]common.PathDomain{
 		true: {

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -63,6 +63,8 @@ func init() {
 
 func TestInterpretPlusOperator(t *testing.T) {
 
+	t.Parallel()
+
 	for ty, value := range integerTestValues {
 
 		t.Run(ty, func(t *testing.T) {
@@ -87,6 +89,8 @@ func TestInterpretPlusOperator(t *testing.T) {
 }
 
 func TestInterpretMinusOperator(t *testing.T) {
+
+	t.Parallel()
 
 	for ty, value := range integerTestValues {
 
@@ -113,6 +117,8 @@ func TestInterpretMinusOperator(t *testing.T) {
 
 func TestInterpretMulOperator(t *testing.T) {
 
+	t.Parallel()
+
 	for ty, value := range integerTestValues {
 
 		t.Run(ty, func(t *testing.T) {
@@ -138,6 +144,8 @@ func TestInterpretMulOperator(t *testing.T) {
 
 func TestInterpretDivOperator(t *testing.T) {
 
+	t.Parallel()
+
 	for ty, value := range integerTestValues {
 
 		t.Run(ty, func(t *testing.T) {
@@ -162,6 +170,8 @@ func TestInterpretDivOperator(t *testing.T) {
 }
 
 func TestInterpretModOperator(t *testing.T) {
+
+	t.Parallel()
 
 	for ty, value := range integerTestValues {
 

--- a/runtime/tests/interpreter/bitwise_test.go
+++ b/runtime/tests/interpreter/bitwise_test.go
@@ -99,6 +99,8 @@ func init() {
 
 func TestInterpretBitwiseOr(t *testing.T) {
 
+	t.Parallel()
+
 	for ty, valueFunc := range bitwiseTestValueFunctions {
 
 		t.Run(ty, func(t *testing.T) {
@@ -123,6 +125,8 @@ func TestInterpretBitwiseOr(t *testing.T) {
 }
 
 func TestInterpretBitwiseXor(t *testing.T) {
+
+	t.Parallel()
 
 	for ty, valueFunc := range bitwiseTestValueFunctions {
 
@@ -149,6 +153,8 @@ func TestInterpretBitwiseXor(t *testing.T) {
 
 func TestInterpretBitwiseAnd(t *testing.T) {
 
+	t.Parallel()
+
 	for ty, valueFunc := range bitwiseTestValueFunctions {
 
 		t.Run(ty, func(t *testing.T) {
@@ -174,6 +180,8 @@ func TestInterpretBitwiseAnd(t *testing.T) {
 
 func TestInterpretBitwiseLeftShift(t *testing.T) {
 
+	t.Parallel()
+
 	for ty, valueFunc := range bitwiseTestValueFunctions {
 
 		t.Run(ty, func(t *testing.T) {
@@ -198,6 +206,8 @@ func TestInterpretBitwiseLeftShift(t *testing.T) {
 }
 
 func TestInterpretBitwiseRightShift(t *testing.T) {
+
+	t.Parallel()
 
 	for ty, valueFunc := range bitwiseTestValueFunctions {
 

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -28,6 +28,8 @@ import (
 
 func TestInterpretCapabilityBorrowResource(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("resource", func(t *testing.T) {
 
 		inter, _ := testAccount(
@@ -308,6 +310,8 @@ func TestInterpretCapabilityBorrowResource(t *testing.T) {
 }
 
 func TestInterpretCapabilityCheck(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("resource", func(t *testing.T) {
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -39,6 +39,8 @@ var dynamicCastingOperations = map[ast.Operation]bool{
 
 func TestInterpretDynamicCastingNumber(t *testing.T) {
 
+	t.Parallel()
+
 	type test struct {
 		ty       sema.Type
 		value    string
@@ -168,6 +170,8 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 
 func TestInterpretDynamicCastingVoid(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.AnyStructType{},
 		&sema.VoidType{},
@@ -256,6 +260,8 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 
 func TestInterpretDynamicCastingString(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.AnyStructType{},
 		&sema.StringType{},
@@ -341,6 +347,8 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 
 func TestInterpretDynamicCastingBool(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.AnyStructType{},
 		&sema.BoolType{},
@@ -425,6 +433,8 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 }
 
 func TestInterpretDynamicCastingAddress(t *testing.T) {
+
+	t.Parallel()
 
 	types := []sema.Type{
 		&sema.AnyStructType{},
@@ -515,6 +525,8 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 }
 
 func TestInterpretDynamicCastingStruct(t *testing.T) {
+
+	t.Parallel()
 
 	types := []string{
 		"AnyStruct",
@@ -754,6 +766,8 @@ func testResourceCastInvalid(t *testing.T, types, fromType, targetType string, o
 
 func TestInterpretDynamicCastingResource(t *testing.T) {
 
+	t.Parallel()
+
 	types := []string{
 		"AnyResource",
 		"R",
@@ -904,6 +918,8 @@ func testStructCastInvalid(t *testing.T, types, fromType, targetType string, ope
 
 func TestInterpretDynamicCastingStructInterface(t *testing.T) {
 
+	t.Parallel()
+
 	types := []string{
 		"AnyStruct",
 		"S",
@@ -954,6 +970,8 @@ func TestInterpretDynamicCastingStructInterface(t *testing.T) {
 
 func TestInterpretDynamicCastingResourceInterface(t *testing.T) {
 
+	t.Parallel()
+
 	types := []string{
 		"AnyResource",
 		"R",
@@ -1003,6 +1021,8 @@ func TestInterpretDynamicCastingResourceInterface(t *testing.T) {
 }
 
 func TestInterpretDynamicCastingSome(t *testing.T) {
+
+	t.Parallel()
 
 	types := []sema.Type{
 		&sema.OptionalType{Type: &sema.IntType{}},
@@ -1104,6 +1124,8 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 
 func TestInterpretDynamicCastingArray(t *testing.T) {
 
+	t.Parallel()
+
 	types := []sema.Type{
 		&sema.VariableSizedType{Type: &sema.IntType{}},
 		&sema.VariableSizedType{Type: &sema.AnyStructType{}},
@@ -1192,6 +1214,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 }
 
 func TestInterpretDynamicCastingDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	types := []sema.Type{
 		&sema.DictionaryType{
@@ -1288,6 +1312,8 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 }
 
 func TestInterpretDynamicCastingResourceType(t *testing.T) {
+
+	t.Parallel()
 
 	for operation := range dynamicCastingOperations {
 
@@ -1675,6 +1701,8 @@ func TestInterpretDynamicCastingResourceType(t *testing.T) {
 }
 
 func TestInterpretDynamicCastingStructType(t *testing.T) {
+
+	t.Parallel()
 
 	for operation := range dynamicCastingOperations {
 
@@ -2195,6 +2223,8 @@ func testReferenceCastInvalid(t *testing.T, types, fromType, targetType string, 
 
 func TestInterpretDynamicCastingAuthorizedResourceReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	for operation := range dynamicCastingOperations {
 
 		t.Run(operation.Symbol(), func(t *testing.T) {
@@ -2601,6 +2631,8 @@ func TestInterpretDynamicCastingAuthorizedResourceReferenceType(t *testing.T) {
 }
 
 func TestInterpretDynamicCastingAuthorizedStructReferenceType(t *testing.T) {
+
+	t.Parallel()
 
 	for operation := range dynamicCastingOperations {
 
@@ -3009,6 +3041,8 @@ func TestInterpretDynamicCastingAuthorizedStructReferenceType(t *testing.T) {
 
 func TestInterpretDynamicCastingUnauthorizedResourceReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	for operation := range dynamicCastingOperations {
 
 		t.Run(operation.Symbol(), func(t *testing.T) {
@@ -3152,6 +3186,8 @@ func TestInterpretDynamicCastingUnauthorizedResourceReferenceType(t *testing.T) 
 }
 
 func TestInterpretDynamicCastingUnauthorizedStructReferenceType(t *testing.T) {
+
+	t.Parallel()
 
 	for operation := range dynamicCastingOperations {
 

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = -0.42
     `)
@@ -43,6 +45,8 @@ func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
 }
 
 func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[string]interpreter.Value{
 		// Fix*
@@ -105,6 +109,8 @@ func init() {
 }
 
 func TestInterpretFixedPointConversions(t *testing.T) {
+
+	t.Parallel()
 
 	// check conversion to integer types
 

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestInterpretForStatement(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
            var sum = 0
@@ -51,6 +53,8 @@ func TestInterpretForStatement(t *testing.T) {
 
 func TestInterpretForStatementWithReturn(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
            for x in [1, 2, 3, 4, 5] {
@@ -72,6 +76,8 @@ func TestInterpretForStatementWithReturn(t *testing.T) {
 }
 
 func TestInterpretForStatementWithContinue(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        fun test(): [Int] {
@@ -100,6 +106,8 @@ func TestInterpretForStatementWithContinue(t *testing.T) {
 
 func TestInterpretForStatementWithBreak(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
            var y = 0
@@ -123,6 +131,8 @@ func TestInterpretForStatementWithBreak(t *testing.T) {
 }
 
 func TestInterpretForStatementEmpty(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        fun test(): Bool {

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -63,6 +63,8 @@ func init() {
 
 func TestInterpretIntegerConversions(t *testing.T) {
 
+	t.Parallel()
+
 	for integerType, value := range testIntegerTypesAndValues {
 
 		t.Run(integerType, func(t *testing.T) {
@@ -99,6 +101,8 @@ func TestInterpretIntegerConversions(t *testing.T) {
 
 func TestInterpretAddressConversion(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: Address = 0x1
       let y = Address(0x2)
@@ -120,6 +124,8 @@ func TestInterpretAddressConversion(t *testing.T) {
 }
 
 func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	for integerType, value := range testIntegerTypesAndValues {
 
@@ -145,6 +151,8 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T
 
 func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *testing.T) {
 
+	t.Parallel()
+
 	for integerType, value := range testIntegerTypesAndValues {
 
 		t.Run(integerType, func(t *testing.T) {
@@ -167,6 +175,8 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *t
 }
 
 func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	for integerType, value := range testIntegerTypesAndValues {
 
@@ -202,6 +212,8 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 }
 
 func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T) {
+
+	t.Parallel()
 
 	for integerType, value := range testIntegerTypesAndValues {
 
@@ -241,6 +253,8 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 
 func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.T) {
 
+	t.Parallel()
+
 	for integerType, value := range testIntegerTypesAndValues {
 
 		t.Run(integerType, func(t *testing.T) {
@@ -267,6 +281,8 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.
 
 func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *testing.T) {
 
+	t.Parallel()
+
 	for integerType, value := range testIntegerTypesAndValues {
 
 		t.Run(integerType, func(t *testing.T) {
@@ -292,6 +308,8 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *
 }
 
 func TestInterpretIntegerLiteralTypeConversionInReturn(t *testing.T) {
+
+	t.Parallel()
 
 	for integerType, value := range testIntegerTypesAndValues {
 
@@ -320,6 +338,8 @@ func TestInterpretIntegerLiteralTypeConversionInReturn(t *testing.T) {
 }
 
 func TestInterpretIntegerLiteralTypeConversionInReturnOptional(t *testing.T) {
+
+	t.Parallel()
 
 	for integerType, value := range testIntegerTypesAndValues {
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -137,6 +137,8 @@ func makeContractValueHandler(
 
 func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
         let x = 1
         let y = true
@@ -182,6 +184,8 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 
 func TestInterpretDeclarations(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
         fun test(): Int {
             return 42
@@ -199,6 +203,8 @@ func TestInterpretDeclarations(t *testing.T) {
 
 func TestInterpretInvalidUnknownDeclarationInvocation(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, ``)
 
 	_, err := inter.Invoke("test")
@@ -206,6 +212,8 @@ func TestInterpretInvalidUnknownDeclarationInvocation(t *testing.T) {
 }
 
 func TestInterpretInvalidNonFunctionDeclarationInvocation(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        let test = 1
@@ -216,6 +224,8 @@ func TestInterpretInvalidNonFunctionDeclarationInvocation(t *testing.T) {
 }
 
 func TestInterpretLexicalScope(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        let x = 10
@@ -256,6 +266,8 @@ func TestInterpretLexicalScope(t *testing.T) {
 
 func TestInterpretFunctionSideEffects(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        var value = 0
 
@@ -281,6 +293,8 @@ func TestInterpretFunctionSideEffects(t *testing.T) {
 }
 
 func TestInterpretNoHoisting(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        let x = 2
@@ -310,6 +324,8 @@ func TestInterpretNoHoisting(t *testing.T) {
 
 func TestInterpretFunctionExpressionsAndScope(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        let x = 10
 
@@ -330,6 +346,8 @@ func TestInterpretFunctionExpressionsAndScope(t *testing.T) {
 
 func TestInterpretVariableAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
            var x = 2
@@ -348,6 +366,8 @@ func TestInterpretVariableAssignment(t *testing.T) {
 }
 
 func TestInterpretGlobalVariableAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        var x = 2
@@ -379,6 +399,8 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 
 func TestInterpretConstantRedeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        let x = 2
 
@@ -403,6 +425,8 @@ func TestInterpretConstantRedeclaration(t *testing.T) {
 }
 
 func TestInterpretParameters(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        fun returnA(a: Int, b: Int): Int {
@@ -430,6 +454,8 @@ func TestInterpretParameters(t *testing.T) {
 
 func TestInterpretArrayIndexing(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
            let z = [0, 3]
@@ -447,6 +473,8 @@ func TestInterpretArrayIndexing(t *testing.T) {
 }
 
 func TestInterpretArrayIndexingAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        let z = [0, 3]
@@ -485,6 +513,8 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 
 func TestInterpretStringIndexing(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let a = "abc"
       let x = a[0]
@@ -507,6 +537,8 @@ func TestInterpretStringIndexing(t *testing.T) {
 }
 
 func TestInterpretStringIndexingUnicode(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun testUnicodeA(): Character {
@@ -538,6 +570,8 @@ func TestInterpretStringIndexingUnicode(t *testing.T) {
 }
 
 func TestInterpretStringIndexingAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let z = "abc"
@@ -572,6 +606,8 @@ func TestInterpretStringIndexingAssignment(t *testing.T) {
 
 func TestInterpretStringIndexingAssignmentUnicode(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(): String {
           let z = "cafe chair"
@@ -591,6 +627,8 @@ func TestInterpretStringIndexingAssignmentUnicode(t *testing.T) {
 }
 
 func TestInterpretStringIndexingAssignmentWithCharacterLiteral(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun test(): String {
@@ -620,6 +658,9 @@ type stringSliceTest struct {
 }
 
 func TestInterpretStringSlicing(t *testing.T) {
+
+	t.Parallel()
+
 	tests := []stringSliceTest{
 		{"abcdef", 0, 6, "abcdef", nil},
 		{"abcdef", 0, 0, "", nil},
@@ -662,6 +703,8 @@ func TestInterpretStringSlicing(t *testing.T) {
 
 func TestInterpretReturnWithoutExpression(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun returnNothing() {
            return
@@ -678,6 +721,8 @@ func TestInterpretReturnWithoutExpression(t *testing.T) {
 }
 
 func TestInterpretReturns(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpretWithOptions(t,
 		`
@@ -705,6 +750,8 @@ func TestInterpretReturns(t *testing.T) {
 }
 
 func TestInterpretEqualOperator(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun testIntegersUnequal(): Bool {
@@ -769,6 +816,8 @@ func TestInterpretEqualOperator(t *testing.T) {
 
 func TestInterpretUnequalOperator(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun testIntegersUnequal(): Bool {
           return 5 != 3
@@ -817,6 +866,8 @@ func TestInterpretUnequalOperator(t *testing.T) {
 
 func TestInterpretLessOperator(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun testIntegersGreater(): Bool {
           return 5 < 3
@@ -849,6 +900,8 @@ func TestInterpretLessOperator(t *testing.T) {
 }
 
 func TestInterpretLessEqualOperator(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun testIntegersGreater(): Bool {
@@ -883,6 +936,8 @@ func TestInterpretLessEqualOperator(t *testing.T) {
 
 func TestInterpretGreaterOperator(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun testIntegersGreater(): Bool {
           return 5 > 3
@@ -916,6 +971,8 @@ func TestInterpretGreaterOperator(t *testing.T) {
 
 func TestInterpretGreaterEqualOperator(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun testIntegersGreater(): Bool {
           return 5 >= 3
@@ -948,6 +1005,8 @@ func TestInterpretGreaterEqualOperator(t *testing.T) {
 }
 
 func TestInterpretOrOperator(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun testTrueTrue(): Bool {
@@ -987,6 +1046,8 @@ func TestInterpretOrOperator(t *testing.T) {
 
 func TestInterpretOrOperatorShortCircuitLeftSuccess(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var x = false
       var y = false
@@ -1022,6 +1083,8 @@ func TestInterpretOrOperatorShortCircuitLeftSuccess(t *testing.T) {
 
 func TestInterpretOrOperatorShortCircuitLeftFailure(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var x = false
       var y = false
@@ -1056,6 +1119,8 @@ func TestInterpretOrOperatorShortCircuitLeftFailure(t *testing.T) {
 }
 
 func TestInterpretAndOperator(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun testTrueTrue(): Bool {
@@ -1095,6 +1160,8 @@ func TestInterpretAndOperator(t *testing.T) {
 
 func TestInterpretAndOperatorShortCircuitLeftSuccess(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var x = false
       var y = false
@@ -1130,6 +1197,8 @@ func TestInterpretAndOperatorShortCircuitLeftSuccess(t *testing.T) {
 
 func TestInterpretAndOperatorShortCircuitLeftFailure(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var x = false
       var y = false
@@ -1164,6 +1233,8 @@ func TestInterpretAndOperatorShortCircuitLeftFailure(t *testing.T) {
 }
 
 func TestInterpretIfStatement(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpretWithOptions(t,
 		`
@@ -1231,6 +1302,8 @@ func TestInterpretIfStatement(t *testing.T) {
 
 func TestInterpretExpressionStatement(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        var x = 0
 
@@ -1265,6 +1338,8 @@ func TestInterpretExpressionStatement(t *testing.T) {
 
 func TestInterpretConditionalOperator(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun testTrue(): Int {
            return true ? 2 : 3
@@ -1294,6 +1369,8 @@ func TestInterpretConditionalOperator(t *testing.T) {
 
 func TestInterpretFunctionBindingInFunction(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun foo(): AnyStruct {
           return foo
@@ -1305,6 +1382,9 @@ func TestInterpretFunctionBindingInFunction(t *testing.T) {
 }
 
 func TestInterpretRecursionFib(t *testing.T) {
+
+	t.Parallel()
+
 	// mainly tests that the function declaration identifier is bound
 	// to the function inside the function and that the arguments
 	// of the function calls are evaluated in the call-site scope
@@ -1332,6 +1412,8 @@ func TestInterpretRecursionFib(t *testing.T) {
 
 func TestInterpretRecursionFactorial(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
         fun factorial(_ n: Int): Int {
             if n < 1 {
@@ -1356,6 +1438,8 @@ func TestInterpretRecursionFactorial(t *testing.T) {
 
 func TestInterpretUnaryIntegerNegation(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = -2
       let y = -(-2)
@@ -1373,6 +1457,8 @@ func TestInterpretUnaryIntegerNegation(t *testing.T) {
 }
 
 func TestInterpretUnaryBooleanNegation(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let a = !true
@@ -1403,6 +1489,8 @@ func TestInterpretUnaryBooleanNegation(t *testing.T) {
 }
 
 func TestInterpretHostFunction(t *testing.T) {
+
+	t.Parallel()
 
 	program, _, err := parser.ParseProgram(`
       pub let a = test(1, 2)
@@ -1473,6 +1561,8 @@ func TestInterpretHostFunction(t *testing.T) {
 }
 
 func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
+
+	t.Parallel()
 
 	program, _, err := parser.ParseProgram(`
       pub let nothing = test(1, true, "test")
@@ -1550,6 +1640,8 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 
 func TestInterpretCompositeDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		switch compositeKind {
@@ -1596,6 +1688,8 @@ func TestInterpretCompositeDeclaration(t *testing.T) {
 
 func TestInterpretStructureSelfUseInInitializer(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
 
       struct Test {
@@ -1620,6 +1714,8 @@ func TestInterpretStructureSelfUseInInitializer(t *testing.T) {
 }
 
 func TestInterpretStructureConstructorUseInInitializerAndFunction(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
 
@@ -1662,6 +1758,8 @@ func TestInterpretStructureConstructorUseInInitializerAndFunction(t *testing.T) 
 
 func TestInterpretStructureSelfUseInFunction(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
 
       struct Test {
@@ -1687,6 +1785,8 @@ func TestInterpretStructureSelfUseInFunction(t *testing.T) {
 
 func TestInterpretStructureConstructorUseInFunction(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Test {
 
@@ -1710,6 +1810,8 @@ func TestInterpretStructureConstructorUseInFunction(t *testing.T) {
 }
 
 func TestInterpretStructureDeclarationWithField(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
 
@@ -1736,6 +1838,8 @@ func TestInterpretStructureDeclarationWithField(t *testing.T) {
 }
 
 func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var value = 0
@@ -1767,6 +1871,8 @@ func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
 
 func TestInterpretStructureFunctionCall(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Test {
           fun foo(): Int {
@@ -1788,6 +1894,8 @@ func TestInterpretStructureFunctionCall(t *testing.T) {
 }
 
 func TestInterpretStructureFieldAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       struct Test {
@@ -1840,6 +1948,8 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 
 func TestInterpretStructureInitializesConstant(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Test {
           let foo: Int
@@ -1861,6 +1971,8 @@ func TestInterpretStructureInitializesConstant(t *testing.T) {
 }
 
 func TestInterpretStructureFunctionMutatesSelf(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       struct Test {
@@ -1894,6 +2006,8 @@ func TestInterpretStructureFunctionMutatesSelf(t *testing.T) {
 
 func TestInterpretFunctionPreCondition(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(x: Int): Int {
           pre {
@@ -1917,6 +2031,8 @@ func TestInterpretFunctionPreCondition(t *testing.T) {
 }
 
 func TestInterpretFunctionPostCondition(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun test(x: Int): Int {
@@ -1943,6 +2059,8 @@ func TestInterpretFunctionPostCondition(t *testing.T) {
 
 func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(x: Int): Int {
           post {
@@ -1967,6 +2085,8 @@ func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
 
 func TestInterpretFunctionWithoutResultAndPostConditionWithResult(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test() {
           post {
@@ -1986,6 +2106,8 @@ func TestInterpretFunctionWithoutResultAndPostConditionWithResult(t *testing.T) 
 }
 
 func TestInterpretFunctionPostConditionWithBefore(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var x = 0
@@ -2011,6 +2133,8 @@ func TestInterpretFunctionPostConditionWithBefore(t *testing.T) {
 }
 
 func TestInterpretFunctionPostConditionWithBeforeFailingPreCondition(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var x = 0
@@ -2038,6 +2162,8 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPreCondition(t *testing.
 
 func TestInterpretFunctionPostConditionWithBeforeFailingPostCondition(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var x = 0
 
@@ -2063,6 +2189,8 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPostCondition(t *testing
 }
 
 func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun test(x: Int): Int {
@@ -2093,6 +2221,8 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 }
 
 func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun test(x: Int): String {
@@ -2127,6 +2257,8 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 
 func TestInterpretFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(x: String): String {
           post {
@@ -2147,6 +2279,8 @@ func TestInterpretFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
 
 func TestInterpretFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(x: String): String {
           post {
@@ -2166,6 +2300,8 @@ func TestInterpretFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
 }
 
 func TestInterpretStructCopyOnDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       struct Cat {
@@ -2197,6 +2333,8 @@ func TestInterpretStructCopyOnDeclaration(t *testing.T) {
 }
 
 func TestInterpretStructCopyOnDeclarationModifiedWithStructFunction(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       struct Cat {
@@ -2233,6 +2371,8 @@ func TestInterpretStructCopyOnDeclarationModifiedWithStructFunction(t *testing.T
 
 func TestInterpretStructCopyOnIdentifierAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Cat {
           var wasFed: Bool
@@ -2265,6 +2405,8 @@ func TestInterpretStructCopyOnIdentifierAssignment(t *testing.T) {
 
 func TestInterpretStructCopyOnIndexingAssignment(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Cat {
           var wasFed: Bool
@@ -2296,6 +2438,8 @@ func TestInterpretStructCopyOnIndexingAssignment(t *testing.T) {
 }
 
 func TestInterpretStructCopyOnMemberAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       struct Cat {
@@ -2336,6 +2480,8 @@ func TestInterpretStructCopyOnMemberAssignment(t *testing.T) {
 
 func TestInterpretStructCopyOnPassing(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Cat {
           var wasFed: Bool
@@ -2366,6 +2512,8 @@ func TestInterpretStructCopyOnPassing(t *testing.T) {
 }
 
 func TestInterpretArrayCopy(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
 
@@ -2398,6 +2546,8 @@ func TestInterpretArrayCopy(t *testing.T) {
 
 func TestInterpretStructCopyInArray(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Foo {
           var bar: Int
@@ -2429,6 +2579,8 @@ func TestInterpretStructCopyInArray(t *testing.T) {
 }
 
 func TestInterpretMutuallyRecursiveFunctions(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun isEven(_ n: Int): Bool {
@@ -2466,6 +2618,8 @@ func TestInterpretMutuallyRecursiveFunctions(t *testing.T) {
 }
 
 func TestInterpretUseBeforeDeclaration(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var tests = 0
@@ -2515,6 +2669,8 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 
 func TestInterpretOptionalVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: Int?? = 2
     `)
@@ -2530,6 +2686,8 @@ func TestInterpretOptionalVariableDeclaration(t *testing.T) {
 }
 
 func TestInterpretOptionalParameterInvokedExternal(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun test(x: Int??): Int?? {
@@ -2554,6 +2712,8 @@ func TestInterpretOptionalParameterInvokedExternal(t *testing.T) {
 }
 
 func TestInterpretOptionalParameterInvokedInternal(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun testActual(x: Int??): Int?? {
@@ -2580,6 +2740,8 @@ func TestInterpretOptionalParameterInvokedInternal(t *testing.T) {
 
 func TestInterpretOptionalReturn(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(x: Int): Int?? {
           return x
@@ -2600,6 +2762,8 @@ func TestInterpretOptionalReturn(t *testing.T) {
 }
 
 func TestInterpretOptionalAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var x: Int?? = 1
@@ -2629,6 +2793,8 @@ func TestInterpretOptionalAssignment(t *testing.T) {
 
 func TestInterpretNil(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
      let x: Int? = nil
    `)
@@ -2641,6 +2807,8 @@ func TestInterpretNil(t *testing.T) {
 
 func TestInterpretOptionalNestingNil(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
      let x: Int?? = nil
    `)
@@ -2652,6 +2820,8 @@ func TestInterpretOptionalNestingNil(t *testing.T) {
 }
 
 func TestInterpretNilReturnValue(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
      fun test(): Int?? {
@@ -2669,6 +2839,8 @@ func TestInterpretNilReturnValue(t *testing.T) {
 }
 
 func TestInterpretSomeReturnValue(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
      fun test(): Int? {
@@ -2690,6 +2862,8 @@ func TestInterpretSomeReturnValue(t *testing.T) {
 
 func TestInterpretSomeReturnValueFromDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
      fun test(): Int? {
          let foo: {String: Int} = {"a": 1}
@@ -2710,6 +2884,8 @@ func TestInterpretSomeReturnValueFromDictionary(t *testing.T) {
 
 func TestInterpretNilCoalescingNilIntToOptional(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let one = 1
       let none: Int? = nil
@@ -2725,6 +2901,8 @@ func TestInterpretNilCoalescingNilIntToOptional(t *testing.T) {
 }
 
 func TestInterpretNilCoalescingNilIntToOptionals(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let one = 1
@@ -2742,6 +2920,8 @@ func TestInterpretNilCoalescingNilIntToOptionals(t *testing.T) {
 
 func TestInterpretNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let one = 1
       let x: Int? = nil ?? one
@@ -2757,6 +2937,8 @@ func TestInterpretNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 
 func TestInterpretNilCoalescingRightSubtype(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: Int? = nil ?? nil
     `)
@@ -2768,6 +2950,8 @@ func TestInterpretNilCoalescingRightSubtype(t *testing.T) {
 }
 
 func TestInterpretNilCoalescingNilInt(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let one = 1
@@ -2783,6 +2967,8 @@ func TestInterpretNilCoalescingNilInt(t *testing.T) {
 
 func TestInterpretNilCoalescingNilLiteralInt(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let one = 1
       let x: Int = nil ?? one
@@ -2795,6 +2981,8 @@ func TestInterpretNilCoalescingNilLiteralInt(t *testing.T) {
 }
 
 func TestInterpretNilCoalescingShortCircuitLeftSuccess(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var x = false
@@ -2831,6 +3019,8 @@ func TestInterpretNilCoalescingShortCircuitLeftSuccess(t *testing.T) {
 
 func TestInterpretNilCoalescingShortCircuitLeftFailure(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var x = false
       var y = false
@@ -2866,6 +3056,8 @@ func TestInterpretNilCoalescingShortCircuitLeftFailure(t *testing.T) {
 
 func TestInterpretNilCoalescingOptionalAnyStructNil(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: AnyStruct? = nil
       let y = x ?? true
@@ -2879,6 +3071,8 @@ func TestInterpretNilCoalescingOptionalAnyStructNil(t *testing.T) {
 
 func TestInterpretNilCoalescingOptionalAnyStructSome(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: AnyStruct? = 2
       let y = x ?? true
@@ -2891,6 +3085,8 @@ func TestInterpretNilCoalescingOptionalAnyStructSome(t *testing.T) {
 }
 
 func TestInterpretNilCoalescingOptionalRightHandSide(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x: Int? = 1
@@ -2908,6 +3104,8 @@ func TestInterpretNilCoalescingOptionalRightHandSide(t *testing.T) {
 
 func TestInterpretNilCoalescingBothOptional(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
      let x: Int?? = 1
      let y: Int? = 2
@@ -2923,6 +3121,8 @@ func TestInterpretNilCoalescingBothOptional(t *testing.T) {
 }
 
 func TestInterpretNilCoalescingBothOptionalLeftNil(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
      let x: Int?? = nil
@@ -2940,6 +3140,8 @@ func TestInterpretNilCoalescingBothOptionalLeftNil(t *testing.T) {
 
 func TestInterpretNilsComparison(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = nil == nil
    `)
@@ -2951,6 +3153,8 @@ func TestInterpretNilsComparison(t *testing.T) {
 }
 
 func TestInterpretNonOptionalNilComparison(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x: Int = 1
@@ -2971,6 +3175,8 @@ func TestInterpretNonOptionalNilComparison(t *testing.T) {
 
 func TestInterpretOptionalNilComparison(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
      let x: Int? = 1
      let y = x == nil
@@ -2983,6 +3189,8 @@ func TestInterpretOptionalNilComparison(t *testing.T) {
 }
 
 func TestInterpretNestedOptionalNilComparison(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x: Int?? = 1
@@ -2997,6 +3205,8 @@ func TestInterpretNestedOptionalNilComparison(t *testing.T) {
 
 func TestInterpretOptionalNilComparisonSwapped(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: Int? = 1
       let y = nil == x
@@ -3010,6 +3220,8 @@ func TestInterpretOptionalNilComparisonSwapped(t *testing.T) {
 
 func TestInterpretNestedOptionalNilComparisonSwapped(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: Int?? = 1
       let y = nil == x
@@ -3022,6 +3234,8 @@ func TestInterpretNestedOptionalNilComparisonSwapped(t *testing.T) {
 }
 
 func TestInterpretNestedOptionalComparisonNils(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x: Int? = nil
@@ -3037,6 +3251,8 @@ func TestInterpretNestedOptionalComparisonNils(t *testing.T) {
 
 func TestInterpretNestedOptionalComparisonValues(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: Int? = 2
       let y: Int?? = 2
@@ -3050,6 +3266,8 @@ func TestInterpretNestedOptionalComparisonValues(t *testing.T) {
 }
 
 func TestInterpretNestedOptionalComparisonMixed(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x: Int? = 2
@@ -3065,6 +3283,8 @@ func TestInterpretNestedOptionalComparisonMixed(t *testing.T) {
 
 func TestInterpretOptionalSomeValueComparison(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
      let x: Int? = 1
      let y = x == 1
@@ -3078,6 +3298,8 @@ func TestInterpretOptionalSomeValueComparison(t *testing.T) {
 
 func TestInterpretOptionalNilValueComparison(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
      let x: Int? = nil
      let y = x == 1
@@ -3090,6 +3312,8 @@ func TestInterpretOptionalNilValueComparison(t *testing.T) {
 }
 
 func TestInterpretCompositeNilEquality(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.AllCompositeKinds {
 
@@ -3149,6 +3373,8 @@ func TestInterpretCompositeNilEquality(t *testing.T) {
 
 func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var branch = 0
 
@@ -3195,6 +3421,8 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 
 func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var branch = 0
 
@@ -3240,6 +3468,8 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 }
 
 func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var branch = 0
@@ -3292,6 +3522,8 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 
 func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var branch = 0
 
@@ -3343,6 +3575,8 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 
 func TestInterpretInterfaceConformanceNoRequirements(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.AllCompositeKinds {
 
 		if compositeKind == common.CompositeKindContract {
@@ -3389,6 +3623,8 @@ func TestInterpretInterfaceConformanceNoRequirements(t *testing.T) {
 }
 
 func TestInterpretInterfaceFieldUse(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -3465,6 +3701,8 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 
 func TestInterpretInterfaceFunctionUse(t *testing.T) {
 
+	t.Parallel()
+
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
 		if !compositeKind.SupportsInterfaces() {
@@ -3527,6 +3765,8 @@ func TestInterpretInterfaceFunctionUse(t *testing.T) {
 }
 
 func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
+
+	t.Parallel()
 
 	for _, compositeKind := range common.CompositeKindsWithBody {
 
@@ -3618,6 +3858,8 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 }
 
 func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[int64]error{
 		0: &interpreter.ConditionError{},
@@ -3735,6 +3977,8 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 
 func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpretWithOptions(t,
 		`
 
@@ -3822,6 +4066,8 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 
 func TestInterpretImport(t *testing.T) {
 
+	t.Parallel()
+
 	checkerImported, err := ParseAndCheck(t, `
       pub fun answer(): Int {
           return 42
@@ -3865,6 +4111,8 @@ func TestInterpretImport(t *testing.T) {
 }
 
 func TestInterpretImportError(t *testing.T) {
+
+	t.Parallel()
 
 	valueDeclarations :=
 		stdlib.StandardLibraryFunctions{
@@ -3932,6 +4180,8 @@ func TestInterpretImportError(t *testing.T) {
 
 func TestInterpretDictionary(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = {"a": 1, "b": 2}
     `)
@@ -3952,6 +4202,8 @@ func TestInterpretDictionary(t *testing.T) {
 }
 
 func TestInterpretDictionaryInsertionOrder(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = {"c": 3, "a": 1, "b": 2}
@@ -3974,6 +4226,8 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 }
 
 func TestInterpretDictionaryIndexingString(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = {"abc": 1, "def": 2}
@@ -4004,6 +4258,8 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 
 func TestInterpretDictionaryIndexingBool(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = {true: 1, false: 2}
       let a = x[true]
@@ -4026,6 +4282,8 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 }
 
 func TestInterpretDictionaryIndexingInt(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = {23: "a", 42: "b"}
@@ -4055,6 +4313,8 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 }
 
 func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = {"abc": 42}
@@ -4116,6 +4376,8 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 }
 
 func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = {"def": 42}
@@ -4180,6 +4442,8 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 
 func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = {"def": 42, "abc": 23}
       fun test() {
@@ -4240,6 +4504,8 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 
 func TestInterpretOptionalAnyStruct(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: AnyStruct? = 42
     `)
@@ -4253,6 +4519,8 @@ func TestInterpretOptionalAnyStruct(t *testing.T) {
 }
 
 func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x: AnyStruct? = 42
@@ -4275,6 +4543,8 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 }
 
 func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x: AnyStruct? = 23
@@ -4304,6 +4574,8 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 
 func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x: AnyStruct? = nil
       let y = x ?? 42
@@ -4330,6 +4602,8 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 
 func TestInterpretLength(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = "cafe\u{301}".length
       let y = [1, 2, 3].length
@@ -4347,6 +4621,8 @@ func TestInterpretLength(t *testing.T) {
 }
 
 func TestInterpretStructureFunctionBindingInside(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
         struct X {
@@ -4377,6 +4653,8 @@ func TestInterpretStructureFunctionBindingInside(t *testing.T) {
 
 func TestInterpretStructureFunctionBindingOutside(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
         struct X {
             fun foo(): X {
@@ -4401,6 +4679,8 @@ func TestInterpretStructureFunctionBindingOutside(t *testing.T) {
 }
 
 func TestInterpretArrayAppend(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let xs = [1, 2, 3]
@@ -4442,6 +4722,8 @@ func TestInterpretArrayAppend(t *testing.T) {
 
 func TestInterpretArrayAppendBound(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(): [Int] {
           let x = [1, 2, 3]
@@ -4467,6 +4749,8 @@ func TestInterpretArrayAppendBound(t *testing.T) {
 
 func TestInterpretArrayConcat(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(): [Int] {
           let a = [1, 2]
@@ -4489,6 +4773,8 @@ func TestInterpretArrayConcat(t *testing.T) {
 }
 
 func TestInterpretArrayConcatBound(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun test(): [Int] {
@@ -4513,6 +4799,8 @@ func TestInterpretArrayConcatBound(t *testing.T) {
 }
 
 func TestInterpretArrayInsert(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = [1, 2, 3]
@@ -4554,6 +4842,8 @@ func TestInterpretArrayInsert(t *testing.T) {
 
 func TestInterpretArrayRemove(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = [1, 2, 3]
       let y = x.remove(at: 1)
@@ -4590,6 +4880,8 @@ func TestInterpretArrayRemove(t *testing.T) {
 }
 
 func TestInterpretArrayRemoveFirst(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = [1, 2, 3]
@@ -4628,6 +4920,8 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 
 func TestInterpretArrayRemoveLast(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
           let x = [1, 2, 3]
           let y = x.removeLast()
@@ -4665,6 +4959,8 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 
 func TestInterpretArrayContains(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun doesContain(): Bool {
           let a = [1, 2]
@@ -4696,6 +4992,8 @@ func TestInterpretArrayContains(t *testing.T) {
 
 func TestInterpretStringConcat(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(): String {
           let a = "abc"
@@ -4713,6 +5011,8 @@ func TestInterpretStringConcat(t *testing.T) {
 }
 
 func TestInterpretStringConcatBound(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       fun test(): String {
@@ -4732,6 +5032,8 @@ func TestInterpretStringConcatBound(t *testing.T) {
 }
 
 func TestInterpretDictionaryRemove(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let xs = {"abc": 1, "def": 2}
@@ -4776,6 +5078,8 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 }
 
 func TestInterpretDictionaryInsert(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let xs = {"abc": 1, "def": 2}
@@ -4826,6 +5130,8 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 
 func TestInterpretDictionaryKeys(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(): [String] {
           let dict = {"def": 2, "abc": 1}
@@ -4849,6 +5155,8 @@ func TestInterpretDictionaryKeys(t *testing.T) {
 
 func TestInterpretDictionaryValues(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       fun test(): [Int] {
           let dict = {"def": 2, "abc": 1}
@@ -4871,6 +5179,8 @@ func TestInterpretDictionaryValues(t *testing.T) {
 }
 
 func TestInterpretDictionaryKeyTypes(t *testing.T) {
+
+	t.Parallel()
 
 	tests := map[string]string{
 		"String":    `"abc"`,
@@ -4914,6 +5224,8 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 
 func TestInterpretIndirectDestroy(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       resource X {}
 
@@ -4933,6 +5245,8 @@ func TestInterpretIndirectDestroy(t *testing.T) {
 }
 
 func TestInterpretUnaryMove(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       resource X {}
@@ -4957,6 +5271,8 @@ func TestInterpretUnaryMove(t *testing.T) {
 }
 
 func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var destroys = 0
@@ -5004,6 +5320,8 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
 
 func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var destroys = 0
 
@@ -5042,6 +5360,9 @@ func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
 }
 
 func TestInterpretClosure(t *testing.T) {
+
+	t.Parallel()
+
 	// Create a closure that increments and returns
 	// a variable each time it is invoked.
 
@@ -5087,6 +5408,8 @@ func TestInterpretClosure(t *testing.T) {
 // See https://github.com/dapperlabs/flow-go/issues/838
 //
 func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
+
+	t.Parallel()
 
 	checkerImported, err := ParseAndCheck(t, `
       // function must have arguments
@@ -5135,6 +5458,8 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
 
 func TestInterpretSwapVariables(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun test(): [Int] {
            var x = 2
@@ -5157,6 +5482,8 @@ func TestInterpretSwapVariables(t *testing.T) {
 }
 
 func TestInterpretSwapArrayAndField(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        struct Foo {
@@ -5189,6 +5516,8 @@ func TestInterpretSwapArrayAndField(t *testing.T) {
 
 func TestInterpretResourceDestroyExpressionNoDestructor(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        resource R {}
 
@@ -5203,6 +5532,8 @@ func TestInterpretResourceDestroyExpressionNoDestructor(t *testing.T) {
 }
 
 func TestInterpretResourceDestroyExpressionDestructor(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        var ranDestructor = false
@@ -5234,6 +5565,8 @@ func TestInterpretResourceDestroyExpressionDestructor(t *testing.T) {
 }
 
 func TestInterpretResourceDestroyExpressionNestedResources(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var ranDestructorA = false
@@ -5291,6 +5624,8 @@ func TestInterpretResourceDestroyExpressionNestedResources(t *testing.T) {
 
 func TestInterpretResourceDestroyArray(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var destructionCount = 0
 
@@ -5321,6 +5656,8 @@ func TestInterpretResourceDestroyArray(t *testing.T) {
 }
 
 func TestInterpretResourceDestroyDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var destructionCount = 0
@@ -5353,6 +5690,8 @@ func TestInterpretResourceDestroyDictionary(t *testing.T) {
 
 func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       var destructionCount = 0
 
@@ -5383,6 +5722,8 @@ func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
 }
 
 func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       var destructionCount = 0
@@ -5419,6 +5760,8 @@ func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
 //
 func TestInterpretResourceDestroyExpressionResourceInterfaceCondition(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       resource interface I {
           destroy() {
@@ -5443,6 +5786,8 @@ func TestInterpretResourceDestroyExpressionResourceInterfaceCondition(t *testing
 //
 func TestInterpretInterfaceInitializer(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct interface I {
           init(a a1: Bool) {
@@ -5464,6 +5809,9 @@ func TestInterpretInterfaceInitializer(t *testing.T) {
 }
 
 func TestInterpretEmitEvent(t *testing.T) {
+
+	t.Parallel()
+
 	var actualEvents []*interpreter.CompositeValue
 
 	inter := parseCheckAndInterpret(t,
@@ -5545,6 +5893,8 @@ func (v testValue) String() string {
 }
 
 func TestInterpretEmitEventParameterTypes(t *testing.T) {
+
+	t.Parallel()
 
 	validTypes := map[string]testValue{
 		"String":    {value: interpreter.NewStringValue("test")},
@@ -5679,6 +6029,8 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 func TestInterpretSwapResourceDictionaryElementReturnSwapped(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       resource X {}
 
@@ -5701,6 +6053,8 @@ func TestInterpretSwapResourceDictionaryElementReturnSwapped(t *testing.T) {
 }
 
 func TestInterpretSwapResourceDictionaryElementReturnDictionary(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       resource X {}
@@ -5738,6 +6092,8 @@ func TestInterpretSwapResourceDictionaryElementReturnDictionary(t *testing.T) {
 
 func TestInterpretSwapResourceDictionaryElementRemoveUsingNil(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       resource X {}
 
@@ -5766,6 +6122,8 @@ func TestInterpretSwapResourceDictionaryElementRemoveUsingNil(t *testing.T) {
 
 func TestInterpretReferenceExpression(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       pub resource R {}
 
@@ -5787,6 +6145,8 @@ func TestInterpretReferenceExpression(t *testing.T) {
 }
 
 func TestInterpretReferenceUse(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       pub resource R {
@@ -5834,6 +6194,8 @@ func TestInterpretReferenceUse(t *testing.T) {
 
 func TestInterpretReferenceUseAccess(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       pub resource R {
           pub(set) var x: Int
@@ -5876,6 +6238,8 @@ func TestInterpretReferenceUseAccess(t *testing.T) {
 
 func TestInterpretReferenceDereferenceFailure(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       pub resource R {
           pub fun foo() {}
@@ -5894,6 +6258,8 @@ func TestInterpretReferenceDereferenceFailure(t *testing.T) {
 }
 
 func TestInterpretInvalidForwardReferenceCall(t *testing.T) {
+
+	t.Parallel()
 
 	// TODO: improve:
 	//   - call to `g` should succeed, but access to `y` should fail with error
@@ -5916,6 +6282,8 @@ func TestInterpretInvalidForwardReferenceCall(t *testing.T) {
 }
 
 func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       resource R {
@@ -5991,6 +6359,8 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 
 func TestInterpretCastingIntLiteralToInt8(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = 42 as Int8
     `)
@@ -6002,6 +6372,8 @@ func TestInterpretCastingIntLiteralToInt8(t *testing.T) {
 }
 
 func TestInterpretCastingIntLiteralToAnyStruct(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       let x = 42 as AnyStruct
@@ -6015,6 +6387,8 @@ func TestInterpretCastingIntLiteralToAnyStruct(t *testing.T) {
 
 func TestInterpretCastingIntLiteralToOptional(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       let x = 42 as Int?
     `)
@@ -6026,6 +6400,8 @@ func TestInterpretCastingIntLiteralToOptional(t *testing.T) {
 }
 
 func TestInterpretCastingResourceToAnyResource(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       resource R {}
@@ -6047,6 +6423,8 @@ func TestInterpretCastingResourceToAnyResource(t *testing.T) {
 }
 
 func TestInterpretOptionalChainingFieldRead(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t,
 		`
@@ -6080,6 +6458,8 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 }
 
 func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t,
 		`
@@ -6115,6 +6495,8 @@ func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
 
 func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t,
 		`
          struct Test {
@@ -6145,6 +6527,8 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 }
 
 func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
+
+	t.Parallel()
 
 	standardLibraryFunctions :=
 		stdlib.StandardLibraryFunctions{
@@ -6185,6 +6569,8 @@ func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
 
 func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
 
+	t.Parallel()
+
 	standardLibraryFunctions :=
 		stdlib.StandardLibraryFunctions{
 			stdlib.PanicFunction,
@@ -6221,6 +6607,8 @@ func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
 }
 
 func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpretWithOptions(t,
 		`
@@ -6274,6 +6662,8 @@ func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) 
 
 func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpretWithOptions(t,
 		`
           pub contract Test {
@@ -6304,6 +6694,8 @@ func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
 }
 
 func TestInterpretFungibleTokenContract(t *testing.T) {
+
+	t.Parallel()
 
 	code := strings.Join(
 		[]string{
@@ -6365,6 +6757,8 @@ func TestInterpretFungibleTokenContract(t *testing.T) {
 }
 
 func TestInterpretContractAccountFieldUse(t *testing.T) {
+
+	t.Parallel()
 
 	code := `
       pub contract Test {
@@ -6429,6 +6823,8 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 
 func TestInterpretConformToImportedInterface(t *testing.T) {
 
+	t.Parallel()
+
 	checkerImported, err := ParseAndCheck(t, `
       struct interface Foo {
           fun check(answer: Int) {
@@ -6476,6 +6872,8 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 }
 
 func TestInterpretFunctionPostConditionInInterface(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
       struct interface SI {
@@ -6530,6 +6928,8 @@ func TestInterpretFunctionPostConditionInInterface(t *testing.T) {
 
 func TestInterpretFunctionPostConditionWithBeforeInInterface(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct interface SI {
           on: Bool
@@ -6583,6 +6983,8 @@ func TestInterpretFunctionPostConditionWithBeforeInInterface(t *testing.T) {
 
 func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpretWithOptions(t, `
           pub contract C {
 
@@ -6619,6 +7021,8 @@ func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
 }
 
 func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
 
@@ -6673,6 +7077,8 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 }
 
 func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpretWithOptions(t,
 		`
@@ -6744,6 +7150,8 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 
 func TestInterpretNonStorageReference(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t,
 		`
           resource NFT {
@@ -6782,6 +7190,8 @@ func TestInterpretNonStorageReference(t *testing.T) {
 
 func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t,
 		`
           resource NFT {
@@ -6808,6 +7218,8 @@ func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
 }
 
 func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t,
 		`
@@ -6855,6 +7267,8 @@ func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
 
 func TestInterpretFix64(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t,
 		`
           let a = 789.00123010
@@ -6881,6 +7295,8 @@ func TestInterpretFix64(t *testing.T) {
 
 func TestInterpretFix64Mul(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t,
 		`
           let a = Fix64(1.1) * -1.1
@@ -6894,6 +7310,8 @@ func TestInterpretFix64Mul(t *testing.T) {
 }
 
 func TestInterpretHexDecode(t *testing.T) {
+
+	t.Parallel()
 
 	expected := interpreter.NewArrayValueUnownedNonCopying(
 		interpreter.NewIntValueFromInt64(71),
@@ -7008,6 +7426,8 @@ func TestInterpretHexDecode(t *testing.T) {
 
 func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
       struct Test {
           let x: Int?
@@ -7030,6 +7450,8 @@ func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 }
 
 func TestInterpretResourceOwnerFieldUse(t *testing.T) {
+
+	t.Parallel()
 
 	storedValues := map[string]interpreter.OptionalValue{}
 
@@ -7135,6 +7557,8 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 
 func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("new to nil", func(t *testing.T) {
 
 		inter := parseCheckAndInterpret(t, `
@@ -7208,6 +7632,8 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 
 func TestInterpretForce(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("non-nil", func(t *testing.T) {
 
 		inter := parseCheckAndInterpret(t, `
@@ -7265,6 +7691,8 @@ func permutations(xs []string) (res [][]string) {
 }
 
 func TestInterpretCompositeValueFieldEncodingOrder(t *testing.T) {
+
+	t.Parallel()
 
 	fieldValues := map[string]int{
 		"a": 1,
@@ -7329,6 +7757,8 @@ func TestInterpretCompositeValueFieldEncodingOrder(t *testing.T) {
 }
 
 func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
+
+	t.Parallel()
 
 	fieldValues := map[string]int{
 		"a": 1,
@@ -7396,6 +7826,8 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 
 func TestInterpretEphemeralReferenceToOptional(t *testing.T) {
 
+	t.Parallel()
+
 	_ = parseCheckAndInterpretWithOptions(t,
 		`
           contract C {
@@ -7431,6 +7863,8 @@ func TestInterpretEphemeralReferenceToOptional(t *testing.T) {
 }
 
 func TestInterpretNestedDeclarationOrder(t *testing.T) {
+
+	t.Parallel()
 
 	t.Run("A, B", func(t *testing.T) {
 		_ = parseCheckAndInterpretWithOptions(t,
@@ -7495,6 +7929,8 @@ func TestInterpretNestedDeclarationOrder(t *testing.T) {
 }
 
 func TestInterpretCountDigits256(t *testing.T) {
+
+	t.Parallel()
 
 	type test struct {
 		Type    sema.Type
@@ -7572,6 +8008,8 @@ func TestInterpretCountDigits256(t *testing.T) {
 }
 
 func TestInterpretFailableCastingCompositeTypeConfusion(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpretWithOptions(t,
 		`

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -31,6 +31,8 @@ import (
 
 func TestInterpretStatementHandler(t *testing.T) {
 
+	t.Parallel()
+
 	checkerImported, err := ParseAndCheck(t, `
       pub fun a() {
           true
@@ -125,6 +127,8 @@ func TestInterpretStatementHandler(t *testing.T) {
 
 func TestInterpretLoopIterationHandler(t *testing.T) {
 
+	t.Parallel()
+
 	checkerImported, err := ParseAndCheck(t, `
       pub fun a() {
           var i = 1
@@ -216,6 +220,8 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 }
 
 func TestInterpretFunctionInvocationHandler(t *testing.T) {
+
+	t.Parallel()
 
 	checkerImported, err := ParseAndCheck(t, `
       pub fun a() {}

--- a/runtime/tests/interpreter/path_test.go
+++ b/runtime/tests/interpreter/path_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestInterpretPath(t *testing.T) {
 
+	t.Parallel()
+
 	for _, domain := range common.AllPathDomainsByIdentifier {
 
 		t.Run(fmt.Sprintf("valid: %s", domain.Name()), func(t *testing.T) {

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -31,6 +31,9 @@ import (
 )
 
 func TestInterpretTransactions(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("NoPrepareFunction", func(t *testing.T) {
 		inter := parseCheckAndInterpret(t, `
           transaction {

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestInterpretResourceUUID(t *testing.T) {
 
+	t.Parallel()
+
 	checkerImported, err := ParseAndCheck(t, `
       pub resource R {}
 

--- a/runtime/tests/interpreter/while_test.go
+++ b/runtime/tests/interpreter/while_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestInterpretWhileStatement(t *testing.T) {
 
+	t.Parallel()
+
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
            var x = 0
@@ -50,6 +52,8 @@ func TestInterpretWhileStatement(t *testing.T) {
 }
 
 func TestInterpretWhileStatementWithReturn(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
@@ -74,6 +78,8 @@ func TestInterpretWhileStatementWithReturn(t *testing.T) {
 }
 
 func TestInterpretWhileStatementWithContinue(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {
@@ -100,6 +106,8 @@ func TestInterpretWhileStatementWithContinue(t *testing.T) {
 }
 
 func TestInterpretWhileStatementWithBreak(t *testing.T) {
+
+	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
        fun test(): Int {

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -39,6 +39,8 @@ import (
 
 func TestParseReplInput(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseReplInput(`
         struct X {}; let x = X(); x
     `)
@@ -53,6 +55,9 @@ func TestParseReplInput(t *testing.T) {
 }
 
 func TestParseInvalidProgramWithRest(t *testing.T) {
+
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 	    .asd
 	`)
@@ -62,6 +67,8 @@ func TestParseInvalidProgramWithRest(t *testing.T) {
 }
 
 func TestParseInvalidIncompleteConstKeyword(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 	    le
@@ -88,6 +95,8 @@ func TestParseInvalidIncompleteConstKeyword(t *testing.T) {
 
 func TestParseInvalidIncompleteStringLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 	    let = "Hello, World!
 	`)
@@ -112,6 +121,8 @@ func TestParseInvalidIncompleteStringLiteral(t *testing.T) {
 }
 
 func TestParseNames(t *testing.T) {
+
+	t.Parallel()
 
 	names := map[string]bool{
 		// Valid: title-case
@@ -181,6 +192,8 @@ func TestParseNames(t *testing.T) {
 
 func TestParseInvalidIncompleteConstantDeclaration1(t *testing.T) {
 
+	t.Parallel()
+
 	actual, inputIsComplete, err := parser.ParseProgram(`
 	    let
 	`)
@@ -207,6 +220,8 @@ func TestParseInvalidIncompleteConstantDeclaration1(t *testing.T) {
 }
 
 func TestParseInvalidIncompleteConstantDeclaration2(t *testing.T) {
+
+	t.Parallel()
 
 	actual, inputIsComplete, err := parser.ParseProgram(`
 	    let =
@@ -267,6 +282,8 @@ func testParse(t *testing.T, code string, expected []Declaration) {
 
 func TestParseBoolExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    let a = true
 	`
@@ -300,6 +317,8 @@ func TestParseBoolExpression(t *testing.T) {
 
 func TestParseIdentifierExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    let b = a
 	`
@@ -331,6 +350,8 @@ func TestParseIdentifierExpression(t *testing.T) {
 }
 
 func TestParseArrayExpression(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    let a = [1, 2]
@@ -380,6 +401,8 @@ func TestParseArrayExpression(t *testing.T) {
 }
 
 func TestParseDictionaryExpression(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    let x = {"a": 1, "b": 2}
@@ -448,6 +471,8 @@ func TestParseDictionaryExpression(t *testing.T) {
 
 func TestParseInvocationExpressionWithoutLabels(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    let a = b(1, 2)
 	`
@@ -507,6 +532,8 @@ func TestParseInvocationExpressionWithoutLabels(t *testing.T) {
 
 // TODO: new parser
 func TestParseInvocationExpressionWithLabels(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 	    let a = b(x: 1, y: 2)
@@ -573,6 +600,8 @@ func TestParseInvocationExpressionWithLabels(t *testing.T) {
 
 func TestParseMemberExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    let a = b.c
 	`
@@ -611,6 +640,8 @@ func TestParseMemberExpression(t *testing.T) {
 
 // TODO: new parser
 func TestParseOptionalMemberExpression(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 	    let a = b?.c
@@ -653,6 +684,8 @@ func TestParseOptionalMemberExpression(t *testing.T) {
 
 // TODO: new parser
 func TestParseIndexExpression(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 	    let a = b[1]
@@ -702,6 +735,8 @@ func TestParseIndexExpression(t *testing.T) {
 
 func TestParseUnaryExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    let foo = -boo
 	`
@@ -737,6 +772,8 @@ func TestParseUnaryExpression(t *testing.T) {
 }
 
 func TestParseOrExpression(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
         let a = false || true
@@ -779,6 +816,8 @@ func TestParseOrExpression(t *testing.T) {
 }
 
 func TestParseAndExpression(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
         let a = false && true
@@ -823,6 +862,8 @@ func TestParseAndExpression(t *testing.T) {
 
 func TestParseEqualityExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
         let a = false == true
 	`
@@ -864,6 +905,8 @@ func TestParseEqualityExpression(t *testing.T) {
 }
 
 func TestParseRelationalExpression(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
         let a = 1 < 2
@@ -910,6 +953,8 @@ func TestParseRelationalExpression(t *testing.T) {
 
 func TestParseAdditiveExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
         let a = 1 + 2
 	`
@@ -955,6 +1000,8 @@ func TestParseAdditiveExpression(t *testing.T) {
 
 func TestParseMultiplicativeExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
         let a = 1 * 2
 	`
@@ -999,6 +1046,8 @@ func TestParseMultiplicativeExpression(t *testing.T) {
 }
 
 func TestParseFunctionExpressionAndReturn(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    let test = fun (): Int { return 1 }
@@ -1069,6 +1118,8 @@ func TestParseFunctionExpressionAndReturn(t *testing.T) {
 
 func TestParseFunctionAndBlock(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    fun test() { return }
 	`
@@ -1121,6 +1172,8 @@ func TestParseFunctionAndBlock(t *testing.T) {
 }
 
 func TestParseFunctionParameterWithoutLabel(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    fun test(x: Int) { }
@@ -1190,6 +1243,8 @@ func TestParseFunctionParameterWithoutLabel(t *testing.T) {
 
 func TestParseFunctionParameterWithLabel(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    fun test(x y: Int) { }
 	`
@@ -1257,6 +1312,8 @@ func TestParseFunctionParameterWithLabel(t *testing.T) {
 }
 
 func TestParseIfStatement(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    fun test() {
@@ -1402,6 +1459,8 @@ func TestParseIfStatement(t *testing.T) {
 
 func TestParseIfStatementWithVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    fun test() {
             if var y = x {
@@ -1518,6 +1577,8 @@ func TestParseIfStatementWithVariableDeclaration(t *testing.T) {
 
 func TestParseIfStatementNoElse(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    fun test() {
             if true {
@@ -1593,6 +1654,8 @@ func TestParseIfStatementNoElse(t *testing.T) {
 }
 
 func TestParseWhileStatement(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    fun test() {
@@ -1684,6 +1747,8 @@ func TestParseWhileStatement(t *testing.T) {
 
 func TestParseForStatement(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    fun test() {
             for x in xs {}
@@ -1750,6 +1815,8 @@ func TestParseForStatement(t *testing.T) {
 }
 
 func TestParseAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    fun test() {
@@ -1819,6 +1886,8 @@ func TestParseAssignment(t *testing.T) {
 }
 
 func TestParseAccessAssignment(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 	    fun test() {
@@ -1937,6 +2006,8 @@ func TestParseAccessAssignment(t *testing.T) {
 
 func TestParseExpressionStatementWithAccess(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 	    fun test() { x.foo.bar[0][1].baz }
 	`)
@@ -2039,6 +2110,8 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 }
 
 func TestParseParametersAndArrayTypes(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		pub fun test(a: Int32, b: [Int32; 2], c: [[Int32; 3]]): [[Int64]] {}
@@ -2195,6 +2268,8 @@ func TestParseParametersAndArrayTypes(t *testing.T) {
 
 func TestParseDictionaryType(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 	    let x: {String: Int} = {}
 	`)
@@ -2250,6 +2325,8 @@ func TestParseDictionaryType(t *testing.T) {
 
 // TODO: remove
 func TestParseIntegerLiterals(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let octal = 0o32
@@ -2354,6 +2431,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 // TODO: remove
 func TestParseIntegerLiteralsWithUnderscores(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let octal = 0o32_45
         let hex = 0xf2_09
@@ -2457,6 +2536,8 @@ func TestParseIntegerLiteralsWithUnderscores(t *testing.T) {
 // TODO: remove
 func TestParseInvalidIntegerLiteralPrefixWithout(t *testing.T) {
 
+	t.Parallel()
+
 	for _, prefix := range []string{"o", "b", "x"} {
 
 		_, _, err := parser.ParseProgram(fmt.Sprintf(`let x = 0%s`, prefix))
@@ -2478,6 +2559,8 @@ func TestParseInvalidIntegerLiteralPrefixWithout(t *testing.T) {
 
 // TODO: remove
 func TestParseInvalidOctalIntegerLiteralWithLeadingUnderscore(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let octal = 0o_32_45
@@ -2520,6 +2603,8 @@ func TestParseInvalidOctalIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 // TODO: remove
 func TestParseIntegerLiteralWithLeadingZeros(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         let decimal = 0123
 	`)
@@ -2556,6 +2641,8 @@ func TestParseIntegerLiteralWithLeadingZeros(t *testing.T) {
 
 // TODO: remove
 func TestParseInvalidOctalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let octal = 0o32_45_
@@ -2596,6 +2683,8 @@ func TestParseInvalidOctalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 // TODO: remove
 func TestParseInvalidBinaryIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let binary = 0b_101010_101010
 	`)
@@ -2634,6 +2723,8 @@ func TestParseInvalidBinaryIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 
 // TODO: remove
 func TestParseInvalidBinaryIntegerLiteralWithTrailingUnderscore(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let binary = 0b101010_101010_
@@ -2674,6 +2765,8 @@ func TestParseInvalidBinaryIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 // TODO: remove
 func TestParseInvalidDecimalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let decimal = 1_234_567_890_
 	`)
@@ -2713,6 +2806,8 @@ func TestParseInvalidDecimalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 // TODO: remove
 func TestParseInvalidHexadecimalIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let hex = 0x_f2_09
 	`)
@@ -2751,6 +2846,8 @@ func TestParseInvalidHexadecimalIntegerLiteralWithLeadingUnderscore(t *testing.T
 
 // TODO: remove
 func TestParseInvalidHexadecimalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let hex = 0xf2_09_
@@ -2792,6 +2889,8 @@ func TestParseInvalidHexadecimalIntegerLiteralWithTrailingUnderscore(t *testing.
 // TODO: remove
 func TestParseInvalidIntegerLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let hex = 0z123
 	`)
@@ -2831,6 +2930,8 @@ func TestParseInvalidIntegerLiteral(t *testing.T) {
 // TODO: remove
 func TestParseDecimalIntegerLiteralWithLeadingZeros(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let decimal = 00123
 	`)
@@ -2868,6 +2969,8 @@ func TestParseDecimalIntegerLiteralWithLeadingZeros(t *testing.T) {
 // TODO: remove
 func TestParseBinaryIntegerLiteralWithLeadingZeros(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let binary = 0b001000
 	`)
@@ -2903,6 +3006,8 @@ func TestParseBinaryIntegerLiteralWithLeadingZeros(t *testing.T) {
 }
 
 func TestParseIntegerTypes(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 		let a: Int8 = 1
@@ -3166,6 +3271,8 @@ func TestParseIntegerTypes(t *testing.T) {
 
 func TestParseFunctionType(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let add: ((Int8, Int16): Int32) = nothing
 	`)
@@ -3241,6 +3348,8 @@ func TestParseFunctionType(t *testing.T) {
 }
 
 func TestParseFunctionArrayType(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let test: [((Int8): Int16); 2] = []
@@ -3323,6 +3432,8 @@ func TestParseFunctionArrayType(t *testing.T) {
 
 func TestParseFunctionTypeWithArrayReturnType(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let test: ((Int8): [Int16; 2]) = nothing
 	`)
@@ -3403,6 +3514,8 @@ func TestParseFunctionTypeWithArrayReturnType(t *testing.T) {
 }
 
 func TestParseFunctionTypeWithFunctionReturnTypeInParentheses(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let test: ((Int8): ((Int16): Int32)) = nothing
@@ -3491,6 +3604,8 @@ func TestParseFunctionTypeWithFunctionReturnTypeInParentheses(t *testing.T) {
 }
 
 func TestParseFunctionTypeWithFunctionReturnType(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 		let test: ((Int8): ((Int16): Int32)) = nothing
@@ -3581,6 +3696,8 @@ func TestParseFunctionTypeWithFunctionReturnType(t *testing.T) {
 
 func TestParseMissingReturnType(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 		let noop: ((): Void) =
             fun () { return }
@@ -3665,6 +3782,8 @@ func TestParseMissingReturnType(t *testing.T) {
 
 func TestParseLeftAssociativity(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
         let a = 1 + 2 + 3
 	`
@@ -3721,6 +3840,8 @@ func TestParseLeftAssociativity(t *testing.T) {
 
 func TestParseNegativeInteger(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
       let a = -42
 	`
@@ -3754,6 +3875,8 @@ func TestParseNegativeInteger(t *testing.T) {
 }
 
 func TestParseNegativeFixedPoint(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
       let a = -42.3
@@ -3791,6 +3914,8 @@ func TestParseNegativeFixedPoint(t *testing.T) {
 
 func TestParseInvalidDoubleIntegerUnary(t *testing.T) {
 
+	t.Parallel()
+
 	program, _, err := parser.ParseProgram(`
 	   var a = 1
 	   let b = --a
@@ -3814,6 +3939,8 @@ func TestParseInvalidDoubleIntegerUnary(t *testing.T) {
 
 func TestParseInvalidDoubleBooleanUnary(t *testing.T) {
 
+	t.Parallel()
+
 	program, _, err := parser.ParseProgram(`
 	   let b = !!true
 	`)
@@ -3835,6 +3962,8 @@ func TestParseInvalidDoubleBooleanUnary(t *testing.T) {
 }
 
 func TestParseTernaryRightAssociativity(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
         let a = 2 > 1
@@ -3929,6 +4058,8 @@ func TestParseTernaryRightAssociativity(t *testing.T) {
 }
 
 func TestParseStructure(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         struct Test {
@@ -4123,6 +4254,8 @@ func TestParseStructure(t *testing.T) {
 
 func TestParseStructureWithConformances(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         struct Test: Foo, Bar {}
 	`)
@@ -4164,6 +4297,8 @@ func TestParseStructureWithConformances(t *testing.T) {
 }
 
 func TestParsePreAndPostConditions(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         fun test(n: Int) {
@@ -4325,6 +4460,8 @@ func TestParsePreAndPostConditions(t *testing.T) {
 
 func TestParseExpression(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseExpression(`
         before(x + before(y)) + z
 	`)
@@ -4393,6 +4530,8 @@ func TestParseExpression(t *testing.T) {
 
 func TestParseString(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseExpression(`
        "test \0\n\r\t\"\'\\ xyz"
 	`)
@@ -4412,6 +4551,8 @@ func TestParseString(t *testing.T) {
 
 func TestParseStringWithUnicode(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseExpression(`
       "this is a test \t\\new line and race car:\n\u{1F3CE}\u{FE0F}"
 	`)
@@ -4430,6 +4571,8 @@ func TestParseStringWithUnicode(t *testing.T) {
 }
 
 func TestParseConditionMessage(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         fun test(n: Int) {
@@ -4550,6 +4693,8 @@ func TestParseConditionMessage(t *testing.T) {
 
 func TestParseOptionalType(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
        let x: Int?? = 1
 	`
@@ -4600,6 +4745,8 @@ func TestParseOptionalType(t *testing.T) {
 
 func TestParseNilCoalescing(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
        let x = nil ?? 1
 	`
@@ -4639,6 +4786,8 @@ func TestParseNilCoalescing(t *testing.T) {
 }
 
 func TestParseNilCoalescingRightAssociativity(t *testing.T) {
+
+	t.Parallel()
 
 	// NOTE: only syntactically, not semantically valid
 	const code = `
@@ -4698,6 +4847,8 @@ func TestParseNilCoalescingRightAssociativity(t *testing.T) {
 
 func TestParseFailableCasting(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
        let x = 0 as? Int
 	`)
@@ -4752,6 +4903,8 @@ func TestParseFailableCasting(t *testing.T) {
 }
 
 func TestParseInterface(t *testing.T) {
+
+	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
 		actual, _, err := parser.ParseProgram(fmt.Sprintf(`
@@ -4889,6 +5042,8 @@ func TestParseInterface(t *testing.T) {
 
 func TestParseImportWithString(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         import "test.bpl"
 	`)
@@ -4931,6 +5086,8 @@ func TestParseImportWithString(t *testing.T) {
 }
 
 func TestParseImportWithAddress(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         import 0x1234
@@ -4975,6 +5132,8 @@ func TestParseImportWithAddress(t *testing.T) {
 
 func TestParseImportWithIdentifiers(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         import A, b from 0x0
 	`)
@@ -5009,6 +5168,8 @@ func TestParseImportWithIdentifiers(t *testing.T) {
 
 func TestParseFieldWithFromIdentifier(t *testing.T) {
 
+	t.Parallel()
+
 	_, _, err := parser.ParseProgram(`
       struct S {
           let from: String
@@ -5020,6 +5181,8 @@ func TestParseFieldWithFromIdentifier(t *testing.T) {
 
 func TestParseFunctionWithFromIdentifier(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
         fun send(from: String, to: String) {}
 	`
@@ -5028,6 +5191,8 @@ func TestParseFunctionWithFromIdentifier(t *testing.T) {
 }
 
 func TestParseImportWithFromIdentifier(t *testing.T) {
+
+	t.Parallel()
 
 	_, _, err := parser.ParseProgram(`
         import from from 0x0
@@ -5038,6 +5203,8 @@ func TestParseImportWithFromIdentifier(t *testing.T) {
 
 func TestParseSemicolonsBetweenDeclarations(t *testing.T) {
 
+	t.Parallel()
+
 	_, _, err := parser.ParseProgram(`
         import from from 0x0;
         fun foo() {};
@@ -5047,6 +5214,8 @@ func TestParseSemicolonsBetweenDeclarations(t *testing.T) {
 }
 
 func TestParseInvalidMultipleSemicolonsBetweenDeclarations(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         let x = 1;;let y = 2
@@ -5073,6 +5242,8 @@ func TestParseInvalidMultipleSemicolonsBetweenDeclarations(t *testing.T) {
 
 func TestParseInvalidTypeWithWhitespace(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
 	    let x: Int ? = 1
 	`)
@@ -5097,6 +5268,8 @@ func TestParseInvalidTypeWithWhitespace(t *testing.T) {
 }
 
 func TestParseResource(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         resource Test {}
@@ -5126,6 +5299,8 @@ func TestParseResource(t *testing.T) {
 }
 
 func TestParseEvent(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         event Transfer(to: Address, from: Address)
@@ -5214,6 +5389,8 @@ func TestParseEvent(t *testing.T) {
 
 func TestParseEventEmitStatement(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
       fun test() {
         emit Transfer(to: 1, from: 2)
@@ -5271,6 +5448,8 @@ func TestParseEventEmitStatement(t *testing.T) {
 
 func TestParseResourceReturnType(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
         fun test(): @X {}
 	`
@@ -5316,6 +5495,8 @@ func TestParseResourceReturnType(t *testing.T) {
 
 func TestParseMovingVariableDeclaration(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
         let x <- y
 	`
@@ -5347,6 +5528,8 @@ func TestParseMovingVariableDeclaration(t *testing.T) {
 }
 
 func TestParseMoveStatement(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         fun test() {
@@ -5417,6 +5600,8 @@ func TestParseMoveStatement(t *testing.T) {
 
 func TestParseMoveOperator(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
       let x = foo(<-y)
 	`
@@ -5468,6 +5653,8 @@ func TestParseMoveOperator(t *testing.T) {
 }
 
 func TestParseResourceParameterType(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
         fun test(x: @X) {}
@@ -5537,6 +5724,8 @@ func TestParseResourceParameterType(t *testing.T) {
 
 func TestParseMovingVariableDeclarationWithTypeAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         let x: @R <- y
 	`)
@@ -5580,6 +5769,8 @@ func TestParseMovingVariableDeclarationWithTypeAnnotation(t *testing.T) {
 }
 
 func TestParseFieldDeclarationWithMoveTypeAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         struct X { x: @R }
@@ -5635,6 +5826,8 @@ func TestParseFieldDeclarationWithMoveTypeAnnotation(t *testing.T) {
 
 func TestParseFunctionTypeWithResourceTypeAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         let f: ((): @R) = g
 	`)
@@ -5689,6 +5882,8 @@ func TestParseFunctionTypeWithResourceTypeAnnotation(t *testing.T) {
 }
 
 func TestParseFunctionExpressionWithResourceTypeAnnotation(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
         let f = fun (): @R { return X }
@@ -5758,6 +5953,8 @@ func TestParseFunctionExpressionWithResourceTypeAnnotation(t *testing.T) {
 
 func TestParseFailableCastingResourceTypeAnnotation(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         let y = x as? @R
 	`)
@@ -5809,6 +6006,8 @@ func TestParseFailableCastingResourceTypeAnnotation(t *testing.T) {
 
 func TestParseCasting(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         let y = x as Y
 	`)
@@ -5858,6 +6057,8 @@ func TestParseCasting(t *testing.T) {
 }
 
 func TestParseFunctionExpressionStatementAfterVariableDeclarationWithCreateExpression(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
       fun test() {
@@ -5974,6 +6175,8 @@ func TestParseFunctionExpressionStatementAfterVariableDeclarationWithCreateExpre
 
 func TestParseIdentifiers(t *testing.T) {
 
+	t.Parallel()
+
 	for _, name := range []string{"foo", "from", "create", "destroy"} {
 		_, _, err := parser.ParseProgram(fmt.Sprintf(`
           let %s = 1
@@ -5987,6 +6190,8 @@ func TestParseIdentifiers(t *testing.T) {
 // does *not* consume an expression from the next statement as the return value
 //
 func TestParseExpressionStatementAfterReturnStatement(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
       fun test() {
@@ -6058,6 +6263,8 @@ func TestParseExpressionStatementAfterReturnStatement(t *testing.T) {
 }
 
 func TestParseSwapStatement(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
       fun test() {
@@ -6146,6 +6353,8 @@ func TestParseSwapStatement(t *testing.T) {
 
 func TestParseDestructor(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
         resource Test {
             destroy() {}
@@ -6204,6 +6413,8 @@ func TestParseDestructor(t *testing.T) {
 
 func TestParseReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
        let x: &[&R] = 1
 	`
@@ -6259,6 +6470,8 @@ func TestParseReferenceType(t *testing.T) {
 
 func TestParseOptionalReference(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
        let x: &R? = 1
 	`
@@ -6309,6 +6522,8 @@ func TestParseOptionalReference(t *testing.T) {
 }
 
 func TestParseRestrictedReferenceTypeWithBaseType(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
        let x: &R{I} = 1
@@ -6373,6 +6588,8 @@ func TestParseRestrictedReferenceTypeWithBaseType(t *testing.T) {
 
 func TestParseRestrictedReferenceTypeWithoutBaseType(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
        let x: &{I} = 1
 	`)
@@ -6429,6 +6646,8 @@ func TestParseRestrictedReferenceTypeWithoutBaseType(t *testing.T) {
 }
 
 func TestParseOptionalRestrictedType(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
        let x: @R{I}? = 1
@@ -6493,6 +6712,8 @@ func TestParseOptionalRestrictedType(t *testing.T) {
 
 func TestParseOptionalRestrictedTypeOnlyRestrictions(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
        let x: @{I}? = 1
 	`)
@@ -6549,6 +6770,8 @@ func TestParseOptionalRestrictedTypeOnlyRestrictions(t *testing.T) {
 }
 
 func TestParseReference(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
        let x = &account.storage[R] as &R
@@ -6613,6 +6836,8 @@ func TestParseReference(t *testing.T) {
 }
 
 func TestParseCompositeDeclarationWithSemicolonSeparatedMembers(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
         struct Kitty { let id: Int ; init(id: Int) { self.id = id } }
@@ -6739,6 +6964,8 @@ func TestParseCompositeDeclarationWithSemicolonSeparatedMembers(t *testing.T) {
 
 func TestParseAccessModifiers(t *testing.T) {
 
+	t.Parallel()
+
 	type declaration struct {
 		name, code string
 	}
@@ -6815,6 +7042,9 @@ func TestParseAccessModifiers(t *testing.T) {
 }
 
 func TestParseTransactionDeclaration(t *testing.T) {
+
+	t.Parallel()
+
 	t.Run("EmptyTransaction", func(t *testing.T) {
 		actual, _, err := parser.ParseProgram(`
 		  transaction {}
@@ -7505,6 +7735,8 @@ func TestParseTransactionDeclaration(t *testing.T) {
 
 func TestParseAuthorizedReferenceType(t *testing.T) {
 
+	t.Parallel()
+
 	actual, _, err := parser.ParseProgram(`
        let x: auth &R = 1
 	`)
@@ -7556,6 +7788,8 @@ func TestParseAuthorizedReferenceType(t *testing.T) {
 
 func TestParseFixedPointExpression(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    let a = -1234_5678_90.0009_8765_4321
 	`
@@ -7590,6 +7824,8 @@ func TestParseFixedPointExpression(t *testing.T) {
 }
 
 func TestParseFixedPointExpressionZeroInteger(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
 	    let a = -0.1
@@ -7794,6 +8030,8 @@ func BenchmarkParseFungibleToken(b *testing.B) {
 
 func TestParsePathLiteral(t *testing.T) {
 
+	t.Parallel()
+
 	const code = `
 	    let a = /foo/bar
 	`
@@ -7829,6 +8067,8 @@ func TestParsePathLiteral(t *testing.T) {
 
 func TestParseInvalidForceCast(t *testing.T) {
 
+	t.Parallel()
+
 	_, _, err := parser.ParseReplInput("1 as!! Int\n")
 
 	require.Error(t, err)
@@ -7848,6 +8088,8 @@ func TestParseInvalidForceCast(t *testing.T) {
 
 func TestParseInvalidNegativeIntegerLiteralWithIncorrectPrefix(t *testing.T) {
 
+	t.Parallel()
+
 	_, _, err := parser.ParseProgram(`
 	    let e = -0K0
 	`)
@@ -7856,6 +8098,8 @@ func TestParseInvalidNegativeIntegerLiteralWithIncorrectPrefix(t *testing.T) {
 }
 
 func TestParseConstantSizedSizedArrayWithTrailingUnderscoreSize(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 	  let T:[d;0_]=0
@@ -7874,6 +8118,8 @@ func TestParseConstantSizedSizedArrayWithTrailingUnderscoreSize(t *testing.T) {
 }
 
 func TestParsePreconditionWithUnaryNegation(t *testing.T) {
+
+	t.Parallel()
 
 	actual, _, err := parser.ParseProgram(`
 	  fun test() {
@@ -7965,6 +8211,8 @@ func TestParsePreconditionWithUnaryNegation(t *testing.T) {
 }
 
 func TestParseBitwiseExpression(t *testing.T) {
+
+	t.Parallel()
 
 	const code = `
       let a = 1 | 2 ^ 3 & 4 << 5 >> 6

--- a/runtime/trampoline/trampoline_test.go
+++ b/runtime/trampoline/trampoline_test.go
@@ -27,6 +27,8 @@ import (
 
 func TestFlatMapDone(t *testing.T) {
 
+	t.Parallel()
+
 	trampoline := Done{23}.
 		FlatMap(func(value interface{}) Trampoline {
 			number := value.(int)
@@ -37,6 +39,8 @@ func TestFlatMapDone(t *testing.T) {
 }
 
 func TestFlatMapMore(t *testing.T) {
+
+	t.Parallel()
 
 	trampoline :=
 		More(func() Trampoline { return Done{23} }).
@@ -49,6 +53,8 @@ func TestFlatMapMore(t *testing.T) {
 }
 
 func TestFlatMap2(t *testing.T) {
+
+	t.Parallel()
 
 	trampoline :=
 		More(func() Trampoline { return Done{23} }).
@@ -68,6 +74,8 @@ func TestFlatMap2(t *testing.T) {
 
 func TestFlatMap3(t *testing.T) {
 
+	t.Parallel()
+
 	trampoline :=
 		More(func() Trampoline {
 			return Done{23}.
@@ -86,6 +94,8 @@ func TestFlatMap3(t *testing.T) {
 
 func TestMap(t *testing.T) {
 
+	t.Parallel()
+
 	trampoline :=
 		More(func() Trampoline { return Done{23} }).
 			Map(func(value interface{}) interface{} {
@@ -98,6 +108,8 @@ func TestMap(t *testing.T) {
 
 func TestMap2(t *testing.T) {
 
+	t.Parallel()
+
 	trampoline :=
 		Done{23}.
 			Map(func(value interface{}) interface{} {
@@ -109,6 +121,8 @@ func TestMap2(t *testing.T) {
 }
 
 func TestEvenOdd(t *testing.T) {
+
+	t.Parallel()
 
 	var even, odd func(n interface{}) Trampoline
 
@@ -144,6 +158,8 @@ func TestEvenOdd(t *testing.T) {
 }
 
 func TestAckermann(t *testing.T) {
+
+	t.Parallel()
 
 	// The recursive implementation of the Ackermann function
 	// results in a stack overflow even for small inputs:


### PR DESCRIPTION
- Flag top-level test functions to be run in parallel
- Flag sub-tests for new parsers to be run in parallel
- Run tests in parallel

This cuts test times in half