### PR TITLE
Resources are temporarily moved into the invoked function

### DIFF
--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -101,7 +101,7 @@ func (checker *Checker) checkAssignment(
 	checker.recordResourceInvalidation(
 		value,
 		valueType,
-		ResourceInvalidationKindMove,
+		ResourceInvalidationKindMoveDefinite,
 	)
 
 	return

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -316,7 +316,7 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 		checker.recordResourceInvalidation(
 			expression.Left,
 			leftType,
-			ResourceInvalidationKindMove,
+			ResourceInvalidationKindMoveDefinite,
 		)
 
 		if !leftIsOptional {

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -41,7 +41,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 		checker.recordResourceInvalidation(
 			leftHandExpression,
 			leftHandType,
-			ResourceInvalidationKindMove,
+			ResourceInvalidationKindMoveDefinite,
 		)
 
 		// If the failable casted type is a resource, the failable cast expression

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1636,7 +1636,7 @@ func (checker *Checker) checkResourceFieldsInvalidated(containerType Type, membe
 // checkResourceUseAfterInvalidation checks if a resource (variable or composite member)
 // is used after it was previously invalidated (moved or destroyed)
 //
-func (checker *Checker) checkResourceUseAfterInvalidation(resource interface{}, useIdentifier ast.Identifier) {
+func (checker *Checker) checkResourceUseAfterInvalidation(resource interface{}, usePosition ast.HasPosition) {
 	resourceInfo := checker.resources.Get(resource)
 	if resourceInfo.Invalidations.Size() == 0 {
 		return
@@ -1644,8 +1644,8 @@ func (checker *Checker) checkResourceUseAfterInvalidation(resource interface{}, 
 
 	checker.report(
 		&ResourceUseAfterInvalidationError{
-			StartPos:      useIdentifier.StartPosition(),
-			EndPos:        useIdentifier.EndPosition(),
+			StartPos:      usePosition.StartPosition(),
+			EndPos:        usePosition.EndPosition(),
 			Invalidations: resourceInfo.Invalidations.All(),
 		},
 	)

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -30,7 +30,9 @@ func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpr
 		return &InvalidType{}
 	}
 
-	if variable.Type.IsResourceType() {
+	valueType := variable.Type
+
+	if valueType.IsResourceType() {
 		checker.checkResourceVariableCapturingInFunction(variable, expression.Identifier)
 		checker.checkResourceUseAfterInvalidation(variable, expression.Identifier)
 		checker.resources.AddUse(variable, expression.Pos)
@@ -38,7 +40,11 @@ func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpr
 
 	checker.checkSelfVariableUseInInitializer(variable, expression.Pos)
 
-	return variable.Type
+	if checker.inInvocation {
+		checker.Elaboration.IdentifierInInvocationTypes[expression] = valueType
+	}
+
+	return valueType
 }
 
 // checkSelfVariableUseInInitializer checks uses of `self` in the initializer

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -33,7 +33,7 @@ func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) as
 	checker.recordResourceInvalidation(
 		expression.Expression,
 		valueType,
-		ResourceInvalidationKindMove,
+		ResourceInvalidationKindMoveDefinite,
 	)
 
 	optionalType, ok := valueType.(*OptionalType)

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -124,7 +124,7 @@ func (checker *Checker) visitVariableDeclaration(declaration *ast.VariableDeclar
 		checker.recordResourceInvalidation(
 			declaration.Value,
 			declarationType,
-			ResourceInvalidationKindMove,
+			ResourceInvalidationKindMoveDefinite,
 		)
 	} else {
 

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -67,6 +67,7 @@ type Elaboration struct {
 	CompositeTypes                         map[TypeID]*CompositeType
 	InterfaceTypes                         map[TypeID]*InterfaceType
 	InvocationExpressionTypeParameterTypes map[*ast.InvocationExpression]map[*TypeParameter]Type
+	IdentifierInInvocationTypes            map[*ast.IdentifierExpression]Type
 }
 
 func NewElaboration() *Elaboration {
@@ -108,5 +109,6 @@ func NewElaboration() *Elaboration {
 		CompositeTypes:                         map[TypeID]*CompositeType{},
 		InterfaceTypes:                         map[TypeID]*InterfaceType{},
 		InvocationExpressionTypeParameterTypes: map[*ast.InvocationExpression]map[*TypeParameter]Type{},
+		IdentifierInInvocationTypes:            map[*ast.IdentifierExpression]Type{},
 	}
 }

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1337,7 +1337,8 @@ func (e *ResourceUseAfterInvalidationError) Cause() (wasMoved, wasDestroyed bool
 	// update cache
 	for _, invalidation := range e.Invalidations {
 		switch invalidation.Kind {
-		case ResourceInvalidationKindMove:
+		case ResourceInvalidationKindMoveDefinite,
+			ResourceInvalidationKindMoveTemporary:
 			wasMoved = true
 		case ResourceInvalidationKindDestroy:
 			wasDestroyed = true
@@ -1445,7 +1446,8 @@ type ResourceInvalidationNote struct {
 func (n ResourceInvalidationNote) Message() string {
 	var action string
 	switch n.Kind {
-	case ResourceInvalidationKindMove:
+	case ResourceInvalidationKindMoveDefinite,
+		ResourceInvalidationKindMoveTemporary:
 		action = "moved"
 	case ResourceInvalidationKindDestroy:
 		action = "destroyed"
@@ -2305,7 +2307,8 @@ type InvalidSelfInvalidationError struct {
 func (e *InvalidSelfInvalidationError) Error() string {
 	var action string
 	switch e.InvalidationKind {
-	case ResourceInvalidationKindMove:
+	case ResourceInvalidationKindMoveDefinite,
+		ResourceInvalidationKindMoveTemporary:
 		action = "move"
 	case ResourceInvalidationKindDestroy:
 		action = "destroy"

--- a/runtime/sema/resource_invalidations.go
+++ b/runtime/sema/resource_invalidations.go
@@ -47,6 +47,12 @@ func (ris ResourceInvalidations) Insert(invalidation ResourceInvalidation) Resou
 	return ResourceInvalidations{newInvalidations}
 }
 
+func (ris ResourceInvalidations) Delete(invalidation ResourceInvalidation) ResourceInvalidations {
+	entry := ResourceInvalidationEntry{invalidation}
+	newInvalidations := ris.invalidations.Delete(entry)
+	return ResourceInvalidations{newInvalidations}
+}
+
 func (ris ResourceInvalidations) Merge(other ResourceInvalidations) ResourceInvalidations {
 	newInvalidations := ris.invalidations.Merge(other.invalidations)
 	return ResourceInvalidations{newInvalidations}

--- a/runtime/sema/resourceinvalidationkind.go
+++ b/runtime/sema/resourceinvalidationkind.go
@@ -28,16 +28,30 @@ type ResourceInvalidationKind uint
 
 const (
 	ResourceInvalidationKindUnknown ResourceInvalidationKind = iota
-	ResourceInvalidationKindMove
+	ResourceInvalidationKindMoveDefinite
+	ResourceInvalidationKindMoveTemporary
 	ResourceInvalidationKindDestroy
 )
 
 func (k ResourceInvalidationKind) Name() string {
 	switch k {
-	case ResourceInvalidationKindMove:
-		return "move"
+	case ResourceInvalidationKindMoveDefinite:
+		return "definite move"
+	case ResourceInvalidationKindMoveTemporary:
+		return "temporary move"
 	case ResourceInvalidationKindDestroy:
 		return "destroy"
+	}
+
+	panic(errors.NewUnreachableError())
+}
+
+func (k ResourceInvalidationKind) IsDefinite() bool {
+	switch k {
+	case ResourceInvalidationKindMoveDefinite, ResourceInvalidationKindDestroy:
+		return true
+	case ResourceInvalidationKindMoveTemporary, ResourceInvalidationKindUnknown:
+		return false
 	}
 
 	panic(errors.NewUnreachableError())

--- a/runtime/sema/resourceinvalidationkind_string.go
+++ b/runtime/sema/resourceinvalidationkind_string.go
@@ -9,13 +9,14 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[ResourceInvalidationKindUnknown-0]
-	_ = x[ResourceInvalidationKindMove-1]
-	_ = x[ResourceInvalidationKindDestroy-2]
+	_ = x[ResourceInvalidationKindMoveDefinite-1]
+	_ = x[ResourceInvalidationKindMoveTemporary-2]
+	_ = x[ResourceInvalidationKindDestroy-3]
 }
 
-const _ResourceInvalidationKind_name = "ResourceInvalidationKindUnknownResourceInvalidationKindMoveResourceInvalidationKindDestroy"
+const _ResourceInvalidationKind_name = "ResourceInvalidationKindUnknownResourceInvalidationKindMoveDefiniteResourceInvalidationKindMoveTemporaryResourceInvalidationKindDestroy"
 
-var _ResourceInvalidationKind_index = [...]uint8{0, 31, 59, 90}
+var _ResourceInvalidationKind_index = [...]uint8{0, 31, 67, 104, 135}
 
 func (i ResourceInvalidationKind) String() string {
 	if i >= ResourceInvalidationKind(len(_ResourceInvalidationKind_index)-1) {

--- a/runtime/sema/resources.go
+++ b/runtime/sema/resources.go
@@ -89,12 +89,24 @@ func (ris *Resources) Get(resource interface{}) ResourceInfo {
 }
 
 // AddInvalidation adds the given invalidation to the set of invalidations for the given resource.
-// Marks the resource to be definitely invalidated.
+// If the invalidation is not temporary, marks the resource to be definitely invalidated.
 //
 func (ris *Resources) AddInvalidation(resource interface{}, invalidation ResourceInvalidation) {
 	info := ris.Get(resource)
-	info.DefinitivelyInvalidated = true
 	info.Invalidations = info.Invalidations.Insert(invalidation)
+	if invalidation.Kind.IsDefinite() {
+		info.DefinitivelyInvalidated = true
+	}
+	entry := ris.entry(resource)
+	ris.resources = ris.resources.Insert(entry, info)
+}
+
+// RemoveTemporaryInvalidation removes the given invalidation
+// from the set of invalidations for the given resource.
+//
+func (ris *Resources) RemoveTemporaryInvalidation(resource interface{}, invalidation ResourceInvalidation) {
+	info := ris.Get(resource)
+	info.Invalidations = info.Invalidations.Delete(invalidation)
 	entry := ris.entry(resource)
 	ris.resources = ris.resources.Insert(entry, info)
 }

--- a/runtime/sema/resources_test.go
+++ b/runtime/sema/resources_test.go
@@ -54,6 +54,7 @@ func TestResources_Add(t *testing.T) {
 	// add invalidation for X
 
 	resources.AddInvalidation(varX, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 1, Column: 1},
 		EndPos:   ast.Position{Line: 1, Column: 1},
 	})
@@ -62,6 +63,7 @@ func TestResources_Add(t *testing.T) {
 		resources.Get(varX).Invalidations.All(),
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 1, Column: 1},
 				EndPos:   ast.Position{Line: 1, Column: 1},
 			},
@@ -73,6 +75,7 @@ func TestResources_Add(t *testing.T) {
 	// add invalidation for X
 
 	resources.AddInvalidation(varX, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 2, Column: 2},
 		EndPos:   ast.Position{Line: 2, Column: 2},
 	})
@@ -81,12 +84,12 @@ func TestResources_Add(t *testing.T) {
 		resources.Get(varX).Invalidations.All(),
 		[]ResourceInvalidation{
 			{
-
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 1, Column: 1},
 				EndPos:   ast.Position{Line: 1, Column: 1},
 			},
 			{
-
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 2, Column: 2},
 				EndPos:   ast.Position{Line: 2, Column: 2},
 			},
@@ -98,6 +101,7 @@ func TestResources_Add(t *testing.T) {
 	// add invalidation for Y
 
 	resources.AddInvalidation(varY, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 3, Column: 3},
 		EndPos:   ast.Position{Line: 3, Column: 3},
 	})
@@ -106,11 +110,12 @@ func TestResources_Add(t *testing.T) {
 		resources.Get(varX).Invalidations.All(),
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 1, Column: 1},
 				EndPos:   ast.Position{Line: 1, Column: 1},
 			},
-
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 2, Column: 2},
 				EndPos:   ast.Position{Line: 2, Column: 2},
 			},
@@ -120,6 +125,7 @@ func TestResources_Add(t *testing.T) {
 		resources.Get(varY).Invalidations.All(),
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 3, Column: 3},
 				EndPos:   ast.Position{Line: 3, Column: 3},
 			},
@@ -147,16 +153,19 @@ func TestResourceResources_FirstRest(t *testing.T) {
 	// add resources for X and Y
 
 	resources.AddInvalidation(varX, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 1, Column: 1},
 		EndPos:   ast.Position{Line: 1, Column: 1},
 	})
 
 	resources.AddInvalidation(varX, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 2, Column: 2},
 		EndPos:   ast.Position{Line: 2, Column: 2},
 	})
 
 	resources.AddInvalidation(varY, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 3, Column: 3},
 		EndPos:   ast.Position{Line: 3, Column: 3},
 	})
@@ -177,10 +186,12 @@ func TestResourceResources_FirstRest(t *testing.T) {
 		result[varX],
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 1, Column: 1},
 				EndPos:   ast.Position{Line: 1, Column: 1},
 			},
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 2, Column: 2},
 				EndPos:   ast.Position{Line: 2, Column: 2},
 			},
@@ -191,6 +202,7 @@ func TestResourceResources_FirstRest(t *testing.T) {
 		result[varY],
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 3, Column: 3},
 				EndPos:   ast.Position{Line: 3, Column: 3},
 			},
@@ -223,10 +235,12 @@ func TestResources_MergeBranches(t *testing.T) {
 	// invalidate X and Y in then branch
 
 	resourcesThen.AddInvalidation(varX, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 1, Column: 1},
 		EndPos:   ast.Position{Line: 1, Column: 1},
 	})
 	resourcesThen.AddInvalidation(varY, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 2, Column: 2},
 		EndPos:   ast.Position{Line: 2, Column: 2},
 	})
@@ -234,10 +248,12 @@ func TestResources_MergeBranches(t *testing.T) {
 	// invalidate Y and Z in else branch
 
 	resourcesElse.AddInvalidation(varX, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 3, Column: 3},
 		EndPos:   ast.Position{Line: 3, Column: 3},
 	})
 	resourcesElse.AddInvalidation(varZ, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 4, Column: 4},
 		EndPos:   ast.Position{Line: 4, Column: 4},
 	})
@@ -245,6 +261,7 @@ func TestResources_MergeBranches(t *testing.T) {
 	// treat var Y already invalidated in main
 	resources := &Resources{}
 	resources.AddInvalidation(varY, ResourceInvalidation{
+		Kind:     ResourceInvalidationKindMoveDefinite,
 		StartPos: ast.Position{Line: 0, Column: 0},
 		EndPos:   ast.Position{Line: 0, Column: 0},
 	})
@@ -260,10 +277,12 @@ func TestResources_MergeBranches(t *testing.T) {
 		varXInfo.Invalidations.All(),
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 1, Column: 1},
 				EndPos:   ast.Position{Line: 1, Column: 1},
 			},
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 3, Column: 3},
 				EndPos:   ast.Position{Line: 3, Column: 3},
 			},
@@ -276,10 +295,12 @@ func TestResources_MergeBranches(t *testing.T) {
 		varYInfo.Invalidations.All(),
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 0, Column: 0},
 				EndPos:   ast.Position{Line: 0, Column: 0},
 			},
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 2, Column: 2},
 				EndPos:   ast.Position{Line: 2, Column: 2},
 			},
@@ -292,6 +313,7 @@ func TestResources_MergeBranches(t *testing.T) {
 		varZInfo.Invalidations.All(),
 		[]ResourceInvalidation{
 			{
+				Kind:     ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Line: 4, Column: 4},
 				EndPos:   ast.Position{Line: 4, Column: 4},
 			},

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -4438,6 +4438,29 @@ func TestCheckResourceMoveMemberInvocation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("valid use, with argument of same type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          resource Test {
+              fun use(_ test: @Test) {
+                  destroy test
+              }
+          }
+
+          fun test() {
+              let test1 <- create Test()
+              let test2 <- create Test()
+              test1.use(<-test2)
+              destroy test1
+          }
+        `)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("valid use, in argument", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -2013,12 +2013,12 @@ func TestCheckInvalidResourceUseAfterIfStatement(t *testing.T) {
 		errs[0].(*sema.ResourceUseAfterInvalidationError).Invalidations,
 		[]sema.ResourceInvalidation{
 			{
-				Kind:     sema.ResourceInvalidationKindMove,
+				Kind:     sema.ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Offset: 164, Line: 9, Column: 23},
 				EndPos:   ast.Position{Offset: 164, Line: 9, Column: 23},
 			},
 			{
-				Kind:     sema.ResourceInvalidationKindMove,
+				Kind:     sema.ResourceInvalidationKindMoveDefinite,
 				StartPos: ast.Position{Offset: 119, Line: 7, Column: 23},
 				EndPos:   ast.Position{Offset: 119, Line: 7, Column: 23},
 			},
@@ -4338,7 +4338,7 @@ func TestCheckInvalidOptionalResourceCoalescingRightSide(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheckWithPanic(t, `
+	_, err := ParseAndCheck(t, `
 
       resource R {}
 
@@ -4365,7 +4365,7 @@ func TestCheckInvalidResourceLossInNestedContractResource(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheckWithPanic(t, `
+	_, err := ParseAndCheck(t, `
 
       pub contract C {
 
@@ -4387,5 +4387,96 @@ func TestCheckInvalidResourceLossInNestedContractResource(t *testing.T) {
 	errs := ExpectCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+}
 
+// https://github.com/onflow/cadence/issues/73
+//
+func TestCheckResourceMoveMemberInvocation(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("invalid use as argument", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          resource Test {
+              fun use(_ test: @Test) {
+                  destroy test
+              }
+          }
+
+          fun test() {
+              let test <- create Test()
+              test.use(<-test)
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
+	})
+
+	t.Run("valid use", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          resource Test {
+              fun use() {}
+          }
+
+          fun test() {
+              let test <- create Test()
+              test.use()
+              destroy test
+          }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("valid use, in argument", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          resource Test {
+              fun use1(_ x: Int) {}
+              fun use2(): Int { return 1 }
+          }
+
+          fun test() {
+              let test <- create Test()
+              test.use1(test.use2())
+              destroy test
+          }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid loss, invalidation is temporary", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          resource Test {
+              fun use() {}
+          }
+
+          fun test() {
+              let test <- create Test()
+              test.use()
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
 }


### PR DESCRIPTION
Closes #73
Closes dapperlabs/flow-go#3932

Properly check that an invocation of a function of a resource is not using the resource after an invalidation, e.g. when the resource was invalidated by moving it into the function as an argument.