### PR TITLE
Don't panic when comparing unsupported value

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1743,6 +1743,10 @@ func (interpreter *Interpreter) testEqual(left, right Value) BoolValue {
 	// TODO: add support for arrays and dictionaries
 
 	switch left := left.(type) {
+	case NilValue:
+		_, ok := right.(NilValue)
+		return BoolValue(ok)
+
 	case EquatableValue:
 		// NOTE: might be NilValue
 		right, ok := right.(EquatableValue)
@@ -1750,10 +1754,6 @@ func (interpreter *Interpreter) testEqual(left, right Value) BoolValue {
 			return false
 		}
 		return left.Equal(right)
-
-	case NilValue:
-		_, ok := right.(NilValue)
-		return BoolValue(ok)
 
 	case *CompositeValue:
 		// TODO: call `equals` if RHS is composite
@@ -1763,9 +1763,10 @@ func (interpreter *Interpreter) testEqual(left, right Value) BoolValue {
 		*DictionaryValue:
 		// TODO:
 		return false
-	}
 
-	panic(errors.NewUnreachableError())
+	default:
+		return false
+	}
 }
 
 func (interpreter *Interpreter) VisitUnaryExpression(expression *ast.UnaryExpression) ast.Repr {

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -1,0 +1,106 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+)
+
+func TestInterpretEquality(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("capability", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpretWithOptions(t,
+			`
+              let maybeCapNonNil: Capability? = cap
+              let maybeCapNil: Capability? = nil
+		      let res1 = maybeCapNonNil != nil
+		      let res2 = maybeCapNil == nil
+		    `,
+			ParseCheckAndInterpretOptions{
+				Options: []interpreter.Option{
+					interpreter.WithPredefinedValues(map[string]interpreter.Value{
+						"cap": interpreter.CapabilityValue{
+							Address: interpreter.NewAddressValue(common.BytesToAddress([]byte{0x1})),
+							Path: interpreter.PathValue{
+								Domain:     common.PathDomainStorage,
+								Identifier: "something",
+							},
+						},
+					}),
+				},
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(map[string]sema.ValueDeclaration{
+						"cap": stdlib.StandardLibraryValue{
+							Name:       "cap",
+							Type:       &sema.CapabilityType{},
+							Kind:       common.DeclarationKindConstant,
+							IsConstant: true,
+						},
+					}),
+				},
+			},
+		)
+
+		assert.Equal(t,
+			interpreter.BoolValue(true),
+			inter.Globals["res1"].Value,
+		)
+
+		assert.Equal(t,
+			interpreter.BoolValue(true),
+			inter.Globals["res2"].Value,
+		)
+	})
+
+	t.Run("function", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		  fun func() {}
+
+          let maybeFuncNonNil: ((): Void)? = func
+          let maybeFuncNil: ((): Void)? = nil
+		  let res1 = maybeFuncNonNil != nil
+		  let res2 = maybeFuncNil == nil
+		`)
+
+		assert.Equal(t,
+			interpreter.BoolValue(true),
+			inter.Globals["res1"].Value,
+		)
+
+		assert.Equal(t,
+			interpreter.BoolValue(true),
+			inter.Globals["res2"].Value,
+		)
+	})
+}

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -41,8 +41,8 @@ func TestInterpretEquality(t *testing.T) {
 			`
               let maybeCapNonNil: Capability? = cap
               let maybeCapNil: Capability? = nil
-		      let res1 = maybeCapNonNil != nil
-		      let res2 = maybeCapNil == nil
+              let res1 = maybeCapNonNil != nil
+              let res2 = maybeCapNil == nil
 		    `,
 			ParseCheckAndInterpretOptions{
 				Options: []interpreter.Option{
@@ -89,8 +89,8 @@ func TestInterpretEquality(t *testing.T) {
 
           let maybeFuncNonNil: ((): Void)? = func
           let maybeFuncNil: ((): Void)? = nil
-		  let res1 = maybeFuncNonNil != nil
-		  let res2 = maybeFuncNil == nil
+          let res1 = maybeFuncNonNil != nil
+          let res2 = maybeFuncNil == nil
 		`)
 
 		assert.Equal(t,


### PR DESCRIPTION
Closes #192 

Any optional value might be compared with nil, even if the inner type of the optional type is not equatable, so don't panic and just return false.

Also, fix the subtyping rules for parameterized types: Instead of always reducing a potentially parameterized type to a base type (e.g. `Capability<T>` to `Capability`), only reduce to the base type if there is a type argument (e.g. only reduce `Capability<T>` to `Capability`, but not `Capability` to `Capability`)