### PR TITLE
Include available declarations in "not declared" error

### DIFF
--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -21,6 +21,7 @@ package sema
 import (
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -1024,6 +1025,7 @@ func (*RepeatedImportError) isSemanticError() {}
 type NotExportedError struct {
 	Name           string
 	ImportLocation ast.Location
+	Available      []string
 	Pos            ast.Position
 }
 
@@ -1033,6 +1035,17 @@ func (e *NotExportedError) Error() string {
 		e.Name,
 		e.ImportLocation,
 	)
+}
+
+func (e *NotExportedError) SecondaryError() string {
+	var builder strings.Builder
+	builder.WriteString("available exported declarations are:\n")
+
+	for _, available := range e.Available {
+		builder.WriteString(fmt.Sprintf(" - `%s`\n", available))
+	}
+
+	return builder.String()
 }
 
 func (*NotExportedError) isSemanticError() {}


### PR DESCRIPTION
Improve the error message that is shown when an identifier cannot be imported by listing all available declarations.

<img width="693" alt="Screen Shot 2020-07-31 at 5 21 05 PM" src="https://user-images.githubusercontent.com/51661/89089461-3d73ce00-d352-11ea-8b70-d4eda47ab4bd.png">

I realized this rough edge in @MaxStalker's live stream: It's likely that code gets deployed to the wrong account and the current error message isn't helpful in resolving the bug. Help the developer realize that the import fails because the wrong code is in the account.