### PR TITLE
Refactor members

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2451,7 +2451,7 @@ func (interpreter *Interpreter) declareCompositeValue(
 
 			if declaration.CompositeKind == common.CompositeKindResource {
 				uuid := interpreter.uuidHandler()
-				fields[sema.UUIDFieldName] = UInt64Value(uuid)
+				fields[sema.ResourceUUIDFieldName] = UInt64Value(uuid)
 			}
 
 			value := &CompositeValue{
@@ -3957,7 +3957,7 @@ func (interpreter *Interpreter) authAccountLinkFunction(addressValue AddressValu
 	})
 }
 
-func (interpreter *Interpreter) authAccountGetLinkTargetFunction(addressValue AddressValue) HostFunctionValue {
+func (interpreter *Interpreter) accountGetLinkTargetFunction(addressValue AddressValue) HostFunctionValue {
 	return NewHostFunctionValue(func(invocation Invocation) Trampoline {
 
 		address := addressValue.ToAddress()

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5340,7 +5340,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 	v.checkStatus(locationRange)
 
 	if v.Kind == common.CompositeKindResource &&
-		name == sema.OwnerFieldName {
+		name == sema.ResourceOwnerFieldName {
 
 		return v.OwnerValue()
 	}
@@ -6281,7 +6281,7 @@ func (v AddressValue) GetMember(_ *Interpreter, _ LocationRange, name string) Va
 			},
 		)
 
-	case sema.ToBytesFunctionName:
+	case sema.AddressTypeToBytesFunctionName:
 		return NewHostFunctionValue(
 			func(invocation Invocation) trampoline.Trampoline {
 				bytes := common.Address(v)
@@ -6472,7 +6472,7 @@ func (v AuthAccountValue) GetMember(inter *Interpreter, _ LocationRange, name st
 		return inter.authAccountUnlinkFunction(v.Address)
 
 	case "getLinkTarget":
-		return inter.authAccountGetLinkTargetFunction(v.Address)
+		return inter.accountGetLinkTargetFunction(v.Address)
 
 	case "getCapability":
 		return accountGetCapabilityFunction(v.Address, true)
@@ -6549,7 +6549,7 @@ func (v PublicAccountValue) GetMember(inter *Interpreter, _ LocationRange, name 
 		return accountGetCapabilityFunction(v.Address, false)
 
 	case "getLinkTarget":
-		return inter.authAccountGetLinkTargetFunction(v.Address)
+		return inter.accountGetLinkTargetFunction(v.Address)
 	}
 
 	return nil

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -256,7 +256,7 @@ func (checker *Checker) visitMemberExpressionAssignment(
 	valueType Type,
 ) (memberType Type) {
 
-	member, isOptional := checker.visitMember(target)
+	_, member, isOptional := checker.visitMember(target)
 
 	if member == nil {
 		return &InvalidType{}

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -63,7 +63,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	isOptionalChainingResult := false
 	if memberExpression, ok := invokedExpression.(*ast.MemberExpression); ok {
 		var member *Member
-		member, isOptionalChainingResult = checker.visitMember(memberExpression)
+		_, member, isOptionalChainingResult = checker.visitMember(memberExpression)
 		if member != nil {
 			expressionType = member.TypeAnnotation.Type
 		}
@@ -251,7 +251,7 @@ func (checker *Checker) checkMemberInvocationArgumentLabels(
 	invocationExpression *ast.InvocationExpression,
 	memberExpression *ast.MemberExpression,
 ) {
-	member, _ := checker.visitMember(memberExpression)
+	_, member, _ := checker.visitMember(memberExpression)
 
 	if member == nil || len(member.ArgumentLabels) == 0 {
 		return

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -21,8 +21,9 @@ package sema
 import "github.com/onflow/cadence/runtime/ast"
 
 type MemberInfo struct {
-	Member     *Member
-	IsOptional bool
+	Member       *Member
+	IsOptional   bool
+	AccessedType Type
 }
 
 type Elaboration struct {

--- a/runtime/sema/member_accesses.go
+++ b/runtime/sema/member_accesses.go
@@ -1,0 +1,71 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common/intervalst"
+)
+
+type MemberAccess struct {
+	StartPos     Position
+	EndPos       Position
+	AccessedType Type
+}
+
+type MemberAccesses struct {
+	tree *intervalst.IntervalST
+}
+
+func NewMemberAccesses() *MemberAccesses {
+	return &MemberAccesses{
+		tree: &intervalst.IntervalST{},
+	}
+}
+
+func (m *MemberAccesses) Put(startPos, endPos ast.Position, accessedType Type) {
+	access := MemberAccess{
+		StartPos:     ASTToSemaPosition(startPos),
+		EndPos:       ASTToSemaPosition(endPos),
+		AccessedType: accessedType,
+	}
+	interval := intervalst.NewInterval(
+		access.StartPos,
+		access.EndPos,
+	)
+	m.tree.Put(interval, access)
+}
+
+func (m *MemberAccesses) Find(pos Position) *MemberAccess {
+	interval, value := m.tree.Search(pos)
+	if interval == nil {
+		return nil
+	}
+	access := value.(MemberAccess)
+	return &access
+}
+
+func (m *MemberAccesses) All() []MemberAccess {
+	values := m.tree.Values()
+	accesses := make([]MemberAccess, len(values))
+	for i, value := range values {
+		accesses[i] = value.(MemberAccess)
+	}
+	return accesses
+}

--- a/runtime/sema/occurrences.go
+++ b/runtime/sema/occurrences.go
@@ -78,7 +78,7 @@ func NewOccurrences() *Occurrences {
 	}
 }
 
-func ToPosition(position ast.Position) Position {
+func ASTToSemaPosition(position ast.Position) Position {
 	return Position{
 		Line:   position.Line,
 		Column: position.Column,
@@ -87,8 +87,8 @@ func ToPosition(position ast.Position) Position {
 
 func (o *Occurrences) Put(startPos, endPos ast.Position, origin *Origin) {
 	occurrence := Occurrence{
-		StartPos: ToPosition(startPos),
-		EndPos:   ToPosition(endPos),
+		StartPos: ASTToSemaPosition(startPos),
+		EndPos:   ASTToSemaPosition(endPos),
 		Origin:   origin,
 	}
 	interval := intervalst.NewInterval(

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -178,6 +179,9 @@ func TestRestrictedType_StringAndID(t *testing.T) {
 	t.Parallel()
 
 	t.Run("base type and restriction", func(t *testing.T) {
+
+		t.Parallel()
+
 		interfaceType := &InterfaceType{
 			CompositeKind: common.CompositeKindResource,
 			Identifier:    "I",
@@ -205,6 +209,9 @@ func TestRestrictedType_StringAndID(t *testing.T) {
 	})
 
 	t.Run("base type and restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
 		i1 := &InterfaceType{
 			CompositeKind: common.CompositeKindResource,
 			Identifier:    "I1",
@@ -238,6 +245,9 @@ func TestRestrictedType_StringAndID(t *testing.T) {
 	})
 
 	t.Run("no restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
 		ty := &RestrictedType{
 			Type: &CompositeType{
 				Kind:       common.CompositeKindResource,
@@ -263,6 +273,8 @@ func TestRestrictedType_Equals(t *testing.T) {
 	t.Parallel()
 
 	t.Run("same base type and more restrictions", func(t *testing.T) {
+
+		t.Parallel()
 
 		i1 := &InterfaceType{
 			CompositeKind: common.CompositeKindResource,
@@ -299,6 +311,8 @@ func TestRestrictedType_Equals(t *testing.T) {
 
 	t.Run("same base type and fewer restrictions", func(t *testing.T) {
 
+		t.Parallel()
+
 		i1 := &InterfaceType{
 			CompositeKind: common.CompositeKindResource,
 			Identifier:    "I1",
@@ -333,6 +347,9 @@ func TestRestrictedType_Equals(t *testing.T) {
 	})
 
 	t.Run("same base type and same restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
 		i1 := &InterfaceType{
 			CompositeKind: common.CompositeKindResource,
 			Identifier:    "I1",
@@ -367,6 +384,8 @@ func TestRestrictedType_Equals(t *testing.T) {
 	})
 
 	t.Run("different base type and same restrictions", func(t *testing.T) {
+
+		t.Parallel()
 
 		i1 := &InterfaceType{
 			CompositeKind: common.CompositeKindResource,
@@ -407,6 +426,9 @@ func TestRestrictedType_GetMember(t *testing.T) {
 	t.Parallel()
 
 	t.Run("forbid undeclared members", func(t *testing.T) {
+
+		t.Parallel()
+
 		resourceType := &CompositeType{
 			Kind:       common.CompositeKindResource,
 			Identifier: "R",
@@ -419,18 +441,30 @@ func TestRestrictedType_GetMember(t *testing.T) {
 		}
 
 		fieldName := "s"
-		resourceType.Members[fieldName] = NewPublicConstantFieldMember(ty.Type, fieldName, &IntType{})
+		resourceType.Members[fieldName] = NewPublicConstantFieldMember(
+			ty.Type,
+			fieldName,
+			&IntType{},
+			"",
+		)
+
+		actualMembers := ty.GetMembers()
+
+		require.Contains(t, actualMembers, fieldName)
 
 		var reportedError error
-		member := ty.GetMember(fieldName, ast.Range{}, func(err error) {
+		actualMember := actualMembers[fieldName].Resolve(fieldName, ast.Range{}, func(err error) {
 			reportedError = err
 		})
 
 		assert.IsType(t, &InvalidRestrictedTypeMemberAccessError{}, reportedError)
-		assert.NotNil(t, member)
+		assert.NotNil(t, actualMember)
 	})
 
 	t.Run("allow declared members", func(t *testing.T) {
+
+		t.Parallel()
+
 		interfaceType := &InterfaceType{
 			CompositeKind: common.CompositeKindResource,
 			Identifier:    "I",
@@ -452,13 +486,26 @@ func TestRestrictedType_GetMember(t *testing.T) {
 
 		fieldName := "s"
 
-		resourceMember := NewPublicConstantFieldMember(restrictedType.Type, fieldName, &IntType{})
-		resourceType.Members[fieldName] = resourceMember
+		resourceType.Members[fieldName] = NewPublicConstantFieldMember(
+			restrictedType.Type,
+			fieldName,
+			&IntType{},
+			"",
+		)
 
-		interfaceMember := NewPublicConstantFieldMember(restrictedType.Type, fieldName, &IntType{})
+		interfaceMember := NewPublicConstantFieldMember(
+			restrictedType.Type,
+			fieldName,
+			&IntType{},
+			"",
+		)
 		interfaceType.Members[fieldName] = interfaceMember
 
-		actualMember := restrictedType.GetMember(fieldName, ast.Range{}, nil)
+		actualMembers := restrictedType.GetMembers()
+
+		require.Contains(t, actualMembers, fieldName)
+
+		actualMember := actualMembers[fieldName].Resolve(fieldName, ast.Range{}, nil)
 
 		assert.Same(t, interfaceMember, actualMember)
 	})

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -305,6 +305,7 @@ func TestCheckImportVirtual(t *testing.T) {
 			&sema.FunctionType{
 				ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.UInt64Type{}),
 			},
+			"",
 		),
 	}
 

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -46,6 +46,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 			&sema.FunctionType{
 				ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.UInt64Type{}),
 			},
+			"",
 		),
 	}
 

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -121,7 +121,7 @@ func TestInterpretResourceUUID(t *testing.T) {
 
 		require.Equal(t,
 			interpreter.UInt64Value(i),
-			res.Fields[sema.UUIDFieldName],
+			res.Fields[sema.ResourceUUIDFieldName],
 		)
 	}
 }


### PR DESCRIPTION
Refactor how members are represented: Instead of only allowing to query for a single, known member by name, return all members, but do so in a lazy manner – only return names and resolvers, functions that produce the actual member.

In addition, provide docstrings for all built-in members. (cc @joshuahannan @10thfloor)

Also, record the positions of all member accesses and store the accessed type for each. This enables querying accessed types by positions, just like occurrences