### PR TITLE
Accept member expressions without name 

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -1000,7 +1000,21 @@ func defineMemberExpression() {
 
 func parseMemberAccess(p *parser, left ast.Expression, optional bool) ast.Expression {
 	p.skipSpaceAndComments(true)
-	identifier := mustIdentifier(p)
+
+	// If there is an identifier, use it.
+	// If not, report an error
+
+	var identifier ast.Identifier
+	if p.current.Is(lexer.TokenIdentifier) {
+		identifier = tokenToIdentifier(p.current)
+		p.next()
+	} else {
+		p.report(fmt.Errorf(
+			"expected member name, got %s",
+			p.current.Type,
+		))
+	}
+
 	return &ast.MemberExpression{
 		Optional:   optional,
 		Expression: left,

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -1522,7 +1522,7 @@ func TestMemberExpression(t *testing.T) {
 		)
 	})
 
-	t.Run("whitespace between", func(t *testing.T) {
+	t.Run("whitespace before", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -1540,6 +1540,37 @@ func TestMemberExpression(t *testing.T) {
 				Identifier: ast.Identifier{
 					Identifier: "n",
 					Pos:        ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("f.")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected member name, got EOF",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
+			},
+			errs,
+		)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.MemberExpression{
+				Expression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "f",
+						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
+					},
+				},
+				Identifier: ast.Identifier{
+					Identifier: "",
 				},
 			},
 			result,

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -83,6 +83,21 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (member *M
 		return memberInfo.Member, memberInfo.IsOptional
 	}
 
+	defer func() {
+		checker.Elaboration.MemberExpressionMemberInfos[expression] =
+			MemberInfo{
+				Member:     member,
+				IsOptional: isOptional,
+			}
+	}()
+
+	// The access expression might have no name,
+	// as the parser accepts invalid programs
+
+	if expression.Identifier.Identifier == "" {
+		return member, isOptional
+	}
+
 	accessedExpression := expression.Expression
 
 	var expressionType Type
@@ -226,12 +241,6 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (member *M
 			)
 		}
 	}
-
-	checker.Elaboration.MemberExpressionMemberInfos[expression] =
-		MemberInfo{
-			Member:     member,
-			IsOptional: isOptional,
-		}
 
 	return member, isOptional
 }

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -707,14 +707,14 @@ func (e *FieldUninitializedError) EndPosition() ast.Position {
 	return e.Pos.Shifted(length - 1)
 }
 
-// FieldTypeNotStorableError is an error that is reported for 
-// field of composite types that are not storable.
+// FieldTypeNotStorableError is an error that is reported for
+// fields of composite types that are not storable.
 //
-// Field types have to be storable because the storage
-// layer needs to know how to store the field, which is not 
-// possible for all types.
+// Field types have to be storable because the storage layer
+// needs to know how to store the field, which is not possible
+// for all types.
 //
-// For example, the type `Int` is a storable type, 
+// For example, the type `Int` is a storable type,
 // whereas a function type is not.
 
 type FieldTypeNotStorableError struct {
@@ -2056,7 +2056,7 @@ type InvalidOptionalChainingError struct {
 
 func (e *InvalidOptionalChainingError) Error() string {
 	return fmt.Sprintf(
-		"cannot use optional chaining: type '%s' is not optional",
+		"cannot use optional chaining: type `%s` is not optional",
 		e.Type.QualifiedString(),
 	)
 }

--- a/runtime/tests/fuzz/crashers_test.go
+++ b/runtime/tests/fuzz/crashers_test.go
@@ -37,7 +37,7 @@ func TestCrashers(t *testing.T) {
 
 	f, err := os.Open(crashersDir)
 	if err != nil {
-		t.Skip()
+		return
 	}
 
 	files, err := f.Readdir(-1)
@@ -51,6 +51,8 @@ func TestCrashers(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
+
+			t.Parallel()
 
 			var data []byte
 			data, err = ioutil.ReadFile(path.Join(crashersDir, name))


### PR DESCRIPTION
Don't fail parsing when a member expression has no name / identifier.
Instead, report an error, and still produce a member expression with an empty name.

This is pre-work for adding code completion of members.
For example, a completion might be requested at the end of a program like `x.`.
To be able to provide completions, checking must be performed. 
However, currently this is not possible, as parsing is failing (it requires a name for the member access)