### PR TITLE
Suggest replacing number conversion function calls 

### DIFF
--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -150,6 +150,7 @@ func (r *REPL) Accept(code string) (inputIsComplete bool) {
 	}
 
 	r.checker.ResetErrors()
+	r.checker.ResetHints()
 
 	for _, element := range result {
 

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -416,7 +416,11 @@ func (checker *Checker) checkInvocation(
 		argumentExpressions[i] = argument.Expression
 	}
 
-	invokableType.CheckArgumentExpressions(checker, argumentExpressions)
+	invokableType.CheckArgumentExpressions(
+		checker,
+		argumentExpressions,
+		ast.NewRangeFromPositioned(invocationExpression),
+	)
 
 	returnType = functionType.ReturnTypeAnnotation.Type.Resolve(typeArguments)
 	if returnType == nil {

--- a/runtime/sema/hints.go
+++ b/runtime/sema/hints.go
@@ -1,0 +1,47 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/ast"
+)
+
+type Hint interface {
+	Hint() string
+	ast.HasPosition
+	isHint()
+}
+
+// ReplacementHint
+
+type ReplacementHint struct {
+	Expression ast.Expression
+	ast.Range
+}
+
+func (h *ReplacementHint) Hint() string {
+	return fmt.Sprintf(
+		"consider replacing with: `%s`",
+		h.Expression,
+	)
+}
+
+func (*ReplacementHint) isHint() {}

--- a/runtime/tests/checker/conversion_test.go
+++ b/runtime/tests/checker/conversion_test.go
@@ -1,0 +1,242 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package checker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+func TestCheckNumberConversionReplacementHint(t *testing.T) {
+
+	t.Parallel()
+
+	// to fixed point type
+
+	//// integer literal
+
+	t.Run("positive integer to signed fixed-point type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = Fix64(1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `(1.0 as Fix64)`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	t.Run("positive integer to unsigned fixed-point type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = UFix64(1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `1.0`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	t.Run("negative integer to signed fixed-point type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = Fix64(-1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `-1.0`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	//// fixed-point literal
+
+	t.Run("positive fixed-point to unsigned fixed-point type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = UFix64(1.2)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `1.2`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	t.Run("negative fixed-point to signed fixed-point type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = Fix64(-1.2)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `-1.2`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	// to integer type
+
+	//// integer literal
+
+	t.Run("positive integer to unsigned integer type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = UInt8(1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `(1 as UInt8)`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	t.Run("positive integer to signed integer type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = Int8(1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `(1 as Int8)`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	t.Run("negative integer to signed integer type", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = Int8(-1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `(-1 as Int8)`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	t.Run("positive integer to Int", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = Int(1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `1`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+
+	t.Run("negative integer to Int", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+           let x = Int(-1)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.ReplacementHint{}, hints[0])
+
+		require.Equal(t,
+			"consider replacing with: `-1`",
+			hints[0].(*sema.ReplacementHint).Hint(),
+		)
+	})
+}


### PR DESCRIPTION
If a number conversion function is called with a number literal, suggest replacing it with a literal and as static cast (if needed):

<img width="540" src="https://user-images.githubusercontent.com/51661/91004801-0cba3980-e58a-11ea-9dc4-5123072900a1.png">

