### PR TITLE
Provide position information in parser errors, use new parser in language server

### DIFF
--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/mattn/go-isatty v0.0.12
-	github.com/onflow/cadence v0.4.0
-	github.com/onflow/flow-go-sdk v0.4.0
+	github.com/onflow/cadence v0.4.1-0.20200604185918-21edaa9bfcdd
+	github.com/onflow/flow-go-sdk v0.5.0
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20191222043438-96c4efab7ee2
 	google.golang.org/grpc v1.29.1
 )

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -24,6 +24,7 @@ github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f h1:0cEys61Sr2hUBEXfNV
 github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
 github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6 h1:Eey/GGQ/E5Xp1P2Lyx1qj007hLZfbi0+CoVeJruGCtI=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6/go.mod h1:Dmm/EzmjnCiweXmzRIAiUWCInVmPgjkzgv5k4tVyXiQ=
 github.com/c-bata/go-prompt v0.2.3/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -120,10 +121,15 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/onflow/cadence/languageserver v0.4.0/go.mod h1:U7adpeLPBbyxYYbAcJ3TQlNDj2ZBNeGgaLj8d7M9LvE=
 github.com/onflow/flow-go-sdk v0.4.0 h1:ZNEE8HQ6xTyr4+RmlxZ2+U/BjKtQDsAB54I+D8AJpZA=
 github.com/onflow/flow-go-sdk v0.4.0/go.mod h1:MHn8oQCkBNcl2rXdYSm9VYYK4ogwEpyrdM/XK/czdlM=
+github.com/onflow/flow-go-sdk v0.5.0 h1:jAEI6aaCS53iynZ+S5U/6jGKOCLR9q4E3vbEyrz76Ik=
+github.com/onflow/flow-go-sdk v0.5.0/go.mod h1:jTb6IjxQDcdoms1z277HUmgeVQ7JmhtCDhRKChiXclk=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200601215056-34a11def1d6b h1:n/KYBKS3/m5g0GNXWLueVUgwcI51XgAXlFBqox2c1uA=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200601215056-34a11def1d6b/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200611205353-548107cc9aca h1:iw0VQx3aic04XPqpgJfw3CmHpkflK5vEb6EHi/hBsk8=
+github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200611205353-548107cc9aca/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -175,9 +181,11 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
 go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5 h1:Q7tZBpemrlsc2I7IyODzhtallWRSm4Q0d09pL6XbQtU=
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -186,6 +194,7 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -195,6 +204,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -223,7 +234,10 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11 h1:Yq9t9jnGoR+dBuitxdo9l6Q7xh/zOyNnYUtDKaQ3x0E=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/languageserver/server/commands.go
+++ b/languageserver/server/commands.go
@@ -159,7 +159,7 @@ func (s *Server) executeScript(conn protocol.Conn, args ...interface{}) (interfa
 	}
 
 	script := []byte(doc.text)
-	res, err := s.flowClient.ExecuteScriptAtLatestBlock(context.Background(), script)
+	res, err := s.flowClient.ExecuteScriptAtLatestBlock(context.Background(), script, nil)
 	if err != nil {
 
 		grpcErr, ok := status.FromError(err)

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/go-test/deep"
 
-	"github.com/onflow/cadence/runtime/parser"
+	parser1 "github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/parser2"
 )
 
@@ -98,7 +98,7 @@ func bench(args []string) {
 
 func benchOldAndNew(code string) (oldResult, newResult testing.BenchmarkResult) {
 	oldResult = benchParse(code, func(code string) (err error) {
-		_, _, err = parser.ParseProgram(code)
+		_, _, err = parser1.ParseProgram(code)
 		return
 	})
 
@@ -170,7 +170,7 @@ func compare(args []string) {
 }
 
 func compareOldAndNew(code string) string {
-	oldResult, _, err := parser.ParseProgram(code)
+	oldResult, _, err := parser1.ParseProgram(code)
 	if err != nil {
 		return fmt.Sprintf("old parser failed: %s", err)
 	}

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -19,8 +19,6 @@
 package parser2
 
 import (
-	"errors"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -772,9 +770,12 @@ func TestParseAccess(t *testing.T) {
 		t.Parallel()
 
 		result, errs := parse("pub ( ")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf("expected keyword \"set\", got EOF"),
+				&SyntaxError{
+					Message: "expected keyword \"set\", got EOF",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
 			},
 			errs,
 		)
@@ -790,9 +791,12 @@ func TestParseAccess(t *testing.T) {
 		t.Parallel()
 
 		result, errs := parse("pub ( set ")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf("expected token ')'"),
+				&SyntaxError{
+					Message: "expected token ')'",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
 			},
 			errs,
 		)
@@ -808,9 +812,12 @@ func TestParseAccess(t *testing.T) {
 		t.Parallel()
 
 		result, errs := parse("pub ( foo )")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf("expected keyword \"set\", got \"foo\""),
+				&SyntaxError{
+					Message: "expected keyword \"set\", got \"foo\"",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
 			},
 			errs,
 		)
@@ -891,9 +898,12 @@ func TestParseAccess(t *testing.T) {
 		t.Parallel()
 
 		result, errs := parse("access ( ")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf("expected keyword \"all\", \"account\", \"contract\", or \"self\", got EOF"),
+				&SyntaxError{
+					Message: "expected keyword \"all\", \"account\", \"contract\", or \"self\", got EOF",
+					Pos:     ast.Position{Offset: 9, Line: 1, Column: 9},
+				},
 			},
 			errs,
 		)
@@ -909,9 +919,12 @@ func TestParseAccess(t *testing.T) {
 		t.Parallel()
 
 		result, errs := parse("access ( self ")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf("expected token ')'"),
+				&SyntaxError{
+					Message: "expected token ')'",
+					Pos:     ast.Position{Offset: 14, Line: 1, Column: 14},
+				},
 			},
 			errs,
 		)
@@ -927,9 +940,12 @@ func TestParseAccess(t *testing.T) {
 		t.Parallel()
 
 		result, errs := parse("access ( foo )")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf("expected keyword \"all\", \"account\", \"contract\", or \"self\", got \"foo\""),
+				&SyntaxError{
+					Message: "expected keyword \"all\", \"account\", \"contract\", or \"self\", got \"foo\"",
+					Pos:     ast.Position{Offset: 9, Line: 1, Column: 9},
+				},
 			},
 			errs,
 		)
@@ -950,9 +966,12 @@ func TestParseImportDeclaration(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseDeclarations(` import`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected end in import declaration: expected string, address, or identifier"),
+				&SyntaxError{
+					Message: "unexpected end in import declaration: expected string, address, or identifier",
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+				},
 			},
 			errs,
 		)
@@ -1016,12 +1035,13 @@ func TestParseImportDeclaration(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseDeclarations(` import 1`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New(
-					"unexpected token in import declaration: " +
+				&SyntaxError{
+					Message: "unexpected token in import declaration: " +
 						"got decimal integer, expected string, address, or identifier",
-				),
+					Pos: ast.Position{Offset: 8, Line: 1, Column: 8},
+				},
 			},
 			errs,
 		)
@@ -1068,12 +1088,13 @@ func TestParseImportDeclaration(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseDeclarations(` import foo "bar"`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New(
-					"unexpected token in import declaration: " +
+				&SyntaxError{
+					Message: "unexpected token in import declaration: " +
 						"got string, expected keyword \"from\" or ','",
-				),
+					Pos: ast.Position{Offset: 12, Line: 1, Column: 12},
+				},
 			},
 			errs,
 		)
@@ -1127,9 +1148,12 @@ func TestParseImportDeclaration(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseDeclarations(` import foo , bar , from 0x42`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New(`expected identifier, got keyword "from"`),
+				&SyntaxError{
+					Message: `expected identifier, got keyword "from"`,
+					Pos:     ast.Position{Offset: 20, Line: 1, Column: 20},
+				},
 			},
 			errs,
 		)
@@ -1678,9 +1702,12 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseDeclarations(" pub struct interface interface { }")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf("expected interface name, got keyword \"interface\""),
+				&SyntaxError{
+					Message: "expected interface name, got keyword \"interface\"",
+					Pos:     ast.Position{Offset: 22, Line: 1, Column: 22},
+				},
 			},
 			errs,
 		)

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -19,7 +19,6 @@
 package parser2
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -33,7 +32,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	parser1 "github.com/onflow/cadence/runtime/parser"
-	"github.com/onflow/cadence/runtime/parser2/lexer"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -749,9 +747,12 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression("\"")
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+				},
 			},
 			errs,
 		)
@@ -773,9 +774,12 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression("\"\n")
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 2, Line: 2, Column: 0},
+				},
 			},
 			errs,
 		)
@@ -796,9 +800,12 @@ func TestParseString(t *testing.T) {
 
 		t.Parallel()
 		result, errs := ParseExpression("\"t")
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
 			},
 			errs,
 		)
@@ -820,9 +827,12 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression("\"t\n")
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 3, Line: 2, Column: 0},
+				},
 			},
 			errs,
 		)
@@ -844,10 +854,16 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression("\"\\")
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("incomplete escape sequence: missing character after escape character"),
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "incomplete escape sequence: missing character after escape character",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
 			},
 			errs,
 		)
@@ -888,9 +904,12 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`"te\Xst"`)
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid escape character: 'X'"),
+				&SyntaxError{
+					Message: "invalid escape character: 'X'",
+					Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
+				},
 			},
 			errs,
 		)
@@ -912,10 +931,16 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`"te\u`)
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("incomplete Unicode escape sequence: missing character '{' after escape character"),
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "incomplete Unicode escape sequence: missing character '{' after escape character",
+					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
+				},
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
+				},
 			},
 			errs,
 		)
@@ -937,10 +962,16 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`"te\us`)
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid Unicode escape sequence: expected '{', got 's'"),
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "invalid Unicode escape sequence: expected '{', got 's'",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
 			},
 			errs,
 		)
@@ -962,10 +993,16 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`"te\u{`)
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("incomplete Unicode escape sequence: missing character '}' after escape character"),
-				errors.New("invalid end of string literal: missing '\"'"),
+				&SyntaxError{
+					Message: "incomplete Unicode escape sequence: missing character '}' after escape character",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
 			},
 			errs,
 		)
@@ -1033,9 +1070,12 @@ func TestParseString(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`"te\u{X}st"`)
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid Unicode escape sequence: expected hex digit, got 'X'"),
+				&SyntaxError{
+					Message: "invalid Unicode escape sequence: expected hex digit, got 'X'",
+					Pos:     ast.Position{Offset: 11, Line: 1, Column: 11},
+				},
 			},
 			errs,
 		)
@@ -1245,7 +1285,7 @@ func TestInvocation(t *testing.T) {
 		result, errs := ParseExpression("f(a:1,b:2)")
 		require.Empty(t, errs)
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			&ast.InvocationExpression{
 				InvokedExpression: &ast.IdentifierExpression{
 					Identifier: ast.Identifier{
@@ -1292,12 +1332,12 @@ func TestInvocation(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseExpression("f(,,)")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf(
-					"expected argument or end of argument list, got %s",
-					lexer.TokenComma,
-				),
+				&SyntaxError{
+					Message: "expected argument or end of argument list, got ','",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
 			},
 			errs,
 		)
@@ -1308,12 +1348,12 @@ func TestInvocation(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseExpression("f(1,,)")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf(
-					"expected argument or end of argument list, got %s",
-					lexer.TokenComma,
-				),
+				&SyntaxError{
+					Message: "expected argument or end of argument list, got ','",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)
@@ -1324,12 +1364,13 @@ func TestInvocation(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseExpression("f(1 2)")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				fmt.Errorf(
-					"unexpected argument in argument list (expecting delimiter or end of argument list), got %s",
-					lexer.TokenDecimalLiteral,
-				),
+				&SyntaxError{
+					Message: "unexpected argument in argument list (expecting delimiter or end of argument list)," +
+						" got decimal integer",
+					Pos: ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)
@@ -2199,9 +2240,12 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0b`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("missing digits"),
+				&SyntaxError{
+					Message: "missing digits",
+					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+				},
 				&InvalidIntegerLiteralError{
 					Literal:                   "0b",
 					IntegerLiteralKind:        IntegerLiteralKindBinary,
@@ -2291,7 +2335,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0b_101010_101010`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
 				&InvalidIntegerLiteralError{
 					Literal:                   "0b_101010_101010",
@@ -2324,7 +2368,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0b101010_101010_`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
 				&InvalidIntegerLiteralError{
 					Literal:                   "0b101010_101010_",
@@ -2357,9 +2401,12 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0o`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("missing digits"),
+				&SyntaxError{
+					Message: "missing digits",
+					Pos:     ast.Position{Line: 1, Column: 1, Offset: 1},
+				},
 				&InvalidIntegerLiteralError{
 					Literal:                   `0o`,
 					IntegerLiteralKind:        IntegerLiteralKindOctal,
@@ -2431,7 +2478,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0o_32_45`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
 				&InvalidIntegerLiteralError{
 					Literal:                   "0o_32_45",
@@ -2464,7 +2511,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0o32_45_`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
 				&InvalidIntegerLiteralError{
 					Literal:                   "0o32_45_",
@@ -2537,7 +2584,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`1_234_567_890_`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
 				&InvalidIntegerLiteralError{
 					Literal:                   "1_234_567_890_",
@@ -2570,9 +2617,12 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0x`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("missing digits"),
+				&SyntaxError{
+					Message: "missing digits",
+					Pos:     ast.Position{Line: 1, Column: 1, Offset: 1},
+				},
 				&InvalidIntegerLiteralError{
 					Literal:                   `0x`,
 					IntegerLiteralKind:        IntegerLiteralKindHexadecimal,
@@ -2644,7 +2694,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0x_f2_09`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
 				&InvalidIntegerLiteralError{
 					Literal:                   "0x_f2_09",
@@ -2677,7 +2727,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0xf2_09_`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
 				&InvalidIntegerLiteralError{
 					Literal:                   `0xf2_09_`,
@@ -2790,9 +2840,12 @@ func TestParseIntegerLiterals(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression(`0z123`)
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid number literal prefix: 'z'"),
+				&SyntaxError{
+					Message: "invalid number literal prefix: 'z'",
+					Pos:     ast.Position{Line: 1, Column: 1, Offset: 1},
+				},
 				&InvalidIntegerLiteralError{
 					Literal:                   `0z123`,
 					IntegerLiteralKind:        IntegerLiteralKindDecimal,
@@ -2873,9 +2926,12 @@ func TestParseFixedPoint(t *testing.T) {
 		t.Parallel()
 
 		result, errs := ParseExpression("0.")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("missing fractional digits"),
+				&SyntaxError{
+					Message: "missing fractional digits",
+					Pos:     ast.Position{Line: 1, Column: 1, Offset: 1},
+				},
 			},
 			errs,
 		)

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
-	oldParser "github.com/onflow/cadence/runtime/parser"
+	parser1 "github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/parser2/lexer"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -1685,7 +1685,7 @@ func BenchmarkParseInfix(b *testing.B) {
 
 	b.Run("old", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _, _ = oldParser.ParseExpression("(8 - 1 + 3) * 6 - ((3 + 7) * 2)")
+			_, _, _ = parser1.ParseExpression("(8 - 1 + 3) * 6 - ((3 + 7) * 2)")
 		}
 	})
 }
@@ -1712,7 +1712,7 @@ func BenchmarkParseArray(b *testing.B) {
 
 	b.Run("old", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _, _ = oldParser.ParseExpression(lit)
+			_, _, _ = parser1.ParseExpression(lit)
 		}
 	})
 }

--- a/runtime/parser2/invalidnumberliteralkind.go
+++ b/runtime/parser2/invalidnumberliteralkind.go
@@ -41,6 +41,8 @@ func (k InvalidNumberLiteralKind) Description() string {
 		return "trailing underscore"
 	case InvalidNumberLiteralKindUnknownPrefix:
 		return "unknown prefix"
+	case InvalidNumberLiteralKindUnknown:
+		return "unknown"
 	}
 
 	panic(errors.NewUnreachableError())

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -91,11 +91,11 @@ func Lex(ctx context.Context, input string) chan Token {
 
 type done struct{}
 
-// run executes the stateFn, which will scan the runes in the input 
+// run executes the stateFn, which will scan the runes in the input
 // and emit tokens to the tokens channel.
 //
-// stateFn might return another stateFn to indicate further scanning work, 
-// or nil if there is no scanning work left to be done, 
+// stateFn might return another stateFn to indicate further scanning work,
+// or nil if there is no scanning work left to be done,
 // i.e. run will keep running the returned stateFn until no more
 // stateFn is returned, which for example happens when reaching the end of the file.
 //

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -26,7 +26,7 @@ const keywordAs = "as"
 
 // stateFn uses the input lexer to read runes and emit tokens.
 //
-// It either returns nil when reaching end of file, 
+// It either returns nil when reaching end of file,
 // or returns another stateFn for more scanning work.
 type stateFn func(*lexer) stateFn
 

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -181,11 +181,20 @@ func (p *parser) next() {
 
 		if token.Is(lexer.TokenError) {
 			// Report error token as error, skip.
-			p.report(token.Value.(error))
+			err := token.Value.(error)
+			parseError, ok := err.(ParseError)
+			if !ok {
+				parseError = &SyntaxError{
+					Pos:     token.StartPos,
+					Message: err.Error(),
+				}
+			}
+			p.report(parseError)
 			continue
 		}
 
 		p.current = token
+
 		return
 	}
 }

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -19,14 +19,15 @@
 package parser2
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/parser2/lexer"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestMain(m *testing.M) {
@@ -92,9 +93,12 @@ func TestParseBuffering(t *testing.T) {
 			return nil
 		})
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("expected token identifier with string value c"),
+				&SyntaxError{
+					Message: "expected token identifier with string value c",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)
@@ -213,9 +217,12 @@ func TestParseBuffering(t *testing.T) {
 			return nil
 		})
 
-		assert.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("expected token identifier with string value d"),
+				&SyntaxError{
+					Message: "expected token identifier with string value d",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
 			},
 			errs,
 		)

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -19,7 +19,6 @@
 package parser2
 
 import (
-	"errors"
 	"math/big"
 	"testing"
 
@@ -442,9 +441,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{ T , }")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("missing type after comma"),
+				&SyntaxError{
+					Message: "missing type after comma",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
 			},
 			errs,
 		)
@@ -455,9 +457,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{ T U }")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected type"),
+				&SyntaxError{
+					Message: "unexpected type",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)
@@ -468,9 +473,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{ T , U : V }")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected colon in restricted type"),
+				&SyntaxError{
+					Message: "unexpected colon in restricted type",
+					Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
+				},
 			},
 			errs,
 		)
@@ -481,9 +489,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("T{ T , U : V }")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New(`unexpected token: got ':', expected ',' or '}'`),
+				&SyntaxError{
+					Message: `unexpected token: got ':', expected ',' or '}'`,
+					Pos:     ast.Position{Offset: 9, Line: 1, Column: 9},
+				},
 			},
 			errs,
 		)
@@ -494,9 +505,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{[T]}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("non-nominal type in restriction list: [T]"),
+				&SyntaxError{
+					Message: "non-nominal type in restriction list: [T]",
+					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
+				},
 			},
 			errs,
 		)
@@ -507,9 +521,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("T{[U]}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected non-nominal type: [U]"),
+				&SyntaxError{
+					Message: "unexpected non-nominal type: [U]",
+					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
+				},
 			},
 			errs,
 		)
@@ -520,9 +537,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{T, [U]}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("non-nominal type in restriction list: [U]"),
+				&SyntaxError{
+					Message: "non-nominal type in restriction list: [U]",
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+				},
 			},
 			errs,
 		)
@@ -533,9 +553,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("T{U, [V]}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected non-nominal type: [V]"),
+				&SyntaxError{
+					Message: "unexpected non-nominal type: [V]",
+					Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
+				},
 			},
 			errs,
 		)
@@ -546,9 +569,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected type"),
+				&SyntaxError{
+					Message: "invalid end of input, expected type",
+					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+				},
 			},
 			errs,
 		)
@@ -559,9 +585,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("T{")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected type"),
+				&SyntaxError{
+					Message: "invalid end of input, expected type",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
 			},
 			errs,
 		)
@@ -572,9 +601,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{U")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected '}'"),
+				&SyntaxError{
+					Message: "invalid end of input, expected '}'",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
 			},
 			errs,
 		)
@@ -585,9 +617,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("T{U")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected '}'"),
+				&SyntaxError{
+					Message: "invalid end of input, expected '}'",
+					Pos:     ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
 			},
 			errs,
 		)
@@ -598,9 +633,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{U,")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected type"),
+				&SyntaxError{
+					Message: "invalid end of input, expected type",
+					Pos:     ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
 			},
 			errs,
 		)
@@ -611,9 +649,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("T{U,")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected type"),
+				&SyntaxError{
+					Message: "invalid end of input, expected type",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)
@@ -624,9 +665,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{,}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected comma in restricted type"),
+				&SyntaxError{
+					Message: "unexpected comma in restricted type",
+					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+				},
 			},
 			errs,
 		)
@@ -637,9 +681,12 @@ func TestParseRestrictedType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("T{,}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected comma"),
+				&SyntaxError{
+					Message: "unexpected comma",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
 			},
 			errs,
 		)
@@ -685,9 +732,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{T:}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("missing dictionary value type"),
+				&SyntaxError{
+					Message: "missing dictionary value type",
+					Pos:     ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
 			},
 			errs,
 		)
@@ -698,9 +748,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{:}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected colon in dictionary type"),
+				&SyntaxError{
+					Message: "unexpected colon in dictionary type",
+					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+				},
 			},
 			errs,
 		)
@@ -711,9 +764,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{:U}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected colon in dictionary type"),
+				&SyntaxError{
+					Message: "unexpected colon in dictionary type",
+					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+				},
 			},
 			errs,
 		)
@@ -724,9 +780,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{T:U,}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected comma in dictionary type"),
+				&SyntaxError{
+					Message: "unexpected comma in dictionary type",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)
@@ -737,9 +796,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{T:U:}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected colon in dictionary type"),
+				&SyntaxError{
+					Message: "unexpected colon in dictionary type",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)
@@ -750,9 +812,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{T::U}")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("unexpected colon in dictionary type"),
+				&SyntaxError{
+					Message: "unexpected colon in dictionary type",
+					Pos:     ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
 			},
 			errs,
 		)
@@ -763,9 +828,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{T:")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected type"),
+				&SyntaxError{
+					Message: "invalid end of input, expected type",
+					Pos:     ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
 			},
 			errs,
 		)
@@ -776,9 +844,12 @@ func TestParseDictionaryType(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseType("{T:U")
-		require.Equal(t,
+		utils.AssertEqualWithDiff(t,
 			[]error{
-				errors.New("invalid end of input, expected '}'"),
+				&SyntaxError{
+					Message: "invalid end of input, expected '}'",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
 			},
 			errs,
 		)

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/parser"
+	parser1 "github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/onflow/cadence/runtime/trampoline"
@@ -110,7 +110,7 @@ func (r *REPL) check(element ast.Element, code string) bool {
 func (r *REPL) Accept(code string) (inputIsComplete bool) {
 	var result []interface{}
 	var err error
-	result, inputIsComplete, err = parser.ParseReplInput(code)
+	result, inputIsComplete, err = parser1.ParseReplInput(code)
 
 	if !inputIsComplete {
 		return

--- a/runtime/sema/before_extractor_test.go
+++ b/runtime/sema/before_extractor_test.go
@@ -25,19 +25,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
 )
 
 func TestBeforeExtractor(t *testing.T) {
 
 	t.Parallel()
 
-	expression, inputIsComplete, err := parser.ParseExpression(`
+	expression, errs := parser2.ParseExpression(`
         before(x + before(y)) + z
     `)
 
-	require.True(t, inputIsComplete)
-	require.NoError(t, err)
+	require.Empty(t, errs)
 
 	extractor := NewBeforeExtractor(nil)
 

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -749,7 +749,7 @@ func TestCheckAccessImportGlobalValue(t *testing.T) {
 				// NOTE: only parse, don't check imported program.
 				// will be checked by checker checking importing program
 
-				imported, _, err := parser.ParseProgram(test)
+				imported, err := parser2.ParseProgram(test)
 
 				require.NoError(t, err)
 
@@ -1849,7 +1849,7 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
 				lastAccessModifier = "priv"
 			}
 
-			imported, _, err := parser.ParseProgram(
+			imported, err := parser2.ParseProgram(
 				fmt.Sprintf(
 					`
                        priv var a = 1
@@ -1903,7 +1903,7 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
 	// NOTE: only parse, don't check imported program.
 	// will be checked by checker checking importing program
 
-	imported, _, err := parser.ParseProgram(`
+	imported, err := parser2.ParseProgram(`
        pub resource R {}
 
        pub fun createR(): @R {

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
-	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -159,7 +159,7 @@ func TestCheckInvalidImportedError(t *testing.T) {
 	// NOTE: only parse, don't check imported program.
 	// will be checked by checker checking importing program
 
-	imported, _, err := parser.ParseProgram(`
+	imported, err := parser2.ParseProgram(`
        let x: Bool = 1
     `)
 
@@ -266,7 +266,7 @@ func TestCheckInvalidImportCycle(t *testing.T) {
 	// will be checked by checker checking importing program
 
 	const code = `import 0x1`
-	imported, _, err := parser.ParseProgram(code)
+	imported, err := parser2.ParseProgram(code)
 
 	require.NoError(t, err)
 

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
-	"github.com/onflow/cadence/runtime/parser"
+	parser1 "github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
@@ -31,7 +31,7 @@ func ParseAndCheckWithOptions(
 	options ParseAndCheckOptions,
 ) (*sema.Checker, error) {
 
-	program, _, err := parser.ParseProgram(code)
+	program, _, err := parser1.ParseProgram(code)
 	if !assert.NoError(t, err) {
 		assert.FailNow(t, errors.UnrollChildErrors(err))
 		return nil, err

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/onflow/cadence/runtime/tests/checker"
@@ -1493,7 +1493,7 @@ func TestInterpretHostFunction(t *testing.T) {
 
 	t.Parallel()
 
-	program, _, err := parser.ParseProgram(`
+	program, err := parser2.ParseProgram(`
       pub let a = test(1, 2)
     `)
 
@@ -1565,7 +1565,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 
 	t.Parallel()
 
-	program, _, err := parser.ParseProgram(`
+	program, err := parser2.ParseProgram(`
       pub let nothing = test(1, true, "test")
     `)
 

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -32,7 +32,7 @@ import (
 
 	. "github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/parser"
+	parser1 "github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -41,7 +41,7 @@ func TestParseReplInput(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseReplInput(`
+	actual, _, err := parser1.ParseReplInput(`
         struct X {}; let x = X(); x
     `)
 
@@ -58,19 +58,19 @@ func TestParseInvalidProgramWithRest(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 	    .asd
 	`)
 
 	assert.Nil(t, actual)
-	assert.IsType(t, parser.Error{}, err)
+	assert.IsType(t, parser1.Error{}, err)
 }
 
 func TestParseInvalidIncompleteConstKeyword(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 	    le
 	`)
 
@@ -78,12 +78,12 @@ func TestParseInvalidIncompleteConstKeyword(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.SyntaxError)
+	syntaxError := errors[0].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 6, Line: 2, Column: 5},
@@ -97,7 +97,7 @@ func TestParseInvalidIncompleteStringLiteral(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 	    let = "Hello, World!
 	`)
 
@@ -105,12 +105,12 @@ func TestParseInvalidIncompleteStringLiteral(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 3)
 
-	syntaxError := errors[0].(*parser.SyntaxError)
+	syntaxError := errors[0].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 26, Line: 2, Column: 11},
@@ -162,7 +162,7 @@ func TestParseNames(t *testing.T) {
 
 		t.Run("old", func(t *testing.T) {
 
-			actual, _, err := parser.ParseProgram(code)
+			actual, _, err := parser1.ParseProgram(code)
 
 			if validExpected {
 				assert.NotNil(t, actual)
@@ -170,7 +170,7 @@ func TestParseNames(t *testing.T) {
 
 			} else {
 				assert.Nil(t, actual)
-				assert.IsType(t, parser.Error{}, err)
+				assert.IsType(t, parser1.Error{}, err)
 			}
 		})
 
@@ -194,7 +194,7 @@ func TestParseInvalidIncompleteConstantDeclaration1(t *testing.T) {
 
 	t.Parallel()
 
-	actual, inputIsComplete, err := parser.ParseProgram(`
+	actual, inputIsComplete, err := parser1.ParseProgram(`
 	    let
 	`)
 
@@ -204,12 +204,12 @@ func TestParseInvalidIncompleteConstantDeclaration1(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError1 := errors[0].(*parser.SyntaxError)
+	syntaxError1 := errors[0].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 11, Line: 3, Column: 1},
@@ -223,7 +223,7 @@ func TestParseInvalidIncompleteConstantDeclaration2(t *testing.T) {
 
 	t.Parallel()
 
-	actual, inputIsComplete, err := parser.ParseProgram(`
+	actual, inputIsComplete, err := parser1.ParseProgram(`
 	    let =
 	`)
 
@@ -233,12 +233,12 @@ func TestParseInvalidIncompleteConstantDeclaration2(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 2)
 
-	syntaxError1 := errors[0].(*parser.SyntaxError)
+	syntaxError1 := errors[0].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 10, Line: 2, Column: 9},
@@ -247,7 +247,7 @@ func TestParseInvalidIncompleteConstantDeclaration2(t *testing.T) {
 
 	assert.Contains(t, syntaxError1.Message, "missing")
 
-	syntaxError2 := errors[1].(*parser.SyntaxError)
+	syntaxError2 := errors[1].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 13, Line: 3, Column: 1},
@@ -264,7 +264,7 @@ func testParse(t *testing.T, code string, expected []Declaration, use func(actua
 	}
 
 	t.Run("old", func(t *testing.T) {
-		actual, _, err := parser.ParseProgram(code)
+		actual, _, err := parser1.ParseProgram(code)
 		require.NoError(t, err)
 		if expected != nil {
 			utils.AssertEqualWithDiff(t, expectedProgram, actual)
@@ -2349,7 +2349,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let octal = 0o32
         let hex = 0xf2
         let binary = 0b101010
@@ -2454,7 +2454,7 @@ func TestParseIntegerLiteralsWithUnderscores(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let octal = 0o32_45
         let hex = 0xf2_09
         let binary = 0b101010_101010
@@ -2561,16 +2561,16 @@ func TestParseInvalidIntegerLiteralPrefixWithout(t *testing.T) {
 
 	for _, prefix := range []string{"o", "b", "x"} {
 
-		_, _, err := parser.ParseProgram(fmt.Sprintf(`let x = 0%s`, prefix))
+		_, _, err := parser1.ParseProgram(fmt.Sprintf(`let x = 0%s`, prefix))
 
 		require.Error(t, err)
 
-		require.IsType(t, parser.Error{}, err)
+		require.IsType(t, parser1.Error{}, err)
 
-		errors := err.(parser.Error).Errors
+		errors := err.(parser1.Error).Errors
 		assert.Len(t, errors, 1)
 
-		syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+		syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 		assert.Equal(t,
 			Position{Offset: 8, Line: 1, Column: 8},
 			syntaxError.StartPos,
@@ -2583,7 +2583,7 @@ func TestParseInvalidOctalIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let octal = 0o_32_45
 	`)
 
@@ -2591,14 +2591,14 @@ func TestParseInvalidOctalIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	require.IsType(t, &parser.InvalidIntegerLiteralError{}, errors[0])
+	require.IsType(t, &parser1.InvalidIntegerLiteralError{}, errors[0])
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 15, Line: 2, Column: 14},
@@ -2611,12 +2611,12 @@ func TestParseInvalidOctalIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindOctal,
+		parser1.IntegerLiteralKindOctal,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindLeadingUnderscore,
+		parser1.InvalidNumberLiteralKindLeadingUnderscore,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 }
@@ -2626,7 +2626,7 @@ func TestParseIntegerLiteralWithLeadingZeros(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
         let decimal = 0123
 	`)
 
@@ -2665,7 +2665,7 @@ func TestParseInvalidOctalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let octal = 0o32_45_
 	`)
 
@@ -2673,12 +2673,12 @@ func TestParseInvalidOctalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 15, Line: 2, Column: 14},
@@ -2691,12 +2691,12 @@ func TestParseInvalidOctalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindOctal,
+		parser1.IntegerLiteralKindOctal,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindTrailingUnderscore,
+		parser1.InvalidNumberLiteralKindTrailingUnderscore,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 }
@@ -2706,7 +2706,7 @@ func TestParseInvalidBinaryIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let binary = 0b_101010_101010
 	`)
 
@@ -2714,12 +2714,12 @@ func TestParseInvalidBinaryIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 16, Line: 2, Column: 15},
@@ -2732,12 +2732,12 @@ func TestParseInvalidBinaryIntegerLiteralWithLeadingUnderscore(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindBinary,
+		parser1.IntegerLiteralKindBinary,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindLeadingUnderscore,
+		parser1.InvalidNumberLiteralKindLeadingUnderscore,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 }
@@ -2747,7 +2747,7 @@ func TestParseInvalidBinaryIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let binary = 0b101010_101010_
 	`)
 
@@ -2755,12 +2755,12 @@ func TestParseInvalidBinaryIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 16, Line: 2, Column: 15},
@@ -2773,12 +2773,12 @@ func TestParseInvalidBinaryIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindBinary,
+		parser1.IntegerLiteralKindBinary,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindTrailingUnderscore,
+		parser1.InvalidNumberLiteralKindTrailingUnderscore,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 }
@@ -2788,7 +2788,7 @@ func TestParseInvalidDecimalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let decimal = 1_234_567_890_
 	`)
 
@@ -2796,12 +2796,12 @@ func TestParseInvalidDecimalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 17, Line: 2, Column: 16},
@@ -2814,12 +2814,12 @@ func TestParseInvalidDecimalIntegerLiteralWithTrailingUnderscore(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindDecimal,
+		parser1.IntegerLiteralKindDecimal,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindTrailingUnderscore,
+		parser1.InvalidNumberLiteralKindTrailingUnderscore,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 }
@@ -2829,7 +2829,7 @@ func TestParseInvalidHexadecimalIntegerLiteralWithLeadingUnderscore(t *testing.T
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let hex = 0x_f2_09
 	`)
 
@@ -2837,12 +2837,12 @@ func TestParseInvalidHexadecimalIntegerLiteralWithLeadingUnderscore(t *testing.T
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 13, Line: 2, Column: 12},
@@ -2855,12 +2855,12 @@ func TestParseInvalidHexadecimalIntegerLiteralWithLeadingUnderscore(t *testing.T
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindHexadecimal,
+		parser1.IntegerLiteralKindHexadecimal,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindLeadingUnderscore,
+		parser1.InvalidNumberLiteralKindLeadingUnderscore,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 }
@@ -2870,7 +2870,7 @@ func TestParseInvalidHexadecimalIntegerLiteralWithTrailingUnderscore(t *testing.
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let hex = 0xf2_09_
 	`)
 
@@ -2878,12 +2878,12 @@ func TestParseInvalidHexadecimalIntegerLiteralWithTrailingUnderscore(t *testing.
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 13, Line: 2, Column: 12},
@@ -2896,12 +2896,12 @@ func TestParseInvalidHexadecimalIntegerLiteralWithTrailingUnderscore(t *testing.
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindHexadecimal,
+		parser1.IntegerLiteralKindHexadecimal,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindTrailingUnderscore,
+		parser1.InvalidNumberLiteralKindTrailingUnderscore,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 
@@ -2912,7 +2912,7 @@ func TestParseInvalidIntegerLiteral(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let hex = 0z123
 	`)
 
@@ -2920,12 +2920,12 @@ func TestParseInvalidIntegerLiteral(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.InvalidIntegerLiteralError)
+	syntaxError := errors[0].(*parser1.InvalidIntegerLiteralError)
 
 	assert.Equal(t,
 		Position{Offset: 13, Line: 2, Column: 12},
@@ -2938,12 +2938,12 @@ func TestParseInvalidIntegerLiteral(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		parser.IntegerLiteralKindUnknown,
+		parser1.IntegerLiteralKindUnknown,
 		syntaxError.IntegerLiteralKind,
 	)
 
 	assert.Equal(t,
-		parser.InvalidNumberLiteralKindUnknownPrefix,
+		parser1.InvalidNumberLiteralKindUnknownPrefix,
 		syntaxError.InvalidIntegerLiteralKind,
 	)
 }
@@ -2953,7 +2953,7 @@ func TestParseDecimalIntegerLiteralWithLeadingZeros(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let decimal = 00123
 	`)
 
@@ -2992,7 +2992,7 @@ func TestParseBinaryIntegerLiteralWithLeadingZeros(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 		let binary = 0b001000
 	`)
 
@@ -3927,7 +3927,7 @@ func TestParseInvalidDoubleIntegerUnary(t *testing.T) {
 
 	t.Parallel()
 
-	program, _, err := parser.ParseProgram(`
+	program, _, err := parser1.ParseProgram(`
 	   var a = 1
 	   let b = --a
 	`)
@@ -3936,15 +3936,15 @@ func TestParseInvalidDoubleIntegerUnary(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
 	assert.Equal(t,
 		[]error{
-			&parser.JuxtaposedUnaryOperatorsError{
+			&parser1.JuxtaposedUnaryOperatorsError{
 				Pos: Position{Offset: 27, Line: 3, Column: 12},
 			},
 		},
-		err.(parser.Error).Errors,
+		err.(parser1.Error).Errors,
 	)
 }
 
@@ -3952,7 +3952,7 @@ func TestParseInvalidDoubleBooleanUnary(t *testing.T) {
 
 	t.Parallel()
 
-	program, _, err := parser.ParseProgram(`
+	program, _, err := parser1.ParseProgram(`
 	   let b = !!true
 	`)
 
@@ -3960,15 +3960,15 @@ func TestParseInvalidDoubleBooleanUnary(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
 	assert.Equal(t,
 		[]error{
-			&parser.JuxtaposedUnaryOperatorsError{
+			&parser1.JuxtaposedUnaryOperatorsError{
 				Pos: Position{Offset: 13, Line: 2, Column: 12},
 			},
 		},
-		err.(parser.Error).Errors,
+		err.(parser1.Error).Errors,
 	)
 }
 
@@ -4471,7 +4471,7 @@ func TestParseExpression(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseExpression(`
+	actual, _, err := parser1.ParseExpression(`
         before(x + before(y)) + z
 	`)
 
@@ -4541,7 +4541,7 @@ func TestParseString(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseExpression(`
+	actual, _, err := parser1.ParseExpression(`
        "test \0\n\r\t\"\'\\ xyz"
 	`)
 
@@ -4562,7 +4562,7 @@ func TestParseStringWithUnicode(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseExpression(`
+	actual, _, err := parser1.ParseExpression(`
       "this is a test \t\\new line and race car:\n\u{1F3CE}\u{FE0F}"
 	`)
 
@@ -4914,7 +4914,7 @@ func TestParseInterface(t *testing.T) {
 	t.Parallel()
 
 	for _, kind := range common.CompositeKindsWithBody {
-		actual, _, err := parser.ParseProgram(fmt.Sprintf(`
+		actual, _, err := parser1.ParseProgram(fmt.Sprintf(`
             %s interface Test {
                 foo: Int
 
@@ -5286,7 +5286,7 @@ func TestParseInvalidMultipleSemicolonsBetweenDeclarations(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
         let x = 1;;let y = 2
 	`)
 
@@ -5294,12 +5294,12 @@ func TestParseInvalidMultipleSemicolonsBetweenDeclarations(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.SyntaxError)
+	syntaxError := errors[0].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 19, Line: 2, Column: 18},
@@ -5314,7 +5314,7 @@ func TestParseInvalidTypeWithWhitespace(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 	    let x: Int ? = 1
 	`)
 
@@ -5322,12 +5322,12 @@ func TestParseInvalidTypeWithWhitespace(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.SyntaxError)
+	syntaxError := errors[0].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 17, Line: 2, Column: 16},
@@ -7971,7 +7971,7 @@ func BenchmarkParseDeploy(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, _, err := parser.ParseProgram(transaction)
+			_, _, err := parser1.ParseProgram(transaction)
 			if err != nil {
 				b.FailNow()
 			}
@@ -7998,7 +7998,7 @@ func BenchmarkParseDeploy(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, _, err := parser.ParseProgram(transaction)
+			_, _, err := parser1.ParseProgram(transaction)
 			if err != nil {
 				b.FailNow()
 			}
@@ -8109,7 +8109,7 @@ func BenchmarkParseFungibleToken(b *testing.B) {
 	b.Run("old", func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			_, _, err := parser.ParseProgram(fungibleTokenContract)
+			_, _, err := parser1.ParseProgram(fungibleTokenContract)
 			if err != nil {
 				b.FailNow()
 			}
@@ -8169,16 +8169,16 @@ func TestParseInvalidForceCast(t *testing.T) {
 
 	t.Parallel()
 
-	_, _, err := parser.ParseReplInput("1 as!! Int\n")
+	_, _, err := parser1.ParseReplInput("1 as!! Int\n")
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	syntaxError := errors[0].(*parser.SyntaxError)
+	syntaxError := errors[0].(*parser1.SyntaxError)
 
 	assert.Equal(t,
 		Position{Offset: 5, Line: 1, Column: 5},
@@ -8190,7 +8190,7 @@ func TestParseInvalidNegativeIntegerLiteralWithIncorrectPrefix(t *testing.T) {
 
 	t.Parallel()
 
-	_, _, err := parser.ParseProgram(`
+	_, _, err := parser1.ParseProgram(`
 	    let e = -0K0
 	`)
 
@@ -8201,7 +8201,7 @@ func TestParseConstantSizedSizedArrayWithTrailingUnderscoreSize(t *testing.T) {
 
 	t.Parallel()
 
-	actual, _, err := parser.ParseProgram(`
+	actual, _, err := parser1.ParseProgram(`
 	  let T:[d;0_]=0
 	`)
 
@@ -8209,12 +8209,12 @@ func TestParseConstantSizedSizedArrayWithTrailingUnderscoreSize(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.IsType(t, parser.Error{}, err)
+	require.IsType(t, parser1.Error{}, err)
 
-	errors := err.(parser.Error).Errors
+	errors := err.(parser1.Error).Errors
 	assert.Len(t, errors, 1)
 
-	require.IsType(t, &parser.InvalidIntegerLiteralError{}, errors[0])
+	require.IsType(t, &parser1.InvalidIntegerLiteralError{}, errors[0])
 }
 
 func TestParsePreconditionWithUnaryNegation(t *testing.T) {

--- a/tools/vscode-extension/package-lock.json
+++ b/tools/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cadence",
-	"version": "0.1.0",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -28,6 +28,7 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.6.0.tgz",
 			"integrity": "sha512-jtk0gf80v4mFyDqaQNokD8GOPMTXpIUL35ewg6jtmuZw41xt56WF9kqCjiiViSRRRYA0RK+RuiVfmJA5pxvMUQ==",
+			"dev": true,
 			"requires": {
 				"@snyk/graphlib": "2.1.9-patch",
 				"tslib": "^1.9.3"
@@ -37,6 +38,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/@snyk/cocoapods-lockfile-parser/-/cocoapods-lockfile-parser-3.2.0.tgz",
 			"integrity": "sha512-DyFqZudOlGXHBOVneLnQnyQ97xZLq+PTF9PhWOmrEzH/tKcLyXhdW/WmDPVNJVyNvogyRZ4cXIj487xy/EeZEw==",
+			"dev": true,
 			"requires": {
 				"@snyk/dep-graph": "1.18.2",
 				"@snyk/ruby-semver": "^2.0.4",
@@ -51,6 +53,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@snyk/composer-lockfile-parser/-/composer-lockfile-parser-1.4.0.tgz",
 			"integrity": "sha512-ga4YTRjJUuP0Ufr+t1IucwVjEFAv66JSBB/zVHP2zy/jmfA3l3ZjlGQSjsRC6Me9P2Z0esQ83AYNZvmIf9pq2w==",
+			"dev": true,
 			"requires": {
 				"@snyk/lodash": "^4.17.15-patch"
 			}
@@ -59,6 +62,7 @@
 			"version": "3.2.0-rc1",
 			"resolved": "https://registry.npmjs.org/@snyk/configstore/-/configstore-3.2.0-rc1.tgz",
 			"integrity": "sha512-CV3QggFY8BY3u8PdSSlUGLibqbqCG1zJRmGM2DhnhcxQDRRPTGTP//l7vJphOVsUP1Oe23+UQsj7KRWpRUZiqg==",
+			"dev": true,
 			"requires": {
 				"dot-prop": "^5.2.0",
 				"graceful-fs": "^4.1.2",
@@ -72,6 +76,7 @@
 			"version": "1.18.2",
 			"resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.18.2.tgz",
 			"integrity": "sha512-v7tIiCH4LmYOSc0xGHKSxSZ2PEDv8zDlYU7ZKSH+1Hk8Qvj3YYEFvtV1iFBHUEQFUen4kQA6lWxlwF8chsNw+w==",
+			"dev": true,
 			"requires": {
 				"@snyk/graphlib": "2.1.9-patch",
 				"@snyk/lodash": "4.17.15-patch",
@@ -85,19 +90,22 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
 		"@snyk/gemfile": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@snyk/gemfile/-/gemfile-1.2.0.tgz",
-			"integrity": "sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA=="
+			"integrity": "sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==",
+			"dev": true
 		},
 		"@snyk/graphlib": {
 			"version": "2.1.9-patch",
 			"resolved": "https://registry.npmjs.org/@snyk/graphlib/-/graphlib-2.1.9-patch.tgz",
 			"integrity": "sha512-uFO/pNMm3pN15QB+hVMU7uaQXhsBNwEA8lOET/VDcdOzLptODhXzkJqSHqt0tZlpdAz6/6Uaj8jY00UvPFgFMA==",
+			"dev": true,
 			"requires": {
 				"@snyk/lodash": "4.17.15-patch"
 			}
@@ -106,6 +114,7 @@
 			"version": "6.2.2-patch",
 			"resolved": "https://registry.npmjs.org/@snyk/inquirer/-/inquirer-6.2.2-patch.tgz",
 			"integrity": "sha512-IUq5bHRL0vtVKtfvd4GOccAIaLYHbcertug2UVZzk5+yY6R/CxfYsnFUTho1h4BdkfNdin2tPjE/5jRF4SKSrw==",
+			"dev": true,
 			"requires": {
 				"@snyk/lodash": "4.17.15-patch",
 				"ansi-escapes": "^3.2.0",
@@ -125,7 +134,8 @@
 				"mute-stream": {
 					"version": "0.0.7",
 					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"dev": true
 				}
 			}
 		},
@@ -133,6 +143,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.8.0.tgz",
 			"integrity": "sha512-dD7hVdEKMMU9CP0jQLm6Q1+l6506rjW0dqQflJ3QOVohNzptYJtTv9pHKzgRu5+q/fgEc35oYi02A0WIQwSvpw==",
+			"dev": true,
 			"requires": {
 				"@snyk/graphlib": "2.1.9-patch",
 				"@snyk/lodash": "4.17.15-patch",
@@ -151,12 +162,14 @@
 				"ci-info": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
 				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -165,6 +178,7 @@
 					"version": "7.1.6",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -177,19 +191,22 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
 		"@snyk/lodash": {
 			"version": "4.17.15-patch",
 			"resolved": "https://registry.npmjs.org/@snyk/lodash/-/lodash-4.17.15-patch.tgz",
-			"integrity": "sha512-e4+t34bGyjjRnwXwI14hqye9J/nRbG9iwaqTgXWHskm5qC+iK0UrjgYdWXiHJCf3Plbpr+1rpW+4LPzZnCGMhQ=="
+			"integrity": "sha512-e4+t34bGyjjRnwXwI14hqye9J/nRbG9iwaqTgXWHskm5qC+iK0UrjgYdWXiHJCf3Plbpr+1rpW+4LPzZnCGMhQ==",
+			"dev": true
 		},
 		"@snyk/rpm-parser": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-1.1.0.tgz",
 			"integrity": "sha512-+DyCagvnpyBjwYTxaPMQGLW4rkpKAw1Jrh8YbZCg7Ix172InBxdve/0zud18Lu2H6xWtDDdMvRDdfl82wlTBvA==",
+			"dev": true,
 			"requires": {
 				"event-loop-spinner": "1.1.0",
 				"typescript": "3.8.3"
@@ -198,7 +215,8 @@
 				"typescript": {
 					"version": "3.8.3",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-					"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+					"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+					"dev": true
 				}
 			}
 		},
@@ -206,6 +224,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@snyk/ruby-semver/-/ruby-semver-2.2.0.tgz",
 			"integrity": "sha512-FqUayoVjcyCsQFYPm3DcaCKdFR4xmapUkCGY+bcNBs3jqCUw687PoP9CPQ1Jvtaw5YpfBNl/62jyntsWCeciuA==",
+			"dev": true,
 			"requires": {
 				"@snyk/lodash": "4.17.15-patch"
 			}
@@ -214,6 +233,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@snyk/snyk-cocoapods-plugin/-/snyk-cocoapods-plugin-2.2.0.tgz",
 			"integrity": "sha512-Ux7hXKawbk30niGBToGkKqHyKzhT3E7sCl0FNkPkHaaGZwPwhFCDyNFxBd4uGgWiQ+kT+RjtH5ahna+bSP69Yg==",
+			"dev": true,
 			"requires": {
 				"@snyk/cli-interface": "1.5.0",
 				"@snyk/cocoapods-lockfile-parser": "3.2.0",
@@ -226,6 +246,7 @@
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-1.5.0.tgz",
 					"integrity": "sha512-+Qo+IO3YOXWgazlo+CKxOuWFLQQdaNCJ9cSfhFQd687/FuesaIxWdInaAdfpsLScq0c6M1ieZslXgiZELSzxbg==",
+					"dev": true,
 					"requires": {
 						"tslib": "^1.9.3"
 					}
@@ -236,6 +257,7 @@
 			"version": "2.5.1-rc2",
 			"resolved": "https://registry.npmjs.org/@snyk/update-notifier/-/update-notifier-2.5.1-rc2.tgz",
 			"integrity": "sha512-dlled3mfpnAt3cQb5hxkFiqfPCj4Yk0xV8Yl5P8PeVv1pUmO7vI4Ka4Mjs4r6CYM5f9kZhviFPQQcWOIDlMRcw==",
+			"dev": true,
 			"requires": {
 				"@snyk/configstore": "3.2.0-rc1",
 				"boxen": "^1.3.0",
@@ -253,6 +275,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@types/agent-base/-/agent-base-4.2.0.tgz",
 			"integrity": "sha512-8mrhPstU+ZX0Ugya8tl5DsDZ1I5ZwQzbL/8PA0z8Gj0k9nql7nkaMzmPVLj+l/nixWaliXi+EBiLA8bptw3z7Q==",
+			"dev": true,
 			"requires": {
 				"@types/events": "*",
 				"@types/node": "*"
@@ -261,17 +284,20 @@
 		"@types/debug": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+			"dev": true
 		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
 		},
 		"@types/js-yaml": {
 			"version": "3.12.3",
 			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.3.tgz",
-			"integrity": "sha512-otRe77JNNWzoVGLKw8TCspKswRoQToys4tuL6XYVBFxjgeM0RUrx7m3jkaTdxILxeGry3zM8mGYkGXMeQ02guA=="
+			"integrity": "sha512-otRe77JNNWzoVGLKw8TCspKswRoQToys4tuL6XYVBFxjgeM0RUrx7m3jkaTdxILxeGry3zM8mGYkGXMeQ02guA==",
+			"dev": true
 		},
 		"@types/mocha": {
 			"version": "2.2.48",
@@ -287,12 +313,14 @@
 		"@types/semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+			"dev": true
 		},
 		"@types/xml2js": {
 			"version": "0.4.5",
 			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
 			"integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -300,17 +328,20 @@
 		"@yarnpkg/lockfile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true
 		},
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"agent-base": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
@@ -331,6 +362,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"dev": true,
 			"requires": {
 				"string-width": "^2.0.0"
 			}
@@ -338,12 +370,14 @@
 		"ansi-escapes": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -356,12 +390,14 @@
 		"ansicolors": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-			"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+			"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+			"dev": true
 		},
 		"archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -374,7 +410,8 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -394,12 +431,14 @@
 		"ast-types": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
+			"dev": true
 		},
 		"async": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -438,7 +477,8 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -453,6 +493,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
 			"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+			"dev": true,
 			"requires": {
 				"buffer": "^5.5.0",
 				"inherits": "^2.0.4",
@@ -468,6 +509,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
 			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+			"dev": true,
 			"requires": {
 				"ansi-align": "^2.0.0",
 				"camelcase": "^4.0.0",
@@ -497,6 +539,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
 			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+			"dev": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4"
@@ -510,7 +553,8 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
@@ -521,17 +565,20 @@
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+			"dev": true
 		},
 		"camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+			"dev": true
 		},
 		"capture-stack-trace": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -552,7 +599,8 @@
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.3",
@@ -570,17 +618,20 @@
 		"ci-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+			"dev": true
 		},
 		"cli-boxes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -588,17 +639,20 @@
 		"cli-spinner": {
 			"version": "0.2.10",
 			"resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.10.tgz",
-			"integrity": "sha512-U0sSQ+JJvSLi1pAYuJykwiA8Dsr15uHEy85iCJ6A+0DjVxivr3d+N2Wjvodeg89uP5K6TswFkKBfAD7B3YSn/Q=="
+			"integrity": "sha512-U0sSQ+JJvSLi1pAYuJykwiA8Dsr15uHEy85iCJ6A+0DjVxivr3d+N2Wjvodeg89uP5K6TswFkKBfAD7B3YSn/Q==",
+			"dev": true
 		},
 		"cli-width": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+			"dev": true
 		},
 		"cliui": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1",
@@ -608,12 +662,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -622,6 +678,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -632,6 +689,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -640,6 +698,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -650,12 +709,14 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.3",
@@ -692,17 +753,20 @@
 		"core-js": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"create-error-class": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"dev": true,
 			"requires": {
 				"capture-stack-trace": "^1.0.0"
 			}
@@ -711,6 +775,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -720,7 +785,8 @@
 		"crypto-random-string": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"dev": true
 		},
 		"css-select": {
 			"version": "1.2.0",
@@ -750,12 +816,14 @@
 		"data-uri-to-buffer": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-			"integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+			"integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
+			"dev": true
 		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -763,22 +831,26 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"degenerator": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
 			"integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+			"dev": true,
 			"requires": {
 				"ast-types": "0.x.x",
 				"escodegen": "1.x.x",
@@ -788,7 +860,8 @@
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
 				}
 			}
 		},
@@ -806,7 +879,8 @@
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
 		},
 		"didyoumean": {
 			"version": "1.2.1",
@@ -823,6 +897,7 @@
 			"version": "0.0.19",
 			"resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.19.tgz",
 			"integrity": "sha512-iDRNFeAB2j4rh/Ecc2gh3fjciVifCMsszfCfHlYF5Wv8yybjZLiRDZUBt/pS3xrAz8uWT8fCHLq4pOQMmwCDwA==",
+			"dev": true,
 			"requires": {
 				"vscode-languageserver-types": "^3.5.0"
 			}
@@ -862,6 +937,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
 			"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
@@ -870,6 +946,7 @@
 			"version": "4.10.0",
 			"resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-4.10.0.tgz",
 			"integrity": "sha512-dEO1oTvreaDCtcvhRdOmmAMubyC+MWqVr1c/1Wvasi+NW4NZeB67qGh1taqowUFh+aCXtPw3SP2eExn6aNkhwA==",
+			"dev": true,
 			"requires": {
 				"@snyk/lodash": "4.17.15-patch",
 				"@types/xml2js": "0.4.5",
@@ -881,7 +958,8 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -896,17 +974,20 @@
 		"email-validator": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-			"integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+			"integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -919,12 +1000,14 @@
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -938,6 +1021,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
 			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
@@ -949,22 +1033,26 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"event-loop-spinner": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-1.1.0.tgz",
 			"integrity": "sha512-YVFs6dPpZIgH665kKckDktEVvSBccSYJmoZUfhNUdv5d3Xv+Q+SKF4Xis1jolq9aBzuW1ZZhQh/m/zU/TPdDhw==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.10.0"
 			}
@@ -973,6 +1061,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -986,12 +1075,14 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -1002,6 +1093,7 @@
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
 					"requires": {
 						"os-tmpdir": "~1.0.2"
 					}
@@ -1029,7 +1121,8 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -1043,6 +1136,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -1050,7 +1144,8 @@
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -1072,7 +1167,8 @@
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -1083,6 +1179,7 @@
 			"version": "0.3.10",
 			"resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
 			"integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "1.1.x",
 				"xregexp": "2.0.0"
@@ -1092,6 +1189,7 @@
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -1102,19 +1200,22 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				}
 			}
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
 		},
 		"get-uri": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
 			"integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
+			"dev": true,
 			"requires": {
 				"data-uri-to-buffer": "1",
 				"debug": "2",
@@ -1128,6 +1229,7 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -1135,12 +1237,14 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -1154,12 +1258,14 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -1179,6 +1285,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
 			"integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"parse-url": "^5.0.0"
@@ -1188,6 +1295,7 @@
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
 			"integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+			"dev": true,
 			"requires": {
 				"git-up": "^4.0.0"
 			}
@@ -1209,6 +1317,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"dev": true,
 			"requires": {
 				"ini": "^1.3.4"
 			}
@@ -1217,6 +1326,7 @@
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"dev": true,
 			"requires": {
 				"create-error-class": "^3.0.0",
 				"duplexer3": "^0.1.4",
@@ -1234,7 +1344,8 @@
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -1272,7 +1383,8 @@
 		"hosted-git-info": {
 			"version": "2.8.8",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"dev": true
 		},
 		"htmlparser2": {
 			"version": "3.10.1",
@@ -1291,6 +1403,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
 			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.4",
@@ -1303,6 +1416,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
@@ -1333,6 +1447,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -1340,22 +1455,26 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+			"dev": true
 		},
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+			"dev": true
 		},
 		"import-lazy": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -1374,22 +1493,26 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
 		},
 		"is-ci": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
 			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+			"dev": true,
 			"requires": {
 				"ci-info": "^1.5.0"
 			}
@@ -1397,17 +1520,20 @@
 		"is-docker": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-			"integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+			"integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"dev": true,
 			"requires": {
 				"global-dirs": "^0.1.0",
 				"is-path-inside": "^1.0.0"
@@ -1416,17 +1542,20 @@
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"dev": true
 		},
 		"is-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
 		},
 		"is-path-inside": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
@@ -1434,17 +1563,20 @@
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+			"dev": true
 		},
 		"is-retry-allowed": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+			"dev": true
 		},
 		"is-ssh": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
 			"integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+			"dev": true,
 			"requires": {
 				"protocols": "^1.1.0"
 			}
@@ -1452,7 +1584,8 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -1463,17 +1596,20 @@
 		"is-wsl": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-			"integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+			"integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -1491,6 +1627,7 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -1536,6 +1673,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
 			"integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
+			"dev": true,
 			"requires": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
@@ -1546,12 +1684,14 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -1565,12 +1705,14 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -1581,6 +1723,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"dev": true,
 			"requires": {
 				"package-json": "^4.0.0"
 			}
@@ -1589,6 +1732,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -1597,6 +1741,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -1606,6 +1751,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
 			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dev": true,
 			"requires": {
 				"immediate": "~3.0.5"
 			}
@@ -1626,47 +1772,56 @@
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
 		},
 		"lodash.assignin": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+			"dev": true
 		},
 		"lodash.clone": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+			"dev": true
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
 		},
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+			"dev": true
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -1675,12 +1830,14 @@
 		"macos-release": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
+			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+			"dev": true
 		},
 		"make-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -1725,7 +1882,8 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -1738,7 +1896,8 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.5",
@@ -1817,7 +1976,8 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -1828,6 +1988,7 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
 			"integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+			"dev": true,
 			"requires": {
 				"async": "^1.4.0",
 				"ini": "^1.3.0",
@@ -1839,6 +2000,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.1.tgz",
 			"integrity": "sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==",
+			"dev": true,
 			"requires": {
 				"debug": "^3.2.6",
 				"iconv-lite": "^0.4.4",
@@ -1849,6 +2011,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1856,29 +2019,34 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
 		"netmask": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+			"dev": true
 		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
 		},
 		"normalize-url": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+			"dev": true
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -1894,7 +2062,8 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -1905,7 +2074,8 @@
 		"object-hash": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-			"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+			"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
@@ -1919,6 +2089,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -1927,6 +2098,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/open/-/open-7.0.3.tgz",
 			"integrity": "sha512-sP2ru2v0P290WFfv49Ap8MF6PkzGNnGlAwHweB4WR4mr5d2d0woiCluUeJ218w7/+PmoBy9JmYgD5A4mLcWOFA==",
+			"dev": true,
 			"requires": {
 				"is-docker": "^2.0.0",
 				"is-wsl": "^2.1.1"
@@ -1936,6 +2108,7 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
 			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.6",
@@ -1959,6 +2132,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
 			"requires": {
 				"lcid": "^1.0.0"
 			}
@@ -1967,6 +2141,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
 			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+			"dev": true,
 			"requires": {
 				"macos-release": "^2.2.0",
 				"windows-release": "^3.1.0"
@@ -1989,17 +2164,20 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
 		},
 		"p-map": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true
 		},
 		"pac-proxy-agent": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
 			"integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
+			"dev": true,
 			"requires": {
 				"agent-base": "^4.2.0",
 				"debug": "^4.1.1",
@@ -2015,6 +2193,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2023,6 +2202,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
 					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+					"dev": true,
 					"requires": {
 						"agent-base": "^4.3.0",
 						"debug": "^3.1.0"
@@ -2032,6 +2212,7 @@
 							"version": "3.2.6",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+							"dev": true,
 							"requires": {
 								"ms": "^2.1.1"
 							}
@@ -2041,7 +2222,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -2049,6 +2231,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
 			"integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+			"dev": true,
 			"requires": {
 				"co": "^4.6.0",
 				"degenerator": "^1.0.4",
@@ -2061,6 +2244,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"dev": true,
 			"requires": {
 				"got": "^6.7.1",
 				"registry-auth-token": "^3.0.1",
@@ -2071,12 +2255,14 @@
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
 		},
 		"parse-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
 			"integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"protocols": "^1.4.0"
@@ -2094,6 +2280,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
 			"integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"normalize-url": "^3.3.0",
@@ -2117,12 +2304,14 @@
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -2144,37 +2333,44 @@
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
 		},
 		"prettier": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "~2.0.3"
 			}
@@ -2182,12 +2378,14 @@
 		"protocols": {
 			"version": "1.4.7",
 			"resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
+			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+			"dev": true
 		},
 		"proxy-agent": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
 			"integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
+			"dev": true,
 			"requires": {
 				"agent-base": "^4.2.0",
 				"debug": "4",
@@ -2203,6 +2401,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2211,6 +2410,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
 					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+					"dev": true,
 					"requires": {
 						"agent-base": "^4.3.0",
 						"debug": "^3.1.0"
@@ -2220,6 +2420,7 @@
 							"version": "3.2.6",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+							"dev": true,
 							"requires": {
 								"ms": "^2.1.1"
 							}
@@ -2230,6 +2431,7 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -2237,24 +2439,28 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true
 				}
 			}
 		},
 		"proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.2.0",
@@ -2266,6 +2472,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -2293,6 +2500,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
 			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+			"dev": true,
 			"requires": {
 				"bytes": "3.1.0",
 				"http-errors": "1.7.3",
@@ -2304,6 +2512,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -2333,6 +2542,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
 			"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+			"dev": true,
 			"requires": {
 				"rc": "^1.1.6",
 				"safe-buffer": "^5.0.1"
@@ -2342,6 +2552,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"dev": true,
 			"requires": {
 				"rc": "^1.0.1"
 			}
@@ -2393,6 +2604,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -2402,6 +2614,7 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -2409,12 +2622,14 @@
 		"run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"rxjs": {
 			"version": "6.5.5",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
 			"integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -2427,17 +2642,20 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"secure-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.7.0",
@@ -2448,6 +2666,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"dev": true,
 			"requires": {
 				"semver": "^5.0.3"
 			}
@@ -2455,17 +2674,20 @@
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
 		},
 		"setprototypeof": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -2473,22 +2695,26 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
 		},
 		"smart-buffer": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+			"dev": true
 		},
 		"snyk": {
 			"version": "1.316.1",
 			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.316.1.tgz",
 			"integrity": "sha512-z+LWT14QoOyOsqCcWGkTNlIBpCQmv7E+kMX3r43/vZeU1F9E6Ll+KVcu1simXZixZaOb97IHHIf4rxxYGw65MA==",
+			"dev": true,
 			"requires": {
 				"@snyk/cli-interface": "2.6.0",
 				"@snyk/configstore": "^3.2.0-rc1",
@@ -2542,12 +2768,14 @@
 				"diff": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -2555,6 +2783,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-3.1.0.tgz",
 			"integrity": "sha512-3UlyogA67/9WOssJ7s4d7gqWQRWyO/LbgdBBNMhhmFDKa7eTUSW+A782CVHgyDSJZ2kNANcMWwMiOL+h3p6zQg==",
+			"dev": true,
 			"requires": {
 				"@snyk/lodash": "4.17.15-patch",
 				"debug": "^4.1.1",
@@ -2565,6 +2794,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2572,7 +2802,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -2580,6 +2811,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-3.1.0.tgz",
 			"integrity": "sha512-ggGTiiCuwLYGdlGW/UBuUXJ7omliH0EnbpLfdlTBoRKvmvgoUo1l4Menk18R1ZVXgcXTwwGK9jmuUpPH+X0VNw==",
+			"dev": true,
 			"requires": {
 				"@snyk/rpm-parser": "^1.1.0",
 				"debug": "^4.1.1",
@@ -2594,6 +2826,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2601,12 +2834,14 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -2614,6 +2849,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.4.0.tgz",
 			"integrity": "sha512-zcLA8u/WreycCjFKBblYfxszg7Fmnemuu9Ug/CE/jqF0yBXsI5DCWMteUvFkoa8DRntfGTlgf98TRl2aTSc2MQ==",
+			"dev": true,
 			"requires": {
 				"toml": "^3.0.0",
 				"tslib": "^1.10.0"
@@ -2623,6 +2859,7 @@
 			"version": "1.14.0",
 			"resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.14.0.tgz",
 			"integrity": "sha512-9L+76De8F6yXWb+O3DA8QUi7+eDF2mOzCOveEPUJGkqWIDmurIiFcVxHJoj0EStjcxb3dX367KKlDlfFx+HiyA==",
+			"dev": true,
 			"requires": {
 				"@snyk/graphlib": "2.1.9-patch",
 				"debug": "^4.1.1",
@@ -2635,6 +2872,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2642,12 +2880,14 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"tmp": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
 					"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+					"dev": true,
 					"requires": {
 						"rimraf": "^2.6.3"
 					}
@@ -2658,6 +2898,7 @@
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.2.5.tgz",
 			"integrity": "sha512-XxPi/B16dGkV1USoyFbpn6LlSJ9SUC6Y6z/4lWuF4spLnKtWwpEb1bwTdBFsxnkUfqzIRtPr0+wcxxXvv9Rvcw==",
+			"dev": true,
 			"requires": {
 				"@snyk/cli-interface": "2.3.0",
 				"@types/debug": "^4.1.4",
@@ -2671,6 +2912,7 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.3.0.tgz",
 					"integrity": "sha512-ecbylK5Ol2ySb/WbfPj0s0GuLQR+KWKFzUgVaoNHaSoN6371qRWwf2uVr+hPUP4gXqCai21Ug/RDArfOhlPwrQ==",
+					"dev": true,
 					"requires": {
 						"tslib": "^1.9.3"
 					}
@@ -2679,6 +2921,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2686,12 +2929,14 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"tmp": {
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
 					"requires": {
 						"os-tmpdir": "~1.0.2"
 					}
@@ -2702,6 +2947,7 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-1.9.1.tgz",
 			"integrity": "sha512-A+CCyBSa4IKok5uEhqT+hV/35RO6APFNLqk9DRRHg7xW2/j//nPX8wTSZUPF8QeRNEk/sX+6df7M1y6PBHGSHA==",
+			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
 				"hosted-git-info": "^2.7.1"
@@ -2711,6 +2957,7 @@
 			"version": "2.15.0",
 			"resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.15.0.tgz",
 			"integrity": "sha512-24HWz27Hc5sw+iHtxtQFy0kltjyFZXJ3vfsPA0TTZAL0tOJXInIuZpWD6njC0Y3/sn9CH5kS2KM8GAM7FyKVig==",
+			"dev": true,
 			"requires": {
 				"@snyk/cli-interface": "2.5.0",
 				"@snyk/java-call-graph-builder": "1.8.0",
@@ -2724,6 +2971,7 @@
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.5.0.tgz",
 					"integrity": "sha512-XMc2SCFH4RBSncZgoPb+BBlNq0NYpEpCzptKi69qyMpBy0VsRqIQqddedaazMCU1xEpXTytq6KMYpzUafZzp5Q==",
+					"dev": true,
 					"requires": {
 						"tslib": "^1.9.3"
 					}
@@ -2732,6 +2980,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2739,12 +2988,14 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"tmp": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
 					"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+					"dev": true,
 					"requires": {
 						"rimraf": "^2.6.3"
 					}
@@ -2752,7 +3003,8 @@
 				"tslib": {
 					"version": "1.11.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+					"dev": true
 				}
 			}
 		},
@@ -2760,6 +3012,7 @@
 			"version": "1.22.0",
 			"resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.22.0.tgz",
 			"integrity": "sha512-l6jLoJxqcIIkQopSdQuAstXdMw5AIgLu+uGc5CYpHyw8fYqOwna8rawwofNeGuwJAAv4nEiNiexeYaR88OCq6Q==",
+			"dev": true,
 			"requires": {
 				"@snyk/graphlib": "2.1.9-patch",
 				"@snyk/lodash": "^4.17.15-patch",
@@ -2776,6 +3029,7 @@
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.17.0.tgz",
 			"integrity": "sha512-t7iZ87LBhCK6P2/mJsQh7Dmk3J9zd+IHL4yoSK95Iyk/gP8r++DZijoRHEXy8BlS+eOtSAj1vgCYvv2eAmG28w==",
+			"dev": true,
 			"requires": {
 				"@snyk/lodash": "4.17.15-patch",
 				"debug": "^3.1.0",
@@ -2789,22 +3043,26 @@
 				"core-js": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-					"integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+					"integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+					"dev": true
 				},
 				"es6-promise": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-					"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+					"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
 				},
 				"jszip": {
 					"version": "3.1.5",
 					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
 					"integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+					"dev": true,
 					"requires": {
 						"core-js": "~2.3.0",
 						"es6-promise": "~3.0.2",
@@ -2817,6 +3075,7 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
 					"integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+					"dev": true,
 					"requires": {
 						"immediate": "~3.0.5"
 					}
@@ -2824,12 +3083,14 @@
 				"process-nextick-args": {
 					"version": "1.0.7",
 					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.0.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -2842,7 +3103,8 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				}
 			}
 		},
@@ -2850,6 +3112,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/snyk-paket-parser/-/snyk-paket-parser-1.6.0.tgz",
 			"integrity": "sha512-6htFynjBe/nakclEHUZ1A3j5Eu32/0pNve5Qm4MFn3YQmJgj7UcAO8hdyK3QfzEY29/kAv/rkJQg+SKshn+N9Q==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
@@ -2858,6 +3121,7 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.9.0.tgz",
 			"integrity": "sha512-uORrEoC47dw0ITZYu5vKqQtmXnbbQs+ZkWeo5bRHGdf10W8e4rNr1S1R4bReiLrSbSisYhVHeFMkdOAiLIPJVQ==",
+			"dev": true,
 			"requires": {
 				"@snyk/cli-interface": "2.3.2",
 				"@snyk/composer-lockfile-parser": "1.4.0",
@@ -2868,6 +3132,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.3.2.tgz",
 					"integrity": "sha512-jmZyxVHqzYU1GfdnWCGdd68WY/lAzpPVyqalHazPj4tFJehrSfEFc82RMTYAMgXEJuvFRFIwhsvXh3sWUhIQmg==",
+					"dev": true,
 					"requires": {
 						"tslib": "^1.9.3"
 					}
@@ -2875,7 +3140,8 @@
 				"tslib": {
 					"version": "1.11.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+					"dev": true
 				}
 			}
 		},
@@ -2883,6 +3149,7 @@
 			"version": "1.13.5",
 			"resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.13.5.tgz",
 			"integrity": "sha512-KI6GHt+Oj4fYKiCp7duhseUj5YhyL/zJOrrJg0u6r59Ux9w8gmkUYT92FHW27ihwuT6IPzdGNEuy06Yv2C9WaQ==",
+			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
 				"email-validator": "^2.0.4",
@@ -2898,7 +3165,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -2906,6 +3174,7 @@
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.17.0.tgz",
 			"integrity": "sha512-EKdVOUlvhiVpXA5TeW8vyxYVqbITAfT+2AbL2ZRiiUNLP5ae+WiNYaPy7aB5HAS9IKBKih+IH8Ag65Xu1IYSYA==",
+			"dev": true,
 			"requires": {
 				"@snyk/cli-interface": "^2.0.3",
 				"tmp": "0.0.33"
@@ -2915,6 +3184,7 @@
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
 					"requires": {
 						"os-tmpdir": "~1.0.2"
 					}
@@ -2925,6 +3195,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/snyk-resolve/-/snyk-resolve-1.0.1.tgz",
 			"integrity": "sha512-7+i+LLhtBo1Pkth01xv+RYJU8a67zmJ8WFFPvSxyCjdlKIcsps4hPQFebhz+0gC5rMemlaeIV6cqwqUf9PEDpw==",
+			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
 				"then-fs": "^2.0.0"
@@ -2934,6 +3205,7 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.4.0.tgz",
 			"integrity": "sha512-aFPtN8WLqIk4E1ulMyzvV5reY1Iksz+3oPnUVib1jKdyTHymmOIYF7z8QZ4UUr52UsgmrD9EA/dq7jpytwFoOQ==",
+			"dev": true,
 			"requires": {
 				"@types/node": "^6.14.4",
 				"@types/semver": "^5.5.0",
@@ -2957,12 +3229,14 @@
 				"@types/node": {
 					"version": "6.14.10",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.10.tgz",
-					"integrity": "sha512-pF4HjZGSog75kGq7B1InK/wt/N08BuPATo+7HRfv7gZUzccebwv/fmWVGs/j6LvSiLWpCuGGhql51M/wcQsNzA=="
+					"integrity": "sha512-pF4HjZGSog75kGq7B1InK/wt/N08BuPATo+7HRfv7gZUzccebwv/fmWVGs/j6LvSiLWpCuGGhql51M/wcQsNzA==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2970,7 +3244,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -2978,6 +3253,7 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.11.0.tgz",
 			"integrity": "sha512-wUqHLAa3MzV6sVO+05MnV+lwc+T6o87FZZaY+43tQPytBI2Wq23O3j4POREM4fa2iFfiQJoEYD6c7xmhiEUsSA==",
+			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
 				"semver": "^6.1.2",
@@ -2990,6 +3266,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2997,17 +3274,20 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				},
 				"tmp": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
 					"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+					"dev": true,
 					"requires": {
 						"rimraf": "^2.6.3"
 					}
@@ -3018,6 +3298,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/snyk-tree/-/snyk-tree-1.0.0.tgz",
 			"integrity": "sha1-D7cxdtvzLngvGRAClBYESPkRHMg=",
+			"dev": true,
 			"requires": {
 				"archy": "^1.0.0"
 			}
@@ -3026,6 +3307,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-1.3.1.tgz",
 			"integrity": "sha1-bgJvkuZK9/zM6h7lPVJIQeQYohI=",
+			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
 				"lodash.clonedeep": "^4.3.0",
@@ -3037,6 +3319,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
 			"integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+			"dev": true,
 			"requires": {
 				"ip": "1.1.5",
 				"smart-buffer": "^4.1.0"
@@ -3046,6 +3329,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
 			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+			"dev": true,
 			"requires": {
 				"agent-base": "~4.2.1",
 				"socks": "~2.3.2"
@@ -3055,6 +3339,7 @@
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
 					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+					"dev": true,
 					"requires": {
 						"es6-promisify": "^5.0.0"
 					}
@@ -3064,12 +3349,14 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.5.12",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
 			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -3100,12 +3387,14 @@
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
 		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -3115,6 +3404,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -3133,6 +3423,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
 			},
@@ -3140,19 +3431,22 @@
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
 				}
 			}
 		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -3166,6 +3460,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
 			"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+			"dev": true,
 			"requires": {
 				"bl": "^4.0.1",
 				"end-of-stream": "^1.4.1",
@@ -3177,12 +3472,14 @@
 		"temp-dir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-			"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="
+			"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+			"dev": true
 		},
 		"tempfile": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
 			"integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+			"dev": true,
 			"requires": {
 				"temp-dir": "^1.0.0",
 				"uuid": "^3.0.1"
@@ -3191,7 +3488,8 @@
 				"temp-dir": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-					"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+					"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+					"dev": true
 				}
 			}
 		},
@@ -3199,6 +3497,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"dev": true,
 			"requires": {
 				"execa": "^0.7.0"
 			}
@@ -3207,6 +3506,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
 			"integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
+			"dev": true,
 			"requires": {
 				"promise": ">=3.2 <8"
 			}
@@ -3214,17 +3514,20 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"thunkify": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
-			"integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
+			"integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
+			"dev": true
 		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.29",
@@ -3237,12 +3540,14 @@
 		"toidentifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
 		},
 		"toml": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -3265,12 +3570,14 @@
 		"tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"dev": true
 		},
 		"tslint": {
 			"version": "5.18.0",
@@ -3326,6 +3633,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -3359,6 +3667,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"dev": true,
 			"requires": {
 				"crypto-random-string": "^1.0.0"
 			}
@@ -3366,12 +3675,14 @@
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
 		},
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+			"dev": true
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -3401,6 +3712,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"dev": true,
 			"requires": {
 				"prepend-http": "^1.0.1"
 			}
@@ -3413,7 +3725,8 @@
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -3509,6 +3822,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -3517,6 +3831,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
 			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1"
 			}
@@ -3524,12 +3839,14 @@
 		"window-size": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+			"dev": true
 		},
 		"windows-release": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
 			"integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
+			"dev": true,
 			"requires": {
 				"execa": "^1.0.0"
 			},
@@ -3538,6 +3855,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -3550,6 +3868,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
 						"get-stream": "^4.0.0",
@@ -3564,6 +3883,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -3573,12 +3893,14 @@
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
@@ -3589,6 +3911,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -3606,6 +3929,7 @@
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
 			"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -3615,12 +3939,14 @@
 		"xdg-basedir": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
 		},
 		"xml2js": {
 			"version": "0.4.23",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
 			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"dev": true,
 			"requires": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -3629,27 +3955,32 @@
 		"xmlbuilder": {
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"dev": true
 		},
 		"xregexp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-			"integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+			"integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yargs": {
 			"version": "3.32.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+			"dev": true,
 			"requires": {
 				"camelcase": "^2.0.1",
 				"cliui": "^3.0.3",
@@ -3663,17 +3994,20 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3682,6 +4016,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3692,6 +4027,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}

--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -130,12 +130,12 @@
     "vscode": "^1.1.28",
     "tslint": "^5.12.1",
     "@types/node": "^10.12.21",
-    "@types/mocha": "^2.2.42"
+    "@types/mocha": "^2.2.42",
+    "snyk": "^1.316.1"
   },
   "dependencies": {
     "vsce": "^1.69.0",
-    "vscode-languageclient": "~4.4.0",
-    "snyk": "^1.316.1"
+    "vscode-languageclient": "~4.4.0"
   },
   "snyk": true
 }


### PR DESCRIPTION
Closes dapperlabs/flow-go#4146

- Provide position information in parser errors: 

  Ensure the reported errors are parse errors. If they are not, create a `SyntaxError` with the current token's position. 

  This PR only adds the position information – in the future we should improve the position information, e.g. for string literals.

- Update the language server
  - Use the new parser
  - Fix the Snyk dependency:
    - Before: 9309 files, 20.48MB
    - After: 862 files, 1.98MB