### PR TITLE
Fix composite-type explicit-conformances record timing

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -413,6 +413,13 @@ func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclarati
 		variable,
 	)
 
+	// Resolve conformances
+
+	conformances := checker.explicitInterfaceConformances(declaration, compositeType)
+	compositeType.ExplicitInterfaceConformances = conformances
+
+	// Register in elaboration
+
 	checker.Elaboration.CompositeDeclarationTypes[declaration] = compositeType
 
 	// Activate new scope for nested declarations
@@ -476,11 +483,6 @@ func (checker *Checker) declareCompositeMembersAndValue(
 		defer checker.valueActivations.Leave()
 
 		checker.declareCompositeNestedTypes(declaration, kind, false)
-
-		// Resolve conformances
-
-		conformances := checker.explicitInterfaceConformances(declaration, compositeType)
-		compositeType.ExplicitInterfaceConformances = conformances
 
 		// NOTE: determine initializer parameter types while nested types are in scope,
 		// and after declaring nested types as the initializer may use nested type in parameters

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -1101,3 +1101,26 @@ func TestCheckRestrictedTypeConformanceOrder(t *testing.T) {
 	})
 
 }
+
+// https://github.com/onflow/cadence/issues/326
+func TestCheckRestrictedConformance(t *testing.T) {
+
+	_, err := ParseAndCheck(t, `
+
+      contract C {
+
+          resource interface RI {
+              fun get(): &R{RI}
+          }
+
+          resource R: RI {
+
+              fun get(): &R{RI} {
+                  return &self as &R{RI}
+              }
+          }
+      }
+    `)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #326

Determine and record explicit composite conformances earlier, before they are used.
