### PR TITLE
Don't return an error when a location type is not supported

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1232,22 +1232,31 @@ func (s *Server) resolveImport(
 	program *ast.Program,
 	err error,
 ) {
+	// NOTE: important, *DON'T* return an error when a location type
+	// is not supported: the import location can simply not be resolved,
+	// no error occurred while resolving it.
+	//
+	// For example, the Crypto contract has an IdentifierLocation,
+	// and we simply return no code for it, so that the checker's
+	// import handler is called which resolves the location
+
 	var code string
 	switch loc := location.(type) {
 	case ast.StringLocation:
 		if s.resolveStringImport == nil {
-			return nil, fmt.Errorf("unable to resolve string location %s", loc)
+			return nil, nil
 		}
 		code, err = s.resolveStringImport(mainPath, loc)
+
 	case ast.AddressLocation:
 		if s.resolveAddressImport == nil {
-			return nil, fmt.Errorf("unable to resolve string location %s", loc)
+			return nil, nil
 		}
 		code, err = s.resolveAddressImport(loc)
-	default:
-		return nil, fmt.Errorf("unable to resolve address location %s", loc)
-	}
 
+	default:
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When a program imported a non-address or non-string location, for example the `Crypto` contract, which has an identifier location, the language server would fail to resolve subsequent imports.

The cause for this was the errors reported for unsupported locations when resolving imports. Just like the runtime and FVM, don't return an error for unsupported locations. Even though the identifier location cannot be resolved to a program (AST), that is not an error – it will be resolved later by the checker's import handler.

The FVM package already handles this in the same (correct) way: https://github.com/dapperlabs/flow-go/blob/456bc394e98849573301c70e69d1aae3e93f4c8e/fvm/env.go#L121-L124

Ref: https://axiomzen.slack.com/archives/CG0B7CJAJ/p1596568853498400