### PR TITLE
Handle empty integer literals in checker

### DIFF
--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -384,7 +384,7 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 			p.report(errs...)
 			location = ast.StringLocation(parsedString)
 
-		case lexer.TokenHexadecimalLiteral:
+		case lexer.TokenHexadecimalIntegerLiteral:
 			location = parseHexadecimalLocation(p.current.Value.(string))
 
 		default:
@@ -403,7 +403,7 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 
 	parseLocation := func() {
 		switch p.current.Type {
-		case lexer.TokenString, lexer.TokenHexadecimalLiteral:
+		case lexer.TokenString, lexer.TokenHexadecimalIntegerLiteral:
 			parseStringOrAddressLocation()
 
 		case lexer.TokenIdentifier:
@@ -509,7 +509,7 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 	p.skipSpaceAndComments(true)
 
 	switch p.current.Type {
-	case lexer.TokenString, lexer.TokenHexadecimalLiteral:
+	case lexer.TokenString, lexer.TokenHexadecimalIntegerLiteral:
 		parseStringOrAddressLocation()
 
 	case lexer.TokenIdentifier:

--- a/runtime/parser2/errors.go
+++ b/runtime/parser2/errors.go
@@ -137,6 +137,8 @@ func (e *InvalidIntegerLiteralError) SecondaryError() string {
 		return "remove the trailing underscore"
 	case InvalidNumberLiteralKindUnknownPrefix:
 		return "did you mean `0x` (hexadecimal), `0b` (binary), or `0o` (octal)?"
+	case InvalidNumberLiteralKindMissingDigits:
+		return "consider adding a 0"
 	}
 
 	panic(errors.NewUnreachableError())

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -350,7 +350,7 @@ func init() {
 	defineCastingExpression()
 
 	defineExpr(literalExpr{
-		tokenType: lexer.TokenBinaryLiteral,
+		tokenType: lexer.TokenBinaryIntegerLiteral,
 		nullDenotation: func(p *parser, token lexer.Token) ast.Expression {
 			literal := token.Value.(string)
 			return parseIntegerLiteral(
@@ -364,7 +364,7 @@ func init() {
 	})
 
 	defineExpr(literalExpr{
-		tokenType: lexer.TokenOctalLiteral,
+		tokenType: lexer.TokenOctalIntegerLiteral,
 		nullDenotation: func(p *parser, token lexer.Token) ast.Expression {
 			literal := token.Value.(string)
 			return parseIntegerLiteral(
@@ -378,7 +378,7 @@ func init() {
 	})
 
 	defineExpr(literalExpr{
-		tokenType: lexer.TokenDecimalLiteral,
+		tokenType: lexer.TokenDecimalIntegerLiteral,
 		nullDenotation: func(p *parser, token lexer.Token) ast.Expression {
 			literal := token.Value.(string)
 			return parseIntegerLiteral(
@@ -392,7 +392,7 @@ func init() {
 	})
 
 	defineExpr(literalExpr{
-		tokenType: lexer.TokenHexadecimalLiteral,
+		tokenType: lexer.TokenHexadecimalIntegerLiteral,
 		nullDenotation: func(p *parser, token lexer.Token) ast.Expression {
 			literal := token.Value.(string)
 			return parseIntegerLiteral(
@@ -406,7 +406,21 @@ func init() {
 	})
 
 	defineExpr(literalExpr{
-		tokenType: lexer.TokenFixedPointLiteral,
+		tokenType: lexer.TokenUnknownBaseIntegerLiteral,
+		nullDenotation: func(p *parser, token lexer.Token) ast.Expression {
+			literal := token.Value.(string)
+			return parseIntegerLiteral(
+				p,
+				literal,
+				literal[2:],
+				IntegerLiteralKindUnknown,
+				token.Range,
+			)
+		},
+	})
+
+	defineExpr(literalExpr{
+		tokenType: lexer.TokenFixedPointNumberLiteral,
 		nullDenotation: func(_ *parser, token lexer.Token) ast.Expression {
 			return parseFixedPointLiteral(
 				token.Value.(string),
@@ -1386,10 +1400,29 @@ func parseIntegerLiteral(p *parser, literal, text string, kind IntegerLiteralKin
 
 	withoutUnderscores := strings.Replace(text, "_", "", -1)
 
-	base := kind.Base()
-	value, ok := new(big.Int).SetString(withoutUnderscores, base)
-	if !ok {
-		report(InvalidNumberLiteralKindUnknown)
+	var value *big.Int
+	var base int
+
+	if kind == IntegerLiteralKindUnknown {
+		base = 1
+
+		report(InvalidNumberLiteralKindUnknownPrefix)
+	} else {
+		base = kind.Base()
+
+		if withoutUnderscores == "" {
+			report(InvalidNumberLiteralKindMissingDigits)
+		} else {
+			var ok bool
+			value, ok = new(big.Int).SetString(withoutUnderscores, base)
+			if !ok {
+				report(InvalidNumberLiteralKindUnknown)
+			}
+		}
+	}
+
+	if value == nil {
+		value = new(big.Int)
 	}
 
 	return &ast.IntegerExpression{

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -2314,7 +2314,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 				&InvalidIntegerLiteralError{
 					Literal:                   "0b",
 					IntegerLiteralKind:        IntegerLiteralKindBinary,
-					InvalidIntegerLiteralKind: InvalidNumberLiteralKindUnknown,
+					InvalidIntegerLiteralKind: InvalidNumberLiteralKindMissingDigits,
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -2326,7 +2326,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 		utils.AssertEqualWithDiff(t,
 			&ast.IntegerExpression{
-				Value: nil,
+				Value: new(big.Int),
 				Base:  2,
 				Range: ast.Range{
 					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -2475,7 +2475,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 				&InvalidIntegerLiteralError{
 					Literal:                   `0o`,
 					IntegerLiteralKind:        IntegerLiteralKindOctal,
-					InvalidIntegerLiteralKind: InvalidNumberLiteralKindUnknown,
+					InvalidIntegerLiteralKind: InvalidNumberLiteralKindMissingDigits,
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -2487,7 +2487,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 		utils.AssertEqualWithDiff(t,
 			&ast.IntegerExpression{
-				Value: nil,
+				Value: new(big.Int),
 				Base:  8,
 				Range: ast.Range{
 					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -2691,7 +2691,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 				&InvalidIntegerLiteralError{
 					Literal:                   `0x`,
 					IntegerLiteralKind:        IntegerLiteralKindHexadecimal,
-					InvalidIntegerLiteralKind: InvalidNumberLiteralKindUnknown,
+					InvalidIntegerLiteralKind: InvalidNumberLiteralKindMissingDigits,
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 						EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -2703,7 +2703,7 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 		utils.AssertEqualWithDiff(t,
 			&ast.IntegerExpression{
-				Value: nil,
+				Value: new(big.Int),
 				Base:  16,
 				Range: ast.Range{
 					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -2913,8 +2913,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 				},
 				&InvalidIntegerLiteralError{
 					Literal:                   `0z123`,
-					IntegerLiteralKind:        IntegerLiteralKindDecimal,
-					InvalidIntegerLiteralKind: InvalidNumberLiteralKindUnknown,
+					IntegerLiteralKind:        IntegerLiteralKindUnknown,
+					InvalidIntegerLiteralKind: InvalidNumberLiteralKindUnknownPrefix,
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 						EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
@@ -2926,8 +2926,8 @@ func TestParseIntegerLiterals(t *testing.T) {
 
 		utils.AssertEqualWithDiff(t,
 			&ast.IntegerExpression{
-				Value: nil,
-				Base:  10,
+				Value: new(big.Int),
+				Base:  1,
 				Range: ast.Range{
 					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 					EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},

--- a/runtime/parser2/invalidnumberliteralkind.go
+++ b/runtime/parser2/invalidnumberliteralkind.go
@@ -31,6 +31,7 @@ const (
 	InvalidNumberLiteralKindLeadingUnderscore
 	InvalidNumberLiteralKindTrailingUnderscore
 	InvalidNumberLiteralKindUnknownPrefix
+	InvalidNumberLiteralKindMissingDigits
 )
 
 func (k InvalidNumberLiteralKind) Description() string {
@@ -41,6 +42,8 @@ func (k InvalidNumberLiteralKind) Description() string {
 		return "trailing underscore"
 	case InvalidNumberLiteralKindUnknownPrefix:
 		return "unknown prefix"
+	case InvalidNumberLiteralKindMissingDigits:
+		return "missing digits"
 	case InvalidNumberLiteralKindUnknown:
 		return "unknown"
 	}

--- a/runtime/parser2/invalidnumberliteralkind_string.go
+++ b/runtime/parser2/invalidnumberliteralkind_string.go
@@ -12,11 +12,12 @@ func _() {
 	_ = x[InvalidNumberLiteralKindLeadingUnderscore-1]
 	_ = x[InvalidNumberLiteralKindTrailingUnderscore-2]
 	_ = x[InvalidNumberLiteralKindUnknownPrefix-3]
+	_ = x[InvalidNumberLiteralKindMissingDigits-4]
 }
 
-const _InvalidNumberLiteralKind_name = "InvalidNumberLiteralKindUnknownInvalidNumberLiteralKindLeadingUnderscoreInvalidNumberLiteralKindTrailingUnderscoreInvalidNumberLiteralKindUnknownPrefix"
+const _InvalidNumberLiteralKind_name = "InvalidNumberLiteralKindUnknownInvalidNumberLiteralKindLeadingUnderscoreInvalidNumberLiteralKindTrailingUnderscoreInvalidNumberLiteralKindUnknownPrefixInvalidNumberLiteralKindMissingDigits"
 
-var _InvalidNumberLiteralKind_index = [...]uint8{0, 31, 72, 114, 151}
+var _InvalidNumberLiteralKind_index = [...]uint8{0, 31, 72, 114, 151, 188}
 
 func (i InvalidNumberLiteralKind) String() string {
 	if i >= InvalidNumberLiteralKind(len(_InvalidNumberLiteralKind_index)-1) {

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -366,10 +366,10 @@ func (l *lexer) scanDecimalOrFixedPointRemainder() TokenType {
 	r := l.next()
 	if r == '.' {
 		l.scanFixedPointRemainder()
-		return TokenFixedPointLiteral
+		return TokenFixedPointNumberLiteral
 	} else {
 		l.backupOne()
-		return TokenDecimalLiteral
+		return TokenDecimalIntegerLiteral
 	}
 }
 

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -74,7 +74,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "01",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -90,7 +90,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "10",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
@@ -128,7 +128,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "1",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
@@ -158,7 +158,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "2",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -189,7 +189,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "3",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
@@ -227,7 +227,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "4",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 10, Offset: 10},
@@ -257,7 +257,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "2",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -288,7 +288,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "3",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
@@ -326,7 +326,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "4",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 10, Offset: 10},
@@ -349,7 +349,7 @@ func TestLexBasic(t *testing.T) {
 			"1 \n  2\n",
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "1",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -365,7 +365,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "2",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 2, Column: 2, Offset: 5},
@@ -396,7 +396,7 @@ func TestLexBasic(t *testing.T) {
 			"1 ?? 2",
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "1",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -427,7 +427,7 @@ func TestLexBasic(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "2",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
@@ -1052,7 +1052,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenBinaryLiteral,
+					Type:  TokenBinaryIntegerLiteral,
 					Value: "0b",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1075,7 +1075,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0b101010`,
 			[]Token{
 				{
-					Type:  TokenBinaryLiteral,
+					Type:  TokenBinaryIntegerLiteral,
 					Value: "0b101010",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1098,7 +1098,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0b001000`,
 			[]Token{
 				{
-					Type:  TokenBinaryLiteral,
+					Type:  TokenBinaryIntegerLiteral,
 					Value: "0b001000",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1121,7 +1121,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0b101010_101010`,
 			[]Token{
 				{
-					Type:  TokenBinaryLiteral,
+					Type:  TokenBinaryIntegerLiteral,
 					Value: "0b101010_101010",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1144,7 +1144,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0b_101010_101010`,
 			[]Token{
 				{
-					Type:  TokenBinaryLiteral,
+					Type:  TokenBinaryIntegerLiteral,
 					Value: "0b_101010_101010",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1167,7 +1167,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0b101010_101010_`,
 			[]Token{
 				{
-					Type:  TokenBinaryLiteral,
+					Type:  TokenBinaryIntegerLiteral,
 					Value: "0b101010_101010_",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1198,7 +1198,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenOctalLiteral,
+					Type:  TokenOctalIntegerLiteral,
 					Value: "0o",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1221,7 +1221,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0o32`,
 			[]Token{
 				{
-					Type:  TokenOctalLiteral,
+					Type:  TokenOctalIntegerLiteral,
 					Value: "0o32",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1244,7 +1244,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0o32_45`,
 			[]Token{
 				{
-					Type:  TokenOctalLiteral,
+					Type:  TokenOctalIntegerLiteral,
 					Value: "0o32_45",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1267,7 +1267,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0o_32_45`,
 			[]Token{
 				{
-					Type:  TokenOctalLiteral,
+					Type:  TokenOctalIntegerLiteral,
 					Value: "0o_32_45",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1290,7 +1290,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0o32_45_`,
 			[]Token{
 				{
-					Type:  TokenOctalLiteral,
+					Type:  TokenOctalIntegerLiteral,
 					Value: "0o32_45_",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1313,7 +1313,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`1234567890`,
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "1234567890",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1336,7 +1336,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`1_234_567_890`,
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "1_234_567_890",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1359,7 +1359,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`1_234_567_890_`,
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "1_234_567_890_",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1390,7 +1390,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenHexadecimalLiteral,
+					Type:  TokenHexadecimalIntegerLiteral,
 					Value: "0x",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1413,7 +1413,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0xf2`,
 			[]Token{
 				{
-					Type:  TokenHexadecimalLiteral,
+					Type:  TokenHexadecimalIntegerLiteral,
 					Value: "0xf2",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1436,7 +1436,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0xf2_09`,
 			[]Token{
 				{
-					Type:  TokenHexadecimalLiteral,
+					Type:  TokenHexadecimalIntegerLiteral,
 					Value: "0xf2_09",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1459,7 +1459,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0x_f2_09`,
 			[]Token{
 				{
-					Type:  TokenHexadecimalLiteral,
+					Type:  TokenHexadecimalIntegerLiteral,
 					Value: "0x_f2_09",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1482,7 +1482,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			`0xf2_09_`,
 			[]Token{
 				{
-					Type:  TokenHexadecimalLiteral,
+					Type:  TokenHexadecimalIntegerLiteral,
 					Value: "0xf2_09_",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1505,7 +1505,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			"0",
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "0",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1528,7 +1528,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			"01",
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "01",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1551,7 +1551,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			"0\n",
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "0",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1582,7 +1582,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 			"00123",
 			[]Token{
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenDecimalIntegerLiteral,
 					Value: "00123",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1613,7 +1613,7 @@ func TestLexIntegerLiterals(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenDecimalLiteral,
+					Type:  TokenUnknownBaseIntegerLiteral,
 					Value: "0z123",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1641,7 +1641,7 @@ func TestLexFixedPoint(t *testing.T) {
 			"1234_5678_90.0009_8765_4321",
 			[]Token{
 				{
-					Type:  TokenFixedPointLiteral,
+					Type:  TokenFixedPointNumberLiteral,
 					Value: "1234_5678_90.0009_8765_4321",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1664,7 +1664,7 @@ func TestLexFixedPoint(t *testing.T) {
 			"0.1",
 			[]Token{
 				{
-					Type:  TokenFixedPointLiteral,
+					Type:  TokenFixedPointNumberLiteral,
 					Value: "0.1",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1695,7 +1695,7 @@ func TestLexFixedPoint(t *testing.T) {
 					},
 				},
 				{
-					Type:  TokenFixedPointLiteral,
+					Type:  TokenFixedPointNumberLiteral,
 					Value: "0.",
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -196,21 +196,21 @@ func numberState(l *lexer) stateFn {
 			if l.endOffset-l.startOffset <= 2 {
 				l.emitError(fmt.Errorf("missing digits"))
 			}
-			l.emitValue(TokenBinaryLiteral)
+			l.emitValue(TokenBinaryIntegerLiteral)
 
 		case 'o':
 			l.scanOctalRemainder()
 			if l.endOffset-l.startOffset <= 2 {
 				l.emitError(fmt.Errorf("missing digits"))
 			}
-			l.emitValue(TokenOctalLiteral)
+			l.emitValue(TokenOctalIntegerLiteral)
 
 		case 'x':
 			l.scanHexadecimalRemainder()
 			if l.endOffset-l.startOffset <= 2 {
 				l.emitError(fmt.Errorf("missing digits"))
 			}
-			l.emitValue(TokenHexadecimalLiteral)
+			l.emitValue(TokenHexadecimalIntegerLiteral)
 
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			tokenType := l.scanDecimalOrFixedPointRemainder()
@@ -218,11 +218,11 @@ func numberState(l *lexer) stateFn {
 
 		case '.':
 			l.scanFixedPointRemainder()
-			l.emitValue(TokenFixedPointLiteral)
+			l.emitValue(TokenFixedPointNumberLiteral)
 
 		case EOF:
 			l.backupOne()
-			l.emitValue(TokenDecimalLiteral)
+			l.emitValue(TokenDecimalIntegerLiteral)
 
 		default:
 			prefixChar := r
@@ -232,10 +232,13 @@ func numberState(l *lexer) stateFn {
 				l.next()
 
 				tokenType := l.scanDecimalOrFixedPointRemainder()
+				if tokenType == TokenDecimalIntegerLiteral {
+					tokenType = TokenUnknownBaseIntegerLiteral
+				}
 				l.emitValue(tokenType)
 			} else {
 				l.backupOne()
-				l.emitValue(TokenDecimalLiteral)
+				l.emitValue(TokenDecimalIntegerLiteral)
 			}
 		}
 

--- a/runtime/parser2/lexer/tokentype.go
+++ b/runtime/parser2/lexer/tokentype.go
@@ -30,11 +30,12 @@ const (
 	TokenError TokenType = iota
 	TokenEOF
 	TokenSpace
-	TokenBinaryLiteral
-	TokenOctalLiteral
-	TokenDecimalLiteral
-	TokenHexadecimalLiteral
-	TokenFixedPointLiteral
+	TokenBinaryIntegerLiteral
+	TokenOctalIntegerLiteral
+	TokenDecimalIntegerLiteral
+	TokenHexadecimalIntegerLiteral
+	TokenUnknownBaseIntegerLiteral
+	TokenFixedPointNumberLiteral
 	TokenIdentifier
 	TokenString
 	TokenPlus
@@ -100,16 +101,18 @@ func (t TokenType) String() string {
 		return "EOF"
 	case TokenSpace:
 		return "space"
-	case TokenBinaryLiteral:
+	case TokenBinaryIntegerLiteral:
 		return "binary integer"
-	case TokenOctalLiteral:
+	case TokenOctalIntegerLiteral:
 		return "octal integer"
-	case TokenDecimalLiteral:
+	case TokenDecimalIntegerLiteral:
 		return "decimal integer"
-	case TokenHexadecimalLiteral:
+	case TokenHexadecimalIntegerLiteral:
 		return "hexadecimal integer"
-	case TokenFixedPointLiteral:
+	case TokenFixedPointNumberLiteral:
 		return "fixed-point number"
+	case TokenUnknownBaseIntegerLiteral:
+		return "integer with unknown base"
 	case TokenIdentifier:
 		return "identifier"
 	case TokenString:


### PR DESCRIPTION
Fixes #353

