### PR TITLE
IDE Improvements

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -1101,7 +1101,7 @@ func applyExprNullDenotation(p *parser, token lexer.Token) ast.Expression {
 	tokenType := token.Type
 	nullDenotation, ok := exprNullDenotations[tokenType]
 	if !ok {
-		panic(fmt.Errorf("missing expression null denotation for token %s", token.Type))
+		panic(fmt.Errorf("unexpected token in expression: %s", token.Type))
 	}
 	return nullDenotation(p, token)
 }
@@ -1109,7 +1109,7 @@ func applyExprNullDenotation(p *parser, token lexer.Token) ast.Expression {
 func applyExprLeftDenotation(p *parser, token lexer.Token, left ast.Expression) ast.Expression {
 	leftDenotation, ok := exprLeftDenotations[token.Type]
 	if !ok {
-		panic(fmt.Errorf("missing expression left denotation for token %s", token.Type))
+		panic(fmt.Errorf("unexpected token in expression: %s", token.Type))
 	}
 	return leftDenotation(p, token, left)
 }

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -81,6 +81,14 @@ func Parse(input string, parse func(*parser) interface{}) (result interface{}, e
 		}
 	}()
 
+	p.current = lexer.Token{
+		Type: lexer.TokenEOF,
+		Range: ast.Range{
+			StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+			EndPos:   ast.Position{Offset: 0, Line: 1, Column: 0},
+		},
+	}
+
 	// Get the initial token
 	p.next()
 
@@ -141,7 +149,13 @@ func (p *parser) next() {
 		token, ok := <-p.tokens
 		if !ok {
 			// Channel closed, return EOF token.
-			token = lexer.Token{Type: lexer.TokenEOF}
+			token = lexer.Token{
+				Type: lexer.TokenEOF,
+				Range: ast.Range{
+					StartPos: p.current.EndPos,
+					EndPos:   p.current.EndPos,
+				},
+			}
 		}
 		return token
 	}

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -228,3 +228,44 @@ func TestParseBuffering(t *testing.T) {
 		)
 	})
 }
+
+func TestParseEOF(t *testing.T) {
+
+	t.Parallel()
+
+	_, errs := Parse("a b", func(p *parser) interface{} {
+		p.mustOneString(lexer.TokenIdentifier, "a")
+		p.skipSpaceAndComments(true)
+		p.mustOneString(lexer.TokenIdentifier, "b")
+
+		p.next()
+
+		assert.Equal(t,
+			lexer.Token{
+				Type: lexer.TokenEOF,
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 3, Line: 1, Column: 3},
+					EndPos:   ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
+			},
+			p.current,
+		)
+
+		p.next()
+
+		assert.Equal(t,
+			lexer.Token{
+				Type: lexer.TokenEOF,
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 3, Line: 1, Column: 3},
+					EndPos:   ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
+			},
+			p.current,
+		)
+
+		return nil
+	})
+
+	assert.Empty(t, errs)
+}

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -633,7 +633,7 @@ func applyTypeNullDenotation(p *parser, token lexer.Token) ast.Type {
 	tokenType := token.Type
 	nullDenotation, ok := typeNullDenotations[tokenType]
 	if !ok {
-		panic(fmt.Errorf("missing type null denotation for token %s", token.Type))
+		panic(fmt.Errorf("unexpected token in type: %s", token.Type))
 	}
 	return nullDenotation(p, token)
 }
@@ -641,7 +641,7 @@ func applyTypeNullDenotation(p *parser, token lexer.Token) ast.Type {
 func applyTypeLeftDenotation(p *parser, token lexer.Token, left ast.Type) ast.Type {
 	leftDenotation, ok := typeLeftDenotations[token.Type]
 	if !ok {
-		panic(fmt.Errorf("missing type left denotation for token %s", token.Type))
+		panic(fmt.Errorf("unexpected token in type: %s", token.Type))
 	}
 	return leftDenotation(p, token, left)
 }

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -291,7 +291,7 @@ func (checker *Checker) visitMemberExpressionAssignment(
 				Name:              member.Identifier.Identifier,
 				RestrictingAccess: member.Access,
 				DeclarationKind:   member.DeclarationKind,
-				Range:             ast.NewRangeFromPositioned(member.Identifier),
+				Range:             ast.NewRangeFromPositioned(target.Identifier),
 			},
 		)
 	}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2051,8 +2051,8 @@ func (e *InvalidAssignmentAccessError) Error() string {
 
 func (e *InvalidAssignmentAccessError) SecondaryError() string {
 	return fmt.Sprintf(
-		"has %s access. Consider making it publicly settable",
-		e.RestrictingAccess.Description(),
+		"consider making it publicly settable with `%s`",
+		ast.AccessPublicSettable.Keyword(),
 	)
 }
 


### PR DESCRIPTION
While writing contracts in Visual Studio Code I encountered a couple issues:

- Parser error messages would refer to null and left denotations, which are implementation details, and confusing to users. I removed the terms from the error messages
- VS Code would not show any diagnostics ("errors"), even though the program was obviously containing syntactical errors. This was caused by position information for some diagnostics being invalid (I'm not sure why the VS Code then didn't show any of them). The invalid position information was caused by tokens which used the Go default values for positions. I fixed this by providing correct defaults (e.g. line = 1)
- The error message for attempting to assign to a private field used the position of the field instead of the position of the assignment