### PR TITLE
Improve indicies/keys when decoding

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -254,7 +254,7 @@ func (d *Decoder) decodeDictionary(v interface{}, path []string) (*DictionaryVal
 		return nil, fmt.Errorf("invalid dictionary encoding: %T", v)
 	}
 
-	encodedKeys, ok := encoded[uint64(0)].([]interface{})
+	encodedKeys, ok := encoded[encodedDictionaryValueKeysFieldKey].([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid dictionary keys encoding")
 	}
@@ -265,7 +265,7 @@ func (d *Decoder) decodeDictionary(v interface{}, path []string) (*DictionaryVal
 		return nil, fmt.Errorf("invalid dictionary keys encoding: %w", err)
 	}
 
-	encodedEntries, ok := encoded[uint64(1)].(map[interface{}]interface{})
+	encodedEntries, ok := encoded[encodedDictionaryValueEntriesFieldKey].(map[interface{}]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid dictionary entries encoding")
 	}
@@ -396,14 +396,14 @@ func (d *Decoder) decodeComposite(v interface{}, path []string) (*CompositeValue
 
 	// Location
 
-	location, err := d.decodeLocation(encoded[uint64(0)])
+	location, err := d.decodeLocation(encoded[encodedCompositeValueLocationFieldKey])
 	if err != nil {
 		return nil, fmt.Errorf("invalid composite location encoding: %w", err)
 	}
 
 	// Type ID
 
-	field2 := encoded[uint64(1)]
+	field2 := encoded[encodedCompositeValueTypeIDFieldKey]
 	encodedTypeID, ok := field2.(string)
 	if !ok {
 		return nil, fmt.Errorf("invalid composite type ID encoding: %T", field2)
@@ -412,7 +412,7 @@ func (d *Decoder) decodeComposite(v interface{}, path []string) (*CompositeValue
 
 	// Kind
 
-	field3 := encoded[uint64(2)]
+	field3 := encoded[encodedCompositeValueKindFieldKey]
 	encodedKind, ok := field3.(uint64)
 	if !ok {
 		return nil, fmt.Errorf("invalid composite kind encoding: %T", field3)
@@ -421,7 +421,7 @@ func (d *Decoder) decodeComposite(v interface{}, path []string) (*CompositeValue
 
 	// Fields
 
-	field4 := encoded[uint64(3)]
+	field4 := encoded[encodedCompositeValueFieldsFieldKey]
 	encodedFields, ok := field4.(map[interface{}]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid composite fields encoding")
@@ -792,19 +792,19 @@ func (d *Decoder) decodeStorageReference(v interface{}) (*StorageReferenceValue,
 		return nil, fmt.Errorf("invalid storage reference encoding: %T", v)
 	}
 
-	authorized, ok := encoded[uint64(0)].(bool)
+	authorized, ok := encoded[encodedStorageReferenceValueAuthorizedFieldKey].(bool)
 	if !ok {
 		return nil, fmt.Errorf("invalid storage reference authorized encoding: %T", authorized)
 	}
 
-	targetStorageAddressBytes, ok := encoded[uint64(1)].([]byte)
+	targetStorageAddressBytes, ok := encoded[encodedStorageReferenceValueTargetStorageAddressFieldKey].([]byte)
 	if !ok {
 		return nil, fmt.Errorf("invalid storage reference target storage address encoding: %T", authorized)
 	}
 
 	targetStorageAddress := common.BytesToAddress(targetStorageAddressBytes)
 
-	targetKey, ok := encoded[uint64(2)].(string)
+	targetKey, ok := encoded[encodedStorageReferenceValueTargetKeyFieldKey].(string)
 	if !ok {
 		return nil, fmt.Errorf("invalid storage reference target key encoding: %T", targetKey)
 	}
@@ -850,13 +850,13 @@ func (d *Decoder) decodePath(v interface{}) (PathValue, error) {
 		return PathValue{}, fmt.Errorf("invalid path encoding: %T", v)
 	}
 
-	field1 := encoded[uint64(0)]
+	field1 := encoded[encodedPathValueDomainFieldKey]
 	domain, ok := field1.(uint64)
 	if !ok {
 		return PathValue{}, fmt.Errorf("invalid path domain encoding: %T", field1)
 	}
 
-	field2 := encoded[uint64(1)]
+	field2 := encoded[encodedPathValueIdentifierFieldKey]
 	identifier, ok := field2.(string)
 	if !ok {
 		return PathValue{}, fmt.Errorf("invalid path identifier encoding: %T", field2)
@@ -876,7 +876,7 @@ func (d *Decoder) decodeCapability(v interface{}) (CapabilityValue, error) {
 
 	// address
 
-	field1 := encoded[uint64(0)]
+	field1 := encoded[encodedCapabilityValueAddressFieldKey]
 	field1Value, err := d.decodeValue(field1, nil)
 	if err != nil {
 		return CapabilityValue{}, fmt.Errorf("invalid capability address: %w", err)
@@ -889,7 +889,7 @@ func (d *Decoder) decodeCapability(v interface{}) (CapabilityValue, error) {
 
 	// path
 
-	field2 := encoded[uint64(1)]
+	field2 := encoded[encodedCapabilityValuePathFieldKey]
 	field2Value, err := d.decodeValue(field2, nil)
 	if err != nil {
 		return CapabilityValue{}, fmt.Errorf("invalid capability path: %w", err)
@@ -904,7 +904,7 @@ func (d *Decoder) decodeCapability(v interface{}) (CapabilityValue, error) {
 
 	var borrowType StaticType
 
-	if field3, ok := encoded[uint64(2)]; ok && field3 != nil {
+	if field3, ok := encoded[encodedCapabilityValueBorrowTypeFieldKey]; ok && field3 != nil {
 
 		decodedStaticType, err := d.decodeStaticType(field3)
 		if err != nil {
@@ -930,7 +930,7 @@ func (d *Decoder) decodeLink(v interface{}) (LinkValue, error) {
 		return LinkValue{}, fmt.Errorf("invalid link encoding")
 	}
 
-	decodedPath, err := d.decodeValue(encoded[uint64(0)], nil)
+	decodedPath, err := d.decodeValue(encoded[encodedLinkValueTargetPathFieldKey], nil)
 	if err != nil {
 		return LinkValue{}, fmt.Errorf("invalid link target path encoding: %w", err)
 	}
@@ -940,7 +940,7 @@ func (d *Decoder) decodeLink(v interface{}) (LinkValue, error) {
 		return LinkValue{}, fmt.Errorf("invalid link target path encoding: %T", decodedPath)
 	}
 
-	decodedStaticType, err := d.decodeStaticType(encoded[uint64(1)])
+	decodedStaticType, err := d.decodeStaticType(encoded[encodedLinkValueTypeFieldKey])
 	if err != nil {
 		return LinkValue{}, fmt.Errorf("invalid link type encoding: %w", err)
 	}
@@ -1019,18 +1019,27 @@ func (d *Decoder) decodeOptionalStaticType(v interface{}) (StaticType, error) {
 	}, nil
 }
 
-func (d *Decoder) decodeLocationAndTypeID(v interface{}) (ast.Location, sema.TypeID, error) {
+func (d *Decoder) decodeLocationAndTypeID(
+	v interface{},
+	locationKeyIndex uint64,
+	typeIDKeyIndex uint64,
+) (
+	ast.Location,
+	sema.TypeID,
+	error,
+) {
+
 	encoded, ok := v.(map[interface{}]interface{})
 	if !ok {
 		return nil, "", fmt.Errorf("invalid static type encoding: %T", v)
 	}
 
-	location, err := d.decodeLocation(encoded[uint64(0)])
+	location, err := d.decodeLocation(encoded[locationKeyIndex])
 	if err != nil {
 		return nil, "", fmt.Errorf("invalid static type location encoding: %w", err)
 	}
 
-	field2 := encoded[uint64(1)]
+	field2 := encoded[typeIDKeyIndex]
 	encodedTypeID, ok := field2.(string)
 	if !ok {
 		return nil, "", fmt.Errorf("invalid static type type ID encoding: %T", field2)
@@ -1041,7 +1050,11 @@ func (d *Decoder) decodeLocationAndTypeID(v interface{}) (ast.Location, sema.Typ
 }
 
 func (d *Decoder) decodeCompositeStaticType(v interface{}) (StaticType, error) {
-	location, typeID, err := d.decodeLocationAndTypeID(v)
+	location, typeID, err := d.decodeLocationAndTypeID(
+		v,
+		encodedCompositeStaticTypeLocationFieldKey,
+		encodedCompositeStaticTypeTypeIDFieldKey,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("invalid composite static type encoding: %w", err)
 	}
@@ -1053,7 +1066,11 @@ func (d *Decoder) decodeCompositeStaticType(v interface{}) (StaticType, error) {
 }
 
 func (d *Decoder) decodeInterfaceStaticType(v interface{}) (StaticType, error) {
-	location, typeID, err := d.decodeLocationAndTypeID(v)
+	location, typeID, err := d.decodeLocationAndTypeID(
+		v,
+		encodedInterfaceStaticTypeLocationFieldKey,
+		encodedInterfaceStaticTypeTypeIDFieldKey,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("invalid interface static type encoding: %w", err)
 	}
@@ -1080,7 +1097,7 @@ func (d *Decoder) decodeConstantSizedStaticType(v interface{}) (StaticType, erro
 		return nil, fmt.Errorf("invalid constant-sized static type encoding: %T", v)
 	}
 
-	field1 := encoded[uint64(0)]
+	field1 := encoded[encodedConstantSizedStaticTypeSizeFieldKey]
 	size, ok := field1.(uint64)
 	if !ok {
 		return nil, fmt.Errorf("invalid constant-sized static type size encoding: %T", field1)
@@ -1095,7 +1112,7 @@ func (d *Decoder) decodeConstantSizedStaticType(v interface{}) (StaticType, erro
 		)
 	}
 
-	staticType, err := d.decodeStaticType(encoded[uint64(1)])
+	staticType, err := d.decodeStaticType(encoded[encodedConstantSizedStaticTypeTypeFieldKey])
 	if err != nil {
 		return nil, fmt.Errorf("invalid constant-sized static type inner type encoding: %w", err)
 	}
@@ -1112,13 +1129,13 @@ func (d *Decoder) decodeReferenceStaticType(v interface{}) (StaticType, error) {
 		return nil, fmt.Errorf("invalid reference static type encoding: %T", v)
 	}
 
-	field1 := encoded[uint64(0)]
+	field1 := encoded[encodedReferenceStaticTypeAuthorizedFieldKey]
 	authorized, ok := field1.(bool)
 	if !ok {
 		return nil, fmt.Errorf("invalid reference static type authorized encoding: %T", field1)
 	}
 
-	staticType, err := d.decodeStaticType(encoded[uint64(1)])
+	staticType, err := d.decodeStaticType(encoded[encodedReferenceStaticTypeTypeFieldKey])
 	if err != nil {
 		return nil, fmt.Errorf("invalid reference static type inner type encoding: %w", err)
 	}
@@ -1135,12 +1152,12 @@ func (d *Decoder) decodeDictionaryStaticType(v interface{}) (StaticType, error) 
 		return nil, fmt.Errorf("invalid dictionary static type encoding: %T", v)
 	}
 
-	keyType, err := d.decodeStaticType(encoded[uint64(0)])
+	keyType, err := d.decodeStaticType(encoded[encodedDictionaryStaticTypeKeyTypeFieldKey])
 	if err != nil {
 		return nil, fmt.Errorf("invalid dictionary static type key type encoding: %w", err)
 	}
 
-	valueType, err := d.decodeStaticType(encoded[uint64(1)])
+	valueType, err := d.decodeStaticType(encoded[encodedDictionaryStaticTypeValueTypeFieldKey])
 	if err != nil {
 		return nil, fmt.Errorf("invalid dictionary static type value type encoding: %w", err)
 	}
@@ -1157,12 +1174,12 @@ func (d *Decoder) decodeRestrictedStaticType(v interface{}) (StaticType, error) 
 		return nil, fmt.Errorf("invalid restricted static type encoding: %T", v)
 	}
 
-	restrictedType, err := d.decodeStaticType(encoded[uint64(0)])
+	restrictedType, err := d.decodeStaticType(encoded[encodedRestrictedStaticTypeTypeFieldKey])
 	if err != nil {
 		return nil, fmt.Errorf("invalid restricted static type key type encoding: %w", err)
 	}
 
-	field2 := encoded[uint64(1)]
+	field2 := encoded[encodedRestrictedStaticTypeRestrictionsFieldKey]
 	encodedRestrictions, ok := field2.([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid restricted static type restrictions encoding: %T", field2)
@@ -1193,7 +1210,7 @@ func (d *Decoder) decodeType(v interface{}) (TypeValue, error) {
 		return TypeValue{}, fmt.Errorf("invalid type encoding")
 	}
 
-	decodedStaticType, err := d.decodeStaticType(encoded[uint64(0)])
+	decodedStaticType, err := d.decodeStaticType(encoded[encodedTypeValueTypeFieldKey])
 	if err != nil {
 		return TypeValue{}, fmt.Errorf("invalid type encoding: %w", err)
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -214,7 +214,7 @@ func init() {
 	}
 }
 
-func fieldKey(t interface{}, name string) uint64 {
+func cborFieldKey(t interface{}, name string) uint64 {
 	rt := reflect.TypeOf(t)
 
 	field, ok := rt.FieldByName(name)
@@ -675,11 +675,11 @@ type encodedDictionaryValue struct {
 	Entries map[string]interface{} `cbor:"1,keyasint"`
 }
 
-var encodedDictionaryValueKeysFieldKey = fieldKey(
+var encodedDictionaryValueKeysFieldKey = cborFieldKey(
 	encodedDictionaryValue{},
 	"Keys",
 )
-var encodedDictionaryValueEntriesFieldKey = fieldKey(
+var encodedDictionaryValueEntriesFieldKey = cborFieldKey(
 	encodedDictionaryValue{},
 	"Entries",
 )
@@ -778,19 +778,19 @@ type encodedCompositeValue struct {
 	Fields   map[string]interface{} `cbor:"3,keyasint"`
 }
 
-var encodedCompositeValueLocationFieldKey = fieldKey(
+var encodedCompositeValueLocationFieldKey = cborFieldKey(
 	encodedCompositeValue{},
 	"Location",
 )
-var encodedCompositeValueTypeIDFieldKey = fieldKey(
+var encodedCompositeValueTypeIDFieldKey = cborFieldKey(
 	encodedCompositeValue{},
 	"TypeID",
 )
-var encodedCompositeValueKindFieldKey = fieldKey(
+var encodedCompositeValueKindFieldKey = cborFieldKey(
 	encodedCompositeValue{},
 	"Kind",
 )
-var encodedCompositeValueFieldsFieldKey = fieldKey(
+var encodedCompositeValueFieldsFieldKey = cborFieldKey(
 	encodedCompositeValue{},
 	"Fields",
 )
@@ -853,15 +853,15 @@ type encodedStorageReferenceValue struct {
 	TargetKey            string `cbor:"2,keyasint"`
 }
 
-var encodedStorageReferenceValueAuthorizedFieldKey = fieldKey(
+var encodedStorageReferenceValueAuthorizedFieldKey = cborFieldKey(
 	encodedStorageReferenceValue{},
 	"Authorized",
 )
-var encodedStorageReferenceValueTargetStorageAddressFieldKey = fieldKey(
+var encodedStorageReferenceValueTargetStorageAddressFieldKey = cborFieldKey(
 	encodedStorageReferenceValue{},
 	"TargetStorageAddress",
 )
-var encodedStorageReferenceValueTargetKeyFieldKey = fieldKey(
+var encodedStorageReferenceValueTargetKeyFieldKey = cborFieldKey(
 	encodedStorageReferenceValue{},
 	"TargetKey",
 )
@@ -886,11 +886,11 @@ type encodedPathValue struct {
 	Identifier string `cbor:"1,keyasint"`
 }
 
-var encodedPathValueDomainFieldKey = fieldKey(
+var encodedPathValueDomainFieldKey = cborFieldKey(
 	encodedPathValue{},
 	"Domain",
 )
-var encodedPathValueIdentifierFieldKey = fieldKey(
+var encodedPathValueIdentifierFieldKey = cborFieldKey(
 	encodedPathValue{},
 	"Identifier",
 )
@@ -908,15 +908,15 @@ type encodedCapabilityValue struct {
 	BorrowType interface{}      `cbor:"2,keyasint"`
 }
 
-var encodedCapabilityValueAddressFieldKey = fieldKey(
+var encodedCapabilityValueAddressFieldKey = cborFieldKey(
 	encodedCapabilityValue{},
 	"Address",
 )
-var encodedCapabilityValuePathFieldKey = fieldKey(
+var encodedCapabilityValuePathFieldKey = cborFieldKey(
 	encodedCapabilityValue{},
 	"Path",
 )
-var encodedCapabilityValueBorrowTypeFieldKey = fieldKey(
+var encodedCapabilityValueBorrowTypeFieldKey = cborFieldKey(
 	encodedCapabilityValue{},
 	"BorrowType",
 )
@@ -970,11 +970,11 @@ type encodedLinkValue struct {
 	Type       interface{}      `cbor:"1,keyasint"`
 }
 
-var encodedLinkValueTargetPathFieldKey = fieldKey(
+var encodedLinkValueTargetPathFieldKey = cborFieldKey(
 	encodedLinkValue{},
 	"TargetPath",
 )
-var encodedLinkValueTypeFieldKey = fieldKey(
+var encodedLinkValueTypeFieldKey = cborFieldKey(
 	encodedLinkValue{},
 	"Type",
 )
@@ -996,11 +996,11 @@ type encodedCompositeStaticType struct {
 	TypeID   string      `cbor:"1,keyasint"`
 }
 
-var encodedCompositeStaticTypeLocationFieldKey = fieldKey(
+var encodedCompositeStaticTypeLocationFieldKey = cborFieldKey(
 	encodedCompositeStaticType{},
 	"Location",
 )
-var encodedCompositeStaticTypeTypeIDFieldKey = fieldKey(
+var encodedCompositeStaticTypeTypeIDFieldKey = cborFieldKey(
 	encodedCompositeStaticType{},
 	"TypeID",
 )
@@ -1011,11 +1011,11 @@ type encodedInterfaceStaticType struct {
 	TypeID   string      `cbor:"1,keyasint"`
 }
 
-var encodedInterfaceStaticTypeLocationFieldKey = fieldKey(
+var encodedInterfaceStaticTypeLocationFieldKey = cborFieldKey(
 	encodedInterfaceStaticType{},
 	"Location",
 )
-var encodedInterfaceStaticTypeTypeIDFieldKey = fieldKey(
+var encodedInterfaceStaticTypeTypeIDFieldKey = cborFieldKey(
 	encodedInterfaceStaticType{},
 	"TypeID",
 )
@@ -1025,11 +1025,11 @@ type encodedConstantSizedStaticType struct {
 	Type interface{} `cbor:"1,keyasint"`
 }
 
-var encodedConstantSizedStaticTypeSizeFieldKey = fieldKey(
+var encodedConstantSizedStaticTypeSizeFieldKey = cborFieldKey(
 	encodedConstantSizedStaticType{},
 	"Size",
 )
-var encodedConstantSizedStaticTypeTypeFieldKey = fieldKey(
+var encodedConstantSizedStaticTypeTypeFieldKey = cborFieldKey(
 	encodedConstantSizedStaticType{},
 	"Type",
 )
@@ -1039,11 +1039,11 @@ type encodedDictionaryStaticType struct {
 	ValueType interface{} `cbor:"1,keyasint"`
 }
 
-var encodedDictionaryStaticTypeKeyTypeFieldKey = fieldKey(
+var encodedDictionaryStaticTypeKeyTypeFieldKey = cborFieldKey(
 	encodedDictionaryStaticType{},
 	"KeyType",
 )
-var encodedDictionaryStaticTypeValueTypeFieldKey = fieldKey(
+var encodedDictionaryStaticTypeValueTypeFieldKey = cborFieldKey(
 	encodedDictionaryStaticType{},
 	"ValueType",
 )
@@ -1053,11 +1053,11 @@ type encodedRestrictedStaticType struct {
 	Restrictions []interface{} `cbor:"1,keyasint"`
 }
 
-var encodedRestrictedStaticTypeTypeFieldKey = fieldKey(
+var encodedRestrictedStaticTypeTypeFieldKey = cborFieldKey(
 	encodedRestrictedStaticType{},
 	"Type",
 )
-var encodedRestrictedStaticTypeRestrictionsFieldKey = fieldKey(
+var encodedRestrictedStaticTypeRestrictionsFieldKey = cborFieldKey(
 	encodedRestrictedStaticType{},
 	"Restrictions",
 )
@@ -1067,11 +1067,11 @@ type encodedReferenceStaticType struct {
 	Type       interface{} `cbor:"1,keyasint"`
 }
 
-var encodedReferenceStaticTypeAuthorizedFieldKey = fieldKey(
+var encodedReferenceStaticTypeAuthorizedFieldKey = cborFieldKey(
 	encodedReferenceStaticType{},
 	"Authorized",
 )
-var encodedReferenceStaticTypeTypeFieldKey = fieldKey(
+var encodedReferenceStaticTypeTypeFieldKey = cborFieldKey(
 	encodedReferenceStaticType{},
 	"Type",
 )
@@ -1235,7 +1235,7 @@ type encodedTypeValue struct {
 	Type interface{} `cbor:"0,keyasint"`
 }
 
-var encodedTypeValueTypeFieldKey = fieldKey(encodedTypeValue{}, "Type")
+var encodedTypeValueTypeFieldKey = cborFieldKey(encodedTypeValue{}, "Type")
 
 func (e *Encoder) prepareTypeValue(v TypeValue) (interface{}, error) {
 	staticType, err := e.prepareStaticType(v.Type)

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -20,6 +20,7 @@ package interpreter
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -201,7 +202,6 @@ func init() {
 		cborTagLinkValue:               encodedLinkValue{},
 		cborTagCompositeStaticType:     encodedCompositeStaticType{},
 		cborTagInterfaceStaticType:     encodedInterfaceStaticType{},
-		cborTagVariableSizedStaticType: encodedVariableSizedStaticType{},
 		cborTagConstantSizedStaticType: encodedConstantSizedStaticType{},
 		cborTagDictionaryStaticType:    encodedDictionaryStaticType{},
 		cborTagRestrictedStaticType:    encodedRestrictedStaticType{},
@@ -212,6 +212,28 @@ func init() {
 	for tag, encodedType := range types {
 		register(tag, encodedType)
 	}
+}
+
+func fieldKey(t interface{}, name string) uint64 {
+	rt := reflect.TypeOf(t)
+
+	field, ok := rt.FieldByName(name)
+	if !ok {
+		panic(fmt.Errorf("missing field %s", name))
+	}
+	tag, ok := field.Tag.Lookup("cbor")
+	if !ok {
+		panic(errors.New("missing cbor tag"))
+	}
+	var index uint64
+	n, err := fmt.Sscanf(tag, "%d,keyasint", &index)
+	if n != 1 {
+		panic(fmt.Errorf("invalid cbor tag in field %s of type %T", name, t))
+	}
+	if err != nil {
+		panic(err)
+	}
+	return index
 }
 
 type EncodingDeferralMove struct {
@@ -653,6 +675,15 @@ type encodedDictionaryValue struct {
 	Entries map[string]interface{} `cbor:"1,keyasint"`
 }
 
+var encodedDictionaryValueKeysFieldKey = fieldKey(
+	encodedDictionaryValue{},
+	"Keys",
+)
+var encodedDictionaryValueEntriesFieldKey = fieldKey(
+	encodedDictionaryValue{},
+	"Entries",
+)
+
 const dictionaryKeyPathPrefix = "k"
 const dictionaryValuePathPrefix = "v"
 
@@ -747,6 +778,23 @@ type encodedCompositeValue struct {
 	Fields   map[string]interface{} `cbor:"3,keyasint"`
 }
 
+var encodedCompositeValueLocationFieldKey = fieldKey(
+	encodedCompositeValue{},
+	"Location",
+)
+var encodedCompositeValueTypeIDFieldKey = fieldKey(
+	encodedCompositeValue{},
+	"TypeID",
+)
+var encodedCompositeValueKindFieldKey = fieldKey(
+	encodedCompositeValue{},
+	"Kind",
+)
+var encodedCompositeValueFieldsFieldKey = fieldKey(
+	encodedCompositeValue{},
+	"Fields",
+)
+
 func (e *Encoder) prepareCompositeValue(
 	v *CompositeValue,
 	path []string,
@@ -755,7 +803,6 @@ func (e *Encoder) prepareCompositeValue(
 	interface{},
 	error,
 ) {
-
 	fields := make(map[string]interface{}, len(v.Fields))
 
 	for name, value := range v.Fields {
@@ -806,6 +853,19 @@ type encodedStorageReferenceValue struct {
 	TargetKey            string `cbor:"2,keyasint"`
 }
 
+var encodedStorageReferenceValueAuthorizedFieldKey = fieldKey(
+	encodedStorageReferenceValue{},
+	"Authorized",
+)
+var encodedStorageReferenceValueTargetStorageAddressFieldKey = fieldKey(
+	encodedStorageReferenceValue{},
+	"TargetStorageAddress",
+)
+var encodedStorageReferenceValueTargetKeyFieldKey = fieldKey(
+	encodedStorageReferenceValue{},
+	"TargetKey",
+)
+
 func (e *Encoder) prepareStorageReferenceValue(v *StorageReferenceValue) interface{} {
 	return encodedStorageReferenceValue{
 		Authorized:           v.Authorized,
@@ -826,6 +886,15 @@ type encodedPathValue struct {
 	Identifier string `cbor:"1,keyasint"`
 }
 
+var encodedPathValueDomainFieldKey = fieldKey(
+	encodedPathValue{},
+	"Domain",
+)
+var encodedPathValueIdentifierFieldKey = fieldKey(
+	encodedPathValue{},
+	"Identifier",
+)
+
 func (e *Encoder) preparePathValue(v PathValue) encodedPathValue {
 	return encodedPathValue{
 		Domain:     uint(v.Domain),
@@ -838,6 +907,19 @@ type encodedCapabilityValue struct {
 	Path       encodedPathValue `cbor:"1,keyasint"`
 	BorrowType interface{}      `cbor:"2,keyasint"`
 }
+
+var encodedCapabilityValueAddressFieldKey = fieldKey(
+	encodedCapabilityValue{},
+	"Address",
+)
+var encodedCapabilityValuePathFieldKey = fieldKey(
+	encodedCapabilityValue{},
+	"Path",
+)
+var encodedCapabilityValueBorrowTypeFieldKey = fieldKey(
+	encodedCapabilityValue{},
+	"BorrowType",
+)
 
 func (e *Encoder) prepareCapabilityValue(v CapabilityValue) (interface{}, error) {
 
@@ -888,6 +970,15 @@ type encodedLinkValue struct {
 	Type       interface{}      `cbor:"1,keyasint"`
 }
 
+var encodedLinkValueTargetPathFieldKey = fieldKey(
+	encodedLinkValue{},
+	"TargetPath",
+)
+var encodedLinkValueTypeFieldKey = fieldKey(
+	encodedLinkValue{},
+	"Type",
+)
+
 func (e *Encoder) prepareLinkValue(v LinkValue) (interface{}, error) {
 	staticType, err := e.prepareStaticType(v.Type)
 	if err != nil {
@@ -905,35 +996,85 @@ type encodedCompositeStaticType struct {
 	TypeID   string      `cbor:"1,keyasint"`
 }
 
+var encodedCompositeStaticTypeLocationFieldKey = fieldKey(
+	encodedCompositeStaticType{},
+	"Location",
+)
+var encodedCompositeStaticTypeTypeIDFieldKey = fieldKey(
+	encodedCompositeStaticType{},
+	"TypeID",
+)
+
 // TODO: optimize, decode location from type ID
 type encodedInterfaceStaticType struct {
 	Location interface{} `cbor:"0,keyasint"`
 	TypeID   string      `cbor:"1,keyasint"`
 }
 
-type encodedVariableSizedStaticType struct {
-	Type interface{} `cbor:"0,keyasint"`
-}
+var encodedInterfaceStaticTypeLocationFieldKey = fieldKey(
+	encodedInterfaceStaticType{},
+	"Location",
+)
+var encodedInterfaceStaticTypeTypeIDFieldKey = fieldKey(
+	encodedInterfaceStaticType{},
+	"TypeID",
+)
 
 type encodedConstantSizedStaticType struct {
 	Size int64       `cbor:"0,keyasint"`
 	Type interface{} `cbor:"1,keyasint"`
 }
 
+var encodedConstantSizedStaticTypeSizeFieldKey = fieldKey(
+	encodedConstantSizedStaticType{},
+	"Size",
+)
+var encodedConstantSizedStaticTypeTypeFieldKey = fieldKey(
+	encodedConstantSizedStaticType{},
+	"Type",
+)
+
 type encodedDictionaryStaticType struct {
 	KeyType   interface{} `cbor:"0,keyasint"`
 	ValueType interface{} `cbor:"1,keyasint"`
 }
+
+var encodedDictionaryStaticTypeKeyTypeFieldKey = fieldKey(
+	encodedDictionaryStaticType{},
+	"KeyType",
+)
+var encodedDictionaryStaticTypeValueTypeFieldKey = fieldKey(
+	encodedDictionaryStaticType{},
+	"ValueType",
+)
 
 type encodedRestrictedStaticType struct {
 	Type         interface{}   `cbor:"0,keyasint"`
 	Restrictions []interface{} `cbor:"1,keyasint"`
 }
 
+var encodedRestrictedStaticTypeTypeFieldKey = fieldKey(
+	encodedRestrictedStaticType{},
+	"Type",
+)
+var encodedRestrictedStaticTypeRestrictionsFieldKey = fieldKey(
+	encodedRestrictedStaticType{},
+	"Restrictions",
+)
+
 type encodedReferenceStaticType struct {
 	Authorized bool        `cbor:"0,keyasint"`
 	Type       interface{} `cbor:"1,keyasint"`
 }
+
+var encodedReferenceStaticTypeAuthorizedFieldKey = fieldKey(
+	encodedReferenceStaticType{},
+	"Authorized",
+)
+var encodedReferenceStaticTypeTypeFieldKey = fieldKey(
+	encodedReferenceStaticType{},
+	"Type",
+)
 
 func (e *Encoder) prepareStaticType(t StaticType) (interface{}, error) {
 	switch v := t.(type) {
@@ -1093,6 +1234,8 @@ func (e *Encoder) prepareRestrictedStaticType(v RestrictedStaticType) (interface
 type encodedTypeValue struct {
 	Type interface{} `cbor:"0,keyasint"`
 }
+
+var encodedTypeValueTypeFieldKey = fieldKey(encodedTypeValue{}, "Type")
 
 func (e *Encoder) prepareTypeValue(v TypeValue) (interface{}, error) {
 	staticType, err := e.prepareStaticType(v.Type)

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1235,7 +1235,10 @@ type encodedTypeValue struct {
 	Type interface{} `cbor:"0,keyasint"`
 }
 
-var encodedTypeValueTypeFieldKey = cborFieldKey(encodedTypeValue{}, "Type")
+var encodedTypeValueTypeFieldKey = cborFieldKey(
+	encodedTypeValue{},
+	"Type",
+)
 
 func (e *Encoder) prepareTypeValue(v TypeValue) (interface{}, error) {
 	staticType, err := e.prepareStaticType(v.Type)


### PR DESCRIPTION
Closes #216 

Instead of using magic values for indexing when decoding, define values that are derived from the struct tags, which are the source of truth and used when encoding.

I still don't like how the fields are strings, i.e. it is not checked at compile time, but at least a mismatch will fail at run-time right at startup.