### PR TITLE
Fix parsing of right bitwise shift and function invocation where type argument is instantiation

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -615,6 +615,15 @@ func defineLessThanOrTypeArgumentsExpression() {
 		})
 }
 
+// defineGreaterThanOrBitwiseRightShiftExpression parses 
+// the greater-than expression (operator `>`, e.g. `1 > 2`) 
+// and the bitwise right shift expression (operator `>>`, e.g. `1 >> 3`).
+//
+// The `>>` operator consists of two `>` tokens, instead of one dedicated `>>` token,
+// because that would introduce a parsing problem for function calls/invocations
+// which have a type argument, where the type argument is a type instantiation,
+// for example, `f<T<U>>()`.
+//
 func defineGreaterThanOrBitwiseRightShiftExpression() {
 
 	setExprMetaLeftDenotation(

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -3257,7 +3257,105 @@ func TestParseLessThanOrTypeArguments(t *testing.T) {
 		)
 	})
 
-	t.Run("precedence, binary expressions", func(t *testing.T) {
+	t.Run("invocation, one type argument, nested type, no spaces", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("a<T<U>>()")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.InvocationExpression{
+				InvokedExpression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "a",
+						Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				TypeArguments: []*ast.TypeAnnotation{
+					{
+						IsResource: false,
+						Type: &ast.InstantiationType{
+							Type: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "T",
+									Pos:        ast.Position{Line: 1, Column: 2, Offset: 2},
+								},
+							},
+							TypeArguments: []*ast.TypeAnnotation{
+								{
+									IsResource: false,
+									Type: &ast.NominalType{
+										Identifier: ast.Identifier{
+											Identifier: "U",
+											Pos:        ast.Position{Line: 1, Column: 4, Offset: 4},
+										},
+									},
+									StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+								},
+							},
+							TypeArgumentsStartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:                ast.Position{Line: 1, Column: 5, Offset: 5},
+						},
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+					},
+				},
+				EndPos: ast.Position{Line: 1, Column: 8, Offset: 8},
+			},
+			result,
+		)
+	})
+
+	t.Run("invocation, one type argument, nested type, spaces", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("a<T< U > >()")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.InvocationExpression{
+				InvokedExpression: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "a",
+						Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				TypeArguments: []*ast.TypeAnnotation{
+					{
+						IsResource: false,
+						Type: &ast.InstantiationType{
+							Type: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "T",
+									Pos:        ast.Position{Line: 1, Column: 2, Offset: 2},
+								},
+							},
+							TypeArguments: []*ast.TypeAnnotation{
+								{
+									IsResource: false,
+									Type: &ast.NominalType{
+										Identifier: ast.Identifier{
+											Identifier: "U",
+											Pos:        ast.Position{Line: 1, Column: 5, Offset: 5},
+										},
+									},
+									StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
+								},
+							},
+							TypeArgumentsStartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:                ast.Position{Line: 1, Column: 7, Offset: 7},
+						},
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+					},
+				},
+				EndPos: ast.Position{Line: 1, Column: 11, Offset: 11},
+			},
+			result,
+		)
+	})
+
+	t.Run("precedence, binary expressions, less than", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -3292,6 +3390,132 @@ func TestParseLessThanOrTypeArguments(t *testing.T) {
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 						EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+					},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("precedence, binary expressions, left shift", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("0 + 1 << 2")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationBitwiseLeftShift,
+				Left: &ast.BinaryExpression{
+					Operation: ast.OperationPlus,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(0),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+						},
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+				},
+				Right: &ast.IntegerExpression{
+					Value: big.NewInt(2),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 9, Offset: 9},
+						EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
+					},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("precedence, binary expressions, greater than", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("0 + 1 > 2")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationGreater,
+				Left: &ast.BinaryExpression{
+					Operation: ast.OperationPlus,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(0),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+						},
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+				},
+				Right: &ast.IntegerExpression{
+					Value: big.NewInt(2),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
+						EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
+					},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("precedence, binary expressions, right shift", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression("0 + 1 >> 2")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.BinaryExpression{
+				Operation: ast.OperationBitwiseRightShift,
+				Left: &ast.BinaryExpression{
+					Operation: ast.OperationPlus,
+					Left: &ast.IntegerExpression{
+						Value: big.NewInt(0),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+						},
+					},
+					Right: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+				},
+				Right: &ast.IntegerExpression{
+					Value: big.NewInt(2),
+					Base:  10,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 9, Offset: 9},
+						EndPos:   ast.Position{Line: 1, Column: 9, Offset: 9},
 					},
 				},
 			},

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -94,8 +94,6 @@ func rootState(l *lexer) stateFn {
 		case '>':
 			r = l.next()
 			switch r {
-			case '>':
-				l.emitType(TokenGreaterGreater)
 			case '=':
 				l.emitType(TokenGreaterEqual)
 			default:

--- a/runtime/parser2/lexer/tokentype.go
+++ b/runtime/parser2/lexer/tokentype.go
@@ -63,7 +63,6 @@ const (
 	TokenLessLess
 	TokenGreater
 	TokenGreaterEqual
-	TokenGreaterGreater
 	TokenEqual
 	TokenEqualEqual
 	TokenExclamationMark
@@ -166,8 +165,6 @@ func (t TokenType) String() string {
 		return `'>'`
 	case TokenGreaterEqual:
 		return `'>='`
-	case TokenGreaterGreater:
-		return `'>>'`
 	case TokenEqual:
 		return `'='`
 	case TokenEqualEqual:

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -1178,4 +1178,88 @@ func TestParseInstantiationType(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("one type argument, no spaces", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseType("T<U>")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.InstantiationType{
+				Type: &ast.NominalType{
+					Identifier: ast.Identifier{
+						Identifier: "T",
+						Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				TypeArguments: []*ast.TypeAnnotation{
+					{
+						IsResource: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "U",
+								Pos:        ast.Position{Line: 1, Column: 2, Offset: 2},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+					},
+				},
+				TypeArgumentsStartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+				EndPos:                ast.Position{Line: 1, Column: 3, Offset: 3},
+			},
+			result,
+		)
+	})
+
+	t.Run("one type argument, nested, with spaces", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseType("T< U< V >  >")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.InstantiationType{
+				Type: &ast.NominalType{
+					Identifier: ast.Identifier{
+						Identifier: "T",
+						Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
+					},
+				},
+				TypeArguments: []*ast.TypeAnnotation{
+					{
+						IsResource: false,
+						Type: &ast.InstantiationType{
+							Type: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "U",
+									Pos:        ast.Position{Line: 1, Column: 3, Offset: 3},
+								},
+							},
+							TypeArguments: []*ast.TypeAnnotation{
+								{
+									IsResource: false,
+									Type: &ast.NominalType{
+										Identifier: ast.Identifier{
+											Identifier: "V",
+											Pos:        ast.Position{Line: 1, Column: 6, Offset: 6},
+										},
+									},
+									StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
+								},
+							},
+							TypeArgumentsStartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:                ast.Position{Line: 1, Column: 8, Offset: 8},
+						},
+						StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
+					},
+				},
+				TypeArgumentsStartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+				EndPos:                ast.Position{Line: 1, Column: 11, Offset: 11},
+			},
+			result,
+		)
+	})
 }


### PR DESCRIPTION
## Bug

Parsing of function invocations which contain a type argument which is a type instantiation is not working, e.g. `f<T<U>>()`.

## Reason

The parser expects a closing '>' token, however the lexer returns a '>>' token.

## Solution

Remove the '>>' token. Replace the twp separate left denotations for '>' and '>>' with a single meta left denotation which  preforms a lookahead for the second '>' token of ">>".