### PR TITLE
Use new parser by default

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -22,7 +22,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -32,7 +32,7 @@ func Fuzz(data []byte) int {
 		return 0
 	}
 
-	program, _, err := parser.ParseProgram(string(data))
+	program, err := parser2.ParseProgram(string(data))
 
 	if err != nil {
 		return 0

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -41,7 +41,7 @@ func PrettyPrintError(err error, filename string, codes map[string]string) {
 		i++
 	}
 
-	if parserError, ok := err.(parser.Error); ok {
+	if parserError, ok := err.(parser2.Error); ok {
 		for _, err := range parserError.Errors {
 			printErr(err, filename)
 		}
@@ -96,7 +96,7 @@ func PrepareChecker(code string, dummyFilename string) (*sema.Checker, func(erro
 
 	must := mustClosure(dummyFilename, codes)
 
-	program, _, err := parser.ParseProgram(code)
+	program, err := parser2.ParseProgram(code)
 	codes[dummyFilename] = code
 	must(err)
 
@@ -104,7 +104,7 @@ func PrepareChecker(code string, dummyFilename string) (*sema.Checker, func(erro
 		switch location := location.(type) {
 		case ast.StringLocation:
 			filename := string(location)
-			imported, _, code, err := parser.ParseProgramFromFile(filename)
+			imported, code, err := parser2.ParseProgramFromFile(filename)
 			codes[filename] = code
 			must(err)
 			return imported, nil

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -21,6 +21,7 @@ package parser2
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/parser2/lexer"
@@ -277,4 +278,20 @@ func ParseProgram(input string) (program *ast.Program, err error) {
 		Declarations: res.([]ast.Declaration),
 	}
 	return
+}
+
+func ParseProgramFromFile(filename string) (program *ast.Program, code string, err error) {
+	var data []byte
+	data, err = ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, "", err
+	}
+
+	code = string(data)
+
+	program, err = ParseProgram(code)
+	if err != nil {
+		return nil, code, err
+	}
+	return program, code, nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -31,7 +31,8 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	runtimeErrors "github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/parser"
+	parser1 "github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/onflow/cadence/runtime/trampoline"
@@ -55,6 +56,7 @@ type Runtime interface {
 	//
 	// This function returns an error if the program contains any syntax or semantic errors.
 	ParseAndCheckProgram(code []byte, runtimeInterface Interface, location Location) error
+	SetUseOldParser(useOldParser bool)
 }
 
 var typeDeclarations = append(
@@ -108,11 +110,29 @@ func reportMetric(
 const contractKey = "contract"
 
 // interpreterRuntime is a interpreter-based version of the Flow runtime.
-type interpreterRuntime struct{}
+type interpreterRuntime struct {
+	useOldParser bool
+}
+
+type Option func(Runtime)
 
 // NewInterpreterRuntime returns a interpreter-based version of the Flow runtime.
-func NewInterpreterRuntime() Runtime {
-	return &interpreterRuntime{}
+func NewInterpreterRuntime(options ...Option) Runtime {
+	runtime := &interpreterRuntime{}
+	for _, option := range options {
+		option(runtime)
+	}
+	return runtime
+}
+
+func WithUseOldParser(useOldParser bool) Option {
+	return func(runtime Runtime) {
+		runtime.SetUseOldParser(useOldParser)
+	}
+}
+
+func (r *interpreterRuntime) SetUseOldParser(useOldParser bool) {
+	r.useOldParser = useOldParser
 }
 
 func (r *interpreterRuntime) ExecuteScript(
@@ -707,10 +727,19 @@ func (r *interpreterRuntime) parse(
 	program *ast.Program,
 	err error,
 ) {
+
+	parse := func() {
+		program, err = parser2.ParseProgram(string(script))
+	}
+
+	if r.useOldParser {
+		parse = func() {
+			program, _, err = parser1.ParseProgram(string(script))
+		}
+	}
+
 	reportMetric(
-		func() {
-			program, _, err = parser.ParseProgram(string(script))
-		},
+		parse,
 		runtimeInterface,
 		func(metrics Metrics, duration time.Duration) {
 			metrics.ProgramParsed(location, duration)


### PR DESCRIPTION
Closes dapperlabs/flow-go#3764

Add a runtime option to use the old parser, if needed.