### PR TITLE
Add WebAssembly package with WASM binary writer and reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install wabt
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v2
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Install dependencies
-      run: sudo apt-get install wabt
+      run: sudo apt-get update && sudo apt-get install wabt
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: build
+    - name: Build
       run: make build
-    - name: test
+    - name: Test
       run: make test
-    - name: check tidy
+    - name: Check tidy
       run: make check-tidy
-    - name: check headers
+    - name: Check headers
       run: make check-headers
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install wabt
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v2
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - name: Install dependencies
+      run: sudo apt-get install wabt
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -24,11 +26,15 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - run: |
-        make build
-        make test
-        make check-tidy
-        make check-headers
+    - name: build
+      run: make build
+    - name: test
+      run: make test
+    - name: check tidy
+      run: make check-tidy
+    - name: check headers
+      run: make check-headers
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/runtime/compiler/wasm/buf.go
+++ b/runtime/compiler/wasm/buf.go
@@ -1,0 +1,85 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+import (
+	"io"
+)
+
+type offset int
+
+// buf is a byte buffer, which allows reading and writing.
+//
+type buf struct {
+	data   []byte
+	offset offset
+}
+
+func (buf *buf) WriteByte(b byte) error {
+	if buf.offset < offset(len(buf.data)) {
+		buf.data[buf.offset] = b
+	} else {
+		buf.data = append(buf.data, b)
+	}
+	buf.offset++
+	return nil
+}
+
+func (buf *buf) WriteBytes(data []byte) error {
+	for _, b := range data {
+		err := buf.WriteByte(b)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (buf *buf) Read(data []byte) (int, error) {
+	n := copy(data, buf.data[buf.offset:])
+	if n == 0 && len(data) != 0 {
+		return 0, io.EOF
+	}
+	buf.offset += offset(n)
+	return n, nil
+}
+
+func (buf *buf) ReadByte() (byte, error) {
+	if buf.offset >= offset(len(buf.data)) {
+		return 0, io.EOF
+	}
+	b := buf.data[buf.offset]
+	buf.offset++
+	return b, nil
+}
+
+func (buf *buf) ReadBytesEqual(expected []byte) (bool, error) {
+	off := buf.offset
+	for _, b := range expected {
+		if off >= offset(len(buf.data)) {
+			return false, io.EOF
+		}
+		if buf.data[off] != b {
+			return false, nil
+		}
+		off++
+	}
+	buf.offset = off
+	return true, nil
+}

--- a/runtime/compiler/wasm/errors.go
+++ b/runtime/compiler/wasm/errors.go
@@ -1,0 +1,481 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+import (
+	"fmt"
+)
+
+// InvalidMagicError is returned when the WASM binary
+// does not start with the magic byte sequence
+//
+type InvalidMagicError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidMagicError) Error() string {
+	return fmt.Sprintf(
+		"invalid magic at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidMagicError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidMagicError is returned when the WASM binary
+// does not have the expected version
+//
+type InvalidVersionError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidVersionError) Error() string {
+	return fmt.Sprintf(
+		"invalid version at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidVersionError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidSectionIDError is returned when the WASM binary specifies
+// an invalid section ID
+//
+type InvalidSectionIDError struct {
+	Offset    int
+	SectionID sectionID
+	ReadError error
+}
+
+func (e InvalidSectionIDError) Error() string {
+	return fmt.Sprintf(
+		"invalid section ID %d at offset %d",
+		e.SectionID,
+		e.Offset,
+	)
+}
+
+func (e InvalidSectionIDError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidDuplicateSectionError is returned when the WASM binary specifies
+// a duplicate section
+//
+type InvalidDuplicateSectionError struct {
+	Offset    int
+	SectionID sectionID
+}
+
+func (e InvalidDuplicateSectionError) Error() string {
+	return fmt.Sprintf(
+		"invalid duplicate section with ID %d at offset %d",
+		e.SectionID,
+		e.Offset,
+	)
+}
+
+// InvalidSectionSizeError is returned when the WASM binary specifies
+// an invalid section size
+//
+type InvalidSectionSizeError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidSectionSizeError) Error() string {
+	return fmt.Sprintf(
+		"invalid section size at offset %d: %s",
+		e.Offset,
+		e.ReadError,
+	)
+}
+
+func (e InvalidSectionSizeError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidValTypeError is returned when the WASM binary specifies
+// an invalid value type
+//
+type InvalidValTypeError struct {
+	Offset    int
+	ValType   ValueType
+	ReadError error
+}
+
+func (e InvalidValTypeError) Error() string {
+	return fmt.Sprintf(
+		"invalid value type %d at offset %d",
+		e.ValType,
+		e.Offset,
+	)
+}
+
+func (e InvalidValTypeError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFuncTypeIndicatorError is returned when the WASM binary specifies
+// an invalid function type indicator
+//
+type InvalidFuncTypeIndicatorError struct {
+	Offset            int
+	FuncTypeIndicator byte
+	ReadError         error
+}
+
+func (e InvalidFuncTypeIndicatorError) Error() string {
+	return fmt.Sprintf(
+		"invalid function type indicator at offset %d: got %x, expected %x",
+		e.Offset,
+		e.FuncTypeIndicator,
+		functionTypeIndicator,
+	)
+}
+
+func (e InvalidFuncTypeIndicatorError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFuncTypeParameterCountError is returned when the WASM binary specifies
+// an invalid func type parameter count
+//
+type InvalidFuncTypeParameterCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidFuncTypeParameterCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid function type parameter count at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidFuncTypeParameterCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFuncTypeParameterTypeError is returned when the WASM binary specifies
+// an invalid function type parameter type
+//
+type InvalidFuncTypeParameterTypeError struct {
+	Index     int
+	ReadError error
+}
+
+func (e InvalidFuncTypeParameterTypeError) Error() string {
+	return fmt.Sprintf(
+		"invalid function type parameter type at index %d",
+		e.Index,
+	)
+}
+
+func (e InvalidFuncTypeParameterTypeError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFuncTypeResultCountError is returned when the WASM binary specifies
+// an invalid func type result count
+//
+type InvalidFuncTypeResultCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidFuncTypeResultCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid function type result count at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidFuncTypeResultCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFuncTypeResultTypeError is returned when the WASM binary specifies
+// an invalid function type result type
+//
+type InvalidFuncTypeResultTypeError struct {
+	Index     int
+	ReadError error
+}
+
+func (e InvalidFuncTypeResultTypeError) Error() string {
+	return fmt.Sprintf(
+		"invalid function type result type at index %d",
+		e.Index,
+	)
+}
+
+func (e InvalidFuncTypeResultTypeError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidTypeSectionTypeCountError is returned when the WASM binary specifies
+// an invalid count in the type section
+//
+type InvalidTypeSectionTypeCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidTypeSectionTypeCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid type count in type section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidTypeSectionTypeCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFunctionSectionFunctionCountError is returned when the WASM binary specifies
+// an invalid count in the function section
+//
+type InvalidFunctionSectionFunctionCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidFunctionSectionFunctionCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid function count in function section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidFunctionSectionFunctionCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFunctionSectionFunctionTypeIDError is returned when the WASM binary specifies
+// an invalid function type ID in the function section
+//
+type InvalidFunctionSectionFunctionTypeIDError struct {
+	Offset    int
+	Index     int
+	ReadError error
+}
+
+func (e InvalidFunctionSectionFunctionTypeIDError) Error() string {
+	return fmt.Sprintf(
+		"invalid function type ID at index %d at offset %d",
+		e.Index,
+		e.Offset,
+	)
+}
+
+func (e InvalidFunctionSectionFunctionTypeIDError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidCodeSectionFunctionCountError is returned when the WASM binary specifies
+// an invalid function count in the code section
+//
+type InvalidCodeSectionFunctionCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidCodeSectionFunctionCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid function count in code section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidCodeSectionFunctionCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidFunctionCodeError is returned when the WASM binary specifies
+// invalid code for a function in the code section
+//
+type InvalidFunctionCodeError struct {
+	Index     int
+	ReadError error
+}
+
+func (e InvalidFunctionCodeError) Error() string {
+	return fmt.Sprintf(
+		"invalid code for function at index %d",
+		e.Index,
+	)
+}
+
+func (e InvalidFunctionCodeError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidCodeSizeError is returned when the WASM binary specifies
+// an invalid code size in the code section
+//
+type InvalidCodeSizeError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidCodeSizeError) Error() string {
+	return fmt.Sprintf(
+		"invalid code size in code section at offset %d",
+		e.Offset,
+	)
+}
+
+// InvalidCodeSectionLocalsCountError is returned when the WASM binary specifies
+// an invalid locals count in the code section
+//
+type InvalidCodeSectionLocalsCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidCodeSectionLocalsCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid locals count in code section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidCodeSectionLocalsCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidCodeSectionCompressedLocalsCountError is returned when the WASM binary specifies
+// an invalid local type in the code section
+//
+type InvalidCodeSectionCompressedLocalsCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidCodeSectionCompressedLocalsCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid compressed local type count in code section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidCodeSectionCompressedLocalsCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidCodeSectionLocalTypeError is returned when the WASM binary specifies
+// an invalid local type in the code section
+//
+type InvalidCodeSectionLocalTypeError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidCodeSectionLocalTypeError) Error() string {
+	return fmt.Sprintf(
+		"invalid local type in code section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidCodeSectionLocalTypeError) Unwrap() error {
+	return e.ReadError
+}
+
+// CodeSectionLocalsCountMismatchError is returned when
+// the sum of the compressed locals locals count in the code section does not match
+// the number of locals in the code section of the WASM binary
+//
+type CodeSectionLocalsCountMismatchError struct {
+	Offset   int
+	Expected uint32
+	Actual   uint32
+}
+
+func (e CodeSectionLocalsCountMismatchError) Error() string {
+	return fmt.Sprintf(
+		"local count mismatch in code section at offset %d: expected %d, got %d",
+		e.Offset,
+		e.Expected,
+		e.Actual,
+	)
+}
+
+// InvalidOpcodeError is returned when the WASM binary specifies
+// an invalid opcode in the code section
+//
+type InvalidOpcodeError struct {
+	Offset    int
+	Opcode    opcode
+	ReadError error
+}
+
+func (e InvalidOpcodeError) Error() string {
+	return fmt.Sprintf(
+		"invalid opcode in code section at offset %d: %x",
+		e.Offset,
+		e.Opcode,
+	)
+}
+
+func (e InvalidOpcodeError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidInstructionArgumentError is returned when the WASM binary specifies
+// an invalid argument for an instruction in the code section
+//
+type InvalidInstructionArgumentError struct {
+	Offset    int
+	Opcode    opcode
+	ReadError error
+}
+
+func (e InvalidInstructionArgumentError) Error() string {
+	return fmt.Sprintf(
+		"invalid argument for instruction with opcode %x in code section at offset %d",
+		e.Opcode,
+		e.Offset,
+	)
+}
+
+func (e InvalidInstructionArgumentError) Unwrap() error {
+	return e.ReadError
+}
+
+// MissingEndInstructionError is returned when the WASM binary
+// misses an end instruction for a function in the code section
+//
+type MissingEndInstructionError struct {
+	Offset int
+}
+
+func (e MissingEndInstructionError) Error() string {
+	return fmt.Sprintf(
+		"missing end instruction in code section at offset %d",
+		e.Offset,
+	)
+}

--- a/runtime/compiler/wasm/function.go
+++ b/runtime/compiler/wasm/function.go
@@ -1,0 +1,34 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// Function represents a function
+//
+type Function struct {
+	Name   string
+	TypeID uint32
+	Code   *Code
+}
+
+// Code represents the code of a function
+//
+type Code struct {
+	Locals       []ValueType
+	Instructions []Instruction
+}

--- a/runtime/compiler/wasm/instruction.go
+++ b/runtime/compiler/wasm/instruction.go
@@ -1,0 +1,45 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+type Instruction interface {
+	write(*WASMWriter) error
+}
+
+// InstructionLocalGet is the 'local.get' instruction
+//
+type InstructionLocalGet struct {
+	Index uint32
+}
+
+func (i InstructionLocalGet) write(wasm *WASMWriter) error {
+	err := wasm.writeOpcode(opcodeLocalGet)
+	if err != nil {
+		return err
+	}
+	return wasm.buf.writeULEB128(i.Index)
+}
+
+// InstructionI32Add is the 'i32.add' instruction
+//
+type InstructionI32Add struct{}
+
+func (i InstructionI32Add) write(wasm *WASMWriter) error {
+	return wasm.writeOpcode(opcodeI32Add)
+}

--- a/runtime/compiler/wasm/leb128.go
+++ b/runtime/compiler/wasm/leb128.go
@@ -1,0 +1,184 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+import (
+	"fmt"
+)
+
+// writeULEB128 encodes and writes the given unsigned integer
+// in canonical (with fewest bytes possible) unsigned little endian base 128 format
+//
+func (buf *buf) writeULEB128(v uint32) error {
+	if v < 128 {
+		err := buf.WriteByte(uint8(v))
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	more := true
+	for more {
+		// low order 7 bits of value
+		c := uint8(v & 0x7f)
+		v >>= 7
+		// more bits to come?
+		more = v != 0
+		if more {
+			// set high order bit of byte
+			c |= 0x80
+		}
+		// emit byte
+		err := buf.WriteByte(c)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeULEB128FixedLength encodes and writes the given unsigned integer
+// in non-canonical (fixed-size, instead of with fewest bytes possible)
+// unsigned little endian base 128 format
+//
+func (buf *buf) writeULEB128FixedLength(v uint32, length int) error {
+	for i := 0; i < length; i++ {
+		c := uint8(v & 0x7f)
+		v >>= 7
+		if i < length-1 {
+			c |= 0x80
+		}
+		err := buf.WriteByte(c)
+		if err != nil {
+			return err
+		}
+	}
+	if v != 0 {
+		return fmt.Errorf("writeULEB128FixedLength: length too small: %d", length)
+	}
+	return nil
+}
+
+// readULEB128 reads and decodes a uint32
+//
+func (buf *buf) readULEB128() (uint32, error) {
+	var result uint32
+	var shift, i uint
+	// only read up to maximum number of bytes
+	for i < max32bitLEB128ByteCount {
+		b, err := buf.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		result |= (uint32(b & 0x7F)) << shift
+		// check high order bit of byte
+		if b&0x80 == 0 {
+			break
+		}
+		shift += 7
+		i++
+	}
+	return result, nil
+}
+
+// writeULEB128 encodes and writes the given signed integer
+// in canonical (with fewest bytes possible) signed little endian base 128 format
+//
+func (buf *buf) writeSLEB128(v int32) error {
+	more := true
+	for more {
+		// low order 7 bits of value
+		c := uint8(v & 0x7f)
+		sign := uint8(v & 0x40)
+		v >>= 7
+		more = !((v == 0 && sign == 0) || (v == -1 && sign != 0))
+		if more {
+			c |= 0x80
+		}
+		err := buf.WriteByte(c)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readULEB128 reads and decodes a uint32
+//
+func (buf *buf) readSLEB128() (int32, error) {
+	var result int32
+	var i uint
+	var b byte = 0x80
+	var signBits int32 = -1
+	var err error
+	for (b&0x80 == 0x80) && i < max32bitLEB128ByteCount {
+		b, err = buf.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		result += int32(b&0x7f) << (i * 7)
+		signBits <<= 7
+		i++
+	}
+	if ((signBits >> 1) & result) != 0 {
+		result += signBits
+	}
+	return result, nil
+}
+
+// max32bitLEB128ByteCount is the maximum number of bytes a 32-bit integer
+// (signed or unsigned) may be encoded as. From
+// https://webassembly.github.io/spec/core/binary/values.html#binary-int:
+//
+// "the total number of bytes encoding a value of type uN must not exceed ceil(N/7) bytes"
+//
+const max32bitLEB128ByteCount = 5
+
+// writeFixedUint32LEB128Space writes a non-canonical 5-byte fixed-size space
+// (instead of the minimal size if canonical encoding would be used)
+//
+func (buf *buf) writeFixedUint32LEB128Space() (offset, error) {
+	off := buf.offset
+	for i := 0; i < max32bitLEB128ByteCount; i++ {
+		err := buf.WriteByte(0)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return off, nil
+}
+
+// writeUint32LEB128SizeAt writes the size, the number of bytes
+// between the given offset and the current offset,
+// as a uint32 in non-canonical 5-byte fixed-size format
+// (instead of the minimal size if canonical encoding would be used)
+// at the given offset
+//
+func (buf *buf) writeUint32LEB128SizeAt(off offset) error {
+	currentOff := buf.offset
+	if currentOff < max32bitLEB128ByteCount || currentOff-max32bitLEB128ByteCount < off {
+		return fmt.Errorf("writeUint32LEB128SizeAt: invalid offset: %d", off)
+	}
+	size := uint32(currentOff - off - max32bitLEB128ByteCount)
+	buf.offset = off
+	defer func() {
+		buf.offset = currentOff
+	}()
+	return buf.writeULEB128FixedLength(size, max32bitLEB128ByteCount)
+}

--- a/runtime/compiler/wasm/leb128_test.go
+++ b/runtime/compiler/wasm/leb128_test.go
@@ -1,0 +1,168 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuf_writeULEB128(t *testing.T) {
+
+	t.Run("DWARF spec", func(t *testing.T) {
+
+		// DWARF Debugging Information Format, Version 3, page 140
+
+		for v, expected := range map[uint32][]byte{
+			2:     {2},
+			127:   {127},
+			128:   {0 + 0x80, 1},
+			129:   {1 + 0x80, 1},
+			130:   {2 + 0x80, 1},
+			12857: {57 + 0x80, 100},
+		} {
+			var b buf
+			err := b.writeULEB128(v)
+			require.NoError(t, err)
+			require.Equal(t, expected, b.data)
+
+			b.offset = 0
+
+			actual, err := b.readULEB128()
+			require.NoError(t, err)
+			require.Equal(t, v, actual)
+		}
+	})
+
+	t.Run("write: max byte count", func(t *testing.T) {
+		var b buf
+		err := b.writeULEB128(math.MaxUint32)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, max32bitLEB128ByteCount, len(b.data))
+	})
+
+	t.Run("read: max byte count", func(t *testing.T) {
+		b := buf{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
+		_, err := b.readULEB128()
+		require.NoError(t, err)
+		require.Equal(t, offset(max32bitLEB128ByteCount), b.offset)
+	})
+}
+
+func TestBuf_writeSLEB128(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("DWARF spec", func(t *testing.T) {
+
+		t.Parallel()
+
+		// DWARF Debugging Information Format, Version 3, page 141
+
+		for v, expected := range map[int32][]byte{
+			2:    {2},
+			-2:   {0x7e},
+			127:  {127 + 0x80, 0},
+			-127: {1 + 0x80, 0x7f},
+			128:  {0 + 0x80, 1},
+			-128: {0 + 0x80, 0x7f},
+			129:  {1 + 0x80, 1},
+			-129: {0x7f + 0x80, 0x7e},
+		} {
+			var b buf
+			err := b.writeSLEB128(v)
+			require.NoError(t, err)
+			require.Equal(t, expected, b.data)
+
+			b.offset = 0
+
+			actual, err := b.readSLEB128()
+			require.NoError(t, err)
+			require.Equal(t, v, actual)
+		}
+	})
+
+	t.Run("write: max byte count", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		err := b.writeSLEB128(math.MaxInt32)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, max32bitLEB128ByteCount, len(b.data))
+
+		var b2 buf
+		err = b2.writeSLEB128(math.MinInt32)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, max32bitLEB128ByteCount, len(b.data))
+	})
+
+	t.Run("read: max byte count", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
+		_, err := b.readSLEB128()
+		require.NoError(t, err)
+		require.Equal(t, offset(max32bitLEB128ByteCount), b.offset)
+	})
+}
+
+func TestBuf_WriteSpaceAndSize(t *testing.T) {
+
+	t.Parallel()
+
+	var b buf
+
+	err := b.WriteByte(101)
+	require.NoError(t, err)
+	err = b.WriteByte(102)
+	require.NoError(t, err)
+
+	off, err := b.writeFixedUint32LEB128Space()
+	require.NoError(t, err)
+	require.Equal(t, offset(2), off)
+	require.Equal(t,
+		[]byte{
+			101, 102,
+			0, 0, 0, 0, 0,
+		},
+		b.data,
+	)
+
+	err = b.WriteByte(104)
+	require.NoError(t, err)
+	err = b.WriteByte(105)
+	require.NoError(t, err)
+	err = b.WriteByte(106)
+	require.NoError(t, err)
+
+	err = b.writeUint32LEB128SizeAt(off)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]byte{
+			101, 102,
+			0x83, 0x80, 0x80, 0x80, 0,
+			104, 105, 106,
+		},
+		b.data,
+	)
+}

--- a/runtime/compiler/wasm/leb128_test.go
+++ b/runtime/compiler/wasm/leb128_test.go
@@ -27,7 +27,11 @@ import (
 
 func TestBuf_writeULEB128(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("DWARF spec", func(t *testing.T) {
+
+		t.Parallel()
 
 		// DWARF Debugging Information Format, Version 3, page 140
 
@@ -53,6 +57,13 @@ func TestBuf_writeULEB128(t *testing.T) {
 	})
 
 	t.Run("write: max byte count", func(t *testing.T) {
+
+		t.Parallel()
+
+		// This test ensures that only up to the maximum number of bytes are written
+		// when writing a LEB128-encoded 32-bit number (see max32bitLEB128ByteCount),
+		// i.e. test that only up to 5 bytes are written.
+
 		var b buf
 		err := b.writeULEB128(math.MaxUint32)
 		require.NoError(t, err)
@@ -60,6 +71,14 @@ func TestBuf_writeULEB128(t *testing.T) {
 	})
 
 	t.Run("read: max byte count", func(t *testing.T) {
+
+		t.Parallel()
+
+		// This test ensures that only up to the maximum number of bytes are read
+		// when reading a LEB128-encoded 32-bit number (see max32bitLEB128ByteCount),
+		// i.e. test that only 5 of the 8 given bytes are read,
+		// to ensure the LEB128 parser doesn't keep reading infinitely.
+
 		b := buf{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
 		_, err := b.readULEB128()
 		require.NoError(t, err)
@@ -104,6 +123,10 @@ func TestBuf_writeSLEB128(t *testing.T) {
 
 		t.Parallel()
 
+		// This test ensures that only up to the maximum number of bytes are written
+		// when writing a LEB128-encoded 32-bit number (see max32bitLEB128ByteCount),
+		// i.e. test that only up to 5 bytes are written.
+
 		var b buf
 		err := b.writeSLEB128(math.MaxInt32)
 		require.NoError(t, err)
@@ -118,6 +141,11 @@ func TestBuf_writeSLEB128(t *testing.T) {
 	t.Run("read: max byte count", func(t *testing.T) {
 
 		t.Parallel()
+
+		// This test ensures that only up to the maximum number of bytes are read
+		// when reading a LEB128-encoded 32-bit number (see max32bitLEB128ByteCount),
+		// i.e. test that only 5 of the 8 given bytes are read,
+		// to ensure the LEB128 parser doesn't keep reading infinitely.
 
 		b := buf{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
 		_, err := b.readSLEB128()

--- a/runtime/compiler/wasm/magic.go
+++ b/runtime/compiler/wasm/magic.go
@@ -18,11 +18,24 @@
 
 package wasm
 
-// wasmMagic is the magic byte sequence that appears at the start of the WASM binary
+// wasmMagic is the magic byte sequence that appears at the start of the WASM binary.
+//
+// See https://webassembly.github.io/spec/core/binary/modules.html#binary-module:
+//
+// The encoding of a module starts with a preamble containing a 4-byte magic number (the string '\0asm')
+//
+// magic ::= 0x00 0x61 0x73 0x6d
 //
 var wasmMagic = []byte{0x00, 0x61, 0x73, 0x6d}
 
 // wasmVersion is the byte sequence that appears after wasmMagic
-// and indicated the version of the WASM binary
+// and indicated the version of the WASM binary.
+//
+// See https://webassembly.github.io/spec/core/binary/modules.html#binary-module:
+//
+// The encoding of a module starts with [...] a version field.
+// The current version of the WebAssembly binary format is 1.
+//
+// version ::= 0x01 0x00 0x00 0x00
 //
 var wasmVersion = []byte{0x01, 0x00, 0x00, 0x00}

--- a/runtime/compiler/wasm/magic.go
+++ b/runtime/compiler/wasm/magic.go
@@ -1,0 +1,28 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// wasmMagic is the magic byte sequence that appears at the start of the WASM binary
+//
+var wasmMagic = []byte{0x00, 0x61, 0x73, 0x6d}
+
+// wasmVersion is the byte sequence that appears after wasmMagic
+// and indicated the version of the WASM binary
+//
+var wasmVersion = []byte{0x01, 0x00, 0x00, 0x00}

--- a/runtime/compiler/wasm/module.go
+++ b/runtime/compiler/wasm/module.go
@@ -1,0 +1,29 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// Module represents a module
+//
+type Module struct {
+	Types []*FunctionType
+	// The type IDs of all functions
+	functionTypeIDs []uint32
+	// The bodies of all functions
+	functionBodies []*Code
+}

--- a/runtime/compiler/wasm/opcode.go
+++ b/runtime/compiler/wasm/opcode.go
@@ -1,0 +1,32 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// opcode is the byte used to indicate a certain instruction in the WASM binary
+//
+type opcode byte
+
+const (
+	// opcodeEnd is the opcode for the 'end' instruction
+	opcodeEnd opcode = 0x0B
+	// opcodeLocalGet is the opcode for the 'local.get' instruction
+	opcodeLocalGet opcode = 0x20
+	// opcodeI32Add is the opcode for the 'i32.add' instruction
+	opcodeI32Add opcode = 0x6a
+)

--- a/runtime/compiler/wasm/reader.go
+++ b/runtime/compiler/wasm/reader.go
@@ -1,0 +1,488 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+import (
+	"io"
+)
+
+// WASMReader allows reading WASM binaries
+//
+type WASMReader struct {
+	buf    *buf
+	Module Module
+}
+
+// readMagicAndVersion reads the magic byte sequence and version at the beginning of the WASM binary
+//
+func (r *WASMReader) readMagicAndVersion() error {
+
+	// Read the magic
+	equal, err := r.buf.ReadBytesEqual(wasmMagic)
+	if err != nil || !equal {
+		return InvalidMagicError{
+			Offset:    int(r.buf.offset),
+			ReadError: err,
+		}
+	}
+
+	// Read the version
+	equal, err = r.buf.ReadBytesEqual(wasmVersion)
+	if err != nil || !equal {
+		return InvalidVersionError{
+			Offset:    int(r.buf.offset),
+			ReadError: err,
+		}
+	}
+
+	return nil
+}
+
+// readSection reads a section in the WASM binary
+//
+func (r *WASMReader) readSection() error {
+	// read the section ID
+	sectionIDOffset := r.buf.offset
+	b, err := r.buf.ReadByte()
+
+	sectionID := sectionID(b)
+
+	if err != nil {
+		return InvalidSectionIDError{
+			SectionID: sectionID,
+			Offset:    int(sectionIDOffset),
+			ReadError: err,
+		}
+	}
+
+	invalidDuplicateSectionError := func() error {
+		return InvalidDuplicateSectionError{
+			SectionID: sectionID,
+			Offset:    int(sectionIDOffset),
+		}
+	}
+
+	switch sectionID {
+	case sectionIDType:
+		if r.Module.Types != nil {
+			return invalidDuplicateSectionError()
+		}
+
+		err = r.readTypeSection()
+		if err != nil {
+			return err
+		}
+
+	case sectionIDFunction:
+		if r.Module.functionTypeIDs != nil {
+			return invalidDuplicateSectionError()
+		}
+
+		err = r.readFunctionSection()
+		if err != nil {
+			return err
+		}
+
+	case sectionIDCode:
+		if r.Module.functionBodies != nil {
+			return invalidDuplicateSectionError()
+		}
+
+		err = r.readCodeSection()
+		if err != nil {
+			return err
+		}
+	}
+
+	return InvalidSectionIDError{
+		SectionID: sectionID,
+		Offset:    int(sectionIDOffset),
+	}
+}
+
+// readSectionSize reads the content size of a section
+//
+func (r *WASMReader) readSectionSize() error {
+	// read the size
+	sizeOffset := r.buf.offset
+	// TODO: use size
+	_, err := r.buf.readULEB128()
+	if err != nil {
+		return InvalidSectionSizeError{
+			Offset:    int(sizeOffset),
+			ReadError: err,
+		}
+	}
+
+	return nil
+}
+
+// readTypeSection reads the section that declares all function types
+// so they can be referenced by index
+//
+func (r *WASMReader) readTypeSection() error {
+
+	err := r.readSectionSize()
+	if err != nil {
+		return err
+	}
+
+	// read the number of types
+	countOffset := r.buf.offset
+	count, err := r.buf.readULEB128()
+	if err != nil {
+		return InvalidTypeSectionTypeCountError{
+			Offset:    int(countOffset),
+			ReadError: err,
+		}
+	}
+
+	funcTypes := make([]*FunctionType, count)
+
+	// read each type
+	for i := uint32(0); i < count; i++ {
+		funcType, err := r.readFuncType()
+		if err != nil {
+			return err
+		}
+		funcTypes[i] = funcType
+	}
+
+	r.Module.Types = funcTypes
+
+	return nil
+}
+
+// readFuncType reads a function type
+//
+func (r *WASMReader) readFuncType() (*FunctionType, error) {
+	// read the function type indicator
+	funcTypeIndicatorOffset := r.buf.offset
+	funcTypeIndicator, err := r.buf.ReadByte()
+	if err != nil || funcTypeIndicator != functionTypeIndicator {
+		return nil, InvalidFuncTypeIndicatorError{
+			Offset:            int(funcTypeIndicatorOffset),
+			FuncTypeIndicator: funcTypeIndicator,
+			ReadError:         err,
+		}
+	}
+
+	// read the number of parameters
+	parameterCountOffset := r.buf.offset
+	parameterCount, err := r.buf.readULEB128()
+	if err != nil {
+		return nil, InvalidFuncTypeParameterCountError{
+			Offset:    int(parameterCountOffset),
+			ReadError: err,
+		}
+	}
+
+	// read the type of each parameter
+
+	parameterTypes := make([]ValueType, parameterCount)
+
+	for i := uint32(0); i < parameterCount; i++ {
+		parameterType, err := r.readValType()
+		if err != nil {
+			return nil, InvalidFuncTypeParameterTypeError{
+				Index:     int(i),
+				ReadError: err,
+			}
+		}
+		parameterTypes[i] = parameterType
+	}
+
+	// read the number of results
+	resultCountOffset := r.buf.offset
+	resultCount, err := r.buf.readULEB128()
+	if err != nil {
+		return nil, InvalidFuncTypeResultCountError{
+			Offset:    int(resultCountOffset),
+			ReadError: err,
+		}
+	}
+
+	// read the type of each result
+
+	resultTypes := make([]ValueType, resultCount)
+
+	for i := uint32(0); i < resultCount; i++ {
+		resultType, err := r.readValType()
+		if err != nil {
+			return nil, InvalidFuncTypeResultTypeError{
+				Index:     int(i),
+				ReadError: err,
+			}
+		}
+		resultTypes[i] = resultType
+	}
+
+	return &FunctionType{
+		Params:  parameterTypes,
+		Results: resultTypes,
+	}, nil
+}
+
+// readValType reads a value type
+//
+func (r *WASMReader) readValType() (ValueType, error) {
+	valTypeOffset := r.buf.offset
+	b, err := r.buf.ReadByte()
+
+	valType := ValueType(b)
+
+	if err != nil {
+		return 0, InvalidValTypeError{
+			Offset:    int(valTypeOffset),
+			ValType:   valType,
+			ReadError: err,
+		}
+	}
+
+	switch valType {
+	case ValueTypeI32, ValueTypeI64:
+		return valType, nil
+	}
+
+	return 0, InvalidValTypeError{
+		Offset:  int(valTypeOffset),
+		ValType: valType,
+	}
+}
+
+// readFunctionSection reads the section that declares the types of functions.
+// The bodies of these functions will later be provided in the code section
+//
+func (r *WASMReader) readFunctionSection() error {
+
+	err := r.readSectionSize()
+	if err != nil {
+		return err
+	}
+
+	// read the number of functions
+	countOffset := r.buf.offset
+	count, err := r.buf.readULEB128()
+	if err != nil {
+		return InvalidFunctionSectionFunctionCountError{
+			Offset:    int(countOffset),
+			ReadError: err,
+		}
+	}
+
+	typeIDs := make([]uint32, count)
+
+	// read the function type ID for each function
+	for i := uint32(0); i < count; i++ {
+		typeIDOffset := r.buf.offset
+		typeID, err := r.buf.readULEB128()
+		if err != nil {
+			return InvalidFunctionSectionFunctionTypeIDError{
+				Index:     int(i),
+				Offset:    int(typeIDOffset),
+				ReadError: err,
+			}
+		}
+		typeIDs[i] = typeID
+	}
+
+	r.Module.functionTypeIDs = typeIDs
+
+	return nil
+}
+
+// readCodeSection reads the section that provides the function bodies for the functions
+// declared by the function section (which only provides the function types)
+//
+func (r *WASMReader) readCodeSection() error {
+
+	err := r.readSectionSize()
+	if err != nil {
+		return err
+	}
+
+	// read the number of functions
+	countOffset := r.buf.offset
+	count, err := r.buf.readULEB128()
+	if err != nil {
+		return InvalidCodeSectionFunctionCountError{
+			Offset:    int(countOffset),
+			ReadError: err,
+		}
+	}
+
+	// read the code of each function
+
+	functionBodies := make([]*Code, count)
+
+	for i := uint32(0); i < count; i++ {
+		functionBody, err := r.readFunctionBody()
+		if err != nil {
+			return InvalidFunctionCodeError{
+				Index:     int(i),
+				ReadError: err,
+			}
+		}
+		functionBodies[i] = functionBody
+	}
+
+	r.Module.functionBodies = functionBodies
+
+	return nil
+}
+
+// readFunctionBody reads the body (locals and instruction) of one function in the code section
+//
+func (r *WASMReader) readFunctionBody() (*Code, error) {
+
+	// read the size
+	sizeOffset := r.buf.offset
+	// TODO: use size
+	_, err := r.buf.readULEB128()
+	if err != nil {
+		return nil, InvalidCodeSizeError{
+			Offset:    int(sizeOffset),
+			ReadError: err,
+		}
+	}
+
+	// read the locals
+	locals, err := r.readLocals()
+	if err != nil {
+		return nil, err
+	}
+
+	// read the instructions
+	instructions, err := r.readInstructions()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Code{
+		Locals:       locals,
+		Instructions: instructions,
+	}, nil
+}
+
+// readLocals reads the locals for one function in the code sections
+//
+func (r *WASMReader) readLocals() ([]ValueType, error) {
+	// read the number of locals
+	localsCountOffset := r.buf.offset
+	localsCount, err := r.buf.readULEB128()
+	if err != nil {
+		return nil, InvalidCodeSectionLocalsCountError{
+			Offset:    int(localsCountOffset),
+			ReadError: err,
+		}
+	}
+
+	locals := make([]ValueType, localsCount)
+
+	// read each local
+	for i := uint32(0); i < localsCount; {
+		compressedLocalsCountOffset := r.buf.offset
+		compressedLocalsCount, err := r.buf.readULEB128()
+		if err != nil {
+			return nil, InvalidCodeSectionCompressedLocalsCountError{
+				Offset:    int(compressedLocalsCountOffset),
+				ReadError: err,
+			}
+		}
+
+		localTypeOffset := r.buf.offset
+		localType, err := r.readValType()
+		if err != nil {
+			return nil, InvalidCodeSectionLocalTypeError{
+				Offset:    int(localTypeOffset),
+				ReadError: err,
+			}
+		}
+
+		locals[i] = localType
+
+		i += compressedLocalsCount
+
+		if i > localsCount {
+			return nil, CodeSectionLocalsCountMismatchError{
+				Actual:   i,
+				Expected: localsCount,
+			}
+		}
+	}
+
+	return locals, nil
+}
+
+// readInstructions reads the instructions for one function in the code sections
+//
+func (r *WASMReader) readInstructions() (instructions []Instruction, err error) {
+
+	for {
+		opcodeOffset := r.buf.offset
+		b, err := r.buf.ReadByte()
+
+		c := opcode(b)
+
+		if err != nil {
+			if err == io.EOF {
+				return nil, MissingEndInstructionError{
+					Offset: int(opcodeOffset),
+				}
+			} else {
+				return nil, InvalidOpcodeError{
+					Offset:    int(opcodeOffset),
+					Opcode:    c,
+					ReadError: err,
+				}
+			}
+		}
+
+		switch c {
+		case opcodeLocalGet:
+			indexOffset := r.buf.offset
+			index, err := r.buf.readULEB128()
+			if err != nil {
+				return nil, InvalidInstructionArgumentError{
+					Offset:    int(indexOffset),
+					Opcode:    c,
+					ReadError: err,
+				}
+			}
+			instructions = append(instructions,
+				InstructionLocalGet{Index: index},
+			)
+
+		case opcodeI32Add:
+			instructions = append(instructions,
+				InstructionI32Add{},
+			)
+
+		case opcodeEnd:
+			return instructions, nil
+
+		default:
+			return nil, InvalidOpcodeError{
+				Offset:    int(opcodeOffset),
+				Opcode:    c,
+				ReadError: err,
+			}
+		}
+	}
+}

--- a/runtime/compiler/wasm/reader.go
+++ b/runtime/compiler/wasm/reader.go
@@ -31,6 +31,10 @@ type WASMReader struct {
 
 // readMagicAndVersion reads the magic byte sequence and version at the beginning of the WASM binary
 //
+// See https://webassembly.github.io/spec/core/binary/modules.html#binary-module:
+//
+// The encoding of a module starts with a preamble containing a 4-byte magic number [...] and a version field.
+//
 func (r *WASMReader) readMagicAndVersion() error {
 
 	// Read the magic

--- a/runtime/compiler/wasm/reader_test.go
+++ b/runtime/compiler/wasm/reader_test.go
@@ -1,0 +1,825 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWasmReader_readMagicAndVersion(t *testing.T) {
+
+	t.Parallel()
+
+	read := func(data []byte) error {
+		b := buf{data: data}
+		r := WASMReader{buf: &b}
+		return r.readMagicAndVersion()
+	}
+
+	t.Run("invalid magic, too short", func(t *testing.T) {
+
+		t.Parallel()
+
+		err := read([]byte{0x0, 0x61})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidMagicError{
+				Offset:    0,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+	})
+
+	t.Run("invalid magic, incorrect", func(t *testing.T) {
+
+		t.Parallel()
+
+		err := read([]byte{0x0, 0x61, 0x73, 0xFF})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidMagicError{
+				Offset:    0,
+				ReadError: nil,
+			},
+			err,
+		)
+	})
+
+	t.Run("invalid version, too short", func(t *testing.T) {
+
+		t.Parallel()
+
+		err := read([]byte{0x0, 0x61, 0x73, 0x6d, 0x1, 0x0})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidVersionError{
+				Offset:    4,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+	})
+
+	t.Run("invalid version, incorrect", func(t *testing.T) {
+
+		t.Parallel()
+
+		err := read([]byte{0x0, 0x61, 0x73, 0x6d, 0x2, 0x0, 0x0, 0x0})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidVersionError{
+				Offset:    4,
+				ReadError: nil,
+			},
+			err,
+		)
+	})
+
+	t.Run("valid magic and version", func(t *testing.T) {
+
+		t.Parallel()
+
+		err := read([]byte{0x0, 0x61, 0x73, 0x6d, 0x1, 0x0, 0x0, 0x0})
+		require.NoError(t, err)
+	})
+}
+
+func TestWasmReader_readValType(t *testing.T) {
+
+	t.Parallel()
+
+	read := func(data []byte) (ValueType, error) {
+		b := buf{data: data}
+		r := WASMReader{buf: &b}
+		return r.readValType()
+	}
+
+	t.Run("too short", func(t *testing.T) {
+
+		t.Parallel()
+
+		valType, err := read([]byte{})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidValTypeError{
+				Offset:    0,
+				ValType:   valType,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Equal(t, ValueType(0), valType)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+
+		t.Parallel()
+
+		valType, err := read([]byte{0xFF})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidValTypeError{
+				Offset:    0,
+				ValType:   0xFF,
+				ReadError: nil,
+			},
+			err,
+		)
+		assert.Equal(t, ValueType(0), valType)
+	})
+
+	t.Run("i32", func(t *testing.T) {
+
+		t.Parallel()
+
+		valType, err := read([]byte{byte(ValueTypeI32)})
+		require.NoError(t, err)
+		assert.Equal(t, ValueTypeI32, valType)
+	})
+
+	t.Run("i64", func(t *testing.T) {
+
+		t.Parallel()
+
+		valType, err := read([]byte{byte(ValueTypeI64)})
+		require.NoError(t, err)
+		assert.Equal(t, ValueTypeI64, valType)
+	})
+}
+
+func TestWasmReader_readTypeSection(t *testing.T) {
+
+	t.Parallel()
+
+	read := func(data []byte) ([]*FunctionType, error) {
+		b := buf{data: data}
+		r := WASMReader{buf: &b}
+		err := r.readTypeSection()
+		if err != nil {
+			return nil, err
+		}
+		return r.Module.Types, nil
+	}
+
+	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 7 (LEB128)
+			0x87, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0x60,
+			// parameter count: 2
+			0x2,
+			// type of parameter 1: i32
+			0x7f,
+			// type of parameter 2: i32
+			0x7f,
+			// return value count: 1
+			0x1,
+			// type of return value 1: i32
+			0x7f,
+		})
+		require.NoError(t, err)
+		assert.Equal(t,
+			[]*FunctionType{
+				{
+					Params:  []ValueType{ValueTypeI32, ValueTypeI32},
+					Results: []ValueType{ValueTypeI32},
+				},
+			},
+			funcTypes,
+		)
+	})
+
+	t.Run("invalid size", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			0x87, 0x80, 0x80,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidSectionSizeError{
+				Offset:    0,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid count", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 7 (LEB128)
+			0x80, 0x80, 0x80, 0x80, 0x0,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidTypeSectionTypeCountError{
+				Offset:    5,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid indicator", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 2 (LEB128)
+			0x82, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0xFF,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFuncTypeIndicatorError{
+				Offset:            6,
+				FuncTypeIndicator: 0xff,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid parameter count", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 4 (LEB128)
+			0x82, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0x60,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFuncTypeParameterCountError{
+				Offset:    7,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid parameter type", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 4 (LEB128)
+			0x84, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0x60,
+			// parameter count: 1
+			0x1,
+			// type of parameter 1
+			0xff,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFuncTypeParameterTypeError{
+				Index: 0,
+				ReadError: InvalidValTypeError{
+					Offset:  8,
+					ValType: 0xFF,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid, parameter type missing", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 4 (LEB128)
+			0x84, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0x60,
+			// parameter count: 2
+			0x2,
+			// type of parameter 1: i32
+			0x7f,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFuncTypeParameterTypeError{
+				Index: 1,
+				ReadError: InvalidValTypeError{
+					Offset:    9,
+					ValType:   0,
+					ReadError: io.EOF,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid result count", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 4 (LEB128)
+			0x83, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0x60,
+			// parameter count
+			0x0,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFuncTypeResultCountError{
+				Offset:    8,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid result type", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 4 (LEB128)
+			0x85, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0x60,
+			// parameter count: 0
+			0x0,
+			// result count: 1
+			0x1,
+			// type of result 1
+			0xff,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFuncTypeResultTypeError{
+				Index: 0,
+				ReadError: InvalidValTypeError{
+					Offset:  9,
+					ValType: 0xFF,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid, result type missing", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 4 (LEB128)
+			0x85, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type
+			0x60,
+			// parameter count: 0
+			0x0,
+			// result count: 2
+			0x2,
+			// type of result 1: i32
+			0x7f,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFuncTypeResultTypeError{
+				Index: 1,
+				ReadError: InvalidValTypeError{
+					Offset:    10,
+					ValType:   0,
+					ReadError: io.EOF,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+}
+
+func TestWasmReader_readFunctionSection(t *testing.T) {
+
+	t.Parallel()
+
+	read := func(data []byte) ([]uint32, error) {
+		b := buf{data: data}
+		r := WASMReader{buf: &b}
+		err := r.readFunctionSection()
+		if err != nil {
+			return nil, err
+		}
+		return r.Module.functionTypeIDs, nil
+	}
+
+	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		typeIDs, err := read([]byte{
+			// section size: 2 (LEB128)
+			0x82, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// type ID of function: 0x23
+			0x23,
+		})
+		require.NoError(t, err)
+		assert.Equal(t,
+			[]uint32{0x23},
+			typeIDs,
+		)
+	})
+
+	t.Run("invalid size", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			0x87, 0x80, 0x80,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidSectionSizeError{
+				Offset:    0,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid count", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 7 (LEB128)
+			0x80, 0x80, 0x80, 0x80, 0x0,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionSectionFunctionCountError{
+				Offset:    5,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid function type ID", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 7 (LEB128)
+			0x81, 0x80, 0x80, 0x80, 0x0,
+			// function count
+			0x1,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionSectionFunctionTypeIDError{
+				Offset:    6,
+				Index:     0,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+}
+
+func TestWasmReader_readCodeSection(t *testing.T) {
+
+	t.Parallel()
+
+	read := func(data []byte) ([]*Code, error) {
+		b := buf{data: data}
+		r := WASMReader{buf: &b}
+		err := r.readCodeSection()
+		if err != nil {
+			return nil, err
+		}
+		return r.Module.functionBodies, nil
+	}
+
+	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		codes, err := read([]byte{
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// code size: 9 (LEB128)
+			0x89, 0x80, 0x80, 0x80, 0x0,
+			// number of locals: 1
+			0x1,
+			// number of locals with this type: 1
+			0x1,
+			// local type: i32
+			0x7f,
+			// opcode: local.get, 0
+			0x20, 0x0,
+			// opcode: local.get 1
+			0x20, 0x1,
+			// opcode: i32.add
+			0x6a,
+			// opcode: end
+			0xb,
+		})
+		require.NoError(t, err)
+		assert.Equal(t,
+			[]*Code{
+				{
+					Locals: []ValueType{
+						ValueTypeI32,
+					},
+					Instructions: []Instruction{
+						InstructionLocalGet{0},
+						InstructionLocalGet{1},
+						InstructionI32Add{},
+					},
+				},
+			},
+			codes,
+		)
+	})
+
+	t.Run("invalid size", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			0x87, 0x80, 0x80,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidSectionSizeError{
+				Offset:    0,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid count", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 7 (LEB128)
+			0x80, 0x80, 0x80, 0x80, 0x0,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidCodeSectionFunctionCountError{
+				Offset:    5,
+				ReadError: io.EOF,
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid code size", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionCodeError{
+				Index: 0,
+				ReadError: InvalidCodeSizeError{
+					Offset:    6,
+					ReadError: io.EOF,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid locals count", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// code size: 9 (LEB128)
+			0x89, 0x80, 0x80, 0x80, 0x0,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionCodeError{
+				Index: 0,
+				ReadError: InvalidCodeSectionLocalsCountError{
+					Offset:    11,
+					ReadError: io.EOF,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid compressed locals count", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// code size: 9 (LEB128)
+			0x89, 0x80, 0x80, 0x80, 0x0,
+			// number of locals: 1
+			0x1,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionCodeError{
+				Index: 0,
+				ReadError: InvalidCodeSectionCompressedLocalsCountError{
+					Offset:    12,
+					ReadError: io.EOF,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid local type", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// code size: 9 (LEB128)
+			0x89, 0x80, 0x80, 0x80, 0x0,
+			// number of locals: 1
+			0x1,
+			// number of locals with this type: 1
+			0x1,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionCodeError{
+				Index: 0,
+				ReadError: InvalidCodeSectionLocalTypeError{
+					Offset: 13,
+					ReadError: InvalidValTypeError{
+						Offset:    13,
+						ValType:   0,
+						ReadError: io.EOF,
+					},
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("invalid instruction", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// code size: 9 (LEB128)
+			0x89, 0x80, 0x80, 0x80, 0x0,
+			// number of locals: 1
+			0x1,
+			// number of locals with this type: 1
+			0x1,
+			// local type: i32
+			0x7f,
+			// invalid opcode
+			0xff,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionCodeError{
+				Index: 0,
+				ReadError: InvalidOpcodeError{
+					Offset:    14,
+					Opcode:    0xff,
+					ReadError: nil,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+
+	t.Run("missing end", func(t *testing.T) {
+
+		t.Parallel()
+
+		funcTypes, err := read([]byte{
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// code size: 9 (LEB128)
+			0x89, 0x80, 0x80, 0x80, 0x0,
+			// number of locals: 1
+			0x1,
+			// number of locals with this type: 1
+			0x1,
+			// local type: i32
+			0x7f,
+			// opcode: local.get, 0
+			0x20, 0x0,
+			// opcode: local.get 1
+			0x20, 0x1,
+			// opcode: i32.add
+			0x6a,
+		})
+		require.Error(t, err)
+		assert.Equal(t,
+			InvalidFunctionCodeError{
+				Index: 0,
+				ReadError: MissingEndInstructionError{
+					Offset: 19,
+				},
+			},
+			err,
+		)
+		assert.Nil(t, funcTypes)
+	})
+}

--- a/runtime/compiler/wasm/reader_test.go
+++ b/runtime/compiler/wasm/reader_test.go
@@ -239,7 +239,7 @@ func TestWasmReader_readTypeSection(t *testing.T) {
 		t.Parallel()
 
 		funcTypes, err := read([]byte{
-			// section size: 7 (LEB128)
+			// section size: 0 (LEB128)
 			0x80, 0x80, 0x80, 0x80, 0x0,
 		})
 		require.Error(t, err)

--- a/runtime/compiler/wasm/section.go
+++ b/runtime/compiler/wasm/section.go
@@ -18,7 +18,24 @@
 
 package wasm
 
-// sectionID is the ID of a section in the WASM binary
+// sectionID is the ID of a section in the WASM binary.
+//
+// See https://webassembly.github.io/spec/core/binary/modules.html#sections:
+//
+// The following section ids are used:
+//
+// 0 = custom section
+// 1 = type section
+// 2 = import section
+// 3 = function section
+// 4 = table section
+// 5 = memory section
+// 6 = global section
+// 7 = export section
+// 8 = start section
+// 9 = element section
+// 10 = code section
+// 11 = data section
 //
 type sectionID byte
 

--- a/runtime/compiler/wasm/section.go
+++ b/runtime/compiler/wasm/section.go
@@ -23,16 +23,7 @@ package wasm
 type sectionID byte
 
 const (
-	sectionIDCustom   sectionID = 0
 	sectionIDType     sectionID = 1
-	sectionIDImport   sectionID = 2
 	sectionIDFunction sectionID = 3
-	sectionIDTable    sectionID = 4
-	sectionIDMemory   sectionID = 5
-	sectionIDGlobal   sectionID = 6
-	sectionIDExport   sectionID = 7
-	sectionIDStart    sectionID = 8
-	sectionIDElement  sectionID = 9
 	sectionIDCode     sectionID = 10
-	sectionIDData     sectionID = 11
 )

--- a/runtime/compiler/wasm/section.go
+++ b/runtime/compiler/wasm/section.go
@@ -1,0 +1,38 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// sectionID is the ID of a section in the WASM binary
+//
+type sectionID byte
+
+const (
+	sectionIDCustom   sectionID = 0
+	sectionIDType     sectionID = 1
+	sectionIDImport   sectionID = 2
+	sectionIDFunction sectionID = 3
+	sectionIDTable    sectionID = 4
+	sectionIDMemory   sectionID = 5
+	sectionIDGlobal   sectionID = 6
+	sectionIDExport   sectionID = 7
+	sectionIDStart    sectionID = 8
+	sectionIDElement  sectionID = 9
+	sectionIDCode     sectionID = 10
+	sectionIDData     sectionID = 11
+)

--- a/runtime/compiler/wasm/type.go
+++ b/runtime/compiler/wasm/type.go
@@ -1,0 +1,43 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// ValueType is the type of a value
+//
+type ValueType byte
+
+const (
+	// ValueTypeI32 is the i32 type
+	// The value is the byte used in the WASM binary
+	ValueTypeI32 ValueType = 0x7F
+	// ValueTypeI64 is the i64 type.
+	// The value is the byte used in the WASM binary
+	ValueTypeI64 ValueType = 0x7E
+)
+
+// functionTypeIndicator is the byte used to indicate a function type in the WASM binary
+const functionTypeIndicator = 0x60
+
+// FunctionType is the type of a function.
+// It may have multiple parameters and return values
+//
+type FunctionType struct {
+	Params  []ValueType
+	Results []ValueType
+}

--- a/runtime/compiler/wasm/wasm.go
+++ b/runtime/compiler/wasm/wasm.go
@@ -1,0 +1,50 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WebAssembly (https://webassembly.org/) is an open standard for portable executable programs.
+// It is designed to be a portable compilation target for programming languages.
+//
+// The standard defines two formats for encoding WebAssembly programs ("modules"):
+//
+// - A machine-optimized binary format (WASM, https://webassembly.github.io/spec/core/binary/index.html),
+// which is not designed to be used by humans
+//
+// - A human-readable text format (WAT, https://webassembly.github.io/spec/core/text/index.html)
+//
+// WebAssembly modules in either format can be converted into the other format.
+//
+// There exists also another textual format, WAST, which is a superset of WAT,
+// but is not part of the official standard.
+//
+// Package wasm implements a representation of WebAssembly modules (Module) and related types,
+// e.g. instructions (Instruction).
+//
+// Package wasm also implements a reader and writer for the binary format:
+//
+// - The reader (WASMReader) allows parsing a WebAssembly module in binary form ([]byte)
+// into an representation of the module (Module).
+//
+// - The writer (WASMWriter) allows encoding the representation of the module (Module)
+// to a WebAssembly program in binary form ([]byte).
+//
+// Package wasm does not currently provide a reader and writer for the textual format (WAT).
+//
+// Package wasm is not a compiler for Cadence programs, but rather a building block that allows
+// reading and writing WebAssembly modules.
+//
+package wasm

--- a/runtime/compiler/wasm/writer.go
+++ b/runtime/compiler/wasm/writer.go
@@ -1,0 +1,222 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// WASMWriter allows writing WASM binaries
+//
+type WASMWriter struct {
+	buf *buf
+}
+
+// writeMagicAndVersion writes the magic byte sequence and version at the beginning of the WASM binary
+//
+func (w *WASMWriter) writeMagicAndVersion() error {
+	err := w.buf.WriteBytes(wasmMagic)
+	if err != nil {
+		return err
+	}
+	return w.buf.WriteBytes(wasmVersion)
+}
+
+// writeSection writes a section in the WASM binary, with the given section ID and the given content.
+// The content is a function that writes the contents of the section.
+//
+func (w *WASMWriter) writeSection(sectionID sectionID, content func() error) error {
+	// write the section ID
+	err := w.buf.WriteByte(byte(sectionID))
+	if err != nil {
+		return err
+	}
+
+	// write the size and the content
+	return w.writeContentWithSize(content)
+}
+
+// writeContentWithSize writes the size of the content,
+// and the content itself
+//
+func (w *WASMWriter) writeContentWithSize(content func() error) error {
+
+	// write the temporary placeholder for the size
+	sizeOffset, err := w.buf.writeFixedUint32LEB128Space()
+	if err != nil {
+		return err
+	}
+
+	// write the content
+	err = content()
+	if err != nil {
+		return err
+	}
+
+	// write the actual size into the size placeholder
+	return w.buf.writeUint32LEB128SizeAt(sizeOffset)
+}
+
+// writeTypeSection writes the section that declares all function types
+// so they can be referenced by index
+//
+func (w *WASMWriter) writeTypeSection(funcTypes []*FunctionType) error {
+	return w.writeSection(sectionIDType, func() error {
+
+		// write the number of types
+		err := w.buf.writeULEB128(uint32(len(funcTypes)))
+		if err != nil {
+			return err
+		}
+
+		// write each type
+		for _, funcType := range funcTypes {
+			err = w.writeFuncType(funcType)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+}
+
+// writeFuncType writes the function type
+//
+func (w *WASMWriter) writeFuncType(funcType *FunctionType) error {
+	// write the type
+	err := w.buf.WriteByte(functionTypeIndicator)
+	if err != nil {
+		return err
+	}
+
+	// write the number of parameters
+	err = w.buf.writeULEB128(uint32(len(funcType.Params)))
+	if err != nil {
+		return err
+	}
+
+	// write the type of each parameter
+	for _, paramType := range funcType.Params {
+		err = w.buf.WriteByte(byte(paramType))
+		if err != nil {
+			return err
+		}
+	}
+
+	// write the number of results
+	err = w.buf.writeULEB128(uint32(len(funcType.Results)))
+	if err != nil {
+		return err
+	}
+
+	// write the type of each result
+	for _, resultType := range funcType.Results {
+		err = w.buf.WriteByte(byte(resultType))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeFunctionSection writes the section that declares the types of functions.
+// The bodies of these functions will later be provided in the code section
+//
+func (w *WASMWriter) writeFunctionSection(functions []*Function) error {
+	return w.writeSection(sectionIDFunction, func() error {
+		// write the number of functions
+		err := w.buf.writeULEB128(uint32(len(functions)))
+		if err != nil {
+			return err
+		}
+
+		// write the function type ID for each function
+		for _, function := range functions {
+			err = w.buf.writeULEB128(function.TypeID)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// writeCodeSection writes the section that provides the function bodies for the functions
+// declared by the function section (which only provides the function types)
+//
+func (w *WASMWriter) writeCodeSection(functions []*Function) error {
+	return w.writeSection(sectionIDCode, func() error {
+		// write the number of code entries (one for each function)
+		err := w.buf.writeULEB128(uint32(len(functions)))
+		if err != nil {
+			return err
+		}
+
+		// write the code for each function
+		for _, function := range functions {
+
+			err := w.writeFunctionBody(function.Code)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// writeFunctionBody writes the body of the function
+//
+func (w *WASMWriter) writeFunctionBody(code *Code) error {
+	return w.writeContentWithSize(func() error {
+
+		// write the number of locals
+		err := w.buf.writeULEB128(uint32(len(code.Locals)))
+		if err != nil {
+			return err
+		}
+
+		// TODO: run-length encode
+		// write each local
+		for _, localValType := range code.Locals {
+			err = w.buf.writeULEB128(1)
+			if err != nil {
+				return err
+			}
+
+			err = w.buf.WriteByte(byte(localValType))
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, instruction := range code.Instructions {
+			err = instruction.write(w)
+			if err != nil {
+				return err
+			}
+		}
+
+		return w.writeOpcode(opcodeEnd)
+	})
+}
+
+func (w *WASMWriter) writeOpcode(opcode opcode) error {
+	return w.buf.WriteByte(byte(opcode))
+}

--- a/runtime/compiler/wasm/writer_test.go
+++ b/runtime/compiler/wasm/writer_test.go
@@ -31,22 +31,22 @@ func wasm2wat(binary []byte) string {
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return ""
+		panic(err)
 	}
 
 	_, err = io.WriteString(stdin, string(binary))
 	if err != nil {
-		return ""
+		panic(err)
 	}
 
 	err = stdin.Close()
 	if err != nil {
-		return ""
+		panic(err)
 	}
 
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		panic(err)
 	}
 
 	return string(out)

--- a/runtime/compiler/wasm/writer_test.go
+++ b/runtime/compiler/wasm/writer_test.go
@@ -19,7 +19,8 @@
 package wasm
 
 import (
-	"io"
+	"io/ioutil"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -27,23 +28,24 @@ import (
 )
 
 func wasm2wat(binary []byte) string {
-	cmd := exec.Command("wasm2wat", "-")
-
-	stdin, err := cmd.StdinPipe()
+	f, err := ioutil.TempFile("", "wasm")
 	if err != nil {
 		panic(err)
 	}
 
-	_, err = io.WriteString(stdin, string(binary))
+	defer os.Remove(f.Name())
+
+	_, err = f.Write(binary)
 	if err != nil {
 		panic(err)
 	}
 
-	err = stdin.Close()
+	err = f.Close()
 	if err != nil {
 		panic(err)
 	}
 
+	cmd := exec.Command("wasm2wat", f.Name())
 	out, err := cmd.Output()
 	if err != nil {
 		panic(err)

--- a/runtime/compiler/wasm/writer_test.go
+++ b/runtime/compiler/wasm/writer_test.go
@@ -1,0 +1,286 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+import (
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func wasm2wat(binary []byte) string {
+	cmd := exec.Command("wasm2wat", "-")
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return ""
+	}
+
+	_, err = io.WriteString(stdin, string(binary))
+	if err != nil {
+		return ""
+	}
+
+	err = stdin.Close()
+	if err != nil {
+		return ""
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return string(out)
+}
+
+func TestWasmWriter_writeMagicAndVersion(t *testing.T) {
+
+	t.Parallel()
+
+	var b buf
+	w := WASMWriter{&b}
+
+	err := w.writeMagicAndVersion()
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]byte{
+			// magic
+			0x0, 0x61, 0x73, 0x6d,
+			// version
+			0x1, 0x0, 0x0, 0x0,
+		},
+		b.data,
+	)
+}
+
+func TestWasmWriter_writeTypeSection(t *testing.T) {
+
+	t.Parallel()
+
+	var b buf
+	w := WASMWriter{&b}
+
+	err := w.writeTypeSection([]*FunctionType{
+		{
+			Params:  []ValueType{ValueTypeI32, ValueTypeI32},
+			Results: []ValueType{ValueTypeI32},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]byte{
+			// section ID: Type = 1
+			0x1,
+			// section size: 7 (LEB128)
+			0x87, 0x80, 0x80, 0x80, 0x0,
+			// type count
+			0x1,
+			// function type indicator
+			0x60,
+			// parameter count: 2
+			0x2,
+			// type of parameter 1: i32
+			0x7f,
+			// type of parameter 2: i32
+			0x7f,
+			// return value count: 1
+			0x1,
+			// type of return value 1: i32
+			0x7f,
+		},
+		b.data,
+	)
+}
+
+func TestWasmWriter_writeFunctionSection(t *testing.T) {
+
+	t.Parallel()
+
+	var b buf
+	w := WASMWriter{&b}
+
+	functions := []*Function{
+		{
+			// not used, just for testing
+			Name:   "add",
+			TypeID: 0,
+			// not used, just for testing
+			Code: &Code{
+				Locals: []ValueType{
+					ValueTypeI32,
+				},
+				Instructions: []Instruction{
+					InstructionLocalGet{0},
+					InstructionLocalGet{1},
+					InstructionI32Add{},
+				},
+			},
+		},
+	}
+
+	err := w.writeFunctionSection(functions)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]byte{
+			// section ID: Function = 3
+			0x3,
+			// section size: 2 (LEB128)
+			0x82, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// type ID of function: 0
+			0x0,
+		},
+		b.data,
+	)
+}
+
+func TestWasmWriter_writeCodeSection(t *testing.T) {
+
+	t.Parallel()
+
+	var b buf
+	w := WASMWriter{&b}
+
+	functions := []*Function{
+		{
+			// not used, just for testing
+			Name: "add",
+			// not used, just for testing
+			TypeID: 0,
+			Code: &Code{
+				Locals: []ValueType{
+					ValueTypeI32,
+				},
+				Instructions: []Instruction{
+					InstructionLocalGet{0},
+					InstructionLocalGet{1},
+					InstructionI32Add{},
+				},
+			},
+		},
+	}
+
+	err := w.writeCodeSection(functions)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]byte{
+			// Section ID: Code = 10
+			0xa,
+			// section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// function count: 1
+			0x1,
+			// code size: 9 (LEB128)
+			0x89, 0x80, 0x80, 0x80, 0x0,
+			// number of locals: 1
+			0x1,
+			// number of locals with this type: 1
+			0x1,
+			// local type: i32
+			0x7f,
+			// opcode: local.get, 0
+			0x20, 0x0,
+			// opcode: local.get 1
+			0x20, 0x1,
+			// opcode: i32.add
+			0x6a,
+			// opcode: end
+			0xb,
+		},
+		b.data,
+	)
+}
+
+func TestWasmWriter(t *testing.T) {
+
+	t.Parallel()
+
+	var b buf
+
+	w := WASMWriter{&b}
+
+	err := w.writeMagicAndVersion()
+	require.NoError(t, err)
+
+	err = w.writeTypeSection([]*FunctionType{
+		{
+			Params:  []ValueType{ValueTypeI32, ValueTypeI32},
+			Results: []ValueType{ValueTypeI32},
+		},
+	})
+	require.NoError(t, err)
+
+	functions := []*Function{
+		{
+			// not used, just for testing
+			Name:   "add",
+			TypeID: 0,
+			Code: &Code{
+				// not used, just for testing
+				Locals: []ValueType{
+					ValueTypeI32,
+				},
+				Instructions: []Instruction{
+					InstructionLocalGet{0},
+					InstructionLocalGet{1},
+					InstructionI32Add{},
+				},
+			},
+		},
+	}
+
+	err = w.writeFunctionSection(functions)
+	require.NoError(t, err)
+
+	err = w.writeCodeSection(functions)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]byte{
+			0x0, 0x61, 0x73, 0x6d, 0x1, 0x0, 0x0, 0x0,
+			0x1, 0x87, 0x80, 0x80, 0x80, 0x0, 0x1, 0x60,
+			0x2, 0x7f, 0x7f, 0x1, 0x7f, 0x3, 0x82, 0x80,
+			0x80, 0x80, 0x0, 0x1, 0x0, 0xa, 0x8f, 0x80,
+			0x80, 0x80, 0x0, 0x1, 0x89, 0x80, 0x80, 0x80,
+			0x0, 0x1, 0x1, 0x7f, 0x20, 0x0, 0x20, 0x1,
+			0x6a, 0xb,
+		},
+		b.data,
+	)
+
+	require.Equal(t,
+		`(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func (;0;) (type 0) (param i32 i32) (result i32)
+    (local i32)
+    local.get 0
+    local.get 1
+    i32.add))
+`,
+		wasm2wat(b.data),
+	)
+}


### PR DESCRIPTION
Start work on experimenting with WebAssembly: Add a new package which allows writing and reading WASM binaries. For now, only enough instructions are implemented to implement an add function, i.e. `local.get`, `i32.add`, and `end`
