### PR TITLE
Switch improvements

### DIFF
--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -11,7 +11,8 @@ If-statements allow a certain piece of code to be executed only when a given con
 The if-statement starts with the `if` keyword, followed by the condition,
 and the code that should be executed if the condition is true
 inside opening and closing braces.
-The condition must be boolean and the braces are required.
+The condition expression must be boolean.
+The braces are required and not optional.
 Parentheses around the condition are optional.
 
 ```cadence
@@ -112,6 +113,78 @@ if let number = noNumber {
 }
 ```
 
+## Switch
+
+Switch-statements compare a value against several possible values of the same type, in order.
+When an equal value is found, the associated block of code is executed.
+
+The switch-statement starts with the `switch` keyword, followed by the tested value,
+followed by the cases inside opening and closing braces.
+The test expression must be equatable.
+The braces are required and not optional.
+
+Each case is a separate branch of code execution
+and starts with the `case` keyword,
+followed by a possible value, a colon (`:`),
+and the block of code that should be executed
+if the case's value is equal to the tested value.
+
+The block of code associated with a switch case
+[does not implicitly fall through](#no-implicit-fallthrough),
+and must contain at least one statement.
+Empty blocks are invalid.
+
+An optional default case may be given by using the `default` keyword.
+The block of code of the default case is executed
+when none of the previous case tests succeeded.
+It must always appear last.
+
+```cadence
+fun word(_ n: Int): String {
+    // Test the value of the parameter `n`
+    switch n {
+    case 1:
+        // If the value of variable `n` is equal to `1`,
+        // then return the string "one"
+        return "one"
+    case 2:
+        // If the value of variable `n` is equal to `1`,
+        // then return the string "two"
+        return "two"
+    default:
+        // If the value of variable `n` is neither equal to `1` nor to `2`,
+        // then return the string "other"
+        return "other"
+    }
+}
+```
+
+### `break`
+
+The block of code associated with a switch case may contain a `break` statement.
+It ends the execution of the switch statement immediately
+and transfers control to the code after the switch statement
+
+### No Implicit Fallthrough
+
+Unlike switch statements in some other languages,
+switch statements in Cadence do not "fall through":
+execution of the switch statement finishes as soon as the block of code
+associated with the first matching case is completed.
+No explicit `break` statement is required.
+
+This makes the switch statement safer and easier to use,
+avoiding the accidental execution of more than one switch case.
+
+Some other languages implicitly fall through
+to the block of code associated with the next case,
+so it is common to write cases with an empty block
+to handle multiple values in the same way.
+
+To prevent developers from writing switch statements
+that assume this behaviour, blocks must have at least one statement.
+Empty blocks are invalid.
+
 ## Looping
 
 ### while-statement
@@ -126,7 +199,7 @@ The condition must be boolean and the braces are required.
 
 The while-statement will first evaluate the condition.
 If it is true, the piece of code is executed and the evaluation of the condition is repeated.
-If the condition is false, the piece of code is not executed 
+If the condition is false, the piece of code is not executed
 and the execution of the whole while-statement is finished.
 Thus, the piece of code is executed zero or more times.
 
@@ -170,7 +243,7 @@ for element in array {
 
 ```
 
-### continue and break
+### `continue` and `break`
 
 In for-loops and while-loops, the `continue` statement can be used to stop
 the current iteration of a loop and start the next iteration.

--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -148,7 +148,7 @@ fun word(_ n: Int): String {
         // then return the string "one"
         return "one"
     case 2:
-        // If the value of variable `n` is equal to `1`,
+        // If the value of variable `n` is equal to `2`,
         // then return the string "two"
         return "two"
     default:
@@ -157,6 +157,39 @@ fun word(_ n: Int): String {
         return "other"
     }
 }
+
+word(1)  // returns "one"
+word(2)  // returns "two"
+word(3)  // returns "other"
+word(4)  // returns "other"
+```
+
+### Duplicate cases
+
+Cases are tested in order, so if a case is duplicated,
+the block of code associated with the first case that succeeds is executed.
+
+```cadence
+fun test(_ n: Int): String {
+    // Test the value of the parameter `n`
+    switch n {
+    case 1:
+        // If the value of variable `n` is equal to `1`,
+        // then return the string "one"
+        return "one"
+    case 1:
+        // If the value of variable `n` is equal to `1`,
+        // then return the string "also one".
+        // This is a duplicate case for the one above.
+        return "also one"
+    default:
+        // If the value of variable `n` is neither equal to `1` nor to `2`,
+        // then return the string "other"
+        return "other"
+    }
+}
+
+word(1) // returns "one", not "also one"
 ```
 
 ### `break`

--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -218,6 +218,36 @@ To prevent developers from writing switch statements
 that assume this behaviour, blocks must have at least one statement.
 Empty blocks are invalid.
 
+```cadence
+fun words(_ n: Int): [String] {
+    // Declare a variable named `result`, an array of strings,
+    // which stores the result
+    let result: [String] = []
+
+    // Test the value of the parameter `n`
+    switch n {
+    case 1:
+        // If the value of variable `n` is equal to `1`,
+        // then append the string "one" to the result array
+        result.append("one")
+    case 2:
+        // If the value of variable `n` is equal to `2`,
+        // then append the string "two" to the result array
+        result.append("two")
+    default:
+        // If the value of variable `n` is neither equal to `1` nor to `2`,
+        // then append the string "other" to the result array
+        result.append("other")
+    }
+    return result
+}
+
+words(1)  // returns `["one"]`
+words(2)  // returns `["two"]`
+words(3)  // returns `["other"]`
+words(4)  // returns `["other"]`
+```
+
 ## Looping
 
 ### while-statement

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -116,7 +116,7 @@ func (checker *Checker) reportResourceUsesInLoop(startPos, endPos ast.Position) 
 
 func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.Repr {
 
-	// check statement is inside loop
+	// Ensure that the `break` statement is inside a loop or switch statement
 
 	if !(checker.inLoop() || checker.inSwitch()) {
 		checker.report(
@@ -132,7 +132,7 @@ func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.R
 
 func (checker *Checker) VisitContinueStatement(statement *ast.ContinueStatement) ast.Repr {
 
-	// check statement is inside loop
+	// Ensure that the `continue` statement is inside a loop statement
 
 	if !checker.inLoop() {
 		checker.report(

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -118,7 +118,7 @@ func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.R
 
 	// check statement is inside loop
 
-	if !checker.inLoop() {
+	if !(checker.inLoop() || checker.inSwitch()) {
 		checker.report(
 			&ControlStatementError{
 				ControlStatement: common.ControlStatementBreak,

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -838,6 +838,10 @@ func (checker *Checker) inLoop() bool {
 	return checker.functionActivations.Current().InLoop()
 }
 
+func (checker *Checker) inSwitch() bool {
+	return checker.functionActivations.Current().InSwitch()
+}
+
 func (checker *Checker) findAndCheckValueVariable(identifier ast.Identifier, recordOccurrence bool) *Variable {
 	variable := checker.valueActivations.Find(identifier.Identifier)
 	if variable == nil {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -480,7 +480,7 @@ type ControlStatementError struct {
 
 func (e *ControlStatementError) Error() string {
 	return fmt.Sprintf(
-		"control statement outside of loop: `%s`",
+		"invalid control statement: `%s`",
 		e.ControlStatement.Symbol(),
 	)
 }
@@ -2887,3 +2887,23 @@ func (e *SwitchDefaultPositionError) Error() string {
 }
 
 func (*SwitchDefaultPositionError) isSemanticError() {}
+
+// MissingSwitchCaseStatementsError
+
+type MissingSwitchCaseStatementsError struct {
+	Pos ast.Position
+}
+
+func (e *MissingSwitchCaseStatementsError) Error() string {
+	return "switch cases must have at least one statement"
+}
+
+func (*MissingSwitchCaseStatementsError) isSemanticError() {}
+
+func (e *MissingSwitchCaseStatementsError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *MissingSwitchCaseStatementsError) EndPosition() ast.Position {
+	return e.Pos
+}

--- a/runtime/sema/function_activations.go
+++ b/runtime/sema/function_activations.go
@@ -21,6 +21,7 @@ package sema
 type FunctionActivation struct {
 	ReturnType           Type
 	Loops                int
+	Switches             int
 	ValueActivationDepth int
 	ReturnInfo           *ReturnInfo
 	ReportedDeadCode     bool
@@ -29,6 +30,10 @@ type FunctionActivation struct {
 
 func (a FunctionActivation) InLoop() bool {
 	return a.Loops > 0
+}
+
+func (a FunctionActivation) InSwitch() bool {
+	return a.Switches > 0
 }
 
 type FunctionActivations struct {
@@ -75,16 +80,18 @@ func (a *FunctionActivations) Current() *FunctionActivation {
 	return a.activations[lastIndex]
 }
 
-func (a *FunctionActivations) EnterLoop() {
-	a.Current().Loops++
-}
-
-func (a *FunctionActivations) LeaveLoop() {
-	a.Current().Loops--
-}
-
 func (a *FunctionActivations) WithLoop(f func()) {
-	a.EnterLoop()
-	defer a.LeaveLoop()
+	a.Current().Loops++
+	defer func() {
+		a.Current().Loops--
+	}()
+	f()
+}
+
+func (a *FunctionActivations) WithSwitch(f func()) {
+	a.Current().Switches++
+	defer func() {
+		a.Current().Switches--
+	}()
 	f()
 }

--- a/runtime/tests/interpreter/switch_test.go
+++ b/runtime/tests/interpreter/switch_test.go
@@ -66,7 +66,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 			actual, err := inter.Invoke("test", argument)
 			require.NoError(t, err)
 
-			assert.Equal(t, actual, expected)
+			assert.Equal(t, expected, actual)
 		}
 	})
 
@@ -105,7 +105,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 			actual, err := inter.Invoke("test", argument)
 			require.NoError(t, err)
 
-			assert.Equal(t, actual, expected)
+			assert.Equal(t, expected, actual)
 		}
 	})
 
@@ -145,7 +145,46 @@ func TestInterpretSwitchStatement(t *testing.T) {
 			actual, err := inter.Invoke("test", argument)
 			require.NoError(t, err)
 
-			assert.Equal(t, actual, expected)
+			assert.Equal(t, expected, actual)
+		}
+	})
+
+	t.Run("no-implicit fallthrough", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t, `
+          fun test(_ x: Int): [String] {
+              let results: [String] = []
+              switch x {
+              case 1:
+                  results.append("1")
+              case 2:
+                  results.append("2")
+              default:
+                  results.append("3")
+              }
+              return results
+          }
+        `)
+
+		for argument, expected := range map[interpreter.Value]interpreter.Value{
+			interpreter.NewIntValueFromInt64(1): interpreter.NewArrayValueUnownedNonCopying(
+				interpreter.NewStringValue("1"),
+			),
+			interpreter.NewIntValueFromInt64(2): interpreter.NewArrayValueUnownedNonCopying(
+				interpreter.NewStringValue("2"),
+			),
+			interpreter.NewIntValueFromInt64(3): interpreter.NewArrayValueUnownedNonCopying(
+				interpreter.NewStringValue("3"),
+			),
+			interpreter.NewIntValueFromInt64(4): interpreter.NewArrayValueUnownedNonCopying(
+				interpreter.NewStringValue("3"),
+			),
+		} {
+
+			actual, err := inter.Invoke("test", argument)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected, actual)
 		}
 	})
 }


### PR DESCRIPTION
Closes #391 

- Document switch statements
- Require switch case bodies to contain at least one statement
- Allow and handle `break` statements in switch statements
