### PR TITLE
Allow returning references from scripts

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -89,22 +89,19 @@ func (d *Decoder) Decode() (value cadence.Value, err error) {
 }
 
 const (
-	typeKey                 = "type"
-	valueKey                = "value"
-	keyKey                  = "key"
-	nameKey                 = "name"
-	fieldsKey               = "fields"
-	idKey                   = "id"
-	authorizedKey           = "authorized"
-	targetStorageAddressKey = "targetStorageAddress"
-	targetKeyKey            = "targetKey"
-	targetPathKey           = "targetPath"
-	borrowTypeKey           = "borrowType"
-	domainKey               = "domain"
-	identifierKey           = "identifier"
-	staticTypeKey           = "staticType"
-	addressKey              = "address"
-	pathKey                 = "path"
+	typeKey       = "type"
+	valueKey      = "value"
+	keyKey        = "key"
+	nameKey       = "name"
+	fieldsKey     = "fields"
+	idKey         = "id"
+	targetPathKey = "targetPath"
+	borrowTypeKey = "borrowType"
+	domainKey     = "domain"
+	identifierKey = "identifier"
+	staticTypeKey = "staticType"
+	addressKey    = "address"
+	pathKey       = "path"
 )
 
 var ErrInvalidJSONCadence = errors.New("invalid JSON Cadence structure")
@@ -187,8 +184,6 @@ func decodeJSON(v interface{}) cadence.Value {
 		return decodeEvent(valueJSON)
 	case contractTypeStr:
 		return decodeContract(valueJSON)
-	case storageReferenceTypeStr:
-		return decodeStorageReference(valueJSON)
 	case linkTypeStr:
 		return decodeLink(valueJSON)
 	case pathTypeStr:
@@ -571,16 +566,6 @@ func decodeContract(valueJSON interface{}) cadence.Contract {
 		Identifier: comp.identifier,
 		Fields:     comp.fieldTypes,
 	})
-}
-
-func decodeStorageReference(valueJSON interface{}) cadence.StorageReference {
-	obj := toObject(valueJSON)
-
-	return cadence.NewStorageReference(
-		obj.GetBool(authorizedKey),
-		decodeAddress(obj.Get(targetStorageAddressKey)),
-		obj.GetString(targetKeyKey),
-	)
 }
 
 func decodeLink(valueJSON interface{}) cadence.Link {

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -125,12 +125,6 @@ type jsonCompositeField struct {
 	Value jsonValue `json:"value"`
 }
 
-type jsonStorageReferenceValue struct {
-	Authorized           bool   `json:"authorized"`
-	TargetStorageAddress string `json:"targetStorageAddress"`
-	TargetKey            string `json:"targetKey"`
-}
-
 type jsonLinkValue struct {
 	TargetPath jsonValue `json:"targetPath"`
 	BorrowType string    `json:"borrowType"`
@@ -152,42 +146,41 @@ type jsonCapabilityValue struct {
 }
 
 const (
-	voidTypeStr             = "Void"
-	optionalTypeStr         = "Optional"
-	boolTypeStr             = "Bool"
-	stringTypeStr           = "String"
-	addressTypeStr          = "Address"
-	intTypeStr              = "Int"
-	int8TypeStr             = "Int8"
-	int16TypeStr            = "Int16"
-	int32TypeStr            = "Int32"
-	int64TypeStr            = "Int64"
-	int128TypeStr           = "Int128"
-	int256TypeStr           = "Int256"
-	uintTypeStr             = "UInt"
-	uint8TypeStr            = "UInt8"
-	uint16TypeStr           = "UInt16"
-	uint32TypeStr           = "UInt32"
-	uint64TypeStr           = "UInt64"
-	uint128TypeStr          = "UInt128"
-	uint256TypeStr          = "UInt256"
-	word8TypeStr            = "Word8"
-	word16TypeStr           = "Word16"
-	word32TypeStr           = "Word32"
-	word64TypeStr           = "Word64"
-	fix64TypeStr            = "Fix64"
-	ufix64TypeStr           = "UFix64"
-	arrayTypeStr            = "Array"
-	dictionaryTypeStr       = "Dictionary"
-	structTypeStr           = "Struct"
-	resourceTypeStr         = "Resource"
-	eventTypeStr            = "Event"
-	contractTypeStr         = "Contract"
-	storageReferenceTypeStr = "StorageReference"
-	linkTypeStr             = "Link"
-	pathTypeStr             = "Path"
-	typeTypeStr             = "Type"
-	capabilityTypeStr       = "Capability"
+	voidTypeStr       = "Void"
+	optionalTypeStr   = "Optional"
+	boolTypeStr       = "Bool"
+	stringTypeStr     = "String"
+	addressTypeStr    = "Address"
+	intTypeStr        = "Int"
+	int8TypeStr       = "Int8"
+	int16TypeStr      = "Int16"
+	int32TypeStr      = "Int32"
+	int64TypeStr      = "Int64"
+	int128TypeStr     = "Int128"
+	int256TypeStr     = "Int256"
+	uintTypeStr       = "UInt"
+	uint8TypeStr      = "UInt8"
+	uint16TypeStr     = "UInt16"
+	uint32TypeStr     = "UInt32"
+	uint64TypeStr     = "UInt64"
+	uint128TypeStr    = "UInt128"
+	uint256TypeStr    = "UInt256"
+	word8TypeStr      = "Word8"
+	word16TypeStr     = "Word16"
+	word32TypeStr     = "Word32"
+	word64TypeStr     = "Word64"
+	fix64TypeStr      = "Fix64"
+	ufix64TypeStr     = "UFix64"
+	arrayTypeStr      = "Array"
+	dictionaryTypeStr = "Dictionary"
+	structTypeStr     = "Struct"
+	resourceTypeStr   = "Resource"
+	eventTypeStr      = "Event"
+	contractTypeStr   = "Contract"
+	linkTypeStr       = "Link"
+	pathTypeStr       = "Path"
+	typeTypeStr       = "Type"
+	capabilityTypeStr = "Capability"
 )
 
 // prepare traverses the object graph of the provided value and constructs
@@ -256,8 +249,6 @@ func (e *Encoder) prepare(v cadence.Value) jsonValue {
 		return e.prepareEvent(x)
 	case cadence.Contract:
 		return e.prepareContract(x)
-	case cadence.StorageReference:
-		return e.prepareStorageReference(x)
 	case cadence.Link:
 		return e.prepareLink(x)
 	case cadence.Path:
@@ -528,17 +519,6 @@ func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, 
 		Value: jsonCompositeValue{
 			ID:     id,
 			Fields: compositeFields,
-		},
-	}
-}
-
-func (e *Encoder) prepareStorageReference(x cadence.StorageReference) jsonValue {
-	return jsonValueObject{
-		Type: storageReferenceTypeStr,
-		Value: jsonStorageReferenceValue{
-			Authorized:           x.Authorized,
-			TargetStorageAddress: encodeBytes(x.TargetStorageAddress.Bytes()),
-			TargetKey:            x.TargetKey,
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -957,21 +957,6 @@ func TestEncodeContract(t *testing.T) {
 	testAllEncodeAndDecode(t, simpleContract, resourceContract)
 }
 
-func TestEncodeStorageReference(t *testing.T) {
-
-	t.Parallel()
-
-	testEncodeAndDecode(
-		t,
-		cadence.NewStorageReference(
-			false,
-			cadence.BytesToAddress([]byte{1, 2, 3, 4, 5}),
-			"foo",
-		),
-		`{"type":"StorageReference","value":{"authorized":false,"targetStorageAddress":"0x0000000102030405","targetKey":"foo"}}`,
-	)
-}
-
 func TestEncodeLink(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -50,6 +50,12 @@ func exportEvent(event exportableEvent) cadence.Event {
 
 type exportResults map[interpreter.Value]cadence.Value
 
+// exportValueWithInterpreter exports the given internal (interpreter) value to an external value.
+//
+// The export is recursive, the results parameter prevents cycles:
+// it is checked at the start of the recursively called function,
+// and pre-set before a recursive call.
+//
 func exportValueWithInterpreter(
 	value interpreter.Value,
 	inter *interpreter.Interpreter,

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -31,117 +31,145 @@ import (
 
 // exportValue converts a runtime value to its native Go representation.
 func exportValue(value exportableValue) cadence.Value {
-	return exportValueWithInterpreter(value.Value, value.Interpreter())
+	return exportValueWithInterpreter(value.Value, value.Interpreter(), exportResults{})
 }
 
 // exportEvent converts a runtime event to its native Go representation.
 func exportEvent(event exportableEvent) cadence.Event {
 	fields := make([]cadence.Value, len(event.Fields))
 
+	results := exportResults{}
+
 	for i, field := range event.Fields {
-		fields[i] = exportValueWithInterpreter(field.Value, field.Interpreter())
+		fields[i] = exportValueWithInterpreter(field.Value, field.Interpreter(), results)
 	}
 
 	eventType := exportType(event.Type, map[sema.TypeID]cadence.Type{}).(*cadence.EventType)
 	return cadence.NewEvent(fields).WithType(eventType)
 }
 
-func exportValueWithInterpreter(value interpreter.Value, inter *interpreter.Interpreter) cadence.Value {
-	switch v := value.(type) {
-	case interpreter.VoidValue:
-		return cadence.NewVoid()
-	case interpreter.NilValue:
-		return cadence.NewOptional(nil)
-	case *interpreter.SomeValue:
-		return exportSomeValue(v, inter)
-	case interpreter.BoolValue:
-		return cadence.NewBool(bool(v))
-	case *interpreter.StringValue:
-		return cadence.NewString(v.Str)
-	case *interpreter.ArrayValue:
-		return exportArrayValue(v, inter)
-	case interpreter.IntValue:
-		return cadence.NewIntFromBig(v.ToBigInt())
-	case interpreter.Int8Value:
-		return cadence.NewInt8(int8(v))
-	case interpreter.Int16Value:
-		return cadence.NewInt16(int16(v))
-	case interpreter.Int32Value:
-		return cadence.NewInt32(int32(v))
-	case interpreter.Int64Value:
-		return cadence.NewInt64(int64(v))
-	case interpreter.Int128Value:
-		return cadence.NewInt128FromBig(v.ToBigInt())
-	case interpreter.Int256Value:
-		return cadence.NewInt256FromBig(v.ToBigInt())
-	case interpreter.UIntValue:
-		return cadence.NewUIntFromBig(v.ToBigInt())
-	case interpreter.UInt8Value:
-		return cadence.NewUInt8(uint8(v))
-	case interpreter.UInt16Value:
-		return cadence.NewUInt16(uint16(v))
-	case interpreter.UInt32Value:
-		return cadence.NewUInt32(uint32(v))
-	case interpreter.UInt64Value:
-		return cadence.NewUInt64(uint64(v))
-	case interpreter.UInt128Value:
-		return cadence.NewUInt128FromBig(v.ToBigInt())
-	case interpreter.UInt256Value:
-		return cadence.NewUInt256FromBig(v.ToBigInt())
-	case interpreter.Word8Value:
-		return cadence.NewWord8(uint8(v))
-	case interpreter.Word16Value:
-		return cadence.NewWord16(uint16(v))
-	case interpreter.Word32Value:
-		return cadence.NewWord32(uint32(v))
-	case interpreter.Word64Value:
-		return cadence.NewWord64(uint64(v))
-	case interpreter.Fix64Value:
-		return cadence.Fix64(v)
-	case interpreter.UFix64Value:
-		return cadence.UFix64(v)
-	case *interpreter.CompositeValue:
-		return exportCompositeValue(v, inter)
-	case *interpreter.DictionaryValue:
-		return exportDictionaryValue(v, inter)
-	case interpreter.AddressValue:
-		return cadence.NewAddress(v)
-	case *interpreter.StorageReferenceValue:
-		return exportStorageReferenceValue(v)
-	case interpreter.LinkValue:
-		return exportLinkValue(v, inter)
-	case interpreter.PathValue:
-		return exportPathValue(v)
-	case interpreter.TypeValue:
-		return exportTypeValue(v, inter)
-	case interpreter.CapabilityValue:
-		return exportCapabilityValue(v, inter)
+type exportResults map[interpreter.Value]cadence.Value
+
+func exportValueWithInterpreter(
+	value interpreter.Value,
+	inter *interpreter.Interpreter,
+	results exportResults,
+) cadence.Value {
+
+	if result, ok := results[value]; ok {
+		return result
 	}
 
-	panic(fmt.Sprintf("cannot export value of type %T", value))
+	results[value] = nil
+
+	result := func() cadence.Value {
+
+		switch v := value.(type) {
+		case interpreter.VoidValue:
+			return cadence.NewVoid()
+		case interpreter.NilValue:
+			return cadence.NewOptional(nil)
+		case *interpreter.SomeValue:
+			return exportSomeValue(v, inter, results)
+		case interpreter.BoolValue:
+			return cadence.NewBool(bool(v))
+		case *interpreter.StringValue:
+			return cadence.NewString(v.Str)
+		case *interpreter.ArrayValue:
+			return exportArrayValue(v, inter, results)
+		case interpreter.IntValue:
+			return cadence.NewIntFromBig(v.ToBigInt())
+		case interpreter.Int8Value:
+			return cadence.NewInt8(int8(v))
+		case interpreter.Int16Value:
+			return cadence.NewInt16(int16(v))
+		case interpreter.Int32Value:
+			return cadence.NewInt32(int32(v))
+		case interpreter.Int64Value:
+			return cadence.NewInt64(int64(v))
+		case interpreter.Int128Value:
+			return cadence.NewInt128FromBig(v.ToBigInt())
+		case interpreter.Int256Value:
+			return cadence.NewInt256FromBig(v.ToBigInt())
+		case interpreter.UIntValue:
+			return cadence.NewUIntFromBig(v.ToBigInt())
+		case interpreter.UInt8Value:
+			return cadence.NewUInt8(uint8(v))
+		case interpreter.UInt16Value:
+			return cadence.NewUInt16(uint16(v))
+		case interpreter.UInt32Value:
+			return cadence.NewUInt32(uint32(v))
+		case interpreter.UInt64Value:
+			return cadence.NewUInt64(uint64(v))
+		case interpreter.UInt128Value:
+			return cadence.NewUInt128FromBig(v.ToBigInt())
+		case interpreter.UInt256Value:
+			return cadence.NewUInt256FromBig(v.ToBigInt())
+		case interpreter.Word8Value:
+			return cadence.NewWord8(uint8(v))
+		case interpreter.Word16Value:
+			return cadence.NewWord16(uint16(v))
+		case interpreter.Word32Value:
+			return cadence.NewWord32(uint32(v))
+		case interpreter.Word64Value:
+			return cadence.NewWord64(uint64(v))
+		case interpreter.Fix64Value:
+			return cadence.Fix64(v)
+		case interpreter.UFix64Value:
+			return cadence.UFix64(v)
+		case *interpreter.CompositeValue:
+			return exportCompositeValue(v, inter, results)
+		case *interpreter.DictionaryValue:
+			return exportDictionaryValue(v, inter, results)
+		case interpreter.AddressValue:
+			return cadence.NewAddress(v)
+		case interpreter.LinkValue:
+			return exportLinkValue(v, inter)
+		case interpreter.PathValue:
+			return exportPathValue(v)
+		case interpreter.TypeValue:
+			return exportTypeValue(v, inter)
+		case interpreter.CapabilityValue:
+			return exportCapabilityValue(v, inter)
+		case *interpreter.EphemeralReferenceValue:
+			return exportValueWithInterpreter(v.Value, inter, results)
+		case *interpreter.StorageReferenceValue:
+			referencedValue := v.ReferencedValue(inter)
+			if referencedValue == nil {
+				return nil
+			}
+			return exportValueWithInterpreter(*referencedValue, inter, results)
+		}
+
+		panic(fmt.Sprintf("cannot export value of type %T", value))
+	}()
+
+	results[value] = result
+
+	return result
 }
 
-func exportSomeValue(v *interpreter.SomeValue, inter *interpreter.Interpreter) cadence.Optional {
+func exportSomeValue(v *interpreter.SomeValue, inter *interpreter.Interpreter, results exportResults) cadence.Optional {
 	if v.Value == nil {
 		return cadence.NewOptional(nil)
 	}
 
-	value := exportValueWithInterpreter(v.Value, inter)
+	value := exportValueWithInterpreter(v.Value, inter, results)
 
 	return cadence.NewOptional(value)
 }
 
-func exportArrayValue(v *interpreter.ArrayValue, inter *interpreter.Interpreter) cadence.Array {
+func exportArrayValue(v *interpreter.ArrayValue, inter *interpreter.Interpreter, results exportResults) cadence.Array {
 	values := make([]cadence.Value, len(v.Values))
 
 	for i, value := range v.Values {
-		values[i] = exportValueWithInterpreter(value, inter)
+		values[i] = exportValueWithInterpreter(value, inter, results)
 	}
 
 	return cadence.NewArray(values)
 }
 
-func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Interpreter) cadence.Value {
+func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Interpreter, results exportResults) cadence.Value {
 
 	dynamicType := v.DynamicType(inter).(interpreter.CompositeDynamicType)
 	staticType := dynamicType.StaticType.(*sema.CompositeType)
@@ -156,7 +184,7 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 
 	for i, field := range fieldNames {
 		fieldValue := v.Fields[field.Identifier]
-		fields[i] = exportValueWithInterpreter(fieldValue, inter)
+		fields[i] = exportValueWithInterpreter(fieldValue, inter, results)
 	}
 
 	switch staticType.Kind {
@@ -185,7 +213,12 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 	))
 }
 
-func exportDictionaryValue(v *interpreter.DictionaryValue, inter *interpreter.Interpreter) cadence.Dictionary {
+func exportDictionaryValue(
+	v *interpreter.DictionaryValue,
+	inter *interpreter.Interpreter,
+	results exportResults,
+) cadence.Dictionary {
+
 	pairs := make([]cadence.KeyValuePair, v.Count())
 
 	for i, keyValue := range v.Keys.Values {
@@ -195,8 +228,8 @@ func exportDictionaryValue(v *interpreter.DictionaryValue, inter *interpreter.In
 
 		value := v.Get(inter, interpreter.LocationRange{}, keyValue).(*interpreter.SomeValue).Value
 
-		convertedKey := exportValueWithInterpreter(keyValue, inter)
-		convertedValue := exportValueWithInterpreter(value, inter)
+		convertedKey := exportValueWithInterpreter(keyValue, inter, results)
+		convertedValue := exportValueWithInterpreter(value, inter, results)
 
 		pairs[i] = cadence.KeyValuePair{
 			Key:   convertedKey,
@@ -205,14 +238,6 @@ func exportDictionaryValue(v *interpreter.DictionaryValue, inter *interpreter.In
 	}
 
 	return cadence.NewDictionary(pairs)
-}
-
-func exportStorageReferenceValue(v *interpreter.StorageReferenceValue) cadence.StorageReference {
-	return cadence.NewStorageReference(
-		v.Authorized,
-		cadence.NewAddress(v.TargetStorageAddress),
-		v.TargetKey,
-	)
 }
 
 func exportLinkValue(v interpreter.LinkValue, inter *interpreter.Interpreter) cadence.Link {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -217,7 +217,7 @@ func TestExportValue(t *testing.T) {
 
 			t.Parallel()
 
-			actual := exportValueWithInterpreter(tt.value, nil)
+			actual := exportValueWithInterpreter(tt.value, nil, exportResults{})
 			assert.Equal(t, tt.expected, actual)
 
 			if !tt.skipReverse {
@@ -651,7 +651,7 @@ func TestExportCapabilityValue(t *testing.T) {
 		},
 		BorrowType: interpreter.PrimitiveStaticTypeInt,
 	}
-	actual := exportValueWithInterpreter(capability, nil)
+	actual := exportValueWithInterpreter(capability, nil, exportResults{})
 	expected := cadence.Capability{
 		Path: cadence.Path{
 			Domain:     "storage",

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -166,51 +166,35 @@ func (e *InvalidTypeAssignmentError) Error() string {
 	)
 }
 
-// ScriptReturnTypeNotStorableError is an error that is reported for
-// script return types that are not storable.
+// InvalidScriptReturnTypeError is an error that is reported for
+// invalid script return types.
 //
-// For example, the type `Int` is a storable type,
-// whereas a function type is not.
-
-type ScriptReturnTypeNotStorableError struct {
+// For example, the type `Int` is valid,
+// whereas a function type is not,
+// because it cannot be exported/serialized.
+//
+type InvalidScriptReturnTypeError struct {
 	Type sema.Type
 }
 
-func (e *ScriptReturnTypeNotStorableError) Error() string {
+func (e *InvalidScriptReturnTypeError) Error() string {
 	return fmt.Sprintf(
-		"return type is non-storable type: `%s`",
+		"invalid script return type: `%s`",
 		e.Type.QualifiedString(),
 	)
 }
 
-// ScriptParamterTypeNotStorableError is an error that is reported for
+// ScriptParameterTypeNotStorableError is an error that is reported for
 // script parameter types that are not storable.
 //
 // For example, the type `Int` is a storable type,
 // whereas a function type is not.
-
+//
 type ScriptParameterTypeNotStorableError struct {
 	Type sema.Type
 }
 
 func (e *ScriptParameterTypeNotStorableError) Error() string {
-	return fmt.Sprintf(
-		"parameter type is non-storable type: `%s`",
-		e.Type.QualifiedString(),
-	)
-}
-
-// TransactionParamterTypeNotStorableError is an error that is reported for
-// transaction parameter types that are not storable.
-//
-// For example, the type `Int` is a storable type,
-// whereas a function type is not.
-
-type TransactionParameterTypeNotStorableError struct {
-	Type sema.Type
-}
-
-func (e *TransactionParameterTypeNotStorableError) Error() string {
 	return fmt.Sprintf(
 		"parameter type is non-storable type: `%s`",
 		e.Type.QualifiedString(),

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6048,7 +6048,7 @@ func (v *StorageReferenceValue) String() string {
 }
 
 func (v *StorageReferenceValue) DynamicType(interpreter *Interpreter) DynamicType {
-	referencedValue := v.referencedValue(interpreter)
+	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{})
 	}
@@ -6086,7 +6086,7 @@ func (*StorageReferenceValue) SetModified(_ bool) {
 	// NO-OP
 }
 
-func (v *StorageReferenceValue) referencedValue(interpreter *Interpreter) *Value {
+func (v *StorageReferenceValue) ReferencedValue(interpreter *Interpreter) *Value {
 	switch referenced := interpreter.readStored(v.TargetStorageAddress, v.TargetKey, false).(type) {
 	case *SomeValue:
 		return &referenced.Value
@@ -6098,7 +6098,7 @@ func (v *StorageReferenceValue) referencedValue(interpreter *Interpreter) *Value
 }
 
 func (v *StorageReferenceValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	referencedValue := v.referencedValue(interpreter)
+	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,
@@ -6109,7 +6109,7 @@ func (v *StorageReferenceValue) GetMember(interpreter *Interpreter, locationRang
 }
 
 func (v *StorageReferenceValue) SetMember(interpreter *Interpreter, locationRange LocationRange, name string, value Value) {
-	referencedValue := v.referencedValue(interpreter)
+	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,
@@ -6120,7 +6120,7 @@ func (v *StorageReferenceValue) SetMember(interpreter *Interpreter, locationRang
 }
 
 func (v *StorageReferenceValue) Get(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
-	referencedValue := v.referencedValue(interpreter)
+	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,
@@ -6132,7 +6132,7 @@ func (v *StorageReferenceValue) Get(interpreter *Interpreter, locationRange Loca
 }
 
 func (v *StorageReferenceValue) Set(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
-	referencedValue := v.referencedValue(interpreter)
+	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,
@@ -6168,7 +6168,7 @@ func (v *EphemeralReferenceValue) String() string {
 }
 
 func (v *EphemeralReferenceValue) DynamicType(interpreter *Interpreter) DynamicType {
-	referencedValue := v.referencedValue()
+	referencedValue := v.ReferencedValue()
 	if referencedValue == nil {
 		panic(DereferenceError{})
 	}
@@ -6202,7 +6202,7 @@ func (*EphemeralReferenceValue) SetModified(_ bool) {
 	// NO-OP
 }
 
-func (v *EphemeralReferenceValue) referencedValue() *Value {
+func (v *EphemeralReferenceValue) ReferencedValue() *Value {
 	// Just like for storage references, references to optionals are unwrapped,
 	// i.e. a reference to `nil` aborts when dereferenced.
 
@@ -6217,7 +6217,7 @@ func (v *EphemeralReferenceValue) referencedValue() *Value {
 }
 
 func (v *EphemeralReferenceValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	referencedValue := v.referencedValue()
+	referencedValue := v.ReferencedValue()
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,
@@ -6228,7 +6228,7 @@ func (v *EphemeralReferenceValue) GetMember(interpreter *Interpreter, locationRa
 }
 
 func (v *EphemeralReferenceValue) SetMember(interpreter *Interpreter, locationRange LocationRange, name string, value Value) {
-	referencedValue := v.referencedValue()
+	referencedValue := v.ReferencedValue()
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,
@@ -6239,7 +6239,7 @@ func (v *EphemeralReferenceValue) SetMember(interpreter *Interpreter, locationRa
 }
 
 func (v *EphemeralReferenceValue) Get(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
-	referencedValue := v.referencedValue()
+	referencedValue := v.ReferencedValue()
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,
@@ -6251,7 +6251,7 @@ func (v *EphemeralReferenceValue) Get(interpreter *Interpreter, locationRange Lo
 }
 
 func (v *EphemeralReferenceValue) Set(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
-	referencedValue := v.referencedValue()
+	referencedValue := v.ReferencedValue()
 	if referencedValue == nil {
 		panic(DereferenceError{
 			LocationRange: locationRange,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -168,11 +168,9 @@ func (r *interpreterRuntime) ExecuteScript(
 	}
 
 	// Ensure the entry point's return type is valid
-	if _, isVoid := epFunctionType.ReturnTypeAnnotation.Type.(*sema.VoidType); !isVoid {
-		if !epFunctionType.ReturnTypeAnnotation.Type.IsExternallyReturnable(map[*sema.Member]bool{}) {
-			return nil, &InvalidScriptReturnTypeError{
-				Type: epFunctionType.ReturnTypeAnnotation.Type,
-			}
+	if !epFunctionType.ReturnTypeAnnotation.Type.IsExternallyReturnable(map[*sema.Member]bool{}) {
+		return nil, &InvalidScriptReturnTypeError{
+			Type: epFunctionType.ReturnTypeAnnotation.Type,
 		}
 	}
 

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -247,7 +247,7 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 
 			var value cadence.Value
 			if entry.value != nil {
-				value = exportValueWithInterpreter(entry.value, inter)
+				value = exportValueWithInterpreter(entry.value, inter, exportResults{})
 			}
 
 			wrapPanic(func() {

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -58,6 +58,10 @@ func (*AuthAccountContractsType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
+func (*AuthAccountContractsType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return false
+}
+
 func (*AuthAccountContractsType) IsEquatable() bool {
 	// TODO: maybe implement equality
 	return false

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -595,7 +595,9 @@ func (checker *Checker) declareCompositeMembersAndValue(
 			)
 		}
 
-		checker.checkMemberStorability(members)
+		if compositeType.Kind == common.CompositeKindContract {
+			checker.checkMemberStorability(members)
+		}
 
 		compositeType.Members = members
 		compositeType.Fields = fields
@@ -718,7 +720,7 @@ func (checker *Checker) declareEnumConstructor(
 			continue
 		}
 		constructorMembers[caseName] = &Member{
-			ContainerType:   constructorType,
+			ContainerType: constructorType,
 			// enum cases are always public
 			Access:          ast.AccessPublic,
 			Identifier:      enumCase.Identifier,

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -304,7 +304,9 @@ func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclar
 		declaration.DeclarationKind(),
 	)
 
-	checker.checkMemberStorability(members)
+	if interfaceType.CompositeKind == common.CompositeKindContract {
+		checker.checkMemberStorability(members)
+	}
 
 	interfaceType.Members = members
 	interfaceType.Fields = fields

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -82,26 +82,40 @@ func (checker *Checker) checkTransactionParameters(declaration *ast.TransactionD
 	checker.checkParameters(declaration.ParameterList, parameters)
 	checker.declareParameters(declaration.ParameterList, parameters)
 
-	// Check that none of the parameters are resources
+	// Check parameter types
 
 	for i, parameter := range parameters {
 		parameterType := parameter.TypeAnnotation.Type
 
-		if parameterType.IsInvalidType() ||
-			!parameterType.IsResourceType() {
+		// Ignore invalid parameter types
 
+		if parameterType.IsInvalidType() {
 			continue
 		}
 
-		astParameter := declaration.ParameterList.Parameters[i]
-		typeRange := ast.NewRangeFromPositioned(astParameter.TypeAnnotation)
+		// Parameters may not be resources
 
-		checker.report(
-			&InvalidResourceTransactionParameterError{
-				Type:  parameterType,
-				Range: typeRange,
-			},
-		)
+		if parameterType.IsResourceType() {
+
+			astParameter := declaration.ParameterList.Parameters[i]
+
+			checker.report(
+				&InvalidResourceTransactionParameterError{
+					Type:  parameterType,
+					Range: ast.NewRangeFromPositioned(astParameter.TypeAnnotation),
+				},
+			)
+		}
+
+		// Parameters must be storable
+
+		if !parameter.TypeAnnotation.Type.IsStorable(map[*Member]bool{}) {
+			checker.report(
+				&InvalidNonStorableTransactionParameterTypeError{
+					Type: parameterType,
+				},
+			)
+		}
 	}
 }
 

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -59,6 +59,11 @@ func (*DeployedContractType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
+func (*DeployedContractType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	// TODO: add support for exporting deployed contracts
+	return false
+}
+
 func (*DeployedContractType) IsEquatable() bool {
 	// TODO:
 	return false

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2303,6 +2303,22 @@ func (e *InvalidResourceTransactionParameterError) Error() string {
 
 func (*InvalidResourceTransactionParameterError) isSemanticError() {}
 
+// InvalidNonStorableTransactionParameterTypeError
+
+type InvalidNonStorableTransactionParameterTypeError struct {
+	Type Type
+	ast.Range
+}
+
+func (e *InvalidNonStorableTransactionParameterTypeError) Error() string {
+	return fmt.Sprintf(
+		"transaction parameter must not be storable: `%s`",
+		e.Type.QualifiedString(),
+	)
+}
+
+func (*InvalidNonStorableTransactionParameterTypeError) isSemanticError() {}
+
 // InvalidTransactionFieldAccessModifierError
 
 type InvalidTransactionFieldAccessModifierError struct {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2312,7 +2312,7 @@ type InvalidNonStorableTransactionParameterTypeError struct {
 
 func (e *InvalidNonStorableTransactionParameterTypeError) Error() string {
 	return fmt.Sprintf(
-		"transaction parameter must not be storable: `%s`",
+		"transaction parameter must be storable: `%s`",
 		e.Type.QualifiedString(),
 	)
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -84,6 +84,9 @@ type Type interface {
 	// e.g. in a field of a composite type.
 	IsStorable(results map[*Member]bool) bool
 
+	// IsExternallyReturnable returns true if a value of this type can be exported
+	IsExternallyReturnable(results map[*Member]bool) bool
+
 	// IsEquatable returns true if values of the type can be equated
 	IsEquatable() bool
 
@@ -400,6 +403,10 @@ func (*MetaType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*MetaType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*MetaType) IsEquatable() bool {
 	return true
 }
@@ -472,7 +479,12 @@ func (*AnyType) IsInvalidType() bool {
 }
 
 func (*AnyType) IsStorable(_ map[*Member]bool) bool {
-	// The actual storability of a value is checked at run-time
+	// `Any` is never a valid type in user programs
+	return false
+}
+
+func (*AnyType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	// `Any` is never a valid type in user programs
 	return false
 }
 
@@ -535,6 +547,10 @@ func (*AnyStructType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*AnyStructType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*AnyStructType) IsEquatable() bool {
 	return false
 }
@@ -591,6 +607,11 @@ func (*AnyResourceType) IsInvalidType() bool {
 
 func (*AnyResourceType) IsStorable(_ map[*Member]bool) bool {
 	// The actual storability of a value is checked at run-time
+	return true
+}
+
+func (*AnyResourceType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	// The actual returnability of a value is checked at run-time
 	return true
 }
 
@@ -652,6 +673,10 @@ func (*NeverType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
+func (*NeverType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return false
+}
+
 func (*NeverType) IsEquatable() bool {
 	return false
 }
@@ -708,6 +733,10 @@ func (*VoidType) IsInvalidType() bool {
 
 func (*VoidType) IsStorable(_ map[*Member]bool) bool {
 	return false
+}
+
+func (*VoidType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
 }
 
 func (*VoidType) IsEquatable() bool {
@@ -768,6 +797,10 @@ func (*InvalidType) IsInvalidType() bool {
 }
 
 func (*InvalidType) IsStorable(_ map[*Member]bool) bool {
+	return false
+}
+
+func (*InvalidType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return false
 }
 
@@ -842,6 +875,10 @@ func (t *OptionalType) IsInvalidType() bool {
 
 func (t *OptionalType) IsStorable(results map[*Member]bool) bool {
 	return t.Type.IsStorable(results)
+}
+
+func (t *OptionalType) IsExternallyReturnable(results map[*Member]bool) bool {
+	return t.Type.IsExternallyReturnable(results)
 }
 
 func (t *OptionalType) IsEquatable() bool {
@@ -988,15 +1025,19 @@ func (t *GenericType) Equal(other Type) bool {
 	return t.TypeParameter == otherType.TypeParameter
 }
 
-func (t *GenericType) IsResourceType() bool {
+func (*GenericType) IsResourceType() bool {
 	return false
 }
 
-func (t *GenericType) IsInvalidType() bool {
+func (*GenericType) IsInvalidType() bool {
 	return false
 }
 
-func (t *GenericType) IsStorable(_ map[*Member]bool) bool {
+func (*GenericType) IsStorable(_ map[*Member]bool) bool {
+	return false
+}
+
+func (*GenericType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return false
 }
 
@@ -1004,7 +1045,7 @@ func (*GenericType) IsEquatable() bool {
 	return false
 }
 
-func (t *GenericType) TypeAnnotationState() TypeAnnotationState {
+func (*GenericType) TypeAnnotationState() TypeAnnotationState {
 	return TypeAnnotationStateValid
 }
 
@@ -1099,6 +1140,10 @@ func (*BoolType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*BoolType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*BoolType) IsEquatable() bool {
 	return true
 }
@@ -1158,6 +1203,10 @@ func (*CharacterType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*CharacterType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*CharacterType) IsEquatable() bool {
 	return true
 }
@@ -1213,6 +1262,10 @@ func (*StringType) IsInvalidType() bool {
 }
 
 func (*StringType) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*StringType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -1395,6 +1448,10 @@ func (*NumberType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*NumberType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*NumberType) IsEquatable() bool {
 	return true
 }
@@ -1458,6 +1515,10 @@ func (*SignedNumberType) IsInvalidType() bool {
 }
 
 func (*SignedNumberType) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*SignedNumberType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -1542,6 +1603,10 @@ func (*IntegerType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*IntegerType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*IntegerType) IsEquatable() bool {
 	return true
 }
@@ -1605,6 +1670,10 @@ func (*SignedIntegerType) IsInvalidType() bool {
 }
 
 func (*SignedIntegerType) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*SignedIntegerType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -1674,6 +1743,10 @@ func (*IntType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*IntType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*IntType) IsEquatable() bool {
 	return true
 }
@@ -1738,6 +1811,10 @@ func (*Int8Type) IsInvalidType() bool {
 }
 
 func (*Int8Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*Int8Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -1810,6 +1887,10 @@ func (*Int16Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*Int16Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*Int16Type) IsEquatable() bool {
 	return true
 }
@@ -1876,6 +1957,10 @@ func (*Int32Type) IsInvalidType() bool {
 }
 
 func (*Int32Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*Int32Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -1948,6 +2033,10 @@ func (*Int64Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*Int64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*Int64Type) IsEquatable() bool {
 	return true
 }
@@ -2014,6 +2103,10 @@ func (*Int128Type) IsInvalidType() bool {
 }
 
 func (*Int128Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*Int128Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -2098,6 +2191,10 @@ func (*Int256Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*Int256Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*Int256Type) IsEquatable() bool {
 	return true
 }
@@ -2179,6 +2276,10 @@ func (*UIntType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*UIntType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*UIntType) IsEquatable() bool {
 	return true
 }
@@ -2245,6 +2346,10 @@ func (*UInt8Type) IsInvalidType() bool {
 }
 
 func (*UInt8Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*UInt8Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -2318,6 +2423,10 @@ func (*UInt16Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*UInt16Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*UInt16Type) IsEquatable() bool {
 	return true
 }
@@ -2385,6 +2494,10 @@ func (*UInt32Type) IsInvalidType() bool {
 }
 
 func (*UInt32Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*UInt32Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -2458,6 +2571,10 @@ func (*UInt64Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*UInt64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*UInt64Type) IsEquatable() bool {
 	return true
 }
@@ -2525,6 +2642,10 @@ func (*UInt128Type) IsInvalidType() bool {
 }
 
 func (*UInt128Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*UInt128Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -2604,6 +2725,10 @@ func (*UInt256Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*UInt256Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*UInt256Type) IsEquatable() bool {
 	return true
 }
@@ -2680,6 +2805,10 @@ func (*Word8Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*Word8Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*Word8Type) IsEquatable() bool {
 	return true
 }
@@ -2747,6 +2876,10 @@ func (*Word16Type) IsInvalidType() bool {
 }
 
 func (*Word16Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*Word16Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -2820,6 +2953,10 @@ func (*Word32Type) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*Word32Type) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*Word32Type) IsEquatable() bool {
 	return true
 }
@@ -2887,6 +3024,10 @@ func (*Word64Type) IsInvalidType() bool {
 }
 
 func (*Word64Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*Word64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -2959,6 +3100,10 @@ func (*FixedPointType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*FixedPointType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*FixedPointType) IsEquatable() bool {
 	return true
 }
@@ -3022,6 +3167,10 @@ func (*SignedFixedPointType) IsInvalidType() bool {
 }
 
 func (*SignedFixedPointType) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*SignedFixedPointType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -3092,6 +3241,10 @@ func (*Fix64Type) IsInvalidType() bool {
 }
 
 func (*Fix64Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*Fix64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -3183,6 +3336,10 @@ func (*UFix64Type) IsInvalidType() bool {
 }
 
 func (*UFix64Type) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*UFix64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -3570,6 +3727,10 @@ func (t *VariableSizedType) IsStorable(results map[*Member]bool) bool {
 	return t.Type.IsStorable(results)
 }
 
+func (t *VariableSizedType) IsExternallyReturnable(results map[*Member]bool) bool {
+	return t.Type.IsExternallyReturnable(results)
+}
+
 func (*VariableSizedType) IsEquatable() bool {
 	// TODO:
 	return false
@@ -3676,6 +3837,10 @@ func (t *ConstantSizedType) IsInvalidType() bool {
 }
 
 func (t *ConstantSizedType) IsStorable(results map[*Member]bool) bool {
+	return t.Type.IsStorable(results)
+}
+
+func (t *ConstantSizedType) IsExternallyReturnable(results map[*Member]bool) bool {
 	return t.Type.IsStorable(results)
 }
 
@@ -4104,6 +4269,11 @@ func (t *FunctionType) IsInvalidType() bool {
 
 func (t *FunctionType) IsStorable(_ map[*Member]bool) bool {
 	// Functions cannot be stored, as they cannot be serialized
+	return false
+}
+
+func (t *FunctionType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	// Functions cannot be exported, as they cannot be serialized
 	return false
 }
 
@@ -4863,11 +5033,47 @@ func (*CompositeType) IsInvalidType() bool {
 
 func (t *CompositeType) IsStorable(results map[*Member]bool) bool {
 
+	// Only structures, resources, and enums can be stored
+
+	switch t.Kind {
+	case common.CompositeKindStructure,
+		common.CompositeKindResource,
+		common.CompositeKindEnum:
+		break
+	default:
+		return false
+	}
+
 	// If this composite type has a member which is non-storable,
 	// then the composite type is not storable.
 
 	for _, member := range t.Members {
 		if !member.IsStorable(results) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (t *CompositeType) IsExternallyReturnable(results map[*Member]bool) bool {
+
+	// Only structures, resources, and enums can be stored
+
+	switch t.Kind {
+	case common.CompositeKindStructure,
+		common.CompositeKindResource,
+		common.CompositeKindEnum:
+		break
+	default:
+		return false
+	}
+
+	// If this composite type has a member which is not externally returnable,
+	// then the composite type is not externally returnable.
+
+	for _, member := range t.Members {
+		if !member.IsExternallyReturnable(results) {
 			return false
 		}
 	}
@@ -4967,6 +5173,10 @@ func (*AuthAccountType) IsInvalidType() bool {
 }
 
 func (*AuthAccountType) IsStorable(_ map[*Member]bool) bool {
+	return false
+}
+
+func (*AuthAccountType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return false
 }
 
@@ -5506,6 +5716,10 @@ func (*PublicAccountType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
+func (*PublicAccountType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return false
+}
+
 func (*PublicAccountType) IsEquatable() bool {
 	return false
 }
@@ -5624,6 +5838,21 @@ func NewPublicConstantFieldMember(
 
 // IsStorable returns whether a member is a storable field
 func (m *Member) IsStorable(results map[*Member]bool) (result bool) {
+	test := func(t Type) bool {
+		return t.IsStorable(results)
+	}
+	return m.testType(test, results)
+}
+
+// IsExternallyReturnable returns whether a member is externally returnable
+func (m *Member) IsExternallyReturnable(results map[*Member]bool) (result bool) {
+	test := func(t Type) bool {
+		return t.IsExternallyReturnable(results)
+	}
+	return m.testType(test, results)
+}
+
+func (m *Member) testType(test func(Type) bool, results map[*Member]bool) (result bool) {
 
 	// Prevent a potential stack overflow due to cyclic declarations
 	// by keeping track of the result for each member
@@ -5636,9 +5865,8 @@ func (m *Member) IsStorable(results map[*Member]bool) (result bool) {
 		return result
 	}
 
-	// Temporarily assume the member is storable while it's type
-	// is checked for storability. If a recursive call occurs,
-	// the check for an existing result will prevent infinite recursion
+	// Temporarily assume the member passes the test while it's type is tested.
+	// If a recursive call occurs, the check for an existing result will prevent infinite recursion
 
 	results[m] = true
 
@@ -5651,14 +5879,9 @@ func (m *Member) IsStorable(results map[*Member]bool) (result bool) {
 
 		if m.DeclarationKind == common.DeclarationKindField {
 
-			// Fields are not storable
-			// if their type is non-storable
-
 			fieldType := m.TypeAnnotation.Type
 
-			if !fieldType.IsInvalidType() &&
-				!fieldType.IsStorable(results) {
-
+			if !fieldType.IsInvalidType() && !test(fieldType) {
 				return false
 			}
 		}
@@ -5755,6 +5978,24 @@ func (t *InterfaceType) IsStorable(results map[*Member]bool) bool {
 
 	for _, member := range t.Members {
 		if !member.IsStorable(results) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (t *InterfaceType) IsExternallyReturnable(results map[*Member]bool) bool {
+
+	if t.CompositeKind != common.CompositeKindStructure {
+		return false
+	}
+
+	// If this interface type has a member which is not externally returnable,
+	// then the interface type is not externally returnable.
+
+	for _, member := range t.Members {
+		if !member.IsExternallyReturnable(results) {
 			return false
 		}
 	}
@@ -5862,6 +6103,11 @@ func (t *DictionaryType) IsInvalidType() bool {
 func (t *DictionaryType) IsStorable(results map[*Member]bool) bool {
 	return t.KeyType.IsStorable(results) &&
 		t.ValueType.IsStorable(results)
+}
+
+func (t *DictionaryType) IsExternallyReturnable(results map[*Member]bool) bool {
+	return t.KeyType.IsExternallyReturnable(results) &&
+		t.ValueType.IsExternallyReturnable(results)
 }
 
 func (*DictionaryType) IsEquatable() bool {
@@ -6152,6 +6398,10 @@ func (t *ReferenceType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
+func (t *ReferenceType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*ReferenceType) IsEquatable() bool {
 	return true
 }
@@ -6249,6 +6499,10 @@ func (*AddressType) IsInvalidType() bool {
 }
 
 func (*AddressType) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*AddressType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -6996,6 +7250,10 @@ func (*TransactionType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
+func (*TransactionType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return false
+}
+
 func (*TransactionType) IsEquatable() bool {
 	return false
 }
@@ -7172,6 +7430,20 @@ func (t *RestrictedType) IsStorable(results map[*Member]bool) bool {
 	return true
 }
 
+func (t *RestrictedType) IsExternallyReturnable(results map[*Member]bool) bool {
+	if t.Type != nil && !t.Type.IsExternallyReturnable(results) {
+		return false
+	}
+
+	for _, restriction := range t.Restrictions {
+		if !restriction.IsExternallyReturnable(results) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (*RestrictedType) IsEquatable() bool {
 	// TODO:
 	return false
@@ -7283,6 +7555,10 @@ func (*PathType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
+func (*PathType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return true
+}
+
 func (*PathType) IsEquatable() bool {
 	// TODO:
 	return false
@@ -7375,6 +7651,10 @@ func (t *CapabilityType) TypeAnnotationState() TypeAnnotationState {
 }
 
 func (*CapabilityType) IsStorable(_ map[*Member]bool) bool {
+	return true
+}
+
+func (*CapabilityType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -7587,6 +7867,10 @@ func (*StorableType) IsInvalidType() bool {
 
 func (*StorableType) IsStorable(_ map[*Member]bool) bool {
 	return true
+}
+
+func (*StorableType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return false
 }
 
 func (*StorableType) IsEquatable() bool {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -82,9 +82,19 @@ type Type interface {
 
 	// IsStorable returns true if the type is allowed to be a stored,
 	// e.g. in a field of a composite type.
+	//
+	// The check if the type is storable is recursive,
+	// the results parameter prevents cycles:
+	// it is checked at the start of the recursively called function,
+	// and pre-set before a recursive call.
 	IsStorable(results map[*Member]bool) bool
 
 	// IsExternallyReturnable returns true if a value of this type can be exported
+	//
+	// The check if the type is externally returnable is recursive,
+	// the results parameter prevents cycles:
+	// it is checked at the start of the recursively called function,
+	// and pre-set before a recursive call.
 	IsExternallyReturnable(results map[*Member]bool) bool
 
 	// IsEquatable returns true if values of the type can be equated

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -336,6 +336,10 @@ func (*BlockType) IsStorable(_ map[*sema.Member]bool) bool {
 	return false
 }
 
+func (*BlockType) IsExternallyReturnable(_ map[*sema.Member]bool) bool {
+	return false
+}
+
 func (*BlockType) IsEquatable() bool {
 	// TODO:
 	return false

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -48,7 +48,7 @@ func TestCheckStorable(t *testing.T) {
 		}
 	}
 
-	generateNestedTypes := func(ty sema.Type) []sema.Type {
+	generateNestedTypes := func(ty sema.Type, includeCapability bool) []sema.Type {
 
 		// TODO: Restricted
 
@@ -60,8 +60,16 @@ func TestCheckStorable(t *testing.T) {
 				KeyType:   &sema.BoolType{},
 				ValueType: ty,
 			},
-			// TODO: https://github.com/onflow/cadence/pull/172
-			// &sema.CapabilityType{BorrowType: ty},
+		}
+
+		if includeCapability {
+			nestedTypes = append(nestedTypes,
+				&sema.CapabilityType{
+					BorrowType: &sema.ReferenceType{
+						Type: ty,
+					},
+				},
+			)
 		}
 
 		if sema.IsValidDictionaryKeyType(ty) {
@@ -82,15 +90,12 @@ func TestCheckStorable(t *testing.T) {
 		ErrorTypes func(compositeKind common.CompositeKind, isInterface bool) []error
 	}
 
-	testCases := []testCase{}
-
-	// Storable types
+	var testCases []testCase
 
 	storableTypes := append(
 		sema.AllNumberTypes[:],
 		&sema.AddressType{},
 		&sema.PathType{},
-		&sema.CapabilityType{},
 		&sema.StringType{},
 		&sema.BoolType{},
 		&sema.MetaType{},
@@ -103,9 +108,38 @@ func TestCheckStorable(t *testing.T) {
 	for _, storableType := range storableTypes {
 		storableTypes = append(
 			storableTypes,
-			generateNestedTypes(storableType)...,
+			generateNestedTypes(storableType, true)...,
 		)
 	}
+
+	nonStorableTypes := []sema.Type{
+		&sema.FunctionType{
+			ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+		},
+		&sema.NeverType{},
+		&sema.VoidType{},
+		&sema.AuthAccountType{},
+		&sema.PublicAccountType{},
+	}
+
+	// Capabilities of non-storable types are storable
+
+	for _, nonStorableType := range nonStorableTypes {
+		storableTypes = append(
+			storableTypes,
+			&sema.CapabilityType{
+				BorrowType: &sema.ReferenceType{
+					Type: nonStorableType,
+				},
+			},
+		)
+	}
+
+	nonStorableTypes = append(nonStorableTypes,
+		&sema.ReferenceType{
+			Type: &sema.BoolType{},
+		},
+	)
 
 	for _, storableType := range storableTypes {
 		testCases = append(testCases,
@@ -136,23 +170,10 @@ func TestCheckStorable(t *testing.T) {
 		},
 	)
 
-	// Non-storable types
-
-	nonStorableTypes := []sema.Type{
-		&sema.FunctionType{
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
-		},
-		&sema.NeverType{},
-		&sema.VoidType{},
-		&sema.AuthAccountType{},
-		&sema.PublicAccountType{},
-		&sema.ReferenceType{Type: &sema.BoolType{}},
-	}
-
 	for _, nonStorableType := range nonStorableTypes[:] {
 		nonStorableTypes = append(
 			nonStorableTypes,
-			generateNestedTypes(nonStorableType)...,
+			generateNestedTypes(nonStorableType, false)...,
 		)
 	}
 
@@ -160,10 +181,14 @@ func TestCheckStorable(t *testing.T) {
 		testCases = append(testCases,
 			testCase{
 				Type: nonStorableType,
-				ErrorTypes: func(_ common.CompositeKind, _ bool) []error {
-					return []error{
-						&sema.FieldTypeNotStorableError{},
+				ErrorTypes: func(kind common.CompositeKind, _ bool) []error {
+					if kind == common.CompositeKindContract {
+						return []error{
+							&sema.FieldTypeNotStorableError{},
+						}
 					}
+
+					return nil
 				},
 			},
 		)

--- a/runtime/tests/checker/transactions_test.go
+++ b/runtime/tests/checker/transactions_test.go
@@ -332,6 +332,21 @@ func TestCheckTransactions(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("InvalidNonStorableParameter", func(t *testing.T) {
+		test(t,
+			`
+		      transaction(x: ((Int): Int)) {
+				execute {
+				  x(0)
+				}
+			  }
+		    `,
+			[]error{
+				&sema.InvalidNonStorableTransactionParameterTypeError{},
+			},
+		)
+	})
 }
 
 func TestCheckTransactionExecuteScope(t *testing.T) {

--- a/values.go
+++ b/values.go
@@ -984,32 +984,6 @@ func (v Link) ToGoValue() interface{} {
 	return nil
 }
 
-// StorageReference
-
-type StorageReference struct {
-	Authorized           bool
-	TargetStorageAddress Address
-	TargetKey            string
-}
-
-func NewStorageReference(authorized bool, targetStorageAddress Address, targetKey string) StorageReference {
-	return StorageReference{
-		Authorized:           authorized,
-		TargetStorageAddress: targetStorageAddress,
-		TargetKey:            targetKey,
-	}
-}
-
-func (StorageReference) isValue() {}
-
-func (v StorageReference) Type() Type {
-	return nil
-}
-
-func (v StorageReference) ToGoValue() interface{} {
-	return nil
-}
-
 // Path
 
 type Path struct {


### PR DESCRIPTION
Closes #358

- Check that transaction parameters are storable statically, instead of only at run-time (when the transaction is executed)
- Check that script return types are exportable. Allow references to be exported. Dereference if possible, and handle potential cycles