### PR TITLE
Language Server: Make the features requiring a Flow client connection optional

### DIFF
--- a/languageserver/cmd/languageserver/main.go
+++ b/languageserver/cmd/languageserver/main.go
@@ -21,9 +21,14 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/onflow/cadence/languageserver"
 )
 
+var enableFlowClientFlag = flag.Bool("enableFlowClient", true, "enable Flow client functionality")
+
 func main() {
-	languageserver.RunWithStdio()
+	flag.Parse()
+	languageserver.RunWithStdio(*enableFlowClientFlag)
 }

--- a/languageserver/languageserver.go
+++ b/languageserver/languageserver.go
@@ -28,7 +28,7 @@ import (
 	"github.com/onflow/cadence/languageserver/server"
 )
 
-func RunWithStdio() {
+func RunWithStdio(enableFlowClient bool) {
 	if isatty.IsTerminal(os.Stdout.Fd()) {
 		print(
 			"This program implements the Language Server Protocol for Cadence.\n" +
@@ -40,7 +40,7 @@ func RunWithStdio() {
 
 	languageServer := server.NewServer()
 
-	_, err := integration.NewFlowIntegration(languageServer)
+	_, err := integration.NewFlowIntegration(languageServer, enableFlowClient)
 	if err != nil {
 		panic(err)
 	}

--- a/languageserver/run.sh
+++ b/languageserver/run.sh
@@ -2,4 +2,4 @@
 
 SCRIPTPATH=$(dirname "$0")
 
-(cd "$SCRIPTPATH" && go run ./cmd/languageserver/main.go)
+(cd "$SCRIPTPATH" && /usr/local/bin/go run ./cmd/languageserver/main.go "$@")


### PR DESCRIPTION
Some clients don't support or make it difficult to send initialization options, which are required to initialize the Flow client.

Instead of requiring the options and always initializing a client, make it optional by adding a flag