### PR TITLE
Fix crash when invoking a function on an undeclared variable

### DIFF
--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -134,6 +134,22 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 		inCreate,
 	)
 
+	checker.checkMemberInvocationResourceInvalidation(invokedExpression)
+
+	// Update the return info for invocations that do not return (i.e. have a `Never` return type)
+
+	if _, ok = returnType.(*NeverType); ok {
+		functionActivation := checker.functionActivations.Current()
+		functionActivation.ReturnInfo.DefinitelyHalted = true
+	}
+
+	if isOptionalChainingResult {
+		return &OptionalType{Type: returnType}
+	}
+	return returnType
+}
+
+func (checker *Checker) checkMemberInvocationResourceInvalidation(invokedExpression ast.Expression) {
 	// If the invocation is on a resource, i.e., a member expression where the accessed expression
 	// is an identifier which refers to a resource, then the resource is temporarily "moved into"
 	// the function and back out after the invocation.
@@ -147,47 +163,42 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	// the arguments might just use to the temporarily moved resource, e.g. `foo.bar(foo.baz)`
 	// and not invalidate it.
 
-	if invokedMemberExpression, ok := invokedExpression.(*ast.MemberExpression); ok {
-		if invocationIdentifierExpression, ok := invokedMemberExpression.Expression.(*ast.IdentifierExpression); ok {
-
-			// Check that an entry for `IdentifierInInvocationTypes` exists,
-			// because the entry might be missing if the invocation was on a non-existent variable
-
-			if valueType, ok := checker.Elaboration.IdentifierInInvocationTypes[invocationIdentifierExpression]; ok {
-
-				invalidation := checker.recordResourceInvalidation(
-					invocationIdentifierExpression,
-					valueType,
-					ResourceInvalidationKindMoveTemporary,
-				)
-
-				if invalidation != nil {
-
-					checker.resources.RemoveTemporaryInvalidation(
-						invalidation.resource,
-						invalidation.invalidation,
-					)
-
-					checker.checkResourceUseAfterInvalidation(
-						invalidation.resource,
-						invocationIdentifierExpression,
-					)
-				}
-			}
-		}
+	invokedMemberExpression, ok := invokedExpression.(*ast.MemberExpression)
+	if !ok {
+		return
+	}
+	invocationIdentifierExpression, ok := invokedMemberExpression.Expression.(*ast.IdentifierExpression)
+	if !ok {
+		return
 	}
 
-	// Update the return info for invocations that do not return (i.e. have a `Never` return type)
+	// Check that an entry for `IdentifierInInvocationTypes` exists,
+	// because the entry might be missing if the invocation was on a non-existent variable
 
-	if _, ok = returnType.(*NeverType); ok {
-		functionActivation := checker.functionActivations.Current()
-		functionActivation.ReturnInfo.DefinitelyHalted = true
+	valueType, ok := checker.Elaboration.IdentifierInInvocationTypes[invocationIdentifierExpression]
+	if !ok {
+		return
 	}
 
-	if isOptionalChainingResult {
-		return &OptionalType{Type: returnType}
+	invalidation := checker.recordResourceInvalidation(
+		invocationIdentifierExpression,
+		valueType,
+		ResourceInvalidationKindMoveTemporary,
+	)
+
+	if invalidation == nil {
+		return
 	}
-	return returnType
+
+	checker.resources.RemoveTemporaryInvalidation(
+		invalidation.resource,
+		invalidation.invalidation,
+	)
+
+	checker.checkResourceUseAfterInvalidation(
+		invalidation.resource,
+		invocationIdentifierExpression,
+	)
 }
 
 func (checker *Checker) checkConstructorInvocationWithResourceResult(

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -150,25 +150,29 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	if invokedMemberExpression, ok := invokedExpression.(*ast.MemberExpression); ok {
 		if invocationIdentifierExpression, ok := invokedMemberExpression.Expression.(*ast.IdentifierExpression); ok {
 
-			valueType := checker.Elaboration.IdentifierInInvocationTypes[invocationIdentifierExpression]
+			// Check that an entry for `IdentifierInInvocationTypes` exists,
+			// because the entry might be missing if the invocation was on a non-existent variable
 
-			invalidation := checker.recordResourceInvalidation(
-				invocationIdentifierExpression,
-				valueType,
-				ResourceInvalidationKindMoveTemporary,
-			)
+			if valueType, ok := checker.Elaboration.IdentifierInInvocationTypes[invocationIdentifierExpression]; ok {
 
-			if invalidation != nil {
-
-				checker.resources.RemoveTemporaryInvalidation(
-					invalidation.resource,
-					invalidation.invalidation,
-				)
-
-				checker.checkResourceUseAfterInvalidation(
-					invalidation.resource,
+				invalidation := checker.recordResourceInvalidation(
 					invocationIdentifierExpression,
+					valueType,
+					ResourceInvalidationKindMoveTemporary,
 				)
+
+				if invalidation != nil {
+
+					checker.resources.RemoveTemporaryInvalidation(
+						invalidation.resource,
+						invalidation.invalidation,
+					)
+
+					checker.checkResourceUseAfterInvalidation(
+						invalidation.resource,
+						invocationIdentifierExpression,
+					)
+				}
 			}
 		}
 	}

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -4502,4 +4502,17 @@ func TestCheckResourceMoveMemberInvocation(t *testing.T) {
 
 		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
 	})
+
+	t.Run("invocation on undeclared variable", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let x = y.isInstance(Type<Int>())
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
 }


### PR DESCRIPTION
Closes #229 

The first commit fixes the problem. The second commit refactors the code into a function. Probably best viewed in split mode
