### PR TITLE
Add `map` function for optionals

### DIFF
--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1911,7 +1911,7 @@ type InvalidResourceArrayMemberError struct {
 
 func (e *InvalidResourceArrayMemberError) Error() string {
 	return fmt.Sprintf(
-		"array %s `%s` is not available for resource arrays",
+		"%s `%s` is not available for resource arrays",
 		e.DeclarationKind.Name(),
 		e.Name,
 	)
@@ -1929,7 +1929,23 @@ type InvalidResourceDictionaryMemberError struct {
 
 func (e *InvalidResourceDictionaryMemberError) Error() string {
 	return fmt.Sprintf(
-		"dictionary %s `%s` is not available for resource dictionaries",
+		"%s `%s` is not available for resource dictionaries",
+		e.DeclarationKind.Name(),
+		e.Name,
+	)
+}
+
+// InvalidResourceOptionalMemberError
+
+type InvalidResourceOptionalMemberError struct {
+	Name            string
+	DeclarationKind common.DeclarationKind
+	ast.Range
+}
+
+func (e *InvalidResourceOptionalMemberError) Error() string {
+	return fmt.Sprintf(
+		"%s `%s` is not available for resource optionals",
 		e.DeclarationKind.Name(),
 		e.Name,
 	)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5883,8 +5883,9 @@ func (t *DictionaryType) Unify(
 		return false
 	}
 
-	return t.KeyType.Unify(otherDictionary.KeyType, typeParameters, report, outerRange) &&
-		t.ValueType.Unify(otherDictionary.ValueType, typeParameters, report, outerRange)
+	keyUnified := t.KeyType.Unify(otherDictionary.KeyType, typeParameters, report, outerRange)
+	valueUnified := t.ValueType.Unify(otherDictionary.ValueType, typeParameters, report, outerRange)
+	return keyUnified || valueUnified
 }
 
 func (t *DictionaryType) Resolve(typeParameters map[*TypeParameter]Type) Type {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -3233,6 +3233,43 @@ func TestInterpretOptionalNilValueComparison(t *testing.T) {
 	)
 }
 
+func TestInterpretOptionalMap(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("some", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t, `
+          let one: Int? = 42
+          let result = one.map(fun (v: Int): String {
+              return v.toString()
+          })
+        `)
+
+		assert.Equal(t,
+			interpreter.NewSomeValueOwningNonCopying(
+				interpreter.NewStringValue("42"),
+			),
+			inter.Globals["result"].Value,
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t, `
+          let none: Int? = nil
+          let result = none.map(fun (v: Int): String {
+              return v.toString()
+          })
+        `)
+
+		assert.Equal(t,
+			interpreter.NilValue{},
+			inter.Globals["result"].Value,
+		)
+	})
+}
+
 func TestInterpretCompositeNilEquality(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
- Implement type unification and type parameter resolution for function types
- Add a `map` function to optionals. This allows e.g.:

  ```swift
  let answer: Int? = 42
  let result = answer.map(fun (_ value: Int): String {
      return value.toString()
  })
  ```

cc @orodio 