### PR TITLE
Copy values on return

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1089,7 +1089,8 @@ func (interpreter *Interpreter) VisitReturnStatement(statement *ast.ReturnStatem
 			valueType := interpreter.Checker.Elaboration.ReturnStatementValueTypes[statement]
 			returnType := interpreter.Checker.Elaboration.ReturnStatementReturnTypes[statement]
 
-			value = interpreter.convertAndBox(value, valueType, returnType)
+			// NOTE: copy on return
+			value = interpreter.copyAndConvert(value, valueType, returnType)
 
 			return functionReturn{value}
 		})

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -8212,3 +8212,31 @@ func TestInterpretInternalAssignment(t *testing.T) {
 		value,
 	)
 }
+
+func TestInterpretCopyOnReturn(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t,
+		`
+          let xs: {String: String} = {}
+
+          fun returnXS(): {String: String} {
+              return xs
+          }
+
+          fun test(): {String: String} {
+              returnXS().insert(key: "foo", "bar")
+              return xs
+          }
+        `,
+	)
+
+	value, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		interpreter.NewDictionaryValueUnownedNonCopying(),
+		value,
+	)
+}


### PR DESCRIPTION
I incorrectly removed the copying of return values in a previous PR (https://github.com/onflow/cadence/pull/288/files#diff-a8c2ab8c721531fd42f8f5ecbad5ca28L1092-R1092), but as @joshuahannan pointed out, call-sites could directly access the returned value without assigning it e.g to a variable (which copies), allowing modification of the returned value.