### PR TITLE
Make reference types non-storable

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5885,8 +5885,7 @@ func (t *ReferenceType) IsInvalidType() bool {
 }
 
 func (t *ReferenceType) IsStorable(_ map[*Member]bool) bool {
-	// TODO: https://github.com/onflow/cadence/issues/189
-	return true
+	return false
 }
 
 func (*ReferenceType) IsEquatable() bool {

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -98,9 +98,6 @@ func TestCheckStorable(t *testing.T) {
 		&sema.AnyStructType{},
 		&sema.AnyResourceType{},
 		&sema.CapabilityType{},
-		// TODO: move to non-storable
-		//   see https://github.com/onflow/cadence/issues/189
-		&sema.ReferenceType{Type: &sema.BoolType{}},
 	)
 
 	for _, storableType := range storableTypes {
@@ -149,6 +146,7 @@ func TestCheckStorable(t *testing.T) {
 		&sema.VoidType{},
 		&sema.AuthAccountType{},
 		&sema.PublicAccountType{},
+		&sema.ReferenceType{Type: &sema.BoolType{}},
 	}
 
 	for _, nonStorableType := range nonStorableTypes[:] {
@@ -242,7 +240,7 @@ func TestCheckStorable(t *testing.T) {
 					// If the tested type is a resource, it also needs a destructor.
 
 					initializer = fmt.Sprintf(
-						` 
+						`
                               init(value: %[1]s%[2]s) {
                                   self.value %[3]s value
                               }
@@ -253,7 +251,7 @@ func TestCheckStorable(t *testing.T) {
 					)
 
 					if isResource {
-						destructor = ` 
+						destructor = `
                               destroy() {
                                   destroy self.value
                               }


### PR DESCRIPTION
Closes #189.

## Description

Make reference types non-storable, update `storable_test.go` assertions.

Testing with the compatibility suite: 
```
2020-08-10 14:48:49,334 INFO Building parse
2020-08-10 14:48:50,364 INFO Building check
2020-08-10 14:48:50,998 INFO Cloning https://github.com/onflow/flow-ft.git (master)
Cloning into '/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft'...
remote: Enumerating objects: 44, done.
remote: Counting objects: 100% (44/44), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 341 (delta 30), reused 29 (delta 25), pack-reused 297
Receiving objects: 100% (341/341), 255.06 KiB | 1.39 MiB/s, done.
Resolving deltas: 100% (188/188), done.
2020-08-10 14:48:52,006 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/FungibleToken.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/FungibleToken.cdc
2020-08-10 14:48:52,173 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/FungibleToken.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/FungibleToken.cdc
2020-08-10 14:48:52,341 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/TokenForwarding.cdc
2020-08-10 14:48:52,342 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/TokenForwarding.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/TokenForwarding.cdc
2020-08-10 14:48:52,364 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/TokenForwarding.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/TokenForwarding.cdc
2020-08-10 14:48:52,391 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/ExampleToken.cdc
2020-08-10 14:48:52,392 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/ExampleToken.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/ExampleToken.cdc
2020-08-10 14:48:52,414 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/ExampleToken.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/contracts/ExampleToken.cdc
2020-08-10 14:48:52,450 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/transfer_tokens.cdc
2020-08-10 14:48:52,451 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/transfer_tokens.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/transfer_tokens.cdc
2020-08-10 14:48:52,472 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/transfer_tokens.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/transfer_tokens.cdc
2020-08-10 14:48:52,502 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/setup_account.cdc
2020-08-10 14:48:52,503 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/setup_account.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/setup_account.cdc
2020-08-10 14:48:52,521 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/setup_account.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/setup_account.cdc
2020-08-10 14:48:52,554 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/mint_tokens.cdc
2020-08-10 14:48:52,555 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/mint_tokens.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/mint_tokens.cdc
2020-08-10 14:48:52,582 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/mint_tokens.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/mint_tokens.cdc
2020-08-10 14:48:52,623 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/burn_tokens.cdc
2020-08-10 14:48:52,624 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/burn_tokens.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/burn_tokens.cdc
2020-08-10 14:48:52,645 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/burn_tokens.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-ft/transactions/burn_tokens.cdc
2020-08-10 14:48:52,686 INFO Cloning https://github.com/onflow/flow-nft.git (master)
Cloning into '/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft'...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 189 (delta 1), reused 2 (delta 0), pack-reused 178
Receiving objects: 100% (189/189), 226.82 KiB | 1.16 MiB/s, done.
Resolving deltas: 100% (73/73), done.
2020-08-10 14:48:53,567 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/NonFungibleToken.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/NonFungibleToken.cdc
2020-08-10 14:48:53,595 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/NonFungibleToken.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/NonFungibleToken.cdc
2020-08-10 14:48:53,618 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/ExampleNFT.cdc
2020-08-10 14:48:53,619 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/ExampleNFT.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/ExampleNFT.cdc
2020-08-10 14:48:53,647 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/ExampleNFT.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/contracts/ExampleNFT.cdc
2020-08-10 14:48:53,681 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/mint_nft.cdc
2020-08-10 14:48:53,683 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/mint_nft.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/mint_nft.cdc
2020-08-10 14:48:53,705 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/mint_nft.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/mint_nft.cdc
2020-08-10 14:48:53,735 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/setup_account.cdc
2020-08-10 14:48:53,736 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/setup_account.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/setup_account.cdc
2020-08-10 14:48:53,757 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/setup_account.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/setup_account.cdc
2020-08-10 14:48:53,784 INFO Preparing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/transfer_nft.cdc
2020-08-10 14:48:53,785 INFO Parsing /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/transfer_nft.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/transfer_nft.cdc
2020-08-10 14:48:53,806 INFO Checking /Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/transfer_nft.cdc
/Users/benjamin/repos/onflow/cadence/compat/suite/flow-nft/transactions/transfer_nft.cdc
$  echo $?
0
```