### PR TITLE
Fix order of conformance declaration and usage

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -472,30 +472,6 @@ func (checker *Checker) declareCompositeMembersAndValue(
 		initializers := declaration.Members.Initializers()
 		compositeType.ConstructorParameters = checker.initializerParameters(initializers)
 
-		// Declare members
-
-		var members map[string]*Member
-		var origins map[string]*Origin
-
-		// Event members are derived from the initializer's parameter list
-
-		if declaration.CompositeKind == common.CompositeKindEvent {
-			members, origins = checker.eventMembersAndOrigins(
-				initializers[0],
-				compositeType,
-			)
-		} else {
-			members, origins = checker.nonEventMembersAndOrigins(
-				compositeType,
-				declaration.Members.Fields,
-				declaration.Members.Functions,
-				kind,
-			)
-		}
-
-		compositeType.Members = members
-		checker.memberOrigins[compositeType] = origins
-
 		// Declare nested declarations' members
 
 		for _, nestedInterfaceDeclaration := range declaration.InterfaceDeclarations {
@@ -545,6 +521,31 @@ func (checker *Checker) declareCompositeMembersAndValue(
 				}
 			}
 		}
+
+		// Declare members
+		// NOTE: *After* declaring nested composite and interface declarations
+
+		var members map[string]*Member
+		var origins map[string]*Origin
+
+		// Event members are derived from the initializer's parameter list
+
+		if declaration.CompositeKind == common.CompositeKindEvent {
+			members, origins = checker.eventMembersAndOrigins(
+				initializers[0],
+				compositeType,
+			)
+		} else {
+			members, origins = checker.nonEventMembersAndOrigins(
+				compositeType,
+				declaration.Members.Fields,
+				declaration.Members.Functions,
+				kind,
+			)
+		}
+
+		compositeType.Members = members
+		checker.memberOrigins[compositeType] = origins
 	})()
 
 	// Always determine composite constructor type

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -1064,3 +1064,19 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 		)
 	})
 }
+
+func TestCheckRestrictedTypeConformanceOrder(t *testing.T) {
+
+	// Test that the conformances for a composite are declared
+	// before functions using them are checked
+
+	_, err := ParseAndCheckWithPanic(t, `
+      contract C {
+          resource interface RI {}
+          resource R: RI {}
+          fun foo(): &R{RI} { panic("") }
+      }
+    `)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Declare nested composite and interface declarations before checking members, so conformances are properly declared when the members are checked, which might use the conformances, e.g. in a restricted type.
