### PR TITLE
Add support for export section in WASM binary writer and reader

### DIFF
--- a/runtime/compiler/wasm/errors.go
+++ b/runtime/compiler/wasm/errors.go
@@ -293,43 +293,43 @@ func (e InvalidImportError) Unwrap() error {
 	return e.ReadError
 }
 
-// InvalidImportTypeIndicatorError is returned when the WASM binary specifies
+// InvalidImportIndicatorError is returned when the WASM binary specifies
 // an invalid type indicator in the import section
 //
-type InvalidImportTypeIndicatorError struct {
-	Offset        int
-	TypeIndicator importTypeIndicator
-	ReadError     error
+type InvalidImportIndicatorError struct {
+	Offset          int
+	ImportIndicator importIndicator
+	ReadError       error
 }
 
-func (e InvalidImportTypeIndicatorError) Error() string {
+func (e InvalidImportIndicatorError) Error() string {
 	return fmt.Sprintf(
-		"invalid import type indicator %d at offset %d",
-		e.TypeIndicator,
+		"invalid import indicator %d at offset %d",
+		e.ImportIndicator,
 		e.Offset,
 	)
 }
 
-func (e InvalidImportTypeIndicatorError) Unwrap() error {
+func (e InvalidImportIndicatorError) Unwrap() error {
 	return e.ReadError
 }
 
-// InvalidImportSectionFunctionTypeIDError is returned when the WASM binary specifies
-// an invalid function type ID in the import section
+// InvalidImportSectionTypeIndexError is returned when the WASM binary specifies
+// an invalid type index in the import section
 //
-type InvalidImportSectionFunctionTypeIDError struct {
+type InvalidImportSectionTypeIndexError struct {
 	Offset    int
 	ReadError error
 }
 
-func (e InvalidImportSectionFunctionTypeIDError) Error() string {
+func (e InvalidImportSectionTypeIndexError) Error() string {
 	return fmt.Sprintf(
-		"invalid function type ID in import section at offset %d",
+		"invalid type index in import section at offset %d",
 		e.Offset,
 	)
 }
 
-func (e InvalidImportSectionFunctionTypeIDError) Unwrap() error {
+func (e InvalidImportSectionTypeIndexError) Unwrap() error {
 	return e.ReadError
 }
 
@@ -352,24 +352,102 @@ func (e InvalidFunctionSectionFunctionCountError) Unwrap() error {
 	return e.ReadError
 }
 
-// InvalidFunctionSectionFunctionTypeIDError is returned when the WASM binary specifies
-// an invalid function type ID in the function section
+// InvalidFunctionSectionTypeIndexError is returned when the WASM binary specifies
+// an invalid type index in the function section
 //
-type InvalidFunctionSectionFunctionTypeIDError struct {
+type InvalidFunctionSectionTypeIndexError struct {
 	Offset    int
 	Index     int
 	ReadError error
 }
 
-func (e InvalidFunctionSectionFunctionTypeIDError) Error() string {
+func (e InvalidFunctionSectionTypeIndexError) Error() string {
 	return fmt.Sprintf(
-		"invalid function type ID in function section at index %d at offset %d",
+		"invalid type index in function section at index %d at offset %d",
 		e.Index,
 		e.Offset,
 	)
 }
 
-func (e InvalidFunctionSectionFunctionTypeIDError) Unwrap() error {
+func (e InvalidFunctionSectionTypeIndexError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidExportSectionExportCountError is returned when the WASM binary specifies
+// an invalid count in the export section
+//
+type InvalidExportSectionExportCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidExportSectionExportCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid export count in export section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidExportSectionExportCountError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidExportError is returned when the WASM binary specifies
+// invalid export in the export section
+//
+type InvalidExportError struct {
+	Index     int
+	ReadError error
+}
+
+func (e InvalidExportError) Error() string {
+	return fmt.Sprintf(
+		"invalid export at index %d",
+		e.Index,
+	)
+}
+
+func (e InvalidExportError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidExportIndicatorError is returned when the WASM binary specifies
+// an invalid type indicator in the export section
+//
+type InvalidExportIndicatorError struct {
+	Offset          int
+	ExportIndicator exportIndicator
+	ReadError       error
+}
+
+func (e InvalidExportIndicatorError) Error() string {
+	return fmt.Sprintf(
+		"invalid export indicator %d at offset %d",
+		e.ExportIndicator,
+		e.Offset,
+	)
+}
+
+func (e InvalidExportIndicatorError) Unwrap() error {
+	return e.ReadError
+}
+
+// InvalidExportSectionFunctionIndexError is returned when the WASM binary specifies
+// an invalid type index in the export section
+//
+type InvalidExportSectionFunctionIndexError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidExportSectionFunctionIndexError) Error() string {
+	return fmt.Sprintf(
+		"invalid type index in export section at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidExportSectionFunctionIndexError) Unwrap() error {
 	return e.ReadError
 }
 

--- a/runtime/compiler/wasm/export.go
+++ b/runtime/compiler/wasm/export.go
@@ -18,14 +18,18 @@
 
 package wasm
 
-// Module represents a module
+// Exports represents an export
 //
-type Module struct {
-	Types []*FunctionType
-	// The type indices of all functions
-	functionTypeIndices []uint32
-	// The bodies of all functions
-	functionBodies []*Code
-	Imports        []*Import
-	Exports        []*Export
+type Export struct {
+	Name string
+	// TODO: add support for tables, memories, and globals
+	FunctionIndex uint32
 }
+
+// exportIndicator is the byte used to indicate the kind of export in the WASM binary
+type exportIndicator byte
+
+const (
+	// exportIndicatorFunction is the byte used to indicate the export of a function in the WASM binary
+	exportIndicatorFunction exportIndicator = 0x0
+)

--- a/runtime/compiler/wasm/function.go
+++ b/runtime/compiler/wasm/function.go
@@ -21,9 +21,9 @@ package wasm
 // Function represents a function
 //
 type Function struct {
-	Name   string
-	TypeID uint32
-	Code   *Code
+	Name      string
+	TypeIndex uint32
+	Code      *Code
 }
 
 // Code represents the code of a function

--- a/runtime/compiler/wasm/import.go
+++ b/runtime/compiler/wasm/import.go
@@ -24,13 +24,13 @@ type Import struct {
 	Module string
 	Name   string
 	// TODO: add support for tables, memories, and globals
-	TypeID uint32
+	TypeIndex uint32
 }
 
-// importTypeIndicator is the byte used to indicate the import type in the WASM binary
-type importTypeIndicator byte
+// importIndicator is the byte used to indicate the kind of import in the WASM binary
+type importIndicator byte
 
 const (
-	// importTypeIndicatorFunction is the byte used to indicate the import of a function in the WASM binary
-	importTypeIndicatorFunction importTypeIndicator = 0x0
+	// importIndicatorFunction is the byte used to indicate the import of a function in the WASM binary
+	importIndicatorFunction importIndicator = 0x0
 )

--- a/runtime/compiler/wasm/leb128_test.go
+++ b/runtime/compiler/wasm/leb128_test.go
@@ -88,7 +88,11 @@ func TestBuf_writeUint32LEB128(t *testing.T) {
 
 func TestBuf_writeUint64LEB128(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("DWARF spec", func(t *testing.T) {
+
+		t.Parallel()
 
 		// DWARF Debugging Information Format, Version 3, page 140
 
@@ -114,6 +118,9 @@ func TestBuf_writeUint64LEB128(t *testing.T) {
 	})
 
 	t.Run("write: max byte count", func(t *testing.T) {
+
+		t.Parallel()
+
 		var b buf
 		err := b.writeUint64LEB128(math.MaxUint64)
 		require.NoError(t, err)
@@ -121,6 +128,9 @@ func TestBuf_writeUint64LEB128(t *testing.T) {
 	})
 
 	t.Run("read: max byte count", func(t *testing.T) {
+
+		t.Parallel()
+
 		b := buf{data: []byte{
 			0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88,
 			0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90,

--- a/runtime/compiler/wasm/reader.go
+++ b/runtime/compiler/wasm/reader.go
@@ -93,12 +93,31 @@ func (r *WASMReader) readSection() error {
 			return err
 		}
 
+	case sectionIDImport:
+		if r.Module.Imports != nil {
+			return invalidDuplicateSectionError()
+		}
+
+		err = r.readImportSection()
+		if err != nil {
+			return err
+		}
+
 	case sectionIDFunction:
-		if r.Module.functionTypeIDs != nil {
+		if r.Module.functionTypeIndices != nil {
 			return invalidDuplicateSectionError()
 		}
 
 		err = r.readFunctionSection()
+		if err != nil {
+			return err
+		}
+	case sectionIDExport:
+		if r.Module.Exports != nil {
+			return invalidDuplicateSectionError()
+		}
+
+		err = r.readExportSection()
 		if err != nil {
 			return err
 		}
@@ -112,12 +131,15 @@ func (r *WASMReader) readSection() error {
 		if err != nil {
 			return err
 		}
+
+	default:
+		return InvalidSectionIDError{
+			SectionID: sectionID,
+			Offset:    int(sectionIDOffset),
+		}
 	}
 
-	return InvalidSectionIDError{
-		SectionID: sectionID,
-		Offset:    int(sectionIDOffset),
-	}
+	return nil
 }
 
 // readSectionSize reads the content size of a section
@@ -291,7 +313,7 @@ func (r *WASMReader) readImportSection() error {
 
 	imports := make([]*Import, count)
 
-	// read the function type ID for each function
+	// read each import
 	for i := uint32(0); i < count; i++ {
 		im, err := r.readImport()
 		if err != nil {
@@ -328,32 +350,32 @@ func (r *WASMReader) readImport() (*Import, error) {
 	indicatorOffset := r.buf.offset
 	b, err := r.buf.ReadByte()
 
-	typeIndicator := importTypeIndicator(b)
+	indicator := importIndicator(b)
 
 	// TODO: add support for tables, memories, and globals
 
-	if err != nil || typeIndicator != importTypeIndicatorFunction {
-		return nil, InvalidImportTypeIndicatorError{
-			TypeIndicator: typeIndicator,
-			Offset:        int(indicatorOffset),
-			ReadError:     err,
+	if err != nil || indicator != importIndicatorFunction {
+		return nil, InvalidImportIndicatorError{
+			ImportIndicator: indicator,
+			Offset:          int(indicatorOffset),
+			ReadError:       err,
 		}
 	}
 
-	// read the function type ID
-	functionTypeIDOffset := r.buf.offset
-	functionTypeID, err := r.buf.readUint32LEB128()
+	// read the type index
+	typeIndexOffset := r.buf.offset
+	typeIndex, err := r.buf.readUint32LEB128()
 	if err != nil {
-		return nil, InvalidImportSectionFunctionTypeIDError{
-			Offset:    int(functionTypeIDOffset),
+		return nil, InvalidImportSectionTypeIndexError{
+			Offset:    int(typeIndexOffset),
 			ReadError: err,
 		}
 	}
 
 	return &Import{
-		Module: module,
-		Name:   name,
-		TypeID: functionTypeID,
+		Module:    module,
+		Name:      name,
+		TypeIndex: typeIndex,
 	}, nil
 }
 
@@ -377,25 +399,105 @@ func (r *WASMReader) readFunctionSection() error {
 		}
 	}
 
-	functionTypeIDs := make([]uint32, count)
+	functionTypeIndices := make([]uint32, count)
 
-	// read the function type ID for each function
+	// read the type index for each function
 	for i := uint32(0); i < count; i++ {
-		functionTypeIDOffset := r.buf.offset
-		functionTypeID, err := r.buf.readUint32LEB128()
+		typeIndexOffset := r.buf.offset
+		typeIndex, err := r.buf.readUint32LEB128()
 		if err != nil {
-			return InvalidFunctionSectionFunctionTypeIDError{
+			return InvalidFunctionSectionTypeIndexError{
 				Index:     int(i),
-				Offset:    int(functionTypeIDOffset),
+				Offset:    int(typeIndexOffset),
 				ReadError: err,
 			}
 		}
-		functionTypeIDs[i] = functionTypeID
+		functionTypeIndices[i] = typeIndex
 	}
 
-	r.Module.functionTypeIDs = functionTypeIDs
+	r.Module.functionTypeIndices = functionTypeIndices
 
 	return nil
+}
+
+// readExportSection reads the section that declares the exports
+//
+func (r *WASMReader) readExportSection() error {
+
+	err := r.readSectionSize()
+	if err != nil {
+		return err
+	}
+
+	// read the number of exports
+	countOffset := r.buf.offset
+	count, err := r.buf.readUint32LEB128()
+	if err != nil {
+		return InvalidExportSectionExportCountError{
+			Offset:    int(countOffset),
+			ReadError: err,
+		}
+	}
+
+	exports := make([]*Export, count)
+
+	// read each export
+	for i := uint32(0); i < count; i++ {
+		im, err := r.readExport()
+		if err != nil {
+			return InvalidExportError{
+				Index:     int(i),
+				ReadError: err,
+			}
+		}
+		exports[i] = im
+	}
+
+	r.Module.Exports = exports
+
+	return nil
+}
+
+// readExport reads an export in the export section
+//
+func (r *WASMReader) readExport() (*Export, error) {
+
+	// read the name
+	name, err := r.readName()
+	if err != nil {
+		return nil, err
+	}
+
+	// read the type indicator
+	indicatorOffset := r.buf.offset
+	b, err := r.buf.ReadByte()
+
+	indicator := exportIndicator(b)
+
+	// TODO: add support for tables, memories, and globals
+
+	if err != nil || indicator != exportIndicatorFunction {
+		return nil, InvalidExportIndicatorError{
+			ExportIndicator: indicator,
+			Offset:          int(indicatorOffset),
+			ReadError:       err,
+		}
+	}
+
+	// read the function type ID
+	functionIndexOffset := r.buf.offset
+	functionIndex, err := r.buf.readUint32LEB128()
+	if err != nil {
+		return nil, InvalidExportSectionFunctionIndexError{
+			Offset:    int(functionIndexOffset),
+			ReadError: err,
+		}
+	}
+
+	return &Export{
+		Name:          name,
+		FunctionIndex: functionIndex,
+	}, nil
 }
 
 // readCodeSection reads the section that provides the function bodies for the functions

--- a/runtime/compiler/wasm/section.go
+++ b/runtime/compiler/wasm/section.go
@@ -43,5 +43,6 @@ const (
 	sectionIDType     sectionID = 1
 	sectionIDImport   sectionID = 2
 	sectionIDFunction sectionID = 3
+	sectionIDExport   sectionID = 7
 	sectionIDCode     sectionID = 10
 )


### PR DESCRIPTION
Also rename incorrect "ID" to "index" and be more precise about function vs type indices.