### PR TITLE
Require an explicit type annotation for variable declarations with empty literal expressions

### DIFF
--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -236,11 +236,22 @@ func (checker *Checker) checkVariableDeclarationUsability(declaration *ast.Varia
 	// Require an explicit type annotation
 
 	if declaration.TypeAnnotation == nil {
-		if arrayExpression, ok := declaration.Value.(*ast.ArrayExpression); ok {
-			if len(arrayExpression.Values) == 0 {
+		switch value := declaration.Value.(type) {
+		case *ast.ArrayExpression:
+			if len(value.Values) == 0 {
 				checker.report(
 					&TypeAnnotationRequiredError{
 						Cause: "empty array literal",
+						Pos:   declaration.Identifier.EndPosition().Shifted(1),
+					},
+				)
+			}
+
+		case *ast.DictionaryExpression:
+			if len(value.Entries) == 0 {
+				checker.report(
+					&TypeAnnotationRequiredError{
+						Cause: "empty dictionary literal",
 						Pos:   declaration.Identifier.EndPosition().Shifted(1),
 					},
 				)

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2777,3 +2777,30 @@ func (e *UnparameterizedTypeInstantiationError) SecondaryError() string {
 		e.ActualTypeArgumentCount,
 	)
 }
+
+// TypeAnnotationRequiredError
+
+type TypeAnnotationRequiredError struct {
+	Cause string
+	Pos   ast.Position
+}
+
+func (e *TypeAnnotationRequiredError) Error() string {
+	if e.Cause != "" {
+		return fmt.Sprintf(
+			"%s requires an explicit type annotation",
+			e.Cause,
+		)
+	}
+	return "explicit type annotation required"
+}
+
+func (*TypeAnnotationRequiredError) isSemanticError() {}
+
+func (e *TypeAnnotationRequiredError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *TypeAnnotationRequiredError) EndPosition() ast.Position {
+	return e.Pos
+}

--- a/runtime/tests/checker/declaration_test.go
+++ b/runtime/tests/checker/declaration_test.go
@@ -599,3 +599,32 @@ func TestCheckInvalidLocalDeclarations(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckVariableDeclarationTypeAnnotationRequired(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty array", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let a = []
+	    `)
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeAnnotationRequiredError{}, errs[0])
+	})
+
+	t.Run("empty dictionary", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let d = {}
+	    `)
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeAnnotationRequiredError{}, errs[0])
+	})
+}


### PR DESCRIPTION
Read @makoto's great blog post (https://medium.com/@makoto_inoue/learning-flow-blockchain-part1-open-world-builders-program-2d9c75c8f1fb) and saw this error:

![]()

<img width="640" src="https://miro.medium.com/max/1400/1*otudm96nRa0Ym_5eO5TsFg.png">

The reason for this error message is not very obvious the declaration of the variable:

```
var ids = []
```

As no explicit type is given, the type is inferred from the value, an empty array expression, which is `[Never]`, i.e. an array which can never have any values. Such a declaration is very common, and almost always the inferred type is not wanted.

Improve this situation by requiring an explicit type annotation for variable declarations when the value is an empty array or dictionary literal and no type annotation is provided:

<img width="640" src="https://user-images.githubusercontent.com/51661/90991086-5fc8c800-e55b-11ea-90e1-1389bb6cfdee.png">

This is the same as in Swift:

```
$ swift
let Welcome to Apple Swift version 5.2.4 (swiftlang-1103.0.32.9 clang-1103.0.32.53).
Type :help for assistance.
  1> let xs = []
error: repl.swift:1:10: error: empty collection literal requires an explicit type
let xs = []
         ^~
```
