### PR TITLE
Add built-in AccountKey type, add addAccountKey function to AuthAccount

### DIFF
--- a/runtime/interpreter/dynamictype.go
+++ b/runtime/interpreter/dynamictype.go
@@ -147,6 +147,12 @@ type AddressDynamicType struct{}
 
 func (AddressDynamicType) IsDynamicType() {}
 
+// AccountKeyDynamicType
+
+type AccountKeyDynamicType struct{}
+
+func (AccountKeyDynamicType) IsDynamicType() {}
+
 // PublishedDynamicType
 
 type PublishedDynamicType struct{}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6019,7 +6019,7 @@ func NewAccountKeyValue(publicKey []byte) AccountKeyValue {
 func (AccountKeyValue) IsValue() {}
 
 func (AccountKeyValue) DynamicType(_ *Interpreter) DynamicType {
-	return AddressDynamicType{}
+	return AccountKeyDynamicType{}
 }
 
 func (v AccountKeyValue) Copy() Value {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4289,6 +4289,21 @@ var authAccountAddPublicKeyFunctionType = &FunctionType{
 	),
 }
 
+var authAccountAddAccountKeyFunctionType = &FunctionType{
+	Parameters: []*Parameter{
+		{
+			Label:      ArgumentLabelNotRequired,
+			Identifier: "accountKey",
+			TypeAnnotation: NewTypeAnnotation(
+				&AccountKeyType{},
+			),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&VoidType{},
+	),
+}
+
 var authAccountRemovePublicKeyFunctionType = &FunctionType{
 	Parameters: []*Parameter{
 		{
@@ -4508,6 +4523,9 @@ func (t *AuthAccountType) GetMember(identifier string, _ ast.Range, _ func(error
 	case "addPublicKey":
 		return newFunction(authAccountAddPublicKeyFunctionType)
 
+	case "addAccountKey":
+		return newFunction(authAccountAddAccountKeyFunctionType)
+
 	case "removePublicKey":
 		return newFunction(authAccountRemovePublicKeyFunctionType)
 
@@ -4622,6 +4640,82 @@ func (*PublicAccountType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err er
 
 func (t *PublicAccountType) Resolve(_ map[*TypeParameter]Type) Type {
 	return t
+}
+
+// AccountKeyType
+
+type AccountKeyType struct{}
+
+func (*AccountKeyType) IsType() {}
+
+func (*AccountKeyType) String() string {
+	return "AccountKey"
+}
+
+func (*AccountKeyType) QualifiedString() string {
+	return "AccountKey"
+}
+
+func (*AccountKeyType) ID() TypeID {
+	return "AccountKey"
+}
+
+func (*AccountKeyType) Equal(other Type) bool {
+	_, ok := other.(*AccountKeyType)
+	return ok
+}
+
+func (*AccountKeyType) IsResourceType() bool {
+	return false
+}
+
+func (*AccountKeyType) TypeAnnotationState() TypeAnnotationState {
+	return TypeAnnotationStateValid
+}
+
+func (*AccountKeyType) IsInvalidType() bool {
+	return false
+}
+
+func (*AccountKeyType) ContainsFirstLevelInterfaceType() bool {
+	return false
+}
+
+func (*AccountKeyType) CanHaveMembers() bool {
+	return true
+}
+
+func (t *AccountKeyType) GetMember(identifier string, _ ast.Range, _ func(error)) *Member {
+	newField := func(fieldType Type) *Member {
+		return NewPublicConstantFieldMember(t, identifier, fieldType)
+	}
+
+	switch identifier {
+	case "publicKey":
+		return newField(&Int8Type{})
+
+	case "signingAlgorithm":
+		return newField(&Int8Type{})
+
+	case "hashingAlgorithm":
+		return newField(&Int8Type{})
+
+	case "weight":
+		return newField(&UInt64Type{})
+
+	default:
+		return nil
+	}
+}
+
+func (t *AccountKeyType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {
+	// return false
+	return false
+}
+
+func (t *AccountKeyType) Resolve(_ map[*TypeParameter]Type) Type {
+	// return t
+	return nil
 }
 
 // Member

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4692,7 +4692,7 @@ func (t *AccountKeyType) GetMember(identifier string, _ ast.Range, _ func(error)
 
 	switch identifier {
 	case "publicKey":
-		return newField(&Int8Type{})
+		return newField(&VariableSizedType{Type: &Int8Type{}})
 
 	case "signingAlgorithm":
 		return newField(&Int8Type{})

--- a/runtime/stdlib/flow_builtin.go
+++ b/runtime/stdlib/flow_builtin.go
@@ -46,6 +46,25 @@ var accountFunctionType = &sema.FunctionType{
 	),
 }
 
+var accountKeyFunctionType = &sema.FunctionType{
+	Parameters: []*sema.Parameter{
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "publicKey",
+			TypeAnnotation: sema.NewTypeAnnotation(
+				&sema.VariableSizedType{
+					// TODO: UInt8. Requires array literals of integer literals
+					//   to be type compatible with with [UInt8]
+					Type: &sema.IntType{},
+				},
+			),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.AccountKeyType{},
+	),
+}
+
 var getAccountFunctionType = &sema.FunctionType{
 	Parameters: []*sema.Parameter{
 		{
@@ -106,12 +125,13 @@ var unsafeRandomFunctionType = &sema.FunctionType{
 // FlowBuiltinImpls defines the set of functions needed to implement the Flow
 // built-in functions.
 type FlowBuiltinImpls struct {
-	CreateAccount   interpreter.HostFunction
-	GetAccount      interpreter.HostFunction
-	Log             interpreter.HostFunction
-	GetCurrentBlock interpreter.HostFunction
-	GetBlock        interpreter.HostFunction
-	UnsafeRandom    interpreter.HostFunction
+	CreateAccount    interpreter.HostFunction
+	GetAccount       interpreter.HostFunction
+	CreateAccountKey interpreter.HostFunction
+	Log              interpreter.HostFunction
+	GetCurrentBlock  interpreter.HostFunction
+	GetBlock         interpreter.HostFunction
+	UnsafeRandom     interpreter.HostFunction
 }
 
 // FlowBuiltInFunctions returns a list of standard library functions, bound to
@@ -128,6 +148,12 @@ func FlowBuiltInFunctions(impls FlowBuiltinImpls) StandardLibraryFunctions {
 			"getAccount",
 			getAccountFunctionType,
 			impls.GetAccount,
+			nil,
+		),
+		NewStandardLibraryFunction(
+			"AccountKey",
+			accountKeyFunctionType,
+			impls.CreateAccountKey,
 			nil,
 		),
 		NewStandardLibraryFunction(

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -59,6 +59,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		panicFunction,
 		panicFunction,
 		panicFunction,
+		panicFunction,
 	)
 
 	// `pubAccount`

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6806,6 +6806,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 								panicFunction,
 								panicFunction,
 								panicFunction,
+								panicFunction,
 							),
 						}
 					},
@@ -7521,6 +7522,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 	values := map[string]interpreter.Value{
 		"account": interpreter.NewAuthAccountValue(
 			addressValue,
+			panicFunction,
 			panicFunction,
 			panicFunction,
 			panicFunction,

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -225,9 +225,11 @@ func TestInterpretTransactions(t *testing.T) {
 			panicFunction,
 			panicFunction,
 			panicFunction,
+			panicFunction,
 		)
 		signer2 := interpreter.NewAuthAccountValue(
 			interpreter.AddressValue{0, 0, 0, 0, 0, 0, 0, 2},
+			panicFunction,
 			panicFunction,
 			panicFunction,
 			panicFunction,
@@ -266,6 +268,7 @@ func TestInterpretTransactions(t *testing.T) {
 		prepareArguments := []interpreter.Value{
 			interpreter.NewAuthAccountValue(
 				interpreter.AddressValue{},
+				panicFunction,
 				panicFunction,
 				panicFunction,
 				panicFunction,


### PR DESCRIPTION
Closes https://github.com/dapperlabs/flow-go/issues/3287

## Description

Implement a native `AccountKey` type, to be used in place of a raw `[]byte` containing the public key bytes.

- [x] Implement test case for `AccountKey`
- [x] Implement `AccountKey` constructor: `AccountKey(publicKey: [Int8])`
- [x] Implement `AccountKey` built-in type.
- [x] Add method to `AuthAccount`, `addAccountKey` (versus updating/replacing `addPublicKey`)

Opening this up for merge in anticipation of refactor to use `crypto` package types.