### PR TITLE
Add a function to parse a literal with a given target type

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -92,7 +92,7 @@ func (e *Encoder) Encode(value cadence.Value) (err error) {
 		}
 	}()
 
-	preparedValue := e.prepare(value)
+	preparedValue := Prepare(value)
 
 	return e.enc.Encode(&preparedValue)
 }
@@ -185,92 +185,92 @@ const (
 
 // prepare traverses the object graph of the provided value and constructs
 // a struct representation that can be marshalled to JSON.
-func (e *Encoder) prepare(v cadence.Value) jsonValue {
+func Prepare(v cadence.Value) jsonValue {
 	switch x := v.(type) {
 	case cadence.Void:
-		return e.prepareVoid()
+		return prepareVoid()
 	case cadence.Optional:
-		return e.prepareOptional(x)
+		return prepareOptional(x)
 	case cadence.Bool:
-		return e.prepareBool(x)
+		return prepareBool(x)
 	case cadence.String:
-		return e.prepareString(x)
+		return prepareString(x)
 	case cadence.Address:
-		return e.prepareAddress(x)
+		return prepareAddress(x)
 	case cadence.Int:
-		return e.prepareInt(x)
+		return prepareInt(x)
 	case cadence.Int8:
-		return e.prepareInt8(x)
+		return prepareInt8(x)
 	case cadence.Int16:
-		return e.prepareInt16(x)
+		return prepareInt16(x)
 	case cadence.Int32:
-		return e.prepareInt32(x)
+		return prepareInt32(x)
 	case cadence.Int64:
-		return e.prepareInt64(x)
+		return prepareInt64(x)
 	case cadence.Int128:
-		return e.prepareInt128(x)
+		return prepareInt128(x)
 	case cadence.Int256:
-		return e.prepareInt256(x)
+		return prepareInt256(x)
 	case cadence.UInt:
-		return e.prepareUInt(x)
+		return prepareUInt(x)
 	case cadence.UInt8:
-		return e.prepareUInt8(x)
+		return prepareUInt8(x)
 	case cadence.UInt16:
-		return e.prepareUInt16(x)
+		return prepareUInt16(x)
 	case cadence.UInt32:
-		return e.prepareUInt32(x)
+		return prepareUInt32(x)
 	case cadence.UInt64:
-		return e.prepareUInt64(x)
+		return prepareUInt64(x)
 	case cadence.UInt128:
-		return e.prepareUInt128(x)
+		return prepareUInt128(x)
 	case cadence.UInt256:
-		return e.prepareUInt256(x)
+		return prepareUInt256(x)
 	case cadence.Word8:
-		return e.prepareWord8(x)
+		return prepareWord8(x)
 	case cadence.Word16:
-		return e.prepareWord16(x)
+		return prepareWord16(x)
 	case cadence.Word32:
-		return e.prepareWord32(x)
+		return prepareWord32(x)
 	case cadence.Word64:
-		return e.prepareWord64(x)
+		return prepareWord64(x)
 	case cadence.Fix64:
-		return e.prepareFix64(x)
+		return prepareFix64(x)
 	case cadence.UFix64:
-		return e.prepareUFix64(x)
+		return prepareUFix64(x)
 	case cadence.Array:
-		return e.prepareArray(x)
+		return prepareArray(x)
 	case cadence.Dictionary:
-		return e.prepareDictionary(x)
+		return prepareDictionary(x)
 	case cadence.Struct:
-		return e.prepareStruct(x)
+		return prepareStruct(x)
 	case cadence.Resource:
-		return e.prepareResource(x)
+		return prepareResource(x)
 	case cadence.Event:
-		return e.prepareEvent(x)
+		return prepareEvent(x)
 	case cadence.Contract:
-		return e.prepareContract(x)
+		return prepareContract(x)
 	case cadence.Link:
-		return e.prepareLink(x)
+		return prepareLink(x)
 	case cadence.Path:
-		return e.preparePath(x)
+		return preparePath(x)
 	case cadence.TypeValue:
-		return e.prepareTypeValue(x)
+		return prepareTypeValue(x)
 	case cadence.Capability:
-		return e.prepareCapability(x)
+		return prepareCapability(x)
 	default:
 		panic(fmt.Errorf("unsupported value: %T, %v", v, v))
 	}
 }
 
-func (e *Encoder) prepareVoid() jsonValue {
+func prepareVoid() jsonValue {
 	return jsonEmptyValueObject{Type: voidTypeStr}
 }
 
-func (e *Encoder) prepareOptional(v cadence.Optional) jsonValue {
+func prepareOptional(v cadence.Optional) jsonValue {
 	var value interface{}
 
 	if v.Value != nil {
-		value = e.prepare(v.Value)
+		value = Prepare(v.Value)
 	}
 
 	return jsonValueObject{
@@ -279,172 +279,172 @@ func (e *Encoder) prepareOptional(v cadence.Optional) jsonValue {
 	}
 }
 
-func (e *Encoder) prepareBool(v cadence.Bool) jsonValue {
+func prepareBool(v cadence.Bool) jsonValue {
 	return jsonValueObject{
 		Type:  boolTypeStr,
 		Value: v,
 	}
 }
 
-func (e *Encoder) prepareString(v cadence.String) jsonValue {
+func prepareString(v cadence.String) jsonValue {
 	return jsonValueObject{
 		Type:  stringTypeStr,
 		Value: v,
 	}
 }
 
-func (e *Encoder) prepareAddress(v cadence.Address) jsonValue {
+func prepareAddress(v cadence.Address) jsonValue {
 	return jsonValueObject{
 		Type:  addressTypeStr,
 		Value: encodeBytes(v.Bytes()),
 	}
 }
 
-func (e *Encoder) prepareInt(v cadence.Int) jsonValue {
+func prepareInt(v cadence.Int) jsonValue {
 	return jsonValueObject{
 		Type:  intTypeStr,
 		Value: encodeBig(v.Big()),
 	}
 }
 
-func (e *Encoder) prepareInt8(v cadence.Int8) jsonValue {
+func prepareInt8(v cadence.Int8) jsonValue {
 	return jsonValueObject{
 		Type:  int8TypeStr,
 		Value: encodeInt(int64(v)),
 	}
 }
 
-func (e *Encoder) prepareInt16(v cadence.Int16) jsonValue {
+func prepareInt16(v cadence.Int16) jsonValue {
 	return jsonValueObject{
 		Type:  int16TypeStr,
 		Value: encodeInt(int64(v)),
 	}
 }
 
-func (e *Encoder) prepareInt32(v cadence.Int32) jsonValue {
+func prepareInt32(v cadence.Int32) jsonValue {
 	return jsonValueObject{
 		Type:  int32TypeStr,
 		Value: encodeInt(int64(v)),
 	}
 }
 
-func (e *Encoder) prepareInt64(v cadence.Int64) jsonValue {
+func prepareInt64(v cadence.Int64) jsonValue {
 	return jsonValueObject{
 		Type:  int64TypeStr,
 		Value: encodeInt(int64(v)),
 	}
 }
 
-func (e *Encoder) prepareInt128(v cadence.Int128) jsonValue {
+func prepareInt128(v cadence.Int128) jsonValue {
 	return jsonValueObject{
 		Type:  int128TypeStr,
 		Value: encodeBig(v.Big()),
 	}
 }
 
-func (e *Encoder) prepareInt256(v cadence.Int256) jsonValue {
+func prepareInt256(v cadence.Int256) jsonValue {
 	return jsonValueObject{
 		Type:  int256TypeStr,
 		Value: encodeBig(v.Big()),
 	}
 }
 
-func (e *Encoder) prepareUInt(v cadence.UInt) jsonValue {
+func prepareUInt(v cadence.UInt) jsonValue {
 	return jsonValueObject{
 		Type:  uintTypeStr,
 		Value: encodeBig(v.Big()),
 	}
 }
 
-func (e *Encoder) prepareUInt8(v cadence.UInt8) jsonValue {
+func prepareUInt8(v cadence.UInt8) jsonValue {
 	return jsonValueObject{
 		Type:  uint8TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareUInt16(v cadence.UInt16) jsonValue {
+func prepareUInt16(v cadence.UInt16) jsonValue {
 	return jsonValueObject{
 		Type:  uint16TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareUInt32(v cadence.UInt32) jsonValue {
+func prepareUInt32(v cadence.UInt32) jsonValue {
 	return jsonValueObject{
 		Type:  uint32TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareUInt64(v cadence.UInt64) jsonValue {
+func prepareUInt64(v cadence.UInt64) jsonValue {
 	return jsonValueObject{
 		Type:  uint64TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareUInt128(v cadence.UInt128) jsonValue {
+func prepareUInt128(v cadence.UInt128) jsonValue {
 	return jsonValueObject{
 		Type:  uint128TypeStr,
 		Value: encodeBig(v.Big()),
 	}
 }
 
-func (e *Encoder) prepareUInt256(v cadence.UInt256) jsonValue {
+func prepareUInt256(v cadence.UInt256) jsonValue {
 	return jsonValueObject{
 		Type:  uint256TypeStr,
 		Value: encodeBig(v.Big()),
 	}
 }
 
-func (e *Encoder) prepareWord8(v cadence.Word8) jsonValue {
+func prepareWord8(v cadence.Word8) jsonValue {
 	return jsonValueObject{
 		Type:  word8TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareWord16(v cadence.Word16) jsonValue {
+func prepareWord16(v cadence.Word16) jsonValue {
 	return jsonValueObject{
 		Type:  word16TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareWord32(v cadence.Word32) jsonValue {
+func prepareWord32(v cadence.Word32) jsonValue {
 	return jsonValueObject{
 		Type:  word32TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareWord64(v cadence.Word64) jsonValue {
+func prepareWord64(v cadence.Word64) jsonValue {
 	return jsonValueObject{
 		Type:  word64TypeStr,
 		Value: encodeUInt(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareFix64(v cadence.Fix64) jsonValue {
+func prepareFix64(v cadence.Fix64) jsonValue {
 	return jsonValueObject{
 		Type:  fix64TypeStr,
 		Value: encodeFix64(int64(v)),
 	}
 }
 
-func (e *Encoder) prepareUFix64(v cadence.UFix64) jsonValue {
+func prepareUFix64(v cadence.UFix64) jsonValue {
 	return jsonValueObject{
 		Type:  ufix64TypeStr,
 		Value: encodeUFix64(uint64(v)),
 	}
 }
 
-func (e *Encoder) prepareArray(v cadence.Array) jsonValue {
+func prepareArray(v cadence.Array) jsonValue {
 	values := make([]jsonValue, len(v.Values))
 
 	for i, value := range v.Values {
-		values[i] = e.prepare(value)
+		values[i] = Prepare(value)
 	}
 
 	return jsonValueObject{
@@ -453,13 +453,13 @@ func (e *Encoder) prepareArray(v cadence.Array) jsonValue {
 	}
 }
 
-func (e *Encoder) prepareDictionary(v cadence.Dictionary) jsonValue {
+func prepareDictionary(v cadence.Dictionary) jsonValue {
 	items := make([]jsonDictionaryItem, len(v.Pairs))
 
 	for i, pair := range v.Pairs {
 		items[i] = jsonDictionaryItem{
-			Key:   e.prepare(pair.Key),
-			Value: e.prepare(pair.Value),
+			Key:   Prepare(pair.Key),
+			Value: Prepare(pair.Value),
 		}
 	}
 
@@ -469,23 +469,23 @@ func (e *Encoder) prepareDictionary(v cadence.Dictionary) jsonValue {
 	}
 }
 
-func (e *Encoder) prepareStruct(v cadence.Struct) jsonValue {
-	return e.prepareComposite(structTypeStr, v.StructType.ID(), v.StructType.Fields, v.Fields)
+func prepareStruct(v cadence.Struct) jsonValue {
+	return prepareComposite(structTypeStr, v.StructType.ID(), v.StructType.Fields, v.Fields)
 }
 
-func (e *Encoder) prepareResource(v cadence.Resource) jsonValue {
-	return e.prepareComposite(resourceTypeStr, v.ResourceType.ID(), v.ResourceType.Fields, v.Fields)
+func prepareResource(v cadence.Resource) jsonValue {
+	return prepareComposite(resourceTypeStr, v.ResourceType.ID(), v.ResourceType.Fields, v.Fields)
 }
 
-func (e *Encoder) prepareEvent(v cadence.Event) jsonValue {
-	return e.prepareComposite(eventTypeStr, v.EventType.ID(), v.EventType.Fields, v.Fields)
+func prepareEvent(v cadence.Event) jsonValue {
+	return prepareComposite(eventTypeStr, v.EventType.ID(), v.EventType.Fields, v.Fields)
 }
 
-func (e *Encoder) prepareContract(v cadence.Contract) jsonValue {
-	return e.prepareComposite(contractTypeStr, v.ContractType.ID(), v.ContractType.Fields, v.Fields)
+func prepareContract(v cadence.Contract) jsonValue {
+	return prepareComposite(contractTypeStr, v.ContractType.ID(), v.ContractType.Fields, v.Fields)
 }
 
-func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {
+func prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {
 	nonFunctionFieldTypes := make([]cadence.Field, 0)
 
 	for _, field := range fieldTypes {
@@ -510,7 +510,7 @@ func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, 
 
 		compositeFields[i] = jsonCompositeField{
 			Name:  fieldType.Identifier,
-			Value: e.prepare(value),
+			Value: Prepare(value),
 		}
 	}
 
@@ -523,17 +523,17 @@ func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, 
 	}
 }
 
-func (e *Encoder) prepareLink(x cadence.Link) jsonValue {
+func prepareLink(x cadence.Link) jsonValue {
 	return jsonValueObject{
 		Type: linkTypeStr,
 		Value: jsonLinkValue{
-			TargetPath: e.preparePath(x.TargetPath),
+			TargetPath: preparePath(x.TargetPath),
 			BorrowType: x.BorrowType,
 		},
 	}
 }
 
-func (e *Encoder) preparePath(x cadence.Path) jsonValue {
+func preparePath(x cadence.Path) jsonValue {
 	return jsonValueObject{
 		Type: pathTypeStr,
 		Value: jsonPathValue{
@@ -543,7 +543,7 @@ func (e *Encoder) preparePath(x cadence.Path) jsonValue {
 	}
 }
 
-func (e *Encoder) prepareTypeValue(x cadence.TypeValue) jsonValue {
+func prepareTypeValue(x cadence.TypeValue) jsonValue {
 	return jsonValueObject{
 		Type: typeTypeStr,
 		Value: jsonTypeValue{
@@ -552,11 +552,11 @@ func (e *Encoder) prepareTypeValue(x cadence.TypeValue) jsonValue {
 	}
 }
 
-func (e *Encoder) prepareCapability(x cadence.Capability) jsonValue {
+func prepareCapability(x cadence.Capability) jsonValue {
 	return jsonValueObject{
 		Type: capabilityTypeStr,
 		Value: jsonCapabilityValue{
-			Path:       e.preparePath(x.Path),
+			Path:       preparePath(x.Path),
 			Address:    encodeBytes(x.Address.Bytes()),
 			BorrowType: x.BorrowType,
 		},

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/languageserver/conversion"
 	"github.com/onflow/cadence/languageserver/jsonrpc2"

--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -156,3 +156,26 @@ describe("getContractInitializerParameters command", () => {
       )
   )
 })
+
+describe("parseEntryPointArguments command", () => {
+
+  async function testCode(code: string) {
+    return withConnection(async (connection) => {
+
+      const uri = await createTestDocument(connection, code)
+
+      const result = await connection.sendRequest(ExecuteCommandRequest.type, {
+        command: "cadence.server.parseEntryPointArguments",
+        arguments: [uri, ['0x42']]
+      })
+
+      expect(result).toEqual([{value: '0x0000000000000042', type: 'Address'}])
+    })
+  }
+
+  test("script", async() =>
+    testCode("pub fun main(a: Address) {}"))
+
+  test("transaction", async() =>
+    testCode("transaction(a: Address) {}"))
+})

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -34,6 +34,11 @@ func exportValue(value exportableValue) cadence.Value {
 	return exportValueWithInterpreter(value.Value, value.Interpreter(), exportResults{})
 }
 
+// ExportValue converts a runtime value to its native Go representation.
+func ExportValue(value interpreter.Value, inter *interpreter.Interpreter) cadence.Value {
+	return exportValueWithInterpreter(value, inter, exportResults{})
+}
+
 // exportEvent converts a runtime event to its native Go representation.
 func exportEvent(event exportableEvent) cadence.Event {
 	fields := make([]cadence.Value, len(event.Fields))

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -1,0 +1,275 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/fixedpoint"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/parser2"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+var InvalidLiteralError = fmt.Errorf("invalid literal")
+var UnsupportedLiteralError = fmt.Errorf("unsupported literal")
+var LiteralExpressionTypeError = fmt.Errorf("input is not a literal")
+
+func ParseLiteral(literal string, ty sema.Type) (cadence.Value, error) {
+	expression, errs := parser2.ParseExpression(literal)
+	if len(errs) > 0 {
+		return nil, parser2.Error{
+			Errors: errs,
+		}
+	}
+
+	return LiteralValue(expression, ty)
+}
+
+func arrayLiteralValue(elements []ast.Expression, elementType sema.Type) (cadence.Value, error) {
+	values := make([]cadence.Value, len(elements))
+
+	for i, element := range elements {
+		convertedElement, err := LiteralValue(element, elementType)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = convertedElement
+	}
+
+	return cadence.NewArray(values), nil
+}
+
+func pathLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error) {
+	pathExpression, ok := expression.(*ast.PathExpression)
+	if !ok {
+		return nil, LiteralExpressionTypeError
+	}
+
+	pathType, err := sema.CheckPathLiteral(pathExpression)
+	if err != nil {
+		return nil, InvalidLiteralError
+	}
+
+	if !sema.IsSubType(pathType, ty) {
+		return nil, fmt.Errorf(
+			"path literal type %s is not subtype of requested path type %s",
+			pathType, ty,
+		)
+	}
+
+	return cadence.Path{
+		Domain:     pathExpression.Domain.Identifier,
+		Identifier: pathExpression.Identifier.Identifier,
+	}, nil
+}
+
+func integerLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error) {
+	integerExpression, ok := expression.(*ast.IntegerExpression)
+	if !ok {
+		return nil, LiteralExpressionTypeError
+	}
+
+	if !sema.CheckIntegerLiteral(integerExpression, ty, nil) {
+		return nil, InvalidLiteralError
+	}
+
+	intValue := interpreter.NewIntValueFromBigInt(integerExpression.Value)
+
+	converter := func(value interpreter.Value, _ *interpreter.Interpreter) interpreter.Value {
+		return value
+	}
+
+	switch ty.(type) {
+	case *sema.IntType, *sema.IntegerType, *sema.SignedIntegerType:
+		break
+	case *sema.Int8Type:
+		converter = interpreter.ConvertInt8
+	case *sema.Int16Type:
+		converter = interpreter.ConvertInt16
+	case *sema.Int32Type:
+		converter = interpreter.ConvertInt32
+	case *sema.Int64Type:
+		converter = interpreter.ConvertInt64
+	case *sema.Int128Type:
+		converter = interpreter.ConvertInt128
+	case *sema.Int256Type:
+		converter = interpreter.ConvertInt256
+
+	case *sema.UIntType:
+		converter = interpreter.ConvertUInt
+	case *sema.UInt8Type:
+		converter = interpreter.ConvertUInt8
+	case *sema.UInt16Type:
+		converter = interpreter.ConvertUInt16
+	case *sema.UInt32Type:
+		converter = interpreter.ConvertUInt32
+	case *sema.UInt64Type:
+		converter = interpreter.ConvertUInt64
+	case *sema.UInt128Type:
+		converter = interpreter.ConvertUInt128
+	case *sema.UInt256Type:
+		converter = interpreter.ConvertUInt256
+
+	case *sema.Word8Type:
+		converter = interpreter.ConvertWord8
+	case *sema.Word16Type:
+		converter = interpreter.ConvertWord16
+	case *sema.Word32Type:
+		converter = interpreter.ConvertWord32
+	case *sema.Word64Type:
+		converter = interpreter.ConvertWord64
+
+	default:
+		return nil, UnsupportedLiteralError
+	}
+
+	result := ExportValue(converter(intValue, nil), nil)
+	return result, nil
+}
+
+func fixedPointLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error) {
+	fixedPointExpression, ok := expression.(*ast.FixedPointExpression)
+	if !ok {
+		return nil, LiteralExpressionTypeError
+	}
+
+	if !sema.CheckFixedPointLiteral(fixedPointExpression, ty, nil) {
+		return nil, InvalidLiteralError
+	}
+
+	// TODO: adjust once/if we support more fixed point types
+
+	value := fixedpoint.ConvertToFixedPointBigInt(
+		fixedPointExpression.Negative,
+		fixedPointExpression.UnsignedInteger,
+		fixedPointExpression.Fractional,
+		fixedPointExpression.Scale,
+		sema.Fix64Scale,
+	)
+
+	switch ty.(type) {
+	case *sema.Fix64Type, *sema.FixedPointType, *sema.SignedFixedPointType:
+		return cadence.Fix64(value.Int64()), nil
+	case *sema.UFix64Type:
+		return cadence.UFix64(value.Uint64()), nil
+	}
+
+	return nil, UnsupportedLiteralError
+}
+
+func LiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error) {
+	switch ty := ty.(type) {
+	case *sema.VariableSizedType:
+		expression, ok := expression.(*ast.ArrayExpression)
+		if !ok {
+			return nil, LiteralExpressionTypeError
+		}
+
+		return arrayLiteralValue(expression.Values, ty.Type)
+
+	case *sema.ConstantSizedType:
+		expression, ok := expression.(*ast.ArrayExpression)
+		if !ok {
+			return nil, LiteralExpressionTypeError
+		}
+
+		return arrayLiteralValue(expression.Values, ty.Type)
+
+	case *sema.OptionalType:
+		if _, ok := expression.(*ast.NilExpression); ok {
+			return cadence.NewOptional(nil), nil
+		}
+
+		converted, err := LiteralValue(expression, ty.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		return cadence.NewOptional(converted), nil
+
+	case *sema.DictionaryType:
+		expression, ok := expression.(*ast.DictionaryExpression)
+		if !ok {
+			return nil, LiteralExpressionTypeError
+		}
+
+		var err error
+
+		pairs := make([]cadence.KeyValuePair, len(expression.Entries))
+
+		for i, entry := range expression.Entries {
+
+			pairs[i].Key, err = LiteralValue(entry.Key, ty.KeyType)
+			if err != nil {
+				return nil, err
+			}
+
+			pairs[i].Value, err = LiteralValue(entry.Value, ty.ValueType)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return cadence.NewDictionary(pairs), nil
+
+	case *sema.StringType:
+		expression, ok := expression.(*ast.StringExpression)
+		if !ok {
+			return nil, LiteralExpressionTypeError
+		}
+
+		return cadence.NewString(expression.Value), nil
+
+	case *sema.BoolType:
+		expression, ok := expression.(*ast.BoolExpression)
+		if !ok {
+			return nil, LiteralExpressionTypeError
+		}
+
+		return cadence.NewBool(expression.Value), nil
+
+	case *sema.AddressType:
+		expression, ok := expression.(*ast.IntegerExpression)
+		if !ok {
+			return nil, LiteralExpressionTypeError
+		}
+
+		if !sema.CheckAddressLiteral(expression, nil) {
+			return nil, InvalidLiteralError
+		}
+
+		return cadence.BytesToAddress(expression.Value.Bytes()), nil
+	}
+
+	switch {
+	case sema.IsSubType(ty, &sema.IntegerType{}):
+		return integerLiteralValue(expression, ty)
+
+	case sema.IsSubType(ty, &sema.FixedPointType{}):
+		return fixedPointLiteralValue(expression, ty)
+
+	case sema.IsSubType(ty, sema.PathType):
+		return pathLiteralValue(expression, ty)
+	}
+
+	return nil, UnsupportedLiteralError
+}

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -1,0 +1,534 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+func TestLiteralValue(t *testing.T) {
+
+	t.Run("String, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`"hello"`, &sema.StringType{})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewString("hello"),
+			value,
+		)
+	})
+
+	t.Run("String, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, &sema.StringType{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("Bool, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, &sema.BoolType{})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewBool(true),
+			value,
+		)
+	})
+
+	t.Run("Bool, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`"hello"`, &sema.BoolType{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("Optional, nil", func(t *testing.T) {
+		value, err := ParseLiteral(`nil`, &sema.OptionalType{Type: &sema.BoolType{}})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewOptional(nil),
+			value,
+		)
+	})
+
+	t.Run("Optional, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, &sema.OptionalType{Type: &sema.BoolType{}})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewOptional(cadence.NewBool(true)),
+			value,
+		)
+	})
+
+	t.Run("Optional, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`"hello"`, &sema.OptionalType{Type: &sema.BoolType{}})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("VariableSizedArray, empty", func(t *testing.T) {
+		value, err := ParseLiteral(`[]`, &sema.VariableSizedType{Type: &sema.BoolType{}})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewArray([]cadence.Value{}),
+			value,
+		)
+	})
+
+	t.Run("VariableSizedArray, one element", func(t *testing.T) {
+		value, err := ParseLiteral(`[true]`, &sema.VariableSizedType{Type: &sema.BoolType{}})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewArray([]cadence.Value{
+				cadence.NewBool(true),
+			}),
+			value,
+		)
+	})
+
+	t.Run("VariableSizedArray, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`"hello"`, &sema.VariableSizedType{Type: &sema.BoolType{}})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("ConstantSizedArray, empty", func(t *testing.T) {
+		value, err := ParseLiteral(`[]`, &sema.ConstantSizedType{Type: &sema.BoolType{}})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewArray([]cadence.Value{}),
+			value,
+		)
+	})
+
+	t.Run("ConstantSizedArray, one element", func(t *testing.T) {
+		value, err := ParseLiteral(`[true]`, &sema.ConstantSizedType{Type: &sema.BoolType{}})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewArray([]cadence.Value{
+				cadence.NewBool(true),
+			}),
+			value,
+		)
+	})
+
+	t.Run("ConstantSizedArray, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`"hello"`, &sema.ConstantSizedType{Type: &sema.BoolType{}})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("Dictionary, empty", func(t *testing.T) {
+		value, err := ParseLiteral(`{}`, &sema.DictionaryType{
+			KeyType:   &sema.StringType{},
+			ValueType: &sema.BoolType{},
+		})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewDictionary([]cadence.KeyValuePair{}),
+			value,
+		)
+	})
+
+	t.Run("Dictionary, one entry", func(t *testing.T) {
+		value, err := ParseLiteral(`{"hello": true}`, &sema.DictionaryType{
+			KeyType:   &sema.StringType{},
+			ValueType: &sema.BoolType{},
+		})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewDictionary([]cadence.KeyValuePair{
+				{
+					Key:   cadence.NewString("hello"),
+					Value: cadence.NewBool(true),
+				},
+			}),
+			value,
+		)
+	})
+
+	t.Run("Dictionary, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`"hello"`, &sema.DictionaryType{
+			KeyType:   &sema.StringType{},
+			ValueType: &sema.BoolType{},
+		})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("Path, valid literal (storage)", func(t *testing.T) {
+		value, err := ParseLiteral(`/storage/foo`, sema.PathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "storage",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("Path, valid literal (private)", func(t *testing.T) {
+		value, err := ParseLiteral(`/private/foo`, sema.PathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "private",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("Path, valid literal (public)", func(t *testing.T) {
+		value, err := ParseLiteral(`/public/foo`, sema.PathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "public",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("Path, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, sema.PathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("StoragePath, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`/storage/foo`, sema.StoragePathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "storage",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("StoragePath, invalid literal (private)", func(t *testing.T) {
+		value, err := ParseLiteral(`/private/foo`, sema.StoragePathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("StoragePath, invalid literal (public)", func(t *testing.T) {
+		value, err := ParseLiteral(`/public/foo`, sema.StoragePathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("StoragePath, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, sema.StoragePathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("CapabilityPath, valid literal (private)", func(t *testing.T) {
+		value, err := ParseLiteral(`/private/foo`, sema.CapabilityPathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "private",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("CapabilityPath, invalid literal (public)", func(t *testing.T) {
+		value, err := ParseLiteral(`/public/foo`, sema.CapabilityPathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "public",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("CapabilityPath, invalid literal (storage)", func(t *testing.T) {
+		value, err := ParseLiteral(`/storage/foo`, sema.CapabilityPathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("CapabilityPath, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, sema.CapabilityPathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("PublicPath, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`/public/foo`, sema.PublicPathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "public",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("PublicPath, invalid literal (private)", func(t *testing.T) {
+		value, err := ParseLiteral(`/private/foo`, sema.PublicPathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("PublicPath, invalid literal (storage)", func(t *testing.T) {
+		value, err := ParseLiteral(`/storage/foo`, sema.PublicPathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("PublicPath, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, sema.PublicPathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("PrivatePath, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`/private/foo`, sema.PrivatePathType)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.Path{
+				Domain:     "private",
+				Identifier: "foo",
+			},
+			value,
+		)
+	})
+
+	t.Run("PrivatePath, invalid literal (public)", func(t *testing.T) {
+		value, err := ParseLiteral(`/public/foo`, sema.PrivatePathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("PrivatePath, invalid literal (storage)", func(t *testing.T) {
+		value, err := ParseLiteral(`/storage/foo`, sema.PrivatePathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("PrivatePath, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`true`, sema.PrivatePathType)
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("Address, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`0x1`, &sema.AddressType{})
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 0, 0, 1}),
+			value,
+		)
+	})
+
+	t.Run("Address, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`1`, &sema.AddressType{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("Fix64, valid literal, positive", func(t *testing.T) {
+		expected, err := cadence.NewFix64FromParts(false, 1, 0)
+		require.NoError(t, err)
+
+		value, err := ParseLiteral(`1.0`, &sema.Fix64Type{})
+		require.NoError(t, err)
+		require.Equal(t, expected, value)
+	})
+
+	t.Run("Fix64, valid literal, negative", func(t *testing.T) {
+		expected, err := cadence.NewFix64FromParts(true, 1, 0)
+		require.NoError(t, err)
+
+		value, err := ParseLiteral(`-1.0`, &sema.Fix64Type{})
+		require.NoError(t, err)
+		require.Equal(t, expected, value)
+	})
+
+	t.Run("Fix64, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`1`, &sema.Fix64Type{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("UFix64, valid literal, positive", func(t *testing.T) {
+		expected, err := cadence.NewUFix64FromParts(1, 0)
+		require.NoError(t, err)
+
+		value, err := ParseLiteral(`1.0`, &sema.UFix64Type{})
+		require.NoError(t, err)
+		require.Equal(t, expected, value)
+	})
+
+	t.Run("UFix64, invalid literal, negative", func(t *testing.T) {
+		value, err := ParseLiteral(`-1.0`, &sema.UFix64Type{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("UFix64, invalid literal, invalid expression", func(t *testing.T) {
+		value, err := ParseLiteral(`1`, &sema.UFix64Type{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("FixedPoint, valid literal, positive", func(t *testing.T) {
+		expected, err := cadence.NewFix64FromParts(false, 1, 0)
+		require.NoError(t, err)
+
+		value, err := ParseLiteral(`1.0`, &sema.FixedPointType{})
+		require.NoError(t, err)
+		require.Equal(t, expected, value)
+	})
+
+	t.Run("FixedPoint, valid literal, negative", func(t *testing.T) {
+		expected, err := cadence.NewFix64FromParts(true, 1, 0)
+		require.NoError(t, err)
+
+		value, err := ParseLiteral(`-1.0`, &sema.FixedPointType{})
+		require.NoError(t, err)
+		require.Equal(t, expected, value)
+	})
+
+	t.Run("FixedPoint, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`1`, &sema.FixedPointType{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	t.Run("SignedFixedPoint, valid literal, positive", func(t *testing.T) {
+		expected, err := cadence.NewFix64FromParts(false, 1, 0)
+		require.NoError(t, err)
+
+		value, err := ParseLiteral(`1.0`, &sema.SignedFixedPointType{})
+		require.NoError(t, err)
+		require.Equal(t, expected, value)
+	})
+
+	t.Run("SignedFixedPoint, valid literal, negative", func(t *testing.T) {
+		expected, err := cadence.NewFix64FromParts(true, 1, 0)
+		require.NoError(t, err)
+
+		value, err := ParseLiteral(`-1.0`, &sema.SignedFixedPointType{})
+		require.NoError(t, err)
+		require.Equal(t, expected, value)
+	})
+
+	t.Run("SignedFixedPoint, invalid literal", func(t *testing.T) {
+		value, err := ParseLiteral(`1`, &sema.SignedFixedPointType{})
+		require.Error(t, err)
+		require.Nil(t, value)
+	})
+
+	for _, unsignedIntegerType := range sema.AllUnsignedIntegerTypes {
+
+		t.Run(
+			fmt.Sprintf(
+				"%s, valid literal, positive",
+				unsignedIntegerType.String(),
+			),
+			func(t *testing.T) {
+				value, err := ParseLiteral(`1`, unsignedIntegerType)
+				require.NoError(t, err)
+				require.NotNil(t, value)
+			},
+		)
+
+		t.Run(
+			fmt.Sprintf(
+				"%s, invalid literal, negative",
+				unsignedIntegerType.String(),
+			),
+			func(t *testing.T) {
+				value, err := ParseLiteral(`-1`, unsignedIntegerType)
+				require.Error(t, err)
+				require.Nil(t, value)
+			},
+		)
+
+		t.Run(
+			fmt.Sprintf(
+				"%s, invalid literal",
+				unsignedIntegerType.String(),
+			),
+			func(t *testing.T) {
+				value, err := ParseLiteral(`true`, unsignedIntegerType)
+				require.Error(t, err)
+				require.Nil(t, value)
+			},
+		)
+	}
+
+	for _, signedIntegerType := range append(
+		sema.AllSignedIntegerTypes[:],
+		&sema.IntegerType{},
+		&sema.SignedIntegerType{},
+	) {
+
+		t.Run(
+			fmt.Sprintf(
+				"%s, valid literal, positive",
+				signedIntegerType.String(),
+			),
+			func(t *testing.T) {
+				value, err := ParseLiteral(`1`, signedIntegerType)
+				require.NoError(t, err)
+				require.NotNil(t, value)
+			},
+		)
+
+		t.Run(
+			fmt.Sprintf(
+				"%s, valid literal, negative",
+				signedIntegerType.String(),
+			),
+			func(t *testing.T) {
+				value, err := ParseLiteral(`-1`, signedIntegerType)
+				require.NoError(t, err)
+				require.NotNil(t, value)
+			},
+		)
+
+		t.Run(
+			fmt.Sprintf(
+				"%s, invalid literal",
+				signedIntegerType.String(),
+			),
+			func(t *testing.T) {
+				value, err := ParseLiteral(`true`, signedIntegerType)
+				require.Error(t, err)
+				require.Nil(t, value)
+			},
+		)
+	}
+}

--- a/runtime/sema/check_path_expression.go
+++ b/runtime/sema/check_path_expression.go
@@ -25,28 +25,34 @@ import (
 
 func (checker *Checker) VisitPathExpression(expression *ast.PathExpression) ast.Repr {
 
+	ty, err := CheckPathLiteral(expression)
+	checker.report(err)
+
+	return ty
+}
+
+func CheckPathLiteral(expression *ast.PathExpression) (Type, error) {
+
 	// Check that the domain is valid
 
 	domainIdentifier := expression.Domain
 
 	domain, ok := common.AllPathDomainsByIdentifier[domainIdentifier.Identifier]
 	if !ok {
-		checker.report(
-			&InvalidPathDomainError{
-				ActualDomain: domainIdentifier.Identifier,
-				Range:        ast.NewRangeFromPositioned(domainIdentifier),
-			},
-		)
+		return PathType, &InvalidPathDomainError{
+			ActualDomain: domainIdentifier.Identifier,
+			Range:        ast.NewRangeFromPositioned(domainIdentifier),
+		}
 	}
 
 	switch domain {
 	case common.PathDomainStorage:
-		return StoragePathType
+		return StoragePathType, nil
 	case common.PathDomainPublic:
-		return PublicPathType
+		return PublicPathType, nil
 	case common.PathDomainPrivate:
-		return PrivatePathType
+		return PrivatePathType, nil
 	default:
-		return PathType
+		return PathType, nil
 	}
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4575,7 +4575,7 @@ func init() {
 					return
 				}
 
-				checker.checkAddressLiteral(intExpression)
+				CheckAddressLiteral(intExpression, checker.report)
 			},
 		},
 	}
@@ -4591,13 +4591,13 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 
 		switch argument := argument.(type) {
 		case *ast.IntegerExpression:
-			if checker.checkIntegerLiteral(argument, targetType) {
+			if CheckIntegerLiteral(argument, targetType, checker.report) {
 
 				suggestIntegerLiteralConversionReplacement(checker, argument, targetType, invocationRange)
 			}
 
 		case *ast.FixedPointExpression:
-			if checker.checkFixedPointLiteral(argument, targetType) {
+			if CheckFixedPointLiteral(argument, targetType, checker.report) {
 
 				suggestFixedPointLiteralConversionReplacement(checker, targetType, argument, invocationRange)
 			}


### PR DESCRIPTION
Closes #416 

Also, add a language server command that parses entry point arguments and returns them as values.
This allows them to be included as transaction arguments.

cc @MaxStalker 