### PR TITLE
Specify storage limits, enforce when encoding, fix bignum encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.14.5'
-    - uses: actions/cache@v1
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+    # - uses: actions/cache@v1
+    #   with:
+    #     path: ~/go/pkg/mod
+    #     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-go-
     - run: |
         make build
         make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.14.5'
-    # - uses: actions/cache@v1
-    #   with:
-    #     path: ~/go/pkg/mod
-    #     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-go-
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - run: |
         make build
         make test

--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5 // indirect
 )
+
+replace github.com/fxamacker/cbor/v2 => github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
-github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -41,6 +39,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154 h1:CSkqhj5tW/xAO4hdGtLsHXJczcpPsWtatCn7Y03scrU=
+github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -13,3 +13,5 @@ require (
 )
 
 replace github.com/onflow/cadence => ../
+replace github.com/fxamacker/cbor/v2 => github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154
+

--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -13,5 +13,5 @@ require (
 )
 
 replace github.com/onflow/cadence => ../
-replace github.com/fxamacker/cbor/v2 => github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154
 
+replace github.com/fxamacker/cbor/v2 => github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -168,6 +168,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
+github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154 h1:CSkqhj5tW/xAO4hdGtLsHXJczcpPsWtatCn7Y03scrU=
+github.com/turbolent/cbor/v2 v2.2.1-0.20200911003300-cac23af49154/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -51,8 +51,6 @@ github.com/ethereum/go-ethereum v1.9.9/go.mod h1:a9TqabFudpDu1nucId+k9S8R9whYaHn
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
-github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -70,15 +70,25 @@ func DecodeValue(b []byte, owner *common.Address, path []string) (Value, error) 
 // It sets the given address as the owner (can be `nil`).
 //
 func NewDecoder(r io.Reader, owner *common.Address) (*Decoder, error) {
-	decMode, err := cbor.DecOptions{}.DecMode()
+	dm, err := decMode()
 	if err != nil {
 		return nil, err
 	}
 
 	return &Decoder{
-		decoder: decMode.NewDecoder(r),
+		decoder: dm.NewDecoder(r),
 		owner:   owner,
+		version: version,
 	}, nil
+}
+
+func decMode() (cbor.DecMode, error) {
+	return cbor.DecOptions{
+		IntDec:           cbor.IntDecConvertNone,
+		MaxArrayElements: 512 * 1024,
+		MaxMapPairs:      512 * 1024,
+		MaxNestedLevels:  256,
+	}.DecMode()
 }
 
 // Decode reads CBOR-encoded bytes from the io.Reader and decodes them to a value.

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -70,7 +70,7 @@ func DecodeValue(b []byte, owner *common.Address, path []string) (Value, error) 
 // It sets the given address as the owner (can be `nil`).
 //
 func NewDecoder(r io.Reader, owner *common.Address) (*Decoder, error) {
-	decMode, err := cbor.DecOptions{}.DecModeWithTags(cborTagSet)
+	decMode, err := cbor.DecOptions{}.DecMode()
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -40,9 +40,6 @@ type cborMap = map[uint64]interface{}
 //
 // DO *NOT* REPLACE EXISTING FIELDS!
 
-const cborTagPositiveBignum = 0x2
-const cborTagNegativeBignum = 0x3
-
 const cborTagBase = 128
 
 // !!! *WARNING* !!!

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -224,7 +224,18 @@ func EncodeValue(value Value, path []string, deferred bool) (
 		return nil, nil, err
 	}
 
-	return w.Bytes(), deferrals, nil
+	dm, err := decMode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	data := w.Bytes()
+	err = dm.Valid(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encoder produced invalid data: %w", err)
+	}
+
+	return data, deferrals, nil
 }
 
 // NewEncoder initializes an Encoder that will write CBOR-encoded bytes

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math/big"
 	"strconv"
 	"strings"
 
@@ -242,7 +241,9 @@ func EncodeValue(value Value, path []string, deferred bool) (
 // to the given io.Writer.
 //
 func NewEncoder(w io.Writer, deferred bool) (*Encoder, error) {
-	encMode, err := cbor.CanonicalEncOptions().EncMode()
+	options := cbor.CanonicalEncOptions()
+	options.BigIntConvert = cbor.BigIntConvertNone
+	encMode, err := options.EncMode()
 	if err != nil {
 		return nil, err
 	}
@@ -432,21 +433,10 @@ func (e *Encoder) prepareBool(v BoolValue) bool {
 	return bool(v)
 }
 
-func (e *Encoder) prepareBig(bigInt *big.Int) cbor.Tag {
-	b := bigInt.Bytes()
-	// positive bignum
-	var tag uint64 = cborTagPositiveBignum
-	if bigInt.Sign() < 0 {
-		// negative bignum
-		tag = cborTagNegativeBignum
-	}
-	return cbor.Tag{Number: tag, Content: b}
-}
-
 func (e *Encoder) prepareInt(v IntValue) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagIntValue,
-		Content: e.prepareBig(v.BigInt),
+		Content: v.BigInt,
 	}
 }
 
@@ -480,21 +470,21 @@ func (e *Encoder) prepareInt64(v Int64Value) cbor.Tag {
 func (e *Encoder) prepareInt128(v Int128Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagInt128Value,
-		Content: e.prepareBig(v.BigInt),
+		Content: v.BigInt,
 	}
 }
 
 func (e *Encoder) prepareInt256(v Int256Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagInt256Value,
-		Content: e.prepareBig(v.BigInt),
+		Content: v.BigInt,
 	}
 }
 
 func (e *Encoder) prepareUInt(v UIntValue) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagUIntValue,
-		Content: e.prepareBig(v.BigInt),
+		Content: v.BigInt,
 	}
 }
 
@@ -529,14 +519,14 @@ func (e *Encoder) prepareUInt64(v UInt64Value) cbor.Tag {
 func (e *Encoder) prepareUInt128(v UInt128Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagUInt128Value,
-		Content: e.prepareBig(v.BigInt),
+		Content: v.BigInt,
 	}
 }
 
 func (e *Encoder) prepareUInt256(v UInt256Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagUInt256Value,
-		Content: e.prepareBig(v.BigInt),
+		Content: v.BigInt,
 	}
 }
 

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -33,6 +33,16 @@ import (
 
 type cborMap = map[uint64]interface{}
 
+
+// Cadence needs to encode different kinds of objects in CBOR, for instance,
+// dictionaries, structs, resources, etc.
+//
+// However, CBOR only provides one native map type, and no support 
+// for directly representing e.g. structs or resources.
+//
+// To be able to encode/decode such semantically different values, 
+// we define custom CBOR tags.
+
 // !!! *WARNING* !!!
 //
 // Only add new fields to encoded structs by

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -623,6 +623,9 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 					0xc3,
 					// byte string, length 1
 					0x41,
+					// `-42` in decimal is is `0x2a` in hex.
+					// CBOR requires negative values to be encoded as `-1-n`, which is `-n - 1`, 
+					// which is `0x2a - 0x01`, which equals to `0x29`.
 					0x29,
 				},
 			},

--- a/runtime/interpreter/magic.go
+++ b/runtime/interpreter/magic.go
@@ -2,12 +2,18 @@ package interpreter
 
 import (
 	"bytes"
+	"encoding/binary"
 )
 
 // Magic is the prefix that is added to all encoded values
 //
-var Magic = []byte{0x0, 0xCA, 0xDE, 0x0, 0x1}
+var Magic = []byte{0x0, 0xCA, 0xDE}
 var MagicLength = len(Magic)
+
+const CurrentEncodingVersion uint16 = 2
+const VersionEncodingLength = 2
+
+var fullPrefixLength = MagicLength + VersionEncodingLength
 
 // HasMagic tests whether the given data  begins with the magic prefix.
 //
@@ -15,19 +21,30 @@ func HasMagic(data []byte) bool {
 	return bytes.HasPrefix(data, Magic)
 }
 
-// StripMagic returns the given data without the magic prefix.
-// If the data doesn't start with Magic, the data is returned unchanged.
+// StripMagic returns the given data without the magic prefix,
+// and the version number included in it.
 //
-func StripMagic(data []byte) []byte {
-	return bytes.TrimPrefix(data, Magic)
+// If the data doesn't start with Magic, the data is returned unchanged
+// and the version is 0.
+//
+func StripMagic(data []byte) (trimmed []byte, version uint16) {
+	if !HasMagic(data) || len(data) < fullPrefixLength {
+		return data, 0
+	}
+
+	version = binary.BigEndian.Uint16(data[MagicLength:fullPrefixLength])
+
+	return data[fullPrefixLength:], version
+
 }
 
 // PrependMagic returns the given data with the magic prefix.
 // The function does *not* check if the data already has the prefix.
 //
-func PrependMagic(unprefixedData []byte) (result []byte) {
-	result = make([]byte, MagicLength+len(unprefixedData))
+func PrependMagic(unprefixedData []byte, version uint16) (result []byte) {
+	result = make([]byte, fullPrefixLength+len(unprefixedData))
 	copy(result[:MagicLength], Magic)
-	copy(result[MagicLength:], unprefixedData)
+	binary.BigEndian.PutUint16(result[MagicLength:fullPrefixLength], version)
+	copy(result[fullPrefixLength:], unprefixedData)
 	return result
 }

--- a/runtime/interpreter/magic.go
+++ b/runtime/interpreter/magic.go
@@ -21,8 +21,7 @@ func HasMagic(data []byte) bool {
 	return bytes.HasPrefix(data, Magic)
 }
 
-// StripMagic returns the given data without the magic prefix,
-// and the version number included in it.
+// StripMagic returns the given data with the magic prefix and version removed.
 //
 // If the data doesn't start with Magic, the data is returned unchanged
 // and the version is 0.

--- a/runtime/interpreter/magic_test.go
+++ b/runtime/interpreter/magic_test.go
@@ -11,14 +11,14 @@ func TestPrependMagic(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		assert.Equal(t,
 			[]byte{0x0, 0xCA, 0xDE, 0x0, 0x1},
-			PrependMagic([]byte{}),
+			PrependMagic([]byte{}, 1),
 		)
 	})
 
 	t.Run("1, 2, 3", func(t *testing.T) {
 		assert.Equal(t,
-			[]byte{0x0, 0xCA, 0xDE, 0x0, 0x1, 1, 2, 3},
-			PrependMagic([]byte{1, 2, 3}),
+			[]byte{0x0, 0xCA, 0xDE, 0x0, 0x4, 1, 2, 3},
+			PrependMagic([]byte{1, 2, 3}, 4),
 		)
 	})
 }

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -147,7 +147,8 @@ func (s *interpreterRuntimeStorage) readValue(
 		panic(err)
 	}
 
-	storedData = interpreter.StripMagic(storedData)
+	var version uint16
+	storedData, version = interpreter.StripMagic(storedData)
 
 	if len(storedData) == 0 {
 		s.cache[fullKey] = cacheEntry{
@@ -161,7 +162,7 @@ func (s *interpreterRuntimeStorage) readValue(
 
 	reportMetric(
 		func() {
-			storedValue, err = interpreter.DecodeValue(storedData, &address, []string{key})
+			storedValue, err = interpreter.DecodeValue(storedData, &address, []string{key}, version)
 		},
 		s.runtimeInterface,
 		func(metrics Metrics, duration time.Duration) {
@@ -301,7 +302,7 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 		}
 
 		if len(newData) > 0 {
-			newData = interpreter.PrependMagic(newData)
+			newData = interpreter.PrependMagic(newData, interpreter.CurrentEncodingVersion)
 		}
 
 		var err error

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -270,7 +270,7 @@ func TestRuntimeMagic(t *testing.T) {
 				[]byte("storage\x1fone"),
 				[]byte{
 					// magic
-					0x0, 0xCA, 0xDE, 0x0, 0x1,
+					0x0, 0xCA, 0xDE, 0x0, 0x2,
 					// CBOR
 					// - tag
 					0xd8, 0x98,
@@ -284,5 +284,4 @@ func TestRuntimeMagic(t *testing.T) {
 		},
 		writes,
 	)
-
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7843,7 +7843,11 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 		encoded, _, err := interpreter.EncodeValue(test, path, false)
 		require.NoError(t, err)
 
-		decoder, err := interpreter.NewDecoder(bytes.NewReader(encoded), owner)
+		decoder, err := interpreter.NewDecoder(
+			bytes.NewReader(encoded),
+			owner,
+			interpreter.CurrentEncodingVersion,
+		)
 		require.NoError(t, err)
 
 		decoded, err := decoder.Decode(path)


### PR DESCRIPTION
Closes #351

- The CBOR library's decoder has limits on the maximum number of items in an array, the maximum number of elements in a map, and the maximum nesting level of containers. Increase these limits, as they are a bit on the low side and users have run into this limit before.

  Also explicitly pin / specify the limits explicitly instead of relying on the defaults of the library (which might change).

- The CBOR library's encoder does not enforce those limits, they are only used when decoding. To ensure Cadence is not encoding data that can not be decoded due to limits, validate the encoding result. This required exporting the validation function in the CBOR library: I [opened an issue](https://github.com/fxamacker/cbor/issues/248) and a [PR](https://github.com/fxamacker/cbor/pull/249). This requires temporarily using a fork which has this change. I hope to switch back to the original as soon as the patch has landed upstream.

- I initially planned to validate the encoded data by traversing the prepared data structure which is encoded, by keeping a depth counter. For that reason I refactored the dedicated struct types to just use `cbor.Tag`. In addition, this made the key fields actual constants (instead of relying on reflection to read struct field tags). 

  However, when implementing this, I found myself unsure if it would implement the same limit checks as the CBOR library's decoder, and eventually decided against this approach, and simply checking the encoded data for validity (which checks the decoding limits). I think this approach is simpler, as it doesn't complicate the encoding code, and doesn't potentially get out of sync with the CBOR library's decoding limit checks.

  I think it's still worth keeping the `cbor.Tag` refactor, as I find it to be an improvement.

- Switching to the fork updated the library, which revealed a bug in the encoding of negative bignums.

  The CBOR library originally didn't support encoding CBOR positive and negative bignums (tags 2 and 3), so I had implemented this according to the RFC. 

  The encoding of negative bignums is specified in http://tools.ietf.org/html/rfc7049#section-2.4.2:
  "For tag value 3, the value of the bignum is -1 - n.".
  However, I made a mistake and didn't adjust by one. This is really only a problem if the ledger data is read by another implementation which assumes the data is RFC-compliant CBOR. The data is correctly decoded though (as proven by tests), so this is not a problem for Flow / Cadence users.
  Still, we should produce correct CBOR data. I therefore bumped the Cadence encoding version from 1 to 2 and added support for decoding data that was written in the old, incorrect format. 

