### PR TITLE
Add JSON serialization support for more AST elements

### DIFF
--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -18,6 +18,10 @@
 
 package ast
 
+import (
+	"encoding/json"
+)
+
 type Block struct {
 	Statements []Statement
 	Range
@@ -27,16 +31,48 @@ func (b *Block) Accept(visitor Visitor) Repr {
 	return visitor.VisitBlock(b)
 }
 
+func (b *Block) MarshalJSON() ([]byte, error) {
+	type Alias Block
+	return json.Marshal(&struct {
+		Type string
+		*Alias
+	}{
+		Type:  "Block",
+		Alias: (*Alias)(b),
+	})
+}
+
 // FunctionBlock
 
 type FunctionBlock struct {
-	*Block
-	PreConditions  *Conditions
-	PostConditions *Conditions
+	Block          *Block
+	PreConditions  *Conditions `json:",omitempty"`
+	PostConditions *Conditions `json:",omitempty"`
 }
 
 func (b *FunctionBlock) Accept(visitor Visitor) Repr {
 	return visitor.VisitFunctionBlock(b)
+}
+
+func (b *FunctionBlock) MarshalJSON() ([]byte, error) {
+	type Alias FunctionBlock
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "FunctionBlock",
+		Range: b.Block.Range,
+		Alias: (*Alias)(b),
+	})
+}
+
+func (b *FunctionBlock) StartPosition() Position {
+	return b.Block.StartPos
+}
+
+func (b *FunctionBlock) EndPosition() Position {
+	return b.Block.EndPos
 }
 
 // Condition
@@ -50,6 +86,8 @@ type Condition struct {
 func (c *Condition) Accept(visitor Visitor) Repr {
 	return visitor.VisitCondition(c)
 }
+
+// Conditions
 
 type Conditions []*Condition
 

--- a/runtime/ast/block_test.go
+++ b/runtime/ast/block_test.go
@@ -1,0 +1,238 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlock_MarshalJSON(t *testing.T) {
+
+	block := &Block{
+		Statements: []Statement{
+			&ExpressionStatement{
+				Expression: &BoolExpression{
+					Value: false,
+					Range: Range{
+						StartPos: Position{Offset: 1, Line: 2, Column: 3},
+						EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+					},
+				},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 7, Line: 8, Column: 9},
+			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+		},
+	}
+
+	actual, err := json.Marshal(block)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "Block",
+            "Statements": [
+                {
+                    "Type": "ExpressionStatement",
+                    "Expression": {
+                        "Type": "BoolExpression",
+                        "Value": false,
+                        "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                        "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                    },
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                    "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                }
+            ],
+            "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+            "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestFunctionBlock_MarshalJSON(t *testing.T) {
+
+	t.Run("with statements", func(t *testing.T) {
+
+		block := &FunctionBlock{
+			Block: &Block{
+				Statements: []Statement{
+					&ExpressionStatement{
+						Expression: &BoolExpression{
+							Value: false,
+							Range: Range{
+								StartPos: Position{Offset: 1, Line: 2, Column: 3},
+								EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+							},
+						},
+					},
+				},
+				Range: Range{
+					StartPos: Position{Offset: 7, Line: 8, Column: 9},
+					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+				},
+			},
+		}
+
+		actual, err := json.Marshal(block)
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`
+            {
+                "Type": "FunctionBlock",
+                "Block": {
+                    "Type": "Block",
+                    "Statements": [
+                        {
+                            "Type": "ExpressionStatement",
+                            "Expression": {
+                                "Type": "BoolExpression",
+                                "Value": false,
+                                "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                            },
+                            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                        }
+                    ],
+                    "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                    "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+                },
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+            }
+            `,
+			string(actual),
+		)
+	})
+
+	t.Run("with preconditions and postconditions", func(t *testing.T) {
+
+		block := &FunctionBlock{
+			Block: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+			PreConditions: &Conditions{
+				{
+					Kind: ConditionKindPre,
+					Test: &BoolExpression{
+						Value: false,
+						Range: Range{
+							StartPos: Position{Offset: 7, Line: 8, Column: 9},
+							EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+						},
+					},
+					Message: &StringExpression{
+						Value: "Pre failed",
+						Range: Range{
+							StartPos: Position{Offset: 13, Line: 14, Column: 15},
+							EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+						},
+					},
+				},
+			},
+			PostConditions: &Conditions{
+				{
+					Kind: ConditionKindPost,
+					Test: &BoolExpression{
+						Value: true,
+						Range: Range{
+							StartPos: Position{Offset: 19, Line: 20, Column: 21},
+							EndPos:   Position{Offset: 22, Line: 23, Column: 24},
+						},
+					},
+					Message: &StringExpression{
+						Value: "Post failed",
+						Range: Range{
+							StartPos: Position{Offset: 25, Line: 26, Column: 27},
+							EndPos:   Position{Offset: 28, Line: 29, Column: 30},
+						},
+					},
+				},
+			},
+		}
+
+		actual, err := json.Marshal(block)
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`
+            {
+                "Type": "FunctionBlock",
+                "Block": {
+                    "Type": "Block",
+                    "Statements": [],
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                    "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                },
+                "PreConditions": [
+                    {
+                        "Kind": "ConditionKindPre",
+                        "Test": {
+                            "Type": "BoolExpression",
+                            "Value": false,
+                            "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                            "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+                        },
+                        "Message": {
+                            "Type": "StringExpression",
+                            "Value": "Pre failed",
+                            "StartPos": {"Offset": 13, "Line": 14, "Column": 15}, 
+                            "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+                        }
+                    }
+                ],
+                "PostConditions": [
+                    {
+                        "Kind": "ConditionKindPost",
+                        "Test": {
+                            "Type": "BoolExpression",
+                            "Value": true,
+                            "StartPos": {"Offset": 19, "Line": 20, "Column": 21}, 
+                            "EndPos": {"Offset": 22, "Line": 23, "Column": 24}
+                        },
+                        "Message": {
+                            "Type": "StringExpression",
+                            "Value": "Post failed",
+                            "StartPos": {"Offset": 25, "Line": 26, "Column": 27}, 
+                            "EndPos": {"Offset": 28, "Line": 29, "Column": 30}
+                        }
+                    }
+                ],
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            }
+            `,
+			string(actual),
+		)
+	})
+}

--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -342,7 +342,7 @@ func (extractor *ExpressionExtractor) ExtractDictionary(expression *DictionaryEx
 
 	// rewrite all value expressions
 
-	rewrittenEntries := make([]Entry, len(expression.Entries))
+	rewrittenEntries := make([]DictionaryEntry, len(expression.Entries))
 
 	for i, entry := range expression.Entries {
 		keyResult := extractor.Extract(entry.Key)
@@ -351,7 +351,7 @@ func (extractor *ExpressionExtractor) ExtractDictionary(expression *DictionaryEx
 		valueResult := extractor.Extract(entry.Value)
 		extractedExpressions = append(extractedExpressions, valueResult.ExtractedExpressions...)
 
-		rewrittenEntries[i] = Entry{
+		rewrittenEntries[i] = DictionaryEntry{
 			Key:   keyResult.RewrittenExpression,
 			Value: valueResult.RewrittenExpression,
 		}

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -20,6 +20,7 @@ package ast
 
 import (
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,5 +72,261 @@ func TestNilExpression_MarshalJSON(t *testing.T) {
         `,
 		string(actual),
 	)
+}
 
+func TestStringExpression_MarshalJSON(t *testing.T) {
+
+	expr := &StringExpression{
+		Value: "Hello, World!",
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "StringExpression",
+            "Value": "Hello, World!",
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestIntegerExpression_MarshalJSON(t *testing.T) {
+
+	expr := &IntegerExpression{
+		Value: big.NewInt(42),
+		Base:  10,
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "IntegerExpression",
+            "Value": "42",
+            "Base": 10,
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestFixedPointExpression_MarshalJSON(t *testing.T) {
+
+	expr := &FixedPointExpression{
+		Negative:        true,
+		UnsignedInteger: big.NewInt(42),
+		Fractional:      big.NewInt(24),
+		Scale:           10,
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "FixedPointExpression",
+            "Negative": true,
+            "UnsignedInteger": "42",
+            "Fractional": "24",
+            "Scale": 10,
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestArrayExpression_MarshalJSON(t *testing.T) {
+
+	expr := &ArrayExpression{
+		Values: []Expression{
+			&BoolExpression{
+				Value: true,
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+			&NilExpression{
+				Pos: Position{Offset: 7, Line: 8, Column: 9},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 10, Line: 11, Column: 12},
+			EndPos:   Position{Offset: 13, Line: 14, Column: 15},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ArrayExpression",
+            "Values": [
+                {
+                    "Type": "BoolExpression",
+                    "Value": true,
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                    "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                },
+                {
+                    "Type": "NilExpression",
+                    "StartPos": {"Offset": 7, "Line": 8, "Column": 9}, 
+                    "EndPos": {"Offset": 9, "Line": 8, "Column": 11}
+                }
+            ],
+            "StartPos": {"Offset": 10, "Line": 11, "Column": 12}, 
+            "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestDictionaryExpression_MarshalJSON(t *testing.T) {
+
+	expr := &DictionaryExpression{
+		Entries: []DictionaryEntry{
+			{
+				Key: &BoolExpression{
+					Value: true,
+					Range: Range{
+						StartPos: Position{Offset: 1, Line: 2, Column: 3},
+						EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+					},
+				},
+				Value: &NilExpression{
+					Pos: Position{Offset: 7, Line: 8, Column: 9},
+				},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 10, Line: 11, Column: 12},
+			EndPos:   Position{Offset: 13, Line: 14, Column: 15},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "DictionaryExpression",
+            "Entries": [
+                {
+                    "Type": "DictionaryEntry",
+                    "Key": {
+                        "Type": "BoolExpression",
+                        "Value": true,
+                        "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                        "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+                    },
+                    "Value": {
+                        "Type": "NilExpression",
+                        "StartPos": {"Offset": 7, "Line": 8, "Column": 9}, 
+                        "EndPos": {"Offset": 9, "Line": 8, "Column": 11}
+                    }
+                }
+            ],
+            "StartPos": {"Offset": 10, "Line": 11, "Column": 12}, 
+            "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestIdentifierExpression_MarshalJSON(t *testing.T) {
+
+	expr := &IdentifierExpression{
+		Identifier: Identifier{
+			Identifier: "foobar",
+			Pos:        Position{Offset: 1, Line: 2, Column: 3},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "IdentifierExpression",
+            "Identifier": {
+                "Identifier": "foobar",
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestPathExpression_MarshalJSON(t *testing.T) {
+
+	expr := &PathExpression{
+		StartPos: Position{Offset: 1, Line: 2, Column: 3},
+		Domain: Identifier{
+			Identifier: "storage",
+			Pos:        Position{Offset: 4, Line: 5, Column: 6},
+		},
+		Identifier: Identifier{
+			Identifier: "foobar",
+			Pos:        Position{Offset: 7, Line: 8, Column: 9},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "PathExpression",
+            "Domain": {
+                "Identifier": "storage",
+                "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                "EndPos": {"Offset": 10, "Line": 5, "Column": 12}
+            },
+            "Identifier": {
+                "Identifier": "foobar",
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "EndPos": {"Offset": 12, "Line": 8, "Column": 14}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 12, "Line": 8, "Column": 14}
+        }
+        `,
+		string(actual),
+	)
 }

--- a/runtime/ast/import.go
+++ b/runtime/ast/import.go
@@ -20,6 +20,7 @@ package ast
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 
 	"github.com/onflow/cadence/runtime/common"
@@ -43,6 +44,16 @@ func (i Identifier) StartPosition() Position {
 func (i Identifier) EndPosition() Position {
 	length := len(i.Identifier)
 	return i.Pos.Shifted(length - 1)
+}
+
+func (i Identifier) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Identifier string
+		Range
+	}{
+		Identifier: i.Identifier,
+		Range:      NewRangeFromPositioned(i),
+	})
 }
 
 // ImportDeclaration

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -18,6 +18,10 @@
 
 package ast
 
+import (
+	"encoding/json"
+)
+
 type Statement interface {
 	Element
 	isStatement()
@@ -219,4 +223,17 @@ func (*ExpressionStatement) isStatement() {}
 
 func (s *ExpressionStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitExpressionStatement(s)
+}
+
+func (s *ExpressionStatement) MarshalJSON() ([]byte, error) {
+	type Alias ExpressionStatement
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "ExpressionStatement",
+		Range: NewRangeFromPositioned(s),
+		Alias: (*Alias)(s),
+	})
 }

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -1,0 +1,60 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpressionStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &ExpressionStatement{
+		Expression: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ExpressionStatement",
+            "Expression": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}

--- a/runtime/ast/transferoperation.go
+++ b/runtime/ast/transferoperation.go
@@ -19,6 +19,8 @@
 package ast
 
 import (
+	"encoding/json"
+
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -32,6 +34,10 @@ const (
 	TransferOperationMove
 	TransferOperationMoveForced
 )
+
+func TransferOperationCount() int {
+	return len(_TransferOperation_index) - 1
+}
 
 func (k TransferOperation) Operator() string {
 	switch k {
@@ -53,4 +59,8 @@ func (k TransferOperation) IsMove() bool {
 	}
 
 	return false
+}
+
+func (k TransferOperation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }

--- a/runtime/ast/transferoperation_test.go
+++ b/runtime/ast/transferoperation_test.go
@@ -1,0 +1,38 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransferOperation_MarshalJSON(t *testing.T) {
+
+	for transferOperation := TransferOperation(0); transferOperation < TransferOperation(TransferOperationCount()); transferOperation++ {
+		actual, err := json.Marshal(transferOperation)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, fmt.Sprintf(`"%s"`, transferOperation), string(actual))
+	}
+}

--- a/runtime/ast/variablekind.go
+++ b/runtime/ast/variablekind.go
@@ -19,6 +19,8 @@
 package ast
 
 import (
+	"encoding/json"
+
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -31,6 +33,10 @@ const (
 	VariableKindVariable
 	VariableKindConstant
 )
+
+func VariableKindCount() int {
+	return len(_VariableKind_index) - 1
+}
 
 var VariableKinds = []VariableKind{
 	VariableKindConstant,
@@ -57,4 +63,8 @@ func (k VariableKind) Keyword() string {
 	}
 
 	panic(errors.NewUnreachableError())
+}
+
+func (k VariableKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }

--- a/runtime/ast/variablekind_test.go
+++ b/runtime/ast/variablekind_test.go
@@ -1,0 +1,38 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVariableKind_MarshalJSON(t *testing.T) {
+
+	for variableKind := VariableKind(0); variableKind < VariableKind(VariableKindCount()); variableKind++ {
+		actual, err := json.Marshal(variableKind)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, fmt.Sprintf(`"%s"`, variableKind), string(actual))
+	}
+}

--- a/runtime/common/compositekind.go
+++ b/runtime/common/compositekind.go
@@ -19,6 +19,8 @@
 package common
 
 import (
+	"encoding/json"
+
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -33,6 +35,10 @@ const (
 	CompositeKindContract
 	CompositeKindEvent
 )
+
+func CompositeKindCount() int {
+	return len(_CompositeKind_index) - 1
+}
 
 var AllCompositeKinds = []CompositeKind{
 	CompositeKindStructure,
@@ -155,4 +161,8 @@ func (k CompositeKind) SupportsInterfaces() bool {
 	}
 
 	panic(errors.NewUnreachableError())
+}
+
+func (k CompositeKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }

--- a/runtime/common/compositekind_test.go
+++ b/runtime/common/compositekind_test.go
@@ -1,0 +1,38 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompositeKind_MarshalJSON(t *testing.T) {
+
+	for compositeKind := CompositeKind(0); compositeKind < CompositeKind(CompositeKindCount()); compositeKind++ {
+		actual, err := json.Marshal(compositeKind)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, fmt.Sprintf(`"%s"`, compositeKind), string(actual))
+	}
+}

--- a/runtime/common/declarationkind.go
+++ b/runtime/common/declarationkind.go
@@ -19,6 +19,8 @@
 package common
 
 import (
+	"encoding/json"
+
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -54,6 +56,10 @@ const (
 	DeclarationKindTypeParameter
 	DeclarationKindPragma
 )
+
+func DeclarationKindCount() int {
+	return len(_DeclarationKind_index) - 1
+}
 
 func (k DeclarationKind) IsTypeDeclaration() bool {
 	switch k {
@@ -173,4 +179,8 @@ func (k DeclarationKind) Keywords() string {
 	default:
 		return ""
 	}
+}
+
+func (k DeclarationKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }

--- a/runtime/common/declarationkind_test.go
+++ b/runtime/common/declarationkind_test.go
@@ -1,0 +1,38 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeclarationKind_MarshalJSON(t *testing.T) {
+
+	for declarationKind := DeclarationKind(0); declarationKind < DeclarationKind(DeclarationKindCount()); declarationKind++ {
+		actual, err := json.Marshal(declarationKind)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, fmt.Sprintf(`"%s"`, declarationKind), string(actual))
+	}
+}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -928,7 +928,7 @@ func (interpreter *Interpreter) functionDeclarationValue(
 		Activation:       lexicalScope,
 		BeforeStatements: beforeStatements,
 		PreConditions:    preConditions,
-		Statements:       declaration.FunctionBlock.Statements,
+		Statements:       declaration.FunctionBlock.Block.Statements,
 		PostConditions:   rewrittenPostConditions,
 	}
 }
@@ -2188,12 +2188,12 @@ func (interpreter *Interpreter) visitExpressionsNonCopying(expressions []ast.Exp
 	return trampoline
 }
 
-func (interpreter *Interpreter) visitEntries(entries []ast.Entry) Trampoline {
+func (interpreter *Interpreter) visitEntries(entries []ast.DictionaryEntry) Trampoline {
 	var trampoline Trampoline = Done{Result: []DictionaryEntryValues{}}
 
 	for _, entry := range entries {
 		// NOTE: important: rebind entry, because it is captured in the closure below
-		func(entry ast.Entry) {
+		func(entry ast.DictionaryEntry) {
 			// append the evaluation of this entry
 			trampoline = trampoline.FlatMap(func(result interface{}) Trampoline {
 				resultEntries := result.([]DictionaryEntryValues)
@@ -2248,6 +2248,8 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 		beforeStatements = postConditionsRewrite.BeforeStatements
 	}
 
+	statements := expression.FunctionBlock.Block.Statements
+
 	function := InterpretedFunctionValue{
 		Interpreter:      interpreter,
 		ParameterList:    expression.ParameterList,
@@ -2255,7 +2257,7 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 		Activation:       lexicalScope,
 		BeforeStatements: beforeStatements,
 		PreConditions:    preConditions,
-		Statements:       expression.FunctionBlock.Statements,
+		Statements:       statements,
 		PostConditions:   rewrittenPostConditions,
 	}
 
@@ -2539,7 +2541,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 		preConditions = *initializer.FunctionBlock.PreConditions
 	}
 
-	statements := initializer.FunctionBlock.Statements
+	statements := initializer.FunctionBlock.Block.Statements
 
 	var beforeStatements []ast.Statement
 	var rewrittenPostConditions ast.Conditions
@@ -2574,7 +2576,7 @@ func (interpreter *Interpreter) compositeDestructorFunction(
 		return nil
 	}
 
-	statements := destructor.FunctionBlock.Statements
+	statements := destructor.FunctionBlock.Block.Statements
 
 	var preConditions ast.Conditions
 
@@ -2675,7 +2677,7 @@ func (interpreter *Interpreter) compositeFunction(
 	}
 
 	parameterList := functionDeclaration.ParameterList
-	statements := functionDeclaration.FunctionBlock.Statements
+	statements := functionDeclaration.FunctionBlock.Block.Statements
 
 	return InterpretedFunctionValue{
 		Interpreter:      interpreter,

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -876,12 +876,12 @@ func defineDictionaryExpression() {
 	setExprNullDenotation(
 		lexer.TokenBraceOpen,
 		func(p *parser, startToken lexer.Token) ast.Expression {
-			var entries []ast.Entry
+			var entries []ast.DictionaryEntry
 			for !p.current.Is(lexer.TokenBraceClose) {
 				key := parseExpression(p, lowestBindingPower)
 				p.mustOne(lexer.TokenColon)
 				value := parseExpression(p, lowestBindingPower)
-				entries = append(entries, ast.Entry{
+				entries = append(entries, ast.DictionaryEntry{
 					Key:   key,
 					Value: value,
 				})

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -517,7 +517,7 @@ func TestParseDictionaryExpression(t *testing.T) {
 
 		utils.AssertEqualWithDiff(t,
 			&ast.DictionaryExpression{
-				Entries: []ast.Entry{
+				Entries: []ast.DictionaryEntry{
 					{
 						Key: &ast.IntegerExpression{
 							Value: big.NewInt(1),

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -33,12 +33,12 @@ func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpr
 	valueType := variable.Type
 
 	if valueType.IsResourceType() {
-		checker.checkResourceVariableCapturingInFunction(variable, expression.Identifier)
-		checker.checkResourceUseAfterInvalidation(variable, expression.Identifier)
-		checker.resources.AddUse(variable, expression.Pos)
+		checker.checkResourceVariableCapturingInFunction(variable, identifier)
+		checker.checkResourceUseAfterInvalidation(variable, identifier)
+		checker.resources.AddUse(variable, identifier.Pos)
 	}
 
-	checker.checkSelfVariableUseInInitializer(variable, expression.Pos)
+	checker.checkSelfVariableUseInInitializer(variable, identifier.Pos)
 
 	if checker.inInvocation {
 		checker.Elaboration.IdentifierInInvocationTypes[expression] = valueType

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -324,25 +324,26 @@ func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclar
 }
 
 func (checker *Checker) checkInterfaceSpecialFunctionBlock(
-	block *ast.FunctionBlock,
+	functionBlock *ast.FunctionBlock,
 	containerKind common.DeclarationKind,
 	implementedKind common.DeclarationKind,
 ) {
 
-	if len(block.Statements) > 0 {
+	statements := functionBlock.Block.Statements
+	if len(statements) > 0 {
 		checker.report(
 			&InvalidImplementationError{
-				Pos:             block.Statements[0].StartPosition(),
+				Pos:             statements[0].StartPosition(),
 				ContainerKind:   containerKind,
 				ImplementedKind: implementedKind,
 			},
 		)
-	} else if (block.PreConditions == nil || len(*block.PreConditions) == 0) &&
-		(block.PostConditions == nil || len(*block.PostConditions) == 0) {
+	} else if (functionBlock.PreConditions == nil || len(*functionBlock.PreConditions) == 0) &&
+		(functionBlock.PostConditions == nil || len(*functionBlock.PostConditions) == 0) {
 
 		checker.report(
 			&InvalidImplementationError{
-				Pos:             block.StartPos,
+				Pos:             functionBlock.StartPosition(),
 				ContainerKind:   containerKind,
 				ImplementedKind: implementedKind,
 			},

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -374,7 +374,7 @@ func TestParseDictionaryExpression(t *testing.T) {
 					Pos:       Position{Offset: 12, Line: 2, Column: 11},
 				},
 				Value: &DictionaryExpression{
-					Entries: []Entry{
+					Entries: []DictionaryEntry{
 						{
 							Key: &StringExpression{
 								Value: "a",


### PR DESCRIPTION
Work towards #210

Add JSON marshalling for:

- Block
- FunctionBlock
- Condition
- StringExpression
- IntegerExpression
- FixedPointExpression
- ArrayExpression
- DictionaryExpression
- IdentifierExpression
- PathExpression
- TransferOperation
- VariableKind
- DeclarationKind
- CompositeKind