### PR TITLE
Remove publicKeys, code parameters from AuthAccount constructor

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -40,8 +40,8 @@ type Interface interface {
 	GetValue(owner, controller, key []byte) (value []byte, err error)
 	// SetValue sets a value for the given key in the storage, controlled and owned by the given accounts.
 	SetValue(owner, controller, key, value []byte) (err error)
-	// CreateAccount creates a new account with the given public keys and code.
-	CreateAccount(publicKeys [][]byte, payer Address) (address Address, err error)
+	// CreateAccount creates a new account.
+	CreateAccount(payer Address) (address Address, err error)
 	// AddAccountKey appends a key to an account.
 	AddAccountKey(address Address, publicKey []byte) error
 	// RemoveAccountKey removes a key from an account by index.
@@ -102,7 +102,7 @@ func (i *EmptyRuntimeInterface) SetValue(_, _, _, _ []byte) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) CreateAccount(_ [][]byte, _ Address) (address Address, err error) {
+func (i *EmptyRuntimeInterface) CreateAccount(_ Address) (address Address, err error) {
 	return Address{}, nil
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1830,6 +1830,107 @@ func TestRuntimeTransaction_CreateAccountEmpty(t *testing.T) {
 	assert.Len(t, events, 1)
 }
 
+func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
+	runtime := NewInterpreterRuntime()
+
+	keyA := cadence.NewArray([]cadence.Value{
+		cadence.NewInt(1),
+		cadence.NewInt(2),
+		cadence.NewInt(3),
+	})
+
+	keyB := cadence.NewArray([]cadence.Value{
+		cadence.NewInt(3),
+		cadence.NewInt(4),
+		cadence.NewInt(5),
+	})
+
+	keys := cadence.NewArray([]cadence.Value{
+		keyA,
+		keyB,
+	})
+
+	var tests = []struct {
+		name     string
+		code     string
+		keyCount int
+		args     []cadence.Value
+	}{
+		{
+			name: "Single key",
+			code: `
+			  transaction(keyA: [Int]) {
+				prepare(signer: AuthAccount) {
+				  let acct = AuthAccount(payer: signer)
+				  acct.addPublicKey(keyA)
+				}
+			  }
+			`,
+			keyCount: 1,
+			args:     []cadence.Value{keyA},
+		},
+		{
+			name: "Multiple keys",
+			code: `
+			  transaction(keys: [[Int]]) {
+				prepare(signer: AuthAccount) {
+				  let acct = AuthAccount(payer: signer)
+				  for key in keys {
+					acct.addPublicKey(key)
+				  }
+				}
+			  }
+			`,
+			keyCount: 2,
+			args:     []cadence.Value{keys},
+		},
+	}
+
+	for _, tt := range tests {
+
+		var events []cadence.Event
+		var keys [][]byte
+
+		runtimeInterface := &testRuntimeInterface{
+			storage: newTestStorage(nil, nil),
+			getSigningAccounts: func() []Address {
+				return []Address{{42}}
+			},
+			createAccount: func(payer Address) (address Address, err error) {
+				return Address{42}, nil
+			},
+			addAccountKey: func(address Address, publicKey []byte) error {
+				keys = append(keys, publicKey)
+				return nil
+			},
+			emitEvent: func(event cadence.Event) {
+				events = append(events, event)
+			},
+			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return jsoncdc.Decode(b)
+			},
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			args := make([][]byte, len(tt.args))
+			for i, arg := range tt.args {
+				args[i], _ = jsoncdc.Encode(arg)
+			}
+
+			err := runtime.ExecuteTransaction([]byte(tt.code), args, runtimeInterface, utils.TestLocation)
+			require.NoError(t, err)
+			assert.Len(t, events, tt.keyCount+1)
+			assert.Len(t, keys, tt.keyCount)
+
+			assert.EqualValues(t, stdlib.AccountCreatedEventType.ID(), events[0].Type().ID())
+
+			for _, event := range events[1:] {
+				assert.EqualValues(t, stdlib.AccountKeyAddedEventType.ID(), event.Type().ID())
+			}
+		})
+	}
+}
+
 func TestRuntimeCyclicImport(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2658,7 +2658,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
               transaction {
                 prepare(signer: AuthAccount) {
                   let acct = AuthAccount(payer: signer)
-				  acct.setCode(%s)
+                  acct.setCode(%s)
                 }
               }
             `,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2557,7 +2557,7 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
           transaction {
             prepare(signer: AuthAccount) {
                 let acct = AuthAccount(payer: signer)
-				acct.setCode(%s)
+                acct.setCode(%s)
             }
           }
         `,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4184,7 +4184,7 @@ var authAccountSetCodeFunctionType = &FunctionType{
 	),
 	// additional arguments are passed to the contract initializer
 	RequiredArgumentCount: (func() *int {
-		var count = 2
+		var count = 1
 		return &count
 	})(),
 }

--- a/runtime/stdlib/flow_builtin.go
+++ b/runtime/stdlib/flow_builtin.go
@@ -35,26 +35,6 @@ var accountFunctionType = &sema.FunctionType{
 	Parameters: []*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "publicKeys",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				&sema.VariableSizedType{
-					Type: &sema.VariableSizedType{
-						Type: &sema.IntType{},
-					},
-				},
-			),
-		},
-		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "code",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				&sema.VariableSizedType{
-					Type: &sema.IntType{},
-				},
-			),
-		},
-		{
-			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "payer",
 			TypeAnnotation: sema.NewTypeAnnotation(
 				&sema.AuthAccountType{},
@@ -64,11 +44,6 @@ var accountFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		&sema.AuthAccountType{},
 	),
-	// additional arguments are passed to the contract initializer
-	RequiredArgumentCount: (func() *int {
-		var count = 3
-		return &count
-	})(),
 }
 
 var getAccountFunctionType = &sema.FunctionType{
@@ -236,8 +211,6 @@ var AccountEventContractsParameter = &sema.Parameter{
 var AccountCreatedEventType = newFlowEventType(
 	"AccountCreated",
 	AccountEventAddressParameter,
-	AccountEventCodeHashParameter,
-	AccountEventContractsParameter,
 )
 
 var AccountKeyAddedEventType = newFlowEventType(


### PR DESCRIPTION
Work towards: https://github.com/dapperlabs/flow-go/issues/3739

## Description

This PR updates the `AuthAccount` constructor by removing the `publicKeys` and `code` arguments.

This PR also adds a separate test case for `AuthAccount.addPublicKey` now that public key functionality is no longer included or tested in account creation tests.