### PR TITLE
Allow export and JSON encoding/decoding of type values and capabilities

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -102,6 +102,7 @@ const (
 	borrowTypeKey           = "borrowType"
 	domainKey               = "domain"
 	identifierKey           = "identifier"
+	staticTypeKey           = "staticType"
 )
 
 var ErrInvalidJSONCadence = errors.New("invalid JSON Cadence structure")
@@ -190,6 +191,8 @@ func decodeJSON(v interface{}) cadence.Value {
 		return decodeLink(valueJSON)
 	case pathTypeStr:
 		return decodePath(valueJSON)
+	case typeTypeStr:
+		return decodeTypeValue(valueJSON)
 	}
 
 	panic(ErrInvalidJSONCadence)
@@ -591,6 +594,14 @@ func decodePath(valueJSON interface{}) cadence.Path {
 	return cadence.Path{
 		Domain:     obj.GetString(domainKey),
 		Identifier: obj.GetString(identifierKey),
+	}
+}
+
+func decodeTypeValue(valueJSON interface{}) cadence.TypeValue {
+	obj := toObject(valueJSON)
+
+	return cadence.TypeValue{
+		StaticType: obj.GetString(staticTypeKey),
 	}
 }
 

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -141,6 +141,10 @@ type jsonPathValue struct {
 	Identifier string `json:"identifier"`
 }
 
+type jsonTypeValue struct {
+	StaticType string `json:"staticType"`
+}
+
 const (
 	voidTypeStr             = "Void"
 	optionalTypeStr         = "Optional"
@@ -176,6 +180,7 @@ const (
 	storageReferenceTypeStr = "StorageReference"
 	linkTypeStr             = "Link"
 	pathTypeStr             = "Path"
+	typeTypeStr             = "Type"
 )
 
 // prepare traverses the object graph of the provided value and constructs
@@ -250,6 +255,8 @@ func (e *Encoder) prepare(v cadence.Value) jsonValue {
 		return e.prepareLink(x)
 	case cadence.Path:
 		return e.preparePath(x)
+	case cadence.TypeValue:
+		return e.prepareTypeValue(x)
 	default:
 		panic(fmt.Errorf("unsupported value: %T, %v", v, v))
 	}
@@ -543,6 +550,15 @@ func (e *Encoder) preparePath(x cadence.Path) jsonValue {
 		Value: jsonPathValue{
 			Domain:     x.Domain,
 			Identifier: x.Identifier,
+		},
+	}
+}
+
+func (e *Encoder) prepareTypeValue(x cadence.TypeValue) jsonValue {
+	return jsonValueObject{
+		Type: typeTypeStr,
+		Value: jsonTypeValue{
+			StaticType: x.StaticType,
 		},
 	}
 }

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -132,8 +132,8 @@ type jsonStorageReferenceValue struct {
 }
 
 type jsonLinkValue struct {
-	TargetPath string `json:"targetPath"`
-	BorrowType string `json:"borrowType"`
+	TargetPath jsonValue `json:"targetPath"`
+	BorrowType string    `json:"borrowType"`
 }
 
 type jsonPathValue struct {
@@ -143,6 +143,12 @@ type jsonPathValue struct {
 
 type jsonTypeValue struct {
 	StaticType string `json:"staticType"`
+}
+
+type jsonCapabilityValue struct {
+	Path       jsonValue `json:"path"`
+	Address    string    `json:"address"`
+	BorrowType string    `json:"borrowType"`
 }
 
 const (
@@ -181,6 +187,7 @@ const (
 	linkTypeStr             = "Link"
 	pathTypeStr             = "Path"
 	typeTypeStr             = "Type"
+	capabilityTypeStr       = "Capability"
 )
 
 // prepare traverses the object graph of the provided value and constructs
@@ -257,6 +264,8 @@ func (e *Encoder) prepare(v cadence.Value) jsonValue {
 		return e.preparePath(x)
 	case cadence.TypeValue:
 		return e.prepareTypeValue(x)
+	case cadence.Capability:
+		return e.prepareCapability(x)
 	default:
 		panic(fmt.Errorf("unsupported value: %T, %v", v, v))
 	}
@@ -538,7 +547,7 @@ func (e *Encoder) prepareLink(x cadence.Link) jsonValue {
 	return jsonValueObject{
 		Type: linkTypeStr,
 		Value: jsonLinkValue{
-			TargetPath: x.TargetPath,
+			TargetPath: e.preparePath(x.TargetPath),
 			BorrowType: x.BorrowType,
 		},
 	}
@@ -559,6 +568,17 @@ func (e *Encoder) prepareTypeValue(x cadence.TypeValue) jsonValue {
 		Type: typeTypeStr,
 		Value: jsonTypeValue{
 			StaticType: x.StaticType,
+		},
+	}
+}
+
+func (e *Encoder) prepareCapability(x cadence.Capability) jsonValue {
+	return jsonValueObject{
+		Type: capabilityTypeStr,
+		Value: jsonCapabilityValue{
+			Path:       e.preparePath(x.Path),
+			Address:    encodeBytes(x.Address.Bytes()),
+			BorrowType: x.BorrowType,
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -983,6 +983,19 @@ func TestEncodeLink(t *testing.T) {
 	)
 }
 
+func TestEncodeType(t *testing.T) {
+
+	t.Parallel()
+
+	testEncodeAndDecode(
+		t,
+		cadence.TypeValue{
+			StaticType: "Int",
+		},
+		`{"type":"Type","value":{"staticType":"Int"}}`,
+	)
+}
+
 func TestDecodeFixedPoints(t *testing.T) {
 
 	t.Parallel()

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -978,8 +978,11 @@ func TestEncodeLink(t *testing.T) {
 
 	testEncodeAndDecode(
 		t,
-		cadence.NewLink("/storage/foo", "Bar"),
-		`{"type":"Link","value":{"targetPath":"/storage/foo","borrowType":"Bar"}}`,
+		cadence.NewLink(
+			cadence.Path{Domain: "storage", Identifier: "foo"},
+			"Bar",
+		),
+		`{"type":"Link","value":{"targetPath":{"type":"Path","value":{"domain":"storage","identifier":"foo"}},"borrowType":"Bar"}}`,
 	)
 }
 
@@ -993,6 +996,21 @@ func TestEncodeType(t *testing.T) {
 			StaticType: "Int",
 		},
 		`{"type":"Type","value":{"staticType":"Int"}}`,
+	)
+}
+
+func TestEncodeCapability(t *testing.T) {
+
+	t.Parallel()
+
+	testEncodeAndDecode(
+		t,
+		cadence.Capability{
+			Path:       cadence.Path{Domain: "storage", Identifier: "foo"},
+			Address:    cadence.BytesToAddress([]byte{1, 2, 3, 4, 5}),
+			BorrowType: "Int",
+		},
+		`{"type":"Capability","value":{"path":{"type":"Path","value":{"domain":"storage","identifier":"foo"}},"borrowType":"Int","address":"0x0000000102030405"}}`,
 	)
 }
 
@@ -1251,13 +1269,11 @@ func TestEncodePath(t *testing.T) {
 
 	t.Parallel()
 
-	testAllEncodeAndDecode(t, []encodeTest{
-		{
-			"Simple",
-			cadence.Path{Domain: "storage", Identifier: "foo"},
-			`{"type":"Path","value":{"domain":"storage","identifier":"foo"}}`,
-		},
-	}...)
+	testEncodeAndDecode(
+		t,
+		cadence.Path{Domain: "storage", Identifier: "foo"},
+		`{"type":"Path","value":{"domain":"storage","identifier":"foo"}}`,
+	)
 }
 
 func convertValueFromScript(t *testing.T, script string) cadence.Value {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -112,6 +112,8 @@ func exportValueWithInterpreter(value interpreter.Value, inter *interpreter.Inte
 		return exportLinkValue(v, inter)
 	case interpreter.PathValue:
 		return exportPathValue(v)
+	case interpreter.TypeValue:
+		return exportTypeValue(v, inter)
 	}
 
 	panic(fmt.Sprintf("cannot export value of type %T", value))
@@ -212,9 +214,10 @@ func exportStorageReferenceValue(v *interpreter.StorageReferenceValue) cadence.V
 }
 
 func exportLinkValue(v interpreter.LinkValue, inter *interpreter.Interpreter) cadence.Value {
+	ty := inter.ConvertStaticToSemaType(v.Type).QualifiedString()
 	return cadence.NewLink(
 		v.TargetPath.String(),
-		inter.ConvertStaticToSemaType(v.Type).QualifiedString(),
+		ty,
 	)
 }
 
@@ -355,5 +358,12 @@ func exportPathValue(v interpreter.PathValue) cadence.Value {
 	return cadence.Path{
 		Domain:     v.Domain.Name(),
 		Identifier: v.Identifier,
+	}
+}
+
+func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) cadence.Value {
+	ty := inter.ConvertStaticToSemaType(v.Type).QualifiedString()
+	return cadence.TypeValue{
+		StaticType: ty,
 	}
 }

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -639,6 +639,31 @@ func TestExportTypeValue(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestExportCapabilityValue(t *testing.T) {
+
+	t.Parallel()
+
+	capability := interpreter.CapabilityValue{
+		Address: interpreter.AddressValue{0x1},
+		Path: interpreter.PathValue{
+			Domain:     common.PathDomainStorage,
+			Identifier: "foo",
+		},
+		BorrowType: interpreter.PrimitiveStaticTypeInt,
+	}
+	actual := exportValueWithInterpreter(capability, nil)
+	expected := cadence.Capability{
+		Path: cadence.Path{
+			Domain:     "storage",
+			Identifier: "foo",
+		},
+		Address:    cadence.Address{0x1},
+		BorrowType: "Int",
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
 const fooID = "Foo"
 
 var fooTypeID = fmt.Sprintf("S.%s.%s", utils.TestLocation, fooID)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -621,6 +621,24 @@ func exportValueFromScript(t *testing.T, script string) cadence.Value {
 	return value
 }
 
+func TestExportTypeValue(t *testing.T) {
+
+	t.Parallel()
+
+	script := `
+        access(all) fun main(): Type {
+            return Type<Int>()
+        }
+    `
+
+	actual := exportValueFromScript(t, script)
+	expected := cadence.TypeValue{
+		StaticType: "Int",
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
 const fooID = "Foo"
 
 var fooTypeID = fmt.Sprintf("S.%s.%s", utils.TestLocation, fooID)

--- a/values.go
+++ b/values.go
@@ -962,12 +962,12 @@ func (v Contract) ToGoValue() interface{} {
 // Link
 
 type Link struct {
-	TargetPath string
+	TargetPath Path
 	// TODO: a future version might want to export the whole type
 	BorrowType string
 }
 
-func NewLink(targetPath string, borrowType string) Link {
+func NewLink(targetPath Path, borrowType string) Link {
 	return Link{
 		TargetPath: targetPath,
 		BorrowType: borrowType,
@@ -1041,5 +1041,24 @@ func (TypeValue) Type() Type {
 }
 
 func (TypeValue) ToGoValue() interface{} {
+	return nil
+}
+
+// Capability
+
+type Capability struct {
+	Path    Path
+	Address Address
+	// TODO: a future version might want to export the whole type
+	BorrowType string
+}
+
+func (Capability) isValue() {}
+
+func (Capability) Type() Type {
+	return CapabilityType{}
+}
+
+func (Capability) ToGoValue() interface{} {
 	return nil
 }

--- a/values.go
+++ b/values.go
@@ -1026,3 +1026,20 @@ func (Path) Type() Type {
 func (Path) ToGoValue() interface{} {
 	return nil
 }
+
+// TypeValue
+
+type TypeValue struct {
+	// TODO: a future version might want to export the whole type
+	StaticType string
+}
+
+func (TypeValue) isValue() {}
+
+func (TypeValue) Type() Type {
+	return MetaType{}
+}
+
+func (TypeValue) ToGoValue() interface{} {
+	return nil
+}


### PR DESCRIPTION
Closes #373 

For now, just like for link values, encode the static type as a string.
A future PR may introduce support for exporting static types and encoding/decoding them, but for now that is not needed.