### PR TITLE
New Parser: More fixes and cleanup

### DIFF
--- a/runtime/parser/program_visitor.go
+++ b/runtime/parser/program_visitor.go
@@ -839,7 +839,13 @@ func (v *ProgramVisitor) VisitInnerType(ctx *InnerTypeContext) interface{} {
 
 func (v *ProgramVisitor) VisitTypeRestrictions(ctx *TypeRestrictionsContext) interface{} {
 	nominalTypeContexts := ctx.AllNominalType()
-	nominalTypes := make([]*ast.NominalType, len(nominalTypeContexts))
+
+	var nominalTypes []*ast.NominalType
+	if len(nominalTypeContexts) == 0 {
+		return nominalTypes
+	}
+
+	nominalTypes = make([]*ast.NominalType, len(nominalTypeContexts))
 
 	for i, context := range nominalTypeContexts {
 		nominalTypes[i] = context.Accept(v).(*ast.NominalType)

--- a/runtime/parser2/comment.go
+++ b/runtime/parser2/comment.go
@@ -56,6 +56,7 @@ func (p *parser) parseCommentContent() (comment string) {
 
 				case lexer.TokenBlockCommentEnd:
 					builder.WriteString(blockCommentEnd)
+					// Skip the comment end (`*/`)
 					p.next()
 					return nil
 

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -355,6 +355,9 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 		//location = ast.IdentifierLocation(identifier.Identifier)
 		locationPos = identifier.Pos
 		endPos = identifier.EndPosition()
+
+		// TODO: remove
+		panic(fmt.Errorf("identifier imports are not supported yet"))
 	}
 
 	parseLocation := func() {

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -35,6 +35,7 @@ func parseDeclarations(p *parser, endTokenType lexer.TokenType) (declarations []
 
 		switch p.current.Type {
 		case lexer.TokenSemicolon:
+			// Skip the semicolon
 			p.next()
 			continue
 
@@ -110,16 +111,19 @@ func parseAccess(p *parser) ast.Access {
 
 	switch p.current.Value {
 	case keywordPriv:
+		// Skip the `priv` keyword
 		p.next()
 		return ast.AccessPrivate
 
 	case keywordPub:
+		// Skip the `pub` keyword
 		p.next()
 		p.skipSpaceAndComments(true)
 		if !p.current.Is(lexer.TokenParenOpen) {
 			return ast.AccessPublic
 		}
 
+		// Skip the opening paren
 		p.next()
 		p.skipSpaceAndComments(true)
 
@@ -138,6 +142,7 @@ func parseAccess(p *parser) ast.Access {
 			))
 		}
 
+		// Skip the `set` keyword
 		p.next()
 		p.skipSpaceAndComments(true)
 
@@ -146,6 +151,7 @@ func parseAccess(p *parser) ast.Access {
 		return ast.AccessPublicSettable
 
 	case keywordAccess:
+		// Skip the `access` keyword
 		p.next()
 		p.skipSpaceAndComments(true)
 
@@ -190,6 +196,7 @@ func parseAccess(p *parser) ast.Access {
 			))
 		}
 
+		// Skip the keyword
 		p.next()
 		p.skipSpaceAndComments(true)
 
@@ -233,12 +240,14 @@ func parseVariableDeclaration(p *parser, access ast.Access, accessPos *ast.Posit
 
 	identifier := tokenToIdentifier(p.current)
 
+	// Skip the identifier
 	p.next()
 	p.skipSpaceAndComments(true)
 
 	var typeAnnotation *ast.TypeAnnotation
 
 	if p.current.Is(lexer.TokenColon) {
+		// Skip the colon
 		p.next()
 		p.skipSpaceAndComments(true)
 
@@ -347,6 +356,7 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 			panic(errors.NewUnreachableError())
 		}
 
+		// Skip the location
 		p.next()
 	}
 
@@ -413,6 +423,7 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 
 					atEnd = true
 
+					// Skip the `from` keyword
 					p.next()
 					p.skipSpaceAndComments(true)
 
@@ -452,7 +463,7 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 
 		if p.current.Value == keywordFrom {
 			identifiers = append(identifiers, identifier)
-
+			// Skip the `from` keyword
 			p.next()
 			p.skipSpaceAndComments(true)
 
@@ -481,7 +492,7 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 
 	case lexer.TokenIdentifier:
 		identifier := tokenToIdentifier(p.current)
-
+		// Skip the identifier
 		p.next()
 		p.skipSpaceAndComments(true)
 
@@ -571,7 +582,7 @@ func parseEventDeclaration(p *parser, access ast.Access, accessPos *ast.Position
 	}
 
 	identifier := tokenToIdentifier(p.current)
-
+	// Skip the identifier
 	p.next()
 
 	parameterList := parseParameterList(p)
@@ -657,7 +668,7 @@ func parseFieldWithVariableKind(p *parser, access ast.Access, accessPos *ast.Pos
 	}
 
 	identifier := tokenToIdentifier(p.current)
-
+	// Skip the identifier
 	p.next()
 	p.skipSpaceAndComments(true)
 
@@ -724,11 +735,12 @@ func parseCompositeOrInterfaceDeclaration(p *parser, access ast.Access, accessPo
 					keywordInterface,
 				))
 			}
-
+			// Skip the `interface` keyword
 			p.next()
 			continue
 		} else {
 			identifier = tokenToIdentifier(p.current)
+			// Skip the identifier
 			p.next()
 			break
 		}
@@ -739,6 +751,7 @@ func parseCompositeOrInterfaceDeclaration(p *parser, access ast.Access, accessPo
 	var conformances []*ast.NominalType
 
 	if p.current.Is(lexer.TokenColon) {
+		// Skip the colon
 		p.next()
 
 		conformances, _ = parseNominalTypes(p, lexer.TokenBraceOpen)
@@ -818,6 +831,7 @@ func parseMembersAndNestedDeclarations(
 
 		switch p.current.Type {
 		case lexer.TokenSemicolon:
+			// Skip the semicolon
 			p.next()
 			continue
 
@@ -908,6 +922,7 @@ func parseMemberOrNestedDeclaration(p *parser) ast.Declaration {
 
 				t := p.current
 				previousIdentifierToken = &t
+				// Skip the identifier
 				p.next()
 				continue
 			}

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -726,7 +726,6 @@ func TestParseFunctionDeclaration(t *testing.T) {
 			result,
 		)
 	})
-
 }
 
 func TestParseAccess(t *testing.T) {
@@ -1851,6 +1850,51 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 					Range: ast.Range{
 						StartPos: ast.Position{Offset: 11, Line: 2, Column: 10},
 						EndPos:   ast.Position{Offset: 216, Line: 12, Column: 10},
+					},
+				},
+			},
+			result,
+		)
+	})
+}
+
+func TestParseTransactionDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("no prepare, execute", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations("transaction { execute {} }")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.TransactionDeclaration{
+					Execute: &ast.SpecialFunctionDeclaration{
+						Kind: common.DeclarationKindExecute,
+						FunctionDeclaration: &ast.FunctionDeclaration{
+							Access: ast.AccessNotSpecified,
+							Identifier: ast.Identifier{
+								Identifier: "execute",
+								Pos:        ast.Position{Offset: 14, Line: 1, Column: 14},
+							},
+							ParameterList: &ast.ParameterList{},
+							FunctionBlock: &ast.FunctionBlock{
+								Block: &ast.Block{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 22, Line: 1, Column: 22},
+										EndPos:   ast.Position{Offset: 23, Line: 1, Column: 23},
+									},
+								},
+							},
+							StartPos: ast.Position{Offset: 14, Line: 1, Column: 14},
+						},
+					},
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 25, Offset: 25},
 					},
 				},
 			},

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -1141,6 +1141,24 @@ func TestParseImportDeclaration(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("no identifiers, identifier location", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations(` import foo`)
+		require.Equal(t,
+			[]error{errors.New("identifier imports are not supported yet")},
+			errs,
+		)
+
+		var expected []ast.Declaration
+
+		utils.AssertEqualWithDiff(t,
+			expected,
+			result,
+		)
+	})
 }
 
 func TestParseEvent(t *testing.T) {

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -432,23 +432,26 @@ func init() {
 		nullDenotation: func(right ast.Expression, tokenRange ast.Range) ast.Expression {
 			switch right := right.(type) {
 			case *ast.IntegerExpression:
-				if right.Value != nil {
-					right.Value.Neg(right.Value)
+				if right.Value.Sign() > 0 {
+					if right.Value != nil {
+						right.Value.Neg(right.Value)
+					}
+					right.StartPos = tokenRange.StartPos
+					return right
 				}
-				right.StartPos = tokenRange.StartPos
-				return right
 
 			case *ast.FixedPointExpression:
-				right.Negative = true
-				right.StartPos = tokenRange.StartPos
-				return right
-
-			default:
-				return &ast.UnaryExpression{
-					Operation:  ast.OperationMinus,
-					Expression: right,
-					StartPos:   tokenRange.StartPos,
+				if !right.Negative {
+					right.Negative = !right.Negative
+					right.StartPos = tokenRange.StartPos
+					return right
 				}
+			}
+
+			return &ast.UnaryExpression{
+				Operation:  ast.OperationMinus,
+				Expression: right,
+				StartPos:   tokenRange.StartPos,
 			}
 		},
 	})

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -537,7 +537,6 @@ func defineLessThanOrTypeArgumentsExpression() {
 			p.startBuffering()
 
 			// Skip the `<` token.
-
 			p.next()
 			p.skipSpaceAndComments(true)
 
@@ -769,11 +768,13 @@ func parseArgumentListRemainder(p *parser) (arguments []*ast.Argument, endPos as
 					p.current.Type,
 				))
 			}
+			// Skip the comma
 			p.next()
 			expectArgument = true
 
 		case lexer.TokenParenClose:
 			endPos = p.current.EndPos
+			// Skip the closing paren
 			p.next()
 			atEnd = true
 
@@ -818,6 +819,7 @@ func parseArgument(p *parser) *ast.Argument {
 		labelStartPos = expr.StartPosition()
 		labelEndPos = expr.EndPosition()
 
+		// Skip the identifier
 		p.next()
 		p.skipSpaceAndComments(true)
 

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -1334,7 +1334,14 @@ func parseIntegerLiteral(p *parser, literal, text string, kind IntegerLiteralKin
 func parseFixedPointPart(part string) (integer *big.Int, scale uint) {
 	withoutUnderscores := strings.Replace(part, "_", "", -1)
 	integer, _ = new(big.Int).SetString(withoutUnderscores, 10)
-	return integer, uint(len(withoutUnderscores))
+	if integer == nil {
+		integer = new(big.Int)
+	}
+	scale = uint(len(withoutUnderscores))
+	if scale == 0 {
+		scale = 1
+	}
+	return integer, scale
 }
 
 func parseFixedPointLiteral(text string, tokenRange ast.Range) *ast.FixedPointExpression {

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -457,12 +457,6 @@ func init() {
 	})
 
 	defineExpr(unaryExpr{
-		tokenType:    lexer.TokenPlus,
-		bindingPower: exprLeftBindingPowerUnaryPrefix,
-		operation:    ast.OperationPlus,
-	})
-
-	defineExpr(unaryExpr{
 		tokenType:    lexer.TokenExclamationMark,
 		bindingPower: exprLeftBindingPowerUnaryPrefix,
 		operation:    ast.OperationNegate,

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -2867,6 +2867,33 @@ func TestParseFixedPoint(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("missing fractional digits", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("0.")
+		require.Equal(t,
+			[]error{
+				errors.New("missing fractional digits"),
+			},
+			errs,
+		)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.FixedPointExpression{
+				Negative:        false,
+				UnsignedInteger: big.NewInt(0),
+				Fractional:      big.NewInt(0),
+				Scale:           1,
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+				},
+			},
+			result,
+		)
+	})
 }
 
 func TestParseLessThanOrTypeArguments(t *testing.T) {

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -218,12 +218,12 @@ func TestParseAdvancedExpression(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseExpression("1 +- 2 ++ 3")
+		result, errs := ParseExpression("1 +- 2 -- 3")
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
-				Operation: ast.OperationPlus,
+				Operation: ast.OperationMinus,
 				Left: &ast.BinaryExpression{
 					Operation: ast.OperationPlus,
 					Left: &ast.IntegerExpression{
@@ -243,17 +243,13 @@ func TestParseAdvancedExpression(t *testing.T) {
 						},
 					},
 				},
-				Right: &ast.UnaryExpression{
-					Operation: ast.OperationPlus,
-					Expression: &ast.IntegerExpression{
-						Value: big.NewInt(3),
-						Base:  10,
-						Range: ast.Range{
-							StartPos: ast.Position{Line: 1, Column: 10, Offset: 10},
-							EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
-						},
+				Right: &ast.IntegerExpression{
+					Value: big.NewInt(-3),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
+						EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
 					},
-					StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 				},
 			},
 			result,

--- a/runtime/parser2/function.go
+++ b/runtime/parser2/function.go
@@ -39,6 +39,7 @@ func parseParameterList(p *parser) (parameterList *ast.ParameterList) {
 	}
 
 	startPos := p.current.StartPos
+	// Skip the opening paren
 	p.next()
 
 	var endPos ast.Position
@@ -61,11 +62,13 @@ func parseParameterList(p *parser) (parameterList *ast.ParameterList) {
 					p.current.Type,
 				))
 			}
+			// Skip the comma
 			p.next()
 			expectParameter = true
 
 		case lexer.TokenParenClose:
 			endPos = p.current.EndPos
+			// Skip the closing paren
 			p.next()
 			atEnd = true
 
@@ -113,6 +116,7 @@ func parseParameter(p *parser) *ast.Parameter {
 	}
 	argumentLabel := ""
 	parameterName := p.current.Value.(string)
+	// Skip the identifier
 	p.next()
 
 	// If another identifier is provided, then the previous identifier
@@ -123,7 +127,7 @@ func parseParameter(p *parser) *ast.Parameter {
 		argumentLabel = parameterName
 		parameterName = p.current.Value.(string)
 		parameterPos = p.current.StartPos
-
+		// Skip the identifier
 		p.next()
 		p.skipSpaceAndComments(true)
 	}
@@ -136,6 +140,7 @@ func parseParameter(p *parser) *ast.Parameter {
 		))
 	}
 
+	// Skip the colon
 	p.next()
 	p.skipSpaceAndComments(true)
 
@@ -182,6 +187,7 @@ func parseFunctionDeclaration(
 
 	identifier := tokenToIdentifier(p.current)
 
+	// Skip the identifier
 	p.next()
 
 	parameterList, returnTypeAnnotation, functionBlock :=
@@ -209,6 +215,7 @@ func parseFunctionParameterListAndRest(
 
 	p.skipSpaceAndComments(true)
 	if p.current.Is(lexer.TokenColon) {
+		// Skip the colon
 		p.next()
 		p.skipSpaceAndComments(true)
 		returnTypeAnnotation = parseTypeAnnotation(p)

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -278,7 +278,6 @@ func (l *lexer) scanLineComment() {
 }
 
 func (l *lexer) acceptWhile(f func(rune) bool) {
-
 	for {
 		r := l.next()
 
@@ -334,9 +333,7 @@ func (l *lexer) scanHexadecimalRemainder() {
 }
 
 func (l *lexer) scanDecimalOrFixedPointRemainder() TokenType {
-	l.acceptWhile(func(r rune) bool {
-		return (r >= '0' && r <= '9') || r == '_'
-	})
+	l.acceptWhile(isDecimalDigitOrUnderscore)
 	r := l.next()
 	if r == '.' {
 		l.scanFixedPointRemainder()
@@ -348,7 +345,15 @@ func (l *lexer) scanDecimalOrFixedPointRemainder() TokenType {
 }
 
 func (l *lexer) scanFixedPointRemainder() {
-	l.acceptWhile(func(r rune) bool {
-		return (r >= '0' && r <= '9') || r == '_'
-	})
+	r := l.next()
+	if !isDecimalDigitOrUnderscore(r) {
+		l.backupOne()
+		l.emitError(fmt.Errorf("missing fractional digits"))
+		return
+	}
+	l.acceptWhile(isDecimalDigitOrUnderscore)
+}
+
+func isDecimalDigitOrUnderscore(r rune) bool {
+	return (r >= '0' && r <= '9') || r == '_'
 }

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -1643,6 +1643,37 @@ func TestLexFixedPoint(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("missing fractional digits", func(t *testing.T) {
+		testLex(t,
+			"0.",
+			[]Token{
+				{
+					Type:  TokenError,
+					Value: errors.New("missing fractional digits"),
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+					},
+				},
+				{
+					Type:  TokenFixedPointLiteral,
+					Value: "0.",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+					},
+				},
+				{
+					Type: TokenEOF,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+						EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+					},
+				},
+			},
+		)
+	})
 }
 
 func TestLexLineComment(t *testing.T) {

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -64,6 +64,7 @@ func Parse(input string, parse func(*parser) interface{}) (result interface{}, e
 		}
 	}()
 
+	// Get the initial token
 	p.next()
 
 	result = parse(p)

--- a/runtime/parser2/statement.go
+++ b/runtime/parser2/statement.go
@@ -79,12 +79,8 @@ func parseStatement(p *parser) ast.Statement {
 	// it might start with a keyword for a declaration
 
 	declaration := parseDeclaration(p)
-	// TODO: allow more
-	switch declaration := declaration.(type) {
-	case *ast.VariableDeclaration:
-		return declaration
-	case *ast.FunctionDeclaration:
-		return declaration
+	if statement, ok := declaration.(ast.Statement); ok {
+		return statement
 	}
 
 	// If it is not a statement or declaration,

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -779,3 +779,97 @@ func TestParseEmit(t *testing.T) {
 		)
 	})
 }
+
+func TestParseFunctionStatementOrExpression(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("function declaration with name", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseStatements("fun foo() {}")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Statement{
+				&ast.FunctionDeclaration{
+					Access: ast.AccessNotSpecified,
+					Identifier: ast.Identifier{
+						Identifier: "foo",
+						Pos:        ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+					ParameterList: &ast.ParameterList{
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 7, Offset: 7},
+							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+						},
+					},
+					ReturnTypeAnnotation: &ast.TypeAnnotation{
+						IsResource: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "",
+								Pos:        ast.Position{Line: 1, Column: 8, Offset: 8},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
+					},
+					FunctionBlock: &ast.FunctionBlock{
+						Block: &ast.Block{
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 10, Offset: 10},
+								EndPos:   ast.Position{Line: 1, Column: 11, Offset: 11},
+							},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("function expression without name", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseStatements("fun () {}")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Statement{
+				&ast.ExpressionStatement{
+					Expression: &ast.FunctionExpression{
+						ParameterList: &ast.ParameterList{
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+								EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
+							},
+						},
+						ReturnTypeAnnotation: &ast.TypeAnnotation{
+							IsResource: false,
+							Type: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "",
+									Pos:        ast.Position{Line: 1, Column: 5, Offset: 5},
+								},
+							},
+							StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
+						},
+						FunctionBlock: &ast.FunctionBlock{
+							Block: &ast.Block{
+								Range: ast.Range{
+									StartPos: ast.Position{Line: 1, Column: 7, Offset: 7},
+									EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+								},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+			},
+			result,
+		)
+	})
+}

--- a/runtime/parser2/transaction.go
+++ b/runtime/parser2/transaction.go
@@ -57,6 +57,7 @@ func parseTransactionDeclaration(p *parser) *ast.TransactionDeclaration {
 		switch p.current.Value {
 		case keywordPrepare:
 			identifier := tokenToIdentifier(p.current)
+			// Skip the `prepare` keyword
 			p.next()
 			prepare = parseSpecialFunctionDeclaration(p, false, ast.AccessNotSpecified, nil, identifier)
 
@@ -80,6 +81,7 @@ func parseTransactionDeclaration(p *parser) *ast.TransactionDeclaration {
 	if execute == nil {
 		p.skipSpaceAndComments(true)
 		if p.current.IsString(lexer.TokenIdentifier, keywordPre) {
+			// Skip the `pre` keyword
 			p.next()
 			conditions := parseConditions(p, ast.ConditionKindPre)
 			preConditions = &conditions
@@ -111,7 +113,7 @@ func parseTransactionDeclaration(p *parser) *ast.TransactionDeclaration {
 				if sawPost {
 					panic(fmt.Errorf("unexpected second post-conditions"))
 				}
-
+				// Skip the `post` keyword
 				p.next()
 				conditions := parseConditions(p, ast.ConditionKindPost)
 				postConditions = &conditions
@@ -128,6 +130,7 @@ func parseTransactionDeclaration(p *parser) *ast.TransactionDeclaration {
 
 		case lexer.TokenBraceClose:
 			endPos = p.current.EndPos
+			// Skip the closing brace
 			p.next()
 			atEnd = true
 
@@ -156,6 +159,7 @@ func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration) {
 
 		switch p.current.Type {
 		case lexer.TokenSemicolon:
+			// Skip the semicolon
 			p.next()
 			continue
 
@@ -183,6 +187,7 @@ func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration) {
 func parseTransactionExecute(p *parser) *ast.SpecialFunctionDeclaration {
 	identifier := tokenToIdentifier(p.current)
 
+	// Skip the `execute` keyword
 	p.next()
 	p.skipSpaceAndComments(true)
 

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -152,10 +152,10 @@ func parseNominalTypeRemainder(p *parser, token lexer.Token) *ast.NominalType {
 	var nestedIdentifiers []ast.Identifier
 
 	for p.current.Is(lexer.TokenDot) {
+		// Skip the dot
 		p.next()
 
 		nestedToken := p.current
-		p.next()
 
 		if !nestedToken.Is(lexer.TokenIdentifier) {
 			panic(fmt.Errorf(
@@ -166,6 +166,9 @@ func parseNominalTypeRemainder(p *parser, token lexer.Token) *ast.NominalType {
 		}
 
 		nestedIdentifier := tokenToIdentifier(nestedToken)
+
+		// Skip the identifier
+		p.next()
 
 		nestedIdentifiers = append(
 			nestedIdentifiers,
@@ -192,6 +195,7 @@ func defineArrayType() {
 			var size *ast.IntegerExpression
 
 			if p.current.Is(lexer.TokenSemicolon) {
+				// Skip the semicolon
 				p.next()
 
 				p.skipSpaceAndComments(true)
@@ -323,6 +327,7 @@ func defineRestrictedOrDictionaryType() {
 							},
 						}
 					}
+					// Skip the comma
 					p.next()
 					expectType = true
 
@@ -346,6 +351,7 @@ func defineRestrictedOrDictionaryType() {
 					} else {
 						panic(fmt.Errorf("unexpected colon in dictionary type"))
 					}
+					// Skip the colon
 					p.next()
 					expectType = true
 
@@ -359,6 +365,7 @@ func defineRestrictedOrDictionaryType() {
 						}
 					}
 					endPos = p.current.EndPos
+					// Skip the closing brace
 					p.next()
 					atEnd = true
 
@@ -430,7 +437,7 @@ func defineRestrictedOrDictionaryType() {
 
 			nominalTypes, endPos := parseNominalTypes(p, lexer.TokenBraceClose)
 
-			// Skip closing brace
+			// Skip the closing brace
 			p.next()
 
 			return &ast.RestrictedType{
@@ -464,6 +471,7 @@ func parseNominalTypes(
 			if expectType {
 				panic(fmt.Errorf("unexpected comma"))
 			}
+			// Skip the comma
 			p.next()
 			expectType = true
 
@@ -552,10 +560,12 @@ func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnota
 					p.current.Type,
 				))
 			}
+			// Skip the comma
 			p.next()
 			expectTypeAnnotation = true
 
 		case lexer.TokenParenClose:
+			// Skip the closing paren
 			p.next()
 			atEnd = true
 
@@ -605,6 +615,7 @@ func parseTypeAnnotation(p *parser) *ast.TypeAnnotation {
 
 	isResource := false
 	if p.current.Is(lexer.TokenAt) {
+		// Skip the `@`
 		p.next()
 		isResource = true
 	}
@@ -681,6 +692,7 @@ func parseCommaSeparatedTypeAnnotations(
 			if expectTypeAnnotation {
 				panic(fmt.Errorf("unexpected comma"))
 			}
+			// Skip the comma
 			p.next()
 			expectTypeAnnotation = true
 

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -196,13 +196,6 @@ func defineArrayType() {
 
 				p.skipSpaceAndComments(true)
 
-				if !p.current.Is(lexer.TokenDecimalLiteral) {
-					panic(fmt.Errorf(
-						"expected size for constant sized type, got %s",
-						p.current.Type,
-					))
-				}
-
 				numberExpression := parseExpression(p, lowestBindingPower)
 
 				integerExpression, ok := numberExpression.(*ast.IntegerExpression)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -2914,7 +2915,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 		require.IsType(t, Error{}, err)
 		err = err.(Error).Unwrap()
 
-		errs := utils.ExpectCheckerErrors(t, err, 1)
+		errs := checker.ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidTopLevelDeclarationError{}, errs[0])
 	})

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -488,6 +488,7 @@ func TestCheckAccessModifierLocalVariableDeclaration(t *testing.T) {
 	}
 }
 
+// TODO: remove
 func TestCheckAccessModifierLocalOptionalBinding(t *testing.T) {
 
 	t.Parallel()
@@ -505,7 +506,7 @@ func TestCheckAccessModifierLocalOptionalBinding(t *testing.T) {
 
 		t.Run(access.Keyword(), func(t *testing.T) {
 
-			_, err := ParseAndCheck(t,
+			_, err := ParseAndCheckWithOptions(t,
 				fmt.Sprintf(
 					`
                       fun test() {
@@ -515,6 +516,9 @@ func TestCheckAccessModifierLocalOptionalBinding(t *testing.T) {
 	                `,
 					access.Keyword(),
 				),
+				ParseAndCheckOptions{
+					SkipNewParser: true,
+				},
 			)
 
 			if expectSuccess {

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func ParseAndCheckAccount(t *testing.T, code string) (*sema.Checker, error) {

--- a/runtime/tests/checker/any_test.go
+++ b/runtime/tests/checker/any_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckAnyStruct(t *testing.T) {

--- a/runtime/tests/checker/assert_test.go
+++ b/runtime/tests/checker/assert_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckAssertWithoutMessage(t *testing.T) {

--- a/runtime/tests/checker/assignment_test.go
+++ b/runtime/tests/checker/assignment_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidUnknownDeclarationAssignment(t *testing.T) {

--- a/runtime/tests/checker/boolean_test.go
+++ b/runtime/tests/checker/boolean_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckBoolean(t *testing.T) {

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckCapability(t *testing.T) {

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckCastingIntLiteralToIntegerType(t *testing.T) {

--- a/runtime/tests/checker/character_test.go
+++ b/runtime/tests/checker/character_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckCharacterLiteral(t *testing.T) {

--- a/runtime/tests/checker/conditional_test.go
+++ b/runtime/tests/checker/conditional_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckConditionalExpressionTest(t *testing.T) {

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckFunctionConditions(t *testing.T) {

--- a/runtime/tests/checker/conformance_test.go
+++ b/runtime/tests/checker/conformance_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidEventTypeRequirementConformance(t *testing.T) {

--- a/runtime/tests/checker/contract_test.go
+++ b/runtime/tests/checker/contract_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidContractAccountField(t *testing.T) {

--- a/runtime/tests/checker/declaration_test.go
+++ b/runtime/tests/checker/declaration_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckConstantAndVariableDeclarations(t *testing.T) {

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 var dynamicCastingOperations = []ast.Operation{

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckEventDeclaration(t *testing.T) {

--- a/runtime/tests/checker/fixedpoint_test.go
+++ b/runtime/tests/checker/fixedpoint_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckFixedPointLiteralTypeConversionInVariableDeclaration(t *testing.T) {

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckForVariableSized(t *testing.T) {

--- a/runtime/tests/checker/force_test.go
+++ b/runtime/tests/checker/force_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckForce(t *testing.T) {

--- a/runtime/tests/checker/function_expression_test.go
+++ b/runtime/tests/checker/function_expression_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidFunctionExpressionReturnValue(t *testing.T) {

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckReferenceInFunction(t *testing.T) {

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.Checker, error) {

--- a/runtime/tests/checker/if_test.go
+++ b/runtime/tests/checker/if_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckIfStatementTest(t *testing.T) {

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidImport(t *testing.T) {

--- a/runtime/tests/checker/indexing_test.go
+++ b/runtime/tests/checker/indexing_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckArrayIndexingWithInteger(t *testing.T) {

--- a/runtime/tests/checker/initialization_test.go
+++ b/runtime/tests/checker/initialization_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 // TODO: test multiple initializers once overloading is supported

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 var allIntegerTypesAndAddressType = append(

--- a/runtime/tests/checker/invalid_test.go
+++ b/runtime/tests/checker/invalid_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckSpuriousIdentifierAssignmentInvalidValueTypeMismatch(t *testing.T) {

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidFunctionCallWithTooFewArguments(t *testing.T) {

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckOptionalChainingNonOptionalFieldRead(t *testing.T) {

--- a/runtime/tests/checker/nesting_test.go
+++ b/runtime/tests/checker/nesting_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckCompositeDeclarationNesting(t *testing.T) {

--- a/runtime/tests/checker/nil_coalescing_test.go
+++ b/runtime/tests/checker/nil_coalescing_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckNilCoalescingNilIntToOptional(t *testing.T) {

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidUnaryBooleanNegationOfInteger(t *testing.T) {

--- a/runtime/tests/checker/optional_test.go
+++ b/runtime/tests/checker/optional_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckOptional(t *testing.T) {

--- a/runtime/tests/checker/overloading_test.go
+++ b/runtime/tests/checker/overloading_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidCompositeInitializerOverloading(t *testing.T) {

--- a/runtime/tests/checker/path_test.go
+++ b/runtime/tests/checker/path_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckPath(t *testing.T) {

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckReferenceTypeOuter(t *testing.T) {

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckRestrictedType(t *testing.T) {

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidReturnValue(t *testing.T) {

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckCharacter(t *testing.T) {

--- a/runtime/tests/checker/swap_test.go
+++ b/runtime/tests/checker/swap_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidUnknownDeclarationSwap(t *testing.T) {

--- a/runtime/tests/checker/tostring_test.go
+++ b/runtime/tests/checker/tostring_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckToString(t *testing.T) {

--- a/runtime/tests/checker/transactions_test.go
+++ b/runtime/tests/checker/transactions_test.go
@@ -358,7 +358,17 @@ func TestCheckTransactions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := ParseAndCheck(t, test.code)
+			// TODO: skip new parser for now. it correctly parses,
+			//   but rejects invalid keywords syntactically,
+			//   instead of semantically
+
+			_, err := ParseAndCheckWithOptions(
+				t,
+				test.code,
+				ParseAndCheckOptions{
+					SkipNewParser: true,
+				},
+			)
 
 			errs := ExpectCheckerErrors(t, err, len(test.errors))
 

--- a/runtime/tests/checker/transactions_test.go
+++ b/runtime/tests/checker/transactions_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckTransactions(t *testing.T) {

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -1,0 +1,101 @@
+package checker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func ParseAndCheck(t *testing.T, code string) (*sema.Checker, error) {
+	return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{})
+}
+
+type ParseAndCheckOptions struct {
+	ImportResolver ast.ImportResolver
+	Location       ast.Location
+	Options        []sema.Option
+	SkipNewParser  bool
+}
+
+func ParseAndCheckWithOptions(
+	t *testing.T,
+	code string,
+	options ParseAndCheckOptions,
+) (*sema.Checker, error) {
+
+	program, _, err := parser.ParseProgram(code)
+	if !assert.NoError(t, err) {
+		assert.FailNow(t, errors.UnrollChildErrors(err))
+		return nil, err
+	}
+
+	if !options.SkipNewParser {
+		program2, err := parser2.ParseProgram(code)
+		if !assert.NoError(t, err) {
+			assert.FailNow(t, errors.UnrollChildErrors(err))
+			return nil, err
+		}
+
+		utils.AssertEqualWithDiff(t, program, program2)
+	}
+
+	if options.ImportResolver != nil {
+		err := program.ResolveImports(options.ImportResolver)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if options.Location == nil {
+		options.Location = utils.TestLocation
+	}
+
+	checkerOptions := append(
+		[]sema.Option{
+			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
+		},
+		options.Options...,
+	)
+
+	checker, err := sema.NewChecker(
+		program,
+		options.Location,
+		checkerOptions...,
+	)
+	if err != nil {
+		return checker, err
+	}
+
+	err = checker.Check()
+	return checker, err
+}
+
+func ExpectCheckerErrors(t *testing.T, err error, len int) []error {
+	if len <= 0 && err == nil {
+		return nil
+	}
+
+	require.Error(t, err)
+
+	assert.IsType(t, &sema.CheckerError{}, err)
+
+	errs := err.(*sema.CheckerError).Errors
+
+	require.Len(t, errs, len)
+
+	// Get the error message, to check that it can be successfully generated
+
+	for _, checkerErr := range errs {
+		_ = checkerErr.Error()
+	}
+
+	return errs
+}

--- a/runtime/tests/checker/utils_test.go
+++ b/runtime/tests/checker/utils_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func ParseAndCheckWithPanic(t *testing.T, code string) (*sema.Checker, error) {

--- a/runtime/tests/checker/while_test.go
+++ b/runtime/tests/checker/while_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence/runtime/sema"
-	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidWhileTest(t *testing.T) {

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -26,14 +26,14 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/interpreter"
-	. "github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/onflow/cadence/runtime/tests/checker"
 )
 
 func TestInterpretStatementHandler(t *testing.T) {
 
 	t.Parallel()
 
-	checkerImported, err := ParseAndCheck(t, `
+	checkerImported, err := checker.ParseAndCheck(t, `
       pub fun a() {
           true
           true
@@ -41,7 +41,7 @@ func TestInterpretStatementHandler(t *testing.T) {
     `)
 	require.NoError(t, err)
 
-	checkerImporting, err := ParseAndCheckWithOptions(t,
+	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
 		`
           import a from "imported"
 
@@ -61,7 +61,7 @@ func TestInterpretStatementHandler(t *testing.T) {
               true
           }
         `,
-		ParseAndCheckOptions{
+		checker.ParseAndCheckOptions{
 			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
 				return checkerImported.Program, nil
 			},
@@ -129,7 +129,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 
 	t.Parallel()
 
-	checkerImported, err := ParseAndCheck(t, `
+	checkerImported, err := checker.ParseAndCheck(t, `
       pub fun a() {
           var i = 1
           while i <= 4 {
@@ -141,7 +141,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
     `)
 	require.NoError(t, err)
 
-	checkerImporting, err := ParseAndCheckWithOptions(t,
+	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
 		`
           import a from "imported"
 
@@ -156,7 +156,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
               a()
           }
         `,
-		ParseAndCheckOptions{
+		checker.ParseAndCheckOptions{
 			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
 				return checkerImported.Program, nil
 			},
@@ -223,7 +223,7 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 
 	t.Parallel()
 
-	checkerImported, err := ParseAndCheck(t, `
+	checkerImported, err := checker.ParseAndCheck(t, `
       pub fun a() {}
 
       pub fun b() {
@@ -236,7 +236,7 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
     `)
 	require.NoError(t, err)
 
-	checkerImporting, err := ParseAndCheckWithOptions(t,
+	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
 		`
           import b from "imported"
 
@@ -256,7 +256,7 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
               true
           }
         `,
-		ParseAndCheckOptions{
+		checker.ParseAndCheckOptions{
 			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
 				return checkerImported.Program, nil
 			},

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -34,7 +35,7 @@ func TestInterpretResourceUUID(t *testing.T) {
 
 	t.Parallel()
 
-	checkerImported, err := ParseAndCheck(t, `
+	checkerImported, err := checker.ParseAndCheck(t, `
       pub resource R {}
 
       pub fun createR(): @R {
@@ -43,7 +44,7 @@ func TestInterpretResourceUUID(t *testing.T) {
     `)
 	require.NoError(t, err)
 
-	checkerImporting, err := ParseAndCheckWithOptions(t,
+	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
 		`
           import createR from "imported"
 
@@ -56,7 +57,7 @@ func TestInterpretResourceUUID(t *testing.T) {
               ]
           }
         `,
-		ParseAndCheckOptions{
+		checker.ParseAndCheckOptions{
 			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
 				assert.Equal(t,
 					ImportedLocation,

--- a/runtime/tests/utils/utils.go
+++ b/runtime/tests/utils/utils.go
@@ -25,13 +25,9 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/errors"
-	"github.com/onflow/cadence/runtime/parser"
-	"github.com/onflow/cadence/runtime/sema"
 )
 
 // TestLocation is used as the default location for programs in tests.
@@ -39,81 +35,6 @@ const TestLocation = ast.StringLocation("test")
 
 // ImportedLocation is used as the default location for imported programs in tests.
 const ImportedLocation = ast.StringLocation("imported")
-
-func ParseAndCheck(t *testing.T, code string) (*sema.Checker, error) {
-	return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{})
-}
-
-type ParseAndCheckOptions struct {
-	ImportResolver ast.ImportResolver
-	Location       ast.Location
-	Options        []sema.Option
-}
-
-func ParseAndCheckWithOptions(
-	t *testing.T,
-	code string,
-	options ParseAndCheckOptions,
-) (*sema.Checker, error) {
-	program, _, err := parser.ParseProgram(code)
-
-	if !assert.NoError(t, err) {
-		assert.FailNow(t, errors.UnrollChildErrors(err))
-		return nil, err
-	}
-
-	if options.ImportResolver != nil {
-		err := program.ResolveImports(options.ImportResolver)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if options.Location == nil {
-		options.Location = TestLocation
-	}
-
-	checkerOptions := append(
-		[]sema.Option{
-			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
-		},
-		options.Options...,
-	)
-
-	checker, err := sema.NewChecker(
-		program,
-		options.Location,
-		checkerOptions...,
-	)
-	if err != nil {
-		return checker, err
-	}
-
-	err = checker.Check()
-	return checker, err
-}
-
-func ExpectCheckerErrors(t *testing.T, err error, len int) []error {
-	if len <= 0 && err == nil {
-		return nil
-	}
-
-	require.Error(t, err)
-
-	assert.IsType(t, &sema.CheckerError{}, err)
-
-	errs := err.(*sema.CheckerError).Errors
-
-	require.Len(t, errs, len)
-
-	// Get the error message, to check that it can be successfully generated
-
-	for _, checkerErr := range errs {
-		_ = checkerErr.Error()
-	}
-
-	return errs
-}
 
 // AssertEqualWithDiff asserts that two objects are equal.
 //


### PR DESCRIPTION
Work towards dapperlabs/flow-go#3764


- Parse checker tests with both old and new parser and compare
- Don't allocate an empty slice for restrictions
- Make `prepare`s in transactions optional
- Don't require decimal literal for constant sized type, this is checked later in sema
- Handle ambiguity between function declaration and function expression statement
- Handle multiple unary negation
- Accept all declarations which are statements
- Fix parsing of fixed-point literals
- Unary plus is not supported, remove it
- Identifier import locations are not supported yet, don't produce a nil location

With these changes, all checker tests can now be parsed using the new parser.
Also, go-fuzz has not reported any more crashers so far.