### PR TITLE
Fix GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push]
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,12 @@
 name: "Code scanning"
 
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
 on:
   push:
-    branches: [master, ]
+    branches: [ master ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
-  schedule:
-    - cron: '0 17 * * 2'
+    branches: [ master ]
 
 jobs:
   CodeQL-Build:


### PR DESCRIPTION
I contacted GitHub support asking why the CI workflows for PR #385 are not run.

Turns out that the UI doesn't show that the jobs' status is "expected", but the cause is that they are actually never run, because the configuration does not specify that the workflow should be triggered for pull requests – the push event is only triggered for this repository, not for forks.
