### PR TITLE
Improve the JSON serialization for some AST elements

### DIFF
--- a/runtime/ast/access.go
+++ b/runtime/ast/access.go
@@ -19,6 +19,8 @@
 package ast
 
 import (
+	"encoding/json"
+
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -36,6 +38,10 @@ const (
 	AccessPublic
 	AccessPublicSettable
 )
+
+func AccessCount() int {
+	return len(_Access_index) - 1
+}
 
 func (a Access) IsLessPermissiveThan(otherAccess Access) bool {
 	return a < otherAccess
@@ -93,4 +99,8 @@ func (a Access) Description() string {
 	}
 
 	panic(errors.NewUnreachableError())
+}
+
+func (a Access) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.String())
 }

--- a/runtime/ast/access_test.go
+++ b/runtime/ast/access_test.go
@@ -20,35 +20,19 @@ package ast
 
 import (
 	"encoding/json"
+	"fmt"
+	"testing"
 
-	"github.com/onflow/cadence/runtime/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-//go:generate stringer -type=ConditionKind
+func TestAccess_MarshalJSON(t *testing.T) {
 
-type ConditionKind uint
+	for access := Access(0); access < Access(AccessCount()); access++ {
+		actual, err := json.Marshal(access)
+		require.NoError(t, err)
 
-const (
-	ConditionKindUnknown ConditionKind = iota
-	ConditionKindPre
-	ConditionKindPost
-)
-
-func ConditionKindCount() int {
-	return len(_ConditionKind_index) - 1
-}
-
-func (k ConditionKind) Name() string {
-	switch k {
-	case ConditionKindPre:
-		return "pre-condition"
-	case ConditionKindPost:
-		return "post-condition"
+		assert.JSONEq(t, fmt.Sprintf(`"%s"`, access), string(actual))
 	}
-
-	panic(errors.NewUnreachableError())
-}
-
-func (k ConditionKind) MarshalJSON() ([]byte, error) {
-	return json.Marshal(k.String())
 }

--- a/runtime/ast/argument.go
+++ b/runtime/ast/argument.go
@@ -18,13 +18,27 @@
 
 package ast
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 type Argument struct {
-	Label         string
-	LabelStartPos *Position
-	LabelEndPos   *Position
+	Label         string    `json:",omitempty"`
+	LabelStartPos *Position `json:",omitempty"`
+	LabelEndPos   *Position `json:",omitempty"`
 	Expression    Expression
+}
+
+func (a Argument) StartPosition() Position {
+	if a.LabelStartPos != nil {
+		return *a.LabelStartPos
+	}
+	return a.Expression.StartPosition()
+}
+
+func (a Argument) EndPosition() Position {
+	return a.Expression.EndPosition()
 }
 
 func (a Argument) String() string {
@@ -35,4 +49,15 @@ func (a Argument) String() string {
 	}
 	builder.WriteString(a.Expression.String())
 	return builder.String()
+}
+
+func (a Argument) MarshalJSON() ([]byte, error) {
+	type Alias Argument
+	return json.Marshal(&struct {
+		Range
+		Alias
+	}{
+		Range: NewRangeFromPositioned(a),
+		Alias: Alias(a),
+	})
 }

--- a/runtime/ast/argument_test.go
+++ b/runtime/ast/argument_test.go
@@ -1,0 +1,100 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArgument_MarshalJSON(t *testing.T) {
+
+	t.Run("without label", func(t *testing.T) {
+
+		argument := Argument{
+			Expression: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+		}
+
+		actual, err := json.Marshal(argument)
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`
+            {
+                "Expression": {
+                    "Type": "BoolExpression",
+                    "Value": false,
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                    "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            }
+            `,
+			string(actual),
+		)
+	})
+
+	t.Run("with label", func(t *testing.T) {
+
+		argument := Argument{
+			Label:         "ok",
+			LabelStartPos: &Position{Offset: 7, Line: 8, Column: 9},
+			LabelEndPos:   &Position{Offset: 10, Line: 11, Column: 12},
+			Expression: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+		}
+
+		actual, err := json.Marshal(argument)
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`
+            {
+                "Label": "ok",
+                "LabelStartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "LabelEndPos": {"Offset": 10, "Line": 11, "Column": 12},
+                "Expression": {
+                    "Type": "BoolExpression",
+                    "Value": false,
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                    "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                },
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9}, 
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            }
+            `,
+			string(actual),
+		)
+	})
+}

--- a/runtime/ast/conditionkind_test.go
+++ b/runtime/ast/conditionkind_test.go
@@ -20,35 +20,19 @@ package ast
 
 import (
 	"encoding/json"
+	"fmt"
+	"testing"
 
-	"github.com/onflow/cadence/runtime/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-//go:generate stringer -type=ConditionKind
+func TestConditionKind_MarshalJSON(t *testing.T) {
 
-type ConditionKind uint
+	for conditionKind := ConditionKind(0); conditionKind < ConditionKind(ConditionKindCount()); conditionKind++ {
+		actual, err := json.Marshal(conditionKind)
+		require.NoError(t, err)
 
-const (
-	ConditionKindUnknown ConditionKind = iota
-	ConditionKindPre
-	ConditionKindPost
-)
-
-func ConditionKindCount() int {
-	return len(_ConditionKind_index) - 1
-}
-
-func (k ConditionKind) Name() string {
-	switch k {
-	case ConditionKindPre:
-		return "pre-condition"
-	case ConditionKindPost:
-		return "post-condition"
+		assert.JSONEq(t, fmt.Sprintf(`"%s"`, conditionKind), string(actual))
 	}
-
-	panic(errors.NewUnreachableError())
-}
-
-func (k ConditionKind) MarshalJSON() ([]byte, error) {
-	return json.Marshal(k.String())
 }

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -19,6 +19,7 @@
 package ast
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
@@ -66,10 +67,21 @@ func (e *BoolExpression) String() string {
 	return "false"
 }
 
+func (e *BoolExpression) MarshalJSON() ([]byte, error) {
+	type Alias BoolExpression
+	return json.Marshal(&struct {
+		Type string
+		*Alias
+	}{
+		Type:  "BoolExpression",
+		Alias: (*Alias)(e),
+	})
+}
+
 // NilExpression
 
 type NilExpression struct {
-	Pos Position
+	Pos Position `json:"-"`
 }
 
 func (*NilExpression) isExpression() {}
@@ -94,6 +106,19 @@ func (e *NilExpression) StartPosition() Position {
 
 func (e *NilExpression) EndPosition() Position {
 	return e.Pos.Shifted(len(NilConstant) - 1)
+}
+
+func (e *NilExpression) MarshalJSON() ([]byte, error) {
+	type Alias NilExpression
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "NilExpression",
+		Range: NewRangeFromPositioned(e),
+		Alias: (*Alias)(e),
+	})
 }
 
 // StringExpression

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -1,0 +1,75 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolExpression_MarshalJSON(t *testing.T) {
+
+	expr := &BoolExpression{
+		Value: false,
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "BoolExpression",
+            "Value": false,
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestNilExpression_MarshalJSON(t *testing.T) {
+
+	expr := &NilExpression{
+		Pos: Position{Offset: 1, Line: 2, Column: 3},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "NilExpression",
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 3, "Line": 2, "Column": 5}
+        }
+        `,
+		string(actual),
+	)
+
+}


### PR DESCRIPTION
Work towards #210

Start improving the JSON serialization for some AST nodes:

- `Access`
- `Argument`
- `ConditionKind`
- `BoolExpression`
- `NilExpression`

