### PR TITLE
Add support for name section in WASM binary

### DIFF
--- a/runtime/compiler/wasm/export.go
+++ b/runtime/compiler/wasm/export.go
@@ -22,7 +22,7 @@ package wasm
 //
 type Export struct {
 	Name string
-	// TODO: add support for tables, memories, and globals
+	// TODO: add support for tables, memories, and globals. adjust name section!
 	FunctionIndex uint32
 }
 

--- a/runtime/compiler/wasm/import.go
+++ b/runtime/compiler/wasm/import.go
@@ -18,13 +18,19 @@
 
 package wasm
 
+import "fmt"
+
 // Import represents an import
 //
 type Import struct {
 	Module string
 	Name   string
-	// TODO: add support for tables, memories, and globals
+	// TODO: add support for tables, memories, and globals. adjust name section!
 	TypeIndex uint32
+}
+
+func (imp Import) FullName() string {
+	return fmt.Sprintf("%s.%s", imp.Module, imp.Name)
 }
 
 // importIndicator is the byte used to indicate the kind of import in the WASM binary

--- a/runtime/compiler/wasm/instructions.go
+++ b/runtime/compiler/wasm/instructions.go
@@ -188,7 +188,7 @@ func (i InstructionBrIf) write(w *WASMWriter) error {
 // InstructionBrTable is the 'br_table' instruction
 //
 type InstructionBrTable struct {
-	LabelIndices      []uint32
+	LabelIndices []uint32
 	DefaultLabelIndex uint32
 }
 
@@ -210,9 +210,9 @@ func (i InstructionBrTable) write(w *WASMWriter) error {
 	for i := 0; i < labelIndicesCount; i++ {
 		labelIndicesElement := labelIndices[i]
 		err = w.buf.writeUint32LEB128(labelIndicesElement)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
 	}
 
 	defaultLabelIndex := i.DefaultLabelIndex
@@ -265,7 +265,7 @@ func (i InstructionCall) write(w *WASMWriter) error {
 // InstructionCallIndirect is the 'call_indirect' instruction
 //
 type InstructionCallIndirect struct {
-	TypeIndex  uint32
+	TypeIndex uint32
 	TableIndex uint32
 }
 
@@ -1690,7 +1690,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		labelIndicesCount, err := r.buf.readUint32LEB128()
 		if err != nil {
 			return nil, InvalidInstructionVectorArgumentCountError{
-				Offset:    int(labelIndicesCountOffset),
+				Offset: int(labelIndicesCountOffset),
 				ReadError: err,
 			}
 		}
@@ -1699,9 +1699,9 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 
 		for i := uint32(0); i < labelIndicesCount; i++ {
 			labelIndicesElement, err := r.readUint32LEB128InstructionArgument()
-			if err != nil {
-				return nil, err
-			}
+		if err != nil {
+			return nil, err
+		}
 			labelIndices[i] = labelIndicesElement
 		}
 
@@ -1711,7 +1711,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		}
 
 		return InstructionBrTable{
-			LabelIndices:      labelIndices,
+			LabelIndices: labelIndices,
 			DefaultLabelIndex: defaultLabelIndex,
 		}, nil
 
@@ -1737,7 +1737,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		}
 
 		return InstructionCallIndirect{
-			TypeIndex:  typeIndex,
+			TypeIndex: typeIndex,
 			TableIndex: tableIndex,
 		}, nil
 

--- a/runtime/compiler/wasm/instructions.go
+++ b/runtime/compiler/wasm/instructions.go
@@ -188,7 +188,7 @@ func (i InstructionBrIf) write(w *WASMWriter) error {
 // InstructionBrTable is the 'br_table' instruction
 //
 type InstructionBrTable struct {
-	LabelIndices []uint32
+	LabelIndices      []uint32
 	DefaultLabelIndex uint32
 }
 
@@ -210,9 +210,9 @@ func (i InstructionBrTable) write(w *WASMWriter) error {
 	for i := 0; i < labelIndicesCount; i++ {
 		labelIndicesElement := labelIndices[i]
 		err = w.buf.writeUint32LEB128(labelIndicesElement)
-	if err != nil {
-		return err
-	}
+		if err != nil {
+			return err
+		}
 	}
 
 	defaultLabelIndex := i.DefaultLabelIndex
@@ -265,7 +265,7 @@ func (i InstructionCall) write(w *WASMWriter) error {
 // InstructionCallIndirect is the 'call_indirect' instruction
 //
 type InstructionCallIndirect struct {
-	TypeIndex uint32
+	TypeIndex  uint32
 	TableIndex uint32
 }
 
@@ -1690,7 +1690,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		labelIndicesCount, err := r.buf.readUint32LEB128()
 		if err != nil {
 			return nil, InvalidInstructionVectorArgumentCountError{
-				Offset: int(labelIndicesCountOffset),
+				Offset:    int(labelIndicesCountOffset),
 				ReadError: err,
 			}
 		}
@@ -1699,9 +1699,9 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 
 		for i := uint32(0); i < labelIndicesCount; i++ {
 			labelIndicesElement, err := r.readUint32LEB128InstructionArgument()
-		if err != nil {
-			return nil, err
-		}
+			if err != nil {
+				return nil, err
+			}
 			labelIndices[i] = labelIndicesElement
 		}
 
@@ -1711,7 +1711,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		}
 
 		return InstructionBrTable{
-			LabelIndices: labelIndices,
+			LabelIndices:      labelIndices,
 			DefaultLabelIndex: defaultLabelIndex,
 		}, nil
 
@@ -1737,7 +1737,7 @@ func (r *WASMReader) readInstruction() (Instruction, error) {
 		}
 
 		return InstructionCallIndirect{
-			TypeIndex: typeIndex,
+			TypeIndex:  typeIndex,
 			TableIndex: tableIndex,
 		}, nil
 

--- a/runtime/compiler/wasm/reader_test.go
+++ b/runtime/compiler/wasm/reader_test.go
@@ -34,7 +34,12 @@ func TestWASMReader_readMagicAndVersion(t *testing.T) {
 	read := func(data []byte) error {
 		b := buf{data: data}
 		r := WASMReader{buf: &b}
-		return r.readMagicAndVersion()
+		err := r.readMagicAndVersion()
+		if err != nil {
+			return err
+		}
+		require.Equal(t, offset(len(b.data)), b.offset)
+		return nil
 	}
 
 	t.Run("invalid magic, too short", func(t *testing.T) {
@@ -113,7 +118,12 @@ func TestWASMReader_readValType(t *testing.T) {
 	read := func(data []byte) (ValueType, error) {
 		b := buf{data: data}
 		r := WASMReader{buf: &b}
-		return r.readValType()
+		valueType, err := r.readValType()
+		if err != nil {
+			return 0, err
+		}
+		require.Equal(t, offset(len(b.data)), b.offset)
+		return valueType, nil
 	}
 
 	t.Run("too short", func(t *testing.T) {
@@ -180,6 +190,7 @@ func TestWASMReader_readTypeSection(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
+		require.Equal(t, offset(len(b.data)), b.offset)
 		return r.Module.Types, nil
 	}
 
@@ -463,6 +474,7 @@ func TestWASMReader_readImportSection(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
+		require.Equal(t, offset(len(b.data)), b.offset)
 		return r.Module.Imports, nil
 	}
 
@@ -703,6 +715,7 @@ func TestWASMReader_readFunctionSection(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
+		require.Equal(t, offset(len(b.data)), b.offset)
 		return r.Module.functionTypeIndices, nil
 	}
 
@@ -796,6 +809,7 @@ func TestWASMReader_readExportSection(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
+		require.Equal(t, offset(len(b.data)), b.offset)
 		return r.Module.Exports, nil
 	}
 
@@ -991,6 +1005,7 @@ func TestWASMReader_readCodeSection(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
+		require.Equal(t, offset(len(b.data)), b.offset)
 		return r.Module.functionBodies, nil
 	}
 
@@ -1267,7 +1282,12 @@ func TestWASMReader_readName(t *testing.T) {
 	read := func(data []byte) (string, error) {
 		b := buf{data: data}
 		r := WASMReader{buf: &b}
-		return r.readName()
+		name, err := r.readName()
+		if err != nil {
+			return "", err
+		}
+		require.Equal(t, offset(len(b.data)), b.offset)
+		return name, nil
 	}
 
 	t.Run("valid", func(t *testing.T) {
@@ -1374,7 +1394,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 
 		expected := InstructionBlock{
 			Block: Block{
-				BlockType:     ValueTypeI32,
+				BlockType: ValueTypeI32,
 				Instructions1: []Instruction{
 					InstructionI32Const{Value: 1},
 				},
@@ -1385,6 +1405,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, expected, actual)
+		require.Equal(t, offset(len(b.data)), b.offset)
 	})
 
 	t.Run("block, type index result", func(t *testing.T) {
@@ -1408,7 +1429,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 
 		expected := InstructionBlock{
 			Block: Block{
-				BlockType:     TypeIndexBlockType{TypeIndex: 2},
+				BlockType: TypeIndexBlockType{TypeIndex: 2},
 				Instructions1: []Instruction{
 					InstructionUnreachable{},
 				},
@@ -1419,6 +1440,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, expected, actual)
+		require.Equal(t, offset(len(b.data)), b.offset)
 	})
 
 	t.Run("block, type index result, type index too large", func(t *testing.T) {
@@ -1503,7 +1525,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 
 		expected := InstructionLoop{
 			Block: Block{
-				BlockType:     ValueTypeI32,
+				BlockType: ValueTypeI32,
 				Instructions1: []Instruction{
 					InstructionI32Const{Value: 1},
 				},
@@ -1514,6 +1536,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, expected, actual)
+		require.Equal(t, offset(len(b.data)), b.offset)
 	})
 
 	t.Run("loop, i32 result, second instructions", func(t *testing.T) {
@@ -1569,7 +1592,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 
 		expected := InstructionIf{
 			Block: Block{
-				BlockType:     ValueTypeI32,
+				BlockType: ValueTypeI32,
 				Instructions1: []Instruction{
 					InstructionI32Const{Value: 1},
 				},
@@ -1580,6 +1603,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, expected, actual)
+		require.Equal(t, offset(len(b.data)), b.offset)
 	})
 
 	t.Run("if-else, i32 result", func(t *testing.T) {
@@ -1609,7 +1633,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 
 		expected := InstructionIf{
 			Block: Block{
-				BlockType:     ValueTypeI32,
+				BlockType: ValueTypeI32,
 				Instructions1: []Instruction{
 					InstructionI32Const{Value: 1},
 				},
@@ -1622,6 +1646,7 @@ func TestWASMReader_readInstruction(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, expected, actual)
+		require.Equal(t, offset(len(b.data)), b.offset)
 	})
 
 	t.Run("br_table", func(t *testing.T) {
@@ -1650,12 +1675,63 @@ func TestWASMReader_readInstruction(t *testing.T) {
 		r := WASMReader{buf: &b}
 
 		expected := InstructionBrTable{
-			LabelIndices: []uint32{3, 2, 1, 0},
+			LabelIndices:      []uint32{3, 2, 1, 0},
 			DefaultLabelIndex: 4,
 		}
 		actual, err := r.readInstruction()
 		require.NoError(t, err)
 
 		require.Equal(t, expected, actual)
+		require.Equal(t, offset(len(b.data)), b.offset)
 	})
+}
+
+func TestWASMReader_readNameSection(t *testing.T) {
+
+	t.Parallel()
+
+	b := buf{
+		data: []byte{
+			// section size: 37 (LEB128)
+			0xa5, 0x80, 0x80, 0x80, 0x0,
+			// name length
+			0x4,
+			// name = "name"
+			0x6e, 0x61, 0x6d, 0x65,
+			// sub-section ID: module name = 0
+			0x0,
+			// sub-section size: 5 (LEB128)
+			0x85, 0x80, 0x80, 0x80, 0x0,
+			// name length
+			0x4,
+			// name = "test"
+			0x74, 0x65, 0x73, 0x74,
+			// sub-section ID: function names = 1
+			0x1,
+			// sub-section size: 15 (LEB128)
+			0x8f, 0x80, 0x80, 0x80, 0x0,
+			// name count
+			0x2,
+			// function index = 0
+			0x0,
+			// name length
+			0x7,
+			// name = "foo.bar"
+			0x66, 0x6f, 0x6f, 0x2e, 0x62, 0x61, 0x72,
+			// function index = 1
+			0x1,
+			// name length
+			0x3,
+			// name = "add"
+			0x61, 0x64, 0x64,
+		},
+		offset: 0,
+	}
+
+	r := WASMReader{buf: &b}
+
+	err := r.readCustomSection()
+	require.NoError(t, err)
+
+	require.Equal(t, offset(len(b.data)), b.offset)
 }

--- a/runtime/compiler/wasm/section.go
+++ b/runtime/compiler/wasm/section.go
@@ -40,6 +40,7 @@ package wasm
 type sectionID byte
 
 const (
+	sectionIDCustom   sectionID = 0
 	sectionIDType     sectionID = 1
 	sectionIDImport   sectionID = 2
 	sectionIDFunction sectionID = 3


### PR DESCRIPTION
Add support for writing part of the name section, i.e. module name and function names.
Skip the section for now when reading.

