### PR TITLE
Add struct as supported event parameter type

### DIFF
--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -20,6 +20,7 @@ package sema
 
 import (
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
 )
 
 // checkEventParameters checks that the event initializer's parameters are valid,
@@ -70,6 +71,19 @@ func IsValidEventParameterType(t Type) bool {
 	case *DictionaryType:
 		return IsValidEventParameterType(t.KeyType) &&
 			IsValidEventParameterType(t.ValueType)
+
+	case *CompositeType:
+		if t.Kind != common.CompositeKindStructure {
+			return false
+		}
+		for _, member := range t.Members {
+			if member.DeclarationKind == common.DeclarationKindField {
+				if !IsValidEventParameterType(member.TypeAnnotation.Type) {
+					return false
+				}
+			}
+		}
+		return true
 
 	default:
 		return IsSubType(t, &NumberType{})

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -265,7 +265,7 @@ func TestCheckEmitEvent(t *testing.T) {
 	})
 }
 
-func TestCheckCompositEvent(t *testing.T) {
+func TestCheckCompositeEvent(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -180,6 +180,7 @@ func TestCheckEventDeclaration(t *testing.T) {
 		assert.IsType(t, &sema.RedeclarationError{}, errs[0])
 		assert.IsType(t, &sema.RedeclarationError{}, errs[1])
 	})
+
 }
 
 func TestCheckEmitEvent(t *testing.T) {
@@ -261,5 +262,24 @@ func TestCheckEmitEvent(t *testing.T) {
 		errs := ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.EmitImportedEventError{}, errs[0])
+	})
+}
+
+func TestCheckCompositEvent(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("ValidEvent", func(t *testing.T) {
+		_, err := ParseAndCheck(t, `
+			pub struct S {}
+
+            event Transfer(param: S)
+
+            fun test() {
+                emit Transfer(param: S())
+            }
+        `)
+
+		require.NoError(t, err)
 	})
 }

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -37,6 +37,9 @@ func TestCheckEventDeclaration(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ValidEvent", func(t *testing.T) {
+
+		t.Parallel()
+
 		checker, err := ParseAndCheck(t, `
             event Transfer(to: Int, from: Int)
         `)
@@ -55,12 +58,13 @@ func TestCheckEventDeclaration(t *testing.T) {
 
 	t.Run("InvalidEventNonPrimitiveTypeComposite", func(t *testing.T) {
 
-		for _, compositeKind := range common.CompositeKindsWithBody {
-			if compositeKind == common.CompositeKindContract {
-				continue
-			}
+		t.Parallel()
+
+		test := func(compositeKind common.CompositeKind) {
 
 			t.Run(compositeKind.Name(), func(t *testing.T) {
+
+				t.Parallel()
 
 				_, err := ParseAndCheck(t,
 					fmt.Sprintf(
@@ -89,18 +93,26 @@ func TestCheckEventDeclaration(t *testing.T) {
 					assert.IsType(t, &sema.InvalidResourceFieldError{}, errs[2])
 
 				case common.CompositeKindStructure:
-					errs := ExpectCheckerErrors(t, err, 1)
-
-					assert.IsType(t, &sema.InvalidEventParameterTypeError{}, errs[0])
+					require.NoError(t, err)
 
 				default:
 					panic(errors.NewUnreachableError())
 				}
 			})
 		}
+
+		for _, compositeKind := range common.CompositeKindsWithBody {
+			if compositeKind == common.CompositeKindContract {
+				continue
+			}
+
+			test(compositeKind)
+		}
 	})
 
 	t.Run("PrimitiveTypedFields", func(t *testing.T) {
+
+		t.Parallel()
 
 		validTypes := append(
 			sema.AllNumberTypes,
@@ -127,6 +139,8 @@ func TestCheckEventDeclaration(t *testing.T) {
 	})
 
 	t.Run("EventParameterType", func(t *testing.T) {
+
+		t.Parallel()
 
 		validTypes := append(
 			[]sema.Type{
@@ -168,6 +182,9 @@ func TestCheckEventDeclaration(t *testing.T) {
 	})
 
 	t.Run("RedeclaredEvent", func(t *testing.T) {
+
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             event Transfer(to: Int, from: Int)
             event Transfer(to: Int)
@@ -262,24 +279,5 @@ func TestCheckEmitEvent(t *testing.T) {
 		errs := ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.EmitImportedEventError{}, errs[0])
-	})
-}
-
-func TestCheckCompositeEvent(t *testing.T) {
-
-	t.Parallel()
-
-	t.Run("ValidEvent", func(t *testing.T) {
-		_, err := ParseAndCheck(t, `
-			pub struct S {}
-
-            event Transfer(param: S)
-
-            fun test() {
-                emit Transfer(param: S())
-            }
-        `)
-
-		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Closes #313 

## Description

Allows structs to be used as event parameters as long as the fields are also valid event parameters

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
