### PR TITLE
New Parser: Function block with pre/post conditions

### DIFF
--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -549,6 +549,140 @@ func TestParseFunctionDeclaration(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("without return type, with pre and post conditions", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseStatements(`
+          fun foo () {
+              pre {
+                 true : "test"
+                 2 > 1 : "foo"
+              }
+
+              post {
+                 false
+              }
+
+              bar()
+          }
+        `)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Statement{
+				&ast.FunctionDeclaration{
+					Identifier: ast.Identifier{
+						Identifier: "foo",
+						Pos:        ast.Position{Line: 2, Column: 14, Offset: 15},
+					},
+					ParameterList: &ast.ParameterList{
+						Parameters: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 2, Column: 18, Offset: 19},
+							EndPos:   ast.Position{Line: 2, Column: 19, Offset: 20},
+						},
+					},
+					ReturnTypeAnnotation: &ast.TypeAnnotation{
+						IsResource: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "",
+								Pos:        ast.Position{Line: 2, Column: 19, Offset: 20},
+							},
+						},
+						StartPos: ast.Position{Line: 2, Column: 19, Offset: 20},
+					},
+					FunctionBlock: &ast.FunctionBlock{
+						PreConditions: &ast.Conditions{
+							{
+								Kind: ast.ConditionKindPre,
+								Test: &ast.BoolExpression{
+									Value: true,
+									Range: ast.Range{
+										StartPos: ast.Position{Line: 4, Column: 17, Offset: 61},
+										EndPos:   ast.Position{Line: 4, Column: 20, Offset: 64},
+									},
+								},
+								Message: &ast.StringExpression{
+									Value: "test",
+									Range: ast.Range{
+										StartPos: ast.Position{Line: 4, Column: 24, Offset: 68},
+										EndPos:   ast.Position{Line: 4, Column: 29, Offset: 73},
+									},
+								},
+							},
+							{
+								Kind: ast.ConditionKindPre,
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationGreater,
+									Left: &ast.IntegerExpression{
+										Value: big.NewInt(2),
+										Base:  10,
+										Range: ast.Range{
+											StartPos: ast.Position{Line: 5, Column: 17, Offset: 92},
+											EndPos:   ast.Position{Line: 5, Column: 17, Offset: 92},
+										},
+									},
+									Right: &ast.IntegerExpression{
+										Value: big.NewInt(1),
+										Base:  10,
+										Range: ast.Range{
+											StartPos: ast.Position{Line: 5, Column: 21, Offset: 96},
+											EndPos:   ast.Position{Line: 5, Column: 21, Offset: 96},
+										},
+									},
+								},
+								Message: &ast.StringExpression{
+									Value: "foo",
+									Range: ast.Range{
+										StartPos: ast.Position{Line: 5, Column: 25, Offset: 100},
+										EndPos:   ast.Position{Line: 5, Column: 29, Offset: 104},
+									},
+								},
+							},
+						},
+						PostConditions: &ast.Conditions{
+							{
+								Kind: ast.ConditionKindPost,
+								Test: &ast.BoolExpression{
+									Value: false,
+									Range: ast.Range{
+										StartPos: ast.Position{Line: 9, Column: 17, Offset: 161},
+										EndPos:   ast.Position{Line: 9, Column: 21, Offset: 165},
+									},
+								},
+								Message: nil,
+							},
+						},
+						Block: &ast.Block{
+							Statements: []ast.Statement{
+								&ast.ExpressionStatement{
+									Expression: &ast.InvocationExpression{
+										InvokedExpression: &ast.IdentifierExpression{
+											Identifier: ast.Identifier{
+												Identifier: "bar",
+												Pos:        ast.Position{Line: 12, Column: 14, Offset: 198},
+											},
+										},
+										EndPos: ast.Position{Line: 12, Column: 18, Offset: 202},
+									},
+								},
+							},
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 2, Column: 21, Offset: 22},
+								EndPos:   ast.Position{Line: 13, Column: 10, Offset: 214},
+							},
+						},
+					},
+					StartPos: ast.Position{Line: 2, Column: 10, Offset: 11},
+				},
+			},
+			result,
+		)
+	})
+
 }
 
 func TestParseAccess(t *testing.T) {

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -803,11 +803,12 @@ func parseExpression(p *parser, rightBindingPower int) ast.Expression {
 	p.skipSpaceAndComments(true)
 	t := p.current
 	p.next()
-	p.skipSpaceAndComments(true)
+
+	newLineAfterLeft := p.skipSpaceAndComments(true)
 
 	left := applyExprNullDenotation(p, t)
 
-	newLineAfterLeft := p.skipSpaceAndComments(true)
+	newLineAfterLeft = p.skipSpaceAndComments(true) || newLineAfterLeft
 
 	if newLineAfterLeft && !exprLeftDenotationAllowsNewline(p.current.Type) {
 		return left

--- a/runtime/parser2/function.go
+++ b/runtime/parser2/function.go
@@ -221,11 +221,6 @@ func parseFunctionParameterListAndRest(p *parser) (
 		}
 	}
 
-	// TODO: parse function block
-	block := parseBlock(p)
-	functionBlock = &ast.FunctionBlock{
-		Block: block,
-	}
-
+	functionBlock = parseFunctionBlock(p)
 	return
 }

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -54,6 +54,8 @@ const keywordContract = "contract"
 const keywordAccount = "account"
 const keywordImport = "import"
 const keywordFrom = "from"
+const keywordPre = "pre"
+const keywordPost = "post"
 
 const lowestBindingPower = 0
 
@@ -131,6 +133,7 @@ func (p *parser) skipSpaceAndComments(skipNewlines bool) (containsNewline bool) 
 		switch p.current.Type {
 		case lexer.TokenSpace:
 			space := p.current.Value.(lexer.Space)
+
 			if space.ContainsNewline {
 				containsNewline = true
 			}

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -4483,6 +4483,7 @@ func TestParsePreAndPostConditions(t *testing.T) {
 				StartPos: Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
+		nil,
 	)
 }
 
@@ -4714,6 +4715,7 @@ func TestParseConditionMessage(t *testing.T) {
 				StartPos: Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
+		nil,
 	)
 }
 
@@ -8258,6 +8260,7 @@ func TestParsePreconditionWithUnaryNegation(t *testing.T) {
 				StartPos: Position{Offset: 4, Line: 2, Column: 3},
 			},
 		},
+		nil,
 	)
 }
 

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -4330,7 +4330,7 @@ func TestParsePreAndPostConditions(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	const code = `
         fun test(n: Int) {
             pre {
                 n != 0
@@ -4341,12 +4341,12 @@ func TestParsePreAndPostConditions(t *testing.T) {
             }
             return 0
         }
-	`)
+	`
 
-	require.NoError(t, err)
-
-	expected := &Program{
-		Declarations: []Declaration{
+	testParse(
+		t,
+		code,
+		[]Declaration{
 			&FunctionDeclaration{
 				Access: AccessNotSpecified,
 				Identifier: Identifier{
@@ -4483,9 +4483,7 @@ func TestParsePreAndPostConditions(t *testing.T) {
 				StartPos: Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
-	}
-
-	utils.AssertEqualWithDiff(t, expected, actual)
+	)
 }
 
 func TestParseExpression(t *testing.T) {
@@ -4604,19 +4602,19 @@ func TestParseConditionMessage(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	const code = `
         fun test(n: Int) {
             pre {
                 n >= 0: "n must be positive"
             }
             return n
         }
-	`)
+	`
 
-	require.NoError(t, err)
-
-	expected := &Program{
-		Declarations: []Declaration{
+	testParse(
+		t,
+		code,
+		[]Declaration{
 			&FunctionDeclaration{
 				Access: AccessNotSpecified,
 				Identifier: Identifier{
@@ -4716,9 +4714,7 @@ func TestParseConditionMessage(t *testing.T) {
 				StartPos: Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
-	}
-
-	utils.AssertEqualWithDiff(t, expected, actual)
+	)
 }
 
 func TestParseOptionalType(t *testing.T) {
@@ -8179,93 +8175,90 @@ func TestParsePreconditionWithUnaryNegation(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	const code = `
 	  fun test() {
           pre {
               true: "one"
               !false: "two"
           }
       }
-	`)
-
-	require.NoError(t, err)
-
-	a := &FunctionDeclaration{
-		Access: AccessNotSpecified,
-		Identifier: Identifier{
-			Identifier: "test",
-			Pos:        Position{Offset: 8, Line: 2, Column: 7},
-		},
-		ParameterList: &ParameterList{
-			Range: Range{
-				StartPos: Position{Offset: 12, Line: 2, Column: 11},
-				EndPos:   Position{Offset: 13, Line: 2, Column: 12},
-			},
-		},
-		ReturnTypeAnnotation: &TypeAnnotation{
-			Type: &NominalType{
+	`
+	testParse(
+		t,
+		code,
+		[]Declaration{
+			&FunctionDeclaration{
+				Access: AccessNotSpecified,
 				Identifier: Identifier{
-					Pos: Position{Offset: 13, Line: 2, Column: 12},
+					Identifier: "test",
+					Pos:        Position{Offset: 8, Line: 2, Column: 7},
 				},
-			},
-			StartPos: Position{Offset: 13, Line: 2, Column: 12},
-		},
-		FunctionBlock: &FunctionBlock{
-			Block: &Block{
-				Range: Range{
-					StartPos: Position{Offset: 15, Line: 2, Column: 14},
-					EndPos:   Position{Offset: 105, Line: 7, Column: 6},
-				},
-			},
-			PreConditions: &Conditions{
-				{
-					Kind: ConditionKindPre,
-					Test: &BoolExpression{
-						Value: true,
-						Range: Range{
-							StartPos: Position{Offset: 47, Line: 4, Column: 14},
-							EndPos:   Position{Offset: 50, Line: 4, Column: 17},
-						},
-					},
-					Message: &StringExpression{
-						Value: "one",
-						Range: Range{
-							StartPos: Position{Offset: 53, Line: 4, Column: 20},
-							EndPos:   Position{Offset: 57, Line: 4, Column: 24},
-						},
+				ParameterList: &ParameterList{
+					Range: Range{
+						StartPos: Position{Offset: 12, Line: 2, Column: 11},
+						EndPos:   Position{Offset: 13, Line: 2, Column: 12},
 					},
 				},
-				{
-					Kind: ConditionKindPre,
-					Test: &UnaryExpression{
-						Operation: OperationNegate,
-						Expression: &BoolExpression{
-							Value: false,
-							Range: Range{
-								StartPos: Position{Offset: 74, Line: 5, Column: 15},
-								EndPos:   Position{Offset: 78, Line: 5, Column: 19},
+				ReturnTypeAnnotation: &TypeAnnotation{
+					Type: &NominalType{
+						Identifier: Identifier{
+							Pos: Position{Offset: 13, Line: 2, Column: 12},
+						},
+					},
+					StartPos: Position{Offset: 13, Line: 2, Column: 12},
+				},
+				FunctionBlock: &FunctionBlock{
+					Block: &Block{
+						Range: Range{
+							StartPos: Position{Offset: 15, Line: 2, Column: 14},
+							EndPos:   Position{Offset: 105, Line: 7, Column: 6},
+						},
+					},
+					PreConditions: &Conditions{
+						{
+							Kind: ConditionKindPre,
+							Test: &BoolExpression{
+								Value: true,
+								Range: Range{
+									StartPos: Position{Offset: 47, Line: 4, Column: 14},
+									EndPos:   Position{Offset: 50, Line: 4, Column: 17},
+								},
+							},
+							Message: &StringExpression{
+								Value: "one",
+								Range: Range{
+									StartPos: Position{Offset: 53, Line: 4, Column: 20},
+									EndPos:   Position{Offset: 57, Line: 4, Column: 24},
+								},
 							},
 						},
-						StartPos: Position{Offset: 73, Line: 5, Column: 14},
-					},
-					Message: &StringExpression{
-						Value: "two",
-						Range: Range{
-							StartPos: Position{Offset: 81, Line: 5, Column: 22},
-							EndPos:   Position{Offset: 85, Line: 5, Column: 26},
+						{
+							Kind: ConditionKindPre,
+							Test: &UnaryExpression{
+								Operation: OperationNegate,
+								Expression: &BoolExpression{
+									Value: false,
+									Range: Range{
+										StartPos: Position{Offset: 74, Line: 5, Column: 15},
+										EndPos:   Position{Offset: 78, Line: 5, Column: 19},
+									},
+								},
+								StartPos: Position{Offset: 73, Line: 5, Column: 14},
+							},
+							Message: &StringExpression{
+								Value: "two",
+								Range: Range{
+									StartPos: Position{Offset: 81, Line: 5, Column: 22},
+									EndPos:   Position{Offset: 85, Line: 5, Column: 26},
+								},
+							},
 						},
 					},
 				},
+				StartPos: Position{Offset: 4, Line: 2, Column: 3},
 			},
 		},
-		StartPos: Position{Offset: 4, Line: 2, Column: 3},
-	}
-
-	expected := &Program{
-		Declarations: []Declaration{a},
-	}
-
-	utils.AssertEqualWithDiff(t, expected, actual)
+	)
 }
 
 func TestParseBitwiseExpression(t *testing.T) {


### PR DESCRIPTION
Work towards dapperlabs/flow-go#3764

Also, fix the requirement that left denotations for `!` and `(` can't precede newlines: consider both cases where whitespace is skipped.