### PR TITLE
Remove controller from storage interface

### DIFF
--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -112,17 +112,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	var reads []testRead
 	var writes []testWrite
 
-	onRead := func(controller, owner, key, value []byte) {
+	onRead := func(owner, key, value []byte) {
 		reads = append(reads, testRead{
-			controller,
 			owner,
 			key,
 		})
 	}
 
-	onWrite := func(controller, owner, key, value []byte) {
+	onWrite := func(owner, key, value []byte) {
 		writes = append(writes, testWrite{
-			controller,
 			owner,
 			key,
 			value,
@@ -594,17 +592,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 	var reads []testRead
 	var writes []testWrite
 
-	onRead := func(controller, owner, key, value []byte) {
+	onRead := func(owner, key, value []byte) {
 		reads = append(reads, testRead{
-			controller,
 			owner,
 			key,
 		})
 	}
 
-	onWrite := func(controller, owner, key, value []byte) {
+	onWrite := func(owner, key, value []byte) {
 		writes = append(writes, testWrite{
-			controller,
 			owner,
 			key,
 			value,
@@ -815,17 +811,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 	var reads []testRead
 	var writes []testWrite
 
-	onRead := func(controller, owner, key, value []byte) {
+	onRead := func(owner, key, value []byte) {
 		reads = append(reads, testRead{
-			controller,
 			owner,
 			key,
 		})
 	}
 
-	onWrite := func(controller, owner, key, value []byte) {
+	onWrite := func(owner, key, value []byte) {
 		writes = append(writes, testWrite{
-			controller,
 			owner,
 			key,
 			value,
@@ -840,10 +834,10 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 	indexWrites := func() (indexedWrites map[string]map[string][]byte) {
 		indexedWrites = map[string]map[string][]byte{}
 		for _, write := range writes {
-			values, ok := indexedWrites[string(write.controller)]
+			values, ok := indexedWrites[string(write.owner)]
 			if !ok {
 				values = map[string][]byte{}
-				indexedWrites[string(write.controller)] = values
+				indexedWrites[string(write.owner)] = values
 			}
 			values[string(write.key)] = write.value
 		}

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -37,9 +37,9 @@ type Interface interface {
 	// CacheProgram adds a parsed program to a cache.
 	CacheProgram(Location, *ast.Program) error
 	// GetValue gets a value for the given key in the storage, controlled and owned by the given accounts.
-	GetValue(owner, controller, key []byte) (value []byte, err error)
+	GetValue(owner, key []byte) (value []byte, err error)
 	// SetValue sets a value for the given key in the storage, controlled and owned by the given accounts.
-	SetValue(owner, controller, key, value []byte) (err error)
+	SetValue(owner, key, value []byte) (err error)
 	// CreateAccount creates a new account.
 	CreateAccount(payer Address) (address Address, err error)
 	// AddAccountKey appends a key to an account.
@@ -55,7 +55,7 @@ type Interface interface {
 	// EmitEvent is called when an event is emitted by the runtime.
 	EmitEvent(cadence.Event)
 	// ValueExists returns true if the given key exists in the storage, controlled and owned by the given accounts.
-	ValueExists(owner, controller, key []byte) (exists bool, err error)
+	ValueExists(owner, key []byte) (exists bool, err error)
 	// GenerateUUID is called to generate a UUID.
 	GenerateUUID() uint64
 	// GetComputationLimit returns the computation limit. A value <= 0 means there is no limit
@@ -105,15 +105,15 @@ func (i *EmptyRuntimeInterface) CacheProgram(_ Location, _ *ast.Program) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) ValueExists(_, _, _ []byte) (exists bool, err error) {
+func (i *EmptyRuntimeInterface) ValueExists(_, _ []byte) (exists bool, err error) {
 	return false, nil
 }
 
-func (i *EmptyRuntimeInterface) GetValue(_, _, _ []byte) (value []byte, err error) {
+func (i *EmptyRuntimeInterface) GetValue(_, _ []byte) (value []byte, err error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) SetValue(_, _, _, _ []byte) error {
+func (i *EmptyRuntimeInterface) SetValue(_, _, _ []byte) error {
 	return nil
 }
 

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -36,9 +36,9 @@ type Interface interface {
 	GetCachedProgram(Location) (*ast.Program, error)
 	// CacheProgram adds a parsed program to a cache.
 	CacheProgram(Location, *ast.Program) error
-	// GetValue gets a value for the given key in the storage, controlled and owned by the given accounts.
+	// GetValue gets a value for the given key in the storage, owned by the given accounts.
 	GetValue(owner, key []byte) (value []byte, err error)
-	// SetValue sets a value for the given key in the storage, controlled and owned by the given accounts.
+	// SetValue sets a value for the given key in the storage, owned by the given accounts.
 	SetValue(owner, key, value []byte) (err error)
 	// CreateAccount creates a new account.
 	CreateAccount(payer Address) (address Address, err error)
@@ -54,7 +54,7 @@ type Interface interface {
 	Log(string)
 	// EmitEvent is called when an event is emitted by the runtime.
 	EmitEvent(cadence.Event)
-	// ValueExists returns true if the given key exists in the storage, controlled and owned by the given accounts.
+	// ValueExists returns true if the given key exists in the storage, owned by the given accounts.
 	ValueExists(owner, key []byte) (exists bool, err error)
 	// GenerateUUID is called to generate a UUID.
 	GenerateUUID() uint64

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -79,8 +79,7 @@ func (s *interpreterRuntimeStorage) valueExists(
 	var exists bool
 	var err error
 	wrapPanic(func() {
-		// TODO: fix controller
-		exists, err = s.runtimeInterface.ValueExists(address[:], []byte{}, []byte(key))
+		exists, err = s.runtimeInterface.ValueExists(address[:], []byte(key))
 	})
 	if err != nil {
 		panic(err)
@@ -131,8 +130,7 @@ func (s *interpreterRuntimeStorage) readValue(
 	var storedData []byte
 	var err error
 	wrapPanic(func() {
-		// TODO: fix controller
-		storedData, err = s.runtimeInterface.GetValue(address[:], nil, []byte(key))
+		storedData, err = s.runtimeInterface.GetValue(address[:], []byte(key))
 	})
 	if err != nil {
 		panic(err)
@@ -275,10 +273,8 @@ func (s *interpreterRuntimeStorage) writeCached() {
 
 		var err error
 		wrapPanic(func() {
-			// TODO: fix controller
 			err = s.runtimeInterface.SetValue(
 				item.storageKey.address[:],
-				nil,
 				[]byte(item.storageKey.key),
 				newData,
 			)
@@ -313,20 +309,17 @@ func (s *interpreterRuntimeStorage) move(
 	oldOwner common.Address, oldKey string,
 	newOwner common.Address, newKey string,
 ) {
-	// TODO: fix controller
-	data, err := s.runtimeInterface.GetValue(oldOwner[:], nil, []byte(oldKey))
+	data, err := s.runtimeInterface.GetValue(oldOwner[:], []byte(oldKey))
 	if err != nil {
 		panic(err)
 	}
 
-	// TODO: fix controller
-	err = s.runtimeInterface.SetValue(oldOwner[:], nil, []byte(oldKey), nil)
+	err = s.runtimeInterface.SetValue(oldOwner[:], []byte(oldKey), nil)
 	if err != nil {
 		panic(err)
 	}
 
-	// TODO: fix controller
-	err = s.runtimeInterface.SetValue(newOwner[:], nil, []byte(newKey), data)
+	err = s.runtimeInterface.SetValue(newOwner[:], []byte(newKey), data)
 	if err != nil {
 		panic(err)
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -45,39 +45,39 @@ import (
 
 type testRuntimeInterfaceStorage struct {
 	storedValues map[string][]byte
-	valueExists  func(controller, owner, key []byte) (exists bool, err error)
-	getValue     func(controller, owner, key []byte) (value []byte, err error)
-	setValue     func(controller, owner, key, value []byte) (err error)
+	valueExists  func(owner, key []byte) (exists bool, err error)
+	getValue     func(owner, key []byte) (value []byte, err error)
+	setValue     func(owner, key, value []byte) (err error)
 }
 
 func newTestStorage(
-	onRead func(controller, owner, key, value []byte),
-	onWrite func(controller, owner, key, value []byte),
+	onRead func(owner, key, value []byte),
+	onWrite func(owner, key, value []byte),
 ) testRuntimeInterfaceStorage {
 
-	storageKey := func(owner, controller, key string) string {
-		return strings.Join([]string{owner, controller, key}, "|")
+	storageKey := func(owner, key string) string {
+		return strings.Join([]string{owner, key}, "|")
 	}
 
 	storedValues := map[string][]byte{}
 
 	storage := testRuntimeInterfaceStorage{
 		storedValues: storedValues,
-		valueExists: func(controller, owner, key []byte) (bool, error) {
-			_, ok := storedValues[storageKey(string(controller), string(owner), string(key))]
+		valueExists: func(owner, key []byte) (bool, error) {
+			_, ok := storedValues[storageKey(string(owner), string(key))]
 			return ok, nil
 		},
-		getValue: func(controller, owner, key []byte) (value []byte, err error) {
-			value = storedValues[storageKey(string(controller), string(owner), string(key))]
+		getValue: func(owner, key []byte) (value []byte, err error) {
+			value = storedValues[storageKey(string(owner), string(key))]
 			if onRead != nil {
-				onRead(controller, owner, key, value)
+				onRead(owner, key, value)
 			}
 			return value, nil
 		},
-		setValue: func(controller, owner, key, value []byte) (err error) {
-			storedValues[storageKey(string(controller), string(owner), string(key))] = value
+		setValue: func(owner, key, value []byte) (err error) {
+			storedValues[storageKey(string(owner), string(key))] = value
 			if onWrite != nil {
-				onWrite(controller, owner, key, value)
+				onWrite(owner, key, value)
 			}
 			return nil
 		},
@@ -140,16 +140,16 @@ func (i *testRuntimeInterface) CacheProgram(location Location, program *ast.Prog
 	return i.cacheProgram(location, program)
 }
 
-func (i *testRuntimeInterface) ValueExists(controller, owner, key []byte) (exists bool, err error) {
-	return i.storage.valueExists(controller, owner, key)
+func (i *testRuntimeInterface) ValueExists(owner, key []byte) (exists bool, err error) {
+	return i.storage.valueExists(owner, key)
 }
 
-func (i *testRuntimeInterface) GetValue(controller, owner, key []byte) (value []byte, err error) {
-	return i.storage.getValue(controller, owner, key)
+func (i *testRuntimeInterface) GetValue(owner, key []byte) (value []byte, err error) {
+	return i.storage.getValue(owner, key)
 }
 
-func (i *testRuntimeInterface) SetValue(controller, owner, key, value []byte) (err error) {
-	return i.storage.setValue(controller, owner, key, value)
+func (i *testRuntimeInterface) SetValue(owner, key, value []byte) (err error) {
+	return i.storage.setValue(owner, key, value)
 }
 
 func (i *testRuntimeInterface) CreateAccount(payer Address) (address Address, err error) {
@@ -3994,19 +3994,19 @@ func TestRuntimeMetrics(t *testing.T) {
 }
 
 type testRead struct {
-	controller, owner, key []byte
+	owner, key []byte
 }
 
 func (r testRead) String() string {
-	return fmt.Sprintf("%x %s", r.controller, r.key)
+	return string(r.key)
 }
 
 type testWrite struct {
-	controller, owner, key, value []byte
+	owner, key, value []byte
 }
 
 func (w testWrite) String() string {
-	return fmt.Sprintf("%x %s", w.controller, w.key)
+	return string(w.key)
 }
 
 func TestRuntimeContractWriteback(t *testing.T) {
@@ -4057,9 +4057,8 @@ func TestRuntimeContractWriteback(t *testing.T) {
 	var loggedMessages []string
 	var writes []testWrite
 
-	onWrite := func(controller, owner, key, value []byte) {
+	onWrite := func(owner, key, value []byte) {
 		writes = append(writes, testWrite{
-			controller,
 			owner,
 			key,
 			value,
@@ -4151,9 +4150,8 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	var loggedMessages []string
 	var writes []testWrite
 
-	onWrite := func(controller, owner, key, value []byte) {
+	onWrite := func(owner, key, value []byte) {
 		writes = append(writes, testWrite{
-			controller,
 			owner,
 			key,
 			value,


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/168

## Description

Remove controller from storage interface methods, as it is not used. Update respective tests.