### PR TITLE
Fix resource dictionary destruction and insertion with deferred values

### DIFF
--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -324,7 +324,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	err = runtime.ExecuteTransaction(replaceTx, nil, runtimeInterface, nextTransactionLocation())
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"3", "4"}, loggedMessages)
+	assert.Equal(t,
+		[]string{
+			"3",
+			`"destroying R"`,
+			"3",
+			"4",
+		},
+		loggedMessages,
+	)
 
 	// TODO: optimize: only value has changed, dictionary itself did not
 
@@ -377,7 +385,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	err = runtime.ExecuteTransaction(removeTx, nil, runtimeInterface, nextTransactionLocation())
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"4", "nil"}, loggedMessages)
+	assert.Equal(t,
+		[]string{
+			"4",
+			`"destroying R"`,
+			"4",
+			"nil",
+		},
+		loggedMessages,
+	)
 
 	// TODO: optimize: only value has changed, dictionary itself did not
 
@@ -456,7 +472,14 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	err = runtime.ExecuteTransaction(destroyTx, nil, runtimeInterface, nextTransactionLocation())
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"1"}, loggedMessages)
+	assert.Equal(t,
+		[]string{
+			"1",
+			`"destroying R"`,
+			"1",
+		},
+		loggedMessages,
+	)
 
 	xStorageKey := []byte("storage\x1fc\x1frs\x1fv\x1fx")
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1893,7 +1893,8 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 				// NOTE: important to convert in optional, as assignment to dictionary
 				// is always considered as an optional
 
-				newDictionary.Insert(key, value)
+				locationRange := interpreter.locationRange(expression)
+				_ = newDictionary.Insert(interpreter, locationRange, key, value)
 			}
 
 			return Done{Result: newDictionary}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5160,10 +5160,9 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, locationRange Locati
 	}
 
 	for _, keyValue := range v.Keys.Values {
+		// Don't use `Entries` here: the value might be deferred and needs to be loaded
+		value := v.Get(interpreter, locationRange, keyValue)
 		maybeDestroy(keyValue)
-	}
-
-	for _, value := range v.Entries {
 		maybeDestroy(value)
 	}
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -257,7 +257,7 @@ func TestSetOwnerDictionaryInsert(t *testing.T) {
 	assert.Equal(t, &newOwner, dictionary.GetOwner())
 	assert.Equal(t, &oldOwner, value.GetOwner())
 
-	dictionary.Insert(keyValue, value)
+	dictionary.Insert(nil, LocationRange{}, keyValue, value)
 
 	assert.Equal(t, &newOwner, dictionary.GetOwner())
 	assert.Equal(t, &newOwner, value.GetOwner())

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -5091,6 +5091,8 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 		interpreter.NewStringValue("def"), interpreter.NewIntValueFromInt64(2),
 	).Copy().(*interpreter.DictionaryValue)
 	expectedDict.Insert(
+		nil,
+		interpreter.LocationRange{},
 		interpreter.NewStringValue("abc"),
 		interpreter.NewIntValueFromInt64(3),
 	)


### PR DESCRIPTION
Related to #128 

When a resource dictionary is destroyed or a key is updated, the value might be deferred. 

Load the deferred values properly instead of only considering loaded values.

Also, simplify/reuse the existing test for ensuring deferred values are properly loaded when removing keys from resource dictionaries.

The diff looks odd, might be best reviewed by looking at the new code in split-diff mode