### PR TITLE
Prepend stored data with magic

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -48,6 +48,7 @@ type Decoder struct {
 // dictionary values (the key), and composites (the field name).
 //
 func DecodeValue(b []byte, owner *common.Address, path []string) (Value, error) {
+
 	reader := bytes.NewReader(b)
 
 	decoder, err := NewDecoder(reader, owner)

--- a/runtime/interpreter/magic.go
+++ b/runtime/interpreter/magic.go
@@ -1,0 +1,33 @@
+package interpreter
+
+import (
+	"bytes"
+)
+
+// Magic is the prefix that is added to all encoded values
+//
+var Magic = []byte{0x0, 0xCA, 0xDE, 0x0, 0x1}
+var MagicLength = len(Magic)
+
+// HasMagic tests whether the given data  begins with the magic prefix.
+//
+func HasMagic(data []byte) bool {
+	return bytes.HasPrefix(data, Magic)
+}
+
+// StripMagic returns the given data without the magic prefix.
+// If the data doesn't start with Magic, the data is returned unchanged.
+//
+func StripMagic(data []byte) []byte {
+	return bytes.TrimPrefix(data, Magic)
+}
+
+// PrependMagic returns the given data with the magic prefix.
+// The function does *not* check if the data already has the prefix.
+//
+func PrependMagic(unprefixedData []byte) (result []byte) {
+	result = make([]byte, MagicLength+len(unprefixedData))
+	copy(result[:MagicLength], Magic)
+	copy(result[MagicLength:], unprefixedData)
+	return result
+}

--- a/runtime/interpreter/magic_test.go
+++ b/runtime/interpreter/magic_test.go
@@ -1,0 +1,24 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrependMagic(t *testing.T) {
+
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t,
+			[]byte{0x0, 0xCA, 0xDE, 0x0, 0x1},
+			PrependMagic([]byte{}),
+		)
+	})
+
+	t.Run("1, 2, 3", func(t *testing.T) {
+		assert.Equal(t,
+			[]byte{0x0, 0xCA, 0xDE, 0x0, 0x1, 1, 2, 3},
+			PrependMagic([]byte{1, 2, 3}),
+		)
+	})
+}

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -147,6 +147,8 @@ func (s *interpreterRuntimeStorage) readValue(
 		panic(err)
 	}
 
+	storedData = interpreter.StripMagic(storedData)
+
 	if len(storedData) == 0 {
 		s.cache[fullKey] = cacheEntry{
 			mustWrite: false,
@@ -298,6 +300,10 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 			}
 		}
 
+		if len(newData) > 0 {
+			newData = interpreter.PrependMagic(newData)
+		}
+
 		var err error
 		wrapPanic(func() {
 			err = s.runtimeInterface.SetValue(
@@ -346,6 +352,7 @@ func (s *interpreterRuntimeStorage) move(
 		panic(err)
 	}
 
+	// NOTE: not prefix with magic, as data is moved, so might already have it
 	err = s.runtimeInterface.SetValue(newOwner[:], []byte(newKey), data)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Closes #182 

Prepend stored data with the magic `0x0, 0xCA, 0xDE, 0x0, 0x1`. 
The last two bytes are a version number.