### PR TITLE
Make FieldTypeNotStorableError a semantic error

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1183,7 +1183,7 @@ func getDiagnosticsForParentError(
 		if !ok {
 			conn.LogMessage(&protocol.LogMessageParams{
 				Type:    protocol.Error,
-				Message: fmt.Sprintf("Unable to convert non-convertable error to disgnostic: %s", err.Error()),
+				Message: fmt.Sprintf("Unable to convert non-convertable error to disgnostic: %T", childErr),
 			})
 			continue
 		}

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1183,7 +1183,7 @@ func getDiagnosticsForParentError(
 		if !ok {
 			conn.LogMessage(&protocol.LogMessageParams{
 				Type:    protocol.Error,
-				Message: fmt.Sprintf("Unable to convert non-convertable error to disgnostic: %T", childErr),
+				Message: fmt.Sprintf("Unable to convert non-convertable error to diagnostic: %T", childErr),
 			})
 			continue
 		}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -752,7 +752,7 @@ type FieldTypeNotStorableError struct {
 	Name string
 	// Field's type
 	Type Type
-	// StartPosition of the error
+	// Start position of the error
 	Pos ast.Position
 }
 
@@ -762,6 +762,17 @@ func (e *FieldTypeNotStorableError) Error() string {
 		e.Name,
 		e.Type,
 	)
+}
+
+func (*FieldTypeNotStorableError) isSemanticError() {}
+
+func (e *FieldTypeNotStorableError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *FieldTypeNotStorableError) EndPosition() ast.Position {
+	length := len(e.Name)
+	return e.Pos.Shifted(length - 1)
 }
 
 // FunctionExpressionInConditionError


### PR DESCRIPTION
The error type `FieldTypeNotStorableError` was not implementing the `SemanticError` interface, so the language server failed to convert and display it. The only indicator was a wrong log message ("Unable to convert non-convertable error to disgnostic")

Reported by @AndrewBurian 🙏 