### PR TITLE
CBOR: Up MaxArrayElements, MaxNestedLevels decoding options

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -51,7 +51,14 @@ func DecodeValue(b []byte, owner *common.Address, path []string) (Value, error) 
 // It sets the given address as the owner (can be `nil`).
 //
 func NewDecoder(r io.Reader, owner *common.Address) (*Decoder, error) {
-	decMode, err := cbor.DecOptions{}.DecModeWithTags(cborTagSet)
+	decMode, err := cbor.DecOptions{
+		// Maximum nested levels permitted.
+		MaxNestedLevels: 256,
+		// Maximum array elements permitted.
+		MaxArrayElements: 134217728,
+		// Forbid indefinite length CBOR items.
+		IndefLength: cbor.IndefLengthForbidden,
+	}.DecModeWithTags(cborTagSet)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Increase CBOR `DecOptions.MaxArrayElements`, `DecOptions.MaxNestedLevels` decoder options (previously set at defaults 131072 and 32 respectively).

## Bug

While running a large test the following error was encountered while attempting to decode a large array from storage:

```
status: SEALED err: code execution failed: Execution failed:
cbor: exceeded max number of elements 131072 for CBOR array
```

Testcase forthcoming, just wanted to put this out there in case it was urgent.