### PR TITLE
Include payer in AuthAccount constructor

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -41,7 +41,7 @@ type Interface interface {
 	// SetValue sets a value for the given key in the storage, controlled and owned by the given accounts.
 	SetValue(owner, controller, key, value []byte) (err error)
 	// CreateAccount creates a new account with the given public keys and code.
-	CreateAccount(publicKeys [][]byte) (address Address, err error)
+	CreateAccount(publicKeys [][]byte, payer Address) (address Address, err error)
 	// AddAccountKey appends a key to an account.
 	AddAccountKey(address Address, publicKey []byte) error
 	// RemoveAccountKey removes a key from an account by index.
@@ -102,7 +102,7 @@ func (i *EmptyRuntimeInterface) SetValue(_, _, _, _ []byte) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) CreateAccount(_ [][]byte) (address Address, err error) {
+func (i *EmptyRuntimeInterface) CreateAccount(_ [][]byte, _ Address) (address Address, err error) {
 	return Address{}, nil
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -791,19 +791,28 @@ func (r *interpreterRuntime) newCreateAccountFunction(
 		for i, pkVal := range pkValues {
 			publicKey, err := interpreter.ByteArrayValueToByteSlice(pkVal)
 			if err != nil {
-				panic(fmt.Sprintf("AuthAccount requires the first parameter to be an array of keys ([[Int]])"))
+				panic(fmt.Sprintf(
+					"%s requires the first parameter to be an array of keys ([[Int]])",
+					&sema.AuthAccountType{},
+				))
 			}
 			publicKeys[i] = publicKey
 		}
 
 		code, err := interpreter.ByteArrayValueToByteSlice(invocation.Arguments[1])
 		if err != nil {
-			panic(fmt.Sprintf("AuthAccount requires the second parameter to be an array of bytes ([Int])"))
+			panic(fmt.Sprintf(
+				"%s requires the second parameter to be an array of bytes ([[Int]])",
+				&sema.AuthAccountType{},
+			))
 		}
 
-		payer, ok := invocation.Arguments[2].(interpreter.AccountValue)
+		payer, ok := invocation.Arguments[2].(interpreter.AuthAccountValue)
 		if !ok {
-			panic(fmt.Sprintf("AuthAccount requires the third parameter to be an AuthAccount"))
+			panic(fmt.Sprintf(
+				"%[1]s requires the third parameter to be an %[1]s",
+				&sema.AuthAccountType{},
+			))
 		}
 
 		var address Address

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3999,10 +3999,9 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	createAccountScript := []byte(`
         transaction {
-            prepare() {
-                AuthAccount(publicKeys: [], code: [])
+            prepare(signer: AuthAccount) {
+                AuthAccount(publicKeys: [], code: [], payer: signer)
             }
-            execute {}
         }
     `)
 
@@ -4029,7 +4028,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	var signerAddresses []Address
 
 	runtimeInterface := &testRuntimeInterface{
-		createAccount: func(publicKeys [][]byte) (address Address, err error) {
+		createAccount: func(publicKeys [][]byte, payer Address) (address Address, err error) {
 			accountCounter++
 			return Address{accountCounter}, nil
 		},
@@ -4059,6 +4058,8 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
+
+	signerAddresses = []Address{{accountCounter}}
 
 	err := runtime.ExecuteTransaction(createAccountScript, nil, runtimeInterface, nextTransactionLocation())
 	require.NoError(t, err)

--- a/runtime/stdlib/flow_builtin.go
+++ b/runtime/stdlib/flow_builtin.go
@@ -53,13 +53,20 @@ var accountFunctionType = &sema.FunctionType{
 				},
 			),
 		},
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "payer",
+			TypeAnnotation: sema.NewTypeAnnotation(
+				&sema.AuthAccountType{},
+			),
+		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		&sema.AuthAccountType{},
 	),
 	// additional arguments are passed to the contract initializer
 	RequiredArgumentCount: (func() *int {
-		var count = 2
+		var count = 3
 		return &count
 	})(),
 }


### PR DESCRIPTION
Work towards: https://github.com/dapperlabs/flow-go/issues/3739

## Description

This PR updates the `AuthAccount` constructor to accept a `payer` argument, from which the account creation fee will be deducted.