### PR TITLE
Refactor types

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -45,8 +45,6 @@ func exportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.AnyResourceType{}
 		case *sema.VoidType:
 			return cadence.VoidType{}
-		case *sema.NeverType:
-			return cadence.NeverType{}
 		case *sema.MetaType:
 			return cadence.MetaType{}
 		case *sema.OptionalType:
@@ -142,6 +140,8 @@ func exportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 		switch t {
 		case sema.PathType:
 			return cadence.PathType{}
+		case sema.NeverType:
+			return cadence.NeverType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -43,8 +43,6 @@ func exportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.AnyStructType{}
 		case *sema.AnyResourceType:
 			return cadence.AnyResourceType{}
-		case *sema.VoidType:
-			return cadence.VoidType{}
 		case *sema.MetaType:
 			return cadence.MetaType{}
 		case *sema.OptionalType:
@@ -142,6 +140,8 @@ func exportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.PathType{}
 		case sema.NeverType:
 			return cadence.NeverType{}
+		case sema.VoidType:
+			return cadence.VoidType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -129,8 +129,6 @@ func exportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return exportRestrictedType(t, results)
 		case *stdlib.BlockType:
 			return cadence.BlockType{}
-		case *sema.PathType:
-			return cadence.PathType{}
 		case *sema.CheckedFunctionType:
 			return exportFunctionType(t.FunctionType, results)
 		case *sema.CapabilityType:
@@ -139,6 +137,11 @@ func exportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.AuthAccountType{}
 		case *sema.PublicAccountType:
 			return cadence.PublicAccountType{}
+		}
+
+		switch t {
+		case sema.PathType:
+			return cadence.PathType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -58,7 +58,7 @@ type ExpressionStatementResult struct {
 
 var emptyFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: &sema.TypeAnnotation{
-		Type: &sema.VoidType{},
+		Type: sema.VoidType,
 	},
 }
 
@@ -1017,7 +1017,7 @@ func (interpreter *Interpreter) visitFunctionBody(
 			// If there is a return type, declare the constant `result`
 			// which has the return value
 
-			if _, isVoid := returnType.(*sema.VoidType); !isVoid {
+			if returnType != sema.VoidType {
 				interpreter.declareVariable(sema.ResultIdentifier, resultValue)
 			}
 
@@ -3094,7 +3094,7 @@ func (interpreter *Interpreter) initializerFunctionWrapper(
 
 	return interpreter.functionConditionsWrapper(
 		firstInitializer.FunctionDeclaration,
-		&sema.VoidType{},
+		sema.VoidType,
 		lexicalScope,
 	)
 }
@@ -3111,7 +3111,7 @@ func (interpreter *Interpreter) destructorFunctionWrapper(
 
 	return interpreter.functionConditionsWrapper(
 		destructor.FunctionDeclaration,
-		&sema.VoidType{},
+		sema.VoidType,
 		lexicalScope,
 	)
 }
@@ -3447,7 +3447,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 						preConditions,
 						executeTrampoline,
 						postConditionsRewrite.RewrittenPostConditions,
-						&sema.VoidType{},
+						sema.VoidType,
 					)
 				})
 		})
@@ -3704,13 +3704,11 @@ func IsSubType(subType DynamicType, superType sema.Type) bool {
 		}
 
 	case VoidDynamicType:
-		switch superType.(type) {
-		case *sema.VoidType, *sema.AnyStructType:
+		if _, ok := superType.(*sema.AnyStructType); ok {
 			return true
-
-		default:
-			return false
 		}
+
+		return superType == sema.VoidType
 
 	case StringDynamicType:
 		switch superType.(type) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3863,13 +3863,11 @@ func IsSubType(subType DynamicType, superType sema.Type) bool {
 		}
 
 	case PathDynamicType:
-		switch superType.(type) {
-		case *sema.PathType, *sema.AnyStructType:
+		if _, ok := superType.(*sema.AnyStructType); ok {
 			return true
-
-		default:
-			return false
 		}
+
+		return superType == sema.PathType
 
 	case PublicAccountDynamicType:
 		switch superType.(type) {

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -81,7 +81,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		// NOTE:
 		value := inter.boxOptional(
 			NilValue{},
-			&sema.OptionalType{Type: &sema.NeverType{}},
+			&sema.OptionalType{Type: sema.NeverType},
 			&sema.OptionalType{Type: &sema.OptionalType{Type: &sema.BoolType{}}},
 		)
 		assert.Equal(t,
@@ -94,7 +94,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		// NOTE:
 		value := inter.boxOptional(
 			NewSomeValueOwningNonCopying(NilValue{}),
-			&sema.OptionalType{Type: &sema.OptionalType{Type: &sema.NeverType{}}},
+			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.NeverType}},
 			&sema.OptionalType{Type: &sema.OptionalType{Type: &sema.BoolType{}}},
 		)
 		assert.Equal(t,

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -146,7 +146,7 @@ func (PrimitiveStaticType) isStaticType() {}
 func (i PrimitiveStaticType) SemaType() sema.Type {
 	switch i {
 	case PrimitiveStaticTypeVoid:
-		return &sema.VoidType{}
+		return sema.VoidType
 
 	case PrimitiveStaticTypeAny:
 		return &sema.AnyType{}
@@ -260,9 +260,6 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 //
 func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	switch t.(type) {
-	case *sema.VoidType:
-		return PrimitiveStaticTypeVoid
-
 	case *sema.AnyType:
 		return PrimitiveStaticTypeAny
 
@@ -365,6 +362,8 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 		return PrimitiveStaticTypePath
 	case sema.NeverType:
 		return PrimitiveStaticTypeNever
+	case sema.VoidType:
+		return PrimitiveStaticTypeVoid
 	}
 
 	return PrimitiveStaticTypeUnknown

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -152,7 +152,7 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return &sema.AnyType{}
 
 	case PrimitiveStaticTypeNever:
-		return &sema.NeverType{}
+		return sema.NeverType
 
 	case PrimitiveStaticTypeAnyStruct:
 		return &sema.AnyStructType{}
@@ -266,9 +266,6 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	case *sema.AnyType:
 		return PrimitiveStaticTypeAny
 
-	case *sema.NeverType:
-		return PrimitiveStaticTypeNever
-
 	case *sema.AnyStructType:
 		return PrimitiveStaticTypeAnyStruct
 
@@ -366,6 +363,8 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	switch t {
 	case sema.PathType:
 		return PrimitiveStaticTypePath
+	case sema.NeverType:
+		return PrimitiveStaticTypeNever
 	}
 
 	return PrimitiveStaticTypeUnknown

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -245,7 +245,7 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 	// Storage
 
 	case PrimitiveStaticTypePath:
-		return &sema.PathType{}
+		return sema.PathType
 	case PrimitiveStaticTypeCapability:
 		return &sema.CapabilityType{}
 
@@ -359,12 +359,14 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 
 	// Storage
 
-	case *sema.PathType:
-		return PrimitiveStaticTypePath
 	case *sema.CapabilityType:
 		return PrimitiveStaticTypeCapability
-
-	default:
-		return PrimitiveStaticTypeUnknown
 	}
+
+	switch t {
+	case sema.PathType:
+		return PrimitiveStaticTypePath
+	}
+
+	return PrimitiveStaticTypeUnknown
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -157,11 +157,9 @@ func (r *interpreterRuntime) ExecuteScript(
 	// Ensure the entry point's parameter types are storable
 	if len(epFunctionType.Parameters) > 0 {
 		for _, param := range epFunctionType.Parameters {
-			if _, isVoid := param.TypeAnnotation.Type.(*sema.VoidType); !isVoid {
-				if !param.TypeAnnotation.Type.IsStorable(map[*sema.Member]bool{}) {
-					return nil, &ScriptParameterTypeNotStorableError{
-						Type: param.TypeAnnotation.Type,
-					}
+			if !param.TypeAnnotation.Type.IsStorable(map[*sema.Member]bool{}) {
+				return nil, &ScriptParameterTypeNotStorableError{
+					Type: param.TypeAnnotation.Type,
 				}
 			}
 		}

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -56,7 +56,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) as
 	checker.Elaboration.ArrayExpressionArgumentTypes[expression] = argumentTypes
 
 	if elementType == nil {
-		elementType = &NeverType{}
+		elementType = NeverType
 	}
 
 	checker.Elaboration.ArrayExpressionElementType[expression] = elementType

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -164,7 +164,7 @@ func (checker *Checker) visitAssignmentValueType(
 			},
 		)
 
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	switch target := targetExpression.(type) {
@@ -192,7 +192,7 @@ func (checker *Checker) visitIdentifierExpressionAssignment(
 	// check identifier was declared before
 	variable := checker.findAndCheckValueVariable(target.Identifier, true)
 	if variable == nil {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	// check identifier is not a constant
@@ -231,7 +231,7 @@ func (checker *Checker) visitIndexExpressionAssignment(
 	elementType = checker.visitIndexExpression(target, true)
 
 	if elementType == nil {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	if !valueType.IsInvalidType() &&
@@ -259,7 +259,7 @@ func (checker *Checker) visitMemberExpressionAssignment(
 	_, member, isOptional := checker.visitMember(target)
 
 	if member == nil {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	if isOptional {

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -334,7 +334,7 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 	}
 
 	if leftIsInvalid || !leftIsOptional {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	leftInner := leftOptional.Type

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -339,7 +339,7 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 
 	leftInner := leftOptional.Type
 
-	if _, ok := leftInner.(*NeverType); ok {
+	if leftInner == NeverType {
 		return rightType
 	}
 	canNarrow := false

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -853,7 +853,7 @@ func (checker *Checker) enumRawType(declaration *ast.CompositeDeclaration) Type 
 			},
 		)
 
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	// Enums may not conform to interfaces,
@@ -934,11 +934,11 @@ func (checker *Checker) checkCompositeConformance(
 
 		initializerType := &FunctionType{
 			Parameters:           compositeType.ConstructorParameters,
-			ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+			ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 		}
 		interfaceInitializerType := &FunctionType{
 			Parameters:           interfaceType.InitializerParameters,
-			ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+			ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 		}
 
 		// TODO: subtype?
@@ -1251,7 +1251,7 @@ func (checker *Checker) compositeConstructorType(
 			&SpecialFunctionType{
 				FunctionType: &FunctionType{
 					Parameters:           constructorFunctionType.Parameters,
-					ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+					ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 				},
 			}
 	}
@@ -1638,7 +1638,7 @@ func (checker *Checker) checkSpecialFunction(
 
 	functionType := &FunctionType{
 		Parameters:           parameters,
-		ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 	}
 
 	checker.checkFunction(

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -83,11 +83,11 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 	}
 
 	if keyType == nil {
-		keyType = &NeverType{}
+		keyType = NeverType
 	}
 
 	if valueType == nil {
-		valueType = &NeverType{}
+		valueType = NeverType
 	}
 
 	if !IsValidDictionaryKeyType(keyType) {
@@ -113,11 +113,14 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 func IsValidDictionaryKeyType(keyType Type) bool {
 	// TODO: implement support for more built-in types here and in interpreter
 	switch keyType := keyType.(type) {
-	case *NeverType, *StringType, *BoolType, *CharacterType, *AddressType:
+	case *StringType, *BoolType, *CharacterType, *AddressType:
 		return true
 	case *CompositeType:
 		return keyType.Kind == common.CompositeKindEnum
 	default:
+		if keyType == NeverType {
+			return true
+		}
 		return IsSubType(keyType, &NumberType{})
 	}
 }

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -27,7 +27,7 @@ func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpr
 	identifier := expression.Identifier
 	variable := checker.findAndCheckValueVariable(identifier, true)
 	if variable == nil {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	valueType := variable.Type
@@ -218,7 +218,7 @@ func (checker *Checker) visitIndexExpression(
 	// by getting the expected element
 
 	if targetType.IsInvalidType() {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	// Check if the type instance is actually indexable. For most types (e.g. arrays and dictionaries)
@@ -235,7 +235,7 @@ func (checker *Checker) visitIndexExpression(
 			},
 		)
 
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	elementType := checker.visitValueIndexingExpression(

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -174,7 +174,7 @@ func (checker *Checker) VisitBoolExpression(_ *ast.BoolExpression) ast.Repr {
 func (checker *Checker) VisitNilExpression(_ *ast.NilExpression) ast.Repr {
 	// TODO: verify
 	return &OptionalType{
-		Type: &NeverType{},
+		Type: NeverType,
 	}
 }
 

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -31,7 +31,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr 
 	valueExpression := statement.Value
 	valueType := valueExpression.Accept(checker).(Type)
 
-	var elementType Type = &InvalidType{}
+	var elementType Type = InvalidType
 
 	if !valueType.IsInvalidType() {
 

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -179,7 +179,8 @@ func (checker *Checker) checkFunction(
 // The return is not needed if the function has a `Void` return type.
 //
 func (checker *Checker) checkFunctionExits(functionBlock *ast.FunctionBlock, returnType Type) {
-	if _, returnTypeIsVoid := returnType.(*VoidType); returnTypeIsVoid {
+
+	if returnType == VoidType {
 		return
 	}
 
@@ -319,7 +320,7 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 
 	// If there is a return type, declare the constant `result` which has the return type
 
-	if _, ok := returnType.(*VoidType); !ok {
+	if returnType != VoidType {
 		checker.declareResult(returnType)
 	}
 

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -282,7 +282,7 @@ func (checker *Checker) handleMissingImports(missing []ast.Identifier, available
 
 		_, err := checker.valueActivations.Declare(variableDeclaration{
 			identifier:               identifier.Identifier,
-			ty:                       &InvalidType{},
+			ty:                       InvalidType,
 			access:                   access,
 			kind:                     common.DeclarationKindValue,
 			pos:                      identifier.Pos,
@@ -294,7 +294,7 @@ func (checker *Checker) handleMissingImports(missing []ast.Identifier, available
 		// NOTE: declare type with invalid type to silence rest of program
 		_, err = checker.typeActivations.DeclareType(typeDeclaration{
 			identifier:               identifier,
-			ty:                       &InvalidType{},
+			ty:                       InvalidType,
 			declarationKind:          common.DeclarationKindType,
 			access:                   access,
 			allowOuterScopeShadowing: false,

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -138,7 +138,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 
 	// Update the return info for invocations that do not return (i.e. have a `Never` return type)
 
-	if _, ok = returnType.(*NeverType); ok {
+	if returnType == NeverType {
 		functionActivation := checker.functionActivations.Current()
 		functionActivation.ReturnInfo.DefinitelyHalted = true
 	}

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -36,7 +36,7 @@ func (checker *Checker) VisitInvocationExpression(invocationExpression *ast.Invo
 				Range: ast.NewRangeFromPositioned(invocationExpression),
 			},
 		)
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	return ty
@@ -79,7 +79,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 				},
 			)
 		}
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	// The invoked expression has a function type,
@@ -425,7 +425,7 @@ func (checker *Checker) checkInvocation(
 	returnType = functionType.ReturnTypeAnnotation.Type.Resolve(typeArguments)
 	if returnType == nil {
 		// TODO: report error? does `checkTypeParameterInference` below already do that?
-		returnType = &InvalidType{}
+		returnType = InvalidType
 	}
 
 	// Check all type parameters have been bound to a type.
@@ -500,7 +500,7 @@ func (checker *Checker) checkInvocationRequiredArgument(
 	if parameterType.Unify(argumentType, typeParameters, checker.report, argumentRange) {
 		parameterType = parameterType.Resolve(typeParameters)
 		if parameterType == nil {
-			parameterType = &InvalidType{}
+			parameterType = InvalidType
 		}
 	}
 

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -45,7 +45,7 @@ func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) 
 	}
 
 	if member == nil {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	accessedSelfMember := checker.accessedSelfMember(expression)

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -106,7 +106,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 	}
 
 	if referenceType == nil {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	return referenceType

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -38,7 +38,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast
 		// and the enclosing function's return type is non-Void,
 		// then the return statement is missing an expression
 
-		if _, ok := returnType.(*VoidType); !ok {
+		if returnType != VoidType {
 			checker.report(
 				&MissingReturnValueError{
 					ExpectedValueType: returnType,
@@ -61,7 +61,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast
 	// If the enclosing function's return type is Void,
 	// then the return statement should not have a return value
 
-	if _, ok := returnType.(*VoidType); ok {
+	if returnType == VoidType {
 		checker.report(
 			&InvalidReturnValueError{
 				Range: ast.NewRangeFromPositioned(statement.Expression),

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -64,7 +64,7 @@ func (checker *Checker) VisitTransactionDeclaration(declaration *ast.Transaction
 
 	checker.visitWithPostConditions(
 		declaration.PostConditions,
-		&VoidType{},
+		VoidType,
 		func() {
 			checker.withSelfResourceInvalidationAllowed(func() {
 				checker.visitTransactionExecuteFunction(declaration.Execute, transactionType)

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -557,7 +557,7 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 		// If the target type is `Never`, the checks below will be performed
 		// (as `Never` is the subtype of all types), but the checks are not valid
 
-		if IsSubType(unwrappedTargetType, &NeverType{}) {
+		if IsSubType(unwrappedTargetType, NeverType) {
 			break
 		}
 
@@ -578,7 +578,7 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 		// If the target type is `Never`, the checks below will be performed
 		// (as `Never` is the subtype of all types), but the checks are not valid
 
-		if IsSubType(unwrappedTargetType, &NeverType{}) {
+		if IsSubType(unwrappedTargetType, NeverType) {
 			break
 		}
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -212,7 +212,7 @@ func NewChecker(program *ast.Program, location ast.Location, options ...Option) 
 
 	functionActivations := &FunctionActivations{}
 	functionActivations.EnterFunction(&FunctionType{
-		ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{})},
+		ReturnTypeAnnotation: NewTypeAnnotation(VoidType)},
 		0,
 	)
 
@@ -898,7 +898,7 @@ func (checker *Checker) ConvertType(t ast.Type) Type {
 
 	case nil:
 		// The AST might contain "holes" if parsing failed
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	panic(&astTypeConversionError{invalidASTType: t})
@@ -1017,7 +1017,7 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 			// If no restricted type is given, and also no restrictions,
 			// the type is ambiguous.
 
-			restrictedType = &InvalidType{}
+			restrictedType = InvalidType
 
 			checker.report(
 				&AmbiguousRestrictedTypeError{
@@ -1243,7 +1243,7 @@ func (checker *Checker) findAndCheckTypeVariable(identifier ast.Identifier, reco
 func (checker *Checker) convertNominalType(t *ast.NominalType) Type {
 	variable := checker.findAndCheckTypeVariable(t.Identifier, true)
 	if variable == nil {
-		return &InvalidType{}
+		return InvalidType
 	}
 
 	ty := variable.Type
@@ -1267,7 +1267,7 @@ func (checker *Checker) convertNominalType(t *ast.NominalType) Type {
 				)
 			}
 
-			return &InvalidType{}
+			return InvalidType
 		}
 
 		resolvedIdentifiers = append(resolvedIdentifiers, identifier)
@@ -1284,7 +1284,7 @@ func (checker *Checker) convertNominalType(t *ast.NominalType) Type {
 					Pos:          t.StartPosition(),
 				},
 			)
-			return &InvalidType{}
+			return InvalidType
 		}
 	}
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -800,7 +800,7 @@ type InvalidReturnValueError struct {
 func (e *InvalidReturnValueError) Error() string {
 	return fmt.Sprintf(
 		"invalid return with value from function with `%s` return type",
-		&VoidType{},
+		VoidType,
 	)
 }
 

--- a/runtime/sema/invalid_type.go
+++ b/runtime/sema/invalid_type.go
@@ -18,37 +18,18 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-)
-
-func (checker *Checker) VisitDestroyExpression(expression *ast.DestroyExpression) (resultType ast.Repr) {
-	resultType = VoidType
-
-	valueType := expression.Expression.Accept(checker).(Type)
-
-	checker.recordResourceInvalidation(
-		expression.Expression,
-		valueType,
-		ResourceInvalidationKindDestroy,
-	)
-
-	// The destruction of any resource type (even compound resource types)
-
-	if valueType.IsInvalidType() {
-		return
-	}
-
-	if !valueType.IsResourceType() {
-
-		checker.report(
-			&InvalidDestructionError{
-				Range: ast.NewRangeFromPositioned(expression.Expression),
-			},
-		)
-
-		return
-	}
-
-	return
+// InvalidType represents a type that is invalid.
+// It is the result of type checking failing and
+// can't be expressed in programs.
+//
+var InvalidType = &NominalType{
+	Name:                 "<<invalid>>",
+	QualifiedName:        "<<invalid>>",
+	TypeID:               "<<invalid>>",
+	IsInvalid:            true,
+	IsResource:           false,
+	Storable:             false,
+	Equatable:            false,
+	ExternallyReturnable: false,
+	IsSuperTypeOf:        nil,
 }

--- a/runtime/sema/never_type.go
+++ b/runtime/sema/never_type.go
@@ -1,0 +1,14 @@
+package sema
+
+// NeverType represents the bottom type
+var NeverType = &NominalType{
+	Name:                 "Never",
+	QualifiedName:        "Never",
+	TypeID:               "Never",
+	IsInvalid:            false,
+	IsResource:           false,
+	Storable:             false,
+	Equatable:            false,
+	ExternallyReturnable: false,
+	IsSuperTypeOf:        nil,
+}

--- a/runtime/sema/never_type.go
+++ b/runtime/sema/never_type.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sema
 
 // NeverType represents the bottom type

--- a/runtime/sema/nominal_type.go
+++ b/runtime/sema/nominal_type.go
@@ -26,6 +26,7 @@ type NominalType struct {
 	Name                 string
 	QualifiedName        string
 	TypeID               TypeID
+	IsInvalid            bool
 	IsResource           bool
 	Storable             bool
 	Equatable            bool
@@ -56,8 +57,8 @@ func (t *NominalType) IsResourceType() bool {
 	return t.IsResource
 }
 
-func (*NominalType) IsInvalidType() bool {
-	return false
+func (t *NominalType) IsInvalidType() bool {
+	return t.IsInvalid
 }
 
 func (t *NominalType) IsStorable(_ map[*Member]bool) bool {

--- a/runtime/sema/nominal_type.go
+++ b/runtime/sema/nominal_type.go
@@ -1,0 +1,93 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import "github.com/onflow/cadence/runtime/ast"
+
+// NominalType represents a simple nominal type.
+//
+type NominalType struct {
+	Name                 string
+	QualifiedName        string
+	TypeID               TypeID
+	IsResource           bool
+	Storable             bool
+	Equatable            bool
+	ExternallyReturnable bool
+	IsSuperTypeOf        func(subType Type) bool
+}
+
+func (*NominalType) IsType() {}
+
+func (t *NominalType) String() string {
+	return t.Name
+}
+
+func (t *NominalType) QualifiedString() string {
+	return t.Name
+}
+
+func (t *NominalType) ID() TypeID {
+	return t.TypeID
+}
+
+func (t *NominalType) Equal(other Type) bool {
+	otherType, ok := other.(*NominalType)
+	return ok && otherType == t
+}
+
+func (t *NominalType) IsResourceType() bool {
+	return t.IsResource
+}
+
+func (*NominalType) IsInvalidType() bool {
+	return false
+}
+
+func (t *NominalType) IsStorable(_ map[*Member]bool) bool {
+	return t.Storable
+}
+
+func (t *NominalType) IsEquatable() bool {
+	return t.Equatable
+}
+
+func (t *NominalType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return t.ExternallyReturnable
+}
+
+func (*NominalType) TypeAnnotationState() TypeAnnotationState {
+	return TypeAnnotationStateValid
+}
+
+func (t *NominalType) RewriteWithRestrictedTypes() (Type, bool) {
+	return t, false
+}
+
+func (*NominalType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {
+	return false
+}
+
+func (t *NominalType) Resolve(_ map[*TypeParameter]Type) Type {
+	return t
+}
+
+func (t *NominalType) GetMembers() map[string]MemberResolver {
+	return withBuiltinMembers(t, nil)
+}

--- a/runtime/sema/path_type.go
+++ b/runtime/sema/path_type.go
@@ -24,6 +24,7 @@ var PathType = &NominalType{
 	Name:          "Path",
 	QualifiedName: "Path",
 	TypeID:        "Path",
+	IsInvalid:     false,
 	IsResource:    false,
 	Storable:      true,
 	// TODO: implement support for equating paths in the future

--- a/runtime/sema/path_type.go
+++ b/runtime/sema/path_type.go
@@ -18,25 +18,16 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
-)
+// PathType
 
-func (checker *Checker) VisitPathExpression(expression *ast.PathExpression) ast.Repr {
-
-	// Check that the domain is valid
-
-	domain := expression.Domain
-
-	if _, ok := common.AllPathDomainsByIdentifier[domain.Identifier]; !ok {
-		checker.report(
-			&InvalidPathDomainError{
-				ActualDomain: domain.Identifier,
-				Range:        ast.NewRangeFromPositioned(domain),
-			},
-		)
-	}
-
-	return PathType
+var PathType = &NominalType{
+	Name:          "Path",
+	QualifiedName: "Path",
+	TypeID:        "Path",
+	IsResource:    false,
+	Storable:      true,
+	// TODO: implement support for equating paths in the future
+	Equatable:            false,
+	ExternallyReturnable: true,
+	IsSuperTypeOf:        nil,
 }

--- a/runtime/sema/storable_type.go
+++ b/runtime/sema/storable_type.go
@@ -28,6 +28,7 @@ var StorableType = &NominalType{
 	Name:          "Storable",
 	QualifiedName: "Storable",
 	TypeID:        "Storable",
+	IsInvalid:     false,
 	// NOTE: Subtypes may be either resource types or not.
 	//
 	// Returning false here is safe, because this type is

--- a/runtime/sema/storable_type.go
+++ b/runtime/sema/storable_type.go
@@ -1,0 +1,45 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+// StorableType is the supertype of all types which are storable.
+//
+// It is only used as e.g. a type bound, but is not accessible
+// to user programs, i.e. can't be used in type annotations
+// for e.g. parameters, return types, fields, etc.
+//
+var StorableType = &NominalType{
+	Name:          "Storable",
+	QualifiedName: "Storable",
+	TypeID:        "Storable",
+	// NOTE: Subtypes may be either resource types or not.
+	//
+	// Returning false here is safe, because this type is
+	// only used as e.g. a type bound, but is not accessible
+	// to user programs, i.e. can't be used in type annotations
+	// for e.g. parameters, return types, fields, etc.
+	IsResource:           false,
+	Storable:             true,
+	Equatable:            false,
+	ExternallyReturnable: false,
+	IsSuperTypeOf: func(subType Type) bool {
+		storableResults := map[*Member]bool{}
+		return subType.IsStorable(storableResults)
+	},
+}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -649,133 +649,6 @@ func (t *AnyResourceType) GetMembers() map[string]MemberResolver {
 	return withBuiltinMembers(t, nil)
 }
 
-// VoidType represents the void type
-type VoidType struct{}
-
-func (*VoidType) IsType() {}
-
-func (*VoidType) String() string {
-	return "Void"
-}
-
-func (*VoidType) QualifiedString() string {
-	return "Void"
-}
-
-func (*VoidType) ID() TypeID {
-	return "Void"
-}
-
-func (*VoidType) Equal(other Type) bool {
-	_, ok := other.(*VoidType)
-	return ok
-}
-
-func (*VoidType) IsResourceType() bool {
-	return false
-}
-
-func (*VoidType) IsInvalidType() bool {
-	return false
-}
-
-func (*VoidType) IsStorable(_ map[*Member]bool) bool {
-	return false
-}
-
-func (*VoidType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*VoidType) IsEquatable() bool {
-	return false
-}
-
-func (*VoidType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *VoidType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*VoidType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *VoidType) Resolve(_ map[*TypeParameter]Type) Type {
-	return t
-}
-
-func (t *VoidType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// InvalidType represents a type that is invalid.
-// It is the result of type checking failing and
-// can't be expressed in programs.
-//
-type InvalidType struct{}
-
-func (*InvalidType) IsType() {}
-
-func (*InvalidType) String() string {
-	return "<<invalid>>"
-}
-
-func (*InvalidType) QualifiedString() string {
-	return "<<invalid>>"
-}
-
-func (*InvalidType) ID() TypeID {
-	return "<<invalid>>"
-}
-
-func (*InvalidType) Equal(other Type) bool {
-	_, ok := other.(*InvalidType)
-	return ok
-}
-
-func (*InvalidType) IsResourceType() bool {
-	return false
-}
-
-func (*InvalidType) IsInvalidType() bool {
-	return true
-}
-
-func (*InvalidType) IsStorable(_ map[*Member]bool) bool {
-	return false
-}
-
-func (*InvalidType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return false
-}
-
-func (*InvalidType) IsEquatable() bool {
-	return false
-}
-
-func (*InvalidType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *InvalidType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*InvalidType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *InvalidType) Resolve(_ map[*TypeParameter]Type) Type {
-	return t
-}
-
-func (t *InvalidType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
 // OptionalType represents the optional variant of another type
 type OptionalType struct {
 	Type Type
@@ -3485,7 +3358,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 							},
 						},
 						ReturnTypeAnnotation: NewTypeAnnotation(
-							&VoidType{},
+							VoidType,
 						),
 					},
 					arrayTypeAppendFunctionDocString,
@@ -3553,7 +3426,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 							},
 						},
 						ReturnTypeAnnotation: NewTypeAnnotation(
-							&VoidType{},
+							VoidType,
 						),
 					},
 					arrayTypeInsertFunctionDocString,
@@ -4497,12 +4370,12 @@ var baseTypes map[string]Type
 func init() {
 
 	baseTypes = map[string]Type{
-		"": &VoidType{},
+		"": VoidType,
 	}
 
 	otherTypes := []Type{
 		&MetaType{},
-		&VoidType{},
+		VoidType,
 		&AnyStructType{},
 		&AnyResourceType{},
 		NeverType,
@@ -5153,7 +5026,7 @@ var authAccountTypeAddPublicKeyFunctionType = &FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&VoidType{},
+		VoidType,
 	),
 }
 
@@ -5172,7 +5045,7 @@ var authAccountTypeRemovePublicKeyFunctionType = &FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&VoidType{},
+		VoidType,
 	),
 }
 
@@ -5207,7 +5080,7 @@ var authAccountTypeSaveFunctionType = func() *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(PathType),
 			},
 		},
-		ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 	}
 }()
 
@@ -5405,7 +5278,7 @@ var authAccountTypeUnlinkFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(PathType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+	ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 }
 
 const authAccountTypeUnlinkFunctionDocString = `
@@ -7147,7 +7020,7 @@ type TransactionType struct {
 func (t *TransactionType) EntryPointFunctionType() *FunctionType {
 	return &FunctionType{
 		Parameters:           append(t.Parameters, t.PrepareParameters...),
-		ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 	}
 }
 
@@ -7155,7 +7028,7 @@ func (t *TransactionType) PrepareFunctionType() *SpecialFunctionType {
 	return &SpecialFunctionType{
 		FunctionType: &FunctionType{
 			Parameters:           t.PrepareParameters,
-			ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+			ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 		},
 	}
 }
@@ -7164,7 +7037,7 @@ func (*TransactionType) ExecuteFunctionType() *SpecialFunctionType {
 	return &SpecialFunctionType{
 		FunctionType: &FunctionType{
 			Parameters:           []*Parameter{},
-			ReturnTypeAnnotation: NewTypeAnnotation(&VoidType{}),
+			ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
 		},
 	}
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -649,68 +649,6 @@ func (t *AnyResourceType) GetMembers() map[string]MemberResolver {
 	return withBuiltinMembers(t, nil)
 }
 
-// NeverType represents the bottom type
-type NeverType struct{}
-
-func (*NeverType) IsType() {}
-
-func (*NeverType) String() string {
-	return "Never"
-}
-
-func (*NeverType) QualifiedString() string {
-	return "Never"
-}
-
-func (*NeverType) ID() TypeID {
-	return "Never"
-}
-
-func (*NeverType) Equal(other Type) bool {
-	_, ok := other.(*NeverType)
-	return ok
-}
-
-func (*NeverType) IsResourceType() bool {
-	return false
-}
-
-func (*NeverType) IsInvalidType() bool {
-	return false
-}
-
-func (*NeverType) IsStorable(_ map[*Member]bool) bool {
-	return false
-}
-
-func (*NeverType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return false
-}
-
-func (*NeverType) IsEquatable() bool {
-	return false
-}
-
-func (*NeverType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *NeverType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*NeverType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *NeverType) Resolve(_ map[*TypeParameter]Type) Type {
-	return t
-}
-
-func (t *NeverType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
 // VoidType represents the void type
 type VoidType struct{}
 
@@ -4567,7 +4505,7 @@ func init() {
 		&VoidType{},
 		&AnyStructType{},
 		&AnyResourceType{},
-		&NeverType{},
+		NeverType,
 		&BoolType{},
 		&CharacterType{},
 		&StringType{},
@@ -6587,7 +6525,7 @@ func IsSubType(subType Type, superType Type) bool {
 		return true
 	}
 
-	if _, ok := subType.(*NeverType); ok {
+	if subType == NeverType {
 		return true
 	}
 
@@ -7128,6 +7066,9 @@ func IsSubType(subType Type, superType Type) bool {
 		}
 
 	case *NominalType:
+		if typedSuperType.IsSuperTypeOf == nil {
+			return false
+		}
 		return typedSuperType.IsSuperTypeOf(subType)
 	}
 
@@ -7189,7 +7130,7 @@ func IsNilType(ty Type) bool {
 		return false
 	}
 
-	if _, ok := optionalType.Type.(*NeverType); !ok {
+	if optionalType.Type != NeverType {
 		return false
 	}
 

--- a/runtime/sema/void_type.go
+++ b/runtime/sema/void_type.go
@@ -18,37 +18,16 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-)
-
-func (checker *Checker) VisitDestroyExpression(expression *ast.DestroyExpression) (resultType ast.Repr) {
-	resultType = VoidType
-
-	valueType := expression.Expression.Accept(checker).(Type)
-
-	checker.recordResourceInvalidation(
-		expression.Expression,
-		valueType,
-		ResourceInvalidationKindDestroy,
-	)
-
-	// The destruction of any resource type (even compound resource types)
-
-	if valueType.IsInvalidType() {
-		return
-	}
-
-	if !valueType.IsResourceType() {
-
-		checker.report(
-			&InvalidDestructionError{
-				Range: ast.NewRangeFromPositioned(expression.Expression),
-			},
-		)
-
-		return
-	}
-
-	return
+// VoidType represents the void type
+//
+var VoidType = &NominalType{
+	Name:                 "Void",
+	QualifiedName:        "Void",
+	TypeID:               "Void",
+	IsInvalid:            false,
+	IsResource:           false,
+	Storable:             false,
+	Equatable:            false,
+	ExternallyReturnable: true,
+	IsSuperTypeOf:        nil,
 }

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -45,7 +45,7 @@ var AssertFunction = NewStandardLibraryFunction(
 			},
 		},
 		ReturnTypeAnnotation: sema.NewTypeAnnotation(
-			&sema.VoidType{},
+			sema.VoidType,
 		),
 		RequiredArgumentCount: sema.RequiredArgumentCount(1),
 	},
@@ -121,7 +121,7 @@ var LogFunction = NewStandardLibraryFunction(
 			},
 		},
 		ReturnTypeAnnotation: sema.NewTypeAnnotation(
-			&sema.VoidType{},
+			sema.VoidType,
 		),
 	},
 	func(invocation interpreter.Invocation) trampoline.Trampoline {

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -89,7 +89,7 @@ var PanicFunction = NewStandardLibraryFunction(
 			},
 		},
 		ReturnTypeAnnotation: sema.NewTypeAnnotation(
-			&sema.NeverType{},
+			sema.NeverType,
 		),
 	},
 	func(invocation interpreter.Invocation) trampoline.Trampoline {

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -73,7 +73,7 @@ var logFunctionType = &sema.FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
-		&sema.VoidType{},
+		sema.VoidType,
 	),
 }
 

--- a/runtime/tests/checker/dictionary_test.go
+++ b/runtime/tests/checker/dictionary_test.go
@@ -45,7 +45,7 @@ func TestCheckIncompleteDictionaryType(t *testing.T) {
 	assert.IsType(t,
 		&sema.DictionaryType{
 			KeyType:   &sema.IntType{},
-			ValueType: &sema.InvalidType{},
+			ValueType: sema.InvalidType,
 		},
 		checker.GlobalValues["dict"].Type,
 	)

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -235,7 +235,7 @@ func TestCheckDynamicCastingNumber(t *testing.T) {
 						for _, otherType := range []sema.Type{
 							&sema.BoolType{},
 							&sema.StringType{},
-							&sema.VoidType{},
+							sema.VoidType,
 						} {
 
 							t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -271,7 +271,7 @@ func TestCheckDynamicCastingVoid(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.AnyStructType{},
-		&sema.VoidType{},
+		sema.VoidType,
 	}
 
 	for _, operation := range dynamicCastingOperations {
@@ -367,7 +367,7 @@ func TestCheckDynamicCastingString(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.BoolType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 				} {
 
@@ -430,7 +430,7 @@ func TestCheckDynamicCastingBool(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 				} {
 
@@ -494,7 +494,7 @@ func TestCheckDynamicCastingAddress(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 					&sema.BoolType{},
 				} {
@@ -580,7 +580,7 @@ func TestCheckDynamicCastingStruct(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 					&sema.BoolType{},
 				} {
@@ -1046,7 +1046,7 @@ func TestCheckDynamicCastingSome(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.OptionalType{Type: &sema.StringType{}},
-					&sema.OptionalType{Type: &sema.VoidType{}},
+					&sema.OptionalType{Type: sema.VoidType},
 					&sema.OptionalType{Type: &sema.BoolType{}},
 				} {
 
@@ -1108,7 +1108,7 @@ func TestCheckDynamicCastingArray(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.BoolType{},
 				} {
 
@@ -1175,7 +1175,7 @@ func TestCheckDynamicCastingDictionary(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.BoolType{},
 				} {
 
@@ -1263,7 +1263,7 @@ func TestCheckDynamicCastingCapability(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.BoolType{},
 				} {
 

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -67,7 +67,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				&sema.FunctionType{
 					TypeParameters:        nil,
 					Parameters:            nil,
-					ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+					ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 					RequiredArgumentCount: nil,
 				},
 			)
@@ -75,7 +75,7 @@ func TestCheckGenericFunction(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t,
-				&sema.VoidType{},
+				sema.VoidType,
 				checker.GlobalValues["res"].Type,
 			)
 		}
@@ -92,7 +92,7 @@ func TestCheckGenericFunction(t *testing.T) {
 			&sema.FunctionType{
 				TypeParameters:        nil,
 				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -120,7 +120,7 @@ func TestCheckGenericFunction(t *testing.T) {
 					typeParameter,
 				},
 				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -148,7 +148,7 @@ func TestCheckGenericFunction(t *testing.T) {
 					typeParameter,
 				},
 				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -194,7 +194,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -240,7 +240,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -279,7 +279,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -318,7 +318,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -363,7 +363,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -418,7 +418,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -579,7 +579,7 @@ func TestCheckGenericFunction(t *testing.T) {
 					typeParameter,
 				},
 				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -615,7 +615,7 @@ func TestCheckGenericFunction(t *testing.T) {
 					typeParameter,
 				},
 				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -653,7 +653,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 				RequiredArgumentCount: nil,
 			},
 		)
@@ -880,7 +880,7 @@ func TestCheckGenericFunctionIsInvalid(t *testing.T) {
 				),
 			},
 		},
-		ReturnTypeAnnotation:  sema.NewTypeAnnotation(&sema.VoidType{}),
+		ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
 		RequiredArgumentCount: nil,
 	}
 

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -326,7 +326,7 @@ func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
 							Name: "foo",
 							Type: &sema.FunctionType{
 								ReturnTypeAnnotation: &sema.TypeAnnotation{
-									Type: &sema.VoidType{},
+									Type: sema.VoidType,
 								},
 								RequiredArgumentCount: func() *int {
 									// NOTE: important to check *all* arguments are optional

--- a/runtime/tests/checker/path_test.go
+++ b/runtime/tests/checker/path_test.go
@@ -50,7 +50,7 @@ func TestCheckPath(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.IsType(t,
-				&sema.PathType{},
+				sema.PathType,
 				checker.GlobalValues["x"].Type,
 			)
 		})

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -116,7 +116,7 @@ func TestCheckStorable(t *testing.T) {
 		&sema.FunctionType{
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
 		},
-		&sema.NeverType{},
+		sema.NeverType,
 		&sema.VoidType{},
 		&sema.AuthAccountType{},
 		&sema.PublicAccountType{},

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -95,14 +95,14 @@ func TestCheckStorable(t *testing.T) {
 	storableTypes := append(
 		sema.AllNumberTypes[:],
 		&sema.AddressType{},
-		&sema.PathType{},
+		sema.PathType,
+		&sema.CapabilityType{},
 		&sema.StringType{},
 		&sema.BoolType{},
 		&sema.MetaType{},
 		&sema.CharacterType{},
 		&sema.AnyStructType{},
 		&sema.AnyResourceType{},
-		&sema.CapabilityType{},
 	)
 
 	for _, storableType := range storableTypes {

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -117,7 +117,7 @@ func TestCheckStorable(t *testing.T) {
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
 		},
 		sema.NeverType,
-		&sema.VoidType{},
+		sema.VoidType,
 		&sema.AuthAccountType{},
 		&sema.PublicAccountType{},
 	}

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -127,7 +127,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 						for _, otherType := range []sema.Type{
 							&sema.BoolType{},
 							&sema.StringType{},
-							&sema.VoidType{},
+							sema.VoidType,
 						} {
 
 							t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -178,7 +178,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.AnyStructType{},
-		&sema.VoidType{},
+		sema.VoidType,
 	}
 
 	for operation, returnsOptional := range dynamicCastingOperations {
@@ -309,7 +309,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.BoolType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 				} {
 
@@ -397,7 +397,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 				} {
 
@@ -489,7 +489,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 					&sema.BoolType{},
 				} {
@@ -619,7 +619,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.IntType{},
 					&sema.BoolType{},
 				} {
@@ -1092,7 +1092,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.OptionalType{Type: &sema.StringType{}},
-					&sema.OptionalType{Type: &sema.VoidType{}},
+					&sema.OptionalType{Type: sema.VoidType},
 					&sema.OptionalType{Type: &sema.BoolType{}},
 				} {
 
@@ -1184,7 +1184,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.BoolType{},
 				} {
 
@@ -1282,7 +1282,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.BoolType{},
 				} {
 
@@ -3440,7 +3440,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
-					&sema.VoidType{},
+					sema.VoidType,
 					&sema.BoolType{},
 				} {
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7928,7 +7928,7 @@ func TestInterpretNestedDestroy(t *testing.T) {
 				},
 			},
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				&sema.VoidType{},
+				sema.VoidType,
 			),
 		},
 		func(invocation interpreter.Invocation) trampoline.Trampoline {


### PR DESCRIPTION
Work towards #369 

Adding new types in the checker currently involves a lot of boilerplate. 
Before adding more types, introduce a simple "nominal type" type, and refactor some types to using it:
- Void
- Never
- Path
- Storable

In addition to reducing boilerplate code and making the future addition of more types easier, this also  reduces allocations and simplifies type checks (Go equality checks instead of Go type checks).