### PR TITLE
Don't report an error for a restriction with an invalid type

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -899,12 +899,14 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 		if !ok || (restrictionCompositeKind != common.CompositeKindResource &&
 			restrictionCompositeKind != common.CompositeKindStructure) {
 
-			checker.report(
-				&InvalidRestrictionTypeError{
-					Type:  restrictionResult,
-					Range: ast.NewRangeFromPositioned(restriction),
-				},
-			)
+			if !restrictionResult.IsInvalidType() {
+				checker.report(
+					&InvalidRestrictionTypeError{
+						Type:  restrictionResult,
+						Range: ast.NewRangeFromPositioned(restriction),
+					},
+				)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Just noticed that when a test case was failing