### PR TITLE
Fix assignment statement parsing and buffering

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -492,7 +492,7 @@ func init() {
 	defineIdentifierExpression()
 
 	setExprNullDenotation(lexer.TokenEOF, func(parser *parser, token lexer.Token) ast.Expression {
-		panic("expected expression")
+		panic(fmt.Errorf("expected expression"))
 	})
 }
 

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -108,6 +108,44 @@ func TestLexBasic(t *testing.T) {
 		)
 	})
 
+	t.Run("assignment", func(t *testing.T) {
+		testLex(t,
+			"x=1",
+			[]Token{
+				{
+					Type:  TokenIdentifier,
+					Value: "x",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				{
+					Type: TokenEqual,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+					},
+				},
+				{
+					Type:  TokenDecimalLiteral,
+					Value: "1",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+						EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+					},
+				},
+				{
+					Type: TokenEOF,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
+						EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+					},
+				},
+			},
+		)
+	})
+
 	t.Run("simple arithmetic: plus and times", func(t *testing.T) {
 		testLex(t,
 			"(2 + 3) * 4",

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -264,6 +264,10 @@ func (p *parser) skipSpaceAndComments(skipNewlines bool) (containsNewline bool) 
 
 func (p *parser) startBuffering() {
 	p.buffering = true
+ 
+ 	// starting buffering should only buffer the current token if there’s nothing 
+ 	// to be read from the buffer, otherwise, the current token would be
+ 	// buffered twice
 	if p.bufferPos >= len(p.bufferedTokens) {
 		p.bufferedTokens = append(p.bufferedTokens, p.current)
 	}

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -264,7 +264,9 @@ func (p *parser) skipSpaceAndComments(skipNewlines bool) (containsNewline bool) 
 
 func (p *parser) startBuffering() {
 	p.buffering = true
-	p.bufferedTokens = append(p.bufferedTokens, p.current)
+	if p.bufferPos >= len(p.bufferedTokens) {
+		p.bufferedTokens = append(p.bufferedTokens, p.current)
+	}
 }
 
 func mustIdentifier(p *parser) ast.Identifier {

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -136,7 +136,7 @@ func (p *parser) maybeTrimBuffer() {
 // Tokens are buffered when syntax ambiguity is involved.
 func (p *parser) next() {
 	// nextFromLexer reads the next token from the lexer.
-	nextFromLexer := func(p *parser) lexer.Token {
+	nextFromLexer := func() lexer.Token {
 		var ok bool
 		token, ok := <-p.tokens
 		if !ok {
@@ -147,7 +147,7 @@ func (p *parser) next() {
 	}
 
 	// nextFromLexer reads the next token from the buffer tokens, assuming there are buffered tokens.
-	nextFromBuffer := func(p *parser) lexer.Token {
+	nextFromBuffer := func() lexer.Token {
 		token := p.bufferedTokens[p.bufferPos]
 		p.bufferPos++
 		p.maybeTrimBuffer()
@@ -159,24 +159,24 @@ func (p *parser) next() {
 
 		// When the syntax has ambiguity, we need to process a series of tokens
 		// multiple times. However, a token can only be consumed once from the lexer's
-		// tokens channel. Therefore, in some circumstances, we need to buffer the tokens from the
-		// lexer.
+		// tokens channel. Therefore, in some circumstances, we need to buffer the tokens
+		// from the lexer.
 		//
-		// buffering tokens allows us to potentially "replay" the buffered tokens later,
+		// Buffering tokens allows us to potentially "replay" the buffered tokens later,
 		// for example to deal with syntax ambiguity
 		if p.buffering {
 			// if we need to buffer the next token
 			// then read the token from the lexer and buffer it.
-			token = nextFromLexer(p)
+			token = nextFromLexer()
 			p.bufferedTokens = append(p.bufferedTokens, token)
 		} else if p.bufferPos < len(p.bufferedTokens) {
 			// if we don't need to buffer the next token and there are tokens buffered before,
 			// then read the token from the buffer.
-			token = nextFromBuffer(p)
+			token = nextFromBuffer()
 		} else {
 			// else no need to buffer, and there is no buffered token,
 			// then read the next token from the lexer.
-			token = nextFromLexer(p)
+			token = nextFromLexer()
 		}
 
 		if token.Is(lexer.TokenError) {

--- a/runtime/parser2/statement.go
+++ b/runtime/parser2/statement.go
@@ -95,7 +95,6 @@ func parseStatement(p *parser) ast.Statement {
 	switch p.current.Type {
 	case lexer.TokenEqual, lexer.TokenLeftArrow, lexer.TokenLeftArrowExclamation:
 		transfer := parseTransfer(p)
-		p.next()
 
 		value := parseExpression(p, lowestBindingPower)
 

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -574,7 +574,41 @@ func TestParseAssignmentStatement(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("copy", func(t *testing.T) {
+	t.Run("copy, no space", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseStatements("x=1")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Statement{
+				&ast.AssignmentStatement{
+					Target: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "x",
+							Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+						},
+					},
+					Transfer: &ast.Transfer{
+						Operation: ast.TransferOperationCopy,
+						Pos:       ast.Position{Line: 1, Column: 1, Offset: 1},
+					},
+					Value: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+						},
+					},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("copy, spaces", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -907,3 +907,54 @@ func TestParseFunctionStatementOrExpression(t *testing.T) {
 		)
 	})
 }
+
+func TestParseStatements(t *testing.T) {
+
+	t.Run("binary expression with less operator", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseStatements("a + b < c\nd")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Statement{
+				&ast.ExpressionStatement{
+					Expression: &ast.BinaryExpression{
+						Operation: ast.OperationLess,
+						Left: &ast.BinaryExpression{
+							Operation: ast.OperationPlus,
+							Left: &ast.IdentifierExpression{
+								Identifier: ast.Identifier{
+									Identifier: "a",
+									Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+								},
+							},
+							Right: &ast.IdentifierExpression{
+								Identifier: ast.Identifier{
+									Identifier: "b",
+									Pos:        ast.Position{Line: 1, Column: 4, Offset: 4},
+								},
+							},
+						},
+						Right: &ast.IdentifierExpression{
+							Identifier: ast.Identifier{
+								Identifier: "c",
+								Pos:        ast.Position{Line: 1, Column: 8, Offset: 8},
+							},
+						},
+					},
+				},
+				&ast.ExpressionStatement{
+					Expression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "d",
+							Pos:        ast.Position{Line: 2, Column: 0, Offset: 10},
+						},
+					},
+				},
+			},
+			result,
+		)
+	})
+}

--- a/runtime/parser2/transaction.go
+++ b/runtime/parser2/transaction.go
@@ -135,7 +135,7 @@ func parseTransactionDeclaration(p *parser) *ast.TransactionDeclaration {
 			atEnd = true
 
 		default:
-			panic(fmt.Errorf("unexpected token %s", p.current.Type))
+			panic(fmt.Errorf("unexpected token: %s", p.current.Type))
 		}
 	}
 

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -56,8 +56,8 @@ func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) 
 
 				checker.report(
 					&UninitializedFieldAccessError{
-						Name: field.Identifier.Identifier,
-						Pos:  field.Identifier.Pos,
+						Name: expression.Identifier.Identifier,
+						Pos:  expression.Identifier.Pos,
 					},
 				)
 			}


### PR DESCRIPTION
The parsing of assignments without any space, e.g. `x=1`, was broken.

The reason was that both that the token after the transfer (e.g. `=`) was skipped.

This uncovered another bug in the parser when buffering: When starting buffering, only buffer the current token, if there are no buffered tokens to be read.

Also, fix the position for uninitialized field access errors 