### PR TITLE
LSP: Initialize Flow integration with commands

### DIFF
--- a/languageserver/integration/integration.go
+++ b/languageserver/integration/integration.go
@@ -40,17 +40,21 @@ func NewFlowIntegration(s *server.Server) (*FlowIntegration, error) {
 		accounts: make(map[flow.Address]AccountPrivateKey),
 	}
 
+	options := []server.Option{
+		server.WithInitializationOptionsHandler(integration.initialize),
+		server.WithDiagnosticProvider(integration.diagnostics),
+		server.WithCodeLensProvider(integration.codeLenses),
+		server.WithAddressImportResolver(integration.resolveAccountImport),
+		server.WithStringImportResolver(resolveFileImport),
+	}
+
 	var commandOptions []server.Option
 	for _, command := range integration.commands() {
 		commandOptions = append(commandOptions, server.WithCommand(command))
 	}
 
 	err := s.SetOptions(
-		server.WithInitializationOptionsHandler(integration.initialize),
-		server.WithDiagnosticProvider(integration.diagnostics),
-		server.WithCodeLensProvider(integration.codeLenses),
-		server.WithAddressImportResolver(integration.resolveAccountImport),
-		server.WithStringImportResolver(resolveFileImport),
+		append(options, commandOptions...)...,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The `commandOptions` slice was just missing from the server initialization 