### PR TITLE
Improve JSON marshalling for more AST elements 

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -599,12 +599,25 @@ func (e *ConditionalExpression) EndPosition() Position {
 	return e.Else.EndPosition()
 }
 
+func (e *ConditionalExpression) MarshalJSON() ([]byte, error) {
+	type Alias ConditionalExpression
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "ConditionalExpression",
+		Range: NewRangeFromPositioned(e),
+		Alias: (*Alias)(e),
+	})
+}
+
 // UnaryExpression
 
 type UnaryExpression struct {
 	Operation  Operation
 	Expression Expression
-	StartPos   Position
+	StartPos   Position `json:"-"`
 }
 
 func (*UnaryExpression) isExpression() {}
@@ -632,6 +645,19 @@ func (e *UnaryExpression) StartPosition() Position {
 
 func (e *UnaryExpression) EndPosition() Position {
 	return e.Expression.EndPosition()
+}
+
+func (e *UnaryExpression) MarshalJSON() ([]byte, error) {
+	type Alias UnaryExpression
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "UnaryExpression",
+		Range: NewRangeFromPositioned(e),
+		Alias: (*Alias)(e),
+	})
 }
 
 // BinaryExpression
@@ -667,6 +693,19 @@ func (e *BinaryExpression) StartPosition() Position {
 
 func (e *BinaryExpression) EndPosition() Position {
 	return e.Right.EndPosition()
+}
+
+func (e *BinaryExpression) MarshalJSON() ([]byte, error) {
+	type Alias BinaryExpression
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "BinaryExpression",
+		Range: NewRangeFromPositioned(e),
+		Alias: (*Alias)(e),
+	})
 }
 
 // FunctionExpression
@@ -777,7 +816,7 @@ func (e *CreateExpression) EndPosition() Position {
 
 type DestroyExpression struct {
 	Expression Expression
-	StartPos   Position
+	StartPos   Position `json:"-"`
 }
 
 func (*DestroyExpression) isExpression() {}
@@ -805,6 +844,19 @@ func (e *DestroyExpression) StartPosition() Position {
 
 func (e *DestroyExpression) EndPosition() Position {
 	return e.Expression.EndPosition()
+}
+
+func (e *DestroyExpression) MarshalJSON() ([]byte, error) {
+	type Alias DestroyExpression
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "DestroyExpression",
+		Range: NewRangeFromPositioned(e),
+		Alias: (*Alias)(e),
+	})
 }
 
 // ReferenceExpression
@@ -847,7 +899,7 @@ func (e *ReferenceExpression) EndPosition() Position {
 
 type ForceExpression struct {
 	Expression Expression
-	EndPos     Position
+	EndPos     Position `json:"-"`
 }
 
 func (*ForceExpression) isExpression() {}
@@ -872,6 +924,19 @@ func (e *ForceExpression) StartPosition() Position {
 
 func (e *ForceExpression) EndPosition() Position {
 	return e.EndPos
+}
+
+func (e *ForceExpression) MarshalJSON() ([]byte, error) {
+	type Alias ForceExpression
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "ForceExpression",
+		Range: NewRangeFromPositioned(e),
+		Alias: (*Alias)(e),
+	})
 }
 
 // PathExpression

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -45,7 +45,7 @@ func TestBoolExpression_MarshalJSON(t *testing.T) {
         {
             "Type": "BoolExpression",
             "Value": false,
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
         }
         `,
@@ -66,7 +66,7 @@ func TestNilExpression_MarshalJSON(t *testing.T) {
 		`
         {
             "Type": "NilExpression",
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 3, "Line": 2, "Column": 5}
         }
         `,
@@ -92,7 +92,7 @@ func TestStringExpression_MarshalJSON(t *testing.T) {
         {
             "Type": "StringExpression",
             "Value": "Hello, World!",
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
         }
         `,
@@ -120,7 +120,7 @@ func TestIntegerExpression_MarshalJSON(t *testing.T) {
             "Type": "IntegerExpression",
             "Value": "42",
             "Base": 10,
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
         }
         `,
@@ -152,7 +152,7 @@ func TestFixedPointExpression_MarshalJSON(t *testing.T) {
             "UnsignedInteger": "42",
             "Fractional": "24",
             "Scale": 10,
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
         }
         `,
@@ -192,16 +192,16 @@ func TestArrayExpression_MarshalJSON(t *testing.T) {
                 {
                     "Type": "BoolExpression",
                     "Value": true,
-                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
                     "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
                 },
                 {
                     "Type": "NilExpression",
-                    "StartPos": {"Offset": 7, "Line": 8, "Column": 9}, 
+                    "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
                     "EndPos": {"Offset": 9, "Line": 8, "Column": 11}
                 }
             ],
-            "StartPos": {"Offset": 10, "Line": 11, "Column": 12}, 
+            "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
             "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
         }
         `,
@@ -245,17 +245,17 @@ func TestDictionaryExpression_MarshalJSON(t *testing.T) {
                     "Key": {
                         "Type": "BoolExpression",
                         "Value": true,
-                        "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                        "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
                         "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
                     },
                     "Value": {
                         "Type": "NilExpression",
-                        "StartPos": {"Offset": 7, "Line": 8, "Column": 9}, 
+                        "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
                         "EndPos": {"Offset": 9, "Line": 8, "Column": 11}
                     }
                 }
             ],
-            "StartPos": {"Offset": 10, "Line": 11, "Column": 12}, 
+            "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
             "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
         }
         `,
@@ -281,10 +281,10 @@ func TestIdentifierExpression_MarshalJSON(t *testing.T) {
             "Type": "IdentifierExpression",
             "Identifier": {
                 "Identifier": "foobar",
-                "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
                 "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
             },
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
         }
         `,
@@ -323,7 +323,7 @@ func TestPathExpression_MarshalJSON(t *testing.T) {
                 "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
                 "EndPos": {"Offset": 12, "Line": 8, "Column": 14}
             },
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 12, "Line": 8, "Column": 14}
         }
         `,
@@ -359,7 +359,7 @@ func TestMemberExpression_MarshalJSON(t *testing.T) {
             "Expression": {
 				"Type": "BoolExpression",
 				"Value": true,
-				"StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+				"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
 				"EndPos": {"Offset": 4, "Line": 5, "Column": 6}
 			},
 		    "Optional": true,
@@ -369,7 +369,7 @@ func TestMemberExpression_MarshalJSON(t *testing.T) {
                 "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
                 "EndPos": {"Offset": 15, "Line": 11, "Column": 17}
             },
-            "StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 15, "Line": 11, "Column": 17}
         }
         `,
@@ -406,16 +406,243 @@ func TestIndexExpression_MarshalJSON(t *testing.T) {
             "TargetExpression": {
 				"Type": "BoolExpression",
 				"Value": true,
-				"StartPos": {"Offset": 1, "Line": 2, "Column": 3}, 
+				"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
 				"EndPos": {"Offset": 4, "Line": 5, "Column": 6}
 			},
 		    "IndexingExpression": {
 				"Type": "NilExpression",
-				"StartPos": {"Offset": 7, "Line": 8, "Column": 9}, 
+				"StartPos": {"Offset": 7, "Line": 8, "Column": 9},
 				"EndPos": {"Offset": 9, "Line": 8, "Column": 11}
 			},
-            "StartPos": {"Offset": 10, "Line": 11, "Column": 12}, 
+            "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
             "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestUnaryExpression_MarshalJSON(t *testing.T) {
+
+	expr := &UnaryExpression{
+		Operation: OperationNegate,
+		Expression: &IntegerExpression{
+			Value: big.NewInt(42),
+			Base:  10,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		StartPos: Position{Offset: 7, Line: 8, Column: 9},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "UnaryExpression",
+            "Operation": "OperationNegate",
+            "Expression": {
+                "Type": "IntegerExpression",
+                "Value": "42",
+                "Base": 10,
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestBinaryExpression_MarshalJSON(t *testing.T) {
+
+	expr := &BinaryExpression{
+		Operation: OperationPlus,
+		Left: &IntegerExpression{
+			Value: big.NewInt(42),
+			Base:  10,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Right: &IntegerExpression{
+			Value: big.NewInt(99),
+			Base:  10,
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "BinaryExpression",
+            "Operation": "OperationPlus",
+            "Left": {
+                "Type": "IntegerExpression",
+                "Value": "42",
+                "Base": 10,
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "Right": {
+                "Type": "IntegerExpression",
+                "Value": "99",
+                "Base": 10,
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestDestroyExpression_MarshalJSON(t *testing.T) {
+
+	expr := &DestroyExpression{
+		Expression: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		StartPos: Position{Offset: 4, Line: 5, Column: 6},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "DestroyExpression",
+            "Expression": {
+                "Type": "IdentifierExpression",
+                "Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+            "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestForceExpression_MarshalJSON(t *testing.T) {
+
+	expr := &ForceExpression{
+		Expression: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		EndPos: Position{Offset: 4, Line: 5, Column: 6},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ForceExpression",
+            "Expression": {
+                "Type": "IdentifierExpression",
+                "Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestConditionalExpression_MarshalJSON(t *testing.T) {
+
+	expr := &ConditionalExpression{
+		Test: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Then: &IntegerExpression{
+			Value: big.NewInt(42),
+			Base:  10,
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+		},
+		Else: &IntegerExpression{
+			Value: big.NewInt(99),
+			Base:  10,
+			Range: Range{
+				StartPos: Position{Offset: 13, Line: 14, Column: 15},
+				EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+			},
+		},
+	}
+
+	actual, err := json.Marshal(expr)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ConditionalExpression",
+            "Test": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "Then": {
+                "Type": "IntegerExpression",
+                "Value": "42",
+                "Base": 10,
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+            },
+            "Else": {
+                "Type": "IntegerExpression",
+                "Value": "99",
+                "Base": 10,
+                "StartPos": {"Offset": 13, "Line": 14, "Column": 15},
+                "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
         }
         `,
 		string(actual),

--- a/runtime/ast/import.go
+++ b/runtime/ast/import.go
@@ -149,6 +149,16 @@ func (l IdentifierLocation) ID() LocationID {
 	return NewLocationID(IdentifierLocationPrefix, string(l))
 }
 
+func (l IdentifierLocation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type       string
+		Identifier string
+	}{
+		Type:       "IdentifierLocation",
+		Identifier: string(l),
+	})
+}
+
 // StringLocation
 
 const StringLocationPrefix = "S"
@@ -157,6 +167,16 @@ type StringLocation string
 
 func (l StringLocation) ID() LocationID {
 	return NewLocationID(StringLocationPrefix, string(l))
+}
+
+func (l StringLocation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type   string
+		String string
+	}{
+		Type:   "StringLocation",
+		String: string(l),
+	})
 }
 
 // AddressLocation
@@ -175,6 +195,16 @@ func (l AddressLocation) ID() LocationID {
 
 func (l AddressLocation) ToAddress() common.Address {
 	return common.BytesToAddress(l)
+}
+
+func (l AddressLocation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type    string
+		Address string
+	}{
+		Type:    "AddressLocation",
+		Address: l.ToAddress().ShortHexWithPrefix(),
+	})
 }
 
 // HasImportLocation

--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -1,0 +1,81 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentifierLocation_MarshalJSON(t *testing.T) {
+
+	loc := IdentifierLocation("test")
+
+	actual, err := json.Marshal(loc)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "IdentifierLocation",
+            "Identifier": "test"
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestStringLocation_MarshalJSON(t *testing.T) {
+
+	loc := StringLocation("test")
+
+	actual, err := json.Marshal(loc)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "StringLocation",
+            "String": "test"
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestAddressLocation_MarshalJSON(t *testing.T) {
+
+	loc := AddressLocation([]byte{1})
+
+	actual, err := json.Marshal(loc)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "AddressLocation",
+            "Address": "0x1"
+        }
+        `,
+		string(actual),
+	)
+}

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -256,6 +256,19 @@ func (s *AssignmentStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitAssignmentStatement(s)
 }
 
+func (s *AssignmentStatement) MarshalJSON() ([]byte, error) {
+	type Alias AssignmentStatement
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "AssignmentStatement",
+		Range: NewRangeFromPositioned(s),
+		Alias: (*Alias)(s),
+	})
+}
+
 // SwapStatement
 
 type SwapStatement struct {
@@ -275,6 +288,19 @@ func (*SwapStatement) isStatement() {}
 
 func (s *SwapStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitSwapStatement(s)
+}
+
+func (s *SwapStatement) MarshalJSON() ([]byte, error) {
+	type Alias SwapStatement
+	return json.Marshal(&struct {
+		Type string
+		Range
+		*Alias
+	}{
+		Type:  "SwapStatement",
+		Range: NewRangeFromPositioned(s),
+		Alias: (*Alias)(s),
+	})
 }
 
 // ExpressionStatement

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -306,3 +306,111 @@ func TestForStatement_MarshalJSON(t *testing.T) {
 		string(actual),
 	)
 }
+
+func TestAssignmentStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &AssignmentStatement{
+		Target: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Transfer: &Transfer{
+			Operation: TransferOperationCopy,
+			Pos:       Position{Offset: 4, Line: 5, Column: 6},
+		},
+		Value: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+		},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "AssignmentStatement",
+            "Target": {
+			    "Type": "IdentifierExpression",
+				"Identifier": {
+					"Identifier": "foobar",
+					"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+					"EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+				},
+				"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+				"EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+			},
+            "Transfer": {
+                "Type": "Transfer",
+                "Operation": "TransferOperationCopy",
+                "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+            },
+            "Value": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+            }, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos":  {"Offset": 10, "Line": 11, "Column": 12}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestSwapStatement_MarshalJSON(t *testing.T) {
+
+	stmt := &SwapStatement{
+		Left: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Right: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 4, Line: 5, Column: 6},
+				EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+			},
+		},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "SwapStatement",
+            "Left": {
+			    "Type": "IdentifierExpression",
+				"Identifier": {
+					"Identifier": "foobar",
+					"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+					"EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+				},
+				"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+				"EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+			},
+            "Right": {
+                "Type": "BoolExpression",
+                "Value": false,
+                "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                "EndPos": {"Offset": 7, "Line": 8, "Column": 9}
+            }, 
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos":   {"Offset": 7, "Line": 8, "Column": 9}
+        }
+        `,
+		string(actual),
+	)
+}

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -1,0 +1,416 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeAnnotation_MarshalJSON(t *testing.T) {
+
+	ty := &TypeAnnotation{
+		IsResource: true,
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		StartPos: Position{Offset: 4, Line: 5, Column: 6},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "TypeAnnotation",
+            "IsResource": true,
+            "AnnotatedType": {
+                "Type": "NominalType",
+                "Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+            "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestNominalType_MarshalJSON(t *testing.T) {
+
+	ty := &NominalType{
+		Identifier: Identifier{
+			Identifier: "foobar",
+			Pos:        Position{Offset: 1, Line: 2, Column: 3},
+		},
+		NestedIdentifiers: []Identifier{
+			{
+				Identifier: "baz",
+				Pos:        Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "NominalType",
+            "Identifier": {
+                "Identifier": "foobar",
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "NestedIdentifiers": [
+                {
+                    "Identifier": "baz",
+                    "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                    "EndPos": {"Offset": 6, "Line": 5, "Column": 8}
+                }
+            ],
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 6, "Line": 5, "Column": 8}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestOptionalType_MarshalJSON(t *testing.T) {
+
+	ty := &OptionalType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		EndPos: Position{Offset: 4, Line: 5, Column: 6},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "OptionalType",
+            "ElementType": {
+                "Type": "NominalType",
+                "Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+            "EndPos": {"Offset": 4, "Line": 5, "Column": 6}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestVariableSizedType_MarshalJSON(t *testing.T) {
+
+	ty := &VariableSizedType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 4, Line: 5, Column: 6},
+			EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+		},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "VariableSizedType",
+            "ElementType": {
+                "Type": "NominalType",
+                "Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+            "EndPos":  {"Offset": 7, "Line": 8, "Column": 9}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestConstantSizedType_MarshalJSON(t *testing.T) {
+
+	ty := &ConstantSizedType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Size: &IntegerExpression{
+			Value: big.NewInt(42),
+			Base:  10,
+			Range: Range{
+				StartPos: Position{Offset: 4, Line: 5, Column: 6},
+				EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 10, Line: 11, Column: 12},
+			EndPos:   Position{Offset: 13, Line: 14, Column: 15},
+		},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ConstantSizedType",
+            "ElementType": {
+                "Type": "NominalType",
+                "Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            },
+            "Size": {
+                "Type": "IntegerExpression",
+                "Value": "42",
+                "Base": 10,
+                "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                "EndPos": {"Offset": 7, "Line": 8, "Column": 9}
+            },
+            "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+            "EndPos":  {"Offset": 13, "Line": 14, "Column": 15}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestDictionaryType_MarshalJSON(t *testing.T) {
+
+	ty := &DictionaryType{
+		KeyType: &NominalType{
+			Identifier: Identifier{
+				Identifier: "AB",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		ValueType: &NominalType{
+			Identifier: Identifier{
+				Identifier: "CD",
+				Pos:        Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 7, Line: 8, Column: 9},
+			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+		},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "DictionaryType",
+            "KeyType": {
+                "Type": "NominalType",
+                "Identifier": {
+                    "Identifier": "AB",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+            },
+            "ValueType": {
+                "Type": "NominalType",
+                "Identifier": {
+                    "Identifier": "CD",
+                    "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                    "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
+                },
+                "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
+            },
+            "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+            "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestFunctionType_MarshalJSON(t *testing.T) {
+
+	ty := &FunctionType{
+		ParameterTypeAnnotations: []*TypeAnnotation{
+			{
+				IsResource: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "AB",
+						Pos:        Position{Offset: 1, Line: 2, Column: 3},
+					},
+				},
+				StartPos: Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		ReturnTypeAnnotation: &TypeAnnotation{
+			IsResource: true,
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "CD",
+					Pos:        Position{Offset: 7, Line: 8, Column: 9},
+				},
+			},
+			StartPos: Position{Offset: 10, Line: 11, Column: 12},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 13, Line: 14, Column: 15},
+			EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+		},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "FunctionType",
+            "ParameterTypeAnnotations": [
+                {
+                    "Type": "TypeAnnotation",
+                    "IsResource": true,
+                    "AnnotatedType": {
+                        "Type": "NominalType",
+                        "Identifier": {
+                            "Identifier": "AB",
+                            "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                            "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+                        },
+                        "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                        "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+                    },
+                    "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                    "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+                }
+           ],
+           "ReturnTypeAnnotation": {
+               "Type": "TypeAnnotation",
+               "IsResource": true,
+               "AnnotatedType": {
+                   "Type": "NominalType",
+                   "Identifier": {
+                       "Identifier": "CD",
+                       "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                       "EndPos": {"Offset": 8, "Line": 8, "Column": 10}
+                   },
+                   "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                   "EndPos": {"Offset": 8, "Line": 8, "Column": 10}
+               },
+               "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+               "EndPos": {"Offset": 8, "Line": 8, "Column": 10}
+           },
+           "StartPos": {"Offset": 13, "Line": 14, "Column": 15},
+           "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestReferenceType_MarshalJSON(t *testing.T) {
+
+	ty := &ReferenceType{
+		Authorized: true,
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "AB",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		StartPos: Position{Offset: 4, Line: 5, Column: 6},
+	}
+
+	actual, err := json.Marshal(ty)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "ReferenceType",
+            "Authorized": true,
+            "ReferencedType": {
+                "Type": "NominalType",
+                "Identifier": {
+                    "Identifier": "AB",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+            },
+            "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+            "EndPos": {"Offset": 2, "Line": 2, "Column": 4}
+        }
+        `,
+		string(actual),
+	)
+}

--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 )
 
 const AddressLength = 8
@@ -66,4 +67,9 @@ func (a Address) Bytes() []byte {
 	}
 
 	return a[leadingZeros:]
+}
+
+func (a Address) ShortHexWithPrefix() string {
+	hexString := fmt.Sprintf("%x", [AddressLength]byte(a))
+	return fmt.Sprintf("0x%s", strings.TrimLeft(hexString, "0"))
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6233,8 +6233,7 @@ func (v AddressValue) KeyString() string {
 }
 
 func (v AddressValue) String() string {
-	hexString := fmt.Sprintf("%x", [common.AddressLength]byte(v))
-	return fmt.Sprintf("0x%s", strings.TrimLeft(hexString, "0"))
+	return common.Address(v).ShortHexWithPrefix()
 }
 
 func (AddressValue) GetOwner() *common.Address {


### PR DESCRIPTION
Work towards #210

Add JSON marshalling for:
- Expressions:
  - ConditionalExpression
  - UnaryExpression
  - BinaryExpression
  - DestroyExpression
  - ForceExpression
- Locations:
  - IdentifierLocation
  - StringLocation
  - AddressLocation
- Statements:
  - AssignmentStatement
  - SwapStatement
- Types:
  - TypeAnnotation
  - NominalType
  - OptionalType
  - VariableSizedType
  - ConstantSizedType
  - DictionaryType
  - FunctionType
  - ReferenceType
