### PR TITLE
Add runtime interface method to receive stats

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -50,6 +50,8 @@ type Interface interface {
 	UpdateAccountCode(address Address, code []byte, checkPermission bool) (err error)
 	// GetSigningAccounts returns the signing accounts.
 	GetSigningAccounts() []Address
+	// Statisicts receives statistics about the runtime of a program.
+	Statistics(stats *Statistics)
 	// Log logs a string.
 	Log(string)
 	// EmitEvent is called when an event is emitted by the runtime.
@@ -120,6 +122,10 @@ func (i *EmptyRuntimeInterface) UpdateAccountCode(_ Address, _ []byte, _ bool) e
 
 func (i *EmptyRuntimeInterface) GetSigningAccounts() []Address {
 	return nil
+}
+
+func (i *EmptyRuntimeInterface) Statistics(_ *Statistics) {
+	return
 }
 
 func (i *EmptyRuntimeInterface) Log(_ string) {}

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -124,9 +124,7 @@ func (i *EmptyRuntimeInterface) GetSigningAccounts() []Address {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) Statistics(_ *Statistics) {
-	return
-}
+func (i *EmptyRuntimeInterface) Statistics(_ *Statistics) {}
 
 func (i *EmptyRuntimeInterface) Log(_ string) {}
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -478,7 +478,7 @@ func (interpreter *Interpreter) SetOnFunctionInvocationHandler(function OnFuncti
 	interpreter.onFunctionInvocation = function
 }
 
-// SetOnCompletionhandler sets the function that is triggered when interpretion of a program has completed.
+// SetOnCompletionhandler sets the function that is triggered when interpretation of a program has completed.
 //
 func (interpreter *Interpreter) SetOnCompletionHandler(function OnCompletionFunc) {
 	interpreter.onCompletion = function

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -608,9 +608,6 @@ func (interpreter *Interpreter) Interpret() (err error) {
 	})
 
 	interpreter.runAllStatements(interpreter.interpret())
-	if interpreter.onCompletion != nil {
-		interpreter.onCompletion(interpreter)
-	}
 
 	return nil
 }
@@ -870,6 +867,12 @@ func (interpreter *Interpreter) InvokeTransaction(index int, arguments ...Value)
 	_ = interpreter.runAllStatements(trampoline)
 
 	return nil
+}
+
+func (interpreter *Interpreter) Complete() {
+	if interpreter.onCompletion != nil {
+		interpreter.onCompletion(interpreter)
+	}
 }
 
 func recoverErrors(onError func(error)) {
@@ -3109,6 +3112,8 @@ func (interpreter *Interpreter) ensureLoaded(location ast.Location, loadProgram 
 		WithOnStatementHandler(interpreter.onStatement),
 		WithOnLoopIterationHandler(interpreter.onLoopIteration),
 		WithOnFunctionInvocationHandler(interpreter.onFunctionInvocation),
+		WithOnCompletionHandler(interpreter.onCompletion),
+		WithStatsReportHandler(interpreter.statsReportHandler),
 		WithStorageExistenceHandler(interpreter.storageExistenceHandler),
 		WithStorageReadHandler(interpreter.storageReadHandler),
 		WithStorageWriteHandler(interpreter.storageWriteHandler),

--- a/runtime/interpreter/stats.go
+++ b/runtime/interpreter/stats.go
@@ -1,0 +1,6 @@
+package interpreter
+
+// Statistics reported to runtime about an interpreted program.
+type Statistics struct {
+	GasConsumed uint64
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -500,6 +500,11 @@ func (r *interpreterRuntime) newInterpreter(
 			})
 			return
 		}),
+		interpreter.WithStatsReportHandler(func(_ *interpreter.Interpreter, stats *interpreter.Statistics) {
+			runtimeInterface.Statistics(&Statistics{
+				GasConsumed: stats.GasConsumed,
+			})
+		}),
 		interpreter.WithContractValueHandler(
 			func(
 				inter *interpreter.Interpreter,
@@ -627,6 +632,10 @@ func (r *interpreterRuntime) meteringInterpreterOptions(runtimeInterface Interfa
 		})
 	}
 
+	getGasConsumed := func() uint64 {
+		return used
+	}
+
 	return []interpreter.Option{
 		interpreter.WithOnStatementHandler(
 			func(_ *interpreter.Statement) {
@@ -641,6 +650,13 @@ func (r *interpreterRuntime) meteringInterpreterOptions(runtimeInterface Interfa
 		interpreter.WithOnFunctionInvocationHandler(
 			func(_ *interpreter.Interpreter, _ int) {
 				checkLimit()
+			},
+		),
+		interpreter.WithOnCompletionHandler(
+			func(interp *interpreter.Interpreter) {
+				interp.ReportStats(&interpreter.Statistics{
+					GasConsumed: getGasConsumed(),
+				})
 			},
 		),
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -94,6 +94,7 @@ type testRuntimeInterface struct {
 	removeAccountKey   func(address Address, index int) (publicKey []byte, err error)
 	updateAccountCode  func(address Address, code []byte, checkPermission bool) (err error)
 	getSigningAccounts func() []Address
+	statistics         func(*Statistics)
 	log                func(string)
 	emitEvent          func(cadence.Event)
 	generateUUID       func() uint64
@@ -157,6 +158,12 @@ func (i *testRuntimeInterface) GetSigningAccounts() []Address {
 		return nil
 	}
 	return i.getSigningAccounts()
+}
+
+func (i *testRuntimeInterface) Statistics(stats *Statistics) {
+	if i.statistics != nil {
+		i.statistics(stats)
+	}
 }
 
 func (i *testRuntimeInterface) Log(message string) {

--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -1,0 +1,24 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+// Statistics reported to runtimeInterface at the end of program execution.
+type Statistics struct {
+	GasConsumed uint64
+}


### PR DESCRIPTION
## Description

While profiling Alan's TXs to determine a reasonable gas limit, I needed a way to expose the gas consumed by interpreted programs (we currently do a check against a limit upon each function invocation, loop iteration etc).

I thought I would make this a bit more generic to support future runtime/interpreter statistics we may want to expose to the Cadence "host" (application implementing the `runtime.Interface`).

Note: 

I realize this is very similar to our `Metrics` system, but (perhaps wrongly) considered that more of a profiling interface and that perhaps there might be merit to exposing certain runtime stats (like gas consumed) via the `runtime.Interface`.

Let me know what you think! Happy to implement via `Metrics`.