### PR TITLE
Use inline code for function signatures

### DIFF
--- a/docs/language/capability-based-access-control.md
+++ b/docs/language/capability-based-access-control.md
@@ -31,10 +31,7 @@ This allows exposing and hiding certain functionality of a stored object.
 
 Capabilities are created using the `link` function of an authorized account (`AuthAccount`):
 
--
-  ```cadence
-  fun link<T: &Any>(_ newCapabilityPath: Path, target: Path): Capability<T>?
-  ```
+- `cadence•fun link<T: &Any>(_ newCapabilityPath: Path, target: Path): Capability<T>?`
 
   `newCapabilityPath` is the public or private path identifying the new capability.
 
@@ -63,20 +60,14 @@ Capabilities are created using the `link` function of an authorized account (`Au
 
 Capabilities can be removed using the `unlink` function of an authorized account (`AuthAccount`):
 
--
-  ```cadence
-  fun unlink(_ path: Path)
-  ```
+- `cadence•fun unlink(_ path: Path)`
 
   `path` is the public or private path identifying the capability that should be removed.
 
 To get the target path for a capability, the `getLinkTarget` function
 of an authorized account (`AuthAccount`) or public account (`PublicAccount`) can be used:
 
--
-  ```cadence
-  fun getLinkTarget(_ path: Path): Path?
-  ```
+- `cadence•fun getLinkTarget(_ path: Path): Path?`
 
   `path` is the public or private path identifying the capability.
   The function returns the link target path,
@@ -86,10 +77,7 @@ of an authorized account (`AuthAccount`) or public account (`PublicAccount`) can
 Existing capabilities can be obtained by using the `getCapability` function
 of authorized accounts (`AuthAccount`) and public accounts (`PublicAccount`):
 
--
-  ```cadence
-  fun getCapability<T>(_ at: Path): Capability<T>?
-  ```
+- `cadence•fun getCapability<T>(_ at: Path): Capability<T>?`
 
   For public accounts, the function returns a capability
   if the given path is public.
@@ -107,10 +95,7 @@ The `getCapability` function does **not** check if the target exists.
 The link is latent.
 The `check` function of the capability can be used to check if the target currently exists and could be borrowed,
 
--
-  ```cadence
-  fun check<T: &Any>(): Bool
-  ```
+- `cadence•fun check<T: &Any>(): Bool`
 
   `T` is the type parameter for the reference type.
   A type argument for the parameter must be provided explicitly.
@@ -121,10 +106,7 @@ The `check` function of the capability can be used to check if the target curren
 Finally, the capability can be borrowed to get a reference to the stored object.
 This can be done using the `borrow` function of the capability:
 
--
-  ```cadence
-  fun borrow<T: &Any>(): T?
-  ```
+- `cadence•fun borrow<T: &Any>(): T?`
 
   The function returns a reference to the object targeted by the capability,
   provided it can be borrowed using the given type.

--- a/docs/language/contracts.md
+++ b/docs/language/contracts.md
@@ -230,7 +230,7 @@ This gives the contract the ability to e.g. read and write to the account's stor
 In order for a contract to be used in Cadence, it needs to be deployed to an account.
 A contract can be deployed to an account using the `setCode` function of the `AuthAccount` type:
 
-- `fun AuthAccount.setCode(_ code: [UInt8], ... contractInitializerArguments)`
+- `cadence•fun AuthAccount.setCode(_ code: [UInt8], ... contractInitializerArguments)`
 
   The `code` parameter is the byte representation of the source code.
   All additional arguments that are given are passed further to the initializer


### PR DESCRIPTION
Depends on https://github.com/onflow/flow/pull/48

Gatsby doesn't seem to render block code fences in bullet points like in the old documentation generator. Switch to inline code and use the language prefix.

