### PR TITLE
Improve JSON marshalling for more AST elements

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -509,6 +509,19 @@ func (e *MemberExpression) EndPosition() Position {
 	}
 }
 
+func (e *MemberExpression) MarshalJSON() ([]byte, error) {
+	type Alias MemberExpression
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "MemberExpression",
+		Range: NewRangeFromPositioned(e),
+		Alias: (*Alias)(e),
+	})
+}
+
 // IndexExpression
 
 type IndexExpression struct {
@@ -539,6 +552,17 @@ func (e *IndexExpression) String() string {
 		"%s[%s]",
 		e.TargetExpression, e.IndexingExpression,
 	)
+}
+
+func (e *IndexExpression) MarshalJSON() ([]byte, error) {
+	type Alias IndexExpression
+	return json.Marshal(&struct {
+		Type string
+		*Alias
+	}{
+		Type:  "IndexExpression",
+		Alias: (*Alias)(e),
+	})
 }
 
 // ConditionalExpression

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -330,3 +330,94 @@ func TestPathExpression_MarshalJSON(t *testing.T) {
 		string(actual),
 	)
 }
+
+func TestMemberExpression_MarshalJSON(t *testing.T) {
+
+	expr := &MemberExpression{
+		Expression: &BoolExpression{
+			Value: true,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Optional:  true,
+		AccessPos: Position{Offset: 7, Line: 8, Column: 9},
+		Identifier: Identifier{
+			Identifier: "foobar",
+			Pos:        Position{Offset: 10, Line: 11, Column: 12},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "MemberExpression",
+            "Expression": {
+				"Type": "BoolExpression",
+				"Value": true,
+				"StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+				"EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+			},
+		    "Optional": true,
+            "AccessPos": {"Offset": 7, "Line": 8, "Column": 9},
+            "Identifier": {
+                "Identifier": "foobar",
+                "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+                "EndPos": {"Offset": 15, "Line": 11, "Column": 17}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 15, "Line": 11, "Column": 17}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestIndexExpression_MarshalJSON(t *testing.T) {
+
+	expr := &IndexExpression{
+		TargetExpression: &BoolExpression{
+			Value: true,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		IndexingExpression: &NilExpression{
+			Pos: Position{Offset: 7, Line: 8, Column: 9},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 10, Line: 11, Column: 12},
+			EndPos:   Position{Offset: 13, Line: 14, Column: 15},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "IndexExpression",
+            "TargetExpression": {
+				"Type": "BoolExpression",
+				"Value": true,
+				"StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+				"EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+			},
+		    "IndexingExpression": {
+				"Type": "NilExpression",
+				"StartPos": {"Offset": 7, "Line": 8, "Column": 9}, 
+				"EndPos": {"Offset": 9, "Line": 8, "Column": 11}
+			},
+            "StartPos": {"Offset": 10, "Line": 11, "Column": 12}, 
+            "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+        }
+        `,
+		string(actual),
+	)
+}

--- a/runtime/ast/operation.go
+++ b/runtime/ast/operation.go
@@ -19,6 +19,8 @@
 package ast
 
 import (
+	"encoding/json"
+
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -53,6 +55,10 @@ const (
 	OperationBitwiseLeftShift
 	OperationBitwiseRightShift
 )
+
+func OperationCount() int {
+	return len(_Operation_index) - 1
+}
 
 func (s Operation) Symbol() string {
 	switch s {
@@ -107,4 +113,8 @@ func (s Operation) Symbol() string {
 	}
 
 	panic(errors.NewUnreachableError())
+}
+
+func (s Operation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
 }

--- a/runtime/ast/operation_test.go
+++ b/runtime/ast/operation_test.go
@@ -1,0 +1,38 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperation_MarshalJSON(t *testing.T) {
+
+	for operation := Operation(0); operation < Operation(OperationCount()); operation++ {
+		actual, err := json.Marshal(operation)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, fmt.Sprintf(`"%s"`, operation), string(actual))
+	}
+}

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -40,6 +40,17 @@ func (s *ReturnStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitReturnStatement(s)
 }
 
+func (s *ReturnStatement) MarshalJSON() ([]byte, error) {
+	type Alias ReturnStatement
+	return json.Marshal(&struct {
+		Type string
+		*Alias
+	}{
+		Type:  "ReturnStatement",
+		Alias: (*Alias)(s),
+	})
+}
+
 // BreakStatement
 
 type BreakStatement struct {
@@ -50,6 +61,17 @@ func (*BreakStatement) isStatement() {}
 
 func (s *BreakStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitBreakStatement(s)
+}
+
+func (s *BreakStatement) MarshalJSON() ([]byte, error) {
+	type Alias BreakStatement
+	return json.Marshal(&struct {
+		Type string
+		*Alias
+	}{
+		Type:  "BreakStatement",
+		Alias: (*Alias)(s),
+	})
 }
 
 // ContinueStatement
@@ -64,6 +86,17 @@ func (s *ContinueStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitContinueStatement(s)
 }
 
+func (s *ContinueStatement) MarshalJSON() ([]byte, error) {
+	type Alias ContinueStatement
+	return json.Marshal(&struct {
+		Type string
+		*Alias
+	}{
+		Type:  "ContinueStatement",
+		Alias: (*Alias)(s),
+	})
+}
+
 // IfStatementTest
 
 type IfStatementTest interface {
@@ -76,7 +109,7 @@ type IfStatement struct {
 	Test     IfStatementTest
 	Then     *Block
 	Else     *Block
-	StartPos Position
+	StartPos Position `json:"-"`
 }
 
 func (s *IfStatement) StartPosition() Position {
@@ -96,12 +129,25 @@ func (s *IfStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitIfStatement(s)
 }
 
+func (s *IfStatement) MarshalJSON() ([]byte, error) {
+	type Alias IfStatement
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "IfStatement",
+		Range: NewRangeFromPositioned(s),
+		Alias: (*Alias)(s),
+	})
+}
+
 // WhileStatement
 
 type WhileStatement struct {
 	Test     Expression
 	Block    *Block
-	StartPos Position
+	StartPos Position `json:"-"`
 }
 
 func (*WhileStatement) isStatement() {}
@@ -118,13 +164,26 @@ func (s *WhileStatement) EndPosition() Position {
 	return s.Block.EndPosition()
 }
 
+func (s *WhileStatement) MarshalJSON() ([]byte, error) {
+	type Alias WhileStatement
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "WhileStatement",
+		Range: NewRangeFromPositioned(s),
+		Alias: (*Alias)(s),
+	})
+}
+
 // ForStatement
 
 type ForStatement struct {
 	Identifier Identifier
 	Value      Expression
 	Block      *Block
-	StartPos   Position
+	StartPos   Position `json:"-"`
 }
 
 func (*ForStatement) isStatement() {}
@@ -139,6 +198,19 @@ func (s *ForStatement) StartPosition() Position {
 
 func (s *ForStatement) EndPosition() Position {
 	return s.Block.EndPosition()
+}
+
+func (s *ForStatement) MarshalJSON() ([]byte, error) {
+	type Alias ForStatement
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "ForStatement",
+		Range: NewRangeFromPositioned(s),
+		Alias: (*Alias)(s),
+	})
 }
 
 // EmitStatement

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -58,3 +58,251 @@ func TestExpressionStatement_MarshalJSON(t *testing.T) {
 		string(actual),
 	)
 }
+
+func TestReturnStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &ReturnStatement{
+		Expression: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 7, Line: 8, Column: 9},
+			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+		},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ReturnStatement",
+            "Expression": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+            "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestBreakStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &BreakStatement{
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "BreakStatement",
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestContinueStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &ContinueStatement{
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ContinueStatement",
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestIfStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &IfStatement{
+		Test: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Then: &Block{
+			Statements: []Statement{},
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+		},
+		Else: &Block{
+			Statements: []Statement{},
+			Range: Range{
+				StartPos: Position{Offset: 13, Line: 14, Column: 15},
+				EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+			},
+		},
+		StartPos: Position{Offset: 19, Line: 20, Column: 21},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "IfStatement",
+            "Test": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "Then": {
+                "Type": "Block",
+                "Statements": [],
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+            },
+            "Else": {
+                "Type": "Block",
+                "Statements": [],
+                "StartPos": {"Offset": 13, "Line": 14, "Column": 15},
+                "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+            },
+            "StartPos": {"Offset": 19, "Line": 20, "Column": 21},
+            "EndPos":   {"Offset": 16, "Line": 17, "Column": 18}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestWhileStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &WhileStatement{
+		Test: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Block: &Block{
+			Statements: []Statement{},
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+		},
+		StartPos: Position{Offset: 13, Line: 14, Column: 15},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "WhileStatement",
+            "Test": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "Block": {
+                "Type": "Block",
+                "Statements": [],
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+            },
+            "StartPos": {"Offset": 13, "Line": 14, "Column": 15},
+            "EndPos":   {"Offset": 10, "Line": 11, "Column": 12}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestForStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &ForStatement{
+		Identifier: Identifier{
+			Identifier: "foobar",
+			Pos:        Position{Offset: 1, Line: 2, Column: 3},
+		},
+		Value: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 4, Line: 5, Column: 6},
+				EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+			},
+		},
+		Block: &Block{
+			Statements: []Statement{},
+			Range: Range{
+				StartPos: Position{Offset: 10, Line: 11, Column: 12},
+				EndPos:   Position{Offset: 13, Line: 14, Column: 15},
+			},
+		},
+		StartPos: Position{Offset: 16, Line: 17, Column: 18},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ForStatement",
+            "Identifier": {
+                "Identifier": "foobar",
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "Value": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                "EndPos": {"Offset": 7, "Line": 8, "Column": 9}
+            },
+            "Block": {
+                "Type": "Block",
+                "Statements": [],
+                "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+                "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+            },
+            "StartPos": {"Offset": 16, "Line": 17, "Column": 18},
+            "EndPos":  {"Offset": 13, "Line": 14, "Column": 15}
+        }
+        `,
+		string(actual),
+	)
+}

--- a/runtime/ast/transfer.go
+++ b/runtime/ast/transfer.go
@@ -18,12 +18,16 @@
 
 package ast
 
+import (
+	"encoding/json"
+)
+
 // Transfer represents the operation in variable declarations
 // and assignments
 //
 type Transfer struct {
 	Operation TransferOperation
-	Pos       Position
+	Pos       Position `json:"-"`
 }
 
 func (f Transfer) StartPosition() Position {
@@ -33,4 +37,17 @@ func (f Transfer) StartPosition() Position {
 func (f Transfer) EndPosition() Position {
 	length := len(f.Operation.Operator())
 	return f.Pos.Shifted(length - 1)
+}
+
+func (f Transfer) MarshalJSON() ([]byte, error) {
+	type Alias Transfer
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "Transfer",
+		Range: NewRangeFromPositioned(f),
+		Alias: (*Alias)(&f),
+	})
 }

--- a/runtime/ast/transfer_test.go
+++ b/runtime/ast/transfer_test.go
@@ -1,0 +1,50 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransfer_MarshalJSON(t *testing.T) {
+
+	expr := Transfer{
+		Operation: TransferOperationMove,
+		Pos:       Position{Offset: 1, Line: 2, Column: 3},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "Transfer",
+            "Operation": "TransferOperationMove",
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+        }
+        `,
+		string(actual),
+	)
+}


### PR DESCRIPTION
Work towards #210

Add JSON marshalling for:

- MemberExpression
- IndexExpression
- Operation
- ReturnStatement
- ReturnStatement
- BreakStatement
- ContinueStatement
- IfStatement
- WhileStatement
- ForStatement
- Transfer