### PR TITLE
Export and encode Link and StorageReference values

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -118,37 +118,43 @@ type jsonCompositeField struct {
 	Value jsonValue `json:"value"`
 }
 
+type jsonLinkValue struct {
+	Target     string `json:"target"`
+	BorrowType string `json:"borrowType"`
+}
+
 const (
-	voidTypeStr       = "Void"
-	optionalTypeStr   = "Optional"
-	boolTypeStr       = "Bool"
-	stringTypeStr     = "String"
-	addressTypeStr    = "Address"
-	intTypeStr        = "Int"
-	int8TypeStr       = "Int8"
-	int16TypeStr      = "Int16"
-	int32TypeStr      = "Int32"
-	int64TypeStr      = "Int64"
-	int128TypeStr     = "Int128"
-	int256TypeStr     = "Int256"
-	uintTypeStr       = "UInt"
-	uint8TypeStr      = "UInt8"
-	uint16TypeStr     = "UInt16"
-	uint32TypeStr     = "UInt32"
-	uint64TypeStr     = "UInt64"
-	uint128TypeStr    = "UInt128"
-	uint256TypeStr    = "UInt256"
-	word8TypeStr      = "Word8"
-	word16TypeStr     = "Word16"
-	word32TypeStr     = "Word32"
-	word64TypeStr     = "Word64"
-	fix64TypeStr      = "Fix64"
-	ufix64TypeStr     = "UFix64"
-	arrayTypeStr      = "Array"
-	dictionaryTypeStr = "Dictionary"
-	structTypeStr     = "Struct"
-	resourceTypeStr   = "Resource"
-	eventTypeStr      = "Event"
+	voidTypeStr             = "Void"
+	optionalTypeStr         = "Optional"
+	boolTypeStr             = "Bool"
+	stringTypeStr           = "String"
+	addressTypeStr          = "Address"
+	intTypeStr              = "Int"
+	int8TypeStr             = "Int8"
+	int16TypeStr            = "Int16"
+	int32TypeStr            = "Int32"
+	int64TypeStr            = "Int64"
+	int128TypeStr           = "Int128"
+	int256TypeStr           = "Int256"
+	uintTypeStr             = "UInt"
+	uint8TypeStr            = "UInt8"
+	uint16TypeStr           = "UInt16"
+	uint32TypeStr           = "UInt32"
+	uint64TypeStr           = "UInt64"
+	uint128TypeStr          = "UInt128"
+	uint256TypeStr          = "UInt256"
+	word8TypeStr            = "Word8"
+	word16TypeStr           = "Word16"
+	word32TypeStr           = "Word32"
+	word64TypeStr           = "Word64"
+	fix64TypeStr            = "Fix64"
+	ufix64TypeStr           = "UFix64"
+	arrayTypeStr            = "Array"
+	dictionaryTypeStr       = "Dictionary"
+	structTypeStr           = "Struct"
+	resourceTypeStr         = "Resource"
+	eventTypeStr            = "Event"
+	linkTypeStr             = "Link"
 )
 
 // prepare traverses the object graph of the provided value and constructs
@@ -215,8 +221,10 @@ func (e *Encoder) prepare(v cadence.Value) jsonValue {
 		return e.prepareResource(x)
 	case cadence.Event:
 		return e.prepareEvent(x)
+	case cadence.Link:
+		return e.prepareLink(x)
 	default:
-		return fmt.Errorf("unsupported value: %T, %v", v, v)
+		panic(fmt.Errorf("unsupported value: %T, %v", v, v))
 	}
 }
 
@@ -473,6 +481,16 @@ func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, 
 		Value: jsonCompositeValue{
 			ID:     id,
 			Fields: compositeFields,
+		},
+	}
+}
+
+func (e *Encoder) prepareLink(x cadence.Link) jsonValue {
+	return jsonValueObject{
+		Type: linkTypeStr,
+		Value: jsonLinkValue{
+			Target:     x.Target,
+			BorrowType: x.BorrowType,
 		},
 	}
 }

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -118,6 +118,12 @@ type jsonCompositeField struct {
 	Value jsonValue `json:"value"`
 }
 
+type jsonStorageReferenceValue struct {
+	Authorized           bool   `json:"authorized"`
+	TargetStorageAddress string `json:"targetStorageAddress"`
+	TargetKey            string `json:"targetKey"`
+}
+
 type jsonLinkValue struct {
 	Target     string `json:"target"`
 	BorrowType string `json:"borrowType"`
@@ -154,6 +160,7 @@ const (
 	structTypeStr           = "Struct"
 	resourceTypeStr         = "Resource"
 	eventTypeStr            = "Event"
+	storageReferenceTypeStr = "StorageReference"
 	linkTypeStr             = "Link"
 )
 
@@ -221,6 +228,8 @@ func (e *Encoder) prepare(v cadence.Value) jsonValue {
 		return e.prepareResource(x)
 	case cadence.Event:
 		return e.prepareEvent(x)
+	case cadence.StorageReference:
+		return e.prepareStorageReference(x)
 	case cadence.Link:
 		return e.prepareLink(x)
 	default:
@@ -481,6 +490,17 @@ func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, 
 		Value: jsonCompositeValue{
 			ID:     id,
 			Fields: compositeFields,
+		},
+	}
+}
+
+func (e *Encoder) prepareStorageReference(x cadence.StorageReference) jsonValue {
+	return jsonValueObject{
+		Type: storageReferenceTypeStr,
+		Value: jsonStorageReferenceValue{
+			Authorized:           x.Authorized,
+			TargetStorageAddress: encodeBytes(x.TargetStorageAddress.Bytes()),
+			TargetKey:            x.TargetKey,
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -43,14 +43,14 @@ func TestEncodeVoid(t *testing.T) {
 
 	t.Parallel()
 
-	testEncode(t, cadence.NewVoid(), `{"type":"Void"}`)
+	testEncodeAndDecode(t, cadence.NewVoid(), `{"type":"Void"}`)
 }
 
 func TestEncodeOptional(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Nil",
 			cadence.NewOptional(nil),
@@ -68,7 +68,7 @@ func TestEncodeBool(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"True",
 			cadence.NewBool(true),
@@ -86,7 +86,7 @@ func TestEncodeString(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Empty",
 			cadence.NewString(""),
@@ -104,7 +104,7 @@ func TestEncodeAddress(t *testing.T) {
 
 	t.Parallel()
 
-	testEncode(
+	testEncodeAndDecode(
 		t,
 		cadence.BytesToAddress([]byte{1, 2, 3, 4, 5}),
 		`{"type":"Address","value":"0x0000000102030405"}`,
@@ -115,7 +115,7 @@ func TestEncodeInt(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Negative",
 			cadence.NewInt(-42),
@@ -148,7 +148,7 @@ func TestEncodeInt8(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Min",
 			cadence.NewInt8(math.MinInt8),
@@ -171,7 +171,7 @@ func TestEncodeInt16(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Min",
 			cadence.NewInt16(math.MinInt16),
@@ -194,7 +194,7 @@ func TestEncodeInt32(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Min",
 			cadence.NewInt32(math.MinInt32),
@@ -217,7 +217,7 @@ func TestEncodeInt64(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Min",
 			cadence.NewInt64(math.MinInt64),
@@ -240,7 +240,7 @@ func TestEncodeInt128(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Min",
 			cadence.NewInt128FromBig(sema.Int128TypeMinIntBig),
@@ -263,7 +263,7 @@ func TestEncodeInt256(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Min",
 			cadence.NewInt256FromBig(sema.Int256TypeMinIntBig),
@@ -286,7 +286,7 @@ func TestEncodeUInt(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewUInt(0),
@@ -309,7 +309,7 @@ func TestEncodeUInt8(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewUInt8(0),
@@ -327,7 +327,7 @@ func TestEncodeUInt16(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewUInt16(0),
@@ -345,7 +345,7 @@ func TestEncodeUInt32(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewUInt32(0),
@@ -363,7 +363,7 @@ func TestEncodeUInt64(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewUInt64(0),
@@ -381,7 +381,7 @@ func TestEncodeUInt128(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewUInt128(0),
@@ -399,7 +399,7 @@ func TestEncodeUInt256(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewUInt256(0),
@@ -417,7 +417,7 @@ func TestEncodeWord8(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewWord8(0),
@@ -435,7 +435,7 @@ func TestEncodeWord16(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewWord16(0),
@@ -453,7 +453,7 @@ func TestEncodeWord32(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewWord32(0),
@@ -471,7 +471,7 @@ func TestEncodeWord64(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.NewWord64(0),
@@ -489,7 +489,7 @@ func TestEncodeFix64(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.Fix64(0),
@@ -517,7 +517,7 @@ func TestEncodeUFix64(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncode(t, []encodeTest{
+	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"Zero",
 			cadence.UFix64(0),
@@ -572,7 +572,7 @@ func TestEncodeArray(t *testing.T) {
 		`{"type":"Array","value":[{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"1"}}]}},{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"2"}}]}},{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"3"}}]}}]}`,
 	}
 
-	testAllEncode(t,
+	testAllEncodeAndDecode(t,
 		emptyArray,
 		intArray,
 		resourceArray,
@@ -661,7 +661,7 @@ func TestEncodeDictionary(t *testing.T) {
 		`{"type":"Dictionary","value":[{"key":{"type":"String","value":"a"},"value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"1"}}]}}},{"key":{"type":"String","value":"b"},"value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"2"}}]}}},{"key":{"type":"String","value":"c"},"value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"3"}}]}}}]}`,
 	}
 
-	testAllEncode(t,
+	testAllEncodeAndDecode(t,
 		simpleDict,
 		nestedDict,
 		resourceDict,
@@ -691,7 +691,7 @@ func TestEncodeResource(t *testing.T) {
 
 		v := convertValueFromScript(t, script)
 
-		testEncode(t, v, expectedJSON)
+		testEncodeAndDecode(t, v, expectedJSON)
 	})
 
 	t.Run("With function member", func(t *testing.T) {
@@ -756,7 +756,7 @@ func TestEncodeResource(t *testing.T) {
 
 		v := convertValueFromScript(t, script)
 
-		testEncode(t, v, expectedJSON)
+		testEncodeAndDecode(t, v, expectedJSON)
 	})
 }
 
@@ -820,7 +820,7 @@ func TestEncodeStruct(t *testing.T) {
 		`{"type":"Struct","value":{"id":"S.test.FooStruct","fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
 	}
 
-	testAllEncode(t, simpleStruct, resourceStruct)
+	testAllEncodeAndDecode(t, simpleStruct, resourceStruct)
 }
 
 func TestEncodeEvent(t *testing.T) {
@@ -883,7 +883,7 @@ func TestEncodeEvent(t *testing.T) {
 		`{"type":"Event","value":{"id":"S.test.FooEvent","fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
 	}
 
-	testAllEncode(t, simpleEvent, resourceEvent)
+	testAllEncodeAndDecode(t, simpleEvent, resourceEvent)
 }
 
 func TestDecodeFixedPoints(t *testing.T) {
@@ -1099,6 +1099,17 @@ func TestDecodeFixedPoints(t *testing.T) {
 	})
 }
 
+func TestEncodeLink(t *testing.T) {
+
+	t.Parallel()
+
+	testEncode(
+		t,
+		cadence.NewLink("/storage/foo", "Bar"),
+		`{"type":"Link","value":{"target":"/storage/foo","borrowType":"Bar"}}`,
+	)
+}
+
 func convertValueFromScript(t *testing.T, script string) cadence.Value {
 	rt := runtime.NewInterpreterRuntime()
 
@@ -1114,25 +1125,35 @@ func convertValueFromScript(t *testing.T, script string) cadence.Value {
 	return value
 }
 
-func testAllEncode(t *testing.T, tests ...encodeTest) {
+func testAllEncodeAndDecode(t *testing.T, tests ...encodeTest) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testEncode(t, test.val, test.expected)
+			testEncodeAndDecode(t, test.val, test.expected)
 		})
 	}
 }
 
-func testEncode(t *testing.T, val cadence.Value, expectedJSON string) {
-	actualJSON, err := json.Encode(val)
+func testEncodeAndDecode(t *testing.T, val cadence.Value, expectedJSON string) {
+	actualJSON := testEncode(t, val, expectedJSON)
+	testDecode(t, actualJSON, val)
+}
+
+func testEncode(t *testing.T, val cadence.Value, expectedJSON string) (actualJSON string) {
+	actualJSONBytes, err := json.Encode(val)
 	require.NoError(t, err)
 
-	assert.JSONEq(t, expectedJSON, string(actualJSON))
+	actualJSON = string(actualJSONBytes)
 
-	// JSON should decode to original value
-	decodedVal, err := json.Decode(actualJSON)
+	assert.JSONEq(t, expectedJSON, actualJSON)
+
+	return actualJSON
+}
+
+func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value) {
+	decodedVal, err := json.Decode([]byte(actualJSON))
 	require.NoError(t, err)
 
-	assert.Equal(t, val, decodedVal)
+	assert.Equal(t, expectedVal, decodedVal)
 }
 
 var fooResourceType = cadence.ResourceType{

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1110,6 +1110,21 @@ func TestEncodeLink(t *testing.T) {
 	)
 }
 
+func TestStorageReference(t *testing.T) {
+
+	t.Parallel()
+
+	testEncode(
+		t,
+		cadence.NewStorageReference(
+			false,
+			cadence.BytesToAddress([]byte{1, 2, 3, 4, 5}),
+			"foo",
+		),
+		`{"type":"StorageReference","value":{"authorized":false,"targetStorageAddress":"0x0000000102030405","targetKey":"foo"}}`,
+	)
+}
+
 func convertValueFromScript(t *testing.T, script string) cadence.Value {
 	rt := runtime.NewInterpreterRuntime()
 

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -106,9 +106,11 @@ func exportValueWithInterpreter(value interpreter.Value, inter *interpreter.Inte
 		return exportDictionaryValue(v, inter)
 	case interpreter.AddressValue:
 		return cadence.NewAddress(v)
+	case interpreter.LinkValue:
+		return exportLinkValue(v, inter)
 	}
 
-	panic(fmt.Sprintf("cannot convert value of type %T", value))
+	panic(fmt.Sprintf("cannot export value of type %T", value))
 }
 
 func exportSomeValue(v *interpreter.SomeValue, inter *interpreter.Interpreter) cadence.Value {
@@ -200,6 +202,13 @@ func exportDictionaryValue(v *interpreter.DictionaryValue, inter *interpreter.In
 	return cadence.NewDictionary(pairs)
 }
 
+func exportLinkValue(v interpreter.LinkValue, inter *interpreter.Interpreter) cadence.Value {
+	return cadence.NewLink(
+		v.TargetPath.String(),
+		inter.ConvertStaticToSemaType(v.Type).QualifiedString(),
+	)
+}
+
 // importValue converts a Cadence value to a runtime value.
 func importValue(value cadence.Value) interpreter.Value {
 	switch v := value.(type) {
@@ -267,7 +276,7 @@ func importValue(value cadence.Value) interpreter.Value {
 		return importCompositeValue(common.CompositeKindEvent, v.EventType.ID(), v.EventType.Fields, v.Fields)
 	}
 
-	panic(fmt.Sprintf("cannot convert value of type %T", value))
+	panic(fmt.Sprintf("cannot import value of type %T", value))
 }
 
 func importOptionalValue(v cadence.Optional) interpreter.Value {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -106,6 +106,8 @@ func exportValueWithInterpreter(value interpreter.Value, inter *interpreter.Inte
 		return exportDictionaryValue(v, inter)
 	case interpreter.AddressValue:
 		return cadence.NewAddress(v)
+	case *interpreter.StorageReferenceValue:
+		return exportStorageReferenceValue(v)
 	case interpreter.LinkValue:
 		return exportLinkValue(v, inter)
 	}
@@ -200,6 +202,14 @@ func exportDictionaryValue(v *interpreter.DictionaryValue, inter *interpreter.In
 	}
 
 	return cadence.NewDictionary(pairs)
+}
+
+func exportStorageReferenceValue(v *interpreter.StorageReferenceValue) cadence.Value {
+	return cadence.NewStorageReference(
+		v.Authorized,
+		cadence.NewAddress(v.TargetStorageAddress),
+		v.TargetKey,
+	)
 }
 
 func exportLinkValue(v interpreter.LinkValue, inter *interpreter.Interpreter) cadence.Value {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4156,7 +4156,7 @@ func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
 
 			if link, ok := value.Value.(LinkValue); ok {
 
-				allowedType := interpreter.convertStaticToSemaType(link.Type)
+				allowedType := interpreter.ConvertStaticToSemaType(link.Type)
 
 				if !sema.IsSubType(allowedType, wantedBorrowType) {
 					return "", false
@@ -4176,7 +4176,7 @@ func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
 	}
 }
 
-func (interpreter *Interpreter) convertStaticToSemaType(staticType StaticType) sema.Type {
+func (interpreter *Interpreter) ConvertStaticToSemaType(staticType StaticType) sema.Type {
 	return ConvertStaticToSemaType(
 		staticType,
 		func(location ast.Location, typeID sema.TypeID) *sema.InterfaceType {
@@ -4257,7 +4257,7 @@ func (interpreter *Interpreter) getMember(self Value, locationRange LocationRang
 
 					// NOTE: not invocation.Self, as that is only set for composite values
 					dynamicType := self.DynamicType(interpreter)
-					ty := interpreter.convertStaticToSemaType(
+					ty := interpreter.ConvertStaticToSemaType(
 						firstArgument.(TypeValue).Type,
 					)
 					result := IsSubType(dynamicType, ty)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -132,8 +132,8 @@ func (v TypeValue) Equal(inter *Interpreter, other Value) BoolValue {
 		return false
 	}
 
-	ty := inter.convertStaticToSemaType(v.Type)
-	otherTy := inter.convertStaticToSemaType(otherMetaType.Type)
+	ty := inter.ConvertStaticToSemaType(v.Type)
+	otherTy := inter.ConvertStaticToSemaType(otherMetaType.Type)
 
 	return BoolValue(ty.Equal(otherTy))
 }
@@ -141,7 +141,7 @@ func (v TypeValue) Equal(inter *Interpreter, other Value) BoolValue {
 func (v TypeValue) GetMember(inter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case "identifier":
-		ty := inter.convertStaticToSemaType(v.Type)
+		ty := inter.ConvertStaticToSemaType(v.Type)
 		return NewStringValue(ty.QualifiedString())
 	}
 
@@ -6618,7 +6618,7 @@ func (CapabilityValue) IsValue() {}
 func (v CapabilityValue) DynamicType(inter *Interpreter) DynamicType {
 	var borrowType *sema.ReferenceType
 	if v.BorrowType != nil {
-		borrowType = inter.convertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
+		borrowType = inter.ConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
 	}
 
 	return CapabilityDynamicType{
@@ -6674,14 +6674,14 @@ func (v CapabilityValue) GetMember(inter *Interpreter, _ LocationRange, name str
 	case "borrow":
 		var borrowType *sema.ReferenceType
 		if v.BorrowType != nil {
-			borrowType = inter.convertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
+			borrowType = inter.ConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
 		}
 		return inter.capabilityBorrowFunction(v.Address, v.Path, borrowType)
 
 	case "check":
 		var borrowType *sema.ReferenceType
 		if v.BorrowType != nil {
-			borrowType = inter.convertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
+			borrowType = inter.ConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
 		}
 		return inter.capabilityCheckFunction(v.Address, v.Path, borrowType)
 

--- a/values.go
+++ b/values.go
@@ -982,3 +982,29 @@ func (v Link) Type() Type {
 func (v Link) ToGoValue() interface{} {
 	return nil
 }
+
+// StorageReference
+
+type StorageReference struct {
+	Authorized           bool
+	TargetStorageAddress Address
+	TargetKey            string
+}
+
+func NewStorageReference(authorized bool, targetStorageAddress Address, targetKey string) StorageReference {
+	return StorageReference{
+		Authorized:           authorized,
+		TargetStorageAddress: targetStorageAddress,
+		TargetKey:            targetKey,
+	}
+}
+
+func (StorageReference) isValue() {}
+
+func (v StorageReference) Type() Type {
+	return nil
+}
+
+func (v StorageReference) ToGoValue() interface{} {
+	return nil
+}

--- a/values.go
+++ b/values.go
@@ -958,3 +958,27 @@ func (v Contract) ToGoValue() interface{} {
 
 	return ret
 }
+
+// Link
+
+type Link struct {
+	Target     string
+	BorrowType string
+}
+
+func NewLink(target string, borrowType string) Link {
+	return Link{
+		Target:     target,
+		BorrowType: borrowType,
+	}
+}
+
+func (Link) isValue() {}
+
+func (v Link) Type() Type {
+	return nil
+}
+
+func (v Link) ToGoValue() interface{} {
+	return nil
+}

--- a/values_test.go
+++ b/values_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-func TestInterpretToBigEndianBytes(t *testing.T) {
+func TestToBigEndianBytes(t *testing.T) {
 
 	typeTests := map[string]map[NumberValue][]byte{
 		// Int*


### PR DESCRIPTION
Closes #259 

## Description

This PR introduces the following changes:
- Runtime can now export values of type `LinkValue` and `StorageReferenceValue`
- Added `cadence.Value` definitions for `cadence.Link` and `cadence.StorageReference`
- Add `JSON-CDC` encoding support for `cadence.Link` and `cadence.StorageReference`
