### PR TITLE
encoding/json: Omit function members when encoding composite values

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -440,14 +440,22 @@ func (e *Encoder) prepareEvent(v cadence.Event) jsonValue {
 }
 
 func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {
-	if len(fieldTypes) != len(fields) {
+	nonFunctionFieldTypes := make([]cadence.Field, 0)
+
+	for _, field := range fieldTypes {
+		if _, ok := field.Type.(cadence.Function); !ok {
+			nonFunctionFieldTypes = append(nonFunctionFieldTypes, field)
+		}
+	}
+
+	if len(nonFunctionFieldTypes) != len(fields) {
 		panic(fmt.Errorf("%s value does not contain fields compatible with declared type", kind))
 	}
 
 	compositeFields := make([]jsonCompositeField, len(fields))
 
 	for i, value := range fields {
-		fieldType := fieldTypes[i]
+		fieldType := nonFunctionFieldTypes[i]
 
 		compositeFields[i] = jsonCompositeField{
 			Name:  fieldType.Identifier,

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -449,7 +449,12 @@ func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, 
 	}
 
 	if len(nonFunctionFieldTypes) != len(fields) {
-		panic(fmt.Errorf("%s value does not contain fields compatible with declared type", kind))
+		panic(fmt.Errorf(
+			"%s field count (%d) does not match declared type (%d)",
+			kind,
+			len(fields),
+			len(nonFunctionFieldTypes),
+		))
 	}
 
 	compositeFields := make([]jsonCompositeField, len(fields))


### PR DESCRIPTION
## Description

This fixes a small bug that was causing JSON-Cadence encoding to fail for composite values with function members declared. The JSON encoder was treating functions as values, but they are not defined in the JSON-Cadence spec and therefor cannot be included in the resulting JSON.