### PR TITLE
encoding/json: Add decode functionality for cadence.StorageReference and cadence.Link

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -98,6 +98,8 @@ const (
 	authorizedKey           = "authorized"
 	targetStorageAddressKey = "targetStorageAddress"
 	targetKeyKey            = "targetKey"
+	targetPathKey           = "targetPath"
+	borrowTypeKey           = "borrowType"
 )
 
 var ErrInvalidJSONCadence = errors.New("invalid JSON Cadence structure")
@@ -180,6 +182,8 @@ func decodeJSON(v interface{}) cadence.Value {
 		return decodeEvent(valueJSON)
 	case storageReferenceTypeStr:
 		return decodeStorageReference(valueJSON)
+	case linkTypeStr:
+		return decodeLink(valueJSON)
 	}
 
 	panic(ErrInvalidJSONCadence)
@@ -553,6 +557,15 @@ func decodeStorageReference(valueJSON interface{}) cadence.StorageReference {
 		obj.GetBool(authorizedKey),
 		decodeAddress(obj.Get(targetStorageAddressKey)),
 		obj.GetString(targetKeyKey),
+	)
+}
+
+func decodeLink(valueJSON interface{}) cadence.Link {
+	obj := toObject(valueJSON)
+
+	return cadence.NewLink(
+		obj.GetString(targetPathKey),
+		obj.GetString(borrowTypeKey),
 	)
 }
 

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -89,12 +89,15 @@ func (d *Decoder) Decode() (value cadence.Value, err error) {
 }
 
 const (
-	typeKey   = "type"
-	valueKey  = "value"
-	keyKey    = "key"
-	nameKey   = "name"
-	fieldsKey = "fields"
-	idKey     = "id"
+	typeKey                 = "type"
+	valueKey                = "value"
+	keyKey                  = "key"
+	nameKey                 = "name"
+	fieldsKey               = "fields"
+	idKey                   = "id"
+	authorizedKey           = "authorized"
+	targetStorageAddressKey = "targetStorageAddress"
+	targetKeyKey            = "targetKey"
 )
 
 var ErrInvalidJSONCadence = errors.New("invalid JSON Cadence structure")
@@ -175,6 +178,8 @@ func decodeJSON(v interface{}) cadence.Value {
 		return decodeStruct(valueJSON)
 	case eventTypeStr:
 		return decodeEvent(valueJSON)
+	case storageReferenceTypeStr:
+		return decodeStorageReference(valueJSON)
 	}
 
 	panic(ErrInvalidJSONCadence)
@@ -541,6 +546,16 @@ func decodeEvent(valueJSON interface{}) cadence.Event {
 	})
 }
 
+func decodeStorageReference(valueJSON interface{}) cadence.StorageReference {
+	obj := toObject(valueJSON)
+
+	return cadence.NewStorageReference(
+		obj.GetBool(authorizedKey),
+		decodeAddress(obj.Get(targetStorageAddressKey)),
+		obj.GetString(targetKeyKey),
+	)
+}
+
 // JSON types
 
 type jsonObject map[string]interface{}
@@ -553,6 +568,11 @@ func (obj jsonObject) Get(key string) interface{} {
 	}
 
 	return v
+}
+
+func (obj jsonObject) GetBool(key string) bool {
+	v := obj.Get(key)
+	return toBool(v)
 }
 
 func (obj jsonObject) GetString(key string) string {

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -125,7 +125,7 @@ type jsonStorageReferenceValue struct {
 }
 
 type jsonLinkValue struct {
-	Target     string `json:"target"`
+	TargetPath string `json:"targetPath"`
 	BorrowType string `json:"borrowType"`
 }
 
@@ -509,7 +509,7 @@ func (e *Encoder) prepareLink(x cadence.Link) jsonValue {
 	return jsonValueObject{
 		Type: linkTypeStr,
 		Value: jsonLinkValue{
-			Target:     x.Target,
+			TargetPath: x.TargetPath,
 			BorrowType: x.BorrowType,
 		},
 	}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1103,7 +1103,7 @@ func TestEncodeLink(t *testing.T) {
 
 	t.Parallel()
 
-	testEncode(
+	testEncodeAndDecode(
 		t,
 		cadence.NewLink("/storage/foo", "Bar"),
 		`{"type":"Link","value":{"targetPath":"/storage/foo","borrowType":"Bar"}}`,

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1106,7 +1106,7 @@ func TestEncodeLink(t *testing.T) {
 	testEncode(
 		t,
 		cadence.NewLink("/storage/foo", "Bar"),
-		`{"type":"Link","value":{"target":"/storage/foo","borrowType":"Bar"}}`,
+		`{"type":"Link","value":{"targetPath":"/storage/foo","borrowType":"Bar"}}`,
 	)
 }
 

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1114,7 +1114,7 @@ func TestStorageReference(t *testing.T) {
 
 	t.Parallel()
 
-	testEncode(
+	testEncodeAndDecode(
 		t,
 		cadence.NewStorageReference(
 			false,

--- a/values.go
+++ b/values.go
@@ -962,13 +962,13 @@ func (v Contract) ToGoValue() interface{} {
 // Link
 
 type Link struct {
-	Target     string
+	TargetPath string
 	BorrowType string
 }
 
-func NewLink(target string, borrowType string) Link {
+func NewLink(targetPath string, borrowType string) Link {
 	return Link{
-		Target:     target,
+		TargetPath: targetPath,
 		BorrowType: borrowType,
 	}
 }


### PR DESCRIPTION
## Description

This PR adds decoding functionality that mirrors the JSON-CDC encoding functionality recently added for `cadence.StorageReference` and `cadence.Link` types.

We previously discussed this not being a strict requirement, but it is useful for users who use JSON-CDC as a storage format and therefore need to convert to/from `cadence.Value` and JSON (e.g. the Playground).