### PR TITLE
Add optional high-level write callback

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -138,6 +138,10 @@ func exportCompositeType(t *sema.CompositeType) cadence.Type {
 	for _, identifier := range fieldNames {
 		field := t.Members[identifier]
 
+		if field.IgnoreInSerialization {
+			continue
+		}
+
 		convertedFieldType := exportType(field.TypeAnnotation.Type)
 
 		fields = append(fields, cadence.Field{
@@ -163,6 +167,12 @@ func exportCompositeType(t *sema.CompositeType) cadence.Type {
 		}
 	case common.CompositeKindEvent:
 		return cadence.EventType{
+			TypeID:     id,
+			Identifier: t.Identifier,
+			Fields:     fields,
+		}
+	case common.CompositeKindContract:
+		return cadence.ContractType{
 			TypeID:     id,
 			Identifier: t.Identifier,
 			Fields:     fields,

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -159,9 +159,23 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 		return cadence.NewResource(fields).WithType(t.(cadence.ResourceType))
 	case common.CompositeKindEvent:
 		return cadence.NewEvent(fields).WithType(t.(cadence.EventType))
+	case common.CompositeKindContract:
+		return cadence.NewContract(fields).WithType(t.(cadence.ContractType))
 	}
 
-	panic(fmt.Errorf("invalid composite kind `%s`, must be Struct, Resource or Event", staticType.Kind))
+	panic(fmt.Errorf(
+		"invalid composite kind `%s`, must be %s",
+		staticType.Kind,
+		common.EnumerateWords(
+			[]string{
+				common.CompositeKindStructure.String(),
+				common.CompositeKindResource.String(),
+				common.CompositeKindEvent.String(),
+				common.CompositeKindContract.String(),
+			},
+			"or",
+		),
+	))
 }
 
 func exportDictionaryValue(v *interpreter.DictionaryValue, inter *interpreter.Interpreter) cadence.Value {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -182,8 +182,11 @@ func exportDictionaryValue(v *interpreter.DictionaryValue, inter *interpreter.In
 	pairs := make([]cadence.KeyValuePair, v.Count())
 
 	for i, keyValue := range v.Keys.Values {
-		key := keyValue.(interpreter.HasKeyString).KeyString()
-		value := v.Entries[key]
+
+		// NOTE: use `Get` instead of accessing `Entries`,
+		// so that the potentially deferred values are loaded from storage
+
+		value := v.Get(inter, interpreter.LocationRange{}, keyValue).(*interpreter.SomeValue).Value
 
 		convertedKey := exportValueWithInterpreter(keyValue, inter)
 		convertedValue := exportValueWithInterpreter(value, inter)

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -168,10 +168,10 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 		staticType.Kind,
 		common.EnumerateWords(
 			[]string{
-				common.CompositeKindStructure.String(),
-				common.CompositeKindResource.String(),
-				common.CompositeKindEvent.String(),
-				common.CompositeKindContract.String(),
+				common.CompositeKindStructure.Name(),
+				common.CompositeKindResource.Name(),
+				common.CompositeKindEvent.Name(),
+				common.CompositeKindContract.Name(),
 			},
 			"or",
 		),

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
 )
 
 const BlockHashLength = 32
@@ -91,7 +90,7 @@ type HighLevelStorage interface {
 	HighLevelStorageEnabled() bool
 
 	// SetCadenceValue sets a value for the given key in the storage, owned by the given account.
-	SetCadenceValue(owner common.Address, key string, value cadence.Value) (err error)
+	SetCadenceValue(owner Address, key string, value cadence.Value) (err error)
 }
 
 type Metrics interface {

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
 )
 
 const BlockHashLength = 32
@@ -79,6 +80,18 @@ type Interface interface {
 		signatureAlgorithm string,
 		hashAlgorithm string,
 	) bool
+}
+
+type HighLevelStorage interface {
+	Interface
+
+	// HighLevelStorageEnabled should return true
+	// if the functions of HighLevelStorage should be called,
+	// e.g. SetCadenceValue
+	HighLevelStorageEnabled() bool
+
+	// SetCadenceValue sets a value for the given key in the storage, owned by the given account.
+	SetCadenceValue(owner common.Address, key string, value cadence.Value) (err error)
 }
 
 type Metrics interface {

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -21,6 +21,7 @@ package parser2
 import (
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
@@ -161,11 +162,16 @@ func parseAccess(p *parser) ast.Access {
 
 		if !p.current.Is(lexer.TokenIdentifier) {
 			panic(fmt.Errorf(
-				"expected keyword %q, %q, %q, or %q, got %s",
-				keywordAll,
-				keywordAccount,
-				keywordContract,
-				keywordSelf,
+				"expected keyword %s, got %s",
+				common.EnumerateWords(
+					[]string{
+						strconv.Quote(keywordAll),
+						strconv.Quote(keywordAccount),
+						strconv.Quote(keywordContract),
+						strconv.Quote(keywordSelf),
+					},
+					"or",
+				),
 				p.current.Type,
 			))
 		}
@@ -187,11 +193,16 @@ func parseAccess(p *parser) ast.Access {
 
 		default:
 			panic(fmt.Errorf(
-				"expected keyword %q, %q, %q, or %q, got %q",
-				keywordAll,
-				keywordAccount,
-				keywordContract,
-				keywordSelf,
+				"expected keyword %s, got %q",
+				common.EnumerateWords(
+					[]string{
+						strconv.Quote(keywordAll),
+						strconv.Quote(keywordAccount),
+						strconv.Quote(keywordContract),
+						strconv.Quote(keywordSelf),
+					},
+					"or",
+				),
 				p.current.Value,
 			))
 		}

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -310,10 +310,6 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 			panic(err)
 		}
 	}
-
-	if s.highLevelStorageEnabled {
-
-	}
 }
 
 func (s *interpreterRuntimeStorage) encodeValue(

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -115,6 +115,7 @@ type testRuntimeInterface struct {
 		signatureAlgorithm string,
 		hashAlgorithm string,
 	) bool
+	setCadenceValue func(owner common.Address, key string, value cadence.Value) (err error)
 }
 
 var _ Interface = &testRuntimeInterface{}
@@ -277,6 +278,14 @@ func (i *testRuntimeInterface) VerifySignature(
 		signatureAlgorithm,
 		hashAlgorithm,
 	)
+}
+
+func (i *testRuntimeInterface) HighLevelStorageEnabled() bool {
+	return i.setCadenceValue != nil
+}
+
+func (i *testRuntimeInterface) SetCadenceValue(owner common.Address, key string, value cadence.Value) (err error) {
+	return i.setCadenceValue(owner, key, value)
 }
 
 func TestRuntimeImport(t *testing.T) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -115,7 +115,7 @@ type testRuntimeInterface struct {
 		signatureAlgorithm string,
 		hashAlgorithm string,
 	) bool
-	setCadenceValue func(owner common.Address, key string, value cadence.Value) (err error)
+	setCadenceValue func(owner Address, key string, value cadence.Value) (err error)
 }
 
 var _ Interface = &testRuntimeInterface{}

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -521,12 +521,13 @@ func (checker *Checker) declareCompositeMembersAndValue(
 				checker.valueActivations.Find(identifier.Identifier)
 
 			declarationMembers[nestedCompositeDeclarationVariable.Identifier] = &Member{
-				Identifier:      identifier,
-				Access:          nestedCompositeDeclaration.Access,
-				ContainerType:   compositeType,
-				TypeAnnotation:  NewTypeAnnotation(nestedCompositeDeclarationVariable.Type),
-				DeclarationKind: nestedCompositeDeclarationVariable.DeclarationKind,
-				VariableKind:    ast.VariableKindConstant,
+				Identifier:            identifier,
+				Access:                nestedCompositeDeclaration.Access,
+				ContainerType:         compositeType,
+				TypeAnnotation:        NewTypeAnnotation(nestedCompositeDeclarationVariable.Type),
+				DeclarationKind:       nestedCompositeDeclarationVariable.DeclarationKind,
+				VariableKind:          ast.VariableKindConstant,
+				IgnoreInSerialization: true,
 			}
 		}
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -112,7 +112,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 		emitEvent: func(event cadence.Event) {
 			events = append(events, event)
 		},
-		setCadenceValue: func(owner common.Address, key string, value cadence.Value) (err error) {
+		setCadenceValue: func(owner Address, key string, value cadence.Value) (err error) {
 			writes = append(writes, write{
 				owner: owner,
 				key:   key,

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1,0 +1,70 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+func TestRuntimeHighLevelStorage(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewInterpreterRuntime()
+
+	tx := []byte(`
+      transaction {
+        prepare(signer: AuthAccount) {
+          signer.save(42, to: /storage/number)
+        }
+      }
+    `)
+
+	var storedValue cadence.Value
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestStorage(nil, nil),
+		getSigningAccounts: func() []Address {
+			return []Address{
+				common.BytesToAddress([]byte{42}),
+			}
+		},
+		setCadenceValue: func(owner common.Address, key string, value cadence.Value) (err error) {
+			if storedValue != nil {
+				t.Fail()
+			}
+			storedValue = value
+
+			return nil
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	err := runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+
+	assert.Equal(t, cadence.NewInt(42), storedValue)
+}

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestRuntimeHighLevelStorage(t *testing.T) {
@@ -34,37 +35,219 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 
 	runtime := NewInterpreterRuntime()
 
-	tx := []byte(`
-      transaction {
-        prepare(signer: AuthAccount) {
-          signer.save(42, to: /storage/number)
-        }
-      }
+	address := common.BytesToAddress([]byte{0xCA, 0xDE})
+	contract := []byte(`
+       pub contract Test {
+
+           pub resource R {
+               pub var i: Int
+
+               init(_ i: Int) {
+                   self.i = i
+               }
+
+               pub fun update(_ i: Int) {
+                   self.i = i
+               }
+           }
+
+           pub fun createR(_ i: Int): @R {
+               return <-create R(i)
+           }
+       }
     `)
 
-	var storedValue cadence.Value
+	deployTx := utils.DeploymentTransaction(contract)
+
+	setupTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	      prepare(signer: AuthAccount) {
+	          let rs <- {
+	             "r1": <- Test.createR(3),
+	             "r2": <- Test.createR(4)
+	          }
+	          signer.save(<-rs, to: /storage/rs)
+	      }
+	   }
+	`)
+
+	changeTx := []byte(`
+	  import Test from 0xCADE
+
+	  transaction {
+
+	      prepare(signer: AuthAccount) {
+	          let rs = signer.borrow<&{String: Test.R}>(from: /storage/rs)!
+              rs["r1"]?.update(5)
+	      }
+	   }
+	`)
+
+	var accountCode []byte
+	var events []cadence.Event
+
+	type write struct {
+		owner common.Address
+		key   string
+		value cadence.Value
+	}
+
+	var writes []write
 
 	runtimeInterface := &testRuntimeInterface{
+		resolveImport: func(_ Location) (bytes []byte, err error) {
+			return accountCode, nil
+		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() []Address {
-			return []Address{
-				common.BytesToAddress([]byte{42}),
-			}
+			return []Address{address}
+		},
+		updateAccountCode: func(address Address, code []byte) (err error) {
+			accountCode = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) {
+			events = append(events, event)
 		},
 		setCadenceValue: func(owner common.Address, key string, value cadence.Value) (err error) {
-			if storedValue != nil {
-				t.Fail()
-			}
-			storedValue = value
-
+			writes = append(writes, write{
+				owner: owner,
+				key:   key,
+				value: value,
+			})
 			return nil
 		},
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+	writes = nil
+
+	err := runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
 	require.NoError(t, err)
 
-	assert.Equal(t, cadence.NewInt(42), storedValue)
+	assert.NotNil(t, accountCode)
+
+	rType := cadence.ResourceType{
+		TypeID:     "A.000000000000cade.Test.R",
+		Identifier: "R",
+		Fields: []cadence.Field{
+			{
+				Identifier: "i",
+				Type:       cadence.IntType{},
+			},
+			{
+				Identifier: "update",
+				Type: cadence.Function{
+					Parameters: []cadence.Parameter{
+						{
+							Label:      "_",
+							Identifier: "i",
+							Type:       cadence.IntType{},
+						},
+					},
+					ReturnType: cadence.VoidType{},
+				}.WithID("((Int):Void)"),
+			},
+			{
+				Identifier: "uuid",
+				Type:       cadence.UInt64Type{},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		[]write{
+			{
+				address,
+				"contract",
+				cadence.NewContract([]cadence.Value{}).WithType(cadence.ContractType{
+					TypeID:     "A.000000000000cade.Test",
+					Identifier: "Test",
+					Fields: []cadence.Field{
+						{
+							Identifier: "createR",
+							Type: cadence.Function{
+								Parameters: []cadence.Parameter{
+									{
+										Label:      "_",
+										Identifier: "i",
+										Type:       cadence.IntType{},
+									},
+								},
+								ReturnType: rType,
+							}.WithID("((Int):A.000000000000cade.Test.R)"),
+						},
+					},
+					Initializers: nil,
+				}),
+			},
+		},
+		writes,
+	)
+
+	writes = nil
+
+	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]write{
+			{
+				address,
+				"storage\x1frs",
+				cadence.NewDictionary([]cadence.KeyValuePair{
+					{
+						Key: cadence.NewString("r1"),
+						Value: cadence.NewResource([]cadence.Value{
+							cadence.NewInt(3),
+							cadence.NewUInt64(0),
+						}).WithType(rType),
+					},
+					{
+						Key: cadence.NewString("r2"),
+						Value: cadence.NewResource([]cadence.Value{
+							cadence.NewInt(4),
+							cadence.NewUInt64(0),
+						}).WithType(rType),
+					},
+				}),
+			},
+		},
+		writes,
+	)
+
+	writes = nil
+
+	err = runtime.ExecuteTransaction(changeTx, nil, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]write{
+			{
+				address,
+				"storage\x1frs",
+				cadence.NewDictionary([]cadence.KeyValuePair{
+					{
+						Key: cadence.NewString("r1"),
+						Value: cadence.NewResource([]cadence.Value{
+							cadence.NewInt(5),
+							cadence.NewUInt64(0),
+						}).WithType(rType),
+					},
+					{
+						Key: cadence.NewString("r2"),
+						Value: cadence.NewResource([]cadence.Value{
+							cadence.NewInt(4),
+							cadence.NewUInt64(0),
+						}).WithType(rType),
+					},
+				}),
+			},
+		},
+		writes,
+	)
 }

--- a/types.go
+++ b/types.go
@@ -508,11 +508,39 @@ func (t EventType) CompositeInitializers() [][]Parameter {
 	return [][]Parameter{t.Initializer}
 }
 
+// ContractType
+
+type ContractType struct {
+	TypeID       string
+	Identifier   string
+	Fields       []Field
+	Initializers [][]Parameter
+}
+
+func (ContractType) isType() {}
+
+func (t ContractType) ID() string {
+	return t.TypeID
+}
+
+func (ContractType) isCompositeType() {}
+
+func (t ContractType) CompositeIdentifier() string {
+	return t.Identifier
+}
+
+func (t ContractType) CompositeFields() []Field {
+	return t.Fields
+}
+
+func (t ContractType) CompositeInitializers() [][]Parameter {
+	return t.Initializers
+}
+
 // Function
 
 type Function struct {
 	typeID     string
-	Identifier string
 	Parameters []Parameter
 	ReturnType Type
 }

--- a/values.go
+++ b/values.go
@@ -926,3 +926,35 @@ func (v Event) ToGoValue() interface{} {
 
 	return ret
 }
+
+// Contract
+
+type Contract struct {
+	ContractType ContractType
+	Fields       []Value
+}
+
+func NewContract(fields []Value) Contract {
+	return Contract{Fields: fields}
+}
+
+func (Contract) isValue() {}
+
+func (v Contract) Type() Type {
+	return v.ContractType
+}
+
+func (v Contract) WithType(typ ContractType) Contract {
+	v.ContractType = typ
+	return v
+}
+
+func (v Contract) ToGoValue() interface{} {
+	ret := make([]interface{}, len(v.Fields))
+
+	for i, field := range v.Fields {
+		ret[i] = field.ToGoValue()
+	}
+
+	return ret
+}


### PR DESCRIPTION
Closes #218

- Add support for exporting contracts
- Add an optional runtime interface which is optionally called when top-level writes occur. The parameters are high-level types (`common.Address` instead of `[]byte` for the address, `string` instead of `[]byte` for the key, `cadence.Value` instead of `[]byte` for the value).

  The main use-case at the moment is observing account storage and rendering it to the user in the Playground.
