### PR TITLE
Report missing return value in return statement

### DIFF
--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -30,47 +30,66 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast
 		functionActivation.ReturnInfo.DefinitelyReturned = true
 	}()
 
-	// check value type matches enclosing function's return type
+	returnType := functionActivation.ReturnType
 
 	if statement.Expression == nil {
+
+		// If the return statement has no expression,
+		// and the enclosing function's return type is Void,
+		// then the return statement is missing an expression
+
+		if _, ok := returnType.(*VoidType); !ok {
+			checker.report(
+				&MissingReturnValueError{
+					ExpectedValueType: returnType,
+					Range:             ast.NewRangeFromPositioned(statement),
+				},
+			)
+		}
+
 		return nil
 	}
 
+	// If the return statement has a return value,
+	// check that the value's type matches the enclosing function's return type
+
 	valueType := statement.Expression.Accept(checker).(Type)
-	returnType := functionActivation.ReturnType
 
 	checker.Elaboration.ReturnStatementValueTypes[statement] = valueType
 	checker.Elaboration.ReturnStatementReturnTypes[statement] = returnType
 
-	if valueType == nil {
-		return nil
-	}
+	// If the enclosing function's return type is Void,
+	// then the return statement should not have a return value
 
-	// return statement has expression, but function has Void return type?
 	if _, ok := returnType.(*VoidType); ok {
 		checker.report(
 			&InvalidReturnValueError{
 				Range: ast.NewRangeFromPositioned(statement.Expression),
 			},
 		)
-	} else {
 
-		if !valueType.IsInvalidType() &&
-			!returnType.IsInvalidType() &&
-			!checker.checkTypeCompatibility(statement.Expression, valueType, returnType) {
-
-			checker.report(
-				&TypeMismatchError{
-					ExpectedType: returnType,
-					ActualType:   valueType,
-					Range:        ast.NewRangeFromPositioned(statement.Expression),
-				},
-			)
-		}
-
-		checker.checkVariableMove(statement.Expression)
-		checker.checkResourceMoveOperation(statement.Expression, valueType)
+		return nil
 	}
+
+	// The return statement has a return value,
+	// and the enclosing function has a non-Void return type.
+	// Check that the types are compatible
+
+	if !valueType.IsInvalidType() &&
+		!returnType.IsInvalidType() &&
+		!checker.checkTypeCompatibility(statement.Expression, valueType, returnType) {
+
+		checker.report(
+			&TypeMismatchError{
+				ExpectedType: returnType,
+				ActualType:   valueType,
+				Range:        ast.NewRangeFromPositioned(statement.Expression),
+			},
+		)
+	}
+
+	checker.checkVariableMove(statement.Expression)
+	checker.checkResourceMoveOperation(statement.Expression, valueType)
 
 	return nil
 }

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -35,7 +35,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast
 	if statement.Expression == nil {
 
 		// If the return statement has no expression,
-		// and the enclosing function's return type is Void,
+		// and the enclosing function's return type is non-Void,
 		// then the return statement is missing an expression
 
 		if _, ok := returnType.(*VoidType); !ok {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -742,9 +742,16 @@ type MissingReturnValueError struct {
 }
 
 func (e *MissingReturnValueError) Error() string {
+	var typeDescription string
+	if e.ExpectedValueType.IsInvalidType() {
+		typeDescription = "non-void"
+	} else {
+		typeDescription = fmt.Sprintf(`%s`, e.ExpectedValueType)
+	}
+
 	return fmt.Sprintf(
-		"missing value in return from function with `%s` return type",
-		e.ExpectedValueType,
+		"missing value in return from function with %s return type",
+		typeDescription,
 	)
 }
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -719,7 +719,7 @@ func (e *FunctionExpressionInConditionError) Error() string {
 
 func (*FunctionExpressionInConditionError) isSemanticError() {}
 
-// UnexpectedReturnValueError
+// InvalidReturnValueError
 
 type InvalidReturnValueError struct {
 	ast.Range
@@ -733,6 +733,22 @@ func (e *InvalidReturnValueError) Error() string {
 }
 
 func (*InvalidReturnValueError) isSemanticError() {}
+
+// MissingReturnValueError
+
+type MissingReturnValueError struct {
+	ExpectedValueType Type
+	ast.Range
+}
+
+func (e *MissingReturnValueError) Error() string {
+	return fmt.Sprintf(
+		"missing value in return from function with `%s` return type",
+		e.ExpectedValueType,
+	)
+}
+
+func (*MissingReturnValueError) isSemanticError() {}
 
 // InvalidImplementationError
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -746,7 +746,7 @@ func (e *MissingReturnValueError) Error() string {
 	if e.ExpectedValueType.IsInvalidType() {
 		typeDescription = "non-void"
 	} else {
-		typeDescription = fmt.Sprintf(`%s`, e.ExpectedValueType)
+		typeDescription = fmt.Sprintf("`%s`", e.ExpectedValueType)
 	}
 
 	return fmt.Sprintf(

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -61,15 +61,86 @@ func TestCheckReturnStatementMissingValue(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheck(t, `
-      fun test(): Int {
-          return
-      }
-    `)
+	t.Run("valid return type", func(t *testing.T) {
 
-	errs := ExpectCheckerErrors(t, err, 1)
+		t.Parallel()
 
-	assert.IsType(t, &sema.MissingReturnValueError{}, errs[0])
+		_, err := ParseAndCheck(t, `
+          fun test(): Int {
+              return
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingReturnValueError{}, errs[0])
+	})
+
+	t.Run("invalid return type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          fun test(): X {
+              return
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+		assert.IsType(t, &sema.MissingReturnValueError{}, errs[1])
+	})
+}
+
+func TestCheckReturnStatementTypeMismatch(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("invalid return type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          fun test(): X {
+              return 1
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
+
+	t.Run("invalid value type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          fun test(): Int {
+              return x
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
+
+	t.Run("invalid value type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          fun test(): Int {
+              return true
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
 }
 
 func TestCheckMissingReturnStatementInterfaceFunction(t *testing.T) {


### PR DESCRIPTION
Closes #176 

Properly check return statements and report an error if the enclosing function has a non-Void return type, but the return statement has no value.