### PR TITLE
Add AuthAccount.unsafeNotInitializingSetCode

### DIFF
--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -150,7 +150,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{common.BytesToAddress(addressValue.Bytes())}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -642,7 +642,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{common.BytesToAddress(addressValue.Bytes())}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -879,7 +879,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 				signer2,
 			}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -1038,7 +1038,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Removal(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{signer}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -1125,7 +1125,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Destruction(t *testing.T
 		getSigningAccounts: func() []Address {
 			return []Address{signer}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -1246,7 +1246,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Insertion(t *testing.T) 
 		getSigningAccounts: func() []Address {
 			return []Address{signer}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -1370,7 +1370,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_ValueTransferAndDestroy(
 		getSigningAccounts: func() []Address {
 			return signers
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -47,7 +47,7 @@ type Interface interface {
 	// RemoveAccountKey removes a key from an account by index.
 	RemoveAccountKey(address Address, index int) (publicKey []byte, err error)
 	// UpdateAccountCode updates the code associated with an account.
-	UpdateAccountCode(address Address, code []byte, checkPermission bool) (err error)
+	UpdateAccountCode(address Address, code []byte) (err error)
 	// GetSigningAccounts returns the signing accounts.
 	GetSigningAccounts() []Address
 	// Log logs a string.
@@ -114,7 +114,7 @@ func (i *EmptyRuntimeInterface) RemoveAccountKey(_ Address, _ int) (publicKey []
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) UpdateAccountCode(_ Address, _ []byte, _ bool) error {
+func (i *EmptyRuntimeInterface) UpdateAccountCode(_ Address, _ []byte) error {
 	return nil
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5958,21 +5958,26 @@ type AccountValue interface {
 // AuthAccountValue
 
 type AuthAccountValue struct {
-	Address                 AddressValue
-	setCodeFunction         FunctionValue
-	addPublicKeyFunction    FunctionValue
-	removePublicKeyFunction FunctionValue
+	Address                              AddressValue
+	setCodeFunction                      FunctionValue
+	unsafeNotInitializingSetCodeFunction FunctionValue
+	addPublicKeyFunction                 FunctionValue
+	removePublicKeyFunction              FunctionValue
 }
 
 func NewAuthAccountValue(
 	address AddressValue,
-	setCodeFunction, addPublicKeyFunction, removePublicKeyFunction FunctionValue,
+	setCodeFunction FunctionValue,
+	unsafeNotInitializingSetCodeFunction FunctionValue,
+	addPublicKeyFunction FunctionValue,
+	removePublicKeyFunction FunctionValue,
 ) AuthAccountValue {
 	return AuthAccountValue{
-		Address:                 address,
-		setCodeFunction:         setCodeFunction,
-		addPublicKeyFunction:    addPublicKeyFunction,
-		removePublicKeyFunction: removePublicKeyFunction,
+		Address:                              address,
+		setCodeFunction:                      setCodeFunction,
+		unsafeNotInitializingSetCodeFunction: unsafeNotInitializingSetCodeFunction,
+		addPublicKeyFunction:                 addPublicKeyFunction,
+		removePublicKeyFunction:              removePublicKeyFunction,
 	}
 }
 
@@ -6068,6 +6073,9 @@ func (v AuthAccountValue) GetMember(inter *Interpreter, _ LocationRange, name st
 
 	case "setCode":
 		return v.setCodeFunction
+
+	case "unsafeNotInitializingSetCode":
+		return v.unsafeNotInitializingSetCodeFunction
 
 	case "addPublicKey":
 		return v.addPublicKeyFunction

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -929,9 +929,7 @@ func (r *interpreterRuntime) newSetCodeFunction(
 				constructorArguments,
 				constructorArgumentTypes,
 				invocation.LocationRange.Range,
-				updateAccountCodeOptions{
-					createContract: options.createContract,
-				},
+				updateAccountCodeOptions(options),
 			)
 
 			codeHashValue := CodeToHashValue(code)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -930,8 +930,7 @@ func (r *interpreterRuntime) newSetCodeFunction(
 				constructorArgumentTypes,
 				invocation.LocationRange.Range,
 				updateAccountCodeOptions{
-					checkPermission: true,
-					createContract:  options.createContract,
+					createContract: options.createContract,
 				},
 			)
 
@@ -956,8 +955,7 @@ func (r *interpreterRuntime) newSetCodeFunction(
 }
 
 type updateAccountCodeOptions struct {
-	checkPermission bool
-	createContract  bool
+	createContract bool
 }
 
 func (r *interpreterRuntime) updateAccountCode(
@@ -1033,7 +1031,7 @@ func (r *interpreterRuntime) updateAccountCode(
 
 	// NOTE: only update account code if contract instantiation succeeded
 	wrapPanic(func() {
-		err = runtimeInterface.UpdateAccountCode(addressValue.ToAddress(), code, options.checkPermission)
+		err = runtimeInterface.UpdateAccountCode(addressValue.ToAddress(), code)
 	})
 	if err != nil {
 		panic(err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -4106,3 +4106,154 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	err = runtime.ExecuteTransaction(callScript, nil, runtimeInterface, nextTransactionLocation())
 	require.NoError(t, err)
 }
+
+func TestRuntimeTransaction_UpdateAccountCodeUnsafeNotInitializing(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewInterpreterRuntime()
+
+	const contract1 = `
+      pub contract Test {
+
+          pub resource R {
+
+              pub let name: String
+
+              init(name: String) {
+                  self.name = name
+              }
+
+              pub fun hello(): Int {
+                  return 1
+              }
+          }
+
+          pub var rs: @{String: R}
+
+          pub fun hello(): Int {
+              return 1
+          }
+
+          init() {
+              self.rs <- {}
+              self.rs["r1"] <-! create R(name: "1")
+          }
+      }
+    `
+
+	const contract2 = `
+      pub contract Test {
+
+          pub resource R {
+
+              pub let name: String
+
+              init(name: String) {
+                  self.name = name
+              }
+
+              pub fun hello(): Int {
+                  return 2
+              }
+          }
+
+          pub var rs: @{String: R}
+
+          pub fun hello(): Int {
+              return 2
+          }
+
+          init() {
+              self.rs <- {}
+              panic("should never be executed")
+          }
+      }
+    `
+
+	newDeployTransaction := func(code, function string) []byte {
+		return []byte(fmt.Sprintf(
+			`
+              transaction {
+
+                  prepare(signer: AuthAccount) {
+                      signer.%s(%s)
+                  }
+              }
+            `,
+			function,
+			ArrayValueFromBytes([]byte(code)).String(),
+		))
+	}
+
+	var accountCode []byte
+	var events []cadence.Event
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestStorage(nil, nil),
+		getSigningAccounts: func() []Address {
+			return []Address{common.BytesToAddress([]byte{0x42})}
+		},
+		resolveImport: func(_ Location) (bytes []byte, err error) {
+			return accountCode, nil
+		},
+		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+			accountCode = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) {
+			events = append(events, event)
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	deployTx1 := newDeployTransaction(contract1, "setCode")
+
+	err := runtime.ExecuteTransaction(deployTx1, nil, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+
+	script1 := []byte(`
+      import 0x42
+
+      pub fun main() {
+          // Check stored data
+
+          assert(Test.rs.length == 1)
+          assert(Test.rs["r1"]?.name == "1")
+
+          // Check functions
+
+          assert(Test.rs["r1"]?.hello() == 1)
+          assert(Test.hello() == 1)
+      }
+    `)
+
+	_, err = runtime.ExecuteScript(script1, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+
+	deployTx2 := newDeployTransaction(contract2, "unsafeNotInitializingSetCode")
+
+	err = runtime.ExecuteTransaction(deployTx2, nil, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+
+	script2 := []byte(`
+      import 0x42
+
+      pub fun main() {
+          // Existing data is still available and the same as before
+
+          assert(Test.rs.length == 1)
+          assert(Test.rs["r1"]?.name == "1")
+
+          // New function code is executed.
+          // Compare with script1 above, which checked 1.
+
+          assert(Test.rs["r1"]?.hello() == 2)
+          assert(Test.hello() == 2)
+      }
+    `)
+
+	_, err = runtime.ExecuteScript(script2, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -92,7 +92,7 @@ type testRuntimeInterface struct {
 	createAccount      func(payer Address) (address Address, err error)
 	addAccountKey      func(address Address, publicKey []byte) error
 	removeAccountKey   func(address Address, index int) (publicKey []byte, err error)
-	updateAccountCode  func(address Address, code []byte, checkPermission bool) (err error)
+	updateAccountCode  func(address Address, code []byte) (err error)
 	getSigningAccounts func() []Address
 	log                func(string)
 	emitEvent          func(cadence.Event)
@@ -148,8 +148,8 @@ func (i *testRuntimeInterface) RemoveAccountKey(address Address, index int) (pub
 	return i.removeAccountKey(address, index)
 }
 
-func (i *testRuntimeInterface) UpdateAccountCode(address Address, code []byte, checkPermission bool) (err error) {
-	return i.updateAccountCode(address, code, checkPermission)
+func (i *testRuntimeInterface) UpdateAccountCode(address Address, code []byte) (err error) {
+	return i.updateAccountCode(address, code)
 }
 
 func (i *testRuntimeInterface) GetSigningAccounts() []Address {
@@ -1774,7 +1774,7 @@ func TestRuntimeTransaction_UpdateAccountCodeEmpty(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{{42}}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -2137,7 +2137,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 				getSigningAccounts: func() []Address {
 					return []Address{{42}}
 				},
-				updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+				updateAccountCode: func(address Address, code []byte) (err error) {
 					accountCode = code
 					return nil
 				},
@@ -2220,7 +2220,7 @@ func TestRuntimeContractAccount(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{common.BytesToAddress(addressValue.Bytes())}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -2312,7 +2312,7 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{addressValue}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -2514,7 +2514,7 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{signerAccount}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			key := string(AddressLocation(address[:]).ID())
 			accountCodes[key] = code
 			return nil
@@ -2624,7 +2624,7 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{signerAccount}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			key := string(AddressLocation(address[:]).ID())
 			accountCodes[key] = code
 			return nil
@@ -2751,7 +2751,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{{0x1}}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			key := string(AddressLocation(address[:]).ID())
 			accountCodes[key] = code
 			return nil
@@ -2977,7 +2977,7 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 				getSigningAccounts: func() []Address {
 					return []Address{addressValue.ToAddress()}
 				},
-				updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+				updateAccountCode: func(address Address, code []byte) (err error) {
 					accountCode = code
 					return nil
 				},
@@ -3094,7 +3094,7 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{address}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			key := string(AddressLocation(address[:]).ID())
 			accountCodes[key] = code
 			return nil
@@ -3248,7 +3248,7 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{address}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			key := string(AddressLocation(address[:]).ID())
 			accountCodes[key] = code
 			return nil
@@ -3407,7 +3407,7 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{address}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			key := string(AddressLocation(address[:]).ID())
 			accountCodes[key] = code
 			return nil
@@ -3799,7 +3799,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{common.BytesToAddress(addressValue.Bytes())}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -3903,7 +3903,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{common.BytesToAddress(addressValue.Bytes())}
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -4079,7 +4079,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return signerAddresses
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			key := string(AddressLocation(address[:]).ID())
 			accountCodes[key] = code
 			return nil
@@ -4197,7 +4197,7 @@ func TestRuntimeTransaction_UpdateAccountCodeUnsafeNotInitializing(t *testing.T)
 		resolveImport: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountCode: func(address Address, code []byte, checkPermission bool) (err error) {
+		updateAccountCode: func(address Address, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4421,7 +4421,7 @@ func (t *AuthAccountType) GetMember(identifier string, _ ast.Range, _ func(error
 	case "address":
 		return newField(&AddressType{})
 
-	case "setCode":
+	case "setCode", "unsafeNotInitializingSetCode":
 		return newFunction(authAccountSetCodeFunctionType)
 
 	case "addPublicKey":

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -58,6 +58,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		panicFunction,
 		panicFunction,
 		panicFunction,
+		panicFunction,
 	)
 
 	// `pubAccount`

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6804,6 +6804,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 								panicFunction,
 								panicFunction,
 								panicFunction,
+								panicFunction,
 							),
 						}
 					},
@@ -7519,6 +7520,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 	values := map[string]interpreter.Value{
 		"account": interpreter.NewAuthAccountValue(
 			addressValue,
+			panicFunction,
 			panicFunction,
 			panicFunction,
 			panicFunction,

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -224,9 +224,11 @@ func TestInterpretTransactions(t *testing.T) {
 			panicFunction,
 			panicFunction,
 			panicFunction,
+			panicFunction,
 		)
 		signer2 := interpreter.NewAuthAccountValue(
 			interpreter.AddressValue{0, 0, 0, 0, 0, 0, 0, 2},
+			panicFunction,
 			panicFunction,
 			panicFunction,
 			panicFunction,
@@ -264,6 +266,7 @@ func TestInterpretTransactions(t *testing.T) {
 		prepareArguments := []interpreter.Value{
 			interpreter.NewAuthAccountValue(
 				interpreter.AddressValue{},
+				panicFunction,
 				panicFunction,
 				panicFunction,
 				panicFunction,


### PR DESCRIPTION
Add `AuthAccount.unsafeNotInitializingSetCode`, which, like `setCode`, updates the account's code, but does **not** create the contract object.

This allows updating the contract code and keeping the stored contract object.
