### PR TITLE
Do not permit for-in ident to shadow outer scope decls

### DIFF
--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -68,7 +68,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr 
 		pos:                      statement.Identifier.Pos,
 		isConstant:               true,
 		argumentLabels:           nil,
-		allowOuterScopeShadowing: true,
+		allowOuterScopeShadowing: false,
 	})
 	checker.report(err)
 	checker.recordVariableDeclarationOccurrence(identifier, variable)

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -187,3 +187,24 @@ func TestCheckInvalidForContinueStatement(t *testing.T) {
 
 	assert.IsType(t, &sema.ControlStatementError{}, errs[0])
 }
+
+func TestCheckInvalidForShadowing(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun x() {
+			var array = ["Hello", "World", "Foo", "Bar"]
+			var element = "Hi"
+			// Not permitted to use previously declared variable as the
+			// iteration variable.
+			for element in array {
+				element
+			}
+		}
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+}

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -136,7 +136,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
               i = i + 1
           }
 
-          for i in [1, 2, 3, 4, 5] {}
+          for n in [1, 2, 3, 4, 5] {}
       }
     `)
 	require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
                   i = i + 1
               }
 
-              for i in [1, 2, 3] {}
+              for n in [1, 2, 3] {}
 
               a()
           }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/72.

## Description 

Do not permit for-in identifier declaration to shadow declarations in the outer scope. Corresponding test case included.

Update test cases that broke this rule.