### PR TITLE
Export component making composite types IDs as separate fields

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -115,9 +115,15 @@ type jsonDictionaryItem struct {
 	Value jsonValue `json:"value"`
 }
 
+type jsonCompositeTypeID struct {
+	Location   string `json:"location"`
+	Identifier string `json:"identifier"`
+}
+
 type jsonCompositeValue struct {
-	ID     string               `json:"id"`
-	Fields []jsonCompositeField `json:"fields"`
+	ID              string               `json:"id"`
+	CompositeTypeID jsonCompositeTypeID  `json:"compositeTypeID"`
+	Fields          []jsonCompositeField `json:"fields"`
 }
 
 type jsonCompositeField struct {
@@ -470,22 +476,22 @@ func (e *Encoder) prepareDictionary(v cadence.Dictionary) jsonValue {
 }
 
 func (e *Encoder) prepareStruct(v cadence.Struct) jsonValue {
-	return e.prepareComposite(structTypeStr, v.StructType.ID(), v.StructType.Fields, v.Fields)
+	return e.prepareComposite(structTypeStr, v.StructType.ID(), v.StructType.CompositeTypeID(), v.StructType.Fields, v.Fields)
 }
 
 func (e *Encoder) prepareResource(v cadence.Resource) jsonValue {
-	return e.prepareComposite(resourceTypeStr, v.ResourceType.ID(), v.ResourceType.Fields, v.Fields)
+	return e.prepareComposite(resourceTypeStr, v.ResourceType.ID(), v.ResourceType.CompositeTypeID(), v.ResourceType.Fields, v.Fields)
 }
 
 func (e *Encoder) prepareEvent(v cadence.Event) jsonValue {
-	return e.prepareComposite(eventTypeStr, v.EventType.ID(), v.EventType.Fields, v.Fields)
+	return e.prepareComposite(eventTypeStr, v.EventType.ID(), v.EventType.CompositeTypeID(), v.EventType.Fields, v.Fields)
 }
 
 func (e *Encoder) prepareContract(v cadence.Contract) jsonValue {
-	return e.prepareComposite(contractTypeStr, v.ContractType.ID(), v.ContractType.Fields, v.Fields)
+	return e.prepareComposite(contractTypeStr, v.ContractType.ID(), v.ContractType.CompositeTypeID(), v.ContractType.Fields, v.Fields)
 }
 
-func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {
+func (e *Encoder) prepareComposite(kind, id string, compositeTypeID cadence.CompositeTypeID, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {
 	nonFunctionFieldTypes := make([]cadence.Field, 0)
 
 	for _, field := range fieldTypes {
@@ -514,11 +520,17 @@ func (e *Encoder) prepareComposite(kind, id string, fieldTypes []cadence.Field, 
 		}
 	}
 
+	jsonCTypeID := jsonCompositeTypeID{
+		compositeTypeID.Location,
+		compositeTypeID.Identifier,
+	}
+
 	return jsonValueObject{
 		Type: kind,
 		Value: jsonCompositeValue{
-			ID:     id,
-			Fields: compositeFields,
+			ID:              id,
+			CompositeTypeID: jsonCTypeID,
+			Fields:          compositeFields,
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -569,7 +569,7 @@ func TestEncodeArray(t *testing.T) {
 				cadence.NewInt(3),
 			}).WithType(fooResourceType),
 		}),
-		`{"type":"Array","value":[{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"1"}}]}},{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"2"}}]}},{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"3"}}]}}]}`,
+		`{"type":"Array","value":[{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"1"}}]}},{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"2"}}]}},{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"3"}}]}}]}`,
 	}
 
 	testAllEncodeAndDecode(t,
@@ -658,7 +658,7 @@ func TestEncodeDictionary(t *testing.T) {
 				}).WithType(fooResourceType),
 			},
 		}),
-		`{"type":"Dictionary","value":[{"key":{"type":"String","value":"a"},"value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"1"}}]}}},{"key":{"type":"String","value":"b"},"value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"2"}}]}}},{"key":{"type":"String","value":"c"},"value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"3"}}]}}}]}`,
+		`{"type":"Dictionary","value":[{"key":{"type":"String","value":"a"},"value":{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"}, "fields":[{"name":"bar","value":{"type":"Int","value":"1"}}]}}},{"key":{"type":"String","value":"b"},"value":{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"2"}}]}}},{"key":{"type":"String","value":"c"},"value":{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"3"}}]}}}]}`,
 	}
 
 	testAllEncodeAndDecode(t,
@@ -690,7 +690,7 @@ func TestEncodeResource(t *testing.T) {
 			}
 		`
 
-		expectedJSON := `{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"bar","value":{"type":"Int","value":"42"}}]}}`
+		expectedJSON := `{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"bar","value":{"type":"Int","value":"42"}}]}}`
 
 		v := convertValueFromScript(t, script)
 
@@ -720,7 +720,7 @@ func TestEncodeResource(t *testing.T) {
 		`
 
 		// function "foo" should be omitted from resulting JSON
-		expectedJSON := `{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"bar","value":{"type":"Int","value":"42"}}]}}`
+		expectedJSON := `{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"bar","value":{"type":"Int","value":"42"}}]}}`
 
 		v := convertValueFromScript(t, script)
 
@@ -760,7 +760,7 @@ func TestEncodeResource(t *testing.T) {
 			}
 		`
 
-		expectedJSON := `{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"bar","value":{"type":"Resource","value":{"id":"S.test.Bar","fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"x","value":{"type":"Int","value":"42"}}]}}}]}}`
+		expectedJSON := `{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"}, "fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"bar","value":{"type":"Resource","value":{"id":"S.test.Bar","compositeTypeID":{"location": "S.test", "identifier":"Bar"}, "fields":[{"name":"uuid","value":{"type":"UInt64","value":"0"}},{"name":"x","value":{"type":"Int","value":"42"}}]}}}]}}`
 
 		v := convertValueFromScript(t, script)
 
@@ -773,7 +773,11 @@ func TestEncodeStruct(t *testing.T) {
 	t.Parallel()
 
 	simpleStructType := &cadence.StructType{
-		TypeID:     "S.test.FooStruct",
+		TypeID: "S.test.FooStruct",
+		StructTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "FooStruct",
+		},
 		Identifier: "FooStruct",
 		Fields: []cadence.Field{
 			{
@@ -795,12 +799,16 @@ func TestEncodeStruct(t *testing.T) {
 				cadence.NewString("foo"),
 			},
 		).WithType(simpleStructType),
-		`{"type":"Struct","value":{"id":"S.test.FooStruct","fields":[{"name":"a","value":{"type":"Int","value":"1"}},{"name":"b","value":{"type":"String","value":"foo"}}]}}`,
+		`{"type":"Struct","value":{"id":"S.test.FooStruct","compositeTypeID":{"location": "S.test", "identifier":"FooStruct"},"fields":[{"name":"a","value":{"type":"Int","value":"1"}},{"name":"b","value":{"type":"String","value":"foo"}}]}}`,
 	}
 
 	resourceStructType := &cadence.StructType{
 		TypeID:     "S.test.FooStruct",
 		Identifier: "FooStruct",
+		StructTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "FooStruct",
+		},
 		Fields: []cadence.Field{
 			{
 				Identifier: "a",
@@ -825,7 +833,7 @@ func TestEncodeStruct(t *testing.T) {
 				).WithType(fooResourceType),
 			},
 		).WithType(resourceStructType),
-		`{"type":"Struct","value":{"id":"S.test.FooStruct","fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
+		`{"type":"Struct","value":{"id":"S.test.FooStruct","compositeTypeID":{"location": "S.test", "identifier":"FooStruct"},"fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
 	}
 
 	testAllEncodeAndDecode(t, simpleStruct, resourceStruct)
@@ -836,7 +844,11 @@ func TestEncodeEvent(t *testing.T) {
 	t.Parallel()
 
 	simpleEventType := &cadence.EventType{
-		TypeID:     "S.test.FooEvent",
+		TypeID: "S.test.FooEvent",
+		EventTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "FooEvent",
+		},
 		Identifier: "FooEvent",
 		Fields: []cadence.Field{
 			{
@@ -858,12 +870,16 @@ func TestEncodeEvent(t *testing.T) {
 				cadence.NewString("foo"),
 			},
 		).WithType(simpleEventType),
-		`{"type":"Event","value":{"id":"S.test.FooEvent","fields":[{"name":"a","value":{"type":"Int","value":"1"}},{"name":"b","value":{"type":"String","value":"foo"}}]}}`,
+		`{"type":"Event","value":{"id":"S.test.FooEvent","compositeTypeID":{"location": "S.test", "identifier":"FooEvent"},"fields":[{"name":"a","value":{"type":"Int","value":"1"}},{"name":"b","value":{"type":"String","value":"foo"}}]}}`,
 	}
 
 	resourceEventType := &cadence.EventType{
 		TypeID:     "S.test.FooEvent",
 		Identifier: "FooEvent",
+		EventTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "FooEvent",
+		},
 		Fields: []cadence.Field{
 			{
 				Identifier: "a",
@@ -888,7 +904,7 @@ func TestEncodeEvent(t *testing.T) {
 				).WithType(fooResourceType),
 			},
 		).WithType(resourceEventType),
-		`{"type":"Event","value":{"id":"S.test.FooEvent","fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
+		`{"type":"Event","value":{"id":"S.test.FooEvent","compositeTypeID":{"location": "S.test", "identifier":"FooEvent"},"fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
 	}
 
 	testAllEncodeAndDecode(t, simpleEvent, resourceEvent)
@@ -901,6 +917,10 @@ func TestEncodeContract(t *testing.T) {
 	simpleContractType := &cadence.ContractType{
 		TypeID:     "S.test.FooContract",
 		Identifier: "FooContract",
+		ContractTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "FooContract",
+		},
 		Fields: []cadence.Field{
 			{
 				Identifier: "a",
@@ -921,12 +941,16 @@ func TestEncodeContract(t *testing.T) {
 				cadence.NewString("foo"),
 			},
 		).WithType(simpleContractType),
-		`{"type":"Contract","value":{"id":"S.test.FooContract","fields":[{"name":"a","value":{"type":"Int","value":"1"}},{"name":"b","value":{"type":"String","value":"foo"}}]}}`,
+		`{"type":"Contract","value":{"id":"S.test.FooContract","compositeTypeID":{"location": "S.test", "identifier":"FooContract"},"fields":[{"name":"a","value":{"type":"Int","value":"1"}},{"name":"b","value":{"type":"String","value":"foo"}}]}}`,
 	}
 
 	resourceContractType := &cadence.ContractType{
 		TypeID:     "S.test.FooContract",
 		Identifier: "FooContract",
+		ContractTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "FooContract",
+		},
 		Fields: []cadence.Field{
 			{
 				Identifier: "a",
@@ -951,7 +975,7 @@ func TestEncodeContract(t *testing.T) {
 				).WithType(fooResourceType),
 			},
 		).WithType(resourceContractType),
-		`{"type":"Contract","value":{"id":"S.test.FooContract","fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
+		`{"type":"Contract","value":{"id":"S.test.FooContract","compositeTypeID":{"location": "S.test", "identifier":"FooContract"},"fields":[{"name":"a","value":{"type":"String","value":"foo"}},{"name":"b","value":{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"bar","value":{"type":"Int","value":"42"}}]}}}]}}`,
 	}
 
 	testAllEncodeAndDecode(t, simpleContract, resourceContract)
@@ -1225,7 +1249,11 @@ func TestExportRecursiveType(t *testing.T) {
 	t.Parallel()
 
 	ty := &cadence.ResourceType{
-		TypeID:     "S.test.Foo",
+		TypeID: "S.test.Foo",
+		ResourceTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "Foo",
+		},
 		Identifier: "Foo",
 		Fields: []cadence.Field{
 			{
@@ -1245,7 +1273,7 @@ func TestExportRecursiveType(t *testing.T) {
 				cadence.Optional{},
 			},
 		}.WithType(ty),
-		`{"type":"Resource","value":{"id":"S.test.Foo","fields":[{"name":"foo","value":{"type": "Optional","value":null}}]}}`,
+		`{"type":"Resource","value":{"id":"S.test.Foo","compositeTypeID":{"location": "S.test", "identifier":"Foo"},"fields":[{"name":"foo","value":{"type": "Optional","value":null}}]}}`,
 	)
 
 }
@@ -1319,6 +1347,10 @@ func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value) {
 var fooResourceType = &cadence.ResourceType{
 	TypeID:     "S.test.Foo",
 	Identifier: "Foo",
+	ResourceTypeID: cadence.CompositeTypeID{
+		Location:   "S.test",
+		Identifier: "Foo",
+	},
 	Fields: []cadence.Field{
 		{
 			Identifier: "bar",

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -190,7 +190,10 @@ func exportConstantSizedType(t *sema.ConstantSizedType, results map[sema.TypeID]
 func exportCompositeType(t *sema.CompositeType, results map[sema.TypeID]cadence.Type) (result cadence.CompositeType) {
 
 	id := string(t.ID())
-
+	compositeTypeID := cadence.CompositeTypeID{
+		Location:   string(t.Location.ID()),
+		Identifier: t.QualifiedIdentifier(),
+	}
 	fieldMembers := make([]*sema.Member, 0, len(t.Fields))
 
 	for _, identifier := range t.Fields {
@@ -208,30 +211,35 @@ func exportCompositeType(t *sema.CompositeType, results map[sema.TypeID]cadence.
 	switch t.Kind {
 	case common.CompositeKindStructure:
 		result = &cadence.StructType{
-			TypeID:     id,
-			Identifier: t.Identifier,
-			Fields:     fields,
+			TypeID:       id,
+			StructTypeID: compositeTypeID,
+			Identifier:   t.Identifier,
+			Fields:       fields,
 		}
 
 	case common.CompositeKindResource:
 		result = &cadence.ResourceType{
-			TypeID:     id,
-			Identifier: t.Identifier,
-			Fields:     fields,
+			TypeID:         id,
+			ResourceTypeID: compositeTypeID,
+			Identifier:     t.Identifier,
+			Fields:         fields,
 		}
 
 	case common.CompositeKindEvent:
+
 		result = &cadence.EventType{
-			TypeID:     id,
-			Identifier: t.Identifier,
-			Fields:     fields,
+			TypeID:      id,
+			EventTypeID: compositeTypeID,
+			Identifier:  t.Identifier,
+			Fields:      fields,
 		}
 
 	case common.CompositeKindContract:
 		result = &cadence.ContractType{
-			TypeID:     id,
-			Identifier: t.Identifier,
-			Fields:     fields,
+			TypeID:         id,
+			ContractTypeID: compositeTypeID,
+			Identifier:     t.Identifier,
+			Fields:         fields,
 		}
 
 	default:

--- a/runtime/convertTypes_test.go
+++ b/runtime/convertTypes_test.go
@@ -53,7 +53,11 @@ func TestExportRecursiveType(t *testing.T) {
 	}
 
 	expected := &cadence.ResourceType{
-		TypeID:     "S.test.Foo",
+		TypeID: "S.test.Foo",
+		ResourceTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "Foo",
+		},
 		Identifier: "Foo",
 		Fields: []cadence.Field{
 			{

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -493,6 +493,10 @@ func TestExportNestedResourceValueFromScript(t *testing.T) {
 	barResourceType := &cadence.ResourceType{
 		TypeID:     "S.test.Bar",
 		Identifier: "Bar",
+		ResourceTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "Bar",
+		},
 		Fields: []cadence.Field{
 			{
 				Identifier: "uuid",
@@ -508,6 +512,10 @@ func TestExportNestedResourceValueFromScript(t *testing.T) {
 	fooResourceType := &cadence.ResourceType{
 		TypeID:     "S.test.Foo",
 		Identifier: "Foo",
+		ResourceTypeID: cadence.CompositeTypeID{
+			Location:   "S.test",
+			Identifier: "Foo",
+		},
 		Fields: []cadence.Field{
 			{
 				Identifier: "uuid",
@@ -667,6 +675,10 @@ func TestExportCapabilityValue(t *testing.T) {
 const fooID = "Foo"
 
 var fooTypeID = fmt.Sprintf("S.%s.%s", utils.TestLocation, fooID)
+var fooCompositeTypeID = cadence.CompositeTypeID{
+	Location:   fmt.Sprintf("S.%s", utils.TestLocation),
+	Identifier: fooID,
+}
 var fooFields = []cadence.Field{
 	{
 		Identifier: "bar",
@@ -685,19 +697,22 @@ var fooResourceFields = []cadence.Field{
 }
 
 var fooStructType = &cadence.StructType{
-	TypeID:     fooTypeID,
-	Identifier: fooID,
-	Fields:     fooFields,
+	TypeID:       fooTypeID,
+	StructTypeID: fooCompositeTypeID,
+	Identifier:   fooID,
+	Fields:       fooFields,
 }
 
 var fooResourceType = &cadence.ResourceType{
-	TypeID:     fooTypeID,
-	Identifier: fooID,
-	Fields:     fooResourceFields,
+	TypeID:         fooTypeID,
+	ResourceTypeID: fooCompositeTypeID,
+	Identifier:     fooID,
+	Fields:         fooResourceFields,
 }
 
 var fooEventType = &cadence.EventType{
-	TypeID:     fooTypeID,
-	Identifier: fooID,
-	Fields:     fooFields,
+	TypeID:      fooTypeID,
+	EventTypeID: fooCompositeTypeID,
+	Identifier:  fooID,
+	Fields:      fooFields,
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -752,8 +752,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 					cadence.
 						NewStruct([]cadence.Value{cadence.NewString("bar")}).
 						WithType(&cadence.StructType{
-							TypeID:     "S.test.Foo",
-							Identifier: "Foo",
+							TypeID:       "S.test.Foo",
+							StructTypeID: fooCompositeTypeID,
+							Identifier:   "Foo",
 							Fields: []cadence.Field{
 								{
 									Identifier: "y",
@@ -789,7 +790,11 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 						cadence.
 							NewStruct([]cadence.Value{cadence.NewString("bar")}).
 							WithType(&cadence.StructType{
-								TypeID:     "S.test.Foo",
+								TypeID: "S.test.Foo",
+								StructTypeID: cadence.CompositeTypeID{
+									Location:   "S.test",
+									Identifier: "Foo",
+								},
 								Identifier: "Foo",
 								Fields: []cadence.Field{
 									{

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -136,7 +136,11 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 	assert.NotNil(t, accountCode)
 
 	rType := &cadence.ResourceType{
-		TypeID:     "AC.000000000000cade.Test.Test.R",
+		TypeID: "AC.000000000000cade.Test.Test.R",
+		ResourceTypeID: cadence.CompositeTypeID{
+			Location:   "AC.000000000000cade.Test",
+			Identifier: "Test.R",
+		},
 		Identifier: "R",
 		Fields: []cadence.Field{
 			{
@@ -156,7 +160,11 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 				address,
 				"contract\x1fTest",
 				cadence.NewContract([]cadence.Value{}).WithType(&cadence.ContractType{
-					TypeID:       "AC.000000000000cade.Test.Test",
+					TypeID: "AC.000000000000cade.Test.Test",
+					ContractTypeID: cadence.CompositeTypeID{
+						Location:   "AC.000000000000cade.Test",
+						Identifier: "Test",
+					},
 					Identifier:   "Test",
 					Fields:       []cadence.Field{},
 					Initializers: nil,

--- a/types.go
+++ b/types.go
@@ -496,6 +496,7 @@ type Parameter struct {
 type CompositeType interface {
 	Type
 	isCompositeType()
+	CompositeTypeID() CompositeTypeID
 	CompositeIdentifier() string
 	CompositeFields() []Field
 	CompositeInitializers() [][]Parameter
@@ -505,6 +506,7 @@ type CompositeType interface {
 
 type StructType struct {
 	TypeID       string
+	StructTypeID CompositeTypeID
 	Identifier   string
 	Fields       []Field
 	Initializers [][]Parameter
@@ -514,6 +516,10 @@ func (*StructType) isType() {}
 
 func (t *StructType) ID() string {
 	return t.TypeID
+}
+
+func (t *StructType) CompositeTypeID() CompositeTypeID {
+	return t.StructTypeID
 }
 
 func (*StructType) isCompositeType() {}
@@ -533,16 +539,21 @@ func (t *StructType) CompositeInitializers() [][]Parameter {
 // ResourceType
 
 type ResourceType struct {
-	TypeID       string
-	Identifier   string
-	Fields       []Field
-	Initializers [][]Parameter
+	TypeID         string
+	ResourceTypeID CompositeTypeID
+	Identifier     string
+	Fields         []Field
+	Initializers   [][]Parameter
 }
 
 func (*ResourceType) isType() {}
 
 func (t *ResourceType) ID() string {
 	return t.TypeID
+}
+
+func (t *ResourceType) CompositeTypeID() CompositeTypeID {
+	return t.ResourceTypeID
 }
 
 func (*ResourceType) isCompositeType() {}
@@ -559,10 +570,15 @@ func (t *ResourceType) CompositeInitializers() [][]Parameter {
 	return t.Initializers
 }
 
-// EventType
+type CompositeTypeID struct {
+	Location   string
+	Identifier string
+}
 
+// EventType
 type EventType struct {
-	TypeID      string
+	TypeID      string // keep for compatibility
+	EventTypeID CompositeTypeID
 	Identifier  string
 	Fields      []Field
 	Initializer []Parameter
@@ -572,6 +588,10 @@ func (*EventType) isType() {}
 
 func (t *EventType) ID() string {
 	return t.TypeID
+}
+
+func (t *EventType) CompositeTypeID() CompositeTypeID {
+	return t.EventTypeID
 }
 
 func (EventType) isCompositeType() {}
@@ -591,16 +611,21 @@ func (t *EventType) CompositeInitializers() [][]Parameter {
 // ContractType
 
 type ContractType struct {
-	TypeID       string
-	Identifier   string
-	Fields       []Field
-	Initializers [][]Parameter
+	TypeID         string
+	Identifier     string
+	Fields         []Field
+	Initializers   [][]Parameter
+	ContractTypeID CompositeTypeID
 }
 
 func (*ContractType) isType() {}
 
 func (t *ContractType) ID() string {
 	return t.TypeID
+}
+
+func (t *ContractType) CompositeTypeID() CompositeTypeID {
+	return t.ContractTypeID
 }
 
 func (*ContractType) isCompositeType() {}


### PR DESCRIPTION
Closes #420

## Description

Adds separate components making composite type ID exported.
For now kept original `TypeID` for compatibility.

______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
