### PR TITLE
Check type parameter bounds when instantiating a parameterized type

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6706,13 +6706,7 @@ func capabilityBorrowFunctionType(borrowType Type) *FunctionType {
 	var typeParameters []*TypeParameter
 
 	if borrowType == nil {
-
-		typeParameter := &TypeParameter{
-			TypeBound: &ReferenceType{
-				Type: &AnyType{},
-			},
-			Name: "T",
-		}
+		typeParameter := capabilityTypeParameter
 
 		typeParameters = []*TypeParameter{
 			typeParameter,
@@ -6739,12 +6733,7 @@ func capabilityCheckFunctionType(borrowType Type) *FunctionType {
 
 	if borrowType == nil {
 		typeParameters = []*TypeParameter{
-			{
-				TypeBound: &ReferenceType{
-					Type: &AnyType{},
-				},
-				Name: "T",
-			},
+			capabilityTypeParameter,
 		}
 	}
 


### PR DESCRIPTION
Closes #219

When parameterized types were implemented, I missed implementing the check for the (optional) type bound.