### PR TITLE
encoding/json: Add encode and decode functionality for cadence.Contract

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -180,6 +180,8 @@ func decodeJSON(v interface{}) cadence.Value {
 		return decodeStruct(valueJSON)
 	case eventTypeStr:
 		return decodeEvent(valueJSON)
+	case contractTypeStr:
+		return decodeContract(valueJSON)
 	case storageReferenceTypeStr:
 		return decodeStorageReference(valueJSON)
 	case linkTypeStr:
@@ -544,6 +546,16 @@ func decodeEvent(valueJSON interface{}) cadence.Event {
 	comp := decodeComposite(valueJSON)
 
 	return cadence.NewEvent(comp.fieldValues).WithType(cadence.EventType{
+		TypeID:     comp.typeID,
+		Identifier: comp.identifier,
+		Fields:     comp.fieldTypes,
+	})
+}
+
+func decodeContract(valueJSON interface{}) cadence.Contract {
+	comp := decodeComposite(valueJSON)
+
+	return cadence.NewContract(comp.fieldValues).WithType(cadence.ContractType{
 		TypeID:     comp.typeID,
 		Identifier: comp.identifier,
 		Fields:     comp.fieldTypes,

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -160,6 +160,7 @@ const (
 	structTypeStr           = "Struct"
 	resourceTypeStr         = "Resource"
 	eventTypeStr            = "Event"
+	contractTypeStr         = "Contract"
 	storageReferenceTypeStr = "StorageReference"
 	linkTypeStr             = "Link"
 )
@@ -228,6 +229,8 @@ func (e *Encoder) prepare(v cadence.Value) jsonValue {
 		return e.prepareResource(x)
 	case cadence.Event:
 		return e.prepareEvent(x)
+	case cadence.Contract:
+		return e.prepareContract(x)
 	case cadence.StorageReference:
 		return e.prepareStorageReference(x)
 	case cadence.Link:
@@ -454,6 +457,10 @@ func (e *Encoder) prepareResource(v cadence.Resource) jsonValue {
 
 func (e *Encoder) prepareEvent(v cadence.Event) jsonValue {
 	return e.prepareComposite(eventTypeStr, v.EventType.ID(), v.EventType.Fields, v.Fields)
+}
+
+func (e *Encoder) prepareContract(v cadence.Contract) jsonValue {
+	return e.prepareComposite(contractTypeStr, v.ContractType.ID(), v.ContractType.Fields, v.Fields)
 }
 
 func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {


### PR DESCRIPTION
## Description

The JSON-CDC encoder didn't support contracts, but it turns out this was failing silently due to the fact that the `prepare` function was not properly panicking with the error. 

This PR updates the `encoding/json` package to support encoding and decoding contracts, which are just another form of composite value.