### PR TITLE
Make sema.ReferenceType exportable

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -94,9 +94,11 @@ func exportType(typ sema.Type) cadence.Type {
 		return exportFunctionType(t)
 	case *sema.AddressType:
 		return cadence.AddressType{}
+	case *sema.ReferenceType:
+		return exportReferenceType(t)
 	}
 
-	panic(fmt.Sprintf("cannot convert type of type %T", typ))
+	panic(fmt.Sprintf("cannot export type of type %T", typ))
 }
 
 func exportOptionalType(t *sema.OptionalType) cadence.Type {
@@ -179,7 +181,7 @@ func exportCompositeType(t *sema.CompositeType) cadence.Type {
 		}
 	}
 
-	panic(fmt.Sprintf("cannot convert type %v of unknown kind %v", t, t.Kind))
+	panic(fmt.Sprintf("cannot export type %v of unknown kind %v", t, t.Kind))
 }
 
 func exportDictionaryType(t *sema.DictionaryType) cadence.Type {
@@ -210,5 +212,12 @@ func exportFunctionType(t *sema.FunctionType) cadence.Type {
 	return cadence.Function{
 		Parameters: parameters,
 		ReturnType: convertedReturnType,
+	}.WithID(string(t.ID()))
+}
+
+func exportReferenceType(t *sema.ReferenceType) cadence.ReferenceType {
+	return cadence.ReferenceType{
+		Authorized: t.Authorized,
+		Type:       exportType(t.Type),
 	}.WithID(string(t.ID()))
 }

--- a/types.go
+++ b/types.go
@@ -591,3 +591,22 @@ func (EventPointer) isType() {}
 func (t EventPointer) ID() string {
 	return t.TypeName
 }
+
+// ReferenceType
+
+type ReferenceType struct {
+	typeID     string
+	Authorized bool
+	Type       Type
+}
+
+func (ReferenceType) isType() {}
+
+func (t ReferenceType) ID() string {
+	return t.typeID
+}
+
+func (t ReferenceType) WithID(id string) ReferenceType {
+	t.typeID = id
+	return t
+}


### PR DESCRIPTION
## Description

This PR updates `sema.ReferenceType` to be an exportable type. 

The Playground was failing with `cannot convert type of type *sema.ReferenceType` when attempting to deploy the `NFTv2.cdc` contract: https://docs.onflow.org/docs/non-fungible-tokens#storing-multiple-nfts-in-a-collection
