### PR TITLE
Record member access position

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -377,6 +377,7 @@ type AccessExpression interface {
 type MemberExpression struct {
 	Expression Expression
 	Optional   bool
+	AccessPos  Position
 	Identifier Identifier
 }
 
@@ -416,7 +417,11 @@ func (e *MemberExpression) StartPosition() Position {
 }
 
 func (e *MemberExpression) EndPosition() Position {
-	return e.Identifier.EndPosition()
+	if e.Identifier.Identifier == "" {
+		return e.AccessPos
+	} else {
+		return e.Identifier.EndPosition()
+	}
 }
 
 // IndexExpression

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -377,6 +377,8 @@ type AccessExpression interface {
 type MemberExpression struct {
 	Expression Expression
 	Optional   bool
+	// The position of the token (`.`, `?.`) that separates the accessed expression
+	// and the identifier of the member
 	AccessPos  Position
 	Identifier Identifier
 }

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -1714,6 +1714,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 																Pos:        ast.Position{Offset: 111, Line: 6, Column: 18},
 															},
 														},
+														AccessPos: ast.Position{Offset: 115, Line: 6, Column: 22},
 														Identifier: ast.Identifier{
 															Identifier: "foo",
 															Pos:        ast.Position{Offset: 116, Line: 6, Column: 23},
@@ -1775,6 +1776,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 															Pos:        ast.Position{Offset: 206, Line: 10, Column: 25},
 														},
 													},
+													AccessPos: ast.Position{Offset: 210, Line: 10, Column: 29},
 													Identifier: ast.Identifier{
 														Identifier: "foo",
 														Pos:        ast.Position{Offset: 211, Line: 10, Column: 30},

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -1124,12 +1124,12 @@ func applyExprMetaLeftDenotation(
 		return left, true
 	}
 
-	skipWhitespace := exprLeftDenotationAllowsWhitespaceAfterToken(p.current.Type)
+	allowWhitespace := exprLeftDenotationAllowsWhitespaceAfterToken(p.current.Type)
 
 	t = p.current
 
 	p.next()
-	if skipWhitespace {
+	if allowWhitespace {
 		p.skipSpaceAndComments(true)
 
 	}

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -1512,6 +1512,7 @@ func TestMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
+				AccessPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 				Identifier: ast.Identifier{
 					Identifier: "n",
 					Pos:        ast.Position{Offset: 2, Line: 1, Column: 2},
@@ -1536,6 +1537,7 @@ func TestMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
+				AccessPos: ast.Position{Offset: 2, Line: 1, Column: 2},
 				Identifier: ast.Identifier{
 					Identifier: "n",
 					Pos:        ast.Position{Offset: 3, Line: 1, Column: 3},
@@ -1568,9 +1570,7 @@ func TestMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
-				Identifier: ast.Identifier{
-					Identifier: "",
-				},
+				AccessPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 			},
 			result,
 		)
@@ -1593,6 +1593,7 @@ func TestMemberExpression(t *testing.T) {
 							Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 						},
 					},
+					AccessPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 					Identifier: ast.Identifier{
 						Identifier: "n",
 						Pos:        ast.Position{Offset: 2, Line: 1, Column: 2},
@@ -1636,6 +1637,7 @@ func TestMemberExpression(t *testing.T) {
 							Pos:        ast.Position{Offset: 4, Line: 1, Column: 4},
 						},
 					},
+					AccessPos: ast.Position{Offset: 5, Line: 1, Column: 5},
 					Identifier: ast.Identifier{
 						Identifier: "n",
 						Pos:        ast.Position{Offset: 6, Line: 1, Column: 6},
@@ -1662,6 +1664,7 @@ func TestMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
+				AccessPos: ast.Position{Offset: 2, Line: 1, Column: 2},
 				Identifier: ast.Identifier{
 					Identifier: "n",
 					Pos:        ast.Position{Offset: 3, Line: 1, Column: 3},
@@ -1912,6 +1915,7 @@ func TestParseForceExpression(t *testing.T) {
 
 		result, errs := ParseExpression("t!")
 		require.Empty(t, errs)
+
 		utils.AssertEqualWithDiff(t,
 			&ast.ForceExpression{
 				Expression: &ast.IdentifierExpression{
@@ -1932,6 +1936,7 @@ func TestParseForceExpression(t *testing.T) {
 
 		result, errs := ParseExpression(" t ! ")
 		require.Empty(t, errs)
+
 		utils.AssertEqualWithDiff(t,
 			&ast.ForceExpression{
 				Expression: &ast.IdentifierExpression{
@@ -1952,6 +1957,7 @@ func TestParseForceExpression(t *testing.T) {
 
 		result, errs := ParseExpression("<-t!")
 		require.Empty(t, errs)
+
 		utils.AssertEqualWithDiff(t,
 			&ast.UnaryExpression{
 				Operation: ast.OperationMove,
@@ -1976,6 +1982,7 @@ func TestParseForceExpression(t *testing.T) {
 
 		result, errs := ParseExpression("10 *  t!")
 		require.Empty(t, errs)
+
 		utils.AssertEqualWithDiff(t,
 			&ast.BinaryExpression{
 				Operation: ast.OperationMul,
@@ -2052,12 +2059,50 @@ func TestParseForceExpression(t *testing.T) {
 									Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
 								},
 							},
+							AccessPos: ast.Position{Line: 2, Column: 0, Offset: 2},
 							Identifier: ast.Identifier{
 								Identifier: "y",
 								Pos:        ast.Position{Line: 2, Column: 1, Offset: 3},
 							},
 						},
 						EndPos: ast.Position{Line: 2, Column: 2, Offset: 4},
+					},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("member access, whitespace", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseStatements("x. y")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid whitespace after '.'",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
+			},
+			errs,
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Statement{
+				&ast.ExpressionStatement{
+					Expression: &ast.MemberExpression{
+						Expression: &ast.IdentifierExpression{
+							Identifier: ast.Identifier{
+								Identifier: "x",
+								Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+							},
+						},
+						AccessPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						Identifier: ast.Identifier{
+							Identifier: "y",
+							Pos:        ast.Position{Line: 1, Column: 3, Offset: 3},
+						},
 					},
 				},
 			},

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -583,6 +583,7 @@ func TestParseMemberExpression(t *testing.T) {
 						Identifier: "c",
 						Pos:        Position{Offset: 16, Line: 2, Column: 15},
 					},
+					AccessPos: Position{Offset: 15, Line: 2, Column: 14},
 				},
 				StartPos: Position{Offset: 6, Line: 2, Column: 5},
 			},
@@ -625,6 +626,7 @@ func TestParseOptionalMemberExpression(t *testing.T) {
 						Identifier: "c",
 						Pos:        Position{Offset: 17, Line: 2, Column: 16},
 					},
+					AccessPos: Position{Offset: 16, Line: 2, Column: 15},
 				},
 				StartPos: Position{Offset: 6, Line: 2, Column: 5},
 			},
@@ -1901,11 +1903,13 @@ func TestParseAccessAssignment(t *testing.T) {
 															Pos:        Position{Offset: 31, Line: 3, Column: 12},
 														},
 													},
+													AccessPos: Position{Offset: 32, Line: 3, Column: 13},
 													Identifier: Identifier{
 														Identifier: "foo",
 														Pos:        Position{Offset: 33, Line: 3, Column: 14},
 													},
 												},
+												AccessPos: Position{Offset: 36, Line: 3, Column: 17},
 												Identifier: Identifier{
 													Identifier: "bar",
 													Pos:        Position{Offset: 37, Line: 3, Column: 18},
@@ -1937,6 +1941,7 @@ func TestParseAccessAssignment(t *testing.T) {
 											EndPos:   Position{Offset: 45, Line: 3, Column: 26},
 										},
 									},
+									AccessPos: Position{Offset: 46, Line: 3, Column: 27},
 									Identifier: Identifier{
 										Identifier: "baz",
 										Pos:        Position{Offset: 47, Line: 3, Column: 28},
@@ -2017,11 +2022,13 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 															Pos:        Position{Offset: 19, Line: 2, Column: 18},
 														},
 													},
+													AccessPos: Position{Offset: 20, Line: 2, Column: 19},
 													Identifier: Identifier{
 														Identifier: "foo",
 														Pos:        Position{Offset: 21, Line: 2, Column: 20},
 													},
 												},
+												AccessPos: Position{Offset: 24, Line: 2, Column: 23},
 												Identifier: Identifier{
 													Identifier: "bar",
 													Pos:        Position{Offset: 25, Line: 2, Column: 24},
@@ -2053,6 +2060,7 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 											EndPos:   Position{Offset: 33, Line: 2, Column: 32},
 										},
 									},
+									AccessPos: Position{Offset: 34, Line: 2, Column: 33},
 									Identifier: Identifier{
 										Identifier: "baz",
 										Pos:        Position{Offset: 35, Line: 2, Column: 34},
@@ -3381,6 +3389,7 @@ func TestParseStructure(t *testing.T) {
 															Pos:        Position{Offset: 103, Line: 6, Column: 16},
 														},
 													},
+													AccessPos: Position{Offset: 107, Line: 6, Column: 20},
 													Identifier: Identifier{
 														Identifier: "foo",
 														Pos:        Position{Offset: 108, Line: 6, Column: 21},
@@ -3442,6 +3451,7 @@ func TestParseStructure(t *testing.T) {
 														Pos:        Position{Offset: 192, Line: 10, Column: 23},
 													},
 												},
+												AccessPos: Position{Offset: 196, Line: 10, Column: 27},
 												Identifier: Identifier{
 													Identifier: "foo",
 													Pos:        Position{Offset: 197, Line: 10, Column: 28},
@@ -5665,6 +5675,7 @@ func TestParseSwapStatement(t *testing.T) {
 											Pos:        Position{Offset: 41, Line: 3, Column: 21},
 										},
 									},
+									AccessPos: Position{Offset: 44, Line: 3, Column: 24},
 									Identifier: Identifier{
 										Identifier: "baz",
 										Pos:        Position{Offset: 45, Line: 3, Column: 25},
@@ -6127,6 +6138,7 @@ func TestParseReference(t *testing.T) {
 									Pos:        Position{Offset: 17, Line: 2, Column: 16},
 								},
 							},
+							AccessPos: Position{Offset: 24, Line: 2, Column: 23},
 							Identifier: Identifier{
 								Identifier: "storage",
 								Pos:        Position{Offset: 25, Line: 2, Column: 24},
@@ -6252,6 +6264,7 @@ func TestParseCompositeDeclarationWithSemicolonSeparatedMembers(t *testing.T) {
 															Pos:        Position{Offset: 54, Line: 2, Column: 53},
 														},
 													},
+													AccessPos: Position{Offset: 58, Line: 2, Column: 57},
 													Identifier: Identifier{
 														Identifier: "id",
 														Pos:        Position{Offset: 59, Line: 2, Column: 58},


### PR DESCRIPTION
Improve parsing of member expressions: 
- Record the position where the access occurs, e.g. the `.` in `foo .bar` or `baz?.`
- Forbid whitespace after the access (parse but report)