### PR TITLE
Refactor activations

### DIFF
--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -21,8 +21,7 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/raviqqe/hamt"
-
+	"github.com/onflow/cadence/runtime/activations"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
@@ -56,7 +55,7 @@ type InterpretedFunctionValue struct {
 	Interpreter      *Interpreter
 	ParameterList    *ast.ParameterList
 	Type             *sema.FunctionType
-	Activation       hamt.Map
+	Activation       activations.Activation
 	BeforeStatements []ast.Statement
 	PreConditions    ast.Conditions
 	Statements       []ast.Statement

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	goRuntime "runtime"
 
-	"github.com/raviqqe/hamt"
-
 	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/runtime/activations"
 	"github.com/onflow/cadence/runtime/ast"
@@ -890,9 +888,13 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 	lexicalScope := interpreter.activations.CurrentOrNew()
 
 	// make the function itself available inside the function
-	lexicalScope = lexicalScope.Insert(common.StringEntry(identifier), variable)
+	lexicalScope = lexicalScope.Insert(identifier, variable)
 
-	variable.Value = interpreter.functionDeclarationValue(declaration, functionType, lexicalScope)
+	variable.Value = interpreter.functionDeclarationValue(
+		declaration,
+		functionType,
+		lexicalScope,
+	)
 
 	// NOTE: no result, so it does *not* act like a return-statement
 	return Done{}
@@ -901,7 +903,7 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 func (interpreter *Interpreter) functionDeclarationValue(
 	declaration *ast.FunctionDeclaration,
 	functionType *sema.FunctionType,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) InterpretedFunctionValue {
 
 	var preConditions ast.Conditions
@@ -2291,17 +2293,16 @@ func (interpreter *Interpreter) VisitCompositeDeclaration(declaration *ast.Compo
 //
 func (interpreter *Interpreter) declareCompositeValue(
 	declaration *ast.CompositeDeclaration,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) (
-	scope hamt.Map,
+	scope activations.Activation,
 	value Value,
 ) {
 	identifier := declaration.Identifier.Identifier
 	variable := interpreter.findOrDeclareVariable(identifier)
 
 	// Make the value available in the initializer
-	lexicalScope = lexicalScope.
-		Insert(common.StringEntry(identifier), variable)
+	lexicalScope = lexicalScope.Insert(identifier, variable)
 
 	// Evaluate nested declarations in a new scope, so values
 	// of nested declarations won't be visible after the containing declaration
@@ -2316,7 +2317,7 @@ func (interpreter *Interpreter) declareCompositeValue(
 		predeclare := func(identifier ast.Identifier) {
 			name := identifier.Identifier
 			lexicalScope = lexicalScope.Insert(
-				common.StringEntry(name),
+				name,
 				interpreter.declareVariable(name, nil),
 			)
 		}
@@ -2517,7 +2518,7 @@ func (interpreter *Interpreter) declareCompositeValue(
 
 func (interpreter *Interpreter) compositeInitializerFunction(
 	compositeDeclaration *ast.CompositeDeclaration,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) *InterpretedFunctionValue {
 
 	// TODO: support multiple overloaded initializers
@@ -2565,7 +2566,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 
 func (interpreter *Interpreter) compositeDestructorFunction(
 	compositeDeclaration *ast.CompositeDeclaration,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) *InterpretedFunctionValue {
 
 	destructor := compositeDeclaration.Members.Destructor()
@@ -2605,7 +2606,7 @@ func (interpreter *Interpreter) compositeDestructorFunction(
 
 func (interpreter *Interpreter) compositeFunctions(
 	compositeDeclaration *ast.CompositeDeclaration,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) map[string]FunctionValue {
 
 	functions := map[string]FunctionValue{}
@@ -2624,7 +2625,7 @@ func (interpreter *Interpreter) compositeFunctions(
 
 func (interpreter *Interpreter) functionWrappers(
 	members *ast.Members,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) map[string]FunctionWrapper {
 
 	functionWrappers := map[string]FunctionWrapper{}
@@ -2650,7 +2651,7 @@ func (interpreter *Interpreter) functionWrappers(
 
 func (interpreter *Interpreter) compositeFunction(
 	functionDeclaration *ast.FunctionDeclaration,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) InterpretedFunctionValue {
 
 	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
@@ -2846,7 +2847,7 @@ func (interpreter *Interpreter) VisitInterfaceDeclaration(declaration *ast.Inter
 
 func (interpreter *Interpreter) declareInterface(
 	declaration *ast.InterfaceDeclaration,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) {
 	// Evaluate nested declarations in a new scope, so values
 	// of nested declarations won't be visible after the containing declaration
@@ -2880,7 +2881,7 @@ func (interpreter *Interpreter) declareInterface(
 
 func (interpreter *Interpreter) declareTypeRequirement(
 	declaration *ast.CompositeDeclaration,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) {
 	// Evaluate nested declarations in a new scope, so values
 	// of nested declarations won't be visible after the containing declaration
@@ -2914,7 +2915,7 @@ func (interpreter *Interpreter) declareTypeRequirement(
 
 func (interpreter *Interpreter) initializerFunctionWrapper(
 	members *ast.Members,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) FunctionWrapper {
 
 	// TODO: support multiple overloaded initializers
@@ -2938,7 +2939,7 @@ func (interpreter *Interpreter) initializerFunctionWrapper(
 
 func (interpreter *Interpreter) destructorFunctionWrapper(
 	members *ast.Members,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) FunctionWrapper {
 
 	destructor := members.Destructor()
@@ -2956,7 +2957,7 @@ func (interpreter *Interpreter) destructorFunctionWrapper(
 func (interpreter *Interpreter) functionConditionsWrapper(
 	declaration *ast.FunctionDeclaration,
 	returnType sema.Type,
-	lexicalScope hamt.Map,
+	lexicalScope activations.Activation,
 ) FunctionWrapper {
 
 	if declaration.FunctionBlock == nil {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -550,8 +550,7 @@ func (interpreter *Interpreter) findVariable(name string) *Variable {
 func (interpreter *Interpreter) findOrDeclareVariable(name string) *Variable {
 	variable := interpreter.findVariable(name)
 	if variable == nil {
-		variable = &Variable{}
-		interpreter.setVariable(name, variable)
+		variable = interpreter.declareVariable(name, nil)
 	}
 	return variable
 }
@@ -1313,7 +1312,8 @@ func (interpreter *Interpreter) movingStorageIndexExpression(expression ast.Expr
 // declareVariable declares a variable in the latest scope
 func (interpreter *Interpreter) declareVariable(identifier string, value Value) *Variable {
 	// NOTE: semantic analysis already checked possible invalid redeclaration
-	variable := &Variable{Value: value}
+	depth := interpreter.activations.Depth()
+	variable := NewVariable(value, depth)
 	interpreter.setVariable(identifier, variable)
 	return variable
 }
@@ -3107,7 +3107,7 @@ func (interpreter *Interpreter) ensureLoaded(
 		// prepare the interpreter
 
 		for name, value := range virtualImport.Globals {
-			variable := &Variable{Value: value}
+			variable := NewVariable(value, 0)
 			subInterpreter.setVariable(name, variable)
 			subInterpreter.Globals[name] = variable
 		}

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -19,13 +19,13 @@
 package interpreter
 
 type Variable struct {
-	Value Value
-	Depth int
+	Value           Value
+	ActivationDepth int
 }
 
 func NewVariable(value Value, depth int) *Variable {
 	return &Variable{
-		Value: value,
-		Depth: depth,
+		Value:           value,
+		ActivationDepth: depth,
 	}
 }

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -20,4 +20,12 @@ package interpreter
 
 type Variable struct {
 	Value Value
+	Depth int
+}
+
+func NewVariable(value Value, depth int) *Variable {
+	return &Variable{
+		Value: value,
+		Depth: depth,
+	}
 }

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1416,7 +1416,7 @@ func (checker *Checker) declareSelfValue(selfType Type) {
 		DeclarationKind: common.DeclarationKindSelf,
 		Type:            selfType,
 		IsConstant:      true,
-		Depth:           depth,
+		ActivationDepth: depth,
 		Pos:             nil,
 	}
 	checker.valueActivations.Set(SelfIdentifier, self)

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -122,7 +122,7 @@ func (checker *Checker) checkResourceVariableCapturingInFunction(variable *Varia
 	}
 
 	if currentFunctionDepth == -1 ||
-		variable.Depth > currentFunctionDepth {
+		variable.ActivationDepth > currentFunctionDepth {
 
 		return
 	}

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -254,7 +254,7 @@ func (checker *Checker) declareParameters(
 
 		// check if variable with this identifier is already declared in the current scope
 		existingVariable := checker.valueActivations.Find(identifier.Identifier)
-		if existingVariable != nil && existingVariable.Depth == depth {
+		if existingVariable != nil && existingVariable.ActivationDepth == depth {
 			checker.report(
 				&RedeclarationError{
 					Kind:        common.DeclarationKindParameter,
@@ -275,7 +275,7 @@ func (checker *Checker) declareParameters(
 			DeclarationKind: common.DeclarationKindParameter,
 			IsConstant:      true,
 			Type:            parameterType,
-			Depth:           depth,
+			ActivationDepth: depth,
 			Pos:             &identifier.Pos,
 		}
 		checker.valueActivations.Set(identifier.Identifier, variable)

--- a/runtime/sema/variable.go
+++ b/runtime/sema/variable.go
@@ -35,8 +35,8 @@ type Variable struct {
 	// IsBaseValue indicates if the variable is a base value,
 	// i.e. it is defined by the checker and not the program
 	IsBaseValue bool
-	// Depth is the depth of scopes in which the variable was declared
-	Depth int
+	// ActivationDepth is the depth of scopes in which the variable was declared
+	ActivationDepth int
 	// ArgumentLabels are the argument labels that must be used in an invocation of the variable
 	ArgumentLabels []string
 	// Pos is the position where the variable was declared

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -19,8 +19,6 @@
 package sema
 
 import (
-	"github.com/raviqqe/hamt"
-
 	"github.com/onflow/cadence/runtime/activations"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -32,7 +30,7 @@ type VariableActivations struct {
 
 func NewValueActivations() *VariableActivations {
 	valueActivations := &activations.Activations{}
-	valueActivations.Push(hamt.NewMap())
+	valueActivations.Push(activations.NewActivation())
 	return &VariableActivations{
 		activations: valueActivations,
 	}
@@ -161,14 +159,14 @@ func (a *VariableActivations) DeclareImplicitConstant(
 func (a *VariableActivations) VariablesDeclaredInAndBelow(depth int) map[string]*Variable {
 	variables := map[string]*Variable{}
 
-	values := a.activations.CurrentOrNew()
+	activation := a.activations.CurrentOrNew()
 
-	var entry hamt.Entry
+	var name string
 	var value interface{}
 
 	for {
-		entry, value, values = values.FirstRest()
-		if entry == nil {
+		name, value, activation = activation.FirstRest()
+		if name == "" {
 			break
 		}
 
@@ -177,8 +175,6 @@ func (a *VariableActivations) VariablesDeclaredInAndBelow(depth int) map[string]
 		if variable.Depth < depth {
 			continue
 		}
-
-		name := string(entry.(common.StringEntry))
 
 		variables[name] = variable
 	}

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -86,7 +86,7 @@ func (a *VariableActivations) Declare(declaration variableDeclaration) (variable
 	existingVariable := a.Find(declaration.identifier)
 	if existingVariable != nil &&
 		(!declaration.allowOuterScopeShadowing ||
-			existingVariable.Depth == depth) {
+			existingVariable.ActivationDepth == depth) {
 
 		err = &RedeclarationError{
 			Kind:        declaration.kind,
@@ -107,7 +107,7 @@ func (a *VariableActivations) Declare(declaration variableDeclaration) (variable
 		Access:          declaration.access,
 		DeclarationKind: declaration.kind,
 		IsConstant:      declaration.isConstant,
-		Depth:           depth,
+		ActivationDepth: depth,
 		Type:            declaration.ty,
 		Pos:             &declaration.pos,
 		ArgumentLabels:  declaration.argumentLabels,
@@ -172,7 +172,7 @@ func (a *VariableActivations) VariablesDeclaredInAndBelow(depth int) map[string]
 
 		variable := value.(*Variable)
 
-		if variable.Depth < depth {
+		if variable.ActivationDepth < depth {
 			continue
 		}
 


### PR DESCRIPTION
While investigating how we can detect when values "on the stack" are freed, I cleaned up the code for  activations by adding a wrapper type and adding a depth field

The implementation detail that an activation is backed by a `hamt.Map` was leaked outside, so I created a type to separate that concern a bit better. Maybe in the future we're changing how the activation is implemented, so this change should make that easier and smoother, because nothing has to change for consumers of this code.

Adding the type also allowed defining the higher-level functions (`FirstRest`, `Find`, `Insert`).
The fact the activation is using a `common.StringEntry` was also leaking out and was cleaned up.