### PR TITLE
Interpreter: Always find the declared variable

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -547,14 +547,6 @@ func (interpreter *Interpreter) findVariable(name string) *Variable {
 	return result.(*Variable)
 }
 
-func (interpreter *Interpreter) findOrDeclareVariable(name string) *Variable {
-	variable := interpreter.findVariable(name)
-	if variable == nil {
-		variable = interpreter.declareVariable(name, nil)
-	}
-	return variable
-}
-
 func (interpreter *Interpreter) setVariable(name string, variable *Variable) {
 	interpreter.activations.Set(name, variable)
 }
@@ -881,7 +873,10 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 
 	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]
 
-	variable := interpreter.findOrDeclareVariable(identifier)
+	variable := interpreter.findVariable(identifier)
+	if variable == nil {
+		panic(errors.NewUnreachableError())
+	}
 
 	// lexical scope: variables in functions are bound to what is visible at declaration time
 	lexicalScope := interpreter.activations.CurrentOrNew()
@@ -2379,7 +2374,11 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 	value Value,
 ) {
 	identifier := declaration.Identifier.Identifier
-	variable := interpreter.findOrDeclareVariable(identifier)
+
+	variable := interpreter.findVariable(identifier)
+	if variable == nil {
+		panic(errors.NewUnreachableError())
+	}
 
 	// Make the value available in the initializer
 	lexicalScope = lexicalScope.Insert(identifier, variable)
@@ -2604,7 +2603,10 @@ func (interpreter *Interpreter) declareEnumConstructor(
 	value Value,
 ) {
 	identifier := declaration.Identifier.Identifier
-	variable := interpreter.findOrDeclareVariable(identifier)
+	variable := interpreter.findVariable(identifier)
+	if variable == nil {
+		panic(errors.NewUnreachableError())
+	}
 
 	lexicalScope = lexicalScope.Insert(identifier, variable)
 


### PR DESCRIPTION
Minor: There is no need to declare a variable, always just find the variable 