### PR TITLE
Replace reporting an error for forcing non-optional with a hint suggesting removal

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3395,7 +3395,7 @@ func (interpreter *Interpreter) VisitForceExpression(expression *ast.ForceExpres
 				)
 
 			default:
-				panic(errors.NewUnreachableError())
+				return result
 			}
 		})
 }

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -38,10 +38,16 @@ func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) as
 
 	optionalType, ok := valueType.(*OptionalType)
 	if !ok {
-		checker.report(
-			&NonOptionalForceError{
-				Type:  valueType,
-				Range: ast.NewRangeFromPositioned(expression.Expression),
+
+		// A non-optional type is forced. Suggest removing it
+
+		checker.hint(
+			&RemovalHint{
+				Description: "unnecessary force operator",
+				Range: ast.Range{
+					StartPos: expression.EndPos,
+					EndPos:   expression.EndPos,
+				},
 			},
 		)
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2591,22 +2591,6 @@ func (e *AmbiguousRestrictedTypeError) Error() string {
 
 func (*AmbiguousRestrictedTypeError) isSemanticError() {}
 
-// NonOptionalForceError
-
-type NonOptionalForceError struct {
-	Type Type
-	ast.Range
-}
-
-func (e *NonOptionalForceError) Error() string {
-	return fmt.Sprintf(
-		"cannot force non-optional type: `%s`",
-		e.Type.QualifiedString(),
-	)
-}
-
-func (*NonOptionalForceError) isSemanticError() {}
-
 // InvalidPathDomainError
 
 type InvalidPathDomainError struct {

--- a/runtime/sema/hints.go
+++ b/runtime/sema/hints.go
@@ -45,3 +45,20 @@ func (h *ReplacementHint) Hint() string {
 }
 
 func (*ReplacementHint) isHint() {}
+
+// RemovalHint
+
+type RemovalHint struct {
+	Description string
+	ast.Range
+}
+
+func (h *RemovalHint) Hint() string {
+	description := h.Description
+	if description == "" {
+		description = "code"
+	}
+	return fmt.Sprintf("consider removing this %s", description)
+}
+
+func (*RemovalHint) isHint() {}

--- a/runtime/tests/checker/force_test.go
+++ b/runtime/tests/checker/force_test.go
@@ -52,16 +52,14 @@ func TestCheckForce(t *testing.T) {
 
 	})
 
-	t.Run("invalid: non-optional", func(t *testing.T) {
+	t.Run("non-optional", func(t *testing.T) {
 
 		checker, err := ParseAndCheck(t, `
           let x: Int = 1
           let y = x!
         `)
 
-		errs := ExpectCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.NonOptionalForceError{}, errs[0])
+		require.NoError(t, err)
 
 		assert.Equal(t,
 			&sema.IntType{},
@@ -72,6 +70,11 @@ func TestCheckForce(t *testing.T) {
 			&sema.IntType{},
 			checker.GlobalValues["y"].Type,
 		)
+
+		hints := checker.Hints()
+
+		require.Len(t, hints, 1)
+		require.IsType(t, &sema.RemovalHint{}, hints[0])
 	})
 
 	t.Run("invalid: force resource multiple times", func(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7694,6 +7694,19 @@ func TestInterpretForce(t *testing.T) {
 
 		assert.IsType(t, &interpreter.ForceNilError{}, err)
 	})
+
+	t.Run("non-optional", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t, `
+          let x: Int = 1
+          let y = x!
+        `)
+
+		assert.Equal(t,
+			interpreter.NewIntValueFromInt64(1),
+			inter.Globals["y"].Value,
+		)
+	})
 }
 
 func permutations(xs []string) (res [][]string) {


### PR DESCRIPTION
Instead of reporting an error when the force operator is used on a non-optional type, only report a hint suggesting to remove it.

This is pre-work for replacing the return type of functions which currently have an return type which is optional which one that is not. Specifically, this will allow changing the signature of `getCapability` without breaking backwards compatibility.