### PR TITLE
Add more WASM instructions

### DIFF
--- a/runtime/compiler/wasm/block.go
+++ b/runtime/compiler/wasm/block.go
@@ -18,9 +18,8 @@
 
 package wasm
 
-// Instruction represents an instruction in the code of a WASM binary
-//
-type Instruction interface {
-	isInstruction()
-	write(*WASMWriter) error
+type Block struct {
+	BlockType     BlockType
+	Instructions1 []Instruction
+	Instructions2 []Instruction
 }

--- a/runtime/compiler/wasm/blocktype.go
+++ b/runtime/compiler/wasm/blocktype.go
@@ -18,9 +18,23 @@
 
 package wasm
 
-// Instruction represents an instruction in the code of a WASM binary
-//
-type Instruction interface {
-	isInstruction()
-	write(*WASMWriter) error
+const emptyBlockType byte = 0x40
+
+type BlockType interface{
+	isBlockType()
+	write(writer *WASMWriter) error
 }
+
+type TypeIndexBlockType struct{
+	TypeIndex uint32
+}
+
+func (t TypeIndexBlockType) write(w *WASMWriter) error {
+	// "the type index in a block type is encoded as a positive signed integer,
+	// so that its signed LEB128 bit pattern cannot collide with the encoding of value types or the special code 0x40,
+	// which correspond to the LEB128 encoding of negative integers.
+	// To avoid any loss in the range of allowed indices, it is treated as a 33 bit signed integer."
+	return w.buf.writeInt64LEB128(int64(t.TypeIndex))
+}
+
+func (TypeIndexBlockType) isBlockType() {}

--- a/runtime/compiler/wasm/buf.go
+++ b/runtime/compiler/wasm/buf.go
@@ -69,6 +69,14 @@ func (buf *buf) ReadByte() (byte, error) {
 	return b, nil
 }
 
+func (buf *buf) PeekByte() (byte, error) {
+	if buf.offset >= offset(len(buf.data)) {
+		return 0, io.EOF
+	}
+	b := buf.data[buf.offset]
+	return b, nil
+}
+
 func (buf *buf) ReadBytesEqual(expected []byte) (bool, error) {
 	off := buf.offset
 	for _, b := range expected {

--- a/runtime/compiler/wasm/errors.go
+++ b/runtime/compiler/wasm/errors.go
@@ -739,3 +739,19 @@ func (e InvalidInstructionVectorArgumentCountError) Error() string {
 func (e InvalidInstructionVectorArgumentCountError) Unwrap() error {
 	return e.ReadError
 }
+
+// InvalidBlockTypeTypeIndexError is returned when the WASM binary specifies
+// an invalid type index as a block type
+//
+type InvalidBlockTypeTypeIndexError struct {
+	TypeIndex int64
+	Offset    int
+}
+
+func (e InvalidBlockTypeTypeIndexError) Error() string {
+	return fmt.Sprintf(
+		"invalid type index in block type at offset %d: %d",
+		e.Offset,
+		e.TypeIndex,
+	)
+}

--- a/runtime/compiler/wasm/errors.go
+++ b/runtime/compiler/wasm/errors.go
@@ -606,14 +606,12 @@ func (e InvalidOpcodeError) Unwrap() error {
 //
 type InvalidInstructionArgumentError struct {
 	Offset    int
-	Opcode    opcode
 	ReadError error
 }
 
 func (e InvalidInstructionArgumentError) Error() string {
 	return fmt.Sprintf(
-		"invalid argument for instruction with opcode %x in code section at offset %d",
-		e.Opcode,
+		"invalid argument in code section at offset %d",
 		e.Offset,
 	)
 }
@@ -706,4 +704,38 @@ func (e IncompleteNameError) Error() string {
 		e.Expected,
 		e.Actual,
 	)
+}
+
+// InvalidBlockSecondInstructionsError is returned when the WASM binary specifies
+// or the writer is given a second set of instructions in a block that
+// is not allowed to have it (only the 'if' instruction may have it)
+//
+type InvalidBlockSecondInstructionsError struct {
+	Offset int
+}
+
+func (e InvalidBlockSecondInstructionsError) Error() string {
+	return fmt.Sprintf(
+		"invalid second set of instructions at offset %d",
+		e.Offset,
+	)
+}
+
+// InvalidInstructionVectorArgumentCountError is returned when the WASM binary specifies
+// an invalid count for a vector argument of an instruction
+//
+type InvalidInstructionVectorArgumentCountError struct {
+	Offset    int
+	ReadError error
+}
+
+func (e InvalidInstructionVectorArgumentCountError) Error() string {
+	return fmt.Sprintf(
+		"invalid vector count for argument of instruction at offset %d",
+		e.Offset,
+	)
+}
+
+func (e InvalidInstructionVectorArgumentCountError) Unwrap() error {
+	return e.ReadError
 }

--- a/runtime/compiler/wasm/functiontype.go
+++ b/runtime/compiler/wasm/functiontype.go
@@ -18,19 +18,6 @@
 
 package wasm
 
-// ValueType is the type of a value
-//
-type ValueType byte
-
-const (
-	// ValueTypeI32 is the i32 type
-	// The value is the byte used in the WASM binary
-	ValueTypeI32 ValueType = 0x7F
-	// ValueTypeI64 is the i64 type.
-	// The value is the byte used in the WASM binary
-	ValueTypeI64 ValueType = 0x7E
-)
-
 // functionTypeIndicator is the byte used to indicate a function type in the WASM binary
 const functionTypeIndicator = 0x60
 
@@ -41,3 +28,4 @@ type FunctionType struct {
 	Params  []ValueType
 	Results []ValueType
 }
+

--- a/runtime/compiler/wasm/gen/main.go
+++ b/runtime/compiler/wasm/gen/main.go
@@ -21,7 +21,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"regexp"
 	"strings"
 	"text/template"
@@ -57,24 +56,23 @@ import (
 {{range .Instructions -}}
 // Instruction{{.Identifier}} is the '{{.Name}}' instruction
 //
-type Instruction{{.Identifier}} struct {{if .Arguments}}{
-{{- range .Arguments}}
-	{{.Identifier}} {{.Type}}{{end}}
+type Instruction{{.Identifier}} struct{{if .Arguments}} {
+{{- range .Arguments}}{{- if .Identifier}}
+	{{.Identifier}} {{.Type.FieldType}}{{end}}{{end}}
 }
 {{- else}}{}{{- end}}
 
-func (i Instruction{{.Identifier}}) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode({{.OpcodeList}})
-	if err != nil {
-		return err
-	}
-{{- range .Arguments}}
+func (Instruction{{.Identifier}}) isInstruction() {}
 
-	err = {{.Write}}
+func (i Instruction{{.Identifier}}) write(w *WASMWriter) error {
+	err := w.writeOpcode({{.OpcodeList}})
 	if err != nil {
 		return err
 	}
-{{- end}}
+{{range .Arguments}}
+	{{.Variable}} := i.{{.Identifier}}
+	{{.Type.Write .Variable}}
+{{end}}
 	return nil
 }
 
@@ -89,24 +87,11 @@ const (
 
 // readInstruction reads an instruction in the WASM binary
 //
-func readInstruction(buf *buf) (Instruction, error) {
-	opcodeOffset := buf.offset
-	b, err := buf.ReadByte()
+func (r *WASMReader) readInstruction() (Instruction, error) {
+	opcodeOffset := r.buf.offset
+	b, err := r.buf.ReadByte()
 
 	c := opcode(b)
-
-	readUint32LEB128 := func() (uint32, error) {
-		offset := buf.offset
-		v, err := buf.readUint32LEB128()
-		if err != nil {
-			return 0, InvalidInstructionArgumentError{
-				Offset:    int(offset),
-				Opcode:    c,
-				ReadError: err,
-			}
-		}
-		return v, nil
-	}
 
 	if err != nil {
 		if err == io.EOF {
@@ -132,10 +117,7 @@ case {{ $key }}:
 {{- if (eq (len $group.Instructions) 1)}}
 {{- with (index $group.Instructions 0) }}
 {{- range .Arguments}}
-	{{.Variable}}, err := {{.Read}}()
-	if err != nil {
-		return nil, err
-	}
+	{{.Type.Read .Variable}}
 {{end}}
 	return Instruction{{.Identifier}}{{if .Arguments}}{
 {{- range .Arguments}}
@@ -157,25 +139,194 @@ default:
 
 type opcodes []byte
 
+type argumentType interface {
+	isArgumentType()
+	FieldType() string
+	Read(variable string) string
+	Write(variable string) string
+}
+
+type ArgumentTypeUint32 struct {}
+
+func (t ArgumentTypeUint32) isArgumentType() {}
+
+func (t ArgumentTypeUint32) FieldType() string {
+	return "uint32"
+}
+
+func (t ArgumentTypeUint32) Read(variable string) string {
+	return fmt.Sprintf(
+		`%s, err := r.readUint32LEB128InstructionArgument()
+	if err != nil {
+		return nil, err
+	}`,
+		variable,
+	)
+}
+
+func (t ArgumentTypeUint32) Write(variable string) string {
+	return fmt.Sprintf(
+		`err = w.buf.writeUint32LEB128(%s)
+	if err != nil {
+		return err
+	}`,
+		variable,
+	)
+}
+
+type ArgumentTypeInt32 struct {}
+
+func (t ArgumentTypeInt32) isArgumentType() {}
+
+func (t ArgumentTypeInt32) FieldType() string {
+	return "int32"
+}
+
+func (t ArgumentTypeInt32) Read(variable string) string {
+	return fmt.Sprintf(
+		`%s, err := r.readInt32LEB128InstructionArgument()
+	if err != nil {
+		return nil, err
+	}`,
+		variable,
+	)
+}
+
+func (t ArgumentTypeInt32) Write(variable string) string {
+	return fmt.Sprintf(
+		`err = w.buf.writeInt32LEB128(%s)
+	if err != nil {
+		return err
+	}`,
+		variable,
+	)
+}
+
+type ArgumentTypeInt64 struct {}
+
+func (t ArgumentTypeInt64) isArgumentType() {}
+
+func (t ArgumentTypeInt64) FieldType() string {
+	return "int64"
+}
+
+func (t ArgumentTypeInt64) Read(variable string) string {
+	return fmt.Sprintf(
+		`%s, err := r.readInt64LEB128InstructionArgument()
+	if err != nil {
+		return nil, err
+	}`,
+		variable,
+	)
+}
+
+func (t ArgumentTypeInt64) Write(variable string) string {
+	return fmt.Sprintf(
+		`err = w.buf.writeInt64LEB128(%s)
+	if err != nil {
+		return err
+	}`,
+		variable,
+	)
+}
+
+
+type ArgumentTypeBlock struct {
+	AllowElse bool
+}
+
+func (t ArgumentTypeBlock) isArgumentType() {}
+
+func (t ArgumentTypeBlock) FieldType() string {
+	return "Block"
+}
+
+func (t ArgumentTypeBlock) Read(variable string) string {
+	return fmt.Sprintf(
+		`%s, err := r.readBlockInstructionArgument(%v)
+	if err != nil {
+		return nil, err
+	}`,
+		variable,
+		t.AllowElse,
+	)
+}
+
+func (t ArgumentTypeBlock) Write(variable string) string {
+	return fmt.Sprintf(
+		`err = w.writeBlockInstructionArgument(%s, %v)
+	if err != nil {
+		return err
+	}`,
+		variable,
+		t.AllowElse,
+	)
+}
+
+type ArgumentTypeVector struct {
+	ArgumentType argumentType
+}
+
+func (t ArgumentTypeVector) isArgumentType() {}
+
+func (t ArgumentTypeVector) FieldType() string {
+	return fmt.Sprintf("[]%s", t.ArgumentType.FieldType())
+}
+
+func (t ArgumentTypeVector) Read(variable string) string {
+	// TODO: improve error
+
+	elementVariable := variable + "Element"
+
+	return fmt.Sprintf(
+		`%[1]sCountOffset := r.buf.offset
+	%[1]sCount, err := r.buf.readUint32LEB128()
+	if err != nil {
+		return nil, InvalidInstructionVectorArgumentCountError{
+			Offset: int(%[1]sCountOffset),
+			ReadError: err,
+		}
+	}
+
+	%[1]s := make(%[2]s, %[1]sCount)
+
+	for i := uint32(0); i < %[1]sCount; i++ {
+		%[3]s
+		%[1]s[i] = %[4]s
+	}`,
+		variable,
+		t.FieldType(),
+		t.ArgumentType.Read(elementVariable),
+		elementVariable,
+	)
+}
+
+func (t ArgumentTypeVector) Write(variable string) string {
+	// TODO: improve error
+
+	elementVariable := variable + "Element"
+
+	return fmt.Sprintf(
+		`%[1]sCount := len(%[1]s)
+	err = w.buf.writeUint32LEB128(uint32(%[1]sCount))
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < %[1]sCount; i++ {
+		%[3]s := %[1]s[i]
+		%[2]s
+	}`,
+		variable,
+		t.ArgumentType.Write(elementVariable),
+		elementVariable,
+	)
+}
+
+
 type argument struct {
 	Identifier string
-	Type       reflect.Kind
-}
-
-func (a argument) Write() (string, error) {
-	switch a.Type {
-	case reflect.Uint32:
-		return fmt.Sprintf("wasm.buf.writeUint32LEB128(i.%s)", a.Identifier), nil
-	}
-	return "", fmt.Errorf("invalid argument type: %s", a.Type)
-}
-
-func (a argument) Read() (string, error) {
-	switch a.Type {
-	case reflect.Uint32:
-		return "readUint32LEB128", nil
-	}
-	return "", fmt.Errorf("invalid argument type: %s", a.Type)
+	Type       argumentType
 }
 
 func (a argument) Variable() string {
@@ -267,6 +418,8 @@ var trailingWhitespaceRegexp = regexp.MustCompile("(?m:[ \t]+$)")
 
 const target = "instructions.go"
 
+var indexArgumentType = ArgumentTypeUint32{}
+
 func main() {
 
 	f, err := os.Create(target)
@@ -332,24 +485,477 @@ func main() {
 
 	declare([]instruction{
 		// Control Instructions
-		{"unreachable", opcodes{0x0}, arguments{}},
-		{"nop", opcodes{0x01}, arguments{}},
-		{"end", opcodes{0x0B}, arguments{}},
-		{"br", opcodes{0x0C}, arguments{{"Index", reflect.Uint32}}},
-		{"br_if", opcodes{0x0D}, arguments{{"Index", reflect.Uint32}}},
-		{"return", opcodes{0x0F}, arguments{}},
-		{"call", opcodes{0x10}, arguments{{"FuncIndex", reflect.Uint32}}},
-		{"call_indirect", opcodes{0x11}, arguments{{"TypeIndex", reflect.Uint32}, {"TableIndex", reflect.Uint32}}},
+		{
+			Name: "unreachable",
+			Opcodes: opcodes{0x0},
+			Arguments: arguments{},
+		},
+		{
+			Name: "nop",
+			Opcodes: opcodes{0x01},
+			Arguments: arguments{},
+		},
+		{
+			Name: "block",
+			Opcodes: opcodes{0x02},
+			Arguments: arguments{
+				{"Block", ArgumentTypeBlock{AllowElse: false}},
+			},
+		},
+		{
+			Name: "loop",
+			Opcodes: opcodes{0x03},
+			Arguments: arguments{
+				{"Block", ArgumentTypeBlock{AllowElse: false}},
+			},
+		},
+		{
+			Name: "if",
+			Opcodes: opcodes{0x04},
+			Arguments: arguments{
+				{"Block", ArgumentTypeBlock{AllowElse: true}},
+			},
+		},
+		{
+			Name: "end",
+			Opcodes: opcodes{0x0B},
+			Arguments: arguments{},
+		},
+		{
+			Name: "br",
+			Opcodes: opcodes{0x0C},
+			Arguments: arguments{
+				{"LabelIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "br_if",
+			Opcodes: opcodes{0x0D},
+			Arguments: arguments{
+				{"LabelIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "br_table",
+			Opcodes: opcodes{0x0E},
+			Arguments: arguments{
+				{"LabelIndices", ArgumentTypeVector{indexArgumentType}},
+				{"DefaultLabelIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "return",
+			Opcodes: opcodes{0x0F},
+			Arguments: arguments{},
+		},
+		{
+			Name: "call",
+			Opcodes: opcodes{0x10},
+			Arguments: arguments{
+				{"FuncIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "call_indirect",
+			Opcodes: opcodes{0x11},
+			Arguments: arguments{
+				{"TypeIndex", indexArgumentType},
+				{"TableIndex", indexArgumentType},
+			},
+		},
+		// Reference Instructions
+		{
+			Name: "ref.null",
+			Opcodes: opcodes{0xD0},
+			Arguments: arguments{
+				{"TypeIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "ref.is_null",
+			Opcodes: opcodes{0xD1},
+			Arguments: arguments{},
+		},
+		{
+			Name: "ref.func",
+			Opcodes: opcodes{0xD2},
+			Arguments: arguments{
+				{"FuncIndex", indexArgumentType},
+			},
+		},
 		// Parametric Instructions
-		{"drop", opcodes{0x1A}, arguments{}},
-		{"select", opcodes{0x1B}, arguments{}},
+		{
+			Name: "drop",
+			Opcodes: opcodes{0x1A},
+			Arguments: arguments{},
+		},
+		{
+			Name: "select",
+			Opcodes: opcodes{0x1B},
+			Arguments: arguments{},
+		},
 		// Variable Instructions
-		{"local.get", opcodes{0x20}, arguments{{"LocalIndex", reflect.Uint32}}},
-		{"local.set", opcodes{0x21}, arguments{{"LocalIndex", reflect.Uint32}}},
-		{"local.tee", opcodes{0x22}, arguments{{"LocalIndex", reflect.Uint32}}},
-		{"global.get", opcodes{0x23}, arguments{{"GlobalIndex", reflect.Uint32}}},
-		{"global.set", opcodes{0x24}, arguments{{"GlobalIndex", reflect.Uint32}}},
+		{
+			Name: "local.get",
+			Opcodes: opcodes{0x20},
+			Arguments: arguments{
+				{"LocalIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "local.set",
+			Opcodes: opcodes{0x21},
+			Arguments: arguments{
+				{"LocalIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "local.tee",
+			Opcodes: opcodes{0x22},
+			Arguments: arguments{
+				{"LocalIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "global.get",
+			Opcodes: opcodes{0x23},
+			Arguments: arguments{
+				{"GlobalIndex", indexArgumentType},
+			},
+		},
+		{
+			Name: "global.set",
+			Opcodes: opcodes{0x24},
+			Arguments: arguments{
+				{"GlobalIndex", indexArgumentType},
+			},
+		},
 		// Numeric Instructions
-		{"i32.add", opcodes{0x6a}, arguments{}},
+		// const instructions are followed by the respective literal
+		{
+			Name: "i32.const",
+			Opcodes: opcodes{0x41},
+			Arguments: arguments{
+				// i32, "Uninterpreted integers are encoded as signed integers."
+				{"Value", ArgumentTypeInt32{}},
+			},
+		},
+		{
+			Name: "i64.const",
+			Opcodes: opcodes{0x42},
+			Arguments: arguments{
+				// i64, "Uninterpreted integers are encoded as signed integers."
+				{"Value", ArgumentTypeInt64{}},
+			},
+		},
+		// All other numeric instructions are plain opcodes without any immediates.
+		{
+			Name: "i32.eqz",
+			Opcodes: opcodes{0x45},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.eq",
+			Opcodes: opcodes{0x46},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.ne",
+			Opcodes: opcodes{0x47},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.lt_s",
+			Opcodes: opcodes{0x48},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.lt_u",
+			Opcodes: opcodes{0x49},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.gt_s",
+			Opcodes: opcodes{0x4a},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.gt_u",
+			Opcodes: opcodes{0x4b},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.le_s",
+			Opcodes: opcodes{0x4c},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.le_u",
+			Opcodes: opcodes{0x4d},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.ge_s",
+			Opcodes: opcodes{0x4e},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.ge_u",
+			Opcodes: opcodes{0x4f},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.eqz",
+			Opcodes: opcodes{0x50},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.eq",
+			Opcodes: opcodes{0x51},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.ne",
+			Opcodes: opcodes{0x52},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.lt_s",
+			Opcodes: opcodes{0x53},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.lt_u",
+			Opcodes: opcodes{0x54},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.gt_s",
+			Opcodes: opcodes{0x55},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.gt_u",
+			Opcodes: opcodes{0x56},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.le_s",
+			Opcodes: opcodes{0x57},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.le_u",
+			Opcodes: opcodes{0x58},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.ge_s",
+			Opcodes: opcodes{0x59},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.ge_u",
+			Opcodes: opcodes{0x5a},
+			Arguments: arguments{},
+		},
+
+		{
+			Name: "i32.clz",
+			Opcodes: opcodes{0x67},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.ctz",
+			Opcodes: opcodes{0x68},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.popcnt",
+			Opcodes: opcodes{0x69},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.add",
+			Opcodes: opcodes{0x6a},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.sub",
+			Opcodes: opcodes{0x6b},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.mul",
+			Opcodes: opcodes{0x6c},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.div_s",
+			Opcodes: opcodes{0x6d},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.div_u",
+			Opcodes: opcodes{0x6e},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.rem_s",
+			Opcodes: opcodes{0x6f},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.rem_u",
+			Opcodes: opcodes{0x70},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.and",
+			Opcodes: opcodes{0x71},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.or",
+			Opcodes: opcodes{0x72},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.xor",
+			Opcodes: opcodes{0x73},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.shl",
+			Opcodes: opcodes{0x74},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.shr_s",
+			Opcodes: opcodes{0x75},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.shr_u",
+			Opcodes: opcodes{0x76},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.rotl",
+			Opcodes: opcodes{0x77},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i32.rotr",
+			Opcodes: opcodes{0x78},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.clz",
+			Opcodes: opcodes{0x79},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.ctz",
+			Opcodes: opcodes{0x7a},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.popcnt",
+			Opcodes: opcodes{0x7b},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.add",
+			Opcodes: opcodes{0x7c},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.sub",
+			Opcodes: opcodes{0x7d},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.mul",
+			Opcodes: opcodes{0x7e},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.div_s",
+			Opcodes: opcodes{0x7f},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.div_u",
+			Opcodes: opcodes{0x80},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.rem_s",
+			Opcodes: opcodes{0x81},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.rem_u",
+			Opcodes: opcodes{0x82},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.and",
+			Opcodes: opcodes{0x83},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.or",
+			Opcodes: opcodes{0x84},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.xor",
+			Opcodes: opcodes{0x85},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.shl",
+			Opcodes: opcodes{0x86},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.shr_s",
+			Opcodes: opcodes{0x87},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.shr_u",
+			Opcodes: opcodes{0x88},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.rotl",
+			Opcodes: opcodes{0x89},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.rotr",
+			Opcodes: opcodes{0x8a},
+			Arguments: arguments{},
+		},
+
+		{
+			Name: "i32.wrap_i64",
+			Opcodes: opcodes{0xa7},
+			Arguments: arguments{},
+		},
+
+		{
+			Name: "i64.extend_i32_s",
+			Opcodes: opcodes{0xac},
+			Arguments: arguments{},
+		},
+		{
+			Name: "i64.extend_i32_u",
+			Opcodes: opcodes{0xad},
+			Arguments: arguments{},
+		},
 	})
 }

--- a/runtime/compiler/wasm/instructions.go
+++ b/runtime/compiler/wasm/instructions.go
@@ -188,7 +188,7 @@ func (i InstructionBrIf) write(w *WASMWriter) error {
 // InstructionBrTable is the 'br_table' instruction
 //
 type InstructionBrTable struct {
-	LabelIndices      []uint32
+	LabelIndices []uint32
 	DefaultLabelIndex uint32
 }
 
@@ -210,9 +210,9 @@ func (i InstructionBrTable) write(w *WASMWriter) error {
 	for i := 0; i < labelIndicesCount; i++ {
 		labelIndicesElement := labelIndices[i]
 		err = w.buf.writeUint32LEB128(labelIndicesElement)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
 	}
 
 	defaultLabelIndex := i.DefaultLabelIndex
@@ -265,7 +265,7 @@ func (i InstructionCall) write(w *WASMWriter) error {
 // InstructionCallIndirect is the 'call_indirect' instruction
 //
 type InstructionCallIndirect struct {
-	TypeIndex  uint32
+	TypeIndex uint32
 	TableIndex uint32
 }
 
@@ -1690,7 +1690,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		labelIndicesCount, err := r.buf.readUint32LEB128()
 		if err != nil {
 			return nil, InvalidInstructionVectorArgumentCountError{
-				Offset:    int(labelIndicesCountOffset),
+				Offset: int(labelIndicesCountOffset),
 				ReadError: err,
 			}
 		}
@@ -1699,9 +1699,9 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 
 		for i := uint32(0); i < labelIndicesCount; i++ {
 			labelIndicesElement, err := r.readUint32LEB128InstructionArgument()
-			if err != nil {
-				return nil, err
-			}
+		if err != nil {
+			return nil, err
+		}
 			labelIndices[i] = labelIndicesElement
 		}
 
@@ -1711,7 +1711,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		}
 
 		return InstructionBrTable{
-			LabelIndices:      labelIndices,
+			LabelIndices: labelIndices,
 			DefaultLabelIndex: defaultLabelIndex,
 		}, nil
 
@@ -1737,7 +1737,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		}
 
 		return InstructionCallIndirect{
-			TypeIndex:  typeIndex,
+			TypeIndex: typeIndex,
 			TableIndex: tableIndex,
 		}, nil
 

--- a/runtime/compiler/wasm/instructions.go
+++ b/runtime/compiler/wasm/instructions.go
@@ -27,87 +27,215 @@ import (
 
 // InstructionUnreachable is the 'unreachable' instruction
 //
-type InstructionUnreachable struct {}
+type InstructionUnreachable struct{}
 
-func (i InstructionUnreachable) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeUnreachable)
+func (InstructionUnreachable) isInstruction() {}
+
+func (i InstructionUnreachable) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeUnreachable)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // InstructionNop is the 'nop' instruction
 //
-type InstructionNop struct {}
+type InstructionNop struct{}
 
-func (i InstructionNop) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeNop)
+func (InstructionNop) isInstruction() {}
+
+func (i InstructionNop) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeNop)
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// InstructionBlock is the 'block' instruction
+//
+type InstructionBlock struct {
+	Block Block
+}
+
+func (InstructionBlock) isInstruction() {}
+
+func (i InstructionBlock) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeBlock)
+	if err != nil {
+		return err
+	}
+
+	block := i.Block
+	err = w.writeBlockInstructionArgument(block, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionLoop is the 'loop' instruction
+//
+type InstructionLoop struct {
+	Block Block
+}
+
+func (InstructionLoop) isInstruction() {}
+
+func (i InstructionLoop) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeLoop)
+	if err != nil {
+		return err
+	}
+
+	block := i.Block
+	err = w.writeBlockInstructionArgument(block, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionIf is the 'if' instruction
+//
+type InstructionIf struct {
+	Block Block
+}
+
+func (InstructionIf) isInstruction() {}
+
+func (i InstructionIf) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeIf)
+	if err != nil {
+		return err
+	}
+
+	block := i.Block
+	err = w.writeBlockInstructionArgument(block, true)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // InstructionEnd is the 'end' instruction
 //
-type InstructionEnd struct {}
+type InstructionEnd struct{}
 
-func (i InstructionEnd) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeEnd)
+func (InstructionEnd) isInstruction() {}
+
+func (i InstructionEnd) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeEnd)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // InstructionBr is the 'br' instruction
 //
 type InstructionBr struct {
-	Index uint32
+	LabelIndex uint32
 }
 
-func (i InstructionBr) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeBr)
+func (InstructionBr) isInstruction() {}
+
+func (i InstructionBr) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeBr)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.Index)
+	labelIndex := i.LabelIndex
+	err = w.buf.writeUint32LEB128(labelIndex)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // InstructionBrIf is the 'br_if' instruction
 //
 type InstructionBrIf struct {
-	Index uint32
+	LabelIndex uint32
 }
 
-func (i InstructionBrIf) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeBrIf)
+func (InstructionBrIf) isInstruction() {}
+
+func (i InstructionBrIf) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeBrIf)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.Index)
+	labelIndex := i.LabelIndex
+	err = w.buf.writeUint32LEB128(labelIndex)
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// InstructionBrTable is the 'br_table' instruction
+//
+type InstructionBrTable struct {
+	LabelIndices      []uint32
+	DefaultLabelIndex uint32
+}
+
+func (InstructionBrTable) isInstruction() {}
+
+func (i InstructionBrTable) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeBrTable)
+	if err != nil {
+		return err
+	}
+
+	labelIndices := i.LabelIndices
+	labelIndicesCount := len(labelIndices)
+	err = w.buf.writeUint32LEB128(uint32(labelIndicesCount))
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < labelIndicesCount; i++ {
+		labelIndicesElement := labelIndices[i]
+		err = w.buf.writeUint32LEB128(labelIndicesElement)
+		if err != nil {
+			return err
+		}
+	}
+
+	defaultLabelIndex := i.DefaultLabelIndex
+	err = w.buf.writeUint32LEB128(defaultLabelIndex)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // InstructionReturn is the 'return' instruction
 //
-type InstructionReturn struct {}
+type InstructionReturn struct{}
 
-func (i InstructionReturn) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeReturn)
+func (InstructionReturn) isInstruction() {}
+
+func (i InstructionReturn) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeReturn)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -117,65 +245,141 @@ type InstructionCall struct {
 	FuncIndex uint32
 }
 
-func (i InstructionCall) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeCall)
+func (InstructionCall) isInstruction() {}
+
+func (i InstructionCall) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeCall)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.FuncIndex)
+	funcIndex := i.FuncIndex
+	err = w.buf.writeUint32LEB128(funcIndex)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // InstructionCallIndirect is the 'call_indirect' instruction
 //
 type InstructionCallIndirect struct {
-	TypeIndex uint32
+	TypeIndex  uint32
 	TableIndex uint32
 }
 
-func (i InstructionCallIndirect) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeCallIndirect)
+func (InstructionCallIndirect) isInstruction() {}
+
+func (i InstructionCallIndirect) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeCallIndirect)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.TypeIndex)
+	typeIndex := i.TypeIndex
+	err = w.buf.writeUint32LEB128(typeIndex)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.TableIndex)
+	tableIndex := i.TableIndex
+	err = w.buf.writeUint32LEB128(tableIndex)
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// InstructionRefNull is the 'ref.null' instruction
+//
+type InstructionRefNull struct {
+	TypeIndex uint32
+}
+
+func (InstructionRefNull) isInstruction() {}
+
+func (i InstructionRefNull) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeRefNull)
+	if err != nil {
+		return err
+	}
+
+	typeIndex := i.TypeIndex
+	err = w.buf.writeUint32LEB128(typeIndex)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionRefIsNull is the 'ref.is_null' instruction
+//
+type InstructionRefIsNull struct{}
+
+func (InstructionRefIsNull) isInstruction() {}
+
+func (i InstructionRefIsNull) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeRefIsNull)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionRefFunc is the 'ref.func' instruction
+//
+type InstructionRefFunc struct {
+	FuncIndex uint32
+}
+
+func (InstructionRefFunc) isInstruction() {}
+
+func (i InstructionRefFunc) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeRefFunc)
+	if err != nil {
+		return err
+	}
+
+	funcIndex := i.FuncIndex
+	err = w.buf.writeUint32LEB128(funcIndex)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // InstructionDrop is the 'drop' instruction
 //
-type InstructionDrop struct {}
+type InstructionDrop struct{}
 
-func (i InstructionDrop) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeDrop)
+func (InstructionDrop) isInstruction() {}
+
+func (i InstructionDrop) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeDrop)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // InstructionSelect is the 'select' instruction
 //
-type InstructionSelect struct {}
+type InstructionSelect struct{}
 
-func (i InstructionSelect) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeSelect)
+func (InstructionSelect) isInstruction() {}
+
+func (i InstructionSelect) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeSelect)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -185,16 +389,20 @@ type InstructionLocalGet struct {
 	LocalIndex uint32
 }
 
-func (i InstructionLocalGet) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeLocalGet)
+func (InstructionLocalGet) isInstruction() {}
+
+func (i InstructionLocalGet) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeLocalGet)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.LocalIndex)
+	localIndex := i.LocalIndex
+	err = w.buf.writeUint32LEB128(localIndex)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -204,16 +412,20 @@ type InstructionLocalSet struct {
 	LocalIndex uint32
 }
 
-func (i InstructionLocalSet) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeLocalSet)
+func (InstructionLocalSet) isInstruction() {}
+
+func (i InstructionLocalSet) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeLocalSet)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.LocalIndex)
+	localIndex := i.LocalIndex
+	err = w.buf.writeUint32LEB128(localIndex)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -223,16 +435,20 @@ type InstructionLocalTee struct {
 	LocalIndex uint32
 }
 
-func (i InstructionLocalTee) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeLocalTee)
+func (InstructionLocalTee) isInstruction() {}
+
+func (i InstructionLocalTee) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeLocalTee)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.LocalIndex)
+	localIndex := i.LocalIndex
+	err = w.buf.writeUint32LEB128(localIndex)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -242,16 +458,20 @@ type InstructionGlobalGet struct {
 	GlobalIndex uint32
 }
 
-func (i InstructionGlobalGet) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeGlobalGet)
+func (InstructionGlobalGet) isInstruction() {}
+
+func (i InstructionGlobalGet) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeGlobalGet)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.GlobalIndex)
+	globalIndex := i.GlobalIndex
+	err = w.buf.writeUint32LEB128(globalIndex)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -261,28 +481,981 @@ type InstructionGlobalSet struct {
 	GlobalIndex uint32
 }
 
-func (i InstructionGlobalSet) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeGlobalSet)
+func (InstructionGlobalSet) isInstruction() {}
+
+func (i InstructionGlobalSet) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeGlobalSet)
 	if err != nil {
 		return err
 	}
 
-	err = wasm.buf.writeUint32LEB128(i.GlobalIndex)
+	globalIndex := i.GlobalIndex
+	err = w.buf.writeUint32LEB128(globalIndex)
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// InstructionI32Const is the 'i32.const' instruction
+//
+type InstructionI32Const struct {
+	Value int32
+}
+
+func (InstructionI32Const) isInstruction() {}
+
+func (i InstructionI32Const) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Const)
+	if err != nil {
+		return err
+	}
+
+	value := i.Value
+	err = w.buf.writeInt32LEB128(value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Const is the 'i64.const' instruction
+//
+type InstructionI64Const struct {
+	Value int64
+}
+
+func (InstructionI64Const) isInstruction() {}
+
+func (i InstructionI64Const) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Const)
+	if err != nil {
+		return err
+	}
+
+	value := i.Value
+	err = w.buf.writeInt64LEB128(value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Eqz is the 'i32.eqz' instruction
+//
+type InstructionI32Eqz struct{}
+
+func (InstructionI32Eqz) isInstruction() {}
+
+func (i InstructionI32Eqz) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Eqz)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Eq is the 'i32.eq' instruction
+//
+type InstructionI32Eq struct{}
+
+func (InstructionI32Eq) isInstruction() {}
+
+func (i InstructionI32Eq) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Eq)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Ne is the 'i32.ne' instruction
+//
+type InstructionI32Ne struct{}
+
+func (InstructionI32Ne) isInstruction() {}
+
+func (i InstructionI32Ne) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Ne)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32LtS is the 'i32.lt_s' instruction
+//
+type InstructionI32LtS struct{}
+
+func (InstructionI32LtS) isInstruction() {}
+
+func (i InstructionI32LtS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32LtS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32LtU is the 'i32.lt_u' instruction
+//
+type InstructionI32LtU struct{}
+
+func (InstructionI32LtU) isInstruction() {}
+
+func (i InstructionI32LtU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32LtU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32GtS is the 'i32.gt_s' instruction
+//
+type InstructionI32GtS struct{}
+
+func (InstructionI32GtS) isInstruction() {}
+
+func (i InstructionI32GtS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32GtS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32GtU is the 'i32.gt_u' instruction
+//
+type InstructionI32GtU struct{}
+
+func (InstructionI32GtU) isInstruction() {}
+
+func (i InstructionI32GtU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32GtU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32LeS is the 'i32.le_s' instruction
+//
+type InstructionI32LeS struct{}
+
+func (InstructionI32LeS) isInstruction() {}
+
+func (i InstructionI32LeS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32LeS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32LeU is the 'i32.le_u' instruction
+//
+type InstructionI32LeU struct{}
+
+func (InstructionI32LeU) isInstruction() {}
+
+func (i InstructionI32LeU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32LeU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32GeS is the 'i32.ge_s' instruction
+//
+type InstructionI32GeS struct{}
+
+func (InstructionI32GeS) isInstruction() {}
+
+func (i InstructionI32GeS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32GeS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32GeU is the 'i32.ge_u' instruction
+//
+type InstructionI32GeU struct{}
+
+func (InstructionI32GeU) isInstruction() {}
+
+func (i InstructionI32GeU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32GeU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Eqz is the 'i64.eqz' instruction
+//
+type InstructionI64Eqz struct{}
+
+func (InstructionI64Eqz) isInstruction() {}
+
+func (i InstructionI64Eqz) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Eqz)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Eq is the 'i64.eq' instruction
+//
+type InstructionI64Eq struct{}
+
+func (InstructionI64Eq) isInstruction() {}
+
+func (i InstructionI64Eq) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Eq)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Ne is the 'i64.ne' instruction
+//
+type InstructionI64Ne struct{}
+
+func (InstructionI64Ne) isInstruction() {}
+
+func (i InstructionI64Ne) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Ne)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64LtS is the 'i64.lt_s' instruction
+//
+type InstructionI64LtS struct{}
+
+func (InstructionI64LtS) isInstruction() {}
+
+func (i InstructionI64LtS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64LtS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64LtU is the 'i64.lt_u' instruction
+//
+type InstructionI64LtU struct{}
+
+func (InstructionI64LtU) isInstruction() {}
+
+func (i InstructionI64LtU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64LtU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64GtS is the 'i64.gt_s' instruction
+//
+type InstructionI64GtS struct{}
+
+func (InstructionI64GtS) isInstruction() {}
+
+func (i InstructionI64GtS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64GtS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64GtU is the 'i64.gt_u' instruction
+//
+type InstructionI64GtU struct{}
+
+func (InstructionI64GtU) isInstruction() {}
+
+func (i InstructionI64GtU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64GtU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64LeS is the 'i64.le_s' instruction
+//
+type InstructionI64LeS struct{}
+
+func (InstructionI64LeS) isInstruction() {}
+
+func (i InstructionI64LeS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64LeS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64LeU is the 'i64.le_u' instruction
+//
+type InstructionI64LeU struct{}
+
+func (InstructionI64LeU) isInstruction() {}
+
+func (i InstructionI64LeU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64LeU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64GeS is the 'i64.ge_s' instruction
+//
+type InstructionI64GeS struct{}
+
+func (InstructionI64GeS) isInstruction() {}
+
+func (i InstructionI64GeS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64GeS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64GeU is the 'i64.ge_u' instruction
+//
+type InstructionI64GeU struct{}
+
+func (InstructionI64GeU) isInstruction() {}
+
+func (i InstructionI64GeU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64GeU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Clz is the 'i32.clz' instruction
+//
+type InstructionI32Clz struct{}
+
+func (InstructionI32Clz) isInstruction() {}
+
+func (i InstructionI32Clz) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Clz)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Ctz is the 'i32.ctz' instruction
+//
+type InstructionI32Ctz struct{}
+
+func (InstructionI32Ctz) isInstruction() {}
+
+func (i InstructionI32Ctz) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Ctz)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Popcnt is the 'i32.popcnt' instruction
+//
+type InstructionI32Popcnt struct{}
+
+func (InstructionI32Popcnt) isInstruction() {}
+
+func (i InstructionI32Popcnt) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Popcnt)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // InstructionI32Add is the 'i32.add' instruction
 //
-type InstructionI32Add struct {}
+type InstructionI32Add struct{}
 
-func (i InstructionI32Add) write(wasm *WASMWriter) error {
-	err := wasm.writeOpcode(opcodeI32Add)
+func (InstructionI32Add) isInstruction() {}
+
+func (i InstructionI32Add) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Add)
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// InstructionI32Sub is the 'i32.sub' instruction
+//
+type InstructionI32Sub struct{}
+
+func (InstructionI32Sub) isInstruction() {}
+
+func (i InstructionI32Sub) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Sub)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Mul is the 'i32.mul' instruction
+//
+type InstructionI32Mul struct{}
+
+func (InstructionI32Mul) isInstruction() {}
+
+func (i InstructionI32Mul) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Mul)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32DivS is the 'i32.div_s' instruction
+//
+type InstructionI32DivS struct{}
+
+func (InstructionI32DivS) isInstruction() {}
+
+func (i InstructionI32DivS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32DivS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32DivU is the 'i32.div_u' instruction
+//
+type InstructionI32DivU struct{}
+
+func (InstructionI32DivU) isInstruction() {}
+
+func (i InstructionI32DivU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32DivU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32RemS is the 'i32.rem_s' instruction
+//
+type InstructionI32RemS struct{}
+
+func (InstructionI32RemS) isInstruction() {}
+
+func (i InstructionI32RemS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32RemS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32RemU is the 'i32.rem_u' instruction
+//
+type InstructionI32RemU struct{}
+
+func (InstructionI32RemU) isInstruction() {}
+
+func (i InstructionI32RemU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32RemU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32And is the 'i32.and' instruction
+//
+type InstructionI32And struct{}
+
+func (InstructionI32And) isInstruction() {}
+
+func (i InstructionI32And) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32And)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Or is the 'i32.or' instruction
+//
+type InstructionI32Or struct{}
+
+func (InstructionI32Or) isInstruction() {}
+
+func (i InstructionI32Or) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Or)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Xor is the 'i32.xor' instruction
+//
+type InstructionI32Xor struct{}
+
+func (InstructionI32Xor) isInstruction() {}
+
+func (i InstructionI32Xor) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Xor)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Shl is the 'i32.shl' instruction
+//
+type InstructionI32Shl struct{}
+
+func (InstructionI32Shl) isInstruction() {}
+
+func (i InstructionI32Shl) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Shl)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32ShrS is the 'i32.shr_s' instruction
+//
+type InstructionI32ShrS struct{}
+
+func (InstructionI32ShrS) isInstruction() {}
+
+func (i InstructionI32ShrS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32ShrS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32ShrU is the 'i32.shr_u' instruction
+//
+type InstructionI32ShrU struct{}
+
+func (InstructionI32ShrU) isInstruction() {}
+
+func (i InstructionI32ShrU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32ShrU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Rotl is the 'i32.rotl' instruction
+//
+type InstructionI32Rotl struct{}
+
+func (InstructionI32Rotl) isInstruction() {}
+
+func (i InstructionI32Rotl) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Rotl)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32Rotr is the 'i32.rotr' instruction
+//
+type InstructionI32Rotr struct{}
+
+func (InstructionI32Rotr) isInstruction() {}
+
+func (i InstructionI32Rotr) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32Rotr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Clz is the 'i64.clz' instruction
+//
+type InstructionI64Clz struct{}
+
+func (InstructionI64Clz) isInstruction() {}
+
+func (i InstructionI64Clz) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Clz)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Ctz is the 'i64.ctz' instruction
+//
+type InstructionI64Ctz struct{}
+
+func (InstructionI64Ctz) isInstruction() {}
+
+func (i InstructionI64Ctz) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Ctz)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Popcnt is the 'i64.popcnt' instruction
+//
+type InstructionI64Popcnt struct{}
+
+func (InstructionI64Popcnt) isInstruction() {}
+
+func (i InstructionI64Popcnt) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Popcnt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Add is the 'i64.add' instruction
+//
+type InstructionI64Add struct{}
+
+func (InstructionI64Add) isInstruction() {}
+
+func (i InstructionI64Add) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Add)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Sub is the 'i64.sub' instruction
+//
+type InstructionI64Sub struct{}
+
+func (InstructionI64Sub) isInstruction() {}
+
+func (i InstructionI64Sub) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Sub)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Mul is the 'i64.mul' instruction
+//
+type InstructionI64Mul struct{}
+
+func (InstructionI64Mul) isInstruction() {}
+
+func (i InstructionI64Mul) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Mul)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64DivS is the 'i64.div_s' instruction
+//
+type InstructionI64DivS struct{}
+
+func (InstructionI64DivS) isInstruction() {}
+
+func (i InstructionI64DivS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64DivS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64DivU is the 'i64.div_u' instruction
+//
+type InstructionI64DivU struct{}
+
+func (InstructionI64DivU) isInstruction() {}
+
+func (i InstructionI64DivU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64DivU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64RemS is the 'i64.rem_s' instruction
+//
+type InstructionI64RemS struct{}
+
+func (InstructionI64RemS) isInstruction() {}
+
+func (i InstructionI64RemS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64RemS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64RemU is the 'i64.rem_u' instruction
+//
+type InstructionI64RemU struct{}
+
+func (InstructionI64RemU) isInstruction() {}
+
+func (i InstructionI64RemU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64RemU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64And is the 'i64.and' instruction
+//
+type InstructionI64And struct{}
+
+func (InstructionI64And) isInstruction() {}
+
+func (i InstructionI64And) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64And)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Or is the 'i64.or' instruction
+//
+type InstructionI64Or struct{}
+
+func (InstructionI64Or) isInstruction() {}
+
+func (i InstructionI64Or) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Or)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Xor is the 'i64.xor' instruction
+//
+type InstructionI64Xor struct{}
+
+func (InstructionI64Xor) isInstruction() {}
+
+func (i InstructionI64Xor) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Xor)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Shl is the 'i64.shl' instruction
+//
+type InstructionI64Shl struct{}
+
+func (InstructionI64Shl) isInstruction() {}
+
+func (i InstructionI64Shl) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Shl)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64ShrS is the 'i64.shr_s' instruction
+//
+type InstructionI64ShrS struct{}
+
+func (InstructionI64ShrS) isInstruction() {}
+
+func (i InstructionI64ShrS) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64ShrS)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64ShrU is the 'i64.shr_u' instruction
+//
+type InstructionI64ShrU struct{}
+
+func (InstructionI64ShrU) isInstruction() {}
+
+func (i InstructionI64ShrU) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64ShrU)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Rotl is the 'i64.rotl' instruction
+//
+type InstructionI64Rotl struct{}
+
+func (InstructionI64Rotl) isInstruction() {}
+
+func (i InstructionI64Rotl) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Rotl)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64Rotr is the 'i64.rotr' instruction
+//
+type InstructionI64Rotr struct{}
+
+func (InstructionI64Rotr) isInstruction() {}
+
+func (i InstructionI64Rotr) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64Rotr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI32WrapI64 is the 'i32.wrap_i64' instruction
+//
+type InstructionI32WrapI64 struct{}
+
+func (InstructionI32WrapI64) isInstruction() {}
+
+func (i InstructionI32WrapI64) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI32WrapI64)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64ExtendI32S is the 'i64.extend_i32_s' instruction
+//
+type InstructionI64ExtendI32S struct{}
+
+func (InstructionI64ExtendI32S) isInstruction() {}
+
+func (i InstructionI64ExtendI32S) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64ExtendI32S)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstructionI64ExtendI32U is the 'i64.extend_i32_u' instruction
+//
+type InstructionI64ExtendI32U struct{}
+
+func (InstructionI64ExtendI32U) isInstruction() {}
+
+func (i InstructionI64ExtendI32U) write(w *WASMWriter) error {
+	err := w.writeOpcode(opcodeI64ExtendI32U)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -291,18 +1464,32 @@ const (
 	opcodeUnreachable opcode = 0x0
 	// opcodeNop is the opcode for the 'nop' instruction
 	opcodeNop opcode = 0x1
+	// opcodeBlock is the opcode for the 'block' instruction
+	opcodeBlock opcode = 0x2
+	// opcodeLoop is the opcode for the 'loop' instruction
+	opcodeLoop opcode = 0x3
+	// opcodeIf is the opcode for the 'if' instruction
+	opcodeIf opcode = 0x4
 	// opcodeEnd is the opcode for the 'end' instruction
 	opcodeEnd opcode = 0xb
 	// opcodeBr is the opcode for the 'br' instruction
 	opcodeBr opcode = 0xc
 	// opcodeBrIf is the opcode for the 'br_if' instruction
 	opcodeBrIf opcode = 0xd
+	// opcodeBrTable is the opcode for the 'br_table' instruction
+	opcodeBrTable opcode = 0xe
 	// opcodeReturn is the opcode for the 'return' instruction
 	opcodeReturn opcode = 0xf
 	// opcodeCall is the opcode for the 'call' instruction
 	opcodeCall opcode = 0x10
 	// opcodeCallIndirect is the opcode for the 'call_indirect' instruction
 	opcodeCallIndirect opcode = 0x11
+	// opcodeRefNull is the opcode for the 'ref.null' instruction
+	opcodeRefNull opcode = 0xd0
+	// opcodeRefIsNull is the opcode for the 'ref.is_null' instruction
+	opcodeRefIsNull opcode = 0xd1
+	// opcodeRefFunc is the opcode for the 'ref.func' instruction
+	opcodeRefFunc opcode = 0xd2
 	// opcodeDrop is the opcode for the 'drop' instruction
 	opcodeDrop opcode = 0x1a
 	// opcodeSelect is the opcode for the 'select' instruction
@@ -317,30 +1504,141 @@ const (
 	opcodeGlobalGet opcode = 0x23
 	// opcodeGlobalSet is the opcode for the 'global.set' instruction
 	opcodeGlobalSet opcode = 0x24
+	// opcodeI32Const is the opcode for the 'i32.const' instruction
+	opcodeI32Const opcode = 0x41
+	// opcodeI64Const is the opcode for the 'i64.const' instruction
+	opcodeI64Const opcode = 0x42
+	// opcodeI32Eqz is the opcode for the 'i32.eqz' instruction
+	opcodeI32Eqz opcode = 0x45
+	// opcodeI32Eq is the opcode for the 'i32.eq' instruction
+	opcodeI32Eq opcode = 0x46
+	// opcodeI32Ne is the opcode for the 'i32.ne' instruction
+	opcodeI32Ne opcode = 0x47
+	// opcodeI32LtS is the opcode for the 'i32.lt_s' instruction
+	opcodeI32LtS opcode = 0x48
+	// opcodeI32LtU is the opcode for the 'i32.lt_u' instruction
+	opcodeI32LtU opcode = 0x49
+	// opcodeI32GtS is the opcode for the 'i32.gt_s' instruction
+	opcodeI32GtS opcode = 0x4a
+	// opcodeI32GtU is the opcode for the 'i32.gt_u' instruction
+	opcodeI32GtU opcode = 0x4b
+	// opcodeI32LeS is the opcode for the 'i32.le_s' instruction
+	opcodeI32LeS opcode = 0x4c
+	// opcodeI32LeU is the opcode for the 'i32.le_u' instruction
+	opcodeI32LeU opcode = 0x4d
+	// opcodeI32GeS is the opcode for the 'i32.ge_s' instruction
+	opcodeI32GeS opcode = 0x4e
+	// opcodeI32GeU is the opcode for the 'i32.ge_u' instruction
+	opcodeI32GeU opcode = 0x4f
+	// opcodeI64Eqz is the opcode for the 'i64.eqz' instruction
+	opcodeI64Eqz opcode = 0x50
+	// opcodeI64Eq is the opcode for the 'i64.eq' instruction
+	opcodeI64Eq opcode = 0x51
+	// opcodeI64Ne is the opcode for the 'i64.ne' instruction
+	opcodeI64Ne opcode = 0x52
+	// opcodeI64LtS is the opcode for the 'i64.lt_s' instruction
+	opcodeI64LtS opcode = 0x53
+	// opcodeI64LtU is the opcode for the 'i64.lt_u' instruction
+	opcodeI64LtU opcode = 0x54
+	// opcodeI64GtS is the opcode for the 'i64.gt_s' instruction
+	opcodeI64GtS opcode = 0x55
+	// opcodeI64GtU is the opcode for the 'i64.gt_u' instruction
+	opcodeI64GtU opcode = 0x56
+	// opcodeI64LeS is the opcode for the 'i64.le_s' instruction
+	opcodeI64LeS opcode = 0x57
+	// opcodeI64LeU is the opcode for the 'i64.le_u' instruction
+	opcodeI64LeU opcode = 0x58
+	// opcodeI64GeS is the opcode for the 'i64.ge_s' instruction
+	opcodeI64GeS opcode = 0x59
+	// opcodeI64GeU is the opcode for the 'i64.ge_u' instruction
+	opcodeI64GeU opcode = 0x5a
+	// opcodeI32Clz is the opcode for the 'i32.clz' instruction
+	opcodeI32Clz opcode = 0x67
+	// opcodeI32Ctz is the opcode for the 'i32.ctz' instruction
+	opcodeI32Ctz opcode = 0x68
+	// opcodeI32Popcnt is the opcode for the 'i32.popcnt' instruction
+	opcodeI32Popcnt opcode = 0x69
 	// opcodeI32Add is the opcode for the 'i32.add' instruction
 	opcodeI32Add opcode = 0x6a
+	// opcodeI32Sub is the opcode for the 'i32.sub' instruction
+	opcodeI32Sub opcode = 0x6b
+	// opcodeI32Mul is the opcode for the 'i32.mul' instruction
+	opcodeI32Mul opcode = 0x6c
+	// opcodeI32DivS is the opcode for the 'i32.div_s' instruction
+	opcodeI32DivS opcode = 0x6d
+	// opcodeI32DivU is the opcode for the 'i32.div_u' instruction
+	opcodeI32DivU opcode = 0x6e
+	// opcodeI32RemS is the opcode for the 'i32.rem_s' instruction
+	opcodeI32RemS opcode = 0x6f
+	// opcodeI32RemU is the opcode for the 'i32.rem_u' instruction
+	opcodeI32RemU opcode = 0x70
+	// opcodeI32And is the opcode for the 'i32.and' instruction
+	opcodeI32And opcode = 0x71
+	// opcodeI32Or is the opcode for the 'i32.or' instruction
+	opcodeI32Or opcode = 0x72
+	// opcodeI32Xor is the opcode for the 'i32.xor' instruction
+	opcodeI32Xor opcode = 0x73
+	// opcodeI32Shl is the opcode for the 'i32.shl' instruction
+	opcodeI32Shl opcode = 0x74
+	// opcodeI32ShrS is the opcode for the 'i32.shr_s' instruction
+	opcodeI32ShrS opcode = 0x75
+	// opcodeI32ShrU is the opcode for the 'i32.shr_u' instruction
+	opcodeI32ShrU opcode = 0x76
+	// opcodeI32Rotl is the opcode for the 'i32.rotl' instruction
+	opcodeI32Rotl opcode = 0x77
+	// opcodeI32Rotr is the opcode for the 'i32.rotr' instruction
+	opcodeI32Rotr opcode = 0x78
+	// opcodeI64Clz is the opcode for the 'i64.clz' instruction
+	opcodeI64Clz opcode = 0x79
+	// opcodeI64Ctz is the opcode for the 'i64.ctz' instruction
+	opcodeI64Ctz opcode = 0x7a
+	// opcodeI64Popcnt is the opcode for the 'i64.popcnt' instruction
+	opcodeI64Popcnt opcode = 0x7b
+	// opcodeI64Add is the opcode for the 'i64.add' instruction
+	opcodeI64Add opcode = 0x7c
+	// opcodeI64Sub is the opcode for the 'i64.sub' instruction
+	opcodeI64Sub opcode = 0x7d
+	// opcodeI64Mul is the opcode for the 'i64.mul' instruction
+	opcodeI64Mul opcode = 0x7e
+	// opcodeI64DivS is the opcode for the 'i64.div_s' instruction
+	opcodeI64DivS opcode = 0x7f
+	// opcodeI64DivU is the opcode for the 'i64.div_u' instruction
+	opcodeI64DivU opcode = 0x80
+	// opcodeI64RemS is the opcode for the 'i64.rem_s' instruction
+	opcodeI64RemS opcode = 0x81
+	// opcodeI64RemU is the opcode for the 'i64.rem_u' instruction
+	opcodeI64RemU opcode = 0x82
+	// opcodeI64And is the opcode for the 'i64.and' instruction
+	opcodeI64And opcode = 0x83
+	// opcodeI64Or is the opcode for the 'i64.or' instruction
+	opcodeI64Or opcode = 0x84
+	// opcodeI64Xor is the opcode for the 'i64.xor' instruction
+	opcodeI64Xor opcode = 0x85
+	// opcodeI64Shl is the opcode for the 'i64.shl' instruction
+	opcodeI64Shl opcode = 0x86
+	// opcodeI64ShrS is the opcode for the 'i64.shr_s' instruction
+	opcodeI64ShrS opcode = 0x87
+	// opcodeI64ShrU is the opcode for the 'i64.shr_u' instruction
+	opcodeI64ShrU opcode = 0x88
+	// opcodeI64Rotl is the opcode for the 'i64.rotl' instruction
+	opcodeI64Rotl opcode = 0x89
+	// opcodeI64Rotr is the opcode for the 'i64.rotr' instruction
+	opcodeI64Rotr opcode = 0x8a
+	// opcodeI32WrapI64 is the opcode for the 'i32.wrap_i64' instruction
+	opcodeI32WrapI64 opcode = 0xa7
+	// opcodeI64ExtendI32S is the opcode for the 'i64.extend_i32_s' instruction
+	opcodeI64ExtendI32S opcode = 0xac
+	// opcodeI64ExtendI32U is the opcode for the 'i64.extend_i32_u' instruction
+	opcodeI64ExtendI32U opcode = 0xad
 )
 
 // readInstruction reads an instruction in the WASM binary
 //
-func readInstruction(buf *buf) (Instruction, error) {
-	opcodeOffset := buf.offset
-	b, err := buf.ReadByte()
+func (r *WASMReader) readInstruction() (Instruction, error) {
+	opcodeOffset := r.buf.offset
+	b, err := r.buf.ReadByte()
 
 	c := opcode(b)
-
-	readUint32LEB128 := func() (uint32, error) {
-		offset := buf.offset
-		v, err := buf.readUint32LEB128()
-		if err != nil {
-			return 0, InvalidInstructionArgumentError{
-				Offset:    int(offset),
-				Opcode:    c,
-				ReadError: err,
-			}
-		}
-		return v, nil
-	}
 
 	if err != nil {
 		if err == io.EOF {
@@ -357,28 +1655,68 @@ func readInstruction(buf *buf) (Instruction, error) {
 	}
 
 	switch c {
+	case opcodeBlock:
+		block, err := r.readBlockInstructionArgument(false)
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionBlock{
+			Block: block,
+		}, nil
+
 	case opcodeBr:
-		index, err := readUint32LEB128()
+		labelIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
 
 		return InstructionBr{
-			Index: index,
+			LabelIndex: labelIndex,
 		}, nil
 
 	case opcodeBrIf:
-		index, err := readUint32LEB128()
+		labelIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
 
 		return InstructionBrIf{
-			Index: index,
+			LabelIndex: labelIndex,
+		}, nil
+
+	case opcodeBrTable:
+		labelIndicesCountOffset := r.buf.offset
+		labelIndicesCount, err := r.buf.readUint32LEB128()
+		if err != nil {
+			return nil, InvalidInstructionVectorArgumentCountError{
+				Offset:    int(labelIndicesCountOffset),
+				ReadError: err,
+			}
+		}
+
+		labelIndices := make([]uint32, labelIndicesCount)
+
+		for i := uint32(0); i < labelIndicesCount; i++ {
+			labelIndicesElement, err := r.readUint32LEB128InstructionArgument()
+			if err != nil {
+				return nil, err
+			}
+			labelIndices[i] = labelIndicesElement
+		}
+
+		defaultLabelIndex, err := r.readUint32LEB128InstructionArgument()
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionBrTable{
+			LabelIndices:      labelIndices,
+			DefaultLabelIndex: defaultLabelIndex,
 		}, nil
 
 	case opcodeCall:
-		funcIndex, err := readUint32LEB128()
+		funcIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
@@ -388,18 +1726,18 @@ func readInstruction(buf *buf) (Instruction, error) {
 		}, nil
 
 	case opcodeCallIndirect:
-		typeIndex, err := readUint32LEB128()
+		typeIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
 
-		tableIndex, err := readUint32LEB128()
+		tableIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
 
 		return InstructionCallIndirect{
-			TypeIndex: typeIndex,
+			TypeIndex:  typeIndex,
 			TableIndex: tableIndex,
 		}, nil
 
@@ -410,7 +1748,7 @@ func readInstruction(buf *buf) (Instruction, error) {
 		return InstructionEnd{}, nil
 
 	case opcodeGlobalGet:
-		globalIndex, err := readUint32LEB128()
+		globalIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +1758,7 @@ func readInstruction(buf *buf) (Instruction, error) {
 		}, nil
 
 	case opcodeGlobalSet:
-		globalIndex, err := readUint32LEB128()
+		globalIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
@@ -432,8 +1770,218 @@ func readInstruction(buf *buf) (Instruction, error) {
 	case opcodeI32Add:
 		return InstructionI32Add{}, nil
 
+	case opcodeI32And:
+		return InstructionI32And{}, nil
+
+	case opcodeI32Clz:
+		return InstructionI32Clz{}, nil
+
+	case opcodeI32Const:
+		value, err := r.readInt32LEB128InstructionArgument()
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionI32Const{
+			Value: value,
+		}, nil
+
+	case opcodeI32Ctz:
+		return InstructionI32Ctz{}, nil
+
+	case opcodeI32DivS:
+		return InstructionI32DivS{}, nil
+
+	case opcodeI32DivU:
+		return InstructionI32DivU{}, nil
+
+	case opcodeI32Eq:
+		return InstructionI32Eq{}, nil
+
+	case opcodeI32Eqz:
+		return InstructionI32Eqz{}, nil
+
+	case opcodeI32GeS:
+		return InstructionI32GeS{}, nil
+
+	case opcodeI32GeU:
+		return InstructionI32GeU{}, nil
+
+	case opcodeI32GtS:
+		return InstructionI32GtS{}, nil
+
+	case opcodeI32GtU:
+		return InstructionI32GtU{}, nil
+
+	case opcodeI32LeS:
+		return InstructionI32LeS{}, nil
+
+	case opcodeI32LeU:
+		return InstructionI32LeU{}, nil
+
+	case opcodeI32LtS:
+		return InstructionI32LtS{}, nil
+
+	case opcodeI32LtU:
+		return InstructionI32LtU{}, nil
+
+	case opcodeI32Mul:
+		return InstructionI32Mul{}, nil
+
+	case opcodeI32Ne:
+		return InstructionI32Ne{}, nil
+
+	case opcodeI32Or:
+		return InstructionI32Or{}, nil
+
+	case opcodeI32Popcnt:
+		return InstructionI32Popcnt{}, nil
+
+	case opcodeI32RemS:
+		return InstructionI32RemS{}, nil
+
+	case opcodeI32RemU:
+		return InstructionI32RemU{}, nil
+
+	case opcodeI32Rotl:
+		return InstructionI32Rotl{}, nil
+
+	case opcodeI32Rotr:
+		return InstructionI32Rotr{}, nil
+
+	case opcodeI32Shl:
+		return InstructionI32Shl{}, nil
+
+	case opcodeI32ShrS:
+		return InstructionI32ShrS{}, nil
+
+	case opcodeI32ShrU:
+		return InstructionI32ShrU{}, nil
+
+	case opcodeI32Sub:
+		return InstructionI32Sub{}, nil
+
+	case opcodeI32WrapI64:
+		return InstructionI32WrapI64{}, nil
+
+	case opcodeI32Xor:
+		return InstructionI32Xor{}, nil
+
+	case opcodeI64Add:
+		return InstructionI64Add{}, nil
+
+	case opcodeI64And:
+		return InstructionI64And{}, nil
+
+	case opcodeI64Clz:
+		return InstructionI64Clz{}, nil
+
+	case opcodeI64Const:
+		value, err := r.readInt64LEB128InstructionArgument()
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionI64Const{
+			Value: value,
+		}, nil
+
+	case opcodeI64Ctz:
+		return InstructionI64Ctz{}, nil
+
+	case opcodeI64DivS:
+		return InstructionI64DivS{}, nil
+
+	case opcodeI64DivU:
+		return InstructionI64DivU{}, nil
+
+	case opcodeI64Eq:
+		return InstructionI64Eq{}, nil
+
+	case opcodeI64Eqz:
+		return InstructionI64Eqz{}, nil
+
+	case opcodeI64ExtendI32S:
+		return InstructionI64ExtendI32S{}, nil
+
+	case opcodeI64ExtendI32U:
+		return InstructionI64ExtendI32U{}, nil
+
+	case opcodeI64GeS:
+		return InstructionI64GeS{}, nil
+
+	case opcodeI64GeU:
+		return InstructionI64GeU{}, nil
+
+	case opcodeI64GtS:
+		return InstructionI64GtS{}, nil
+
+	case opcodeI64GtU:
+		return InstructionI64GtU{}, nil
+
+	case opcodeI64LeS:
+		return InstructionI64LeS{}, nil
+
+	case opcodeI64LeU:
+		return InstructionI64LeU{}, nil
+
+	case opcodeI64LtS:
+		return InstructionI64LtS{}, nil
+
+	case opcodeI64LtU:
+		return InstructionI64LtU{}, nil
+
+	case opcodeI64Mul:
+		return InstructionI64Mul{}, nil
+
+	case opcodeI64Ne:
+		return InstructionI64Ne{}, nil
+
+	case opcodeI64Or:
+		return InstructionI64Or{}, nil
+
+	case opcodeI64Popcnt:
+		return InstructionI64Popcnt{}, nil
+
+	case opcodeI64RemS:
+		return InstructionI64RemS{}, nil
+
+	case opcodeI64RemU:
+		return InstructionI64RemU{}, nil
+
+	case opcodeI64Rotl:
+		return InstructionI64Rotl{}, nil
+
+	case opcodeI64Rotr:
+		return InstructionI64Rotr{}, nil
+
+	case opcodeI64Shl:
+		return InstructionI64Shl{}, nil
+
+	case opcodeI64ShrS:
+		return InstructionI64ShrS{}, nil
+
+	case opcodeI64ShrU:
+		return InstructionI64ShrU{}, nil
+
+	case opcodeI64Sub:
+		return InstructionI64Sub{}, nil
+
+	case opcodeI64Xor:
+		return InstructionI64Xor{}, nil
+
+	case opcodeIf:
+		block, err := r.readBlockInstructionArgument(true)
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionIf{
+			Block: block,
+		}, nil
+
 	case opcodeLocalGet:
-		localIndex, err := readUint32LEB128()
+		localIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
@@ -443,7 +1991,7 @@ func readInstruction(buf *buf) (Instruction, error) {
 		}, nil
 
 	case opcodeLocalSet:
-		localIndex, err := readUint32LEB128()
+		localIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +2001,7 @@ func readInstruction(buf *buf) (Instruction, error) {
 		}, nil
 
 	case opcodeLocalTee:
-		localIndex, err := readUint32LEB128()
+		localIndex, err := r.readUint32LEB128InstructionArgument()
 		if err != nil {
 			return nil, err
 		}
@@ -462,8 +2010,41 @@ func readInstruction(buf *buf) (Instruction, error) {
 			LocalIndex: localIndex,
 		}, nil
 
+	case opcodeLoop:
+		block, err := r.readBlockInstructionArgument(false)
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionLoop{
+			Block: block,
+		}, nil
+
 	case opcodeNop:
 		return InstructionNop{}, nil
+
+	case opcodeRefFunc:
+		funcIndex, err := r.readUint32LEB128InstructionArgument()
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionRefFunc{
+			FuncIndex: funcIndex,
+		}, nil
+
+	case opcodeRefIsNull:
+		return InstructionRefIsNull{}, nil
+
+	case opcodeRefNull:
+		typeIndex, err := r.readUint32LEB128InstructionArgument()
+		if err != nil {
+			return nil, err
+		}
+
+		return InstructionRefNull{
+			TypeIndex: typeIndex,
+		}, nil
 
 	case opcodeReturn:
 		return InstructionReturn{}, nil

--- a/runtime/compiler/wasm/leb128_test.go
+++ b/runtime/compiler/wasm/leb128_test.go
@@ -25,22 +25,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuf_writeUint32LEB128(t *testing.T) {
+func TestBuf_Uint32LEB128(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("DWARF spec", func(t *testing.T) {
+	t.Run("DWARF spec + more", func(t *testing.T) {
 
 		t.Parallel()
 
 		// DWARF Debugging Information Format, Version 3, page 140
 
 		for v, expected := range map[uint32][]byte{
+			0:     {0x00},
+			1:     {0x01},
 			2:     {2},
+			63:    {0x3f},
+			64:    {0x40},
 			127:   {127},
 			128:   {0 + 0x80, 1},
 			129:   {1 + 0x80, 1},
 			130:   {2 + 0x80, 1},
+			0x90:  {0x90, 0x01},
+			0x100: {0x80, 0x02},
+			0x101: {0x81, 0x02},
+			0xff:  {0xff, 0x01},
 			12857: {57 + 0x80, 100},
 		} {
 			var b buf
@@ -86,22 +94,30 @@ func TestBuf_writeUint32LEB128(t *testing.T) {
 	})
 }
 
-func TestBuf_writeUint64LEB128(t *testing.T) {
+func TestBuf_Uint64LEB128(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("DWARF spec", func(t *testing.T) {
+	t.Run("DWARF spec + more", func(t *testing.T) {
 
 		t.Parallel()
 
 		// DWARF Debugging Information Format, Version 3, page 140
 
 		for v, expected := range map[uint64][]byte{
+			0:     {0x00},
+			1:     {0x01},
 			2:     {2},
+			63:    {0x3f},
+			64:    {0x40},
 			127:   {127},
 			128:   {0 + 0x80, 1},
 			129:   {1 + 0x80, 1},
 			130:   {2 + 0x80, 1},
+			0x90:  {0x90, 0x01},
+			0x100: {0x80, 0x02},
+			0x101: {0x81, 0x02},
+			0xff:  {0xff, 0x01},
 			12857: {57 + 0x80, 100},
 		} {
 			var b buf
@@ -141,25 +157,34 @@ func TestBuf_writeUint64LEB128(t *testing.T) {
 	})
 }
 
-func TestBuf_writeInt32LEB128(t *testing.T) {
+func TestBuf_Int32LEB128(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("DWARF spec", func(t *testing.T) {
+	t.Run("DWARF spec + more", func(t *testing.T) {
 
 		t.Parallel()
 
 		// DWARF Debugging Information Format, Version 3, page 141
 
 		for v, expected := range map[int32][]byte{
-			2:    {2},
-			-2:   {0x7e},
-			127:  {127 + 0x80, 0},
-			-127: {1 + 0x80, 0x7f},
-			128:  {0 + 0x80, 1},
-			-128: {0 + 0x80, 0x7f},
-			129:  {1 + 0x80, 1},
-			-129: {0x7f + 0x80, 0x7e},
+			0:      {0x00},
+			1:      {0x01},
+			-1:     {0x7f},
+			2:      {2},
+			-2:     {0x7e},
+			63:     {0x3f},
+			-63:    {0x41},
+			64:     {0xc0, 0x00},
+			-64:    {0x40},
+			-65:    {0xbf, 0x7f},
+			127:    {127 + 0x80, 0},
+			-127:   {1 + 0x80, 0x7f},
+			128:    {0 + 0x80, 1},
+			-128:   {0 + 0x80, 0x7f},
+			129:    {1 + 0x80, 1},
+			-129:   {0x7f + 0x80, 0x7e},
+			-12345: {0xc7, 0x9f, 0x7f},
 		} {
 			var b buf
 			err := b.writeInt32LEB128(v)
@@ -209,25 +234,34 @@ func TestBuf_writeInt32LEB128(t *testing.T) {
 	})
 }
 
-func TestBuf_writeInt64LEB128(t *testing.T) {
+func TestBuf_Int64LEB128(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("DWARF spec", func(t *testing.T) {
+	t.Run("DWARF spec + more", func(t *testing.T) {
 
 		t.Parallel()
 
 		// DWARF Debugging Information Format, Version 3, page 141
 
 		for v, expected := range map[int64][]byte{
-			2:    {2},
-			-2:   {0x7e},
-			127:  {127 + 0x80, 0},
-			-127: {1 + 0x80, 0x7f},
-			128:  {0 + 0x80, 1},
-			-128: {0 + 0x80, 0x7f},
-			129:  {1 + 0x80, 1},
-			-129: {0x7f + 0x80, 0x7e},
+			0:      {0x00},
+			1:      {0x01},
+			-1:     {0x7f},
+			2:      {2},
+			-2:     {0x7e},
+			63:     {0x3f},
+			-63:    {0x41},
+			64:     {0xc0, 0x00},
+			-64:    {0x40},
+			-65:    {0xbf, 0x7f},
+			127:    {127 + 0x80, 0},
+			-127:   {1 + 0x80, 0x7f},
+			128:    {0 + 0x80, 1},
+			-128:   {0 + 0x80, 0x7f},
+			129:    {1 + 0x80, 1},
+			-129:   {0x7f + 0x80, 0x7e},
+			-12345: {0xc7, 0x9f, 0x7f},
 		} {
 			var b buf
 			err := b.writeInt64LEB128(v)

--- a/runtime/compiler/wasm/opcode.go
+++ b/runtime/compiler/wasm/opcode.go
@@ -17,3 +17,9 @@
  */
 
 package wasm
+
+// opcode is the byte used to indicate a certain instruction in the WASM binary
+//
+type opcode byte
+
+const opcodeElse opcode = 0x05

--- a/runtime/compiler/wasm/reader.go
+++ b/runtime/compiler/wasm/reader.go
@@ -19,6 +19,7 @@
 package wasm
 
 import (
+	"math"
 	"unicode/utf8"
 )
 
@@ -626,9 +627,8 @@ func (r *WASMReader) readLocals() ([]ValueType, error) {
 // readInstructions reads the instructions for one function in the code sections
 //
 func (r *WASMReader) readInstructions() (instructions []Instruction, err error) {
-
 	for {
-		instruction, err := readInstruction(r.buf)
+		instruction, err := r.readInstruction()
 		if err != nil {
 			return nil, err
 		}
@@ -686,4 +686,168 @@ func (r *WASMReader) readName() (string, error) {
 	}
 
 	return string(name), nil
+}
+
+// readUint32LEB128InstructionArgument reads a uint32 instruction argument
+// (in LEB128 format)
+//
+func (r *WASMReader) readUint32LEB128InstructionArgument() (uint32, error) {
+	offset := r.buf.offset
+	v, err := r.buf.readUint32LEB128()
+	if err != nil {
+		return 0, InvalidInstructionArgumentError{
+			Offset:    int(offset),
+			ReadError: err,
+		}
+	}
+	return v, nil
+}
+
+// readInt32LEB128InstructionArgument reads an int32 instruction argument
+// (in LEB128 format)
+//
+func (r *WASMReader) readInt32LEB128InstructionArgument() (int32, error) {
+	offset := r.buf.offset
+	v, err := r.buf.readInt32LEB128()
+	if err != nil {
+		return 0, InvalidInstructionArgumentError{
+			Offset:    int(offset),
+			ReadError: err,
+		}
+	}
+	return v, nil
+}
+
+// readInt64LEB128InstructionArgument reads an int64 instruction argument
+// (in LEB128 format)
+//
+func (r *WASMReader) readInt64LEB128InstructionArgument() (int64, error) {
+	offset := r.buf.offset
+	v, err := r.buf.readInt64LEB128()
+	if err != nil {
+		return 0, InvalidInstructionArgumentError{
+			Offset:    int(offset),
+			ReadError: err,
+		}
+	}
+	return v, nil
+}
+
+// readBlockInstructionArgument reads a block instruction argument
+//
+func (r *WASMReader) readBlockInstructionArgument(allowElse bool) (Block, error) {
+	// read the block type.
+	blockType, err := r.readBlockType()
+	if err != nil {
+		// TODO: improve error
+		return Block{}, err
+	}
+
+	// read the first sequence of instructions.
+	// `readInstructions` cannot be used, as it does not handle the `else` instruction / opcode.
+
+	var instructions1 []Instruction
+
+	sawElse := false
+
+	for {
+		b, err := r.buf.PeekByte()
+		if b == byte(opcodeElse) {
+			if !allowElse {
+				return Block{}, InvalidBlockSecondInstructionsError{
+					Offset: int(r.buf.offset),
+
+				}
+			}
+			r.buf.offset++
+			sawElse = true
+			break
+		}
+
+		instruction, err := r.readInstruction()
+		if err != nil {
+			// TODO: improve error
+			return Block{}, err
+		}
+
+		if _, ok := instruction.(InstructionEnd); ok {
+			break
+		}
+
+		instructions1 = append(instructions1, instruction)
+	}
+
+	var instructions2 []Instruction
+	if sawElse {
+		// the first set of instructions contained an `else` instruction / opcode,
+		// so read the second set of instructions. the validity was already checked above.
+
+		instructions2, err = r.readInstructions()
+		if err != nil {
+			// TODO: improve error
+			return Block{}, err
+		}
+	}
+
+	return Block{
+		BlockType: blockType,
+		Instructions1: instructions1,
+		Instructions2: instructions2,
+	}, nil
+}
+
+func (r *WASMReader) readBlockType() (BlockType, error) {
+	// it may be the empty block type
+	b, err := r.buf.PeekByte()
+	if err != nil {
+		// TODO: improve error
+		return nil, err
+	}
+	if b == emptyBlockType {
+		r.buf.offset++
+		return nil, nil
+	}
+
+	// it may be a value type
+	blockType, err := r.readBlockTypeValueType()
+	if err != nil {
+		// TODO: improve error
+		return nil, err
+	}
+
+	if blockType != nil {
+		return blockType, nil
+	}
+
+	// the block type is not a value type,
+	// it must be a type index.
+
+	typeIndex, err := r.buf.readInt64LEB128()
+	if err != nil {
+		// TODO: improve error
+		return nil, err
+	}
+	if typeIndex > math.MaxUint32 {
+		// TODO: report error
+	}
+
+	return TypeIndexBlockType{
+		TypeIndex: uint32(typeIndex),
+	}, nil
+}
+
+// readBlockTypeValueType reads a value type block type
+// and returns nil if the next byte is not a valid value type
+//
+func (r *WASMReader) readBlockTypeValueType() (BlockType, error) {
+	b, err := r.buf.PeekByte()
+	if err != nil {
+		return nil, err
+	}
+	valueType := AsValueType(b)
+	if valueType == 0 {
+		return nil, nil
+	}
+	r.buf.offset++
+	return valueType, nil
 }

--- a/runtime/compiler/wasm/reader.go
+++ b/runtime/compiler/wasm/reader.go
@@ -752,6 +752,10 @@ func (r *WASMReader) readBlockInstructionArgument(allowElse bool) (Block, error)
 
 	for {
 		b, err := r.buf.PeekByte()
+		if err != nil {
+			// TODO: improve error
+			return Block{}, err
+		}
 		if b == byte(opcodeElse) {
 			if !allowElse {
 				return Block{}, InvalidBlockSecondInstructionsError{
@@ -822,13 +826,20 @@ func (r *WASMReader) readBlockType() (BlockType, error) {
 	// the block type is not a value type,
 	// it must be a type index.
 
+	typeIndexOffset := r.buf.offset
 	typeIndex, err := r.buf.readInt64LEB128()
 	if err != nil {
 		// TODO: improve error
 		return nil, err
 	}
-	if typeIndex > math.MaxUint32 {
-		// TODO: report error
+
+	// the type index was read as a int64,
+	// but must fit a uint32
+	if typeIndex < 0 || typeIndex > math.MaxUint32 {
+		return nil, InvalidBlockTypeTypeIndexError{
+			Offset: int(typeIndexOffset),
+			TypeIndex: typeIndex,
+		}
 	}
 
 	return TypeIndexBlockType{

--- a/runtime/compiler/wasm/reader_test.go
+++ b/runtime/compiler/wasm/reader_test.go
@@ -1346,3 +1346,286 @@ func TestWASMReader_readName(t *testing.T) {
 		assert.Empty(t, name)
 	})
 }
+
+func TestWASMReader_readInstruction(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("block, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// block
+				0x02,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// end
+				0x0b,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		expected := InstructionBlock{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: nil,
+			},
+		}
+		actual, err := r.readInstruction()
+		require.NoError(t, err)
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("block, type index result", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// block
+				0x02,
+				// type index: 2
+				0x2,
+				// unreachable
+				0x0,
+				// end
+				0x0b,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		expected := InstructionBlock{
+			Block: Block{
+				BlockType:     TypeIndexBlockType{TypeIndex: 2},
+				Instructions1: []Instruction{
+					InstructionUnreachable{},
+				},
+				Instructions2: nil,
+			},
+		}
+		actual, err := r.readInstruction()
+		require.NoError(t, err)
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("block, i32 result, second instructions", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// block
+				0x02,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// else
+				0x05,
+				// i32.const
+				0x41,
+				0x02,
+				// end
+				0x0b,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		_, err := r.readInstruction()
+		require.Equal(t, InvalidBlockSecondInstructionsError{
+			Offset: 4,
+		}, err)
+	})
+
+	t.Run("loop, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// loop
+				0x03,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// end
+				0x0b,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		expected := InstructionLoop{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: nil,
+			},
+		}
+		actual, err := r.readInstruction()
+		require.NoError(t, err)
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("loop, i32 result, second instructions", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// loop
+				0x03,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// else
+				0x05,
+				// i32.const
+				0x41,
+				0x02,
+				// end
+				0x0b,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		_, err := r.readInstruction()
+		require.Equal(t, InvalidBlockSecondInstructionsError{
+			Offset: 4,
+		}, err)
+	})
+
+	t.Run("if, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// if
+				0x04,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// end
+				0x0b,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		expected := InstructionIf{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: nil,
+			},
+		}
+		actual, err := r.readInstruction()
+		require.NoError(t, err)
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("if-else, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// loop
+				0x04,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// else
+				0x05,
+				// i32.const
+				0x41,
+				0x02,
+				// end
+				0x0b,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		expected := InstructionIf{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: []Instruction{
+					InstructionI32Const{Value: 2},
+				},
+			},
+		}
+		actual, err := r.readInstruction()
+		require.NoError(t, err)
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("br_table", func(t *testing.T) {
+
+		t.Parallel()
+
+		b := buf{
+			data: []byte{
+				// br_table
+				0x0e,
+				// number of branch depths
+				0x04,
+				// 1. branch depth
+				0x03,
+				// 2. branch depth
+				0x02,
+				// 3. branch depth
+				0x01,
+				// 4. branch depth
+				0x00,
+				// default branch depth
+				0x04,
+			},
+			offset: 0,
+		}
+		r := WASMReader{buf: &b}
+
+		expected := InstructionBrTable{
+			LabelIndices: []uint32{3, 2, 1, 0},
+			DefaultLabelIndex: 4,
+		}
+		actual, err := r.readInstruction()
+		require.NoError(t, err)
+
+		require.Equal(t, expected, actual)
+	})
+}

--- a/runtime/compiler/wasm/valuetype.go
+++ b/runtime/compiler/wasm/valuetype.go
@@ -1,0 +1,72 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wasm
+
+// ValueType is the type of a value
+//
+type ValueType byte
+
+const (
+	// ValueTypeI32 is the `i32` type,
+	// the type of 32 bit integers.
+	// The value is the byte used in the WASM binary
+	ValueTypeI32 ValueType = 0x7F
+
+	// ValueTypeI64 is the `i64` type,
+	// the type of 64 bit integers.
+	// The value is the byte used in the WASM binary
+	ValueTypeI64 ValueType = 0x7E
+
+	// ValueTypeFuncRef is the `funcref` type,
+	// the type of first-class references to functions.
+	// The value is the byte used in the WASM binary
+	ValueTypeFuncRef ValueType = 0x70
+
+	// ValueTypeExternRef is the `funcref` type,
+	// the type of first-class references to objects owned by the embedder.
+	// The value is the byte used in the WASM binary
+	ValueTypeExternRef ValueType = 0x6F
+)
+
+// AsValueType returns the value type for the given byte,
+// or 0 if the byte is not a valid value type
+//
+func AsValueType(b byte) ValueType {
+	switch ValueType(b) {
+	case ValueTypeI32:
+		return ValueTypeI32
+
+	case ValueTypeI64:
+		return ValueTypeI64
+
+	case ValueTypeFuncRef:
+		return ValueTypeFuncRef
+
+	case ValueTypeExternRef:
+		return ValueTypeExternRef
+	}
+
+	return 0
+}
+
+func (ValueType) isBlockType() {}
+
+func (t ValueType) write(w *WASMWriter) error {
+	return w.buf.WriteByte(byte(t))
+}

--- a/runtime/compiler/wasm/writer_test.go
+++ b/runtime/compiler/wasm/writer_test.go
@@ -495,3 +495,273 @@ func TestWASMWriterReader(t *testing.T) {
 		b.offset,
 	)
 }
+
+func TestWASMWriter_writeInstruction(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("block, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionBlock{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: nil,
+			},
+		}
+		err := instruction.write(&w)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			[]byte{
+				// block
+				0x02,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// end
+				0x0b,
+			},
+			b.data,
+		)
+	})
+
+	t.Run("block, type index result", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionBlock{
+			Block: Block{
+				BlockType:     TypeIndexBlockType{TypeIndex: 2},
+				Instructions1: []Instruction{
+					InstructionUnreachable{},
+				},
+				Instructions2: nil,
+			},
+		}
+		err := instruction.write(&w)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			[]byte{
+				// block
+				0x02,
+				// type index: 2
+				0x2,
+				// unreachable
+				0x0,
+				// end
+				0x0b,
+			},
+			b.data,
+		)
+	})
+
+	t.Run("block, i32 result, second instructions", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionBlock{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: []Instruction{
+					InstructionI32Const{Value: 2},
+				},
+			},
+		}
+		err := instruction.write(&w)
+		require.Equal(t, InvalidBlockSecondInstructionsError{
+			Offset: 4,
+		}, err)
+	})
+
+	t.Run("loop, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionLoop{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: nil,
+			},
+		}
+		err := instruction.write(&w)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			[]byte{
+				// loop
+				0x03,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// end
+				0x0b,
+			},
+			b.data,
+		)
+	})
+
+	t.Run("loop, i32 result, second instructions", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionLoop{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: []Instruction{
+					InstructionI32Const{Value: 2},
+				},
+			},
+		}
+		err := instruction.write(&w)
+		require.Equal(t, InvalidBlockSecondInstructionsError{
+			Offset: 4,
+		}, err)
+	})
+
+	t.Run("if, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionIf{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: nil,
+			},
+		}
+		err := instruction.write(&w)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			[]byte{
+				// if
+				0x04,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// end
+				0x0b,
+			},
+			b.data,
+		)
+	})
+
+	t.Run("if-else, i32 result", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionIf{
+			Block: Block{
+				BlockType:     ValueTypeI32,
+				Instructions1: []Instruction{
+					InstructionI32Const{Value: 1},
+				},
+				Instructions2: []Instruction{
+					InstructionI32Const{Value: 2},
+				},
+			},
+		}
+		err := instruction.write(&w)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			[]byte{
+				// ii
+				0x04,
+				// i32
+				0x7f,
+				// i32.const
+				0x41,
+				0x01,
+				// else
+				0x05,
+				// i32.const
+				0x41,
+				0x02,
+				// end
+				0x0b,
+			},
+			b.data,
+		)
+	})
+
+
+	t.Run("br_table", func(t *testing.T) {
+
+		t.Parallel()
+
+		var b buf
+		w := WASMWriter{&b}
+
+		instruction := InstructionBrTable{
+			LabelIndices: []uint32{3, 2, 1, 0},
+			DefaultLabelIndex: 4,
+		}
+		err := instruction.write(&w)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			[]byte{
+				// br_table
+				0x0e,
+				// number of branch depths
+				0x04,
+				// 1. branch depth
+				0x03,
+				// 2. branch depth
+				0x02,
+				// 3. branch depth
+				0x01,
+				// 4. branch depth
+				0x00,
+				// default branch depth
+				0x04,
+			},
+			b.data,
+		)
+	})
+}


### PR DESCRIPTION
Add more numeric and control instructions, including the block instructions (e.g. `block`, `loop`, `if`) and `br_table`. Also add some of the types and instructions from the [reference types proposal](https://webassembly.github.io/reference-types/core/syntax/instructions.html#syntax-instr-ref)