### PR TITLE
Panic with array index out of bounds error

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -61,7 +61,7 @@ type NotDeclaredError struct {
 	Name         string
 }
 
-func (e *NotDeclaredError) Error() string {
+func (e NotDeclaredError) Error() string {
 	return fmt.Sprintf(
 		"cannot find %s in this scope: `%s`",
 		e.ExpectedKind.Name(),
@@ -69,7 +69,7 @@ func (e *NotDeclaredError) Error() string {
 	)
 }
 
-func (e *NotDeclaredError) SecondaryError() string {
+func (e NotDeclaredError) SecondaryError() string {
 	return "not found in this scope"
 }
 
@@ -79,7 +79,7 @@ type NotInvokableError struct {
 	Value Value
 }
 
-func (e *NotInvokableError) Error() string {
+func (e NotInvokableError) Error() string {
 	return fmt.Sprintf("cannot call value: %#+v", e.Value)
 }
 
@@ -90,22 +90,12 @@ type ArgumentCountError struct {
 	ArgumentCount  int
 }
 
-func (e *ArgumentCountError) Error() string {
+func (e ArgumentCountError) Error() string {
 	return fmt.Sprintf(
 		"incorrect number of arguments: expected %d, got %d",
 		e.ParameterCount,
 		e.ArgumentCount,
 	)
-}
-
-// InvalidParameterTypeInInvocationError
-
-type InvalidParameterTypeInInvocationError struct {
-	InvalidParameterType sema.Type
-}
-
-func (e *InvalidParameterTypeInInvocationError) Error() string {
-	return fmt.Sprintf("cannot invoke functions with parameter type: `%s`", e.InvalidParameterType)
 }
 
 // TransactionNotDeclaredError
@@ -114,7 +104,7 @@ type TransactionNotDeclaredError struct {
 	Index int
 }
 
-func (e *TransactionNotDeclaredError) Error() string {
+func (e TransactionNotDeclaredError) Error() string {
 	return fmt.Sprintf(
 		"cannot find transaction with index %d in this scope",
 		e.Index,
@@ -129,7 +119,7 @@ type ConditionError struct {
 	LocationRange
 }
 
-func (e *ConditionError) Error() string {
+func (e ConditionError) Error() string {
 	if e.Message == "" {
 		return fmt.Sprintf("%s failed", e.ConditionKind.Name())
 	}
@@ -142,7 +132,7 @@ type RedeclarationError struct {
 	Name string
 }
 
-func (e *RedeclarationError) Error() string {
+func (e RedeclarationError) Error() string {
 	return fmt.Sprintf("cannot redeclare: `%s` is already declared", e.Name)
 }
 
@@ -152,7 +142,7 @@ type DereferenceError struct {
 	LocationRange
 }
 
-func (e *DereferenceError) Error() string {
+func (e DereferenceError) Error() string {
 	return "dereference failed"
 }
 
@@ -187,7 +177,7 @@ type DestroyedCompositeError struct {
 	LocationRange
 }
 
-func (e *DestroyedCompositeError) Error() string {
+func (e DestroyedCompositeError) Error() string {
 	return fmt.Sprintf("%s is destroyed and cannot be accessed anymore", e.CompositeKind.Name())
 }
 
@@ -197,7 +187,7 @@ type ForceAssignmentToNonNilResourceError struct {
 	LocationRange
 }
 
-func (e *ForceAssignmentToNonNilResourceError) Error() string {
+func (e ForceAssignmentToNonNilResourceError) Error() string {
 	return "force assignment to non-nil resource-typed value"
 }
 
@@ -207,7 +197,7 @@ type ForceNilError struct {
 	LocationRange
 }
 
-func (e *ForceNilError) Error() string {
+func (e ForceNilError) Error() string {
 	return "unexpectedly found nil while forcing an Optional value"
 }
 
@@ -218,7 +208,7 @@ type TypeMismatchError struct {
 	LocationRange
 }
 
-func (e *TypeMismatchError) Error() string {
+func (e TypeMismatchError) Error() string {
 	return fmt.Sprintf(
 		"unexpectedly found non-`%s` while force-casting value",
 		e.ExpectedType.QualifiedString(),
@@ -233,11 +223,11 @@ type InvalidPathDomainError struct {
 	LocationRange
 }
 
-func (e *InvalidPathDomainError) Error() string {
+func (e InvalidPathDomainError) Error() string {
 	return "invalid path domain"
 }
 
-func (e *InvalidPathDomainError) SecondaryError() string {
+func (e InvalidPathDomainError) SecondaryError() string {
 
 	domainNames := make([]string, len(e.ExpectedDomains))
 
@@ -260,7 +250,7 @@ type OverwriteError struct {
 	LocationRange
 }
 
-func (e *OverwriteError) Error() string {
+func (e OverwriteError) Error() string {
 	return fmt.Sprintf(
 		"failed to save object: path %s in account %s already stores an object",
 		e.Path,
@@ -276,7 +266,7 @@ type CyclicLinkError struct {
 	LocationRange
 }
 
-func (e *CyclicLinkError) Error() string {
+func (e CyclicLinkError) Error() string {
 	var builder strings.Builder
 	for i, path := range e.Paths {
 		if i > 0 {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -292,3 +292,19 @@ func (e *CyclicLinkError) Error() string {
 		paths,
 	)
 }
+
+// ArrayIndexOutOfBoundsError
+
+type ArrayIndexOutOfBoundsError struct {
+	Index    int
+	MaxIndex int
+	LocationRange
+}
+
+func (e ArrayIndexOutOfBoundsError) Error() string {
+	return fmt.Sprintf(
+		"array index out of bounds: got %d, expected max %d",
+		e.Index,
+		e.MaxIndex,
+	)
+}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -719,7 +719,7 @@ func (interpreter *Interpreter) prepareInvokeVariable(
 	// function must be defined as a global variable
 	variable, ok := interpreter.Globals[functionName]
 	if !ok {
-		return nil, &NotDeclaredError{
+		return nil, NotDeclaredError{
 			ExpectedKind: common.DeclarationKindFunction,
 			Name:         functionName,
 		}
@@ -730,7 +730,7 @@ func (interpreter *Interpreter) prepareInvokeVariable(
 	// the global variable must be declared as a function
 	functionValue, ok := variableValue.(FunctionValue)
 	if !ok {
-		return nil, &NotInvokableError{
+		return nil, NotInvokableError{
 			Value: variableValue,
 		}
 	}
@@ -741,7 +741,7 @@ func (interpreter *Interpreter) prepareInvokeVariable(
 	invokableType, ok := ty.(sema.InvokableType)
 
 	if !ok {
-		return nil, &NotInvokableError{
+		return nil, NotInvokableError{
 			Value: variableValue,
 		}
 	}
@@ -756,7 +756,7 @@ func (interpreter *Interpreter) prepareInvokeTransaction(
 	arguments []Value,
 ) (trampoline Trampoline, err error) {
 	if index >= len(interpreter.Transactions) {
-		return nil, &TransactionNotDeclaredError{Index: index}
+		return nil, TransactionNotDeclaredError{Index: index}
 	}
 
 	functionValue := interpreter.Transactions[index]
@@ -787,7 +787,7 @@ func (interpreter *Interpreter) prepareInvoke(
 		if functionType.RequiredArgumentCount == nil ||
 			argumentCount < *functionType.RequiredArgumentCount {
 
-			return nil, &ArgumentCountError{
+			return nil, ArgumentCountError{
 				ParameterCount: parameterCount,
 				ArgumentCount:  argumentCount,
 			}
@@ -800,7 +800,7 @@ func (interpreter *Interpreter) prepareInvoke(
 		// TODO: value type is not known, reject for now
 		switch parameterType.(type) {
 		case *sema.AnyStructType, *sema.AnyResourceType:
-			return nil, &NotInvokableError{
+			return nil, NotInvokableError{
 				Value: functionValue,
 			}
 		}
@@ -936,7 +936,7 @@ func (interpreter *Interpreter) functionDeclarationValue(
 // NOTE: consider using NewInterpreter if the value should be predefined in all programs
 func (interpreter *Interpreter) ImportValue(name string, value Value) error {
 	if _, ok := interpreter.Globals[name]; ok {
-		return &RedeclarationError{
+		return RedeclarationError{
 			Name: name,
 		}
 	}
@@ -1059,7 +1059,7 @@ func (interpreter *Interpreter) visitConditions(conditions []*ast.Condition) Tra
 					Then(func(result interface{}) {
 						message := result.(*StringValue).Str
 
-						panic(&ConditionError{
+						panic(ConditionError{
 							ConditionKind: condition.Kind,
 							Message:       message,
 							LocationRange: interpreter.locationRange(condition.Test),
@@ -1422,7 +1422,7 @@ func (interpreter *Interpreter) visitAssignment(
 				if _, ok := target.(NilValue); !ok {
 					locationRange := interpreter.locationRange(position)
 
-					panic(&ForceAssignmentToNonNilResourceError{
+					panic(ForceAssignmentToNonNilResourceError{
 						LocationRange: locationRange,
 					})
 				}
@@ -3492,7 +3492,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 				case ast.OperationForceCast:
 					if !isSubType {
 						panic(
-							&TypeMismatchError{
+							TypeMismatchError{
 								ExpectedType:  expectedType,
 								LocationRange: interpreter.locationRange(expression.Expression),
 							},
@@ -3553,7 +3553,7 @@ func (interpreter *Interpreter) VisitForceExpression(expression *ast.ForceExpres
 
 			case NilValue:
 				panic(
-					&ForceNilError{
+					ForceNilError{
 						LocationRange: interpreter.locationRange(expression.Expression),
 					},
 				)
@@ -3930,7 +3930,7 @@ func mustPathDomain(
 	}
 
 	panic(
-		&InvalidPathDomainError{
+		InvalidPathDomainError{
 			ActualDomain:    path.Domain,
 			ExpectedDomains: expectedDomains,
 			LocationRange:   locationRange,
@@ -3971,7 +3971,7 @@ func (interpreter *Interpreter) authAccountSaveFunction(addressValue AddressValu
 
 		if interpreter.storedValueExists(address, key) {
 			panic(
-				&OverwriteError{
+				OverwriteError{
 					Address:       addressValue,
 					Path:          path,
 					LocationRange: invocation.LocationRange,
@@ -4356,7 +4356,7 @@ func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
 		// Detect cyclic links
 
 		if _, ok := seenKeys[key]; ok {
-			panic(&CyclicLinkError{
+			panic(CyclicLinkError{
 				Address:       addressValue,
 				Paths:         paths,
 				LocationRange: locationRange,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5294,7 +5294,7 @@ func (v *CompositeValue) Copy() Value {
 
 func (v *CompositeValue) checkStatus(locationRange LocationRange) {
 	if v.destroyed {
-		panic(&DestroyedCompositeError{
+		panic(DestroyedCompositeError{
 			CompositeKind: v.Kind,
 			LocationRange: locationRange,
 		})
@@ -6050,7 +6050,7 @@ func (v *StorageReferenceValue) String() string {
 func (v *StorageReferenceValue) DynamicType(interpreter *Interpreter) DynamicType {
 	referencedValue := v.referencedValue(interpreter)
 	if referencedValue == nil {
-		panic(&DereferenceError{})
+		panic(DereferenceError{})
 	}
 
 	innerType := (*referencedValue).DynamicType(interpreter)
@@ -6100,7 +6100,7 @@ func (v *StorageReferenceValue) referencedValue(interpreter *Interpreter) *Value
 func (v *StorageReferenceValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
 	referencedValue := v.referencedValue(interpreter)
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -6111,7 +6111,7 @@ func (v *StorageReferenceValue) GetMember(interpreter *Interpreter, locationRang
 func (v *StorageReferenceValue) SetMember(interpreter *Interpreter, locationRange LocationRange, name string, value Value) {
 	referencedValue := v.referencedValue(interpreter)
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -6122,7 +6122,7 @@ func (v *StorageReferenceValue) SetMember(interpreter *Interpreter, locationRang
 func (v *StorageReferenceValue) Get(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
 	referencedValue := v.referencedValue(interpreter)
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -6134,7 +6134,7 @@ func (v *StorageReferenceValue) Get(interpreter *Interpreter, locationRange Loca
 func (v *StorageReferenceValue) Set(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
 	referencedValue := v.referencedValue(interpreter)
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -6170,7 +6170,7 @@ func (v *EphemeralReferenceValue) String() string {
 func (v *EphemeralReferenceValue) DynamicType(interpreter *Interpreter) DynamicType {
 	referencedValue := v.referencedValue()
 	if referencedValue == nil {
-		panic(&DereferenceError{})
+		panic(DereferenceError{})
 	}
 
 	innerType := (*referencedValue).DynamicType(interpreter)
@@ -6219,7 +6219,7 @@ func (v *EphemeralReferenceValue) referencedValue() *Value {
 func (v *EphemeralReferenceValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
 	referencedValue := v.referencedValue()
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -6230,7 +6230,7 @@ func (v *EphemeralReferenceValue) GetMember(interpreter *Interpreter, locationRa
 func (v *EphemeralReferenceValue) SetMember(interpreter *Interpreter, locationRange LocationRange, name string, value Value) {
 	referencedValue := v.referencedValue()
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -6241,7 +6241,7 @@ func (v *EphemeralReferenceValue) SetMember(interpreter *Interpreter, locationRa
 func (v *EphemeralReferenceValue) Get(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
 	referencedValue := v.referencedValue()
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -6253,7 +6253,7 @@ func (v *EphemeralReferenceValue) Get(interpreter *Interpreter, locationRange Lo
 func (v *EphemeralReferenceValue) Set(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
 	referencedValue := v.referencedValue()
 	if referencedValue == nil {
-		panic(&DereferenceError{
+		panic(DereferenceError{
 			LocationRange: locationRange,
 		})
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -528,8 +528,19 @@ func (v *ArrayValue) Concat(other ConcatenatableValue) Value {
 	return NewArrayValueUnownedNonCopying(concatenated...)
 }
 
-func (v *ArrayValue) Get(_ *Interpreter, _ LocationRange, key Value) Value {
+func (v *ArrayValue) Get(_ *Interpreter, locationRange LocationRange, key Value) Value {
 	integerKey := key.(NumberValue).ToInt()
+	count := v.Count()
+
+	// Check bounds
+	if integerKey < 0 || integerKey >= count {
+		panic(ArrayIndexOutOfBoundsError{
+			Index:         integerKey,
+			MaxIndex:      count - 1,
+			LocationRange: locationRange,
+		})
+	}
+
 	return v.Values[integerKey]
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3165,7 +3165,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 				} else {
 					require.Error(t, err)
 					require.IsType(t, Error{}, err)
-					assert.IsType(t, &interpreter.ConditionError{}, err.(Error).Err)
+					assert.IsType(t, interpreter.ConditionError{}, err.(Error).Err)
 				}
 			})
 		}

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -173,7 +173,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.OverwriteError{}, err)
+				require.IsType(t, interpreter.OverwriteError{}, err)
 			})
 		})
 
@@ -205,7 +205,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 
 		}
@@ -255,7 +255,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.OverwriteError{}, err)
+				require.IsType(t, interpreter.OverwriteError{}, err)
 			})
 		})
 
@@ -287,7 +287,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 
 		}
@@ -404,7 +404,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 		}
 	})
@@ -515,7 +515,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 		}
 	})
@@ -635,7 +635,7 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+			require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 		})
 	}
 
@@ -771,7 +771,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 		}
 	})
@@ -902,7 +902,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 		}
 	})
@@ -1068,7 +1068,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 		}
 	})
@@ -1229,7 +1229,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 				require.Error(t, err)
 
-				require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+				require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 			})
 		}
 	})
@@ -1318,7 +1318,7 @@ func TestInterpretAuthAccount_unlink(t *testing.T) {
 
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+			require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 		})
 	})
 
@@ -1400,7 +1400,7 @@ func TestInterpretAuthAccount_unlink(t *testing.T) {
 
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+			require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 		})
 	})
 }
@@ -1501,7 +1501,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 					require.Error(t, err)
 
-					require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+					require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 				})
 			})
 
@@ -1593,7 +1593,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 					require.Error(t, err)
 
-					require.IsType(t, &interpreter.InvalidPathDomainError{}, err)
+					require.IsType(t, interpreter.InvalidPathDomainError{}, err)
 				})
 			})
 		})

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -156,7 +156,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.ForceNilError{}, err)
+			require.IsType(t, interpreter.ForceNilError{}, err)
 		})
 
 		t.Run("loop", func(t *testing.T) {
@@ -164,7 +164,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.CyclicLinkError{}, err)
+			require.IsType(t, interpreter.CyclicLinkError{}, err)
 
 			require.Equal(t,
 				err.Error(),
@@ -307,7 +307,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.ForceNilError{}, err)
+			require.IsType(t, interpreter.ForceNilError{}, err)
 		})
 
 		t.Run("loop", func(t *testing.T) {
@@ -315,7 +315,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.CyclicLinkError{}, err)
+			require.IsType(t, interpreter.CyclicLinkError{}, err)
 
 			require.Equal(t,
 				err.Error(),
@@ -471,7 +471,7 @@ func TestInterpretCapability_check(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.CyclicLinkError{}, err)
+			require.IsType(t, interpreter.CyclicLinkError{}, err)
 
 			require.Equal(t,
 				err.Error(),
@@ -622,7 +622,7 @@ func TestInterpretCapability_check(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t, &interpreter.CyclicLinkError{}, err)
+			require.IsType(t, interpreter.CyclicLinkError{}, err)
 
 			require.Equal(t,
 				err.Error(),

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -159,7 +159,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 									)
 								} else {
 									assert.IsType(t,
-										&interpreter.TypeMismatchError{},
+										interpreter.TypeMismatchError{},
 										err,
 									)
 								}
@@ -252,7 +252,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -340,7 +340,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -428,7 +428,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -521,7 +521,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -611,7 +611,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 						)
 					} else {
 						assert.IsType(t,
-							&interpreter.TypeMismatchError{},
+							interpreter.TypeMismatchError{},
 							err,
 						)
 					}
@@ -653,7 +653,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -765,7 +765,7 @@ func testResourceCastInvalid(t *testing.T, types, fromType, targetType string, o
 		require.Error(t, err)
 
 		require.IsType(t,
-			&interpreter.TypeMismatchError{},
+			interpreter.TypeMismatchError{},
 			err,
 		)
 
@@ -917,7 +917,7 @@ func testStructCastInvalid(t *testing.T, types, fromType, targetType string, ope
 		require.Error(t, err)
 
 		require.IsType(t,
-			&interpreter.TypeMismatchError{},
+			interpreter.TypeMismatchError{},
 			err,
 		)
 
@@ -1122,7 +1122,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -1214,7 +1214,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -1313,7 +1313,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}
@@ -2225,7 +2225,7 @@ func testReferenceCastInvalid(t *testing.T, types, fromType, targetType string, 
 		require.Error(t, err)
 
 		require.IsType(t,
-			&interpreter.TypeMismatchError{},
+			interpreter.TypeMismatchError{},
 			err,
 		)
 
@@ -3473,7 +3473,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 							)
 						} else {
 							assert.IsType(t,
-								&interpreter.TypeMismatchError{},
+								interpreter.TypeMismatchError{},
 								err,
 							)
 						}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -214,7 +214,7 @@ func TestInterpretInvalidUnknownDeclarationInvocation(t *testing.T) {
 	inter := parseCheckAndInterpret(t, ``)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, &interpreter.NotDeclaredError{}, err)
+	assert.IsType(t, interpreter.NotDeclaredError{}, err)
 }
 
 func TestInterpretInvalidNonFunctionDeclarationInvocation(t *testing.T) {
@@ -226,7 +226,7 @@ func TestInterpretInvalidNonFunctionDeclarationInvocation(t *testing.T) {
    `)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, &interpreter.NotInvokableError{}, err)
+	assert.IsType(t, interpreter.NotInvokableError{}, err)
 }
 
 func TestInterpretLexicalScope(t *testing.T) {
@@ -1911,7 +1911,7 @@ func TestInterpretFunctionPreCondition(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -1938,7 +1938,7 @@ func TestInterpretFunctionPostCondition(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -1964,7 +1964,7 @@ func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -2042,11 +2042,11 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPreCondition(t *testing.
 
 	_, err := inter.Invoke("test")
 
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
 		ast.ConditionKindPre,
-		err.(*interpreter.ConditionError).ConditionKind,
+		err.(interpreter.ConditionError).ConditionKind,
 	)
 }
 
@@ -2070,11 +2070,11 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPostCondition(t *testing
 
 	_, err := inter.Invoke("test")
 
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
 		ast.ConditionKindPost,
-		err.(*interpreter.ConditionError).ConditionKind,
+		err.(interpreter.ConditionError).ConditionKind,
 	)
 }
 
@@ -2096,11 +2096,11 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
 		"y should be zero",
-		err.(*interpreter.ConditionError).Message,
+		err.(interpreter.ConditionError).Message,
 	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
@@ -2128,11 +2128,11 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
 		"return value",
-		err.(*interpreter.ConditionError).Message,
+		err.(interpreter.ConditionError).Message,
 	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
@@ -2159,11 +2159,11 @@ func TestInterpretFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
 		"parameter value",
-		err.(*interpreter.ConditionError).Message,
+		err.(interpreter.ConditionError).Message,
 	)
 }
 
@@ -2181,11 +2181,11 @@ func TestInterpretFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 
 	assert.Equal(t,
 		"parameter value",
-		err.(*interpreter.ConditionError).Message,
+		err.(interpreter.ConditionError).Message,
 	)
 }
 
@@ -3582,7 +3582,7 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			)
 
 			_, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(0))
-			assert.IsType(t, &interpreter.ConditionError{}, err)
+			assert.IsType(t, interpreter.ConditionError{}, err)
 
 			value, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(1))
 			require.NoError(t, err)
@@ -3594,7 +3594,7 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 
 			_, err = inter.Invoke("callTest", interpreter.NewIntValueFromInt64(2))
 			assert.IsType(t,
-				&interpreter.ConditionError{},
+				interpreter.ConditionError{},
 				err,
 			)
 		})
@@ -3606,9 +3606,9 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 	t.Parallel()
 
 	tests := map[int64]error{
-		0: &interpreter.ConditionError{},
+		0: interpreter.ConditionError{},
 		1: nil,
-		2: &interpreter.ConditionError{},
+		2: interpreter.ConditionError{},
 	}
 
 	for _, compositeKind := range common.CompositeKindsWithFieldsAndFunctions {
@@ -3770,23 +3770,23 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	t.Run("-1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(-1))
 		require.IsType(t,
-			&interpreter.ConditionError{},
+			interpreter.ConditionError{},
 			err,
 		)
 
 		// NOTE: The type requirement condition (`Test.Nested`) is evaluated first,
 		//  before the type's conformances (`Also`)
 
-		assert.Equal(t, err.(*interpreter.ConditionError).Message, "x >= 1")
+		assert.Equal(t, err.(interpreter.ConditionError).Message, "x >= 1")
 	})
 
 	t.Run("0", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(0))
 		assert.IsType(t,
-			&interpreter.ConditionError{},
+			interpreter.ConditionError{},
 			err,
 		)
-		assert.Equal(t, "x >= 1", err.(*interpreter.ConditionError).Message)
+		assert.Equal(t, "x >= 1", err.(interpreter.ConditionError).Message)
 	})
 
 	t.Run("1", func(t *testing.T) {
@@ -3802,7 +3802,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	t.Run("2", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
 		assert.IsType(t,
-			&interpreter.ConditionError{},
+			interpreter.ConditionError{},
 			err,
 		)
 	})
@@ -5590,7 +5590,7 @@ func TestInterpretResourceDestroyExpressionResourceInterfaceCondition(t *testing
     `)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 }
 
 // TestInterpretInterfaceInitializer tests that the interface's initializer
@@ -5617,7 +5617,7 @@ func TestInterpretInterfaceInitializer(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 }
 
 func TestInterpretEmitEvent(t *testing.T) {
@@ -6099,7 +6099,7 @@ func TestInterpretReferenceDereferenceFailure(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, &interpreter.DestroyedCompositeError{}, err)
+	assert.IsType(t, interpreter.DestroyedCompositeError{}, err)
 }
 
 func TestInterpretInvalidForwardReferenceCall(t *testing.T) {
@@ -6738,7 +6738,7 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 }
 
 func TestInterpretFunctionPostConditionInInterface(t *testing.T) {
@@ -6793,7 +6793,7 @@ func TestInterpretFunctionPostConditionInInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test2")
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 }
 
 func TestInterpretFunctionPostConditionWithBeforeInInterface(t *testing.T) {
@@ -6848,7 +6848,7 @@ func TestInterpretFunctionPostConditionWithBeforeInInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test2")
-	assert.IsType(t, &interpreter.ConditionError{}, err)
+	assert.IsType(t, interpreter.ConditionError{}, err)
 }
 
 func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
@@ -6928,8 +6928,8 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
 		require.Error(t, err)
 
-		require.IsType(t, &interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid init", err.(*interpreter.ConditionError).Message)
+		require.IsType(t, interpreter.ConditionError{}, err)
+		assert.Equal(t, "invalid init", err.(interpreter.ConditionError).Message)
 	})
 
 	t.Run("2", func(t *testing.T) {
@@ -6941,8 +6941,8 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(3))
 		require.Error(t, err)
 
-		require.IsType(t, &interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid destroy", err.(*interpreter.ConditionError).Message)
+		require.IsType(t, interpreter.ConditionError{}, err)
+		assert.Equal(t, "invalid destroy", err.(interpreter.ConditionError).Message)
 	})
 }
 
@@ -7000,8 +7000,8 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
 		require.Error(t, err)
 
-		require.IsType(t, &interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid init", err.(*interpreter.ConditionError).Message)
+		require.IsType(t, interpreter.ConditionError{}, err)
+		assert.Equal(t, "invalid init", err.(interpreter.ConditionError).Message)
 	})
 
 	t.Run("2", func(t *testing.T) {
@@ -7013,8 +7013,8 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(3))
 		require.Error(t, err)
 
-		require.IsType(t, &interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid destroy", err.(*interpreter.ConditionError).Message)
+		require.IsType(t, interpreter.ConditionError{}, err)
+		assert.Equal(t, "invalid destroy", err.(interpreter.ConditionError).Message)
 	})
 }
 
@@ -7084,7 +7084,7 @@ func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
 
-	assert.IsType(t, &interpreter.DestroyedCompositeError{}, err)
+	assert.IsType(t, interpreter.DestroyedCompositeError{}, err)
 }
 
 func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
@@ -7131,7 +7131,7 @@ func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
 		_, err := inter.Invoke("testNil")
 		require.Error(t, err)
 
-		assert.IsType(t, &interpreter.DereferenceError{}, err)
+		assert.IsType(t, interpreter.DereferenceError{}, err)
 	})
 }
 
@@ -7460,7 +7460,7 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		assert.IsType(t, &interpreter.ForceAssignmentToNonNilResourceError{}, err)
+		assert.IsType(t, interpreter.ForceAssignmentToNonNilResourceError{}, err)
 	})
 
 	t.Run("existing to nil", func(t *testing.T) {
@@ -7496,7 +7496,7 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		assert.IsType(t, &interpreter.ForceAssignmentToNonNilResourceError{}, err)
+		assert.IsType(t, interpreter.ForceAssignmentToNonNilResourceError{}, err)
 	})
 }
 
@@ -7537,7 +7537,7 @@ func TestInterpretForce(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		assert.IsType(t, &interpreter.ForceNilError{}, err)
+		assert.IsType(t, interpreter.ForceNilError{}, err)
 	})
 
 	t.Run("non-optional", func(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -478,6 +478,35 @@ func TestInterpretArrayIndexing(t *testing.T) {
 	)
 }
 
+func TestInterpretInvalidArrayIndexing(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+       fun test(): Int {
+           let z = [0, 3]
+           return z[2]
+       }
+    `)
+
+	_, err := inter.Invoke("test")
+
+	require.Equal(t,
+		interpreter.ArrayIndexOutOfBoundsError{
+			Index:    2,
+			MaxIndex: 1,
+			LocationRange: interpreter.LocationRange{
+				Location: TestLocation,
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 71, Line: 4, Column: 19},
+					EndPos:   ast.Position{Offset: 73, Line: 4, Column: 21},
+				},
+			},
+		},
+		err,
+	)
+}
+
 func TestInterpretArrayIndexingAssignment(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -104,9 +104,9 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(0)
-		require.IsType(t, &interpreter.ConditionError{}, err)
+		require.IsType(t, interpreter.ConditionError{}, err)
 
-		conditionErr := err.(*interpreter.ConditionError)
+		conditionErr := err.(interpreter.ConditionError)
 
 		assert.Equal(t, conditionErr.ConditionKind, ast.ConditionKindPre)
 	})
@@ -156,9 +156,9 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(0)
-		require.IsType(t, &interpreter.ConditionError{}, err)
+		require.IsType(t, interpreter.ConditionError{}, err)
 
-		conditionErr := err.(*interpreter.ConditionError)
+		conditionErr := err.(interpreter.ConditionError)
 
 		assert.Equal(t, conditionErr.ConditionKind, ast.ConditionKindPost)
 	})
@@ -188,7 +188,7 @@ func TestInterpretTransactions(t *testing.T) {
 
 		// third transaction is not declared
 		err = inter.InvokeTransaction(2)
-		assert.IsType(t, &interpreter.TransactionNotDeclaredError{}, err)
+		assert.IsType(t, interpreter.TransactionNotDeclaredError{}, err)
 	})
 
 	t.Run("TooFewArguments", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(0)
-		assert.IsType(t, &interpreter.ArgumentCountError{}, err)
+		assert.IsType(t, interpreter.ArgumentCountError{}, err)
 	})
 
 	panicFunction := interpreter.NewHostFunctionValue(func(invocation interpreter.Invocation) trampoline.Trampoline {
@@ -234,11 +234,11 @@ func TestInterpretTransactions(t *testing.T) {
 
 		// first transaction
 		err := inter.InvokeTransaction(0, signer1)
-		assert.IsType(t, &interpreter.ArgumentCountError{}, err)
+		assert.IsType(t, interpreter.ArgumentCountError{}, err)
 
 		// second transaction
 		err = inter.InvokeTransaction(0, signer1, signer2)
-		assert.IsType(t, &interpreter.ArgumentCountError{}, err)
+		assert.IsType(t, interpreter.ArgumentCountError{}, err)
 	})
 
 	t.Run("Parameters", func(t *testing.T) {


### PR DESCRIPTION
Check that the index of an array access is within bounds and panic with a dedicated error, instead of relying on Go's bounds check and it returning an error indistinguishable from an out-of-bounds error in the implementation of Cadence itself. 

I will backport this to 0.9.0 and release as 0.9.1.