### PR TITLE
Treat carriage returns as space

### DIFF
--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -275,7 +275,7 @@ func (l *lexer) scanSpace() (containsNewline bool) {
 	// parse more, if any
 	l.acceptWhile(func(r rune) bool {
 		switch r {
-		case ' ', '\t':
+		case ' ', '\t', '\r':
 			return true
 		case '\n':
 			containsNewline = true

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -104,7 +104,7 @@ func rootState(l *lexer) stateFn {
 			}
 		case '_':
 			return identifierState
-		case ' ', '\t':
+		case ' ', '\t', '\r':
 			return spaceState(false)
 		case '\n':
 			return spaceState(true)


### PR DESCRIPTION
On *nix systems line breaks are line feeds (LF). 
On Windows, line breaks are carriage return (CR) + LF.
Consider CR as space.