### PR TITLE
Improve Language Server command to get entry point parameters

### DIFF
--- a/languageserver/protocol/server.go
+++ b/languageserver/protocol/server.go
@@ -36,6 +36,7 @@ type Server struct {
 // the language server to push various types of messages to the client.
 // https://microsoft.github.io/language-server-protocol/specifications/specification-3-14
 type Conn interface {
+	Notify(method string, params interface{})
 	ShowMessage(params *ShowMessageParams)
 	LogMessage(params *LogMessageParams)
 	PublishDiagnostics(params *PublishDiagnosticsParams)
@@ -49,19 +50,24 @@ type connection struct {
 // ShowMessage displays a notification message to the client. It is visible to
 // the user.
 func (conn *connection) ShowMessage(params *ShowMessageParams) {
-	conn.jsonrpc2Server.Notify("window/showMessage", params)
+	conn.Notify("window/showMessage", params)
 }
 
 // LogMessage logs a message to the Cadence terminal in VS Code. It isn't
 // visible to the user unless they go looking for it.
 func (conn *connection) LogMessage(params *LogMessageParams) {
-	conn.jsonrpc2Server.Notify("window/logMessage", params)
+	conn.Notify("window/logMessage", params)
 }
 
 // PublishDiagnostics is used to report errors for a document, typically syntax
 // or semantic errors in the code.
 func (conn *connection) PublishDiagnostics(params *PublishDiagnosticsParams) {
-	conn.jsonrpc2Server.Notify("textDocument/publishDiagnostics", params)
+	conn.Notify("textDocument/publishDiagnostics", params)
+}
+
+// Notify sends a notification to the client.
+func (conn *connection) Notify(method string, params interface{}) {
+	conn.jsonrpc2Server.Notify(method, params)
 }
 
 // RegisterCapability is used to dynamically inform the client that the server

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1376,9 +1376,14 @@ func (s *Server) getEntryPointParameters(_ protocol.Conn, args ...interface{}) (
 			map[sema.TypeID]cadence.Type{},
 		)
 
+		var typeID string
+		if parameterType != nil {
+			typeID = parameterType.ID()
+		}
+
 		encodedParameters[i] = encodedParameter{
 			Name: parameter.EffectiveArgumentLabel(),
-			Type: parameterType.ID(),
+			Type: typeID,
 		}
 	}
 

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -150,6 +150,8 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.NeverType{}
 		case sema.VoidType:
 			return cadence.VoidType{}
+		case sema.InvalidType:
+			return nil
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.10.0"
+const Version = "v0.11.0"


### PR DESCRIPTION
Calling the language server command to get the entry point parameters should be done after the server has completed checking successfully. Notify the client with a custom notification.

Also, the `ExportType` function might be called with an invalid type, so handle it properly.