### PR TITLE
New parser: Type arguments for invocations

### DIFF
--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -3013,4 +3013,81 @@ func TestParseLessThanOrTypeArguments(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("precedence, invocation in binary expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("1 + a<>()")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationPlus,
+				Left: &ast.IntegerExpression{
+					Value: big.NewInt(1),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				Right: &ast.InvocationExpression{
+					InvokedExpression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "a",
+							Pos:        ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+					TypeArguments: nil,
+					Arguments:     nil,
+					EndPos:        ast.Position{Line: 1, Column: 8, Offset: 8},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("precedence, binary expressions", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("0 + 1 < 2")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationLess,
+				Left: &ast.BinaryExpression{
+					Operation: ast.OperationPlus,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(0),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+						},
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+				},
+				Right: &ast.IntegerExpression{
+					Value: big.NewInt(2),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
+						EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+					},
+				},
+			},
+			result,
+		)
+	})
+
 }

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -2365,7 +2365,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		)
 	})
 
-	t.Run("octal with leading underscore", func(t *testing.T) {
+	t.Run("octal with trailing underscore", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -2807,3 +2807,210 @@ func TestParseFixedPoint(t *testing.T) {
 		)
 	})
 }
+
+func TestParseLessThanOrTypeArguments(t *testing.T) {
+
+	t.Run("binary expression with less operator", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("1 < 2")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationLess,
+				Left: &ast.IntegerExpression{
+					Value: big.NewInt(1),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				Right: &ast.IntegerExpression{
+					Value: big.NewInt(2),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+						EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("invocation, zero type arguments, zero arguments", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("a < > ()")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.InvocationExpression{
+				InvokedExpression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "a",
+						Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				TypeArguments: nil,
+				Arguments:     nil,
+				EndPos:        ast.Position{Line: 1, Column: 7, Offset: 7},
+			},
+			result,
+		)
+	})
+
+	t.Run("invocation, one type argument, one argument", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("a < { K : V } > ( 1 )")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.InvocationExpression{
+				InvokedExpression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "a",
+						Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				TypeArguments: []*ast.TypeAnnotation{
+					{
+						IsResource: false,
+						Type: &ast.DictionaryType{
+							KeyType: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "K",
+									Pos:        ast.Position{Line: 1, Column: 6, Offset: 6},
+								},
+							},
+							ValueType: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "V",
+									Pos:        ast.Position{Line: 1, Column: 10, Offset: 10},
+								},
+							},
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+								EndPos:   ast.Position{Line: 1, Column: 12, Offset: 12},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+				},
+				Arguments: []*ast.Argument{
+					{
+						Expression: &ast.IntegerExpression{
+							Value: big.NewInt(1),
+							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 18, Offset: 18},
+								EndPos:   ast.Position{Line: 1, Column: 18, Offset: 18},
+							},
+						},
+					},
+				},
+				EndPos: ast.Position{Line: 1, Column: 20, Offset: 20},
+			},
+			result,
+		)
+	})
+
+	t.Run("invocation, three type arguments, two arguments", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("a < { K : V } , @R , [ S ] > ( 1 , 2 )")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.InvocationExpression{
+				InvokedExpression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "a",
+						Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				TypeArguments: []*ast.TypeAnnotation{
+					{
+						IsResource: false,
+						Type: &ast.DictionaryType{
+							KeyType: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "K",
+									Pos:        ast.Position{Line: 1, Column: 6, Offset: 6},
+								},
+							},
+							ValueType: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "V",
+									Pos:        ast.Position{Line: 1, Column: 10, Offset: 10},
+								},
+							},
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+								EndPos:   ast.Position{Line: 1, Column: 12, Offset: 12},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+					{
+						IsResource: true,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "R",
+								Pos:        ast.Position{Line: 1, Column: 17, Offset: 17},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 16, Offset: 16},
+					},
+					{
+						IsResource: false,
+						Type: &ast.VariableSizedType{
+							Type: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "S",
+									Pos:        ast.Position{Line: 1, Column: 23, Offset: 23},
+								},
+							},
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 21, Offset: 21},
+								EndPos:   ast.Position{Line: 1, Column: 25, Offset: 25},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 21, Offset: 21},
+					},
+				},
+				Arguments: []*ast.Argument{
+					{
+						Expression: &ast.IntegerExpression{
+							Value: big.NewInt(1),
+							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 31, Offset: 31},
+								EndPos:   ast.Position{Line: 1, Column: 31, Offset: 31},
+							},
+						},
+					},
+					{
+						Expression: &ast.IntegerExpression{
+							Value: big.NewInt(2),
+							Base:  10,
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 35, Offset: 35},
+								EndPos:   ast.Position{Line: 1, Column: 35, Offset: 35},
+							},
+						},
+					},
+				},
+				EndPos: ast.Position{Line: 1, Column: 37, Offset: 37},
+			},
+			result,
+		)
+	})
+}

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -35,7 +35,7 @@ type parser struct {
 	errors  []error
 }
 
-func Parse(input string, f func(*parser) interface{}) (result interface{}, errors []error) {
+func Parse(input string, parse func(*parser) interface{}) (result interface{}, errors []error) {
 	ctx, cancelLexer := context.WithCancel(context.Background())
 
 	defer cancelLexer()
@@ -62,13 +62,13 @@ func Parse(input string, f func(*parser) interface{}) (result interface{}, error
 
 	p.next()
 
-	expr := f(p)
+	result = parse(p)
 
 	if !p.current.Is(lexer.TokenEOF) {
 		p.report(fmt.Errorf("unexpected token: %v", p.current))
 	}
 
-	return expr, p.errors
+	return result, p.errors
 }
 
 func (p *parser) report(err ...error) {

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -19,10 +19,14 @@
 package parser2
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+
+	"github.com/onflow/cadence/runtime/parser2/lexer"
 )
 
 func TestMain(m *testing.M) {
@@ -35,4 +39,185 @@ func TestParseInvalid(t *testing.T) {
 
 	_, errs := ParseExpression("#")
 	require.NotEmpty(t, errs)
+}
+
+func TestParseBuffering(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("buffer and accept, valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := Parse("a b c d", func(p *parser) interface{} {
+			p.mustOneString(lexer.TokenIdentifier, "a")
+			p.mustOne(lexer.TokenSpace)
+
+			p.startBuffering()
+
+			p.mustOneString(lexer.TokenIdentifier, "b")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "c")
+
+			p.acceptBuffered()
+
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "d")
+
+			return nil
+		})
+
+		assert.Empty(t, errs)
+	})
+
+	t.Run("buffer and accept, invalid", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := Parse("a b x d", func(p *parser) interface{} {
+			p.mustOneString(lexer.TokenIdentifier, "a")
+			p.mustOne(lexer.TokenSpace)
+
+			p.startBuffering()
+
+			p.mustOneString(lexer.TokenIdentifier, "b")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "c")
+
+			p.acceptBuffered()
+
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "d")
+
+			return nil
+		})
+
+		assert.Equal(t,
+			[]error{
+				errors.New("expected token identifier with string value c"),
+			},
+			errs,
+		)
+	})
+
+	t.Run("buffer and replay, valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := Parse("a b c d", func(p *parser) interface{} {
+			p.mustOneString(lexer.TokenIdentifier, "a")
+			p.mustOne(lexer.TokenSpace)
+
+			p.startBuffering()
+
+			p.mustOneString(lexer.TokenIdentifier, "b")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "c")
+
+			p.replayBuffered()
+
+			p.mustOneString(lexer.TokenIdentifier, "b")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "c")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "d")
+
+			return nil
+		})
+
+		assert.Empty(t, errs)
+	})
+
+	t.Run("buffer and replay, invalid first", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := Parse("a b c d", func(p *parser) interface{} {
+			p.mustOneString(lexer.TokenIdentifier, "a")
+			p.mustOne(lexer.TokenSpace)
+
+			p.startBuffering()
+
+			firstSucceeded := false
+			firstFailed := false
+
+			(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						firstFailed = true
+					}
+				}()
+
+				p.mustOneString(lexer.TokenIdentifier, "x")
+				p.mustOne(lexer.TokenSpace)
+				p.mustOneString(lexer.TokenIdentifier, "c")
+
+				firstSucceeded = true
+			})()
+
+			assert.True(t, firstFailed)
+			assert.False(t, firstSucceeded)
+
+			p.replayBuffered()
+
+			p.mustOneString(lexer.TokenIdentifier, "b")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "c")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "d")
+
+			return nil
+		})
+
+		assert.Empty(t, errs)
+	})
+
+	t.Run("buffer and replay, invalid first and invalid second", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := Parse("a b c x", func(p *parser) interface{} {
+			p.mustOneString(lexer.TokenIdentifier, "a")
+			p.mustOne(lexer.TokenSpace)
+
+			p.startBuffering()
+
+			firstSucceeded := false
+			firstFailed := false
+
+			(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						firstFailed = true
+					}
+				}()
+
+				p.mustOneString(lexer.TokenIdentifier, "x")
+				p.mustOne(lexer.TokenSpace)
+				p.mustOneString(lexer.TokenIdentifier, "c")
+
+				firstSucceeded = true
+			})()
+
+			assert.True(t, firstFailed)
+			assert.False(t, firstSucceeded)
+
+			p.replayBuffered()
+
+			p.mustOneString(lexer.TokenIdentifier, "b")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "c")
+			p.mustOne(lexer.TokenSpace)
+			p.mustOneString(lexer.TokenIdentifier, "d")
+
+			return nil
+		})
+
+		assert.Equal(t,
+			[]error{
+				errors.New("expected token identifier with string value d"),
+			},
+			errs,
+		)
+	})
 }

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -642,7 +642,7 @@ func TestParseAssignmentStatement(t *testing.T) {
 		)
 	})
 
-	t.Run("move", func(t *testing.T) {
+	t.Run("force move", func(t *testing.T) {
 
 		t.Parallel()
 


### PR DESCRIPTION
Work towards dapperlabs/flow-go#3764

Parsing type arguments for invocations is ambiguous: The less-than token `<` may either introduce an invocation with type arguments, a closing greater-than token `>`, and an argument list; or it is a comparsion binary expression. 

Handling the ambiguity required two changes to the parser:

1. Introduce buffering: Allow tokens to be recorded while they are read from the lexer and then replayed or accepted (discarded). This enables looking ahead and reparsing previously parsed tokens.

    In the case of the ambiguity, this enables first attempting to parse type arguments, a closing greater-than token `>`, and the start of an argument list , i.e. the open paren token `(`. 

    If this parse fails, the right-hand side of the comparison binary expression is parsed.

2. Introduce "meta" left-denotations: Normal left denotations are applied if the right binding power is less than the left binding power of the current token. Meta-left denotations allow determining the left binding power based on parsing more tokens.

    In the case of the ambiguity, the left binding power can not be determined based alone on the single token (`<`), but a lookahead as described above.