### PR TITLE
Handle parsing ambiguity of return types

### DIFF
--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -865,6 +865,72 @@ func TestParseFunctionDeclaration(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("without space after return type", func(t *testing.T) {
+
+		// A brace after the return type is ambiguous:
+		// It could be the start of a restricted type.
+		// However, if there is space after the brace, which is most common
+		// in function declarations, we consider it not a restricted type
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations("fun main(): Int{ return 1 }")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.FunctionDeclaration{
+					Identifier: ast.Identifier{
+						Identifier: "main",
+						Pos:        ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+					ParameterList: &ast.ParameterList{
+						Parameters: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
+							EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
+						},
+					},
+					ReturnTypeAnnotation: &ast.TypeAnnotation{
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "Int",
+								Pos:        ast.Position{Line: 1, Column: 12, Offset: 12},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 12, Offset: 12},
+					},
+					FunctionBlock: &ast.FunctionBlock{
+						Block: &ast.Block{
+							Statements: []ast.Statement{
+								&ast.ReturnStatement{
+									Expression: &ast.IntegerExpression{
+										Value: big.NewInt(1),
+										Base:  10,
+										Range: ast.Range{
+											StartPos: ast.Position{Line: 1, Column: 24, Offset: 24},
+											EndPos:   ast.Position{Line: 1, Column: 24, Offset: 24},
+										},
+									},
+									Range: ast.Range{
+										StartPos: ast.Position{Line: 1, Column: 17, Offset: 17},
+										EndPos:   ast.Position{Line: 1, Column: 24, Offset: 24},
+									},
+								},
+							},
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 15, Offset: 15},
+								EndPos:   ast.Position{Line: 1, Column: 26, Offset: 26},
+							},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+				},
+			},
+			result,
+		)
+	})
 }
 
 func TestParseAccess(t *testing.T) {

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -456,10 +456,7 @@ func defineRestrictedOrDictionaryType() {
 	// This handles the ambiguous case where a function return type's open brace
 	// may either be a restricted type (if there is no whitespace)
 	// or the start of the function body (if there is whitespace).
-	//
-	// In the fu
 
-	//setTypeLeftBindingPower(lexer.TokenBraceOpen, typeLeftBindingPowerRestriction)
 	setTypeMetaLeftDenotation(
 		lexer.TokenBraceOpen,
 		func(p *parser, rightBindingPower int, left ast.Type) (result ast.Type, done bool) {

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -358,7 +358,7 @@ func TestParseRestrictedType(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseType("T{ U , V }")
+		result, errs := ParseType("T{U , V }")
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
@@ -373,19 +373,19 @@ func TestParseRestrictedType(t *testing.T) {
 					{
 						Identifier: ast.Identifier{
 							Identifier: "U",
-							Pos:        ast.Position{Line: 1, Column: 3, Offset: 3},
+							Pos:        ast.Position{Line: 1, Column: 2, Offset: 2},
 						},
 					},
 					{
 						Identifier: ast.Identifier{
 							Identifier: "V",
-							Pos:        ast.Position{Line: 1, Column: 7, Offset: 7},
+							Pos:        ast.Position{Line: 1, Column: 6, Offset: 6},
 						},
 					},
 				},
 				Range: ast.Range{
 					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
-					EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
+					EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
 				},
 			},
 			result,
@@ -488,12 +488,12 @@ func TestParseRestrictedType(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseType("T{ T , U : V }")
+		_, errs := ParseType("T{U , V : W }")
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: `unexpected token: got ':', expected ',' or '}'`,
-					Pos:     ast.Position{Offset: 9, Line: 1, Column: 9},
+					Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
 				},
 			},
 			errs,


### PR DESCRIPTION
Closes #258

Handle the parsing ambiguity when parsing a return type which involves a open curly brace

cc @MaxStalker