### PR TITLE
Allow import of multiple programs per address location

### DIFF
--- a/runtime/ast/program_test.go
+++ b/runtime/ast/program_test.go
@@ -20,97 +20,11 @@ package ast
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestProgram_ResolveImports(t *testing.T) {
-
-	t.Parallel()
-
-	makeImportingProgram := func(imported string) *Program {
-		return &Program{
-			Declarations: []Declaration{
-				&ImportDeclaration{
-					Location: StringLocation(imported),
-				},
-			},
-		}
-	}
-
-	a := makeImportingProgram("b")
-	b := makeImportingProgram("c")
-	c := &Program{}
-
-	err := a.ResolveImports(func(location Location) (*Program, error) {
-		switch location {
-		case StringLocation("b"):
-			return b, nil
-		case StringLocation("c"):
-			return c, nil
-		default:
-			return nil, fmt.Errorf("tried to resolve unknown import location: %s", location)
-		}
-	})
-
-	require.NoError(t, err)
-
-	importsA := a.ImportedPrograms()
-
-	actual := importsA[StringLocation("b").ID()]
-	if actual != b {
-		assert.Fail(t, "not b", actual)
-	}
-
-	importsB := b.ImportedPrograms()
-
-	actual = importsB[StringLocation("c").ID()]
-	if actual != c {
-		assert.Fail(t, "not c", actual)
-	}
-}
-
-func TestProgram_ResolveImportsCycle(t *testing.T) {
-
-	t.Parallel()
-
-	makeImportingProgram := func(imported string) *Program {
-		return &Program{
-			Declarations: []Declaration{
-				&ImportDeclaration{
-					Location: StringLocation(imported),
-				},
-			},
-		}
-	}
-
-	a := makeImportingProgram("b")
-	b := makeImportingProgram("c")
-	c := makeImportingProgram("a")
-
-	err := a.ResolveImports(func(location Location) (*Program, error) {
-		switch location {
-		case StringLocation("a"):
-			return a, nil
-		case StringLocation("b"):
-			return b, nil
-		case StringLocation("c"):
-			return c, nil
-		default:
-			return nil, fmt.Errorf("tried to resolve unknown import location: %s", location)
-		}
-	})
-
-	assert.Equal(t,
-		err,
-		CyclicImportsError{
-			Location: StringLocation("b"),
-		},
-	)
-}
 
 func TestProgram_MarshalJSON(t *testing.T) {
 
@@ -126,6 +40,7 @@ func TestProgram_MarshalJSON(t *testing.T) {
 	assert.JSONEq(t,
 		`
         {
+            "Type": "Program",
             "Declarations": []
         }
         `,

--- a/runtime/cmd/check/main.go
+++ b/runtime/cmd/check/main.go
@@ -172,8 +172,9 @@ func runPath(path string, bench bool) (res result, succeeded bool) {
 	var err error
 	var checker *sema.Checker
 	var program *ast.Program
-	var codes map[string]string
 	var must func(error)
+
+	codes := map[string]string{}
 
 	func() {
 		defer func() {
@@ -183,9 +184,9 @@ func runPath(path string, bench bool) (res result, succeeded bool) {
 			}
 		}()
 
-		program, codes, must = cmd.PrepareProgram(code, path)
+		program, must = cmd.PrepareProgram(code, path, codes)
 
-		checker, _ = cmd.PrepareChecker(program, path, must)
+		checker, _ = cmd.PrepareChecker(program, path, codes, must)
 
 		err = checker.Check()
 		if err != nil {
@@ -202,7 +203,7 @@ func runPath(path string, bench bool) (res result, succeeded bool) {
 	if bench && err == nil {
 		benchRes := testing.Benchmark(func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				checker, must = cmd.PrepareChecker(program, path, must)
+				checker, must = cmd.PrepareChecker(program, path, codes, must)
 				must(checker.Check())
 				if err != nil {
 					panic(err)

--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -133,7 +133,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	}
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(onRead, onWrite),
@@ -613,7 +613,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 	}
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(onRead, onWrite),
@@ -845,7 +845,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 	}
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(onRead, onWrite),
@@ -997,7 +997,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Removal(t *testing.T) {
 	signer := common.BytesToAddress([]byte{0x1})
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, nil),
@@ -1074,7 +1074,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Destruction(t *testing.T
 	signer := common.BytesToAddress([]byte{0x1})
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, nil),
@@ -1185,7 +1185,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Insertion(t *testing.T) 
 	signer := common.BytesToAddress([]byte{0x1})
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, nil),
@@ -1299,7 +1299,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_ValueTransferAndDestroy(
 	testStorage := newTestStorage(nil, nil)
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: testStorage,

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 const BlockHashLength = 32
@@ -36,9 +37,13 @@ type Block struct {
 	Timestamp int64
 }
 
+type ResolvedLocation = sema.ResolvedLocation
+
 type Interface interface {
-	// ResolveImport resolves an import of a program.
-	ResolveImport(Location) ([]byte, error)
+	// ResolveLocation resolves an import location.
+	ResolveLocation(identifiers []Identifier, location Location) []ResolvedLocation
+	// GetCode returns the code at a given location
+	GetCode(location Location) ([]byte, error)
 	// GetCachedProgram attempts to get a parsed program from a cache.
 	GetCachedProgram(Location) (*ast.Program, error)
 	// CacheProgram adds a parsed program to a cache.
@@ -115,7 +120,16 @@ type EmptyRuntimeInterface struct{}
 
 var _ Interface = &EmptyRuntimeInterface{}
 
-func (i *EmptyRuntimeInterface) ResolveImport(_ Location) ([]byte, error) {
+func (i *EmptyRuntimeInterface) ResolveLocation(identifiers []Identifier, location Location) []ResolvedLocation {
+	return []ResolvedLocation{
+		{
+			Location:    location,
+			Identifiers: identifiers,
+		},
+	}
+}
+
+func (i *EmptyRuntimeInterface) GetCode(_ Location) ([]byte, error) {
 	return nil, nil
 }
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3137,12 +3137,21 @@ func (interpreter *Interpreter) VisitPragmaDeclaration(_ *ast.PragmaDeclaration)
 
 func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDeclaration) ast.Repr {
 
-	location := declaration.Location
+	resolvedLocations := interpreter.Checker.Elaboration.ImportDeclarationsResolvedLocations[declaration]
+
+	for _, resolvedLocation := range resolvedLocations {
+		interpreter.importResolvedLocation(resolvedLocation)
+	}
+
+	return Done{}
+}
+
+func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.ResolvedLocation) {
 
 	subInterpreter := interpreter.ensureLoaded(
-		location,
+		resolvedLocation.Location,
 		func() Import {
-			return interpreter.importLocationHandler(interpreter, location)
+			return interpreter.importLocationHandler(interpreter, resolvedLocation.Location)
 		},
 	)
 
@@ -3150,10 +3159,10 @@ func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDe
 	// which variables need to be declared
 
 	var variables map[string]*Variable
-	identifierLength := len(declaration.Identifiers)
+	identifierLength := len(resolvedLocation.Identifiers)
 	if identifierLength > 0 {
 		variables = make(map[string]*Variable, identifierLength)
-		for _, identifier := range declaration.Identifiers {
+		for _, identifier := range resolvedLocation.Identifiers {
 			variables[identifier.Identifier] =
 				subInterpreter.Globals[identifier.Identifier]
 		}
@@ -3179,8 +3188,6 @@ func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDe
 		interpreter.setVariable(name, variable)
 		interpreter.Globals[name] = variable
 	}
-
-	return Done{}
 }
 
 func (interpreter *Interpreter) VisitTransactionDeclaration(declaration *ast.TransactionDeclaration) ast.Repr {

--- a/runtime/locations.go
+++ b/runtime/locations.go
@@ -25,18 +25,21 @@ import (
 )
 
 type (
-	Location        = ast.Location
-	LocationID      = ast.LocationID
-	StringLocation  = ast.StringLocation
-	AddressLocation = ast.AddressLocation
+	Location                = ast.Location
+	LocationID              = ast.LocationID
+	StringLocation          = ast.StringLocation
+	AddressLocation         = ast.AddressLocation
+	AddressContractLocation = ast.AddressContractLocation
+	Identifier              = ast.Identifier
 )
 
 const (
-	IdentifierLocationPrefix  = ast.IdentifierLocationPrefix
-	StringLocationPrefix      = ast.StringLocationPrefix
-	AddressLocationPrefix     = ast.AddressLocationPrefix
-	TransactionLocationPrefix = "t"
-	ScriptLocationPrefix      = "s"
+	IdentifierLocationPrefix      = ast.IdentifierLocationPrefix
+	StringLocationPrefix          = ast.StringLocationPrefix
+	AddressLocationPrefix         = ast.AddressLocationPrefix
+	AddressContractLocationPrefix = ast.AddressContractLocationPrefix
+	TransactionLocationPrefix     = "t"
+	ScriptLocationPrefix          = "s"
 )
 
 // TransactionLocation

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -39,7 +39,7 @@ type REPL struct {
 	onResult func(interpreter.Value)
 }
 
-func NewREPL(onError func(error), onResult func(interpreter.Value)) (*REPL, error) {
+func NewREPL(onError func(error), onResult func(interpreter.Value), checkerOptions []sema.Option) (*REPL, error) {
 
 	valueDeclarations := append(
 		stdlib.FlowBuiltInFunctions(stdlib.FlowBuiltinImpls{
@@ -63,12 +63,19 @@ func NewREPL(onError func(error), onResult func(interpreter.Value)) (*REPL, erro
 		stdlib.BuiltinFunctions...,
 	)
 
+	checkerOptions = append(
+		[]sema.Option{
+			sema.WithPredeclaredValues(valueDeclarations.ToValueDeclarations()),
+			sema.WithPredeclaredTypes(typeDeclarations),
+			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
+		},
+		checkerOptions...,
+	)
+
 	checker, err := sema.NewChecker(
 		nil,
 		REPLLocation{},
-		sema.WithPredeclaredValues(valueDeclarations.ToValueDeclarations()),
-		sema.WithPredeclaredTypes(typeDeclarations),
-		sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
+		checkerOptions...,
 	)
 	if err != nil {
 		return nil, err

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2358,17 +2358,6 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 	}
 }
 
-
-func ArrayValueFromBytes(bytes []byte) *interpreter.ArrayValue {
-	byteValues := make([]interpreter.Value, len(bytes))
-
-	for i, b := range bytes {
-		byteValues[i] = interpreter.UInt8Value(b)
-	}
-
-	return interpreter.NewArrayValueUnownedNonCopying(byteValues...)
-}
-
 func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -87,7 +87,8 @@ func newTestStorage(
 }
 
 type testRuntimeInterface struct {
-	resolveImport      func(Location) ([]byte, error)
+	resolveLocation    func(identifiers []Identifier, location Location) []ResolvedLocation
+	getCode            func(_ Location) ([]byte, error)
 	getCachedProgram   func(Location) (*ast.Program, error)
 	cacheProgram       func(Location, *ast.Program) error
 	storage            testRuntimeInterfaceStorage
@@ -121,11 +122,23 @@ type testRuntimeInterface struct {
 
 var _ Interface = &testRuntimeInterface{}
 
-func (i *testRuntimeInterface) ResolveImport(location Location) ([]byte, error) {
-	if i.resolveImport == nil {
+func (i *testRuntimeInterface) ResolveLocation(identifiers []Identifier, location Location) []ResolvedLocation {
+	if i.resolveLocation == nil {
+		return []ResolvedLocation{
+			{
+				Location:    location,
+				Identifiers: identifiers,
+			},
+		}
+	}
+	return i.resolveLocation(identifiers, location)
+}
+
+func (i *testRuntimeInterface) GetCode(location Location) ([]byte, error) {
+	if i.getCode == nil {
 		return nil, nil
 	}
-	return i.resolveImport(location)
+	return i.getCode(location)
 }
 
 func (i *testRuntimeInterface) GetCachedProgram(location Location) (*ast.Program, error) {
@@ -328,7 +341,7 @@ func TestRuntimeImport(t *testing.T) {
     `)
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("imported"):
 				return importedScript, nil
@@ -375,7 +388,7 @@ func TestRuntimeProgramCache(t *testing.T) {
 			programCache[location.ID()] = program
 			return nil
 		},
-		resolveImport: func(location Location) ([]byte, error) {
+		getCode: func(location Location) ([]byte, error) {
 			switch location {
 			case importedScriptLocation:
 				return importedScript, nil
@@ -1242,7 +1255,7 @@ func TestRuntimeStorage(t *testing.T) {
 			var loggedMessages []string
 
 			runtimeInterface := &testRuntimeInterface{
-				resolveImport: func(location Location) ([]byte, error) {
+				getCode: func(location Location) ([]byte, error) {
 					switch location {
 					case StringLocation("imported"):
 						return imported, nil
@@ -1334,7 +1347,7 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("container"):
 				return container, nil
@@ -1410,7 +1423,7 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("deep-thought"):
 				return deepThought, nil
@@ -1486,7 +1499,7 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("imported"):
 				return imported, nil
@@ -1563,7 +1576,7 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
     `)
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("imported"):
 				return imported, nil
@@ -1630,7 +1643,7 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("imported"):
 				return imported, nil
@@ -1703,7 +1716,7 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("imported"):
 				return imported, nil
@@ -1788,7 +1801,7 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("imported1"):
 				return imported1, nil
@@ -1980,7 +1993,7 @@ func TestRuntimeStorageChanges(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case StringLocation("imported"):
 				return imported, nil
@@ -2128,7 +2141,7 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) ([]byte, error) {
+		getCode: func(location Location) ([]byte, error) {
 			switch location {
 			case StringLocation("imported"):
 				return imported, nil
@@ -2345,48 +2358,6 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 	}
 }
 
-func TestRuntimeCyclicImport(t *testing.T) {
-
-	t.Parallel()
-
-	runtime := NewInterpreterRuntime()
-
-	imported := []byte(`
-      import "imported"
-    `)
-
-	script := []byte(
-		`
-          import "imported"
-
-          transaction {
-            execute {}
-          }
-        `,
-	)
-
-	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
-			switch location {
-			case StringLocation("imported"):
-				return imported, nil
-			default:
-				return nil, fmt.Errorf("unknown import location: %s", location)
-			}
-		},
-		getSigningAccounts: func() []Address {
-			return nil
-		},
-	}
-
-	nextTransactionLocation := newTransactionLocationGenerator()
-
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
-
-	require.Error(t, err)
-	require.IsType(t, Error{}, err)
-	assert.IsType(t, ast.CyclicImportsError{}, err.(Error).Unwrap())
-}
 
 func ArrayValueFromBytes(bytes []byte) *interpreter.ArrayValue {
 	byteValues := make([]interpreter.Value, len(bytes))
@@ -2622,7 +2593,7 @@ func TestRuntimeContractAccount(t *testing.T) {
 	var events []cadence.Event
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, nil),
@@ -2704,7 +2675,7 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 	var loggedMessage string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, nil),
@@ -2895,7 +2866,7 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 	signerAccount := address1Value
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -3002,7 +2973,7 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 	signerAccount := address1Value
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -3127,7 +3098,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 	var nextAccount byte = 0x2
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -3390,7 +3361,7 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 			var events []cadence.Event
 
 			runtimeInterface := &testRuntimeInterface{
-				resolveImport: func(_ Location) (bytes []byte, err error) {
+				getCode: func(_ Location) (bytes []byte, err error) {
 					return accountCode, nil
 				},
 				storage: newTestStorage(nil, nil),
@@ -3494,7 +3465,7 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -3636,7 +3607,7 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -3783,7 +3754,7 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -4000,7 +3971,7 @@ func TestRuntimeMetrics(t *testing.T) {
 			getSigningAccounts: func() []Address {
 				return []Address{{42}}
 			},
-			resolveImport: func(location Location) (bytes []byte, err error) {
+			getCode: func(location Location) (bytes []byte, err error) {
 				switch location {
 				case imported1Location:
 					return importedScript1, nil
@@ -4165,7 +4136,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 	}
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, onWrite),
@@ -4258,7 +4229,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	}
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, onWrite),
@@ -4417,7 +4388,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			accountCounter++
 			return Address{accountCounter}, nil
 		},
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -4520,7 +4491,7 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 			accountCounter++
 			return Address{accountCounter}, nil
 		},
-		resolveImport: func(location Location) (bytes []byte, err error) {
+		getCode: func(location Location) (bytes []byte, err error) {
 			key := string(location.(AddressLocation).ID())
 			return accountCodes[key], nil
 		},
@@ -4654,7 +4625,7 @@ func TestRuntimeTransaction_UpdateAccountCodeUnsafeNotInitializing(t *testing.T)
 		getSigningAccounts: func() []Address {
 			return []Address{common.BytesToAddress([]byte{0x42})}
 		},
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		updateAccountCode: func(address Address, code []byte) (err error) {

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -23,6 +23,21 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
+// Import declarations are handled in two phases:
+//
+// 1. Resolution of the import statement.
+//
+//     The default case is that one location is resolved to one location (itself),
+//     though e.g. an address location may also be resolved into multiple "address contract" locations.
+//
+//     For example, an import declaration `import a, b from 0x1` specifies the import of the declarations with
+//     the identifiers `a` and `b` from the address location `0x1`.
+//     This import declaration might be resolved into just the location itself, i.e. the address location `0x1`,
+//     but could also be resolved into multiple locations, e.g. the address contract locations `0x1.a` and `0x1.b`.
+//
+// 2. Acquiring the programs for the resolved imports. For each resolved import a separate program can be returned.
+//
+
 func (checker *Checker) VisitImportDeclaration(_ *ast.ImportDeclaration) ast.Repr {
 	// Handled in `declareImportDeclaration`
 	panic(&UnreachableStatementError{})

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -112,7 +112,6 @@ type Checker struct {
 	locationHandler                    LocationHandlerFunc
 	importHandler                      ImportHandlerFunc
 	checkHandler                       CheckHandlerFunc
-	isImporting                        bool
 }
 
 type Option func(*Checker) error

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -112,6 +112,7 @@ type Checker struct {
 	locationHandler                    LocationHandlerFunc
 	importHandler                      ImportHandlerFunc
 	checkHandler                       CheckHandlerFunc
+	isChecking                         bool
 }
 
 type Option func(*Checker) error
@@ -332,6 +333,7 @@ func (checker *Checker) IsChecked() bool {
 
 func (checker *Checker) Check() error {
 	if !checker.IsChecked() {
+		checker.isChecking = true
 		checker.errors = nil
 		check := func() {
 			checker.Program.Accept(checker)
@@ -341,6 +343,7 @@ func (checker *Checker) Check() error {
 		} else {
 			check()
 		}
+		checker.isChecking = false
 		checker.isChecked = true
 	}
 	err := checker.CheckerError()

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -65,7 +65,16 @@ var beforeType = func() *FunctionType {
 
 type ValidTopLevelDeclarationsHandlerFunc = func(ast.Location) []common.DeclarationKind
 
-type ImportHandlerFunc = func(location ast.Location) Import
+type CheckHandlerFunc func(location ast.Location, check func())
+
+type ResolvedLocation struct {
+	Location    ast.Location
+	Identifiers []ast.Identifier
+}
+
+type LocationHandlerFunc func(identifiers []ast.Identifier, location ast.Location) []ResolvedLocation
+
+type ImportHandlerFunc func(checker *Checker, location ast.Location) (Import, *CheckerError)
 
 // Checker
 
@@ -91,7 +100,6 @@ type Checker struct {
 	MemberAccesses                     *MemberAccesses
 	variableOrigins                    map[*Variable]*Origin
 	memberOrigins                      map[Type]map[string]*Origin
-	seenImports                        map[ast.LocationID]bool
 	isChecked                          bool
 	inCreate                           bool
 	inInvocation                       bool
@@ -100,9 +108,11 @@ type Checker struct {
 	Elaboration                        *Elaboration
 	currentMemberExpression            *ast.MemberExpression
 	validTopLevelDeclarationsHandler   ValidTopLevelDeclarationsHandlerFunc
-	importHandler                      ImportHandlerFunc
 	beforeExtractor                    *BeforeExtractor
+	locationHandler                    LocationHandlerFunc
+	importHandler                      ImportHandlerFunc
 	checkHandler                       CheckHandlerFunc
+	isImporting                        bool
 }
 
 type Option func(*Checker) error
@@ -164,14 +174,22 @@ func WithAllCheckers(allCheckers map[ast.LocationID]*Checker) Option {
 	}
 }
 
-type CheckHandlerFunc func(location ast.Location, check func())
-
 // WithCheckHandler returns a checker option which sets
 // the given function as the handler for the checking of the program.
 //
 func WithCheckHandler(handler CheckHandlerFunc) Option {
 	return func(checker *Checker) error {
 		checker.checkHandler = handler
+		return nil
+	}
+}
+
+// WithLocationHandler returns a checker option which sets
+// the given handler as function which is used to resolve locations.
+//
+func WithLocationHandler(handler LocationHandlerFunc) Option {
+	return func(checker *Checker) error {
+		checker.locationHandler = handler
 		return nil
 	}
 }
@@ -226,7 +244,6 @@ func NewChecker(program *ast.Program, location ast.Location, options ...Option) 
 		containerTypes:      map[Type]bool{},
 		variableOrigins:     map[*Variable]*Origin{},
 		memberOrigins:       map[Type]map[string]*Origin{},
-		seenImports:         map[ast.LocationID]bool{},
 		Elaboration:         NewElaboration(),
 	}
 

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -60,10 +60,11 @@ type Elaboration struct {
 	PostConditionsRewrite                  map[*ast.Conditions]PostConditionsRewrite
 	EmitStatementEventTypes                map[*ast.EmitStatement]*CompositeType
 	// Keyed by qualified identifier
-	CompositeTypes                    map[TypeID]*CompositeType
-	InterfaceTypes                    map[TypeID]*InterfaceType
-	InvocationExpressionTypeArguments map[*ast.InvocationExpression]map[*TypeParameter]Type
-	IdentifierInInvocationTypes       map[*ast.IdentifierExpression]Type
+	CompositeTypes                      map[TypeID]*CompositeType
+	InterfaceTypes                      map[TypeID]*InterfaceType
+	InvocationExpressionTypeArguments   map[*ast.InvocationExpression]map[*TypeParameter]Type
+	IdentifierInInvocationTypes         map[*ast.IdentifierExpression]Type
+	ImportDeclarationsResolvedLocations map[*ast.ImportDeclaration][]ResolvedLocation
 }
 
 func NewElaboration() *Elaboration {
@@ -104,5 +105,6 @@ func NewElaboration() *Elaboration {
 		InterfaceTypes:                         map[TypeID]*InterfaceType{},
 		InvocationExpressionTypeArguments:      map[*ast.InvocationExpression]map[*TypeParameter]Type{},
 		IdentifierInInvocationTypes:            map[*ast.IdentifierExpression]Type{},
+		ImportDeclarationsResolvedLocations:    map[*ast.ImportDeclaration][]ResolvedLocation{},
 	}
 }

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2775,3 +2775,16 @@ func (e *TypeAnnotationRequiredError) StartPosition() ast.Position {
 func (e *TypeAnnotationRequiredError) EndPosition() ast.Position {
 	return e.Pos
 }
+
+// CyclicImportsError
+
+type CyclicImportsError struct {
+	Location ast.Location
+	ast.Range
+}
+
+func (e *CyclicImportsError) Error() string {
+	return fmt.Sprintf("cyclic import of `%s`", e.Location)
+}
+
+func (*CyclicImportsError) isSemanticError() {}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -994,31 +994,10 @@ type UnresolvedImportError struct {
 }
 
 func (e *UnresolvedImportError) Error() string {
-	return fmt.Sprintf(
-		"import of location `%s` could not be resolved",
-		e.ImportLocation,
-	)
+	return "import could not be resolved"
 }
 
 func (*UnresolvedImportError) isSemanticError() {}
-
-// RepeatedImportError
-
-// TODO: make warning?
-
-type RepeatedImportError struct {
-	ImportLocation ast.Location
-	ast.Range
-}
-
-func (e *RepeatedImportError) Error() string {
-	return fmt.Sprintf(
-		"repeated import of location `%s`",
-		e.ImportLocation,
-	)
-}
-
-func (*RepeatedImportError) isSemanticError() {}
 
 // NotExportedError
 
@@ -1064,7 +1043,7 @@ func (e *NotExportedError) EndPosition() ast.Position {
 type ImportedProgramError struct {
 	CheckerError   *CheckerError
 	ImportLocation ast.Location
-	Pos            ast.Position
+	ast.Range
 }
 
 func (e *ImportedProgramError) Error() string {
@@ -1079,14 +1058,6 @@ func (e *ImportedProgramError) ChildErrors() []error {
 }
 
 func (*ImportedProgramError) isSemanticError() {}
-
-func (e *ImportedProgramError) StartPosition() ast.Position {
-	return e.Pos
-}
-
-func (e *ImportedProgramError) EndPosition() ast.Position {
-	return e.Pos
-}
 
 // AlwaysFailingNonResourceCastingTypeError
 

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -44,7 +44,7 @@ type ImportElement struct {
 // CheckerImport
 
 type CheckerImport struct {
-	*Checker
+	Checker *Checker
 }
 
 func variablesToImportElements(variables map[string]*Variable) map[string]ImportElement {
@@ -70,7 +70,7 @@ func (i CheckerImport) IsImportableValue(name string) bool {
 		return false
 	}
 
-	_, isPredeclaredValue := i.PredeclaredValues[name]
+	_, isPredeclaredValue := i.Checker.PredeclaredValues[name]
 	return !isPredeclaredValue
 }
 
@@ -79,7 +79,7 @@ func (i CheckerImport) AllTypeElements() map[string]ImportElement {
 }
 
 func (i CheckerImport) IsImportableType(name string) bool {
-	_, isPredeclaredType := i.PredeclaredTypes[name]
+	_, isPredeclaredType := i.Checker.PredeclaredTypes[name]
 	return !isPredeclaredType
 }
 

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -30,6 +30,7 @@ type Import interface {
 	IsImportableValue(name string) bool
 	AllTypeElements() map[string]ImportElement
 	IsImportableType(name string) bool
+	IsChecking() bool
 }
 
 // ImportElement
@@ -83,6 +84,10 @@ func (i CheckerImport) IsImportableType(name string) bool {
 	return !isPredeclaredType
 }
 
+func (i CheckerImport) IsChecking() bool {
+	return i.Checker.isChecking
+}
+
 // VirtualImport
 
 type VirtualImport struct {
@@ -102,6 +107,10 @@ func (i VirtualImport) AllTypeElements() map[string]ImportElement {
 	return i.TypeElements
 }
 
-func (i VirtualImport) IsImportableType(_ string) bool {
+func (VirtualImport) IsImportableType(_ string) bool {
 	return true
+}
+
+func (VirtualImport) IsChecking() bool {
+	return false
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3868,7 +3868,8 @@ func (p TypeParameter) Equal(other *TypeParameter) bool {
 
 func (p TypeParameter) checkTypeBound(ty Type, typeRange ast.Range) error {
 	if p.TypeBound == nil ||
-		p.TypeBound.IsInvalidType() {
+		p.TypeBound.IsInvalidType() ||
+		ty.IsInvalidType() {
 
 		return nil
 	}

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -98,7 +98,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 	var writes []write
 
 	runtimeInterface := &testRuntimeInterface{
-		resolveImport: func(_ Location) (bytes []byte, err error) {
+		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestStorage(nil, nil),

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -720,11 +720,25 @@ func TestCheckAccessImportGlobalValue(t *testing.T) {
                        import a, b, c from "imported"
                     `,
 					ParseAndCheckOptions{
-						ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-							return imported, nil
-						},
 						Options: []sema.Option{
 							sema.WithAccessCheckMode(checkMode),
+							sema.WithImportHandler(
+								func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+									importChecker, err := checker.EnsureLoaded(
+										location,
+										func() *ast.Program {
+											return imported
+										},
+									)
+									if err != nil {
+										return nil, err
+									}
+
+									return sema.CheckerImport{
+										Checker: importChecker,
+									}, nil
+								},
+							),
 						},
 					},
 				)
@@ -1844,11 +1858,25 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
                   }
                 `,
 				ParseAndCheckOptions{
-					ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-						return imported, nil
-					},
 					Options: []sema.Option{
 						sema.WithAccessCheckMode(checkMode),
+						sema.WithImportHandler(
+							func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+								importChecker, err := checker.EnsureLoaded(
+									location,
+									func() *ast.Program {
+										return imported
+									},
+								)
+								if err != nil {
+									return nil, err
+								}
+
+								return sema.CheckerImport{
+									Checker: importChecker,
+								}, nil
+							},
+						),
 					},
 				},
 			)
@@ -1891,8 +1919,24 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
            }
         `,
 		ParseAndCheckOptions{
-			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-				return imported, nil
+			Options: []sema.Option{
+				sema.WithImportHandler(
+					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+						importChecker, err := checker.EnsureLoaded(
+							location,
+							func() *ast.Program {
+								return imported
+							},
+						)
+						if err != nil {
+							return nil, err
+						}
+
+						return sema.CheckerImport{
+							Checker: importChecker,
+						}, nil
+					},
+				),
 			},
 		},
 	)

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -104,6 +104,7 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	importedCheckerY, err := ParseAndCheckWithOptions(t,
 		`
@@ -120,7 +121,6 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 			},
 		},
 	)
-
 	require.NoError(t, err)
 
 	_, err = ParseAndCheckWithOptions(t,
@@ -227,6 +227,7 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	importedCheckerY, err := ParseAndCheckWithOptions(t,
 		`
@@ -243,7 +244,6 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 			},
 		},
 	)
-
 	require.NoError(t, err)
 
 	_, err = ParseAndCheckWithOptions(t,

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -1172,9 +1172,14 @@ func TestCheckInvalidCreateImportedResource(t *testing.T) {
 
 	t.Parallel()
 
-	checker, err := ParseAndCheck(t, `
-      pub resource R {}
-	`)
+	importedChecker, err := ParseAndCheckWithOptions(t,
+		`
+          pub resource R {}
+	    `,
+		ParseAndCheckOptions{
+			Location: ImportedLocation,
+		},
+	)
 
 	require.NoError(t, err)
 
@@ -1187,8 +1192,14 @@ func TestCheckInvalidCreateImportedResource(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-				return checker.Program, nil
+			Options: []sema.Option{
+				sema.WithImportHandler(
+					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+						return sema.CheckerImport{
+							Checker: importedChecker,
+						}, nil
+					},
+				),
 			},
 		},
 	)

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -36,7 +36,6 @@ func ParseAndCheck(t *testing.T, code string) (*sema.Checker, error) {
 }
 
 type ParseAndCheckOptions struct {
-	ImportResolver   ast.ImportResolver
 	Location         ast.Location
 	IgnoreParseError bool
 	Options          []sema.Option
@@ -52,13 +51,6 @@ func ParseAndCheckWithOptions(
 	if !options.IgnoreParseError && !assert.NoError(t, err) {
 		assert.FailNow(t, errors.UnrollChildErrors(err))
 		return nil, err
-	}
-
-	if options.ImportResolver != nil {
-		err := program.ResolveImports(options.ImportResolver)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if options.Location == nil {

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -119,6 +119,12 @@ func TestInterpretVirtualImport(t *testing.T) {
 	)
 }
 
+// TestInterpretImportMultipleProgramsFromLocation demonstrates how two declarations (`a` and `b`)
+// can be imported from the same location (address location `0x1`).
+// The single location (address location `0x1`) is resolved to two locations
+// (address contract locations `0x1.a` and `0x1.b`).
+// Each requested declaration is so imported from a a separate program.
+//
 func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -133,10 +133,12 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 
 	importedCheckerA, err := checker.ParseAndCheckWithOptions(t,
 		`
+          // this function *SHOULD* be imported in the importing program
           pub fun a(): Int {
               return 1
           }
 
+          // this function should *NOT* be imported in the importing program
           pub fun b(): Int {
               return 11
           }
@@ -152,10 +154,12 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 
 	importedCheckerB, err := checker.ParseAndCheckWithOptions(t,
 		`
+          // this function *SHOULD* be imported in the importing program
           pub fun b(): Int {
               return 2
           }
 
+          // this function should *NOT* be imported in the importing program
           pub fun a(): Int {
               return 22
           }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4027,14 +4027,19 @@ func TestInterpretImport(t *testing.T) {
 
 	t.Parallel()
 
-	checkerImported, err := checker.ParseAndCheck(t, `
-      pub fun answer(): Int {
-          return 42
-      }
-    `)
+	importedChecker, err := checker.ParseAndCheckWithOptions(t,
+		`
+          pub fun answer(): Int {
+              return 42
+          }
+        `,
+		checker.ParseAndCheckOptions{
+			Location: ImportedLocation,
+		},
+	)
 	require.NoError(t, err)
 
-	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
+	importingChecker, err := checker.ParseAndCheckWithOptions(t,
 		`
           import answer from "imported"
 
@@ -4043,19 +4048,26 @@ func TestInterpretImport(t *testing.T) {
           }
         `,
 		checker.ParseAndCheckOptions{
-			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-				assert.Equal(t,
-					ImportedLocation,
-					location,
-				)
-				return checkerImported.Program, nil
+			Options: []sema.Option{
+				sema.WithImportHandler(
+					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+						assert.Equal(t,
+							ImportedLocation,
+							location,
+						)
+
+						return sema.CheckerImport{
+							Checker: importedChecker,
+						}, nil
+					},
+				),
 			},
 		},
 	)
 	require.NoError(t, err)
 
 	inter, err := interpreter.NewInterpreter(
-		checkerImporting,
+		importingChecker,
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location ast.Location) interpreter.Import {
 				assert.Equal(t,
@@ -4063,7 +4075,7 @@ func TestInterpretImport(t *testing.T) {
 					location,
 				)
 				return interpreter.ProgramImport{
-					Program: checkerImported.Program,
+					Program: importedChecker.Program,
 				}
 			},
 		),
@@ -4091,7 +4103,7 @@ func TestInterpretImportError(t *testing.T) {
 			stdlib.PanicFunction,
 		}.ToValueDeclarations()
 
-	checkerImported, err := checker.ParseAndCheckWithOptions(t,
+	importedChecker, err := checker.ParseAndCheckWithOptions(t,
 		`
           pub fun answer(): Int {
               return panic("?!")
@@ -4105,7 +4117,7 @@ func TestInterpretImportError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
+	importingChecker, err := checker.ParseAndCheckWithOptions(t,
 		`
           import answer from "imported"
 
@@ -4116,13 +4128,18 @@ func TestInterpretImportError(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithPredeclaredValues(valueDeclarations),
-			},
-			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-				assert.Equal(t,
-					ImportedLocation,
-					location,
-				)
-				return checkerImported.Program, nil
+				sema.WithImportHandler(
+					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+						assert.Equal(t,
+							ImportedLocation,
+							location,
+						)
+
+						return sema.CheckerImport{
+							Checker: importedChecker,
+						}, nil
+					},
+				),
 			},
 		},
 	)
@@ -4133,7 +4150,7 @@ func TestInterpretImportError(t *testing.T) {
 	}.ToValues()
 
 	inter, err := interpreter.NewInterpreter(
-		checkerImporting,
+		importingChecker,
 		interpreter.WithPredefinedValues(values),
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location ast.Location) interpreter.Import {
@@ -4142,7 +4159,7 @@ func TestInterpretImportError(t *testing.T) {
 					location,
 				)
 				return interpreter.ProgramImport{
-					Program: checkerImported.Program,
+					Program: importedChecker.Program,
 				}
 			},
 		),
@@ -5396,21 +5413,26 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
 
 	t.Parallel()
 
-	checkerImported, err := checker.ParseAndCheck(t, `
-      // function must have arguments
-      pub fun x(x: Int) {}
+	importedChecker, err := checker.ParseAndCheckWithOptions(t,
+		`
+          // function must have arguments
+          pub fun x(x: Int) {}
 
-      // invocation must be in composite
-      pub struct Y {
+          // invocation must be in composite
+          pub struct Y {
 
-          pub fun x() {
-              x(x: 1)
+              pub fun x() {
+                  x(x: 1)
+              }
           }
-      }
-    `)
+        `,
+		checker.ParseAndCheckOptions{
+			Location: ImportedLocation,
+		},
+	)
 	require.NoError(t, err)
 
-	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
+	importingChecker, err := checker.ParseAndCheckWithOptions(t,
 		`
           import Y from "imported"
 
@@ -5420,19 +5442,26 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
           }
         `,
 		checker.ParseAndCheckOptions{
-			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-				assert.Equal(t,
-					ImportedLocation,
-					location,
-				)
-				return checkerImported.Program, nil
+			Options: []sema.Option{
+				sema.WithImportHandler(
+					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+						assert.Equal(t,
+							ImportedLocation,
+							location,
+						)
+
+						return sema.CheckerImport{
+							Checker: importedChecker,
+						}, nil
+					},
+				),
 			},
 		},
 	)
 	require.NoError(t, err)
 
 	inter, err := interpreter.NewInterpreter(
-		checkerImporting,
+		importingChecker,
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location ast.Location) interpreter.Import {
 				assert.Equal(t,
@@ -5440,7 +5469,7 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
 					location,
 				)
 				return interpreter.ProgramImport{
-					Program: checkerImported.Program,
+					Program: importedChecker.Program,
 				}
 			},
 		),
@@ -6857,18 +6886,23 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 
 	t.Parallel()
 
-	checkerImported, err := checker.ParseAndCheck(t, `
-      struct interface Foo {
-          fun check(answer: Int) {
-              pre {
-                  answer == 42
+	importedChecker, err := checker.ParseAndCheckWithOptions(t,
+		`
+          struct interface Foo {
+              fun check(answer: Int) {
+                  pre {
+                      answer == 42
+                  }
               }
           }
-      }
-	`)
+	    `,
+		checker.ParseAndCheckOptions{
+			Location: ImportedLocation,
+		},
+	)
 	require.NoError(t, err)
 
-	checkerImporting, err := checker.ParseAndCheckWithOptions(t,
+	importingChecker, err := checker.ParseAndCheckWithOptions(t,
 		`
           import Foo from "imported"
 
@@ -6882,19 +6916,26 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
           }
         `,
 		checker.ParseAndCheckOptions{
-			ImportResolver: func(location ast.Location) (program *ast.Program, e error) {
-				assert.Equal(t,
-					ast.StringLocation("imported"),
-					location,
-				)
-				return checkerImported.Program, nil
+			Options: []sema.Option{
+				sema.WithImportHandler(
+					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+						assert.Equal(t,
+							ImportedLocation,
+							location,
+						)
+
+						return sema.CheckerImport{
+							Checker: importedChecker,
+						}, nil
+					},
+				),
 			},
 		},
 	)
 	require.NoError(t, err)
 
 	inter, err := interpreter.NewInterpreter(
-		checkerImporting,
+		importingChecker,
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location ast.Location) interpreter.Import {
 				assert.Equal(t,
@@ -6902,7 +6943,7 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 					location,
 				)
 				return interpreter.ProgramImport{
-					Program: checkerImported.Program,
+					Program: importedChecker.Program,
 				}
 			},
 		),

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -4348,7 +4348,7 @@ func TestParseImportWithString(t *testing.T) {
 	t.Parallel()
 
 	const code = `
-        import "test.bpl"
+        import "test.cdc"
 	`
 
 	testParse(
@@ -4357,7 +4357,7 @@ func TestParseImportWithString(t *testing.T) {
 		[]Declaration{
 			&ImportDeclaration{
 				Identifiers: nil,
-				Location:    StringLocation("test.bpl"),
+				Location:    StringLocation("test.cdc"),
 				Range: Range{
 					StartPos: Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   Position{Offset: 25, Line: 2, Column: 24},
@@ -4365,26 +4365,7 @@ func TestParseImportWithString(t *testing.T) {
 				LocationPos: Position{Offset: 16, Line: 2, Column: 15},
 			},
 		},
-		func(actual *Program) {
-
-			importLocation := StringLocation("test.bpl")
-
-			actualImports := actual.ImportedPrograms()
-
-			assert.Equal(t,
-				map[LocationID]*Program{},
-				actualImports,
-			)
-
-			actualImports[importLocation.ID()] = &Program{}
-
-			assert.Equal(t,
-				map[LocationID]*Program{
-					importLocation.ID(): {},
-				},
-				actualImports,
-			)
-		},
+		nil,
 	)
 }
 
@@ -4410,26 +4391,7 @@ func TestParseImportWithAddress(t *testing.T) {
 				LocationPos: Position{Offset: 16, Line: 2, Column: 15},
 			},
 		},
-		func(actual *Program) {
-
-			importLocation := AddressLocation{18, 52}
-
-			actualImports := actual.ImportedPrograms()
-
-			assert.Equal(t,
-				map[LocationID]*Program{},
-				actualImports,
-			)
-
-			actualImports[importLocation.ID()] = &Program{}
-
-			assert.Equal(t,
-				map[LocationID]*Program{
-					importLocation.ID(): {},
-				},
-				actualImports,
-			)
-		},
+		nil,
 	)
 }
 


### PR DESCRIPTION
Work towards #221

Refactor how programs are imported.

Previously, the code that handles imports assumed that each import location (e.g. an address like `0x1` maps to one program, and the specifically given identifiers in the import statement (if any, otherwise all identifiers) are imported from this single program.


The code that handles imports was previously partially implemented in the AST package and partially in the checker package (`sema`). This PR removes the code in the AST package and implements it fully in the checker package. It is now split into two phases: 

1. Resolution of the import statement. 

    The default case is that one location is resolved to one location (itself), though now an address location may also be resolved into multiple "address contract" locations (naming suggestions welcome).

    For example, an import statement `import a, b from 0x1` specifies the specific identifiers `a` and `b` and the address location `0x1`. It might be resolved into just the location itself, i.e. the address location `0x1`, but can now also resolved into multiple locations, e.g. the address contract location `0x1.a` and the address contract location `0x1.b`.

2. Acquiring the programs for the resolved imports. For each resolved import a separate program can be returned.

The split of the import code into resolution and acquisition required changes to `runtime.Interface`.
Exposing the two phases allows greater flexibility and implementing backwards compatibility for existing deployed contracts in the host environment. 

If we want to keep backwards compatibility of the interface we can revert the changes and hard-code how addresses are resolved, however, I can't quite see how we could keep backwards compatibility for already deployed contracts.

In addition, this refactor also enables repeated imports from the same locations, which was previously not supported, e.g. `import a from 0x1; import b from 0x1`.

While I adjusted the code for the REPL, I added support for importing local files.

