### PR TITLE
Insert argument list when completing functions, offer keyword snippets

### DIFF
--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/mattn/go-isatty v0.0.12
-	github.com/mitchellh/mapstructure v1.3.2
+	github.com/mitchellh/mapstructure v1.3.3
 	github.com/onflow/cadence v0.6.0
 	github.com/onflow/flow-go-sdk v0.8.0
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20191222043438-96c4efab7ee2

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -111,8 +111,8 @@ github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvrWyR0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYGN7GeoRg=
-github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
+github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -781,8 +781,9 @@ func (s *Server) prepareFunctionMemberCompletionItem(
 		if i > 0 {
 			builder.WriteString(", ")
 		}
-		if parameter.Label != sema.ArgumentLabelNotRequired {
-			builder.WriteString(parameter.Label)
+		label := parameter.EffectiveArgumentLabel()
+		if label != sema.ArgumentLabelNotRequired {
+			builder.WriteString(label)
 			builder.WriteString(": ")
 		}
 		builder.WriteString("${")

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -459,10 +459,217 @@ type CompletionItemData struct {
 	URI protocol.DocumentUri `json:"uri"`
 }
 
+var statementCompletionItems = []*protocol.CompletionItem{
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "for",
+		Detail:           "for-in loop",
+		InsertText:       "for $1 in $2 {\n\t$0\n}",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "while",
+		Detail:           "while loop",
+		InsertText:       "while $1 {\n\t$0\n}",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "if",
+		Detail:           "if statement",
+		InsertText:       "if $1 {\n\t$0\n}",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "if else",
+		Detail:           "if-else statement",
+		InsertText:       "if $1 {\n\t$2\n} else {\n\t$0\n}",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "else",
+		Detail:           "else block",
+		InsertText:       "else {\n\t$0\n}",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "if let",
+		Detail:           "if-let statement",
+		InsertText:       "if let $1 = $2 {\n\t$0\n}",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "return",
+		Detail:           "return statement",
+		InsertText:       "return $0",
+	},
+	{
+		Kind:   protocol.KeywordCompletion,
+		Label:  "break",
+		Detail: "break statement",
+	},
+	{
+		Kind:   protocol.KeywordCompletion,
+		Label:  "continue",
+		Detail: "continue statement",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "emit",
+		Detail:           "emit statement",
+		InsertText:       "emit $0",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "destroy",
+		Detail:           "destroy expression",
+		InsertText:       "destroy $0",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "pre",
+		Detail:           "pre conditions",
+		InsertText:       "pre {\n\t$0\n}",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "post",
+		Detail:           "post conditions",
+		InsertText:       "post {\n\t$0\n}",
+	},
+}
+
+var expressionCompletionItems = []*protocol.CompletionItem{
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "create",
+		Detail:           "create statement",
+		InsertText:       "create $0",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "create",
+		Detail:           "create statement",
+		InsertText:       "create $0",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "let",
+		Detail:           "constant declaration",
+		InsertText:       "let $1 = $0",
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "var",
+		Detail:           "variable declaration",
+		InsertText:       "var $1 = $0",
+	},
+}
+
+const accessOptions = "pub,priv,pub(set),access(contract),access(account)"
+
+var declarationCompletionItems = []*protocol.CompletionItem{
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "struct",
+		Detail:           "struct declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} struct $2 {\n\t$0\n}", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "resource",
+		Detail:           "resource declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} resource $2 {\n\t$0\n}", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "contract",
+		Detail:           "contract declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} contract $2 {\n\t$0\n}", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "struct interface",
+		Detail:           "struct interface declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} struct interface $2 {\n\t$0\n}", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "resource interface",
+		Detail:           "resource interface declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} resource interface $2 {\n\t$0\n}", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "contract interface",
+		Detail:           "contract interface declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} contract interface $2 {\n\t$0\n}", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "event",
+		Detail:           "event declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} event $2($0)", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "fun",
+		Detail:           "function declaration",
+		InsertText:       fmt.Sprintf("${1|%s|} fun $2($3)${4:: $5} {\n\t$0\n}", accessOptions),
+	},
+}
+
+var containerCompletionItems = []*protocol.CompletionItem{
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "var",
+		Detail:           "variable field",
+		InsertText:       fmt.Sprintf("${1|%s|} var $2: $0", accessOptions),
+	},
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "let",
+		Detail:           "constant field",
+		InsertText:       fmt.Sprintf("${1|%s|} let $2: $0", accessOptions),
+	},
+	// alias for the above
+	{
+		Kind:             protocol.KeywordCompletion,
+		InsertTextFormat: protocol.SnippetTextFormat,
+		Label:            "const",
+		Detail:           "constant field",
+		InsertText:       fmt.Sprintf("${1|%s|} let $2: $0", accessOptions),
+	},
+}
+
 // Completion is called to compute completion items at a given cursor position.
 //
 func (s *Server) Completion(
-	conn protocol.Conn,
+	_ protocol.Conn,
 	params *protocol.CompletionParams,
 ) (
 	items []*protocol.CompletionItem,
@@ -489,6 +696,17 @@ func (s *Server) Completion(
 
 	items = append(items, memberCompletions...)
 
+	// TODO: make conditional on position being inside a function declaration
+	items = append(items, statementCompletionItems...)
+
+	// TODO: make conditional on position being inside a function declaration
+	items = append(items, expressionCompletionItems...)
+
+	// TODO: make conditional on position being outside a function declaration
+	items = append(items, declarationCompletionItems...)
+
+	// TODO: make conditional on position being inside a container, but not a function declaration
+	items = append(items, containerCompletionItems...)
 
 	return
 }


### PR DESCRIPTION
⚠️ Depends on #257

1. When offering a completion item for a function, also insert the argument list, including argument labels

    ![argument-list](https://user-images.githubusercontent.com/51661/88468468-196b4500-ce99-11ea-8312-de345c0f0744.gif)

2. Offer completions for common keywords and provide snippets with placeholders. 
    This is inspired by @MaxStalker's great work on snippets for the extension: 
    https://twitter.com/MaxStalker/status/1279860880654708736

    By offering the snippets in the language server, they are not restricted to Visual Studio Code,
    and in the future we can offer keyword completions based on context, as indicated by the TODOs.
    I think it's better to already offer them all now, even when they are not applicable, then to 
    hold off offering anything because we can't yet differentiate context.
  
    ![keywords](https://user-images.githubusercontent.com/51661/88468559-70254e80-ce9a-11ea-95cd-ce231dbeed46.gif)
 
