### PR TITLE
Fix move of resource dictionary value

### DIFF
--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -755,7 +755,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 	)
 }
 
-func TestRuntimeStorageDeferredResourceDictionaryValues_Transfer(t *testing.T) {
+func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *testing.T) {
 
 	signer1 := common.BytesToAddress([]byte{0x1})
 	signer2 := common.BytesToAddress([]byte{0x2})
@@ -1273,7 +1273,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Insertion(t *testing.T) 
 	require.NoError(t, err)
 }
 
-func TestRuntimeStorageDeferredResourceDictionaryValues_TransferAndDestroy(t *testing.T) {
+func TestRuntimeStorageDeferredResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 
 	runtime := NewInterpreterRuntime()
 
@@ -1360,11 +1360,13 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_TransferAndDestroy(t *te
 
 	var signers []Address
 
+	testStorage := newTestStorage(nil, nil)
+
 	runtimeInterface := &testRuntimeInterface{
 		resolveImport: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestStorage(nil, nil),
+		storage: testStorage,
 		getSigningAccounts: func() []Address {
 			return signers
 		},

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -1,12 +1,10 @@
 package interpreter
 
 import (
-	"fmt"
 	"math"
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
@@ -38,14 +36,7 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 		require.NoError(t, err)
 
 		if test.encoded != nil {
-			if !assert.Equal(t, test.encoded, encoded) {
-				fmt.Printf(
-					"\nExpected :%x\n"+
-						"Actual   :%x\n\n",
-					test.encoded,
-					encoded,
-				)
-			}
+			utils.AssertEqualWithDiff(t, test.encoded, encoded)
 		}
 	} else {
 		encoded = test.encoded
@@ -63,13 +54,13 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 				test.decodedValue.SetOwner(&testOwner)
 				expectedValue = test.decodedValue
 			}
-			require.Equal(t, expectedValue, decoded)
+			utils.AssertEqualWithDiff(t, expectedValue, decoded)
 		}
 	}
 
 	if test.value != nil {
 		if test.deferred {
-			require.Equal(t, test.deferrals, deferrals)
+			utils.AssertEqualWithDiff(t, test.deferrals, deferrals)
 		} else {
 			require.Empty(t, deferrals.Values)
 			require.Empty(t, deferrals.Moves)
@@ -252,25 +243,28 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 
 	t.Run("non-empty", func(t *testing.T) {
 		key1 := NewStringValue("test")
-		key1.modified = false
 		value1 := NewArrayValueUnownedNonCopying()
-		value1.modified = false
 
 		key2 := BoolValue(true)
 		value2 := BoolValue(false)
 
 		key3 := NewStringValue("foo")
-		key3.modified = false
 		value3 := NewStringValue("bar")
-		value3.modified = false
 
 		expected := NewDictionaryValueUnownedNonCopying(
 			key1, value1,
 			key2, value2,
 			key3, value3,
 		)
+
 		expected.modified = false
 		expected.Keys.modified = false
+
+		key1.modified = false
+		value1.modified = false
+
+		key3.modified = false
+		value3.modified = false
 
 		testEncodeDecode(t,
 			encodeDecodeTest{

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -86,8 +86,12 @@ func (InterpretedFunctionValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (InterpretedFunctionValue) Modified() bool {
+func (InterpretedFunctionValue) IsModified() bool {
 	return false
+}
+
+func (InterpretedFunctionValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (InterpretedFunctionValue) isFunctionValue() {}
@@ -137,8 +141,12 @@ func (HostFunctionValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (HostFunctionValue) Modified() bool {
+func (HostFunctionValue) IsModified() bool {
 	return false
+}
+
+func (HostFunctionValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (HostFunctionValue) isFunctionValue() {}
@@ -185,8 +193,12 @@ func (BoundFunctionValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (BoundFunctionValue) Modified() bool {
+func (BoundFunctionValue) IsModified() bool {
 	return false
+}
+
+func (BoundFunctionValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (BoundFunctionValue) isFunctionValue() {}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -27,7 +27,8 @@ type Value interface {
 	Copy() Value
 	GetOwner() *common.Address
 	SetOwner(address *common.Address)
-	Modified() bool
+	IsModified() bool
+	SetModified(modified bool)
 }
 
 // ValueIndexableValue
@@ -92,8 +93,12 @@ func (VoidValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (VoidValue) Modified() bool {
+func (VoidValue) IsModified() bool {
 	return false
+}
+
+func (VoidValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (VoidValue) String() string {
@@ -123,8 +128,12 @@ func (BoolValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (BoolValue) Modified() bool {
+func (BoolValue) IsModified() bool {
 	return false
+}
+
+func (BoolValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v BoolValue) Negate() BoolValue {
@@ -180,8 +189,12 @@ func (*StringValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (v *StringValue) Modified() bool {
+func (v *StringValue) IsModified() bool {
 	return v.modified
+}
+
+func (v *StringValue) SetModified(modified bool) {
+	v.modified = modified
 }
 
 func (v *StringValue) String() string {
@@ -322,10 +335,6 @@ func (*StringValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 	panic(errors.NewUnreachableError())
 }
 
-func (v *StringValue) SetModified(modified bool) {
-	v.modified = false
-}
-
 // ArrayValue
 
 type ArrayValue struct {
@@ -391,18 +400,22 @@ func (v *ArrayValue) SetOwner(owner *common.Address) {
 	}
 }
 
-func (v *ArrayValue) Modified() bool {
+func (v *ArrayValue) IsModified() bool {
 	if v.modified {
 		return true
 	}
 
 	for _, value := range v.Values {
-		if value.Modified() {
+		if value.IsModified() {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (v *ArrayValue) SetModified(modified bool) {
+	v.modified = modified
 }
 
 func (v *ArrayValue) Destroy(interpreter *Interpreter, locationRange LocationRange) trampoline.Trampoline {
@@ -591,10 +604,6 @@ func (v *ArrayValue) Count() int {
 	return len(v.Values)
 }
 
-func (v *ArrayValue) SetModified(modified bool) {
-	v.modified = modified
-}
-
 // NumberValue
 
 type NumberValue interface {
@@ -676,8 +685,12 @@ func (IntValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (IntValue) Modified() bool {
+func (IntValue) IsModified() bool {
 	return false
+}
+
+func (IntValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v IntValue) ToInt() int {
@@ -863,8 +876,12 @@ func (Int8Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Int8Value) Modified() bool {
+func (Int8Value) IsModified() bool {
 	return false
+}
+
+func (Int8Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Int8Value) String() string {
@@ -1078,8 +1095,12 @@ func (Int16Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Int16Value) Modified() bool {
+func (Int16Value) IsModified() bool {
 	return false
+}
+
+func (Int16Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Int16Value) String() string {
@@ -1293,8 +1314,12 @@ func (Int32Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Int32Value) Modified() bool {
+func (Int32Value) IsModified() bool {
 	return false
+}
+
+func (Int32Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Int32Value) String() string {
@@ -1508,8 +1533,12 @@ func (Int64Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Int64Value) Modified() bool {
+func (Int64Value) IsModified() bool {
 	return false
+}
+
+func (Int64Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Int64Value) String() string {
@@ -1731,8 +1760,12 @@ func (Int128Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Int128Value) Modified() bool {
+func (Int128Value) IsModified() bool {
 	return false
+}
+
+func (Int128Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Int128Value) ToInt() int {
@@ -2006,8 +2039,12 @@ func (Int256Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Int256Value) Modified() bool {
+func (Int256Value) IsModified() bool {
 	return false
+}
+
+func (Int256Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Int256Value) ToInt() int {
@@ -2302,8 +2339,12 @@ func (UIntValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UIntValue) Modified() bool {
+func (UIntValue) IsModified() bool {
 	return false
+}
+
+func (UIntValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UIntValue) ToInt() int {
@@ -2492,8 +2533,12 @@ func (UInt8Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UInt8Value) Modified() bool {
+func (UInt8Value) IsModified() bool {
 	return false
+}
+
+func (UInt8Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UInt8Value) String() string {
@@ -2674,8 +2719,12 @@ func (UInt16Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UInt16Value) Modified() bool {
+func (UInt16Value) IsModified() bool {
 	return false
+}
+
+func (UInt16Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UInt16Value) String() string {
@@ -2856,8 +2905,12 @@ func (UInt32Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UInt32Value) Modified() bool {
+func (UInt32Value) IsModified() bool {
 	return false
+}
+
+func (UInt32Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UInt32Value) String() string {
@@ -3039,8 +3092,12 @@ func (UInt64Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UInt64Value) Modified() bool {
+func (UInt64Value) IsModified() bool {
 	return false
+}
+
+func (UInt64Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UInt64Value) String() string {
@@ -3235,8 +3292,12 @@ func (UInt128Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UInt128Value) Modified() bool {
+func (UInt128Value) IsModified() bool {
 	return false
+}
+
+func (UInt128Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UInt128Value) ToInt() int {
@@ -3480,8 +3541,12 @@ func (UInt256Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UInt256Value) Modified() bool {
+func (UInt256Value) IsModified() bool {
 	return false
+}
+
+func (UInt256Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UInt256Value) ToInt() int {
@@ -3715,8 +3780,12 @@ func (Word8Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Word8Value) Modified() bool {
+func (Word8Value) IsModified() bool {
 	return false
+}
+
+func (Word8Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Word8Value) String() string {
@@ -3858,8 +3927,12 @@ func (Word16Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Word16Value) Modified() bool {
+func (Word16Value) IsModified() bool {
 	return false
+}
+
+func (Word16Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Word16Value) String() string {
@@ -4001,8 +4074,12 @@ func (Word32Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Word32Value) Modified() bool {
+func (Word32Value) IsModified() bool {
 	return false
+}
+
+func (Word32Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Word32Value) String() string {
@@ -4145,8 +4222,12 @@ func (Word64Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Word64Value) Modified() bool {
+func (Word64Value) IsModified() bool {
 	return false
+}
+
+func (Word64Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Word64Value) String() string {
@@ -4306,8 +4387,12 @@ func (Fix64Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (Fix64Value) Modified() bool {
+func (Fix64Value) IsModified() bool {
 	return false
+}
+
+func (Fix64Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v Fix64Value) String() string {
@@ -4546,8 +4631,12 @@ func (UFix64Value) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (UFix64Value) Modified() bool {
+func (UFix64Value) IsModified() bool {
 	return false
+}
+
+func (UFix64Value) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v UFix64Value) String() string {
@@ -4882,30 +4971,34 @@ func (v *CompositeValue) SetOwner(owner *common.Address) {
 	}
 }
 
-func (v *CompositeValue) Modified() bool {
+func (v *CompositeValue) IsModified() bool {
 	if v.modified {
 		return true
 	}
 
 	for _, value := range v.Fields {
-		if value.Modified() {
+		if value.IsModified() {
 			return true
 		}
 	}
 
 	for _, value := range v.InjectedFields {
-		if value.Modified() {
+		if value.IsModified() {
 			return true
 		}
 	}
 
 	for _, value := range v.NestedValues {
-		if value.Modified() {
+		if value.IsModified() {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (v *CompositeValue) SetModified(modified bool) {
+	v.modified = modified
 }
 
 func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
@@ -5126,22 +5219,26 @@ func (v *DictionaryValue) SetOwner(owner *common.Address) {
 	}
 }
 
-func (v *DictionaryValue) Modified() bool {
+func (v *DictionaryValue) IsModified() bool {
 	if v.modified {
 		return true
 	}
 
-	if v.Keys.Modified() {
+	if v.Keys.IsModified() {
 		return true
 	}
 
 	for _, value := range v.Entries {
-		if value.Modified() {
+		if value.IsModified() {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (v *DictionaryValue) SetModified(modified bool) {
+	v.modified = modified
 }
 
 func (v *DictionaryValue) Destroy(interpreter *Interpreter, locationRange LocationRange) trampoline.Trampoline {
@@ -5376,6 +5473,13 @@ func (v *DictionaryValue) Insert(inter *Interpreter, locationRange LocationRange
 
 	value.SetOwner(v.Owner)
 
+	// Mark the inserted value itself modified.
+	// It might have been stored as a deferred value and loaded,
+	// so must be written (potentially as a deferred value again),
+	// and would otherwise be ignored by the writeback optimization.
+
+	value.SetModified(true)
+
 	v.Entries[key] = value
 
 	switch existingValue := existingValue.(type) {
@@ -5389,10 +5493,6 @@ func (v *DictionaryValue) Insert(inter *Interpreter, locationRange LocationRange
 	default:
 		panic(errors.NewUnreachableError())
 	}
-}
-
-func (v *DictionaryValue) SetModified(modified bool) {
-	v.modified = modified
 }
 
 type DictionaryEntryValues struct {
@@ -5432,8 +5532,12 @@ func (NilValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (NilValue) Modified() bool {
+func (NilValue) IsModified() bool {
 	return false
+}
+
+func (NilValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v NilValue) Destroy(_ *Interpreter, _ LocationRange) trampoline.Trampoline {
@@ -5489,8 +5593,12 @@ func (v *SomeValue) SetOwner(owner *common.Address) {
 	v.Value.SetOwner(owner)
 }
 
-func (v *SomeValue) Modified() bool {
-	return v.Value.Modified()
+func (v *SomeValue) IsModified() bool {
+	return v.Value.IsModified()
+}
+
+func (v *SomeValue) SetModified(modified bool) {
+	v.Value.SetModified(modified)
 }
 
 func (v *SomeValue) Destroy(interpreter *Interpreter, locationRange LocationRange) trampoline.Trampoline {
@@ -5542,8 +5650,12 @@ func (v *StorageReferenceValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (*StorageReferenceValue) Modified() bool {
+func (*StorageReferenceValue) IsModified() bool {
 	return false
+}
+
+func (*StorageReferenceValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v *StorageReferenceValue) referencedValue(interpreter *Interpreter) *Value {
@@ -5652,8 +5764,12 @@ func (v *EphemeralReferenceValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (*EphemeralReferenceValue) Modified() bool {
+func (*EphemeralReferenceValue) IsModified() bool {
 	return false
+}
+
+func (*EphemeralReferenceValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v *EphemeralReferenceValue) referencedValue() *Value {
@@ -5788,8 +5904,12 @@ func (AddressValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (AddressValue) Modified() bool {
+func (AddressValue) IsModified() bool {
 	return false
+}
+
+func (AddressValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v AddressValue) Equal(other Value) BoolValue {
@@ -5881,8 +6001,12 @@ func (AuthAccountValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (AuthAccountValue) Modified() bool {
+func (AuthAccountValue) IsModified() bool {
 	return false
+}
+
+func (AuthAccountValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v AuthAccountValue) Destroy(_ *Interpreter, _ LocationRange) trampoline.Trampoline {
@@ -6022,8 +6146,12 @@ func (PublicAccountValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (PublicAccountValue) Modified() bool {
+func (PublicAccountValue) IsModified() bool {
 	return false
+}
+
+func (PublicAccountValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v PublicAccountValue) Destroy(_ *Interpreter, _ LocationRange) trampoline.Trampoline {
@@ -6080,8 +6208,12 @@ func (PathValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (PathValue) Modified() bool {
+func (PathValue) IsModified() bool {
 	return false
+}
+
+func (PathValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v PathValue) Destroy(_ *Interpreter, _ LocationRange) trampoline.Trampoline {
@@ -6122,8 +6254,12 @@ func (CapabilityValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (CapabilityValue) Modified() bool {
+func (CapabilityValue) IsModified() bool {
 	return false
+}
+
+func (CapabilityValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v CapabilityValue) Destroy(_ *Interpreter, _ LocationRange) trampoline.Trampoline {
@@ -6181,8 +6317,12 @@ func (LinkValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (LinkValue) Modified() bool {
+func (LinkValue) IsModified() bool {
 	return false
+}
+
+func (LinkValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v LinkValue) Destroy(_ *Interpreter, _ LocationRange) trampoline.Trampoline {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1304,8 +1304,12 @@ func (BlockValue) SetOwner(_ *common.Address) {
 	// NO-OP: value cannot be owned
 }
 
-func (BlockValue) Modified() bool {
+func (BlockValue) IsModified() bool {
 	return false
+}
+
+func (BlockValue) SetModified(_ bool) {
+	// NO-OP
 }
 
 func (v BlockValue) GetMember(_ *interpreter.Interpreter, _ interpreter.LocationRange, name string) interpreter.Value {

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -221,7 +221,7 @@ func (s *interpreterRuntimeStorage) writeCached() {
 
 	for fullKey, entry := range s.cache {
 
-		if !entry.mustWrite && entry.value != nil && !entry.value.Modified() {
+		if !entry.mustWrite && entry.value != nil && !entry.value.IsModified() {
 			continue
 		}
 
@@ -252,7 +252,7 @@ func (s *interpreterRuntimeStorage) writeCached() {
 					key:     deferredKey,
 				}
 
-				if !deferredValue.Modified() {
+				if !deferredValue.IsModified() {
 					continue
 				}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -42,9 +42,10 @@ import (
 )
 
 type testRuntimeInterfaceStorage struct {
-	valueExists func(controller, owner, key []byte) (exists bool, err error)
-	getValue    func(controller, owner, key []byte) (value []byte, err error)
-	setValue    func(controller, owner, key, value []byte) (err error)
+	storedValues map[string][]byte
+	valueExists  func(controller, owner, key []byte) (exists bool, err error)
+	getValue     func(controller, owner, key []byte) (value []byte, err error)
+	setValue     func(controller, owner, key, value []byte) (err error)
 }
 
 func newTestStorage(
@@ -59,6 +60,7 @@ func newTestStorage(
 	storedValues := map[string][]byte{}
 
 	storage := testRuntimeInterfaceStorage{
+		storedValues: storedValues,
 		valueExists: func(controller, owner, key []byte) (bool, error) {
 			_, ok := storedValues[storageKey(string(controller), string(owner), string(key))]
 			return ok, nil

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -500,7 +500,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 		actualArray,
 	)
 
-	assert.True(t, actualArray.Modified())
+	assert.True(t, actualArray.IsModified())
 
 	assert.Equal(t,
 		[]interpreter.Value{
@@ -596,7 +596,7 @@ func TestInterpretStringIndexingAssignment(t *testing.T) {
 		actualString,
 	)
 
-	assert.True(t, actualString.Modified())
+	assert.True(t, actualString.IsModified())
 
 	assert.Equal(t,
 		"dbc",
@@ -1923,7 +1923,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 
 	test := inter.Globals["test"].Value.(*interpreter.CompositeValue)
 
-	assert.True(t, test.Modified())
+	assert.True(t, test.IsModified())
 
 	assert.Equal(t,
 		interpreter.NewIntValueFromInt64(1),
@@ -1933,7 +1933,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 	value, err := inter.Invoke("callTest")
 	require.NoError(t, err)
 
-	assert.True(t, test.Modified())
+	assert.True(t, test.IsModified())
 
 	assert.Equal(t,
 		interpreter.VoidValue{},
@@ -4198,7 +4198,7 @@ func TestInterpretDictionary(t *testing.T) {
 		actualDict,
 	)
 
-	assert.True(t, actualDict.Modified())
+	assert.True(t, actualDict.IsModified())
 }
 
 func TestInterpretDictionaryInsertionOrder(t *testing.T) {
@@ -4222,7 +4222,7 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 		actualDict,
 	)
 
-	assert.True(t, actualDict.Modified())
+	assert.True(t, actualDict.IsModified())
 }
 
 func TestInterpretDictionaryIndexingString(t *testing.T) {
@@ -4372,7 +4372,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 		actualDict.Keys.Values,
 	)
 
-	assert.True(t, actualDict.Modified())
+	assert.True(t, actualDict.IsModified())
 }
 
 func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
@@ -4437,7 +4437,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 		actualDict.Keys.Values,
 	)
 
-	assert.True(t, actualDict.Modified())
+	assert.True(t, actualDict.IsModified())
 }
 
 func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
@@ -4499,7 +4499,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 		actualDict.Keys.Values,
 	)
 
-	assert.True(t, actualDict.Modified())
+	assert.True(t, actualDict.IsModified())
 }
 
 func TestInterpretOptionalAnyStruct(t *testing.T) {
@@ -4707,7 +4707,7 @@ func TestInterpretArrayAppend(t *testing.T) {
 		actualArray,
 	)
 
-	assert.True(t, actualArray.Modified())
+	assert.True(t, actualArray.IsModified())
 
 	assert.Equal(t,
 		[]interpreter.Value{
@@ -4827,7 +4827,7 @@ func TestInterpretArrayInsert(t *testing.T) {
 		actualArray,
 	)
 
-	assert.True(t, actualArray.Modified())
+	assert.True(t, actualArray.IsModified())
 
 	assert.Equal(t,
 		[]interpreter.Value{
@@ -4863,7 +4863,7 @@ func TestInterpretArrayRemove(t *testing.T) {
 		actualArray,
 	)
 
-	assert.True(t, actualArray.Modified())
+	assert.True(t, actualArray.IsModified())
 
 	assert.Equal(t,
 		[]interpreter.Value{
@@ -4902,7 +4902,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 		actualArray,
 	)
 
-	assert.True(t, actualArray.Modified())
+	assert.True(t, actualArray.IsModified())
 
 	assert.Equal(t,
 		[]interpreter.Value{
@@ -4941,7 +4941,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 		actualArray,
 	)
 
-	assert.True(t, actualArray.Modified())
+	assert.True(t, actualArray.IsModified())
 
 	assert.Equal(t,
 		[]interpreter.Value{
@@ -5067,7 +5067,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 		actualDict.Keys.Values,
 	)
 
-	assert.True(t, actualDict.Modified())
+	assert.True(t, actualDict.IsModified())
 
 	assert.Equal(t,
 		interpreter.NewSomeValueOwningNonCopying(
@@ -5120,7 +5120,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 		actualDict.Keys.Values,
 	)
 
-	assert.True(t, actualDict.Modified())
+	assert.True(t, actualDict.IsModified())
 
 	assert.Equal(t,
 		interpreter.NewSomeValueOwningNonCopying(


### PR DESCRIPTION
We already handled the move/transfer of dictionaries with deferred values by moving the the deferred storage keys.

However, we also have to handle the move/transfer of a dictionary value from one dictionary to another: If the value is not modified, the writeback optimization will ignore the new value in the receiving dictionary, so mark the moved/transferred value as modified.