### PR TITLE
adding a cadence minifier

### DIFF
--- a/runtime/cmd/minifier/minifier.go
+++ b/runtime/cmd/minifier/minifier.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+const commentsPrefix = "//"
+
+// A minifier to minify a Cadence script file. Currently, it only removes comments and new lines.
+// Usage: go run minifier.go -i inputfile.cdc -o outputfile.cdc
+// e.g. go run minifier.go -i ../../../transactions/transfer_tokens.cdc -o /tmp/test.cdc
+func main() {
+	inputFile := flag.String("i", "", "the cadence file to minify")
+	outputFile := flag.String("o", "", "the output file")
+	flag.Parse()
+
+	if *inputFile == "" {
+		log.Fatal("input file not provided")
+	}
+
+	if *outputFile == "" {
+		log.Fatal("output file not provided")
+	}
+
+	log.Println("input file:", *inputFile)
+	log.Println("output file:", *outputFile)
+
+	err := minify(*inputFile, *outputFile)
+	if err != nil {
+		log.Fatalf("failed to minify %s", *inputFile)
+	}
+
+	log.Println("done")
+}
+
+func minify(inputFile, outputFile string) error {
+	input, err := os.Open(inputFile)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+
+	output, err := os.Create(outputFile)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	reader := bufio.NewReader(input)
+	writer := bufio.NewWriter(output)
+
+	eof := false
+	for {
+
+		if eof {
+			return nil
+		}
+
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				// we have reached the eof but need to still process the last line
+				eof = true
+			} else {
+				return err
+			}
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, commentsPrefix) {
+			continue
+		}
+		_, err = writer.WriteString(line)
+		if err != nil {
+			return err
+		}
+
+		if !eof {
+			_, err = writer.WriteRune('\n')
+			if err != nil {
+				return err
+			}
+		}
+
+		err = writer.Flush()
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/runtime/cmd/minifier/minifier.go
+++ b/runtime/cmd/minifier/minifier.go
@@ -1,3 +1,20 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package main
 
 import (

--- a/runtime/cmd/minifier/minifier_test.go
+++ b/runtime/cmd/minifier/minifier_test.go
@@ -1,3 +1,20 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package main
 
 import (

--- a/runtime/cmd/minifier/minifier_test.go
+++ b/runtime/cmd/minifier/minifier_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cadenceTestScript = `// This transaction is a template for a transaction that
+// could be used by anyone to send tokens to another account
+// that has been set up to receive tokens.
+//
+// The withdraw amount and the account from getAccount
+// would be the parameters to the transaction
+
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import ExampleToken from 0xTOKENADDRESS
+
+transaction(amount: UFix64, to: Address) {
+
+    // The Vault resource that holds the tokens that are being transferred
+    let sentVault: @FungibleToken.Vault
+
+    prepare(signer: AuthAccount) {
+
+        // Get a reference to the signer's stored vault
+        let vaultRef = signer.borrow<&ExampleToken.Vault>(from: /storage/exampleTokenVault)
+			?? panic("Could not borrow reference to the owner's Vault!")
+
+        // Withdraw tokens from the signer's stored vault
+        self.sentVault <- vaultRef.withdraw(amount: amount)
+    }
+
+    execute {
+
+        // Get the recipient's public account object
+        let recipient = getAccount(to)
+
+        // Get a reference to the recipient's Receiver
+        let receiverRef = recipient.getCapability(/public/exampleTokenReceiver)!.borrow<&{FungibleToken.Receiver}>()
+			?? panic("Could not borrow receiver reference to the recipient's Vault")
+
+        // Deposit the withdrawn tokens in the recipient's receiver
+        receiverRef.deposit(from: <-self.sentVault)
+    }
+}
+
+`
+
+const expectedOutput = `import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import ExampleToken from 0xTOKENADDRESS
+transaction(amount: UFix64, to: Address) {
+let sentVault: @FungibleToken.Vault
+prepare(signer: AuthAccount) {
+let vaultRef = signer.borrow<&ExampleToken.Vault>(from: /storage/exampleTokenVault)
+?? panic("Could not borrow reference to the owner's Vault!")
+self.sentVault <- vaultRef.withdraw(amount: amount)
+}
+execute {
+let recipient = getAccount(to)
+let receiverRef = recipient.getCapability(/public/exampleTokenReceiver)!.borrow<&{FungibleToken.Receiver}>()
+?? panic("Could not borrow receiver reference to the recipient's Vault")
+receiverRef.deposit(from: <-self.sentVault)
+}
+}
+`
+
+// Test to test the minifier function
+func TestMinify(t *testing.T) {
+	// create an input file with the test cadence script
+	inputFile, err := ioutil.TempFile("", "test_*.cdc")
+	require.NoError(t, err)
+	inputFileName := inputFile.Name()
+	_, err = inputFile.WriteString(cadenceTestScript)
+	require.NoError(t, err)
+	err = inputFile.Close()
+	require.NoError(t, err)
+
+	// get a valid output file path
+	outputFile, err := ioutil.TempFile("", "minified_test_*.cdc")
+	require.NoError(t, err)
+	err = outputFile.Close()
+	require.NoError(t, err)
+	outputFileName := outputFile.Name()
+	err = os.Remove(outputFileName)
+	require.NoError(t, err)
+
+	// call minify
+	err = minify(inputFileName, outputFileName)
+
+	// assert no error
+	require.NoError(t, err)
+
+	defer os.Remove(outputFileName)
+
+	// read the output file contents and assert the contents
+	actualOutput, err := ioutil.ReadFile(outputFileName)
+	require.NoError(t, err)
+	assert.Equal(t, expectedOutput, string(actualOutput))
+}


### PR DESCRIPTION
Closes #???

## Description

This change adds a little minifier for a cadence script. Currently it does very little in terms of minification. It only removes comment lines and preceding and trailing white spaces from a cadence script.

______

For contributor use:

- [X] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
