### PR TITLE
Add position information to interpreter errors

### DIFF
--- a/runtime/ast/position.go
+++ b/runtime/ast/position.go
@@ -78,11 +78,11 @@ type Range struct {
 	EndPos   Position
 }
 
-func (e *Range) StartPosition() Position {
+func (e Range) StartPosition() Position {
 	return e.StartPos
 }
 
-func (e *Range) EndPosition() Position {
+func (e Range) EndPosition() Position {
 	return e.EndPos
 }
 

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -43,6 +43,20 @@ func (e *unsupportedOperation) Error() string {
 	)
 }
 
+// Error is the containing type for all errors produced by the interpreter.
+type Error struct {
+	Err error
+	LocationRange
+}
+
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+func (e Error) Error() string {
+	return e.Err.Error()
+}
+
 // ExternalError is an error that occurred externally.
 // It contains the recovered value.
 //

--- a/runtime/interpreter/statement_trampoline.go
+++ b/runtime/interpreter/statement_trampoline.go
@@ -19,6 +19,7 @@
 package interpreter
 
 import (
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/trampoline"
 )
 
@@ -28,7 +29,7 @@ import (
 type StatementTrampoline struct {
 	F           func() trampoline.Trampoline
 	Interpreter *Interpreter
-	Line        int
+	Statement   ast.Statement
 }
 
 // Resume returns the paused computation

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1136,9 +1136,7 @@ func TestRuntimeProgramWithNoTransaction(t *testing.T) {
 
 	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
 
-	require.IsType(t, Error{}, err)
-	err = err.(Error).Unwrap()
-	assert.IsType(t, InvalidTransactionCountError{}, err)
+	utils.RequireErrorAs(t, err, &InvalidTransactionCountError{})
 }
 
 func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
@@ -1162,9 +1160,7 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
 
 	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
 
-	require.IsType(t, Error{}, err)
-	err = err.(Error).Unwrap()
-	assert.IsType(t, InvalidTransactionCountError{}, err)
+	utils.RequireErrorAs(t, err, &InvalidTransactionCountError{})
 }
 
 func TestRuntimeStorage(t *testing.T) {
@@ -3206,13 +3202,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 				} else {
 					require.Error(t, err)
 
-					require.IsType(t, Error{}, err)
-					err = err.(Error).Unwrap()
-
-					require.IsType(t, interpreter.Error{}, err)
-					err = err.(interpreter.Error).Unwrap()
-
-					assert.IsType(t, interpreter.ConditionError{}, err)
+					utils.RequireErrorAs(t, err, &interpreter.ConditionError{})
 				}
 			})
 		}
@@ -4837,8 +4827,8 @@ func TestRuntime(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				require.IsType(t, Error{}, err)
-				assert.IsType(t, InvalidEntryPointParameterCountError{}, err.(Error).Unwrap())
+
+				utils.RequireErrorAs(t, err, &InvalidEntryPointParameterCountError{})
 			}
 		})
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3205,8 +3205,14 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 					assert.NoError(t, err)
 				} else {
 					require.Error(t, err)
+
 					require.IsType(t, Error{}, err)
-					assert.IsType(t, interpreter.ConditionError{}, err.(Error).Err)
+					err = err.(Error).Unwrap()
+
+					require.IsType(t, interpreter.Error{}, err)
+					err = err.(interpreter.Error).Unwrap()
+
+					assert.IsType(t, interpreter.ConditionError{}, err)
 				}
 			})
 		}
@@ -3952,6 +3958,9 @@ func TestRuntimeComputationLimit(t *testing.T) {
 
 				require.IsType(t, Error{}, err)
 				err = err.(Error).Unwrap()
+
+				require.IsType(t, interpreter.Error{}, err)
+				err = err.(interpreter.Error).Unwrap()
 
 				assert.Equal(t,
 					ComputationLimitExceededError{

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/utils"
 	"github.com/onflow/cadence/runtime/trampoline"
 )
 
@@ -173,13 +174,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t, interpreter.OverwriteError{}, err)
+			utils.RequireErrorAs(t, err, &interpreter.OverwriteError{})
 		})
 	})
 
@@ -227,13 +222,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t, interpreter.OverwriteError{}, err)
+			utils.RequireErrorAs(t, err, &interpreter.OverwriteError{})
 		})
 	})
 }

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -173,6 +173,12 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 			require.Error(t, err)
 
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
+
 			require.IsType(t, interpreter.OverwriteError{}, err)
 		})
 	})
@@ -220,6 +226,12 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 			_, err := inter.Invoke("test")
 
 			require.Error(t, err)
+
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
 
 			require.IsType(t, interpreter.OverwriteError{}, err)
 		})

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -158,6 +158,12 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
 
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
+
 			require.IsType(t, interpreter.ForceNilError{}, err)
 		})
 
@@ -165,6 +171,12 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
+
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
 
 			require.IsType(t, interpreter.CyclicLinkError{}, err)
 
@@ -271,7 +283,10 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			value, err := inter.Invoke("single")
 			require.NoError(t, err)
 
-			require.Equal(t, interpreter.NewIntValueFromInt64(42), value)
+			require.Equal(t,
+				interpreter.NewIntValueFromInt64(42),
+				value,
+			)
 		})
 
 		t.Run("single S2", func(t *testing.T) {
@@ -303,13 +318,22 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			value, err := inter.Invoke("double")
 			require.NoError(t, err)
 
-			require.Equal(t, interpreter.NewIntValueFromInt64(42), value)
+			require.Equal(t,
+				interpreter.NewIntValueFromInt64(42),
+				value,
+			)
 		})
 
 		t.Run("nonExistent", func(t *testing.T) {
 
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
+
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
 
 			require.IsType(t, interpreter.ForceNilError{}, err)
 		})
@@ -318,6 +342,12 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
+
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
 
 			require.IsType(t, interpreter.CyclicLinkError{}, err)
 
@@ -477,7 +507,16 @@ func TestInterpretCapability_check(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t, interpreter.CyclicLinkError{}, err)
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
+
+			require.IsType(t,
+				interpreter.CyclicLinkError{},
+				err,
+			)
 
 			require.Equal(t,
 				err.Error(),
@@ -629,6 +668,12 @@ func TestInterpretCapability_check(t *testing.T) {
 
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
+
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
 
 			require.IsType(t, interpreter.CyclicLinkError{}, err)
 

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestInterpretCapability_borrow(t *testing.T) {
@@ -158,13 +159,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t, interpreter.ForceNilError{}, err)
+			utils.RequireErrorAs(t, err, &interpreter.ForceNilError{})
 		})
 
 		t.Run("loop", func(t *testing.T) {
@@ -172,16 +167,11 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t, interpreter.CyclicLinkError{}, err)
+			var cyclicLinkErr interpreter.CyclicLinkError
+			utils.RequireErrorAs(t, err, &cyclicLinkErr)
 
 			require.Equal(t,
-				err.Error(),
+				cyclicLinkErr.Error(),
 				"cyclic link in account 0x2a: /public/loop1 -> /public/loop2 -> /public/loop1",
 			)
 		})
@@ -329,13 +319,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t, interpreter.ForceNilError{}, err)
+			utils.RequireErrorAs(t, err, &interpreter.ForceNilError{})
 		})
 
 		t.Run("loop", func(t *testing.T) {
@@ -343,16 +327,11 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t, interpreter.CyclicLinkError{}, err)
+			var cyclicLinkErr interpreter.CyclicLinkError
+			utils.RequireErrorAs(t, err, &cyclicLinkErr)
 
 			require.Equal(t,
-				err.Error(),
+				cyclicLinkErr.Error(),
 				"cyclic link in account 0x2a: /public/loop1 -> /public/loop2 -> /public/loop1",
 			)
 		})
@@ -507,19 +486,11 @@ func TestInterpretCapability_check(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t,
-				interpreter.CyclicLinkError{},
-				err,
-			)
+			var cyclicLinkErr interpreter.CyclicLinkError
+			utils.RequireErrorAs(t, err, &cyclicLinkErr)
 
 			require.Equal(t,
-				err.Error(),
+				cyclicLinkErr.Error(),
 				"cyclic link in account 0x2a: /public/loop1 -> /public/loop2 -> /public/loop1",
 			)
 		})
@@ -669,16 +640,11 @@ func TestInterpretCapability_check(t *testing.T) {
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
 
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
-
-			require.IsType(t, interpreter.CyclicLinkError{}, err)
+			var cyclicLinkErr interpreter.CyclicLinkError
+			utils.RequireErrorAs(t, err, &cyclicLinkErr)
 
 			require.Equal(t,
-				err.Error(),
+				cyclicLinkErr.Error(),
 				"cyclic link in account 0x2a: /public/loop1 -> /public/loop2 -> /public/loop1",
 			)
 		})

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -158,6 +158,12 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 										result,
 									)
 								} else {
+									require.IsType(t,
+										interpreter.Error{},
+										err,
+									)
+									err = err.(interpreter.Error).Unwrap()
+
 									assert.IsType(t,
 										interpreter.TypeMismatchError{},
 										err,
@@ -251,6 +257,12 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -339,6 +351,12 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -427,6 +445,12 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -520,6 +544,12 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -610,6 +640,12 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 							result,
 						)
 					} else {
+						require.IsType(t,
+							interpreter.Error{},
+							err,
+						)
+						err = err.(interpreter.Error).Unwrap()
+
 						assert.IsType(t,
 							interpreter.TypeMismatchError{},
 							err,
@@ -652,6 +688,12 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -763,6 +805,12 @@ func testResourceCastInvalid(t *testing.T, types, fromType, targetType string, o
 
 	case ast.OperationForceCast:
 		require.Error(t, err)
+
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
 
 		require.IsType(t,
 			interpreter.TypeMismatchError{},
@@ -915,6 +963,12 @@ func testStructCastInvalid(t *testing.T, types, fromType, targetType string, ope
 
 	case ast.OperationForceCast:
 		require.Error(t, err)
+
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
 
 		require.IsType(t,
 			interpreter.TypeMismatchError{},
@@ -1121,6 +1175,12 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -1213,6 +1273,12 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -1312,6 +1378,12 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,
@@ -2223,6 +2295,12 @@ func testReferenceCastInvalid(t *testing.T, types, fromType, targetType string, 
 
 	case ast.OperationForceCast:
 		require.Error(t, err)
+
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
 
 		require.IsType(t,
 			interpreter.TypeMismatchError{},
@@ -3472,6 +3550,12 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 								result,
 							)
 						} else {
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
 							assert.IsType(t,
 								interpreter.TypeMismatchError{},
 								err,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -158,16 +158,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 										result,
 									)
 								} else {
-									require.IsType(t,
-										interpreter.Error{},
-										err,
-									)
-									err = err.(interpreter.Error).Unwrap()
-
-									assert.IsType(t,
-										interpreter.TypeMismatchError{},
-										err,
-									)
+									utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 								}
 							})
 						}
@@ -257,16 +248,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -351,16 +333,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -445,16 +418,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -544,16 +508,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -640,16 +595,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 							result,
 						)
 					} else {
-						require.IsType(t,
-							interpreter.Error{},
-							err,
-						)
-						err = err.(interpreter.Error).Unwrap()
-
-						assert.IsType(t,
-							interpreter.TypeMismatchError{},
-							err,
-						)
+						utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 					}
 				})
 
@@ -688,16 +634,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -804,18 +741,7 @@ func testResourceCastInvalid(t *testing.T, types, fromType, targetType string, o
 		)
 
 	case ast.OperationForceCast:
-		require.Error(t, err)
-
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		require.IsType(t,
-			interpreter.TypeMismatchError{},
-			err,
-		)
+		utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -962,18 +888,7 @@ func testStructCastInvalid(t *testing.T, types, fromType, targetType string, ope
 		)
 
 	case ast.OperationForceCast:
-		require.Error(t, err)
-
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		require.IsType(t,
-			interpreter.TypeMismatchError{},
-			err,
-		)
+		utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -1175,16 +1090,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -1273,16 +1179,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -1378,16 +1275,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}
@@ -2294,18 +2182,7 @@ func testReferenceCastInvalid(t *testing.T, types, fromType, targetType string, 
 		)
 
 	case ast.OperationForceCast:
-		require.Error(t, err)
-
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		require.IsType(t,
-			interpreter.TypeMismatchError{},
-			err,
-		)
+		utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -3550,16 +3427,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 								result,
 							)
 						} else {
-							require.IsType(t,
-								interpreter.Error{},
-								err,
-							)
-							err = err.(interpreter.Error).Unwrap()
-
-							assert.IsType(t,
-								interpreter.TypeMismatchError{},
-								err,
-							)
+							utils.RequireErrorAs(t, err, &interpreter.TypeMismatchError{})
 						}
 					})
 				}

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
@@ -295,15 +296,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		`)
 
 		_, err := inter.Invoke("test")
-		require.Error(t, err)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		assert.IsType(t, interpreter.UnderflowError{}, err)
+		utils.RequireErrorAs(t, err, &interpreter.UnderflowError{})
 	})
 
 	t.Run("invalid UFix64 > max Fix64 int to Fix64", func(t *testing.T) {
@@ -321,15 +315,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
-		require.Error(t, err)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		assert.IsType(t, interpreter.OverflowError{}, err)
+		utils.RequireErrorAs(t, err, &interpreter.OverflowError{})
 	})
 
 	t.Run("invalid negative integer to UFix64", func(t *testing.T) {
@@ -357,9 +344,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					interpreter.Error{},
 					err,
 				)
-				err = err.(interpreter.Error).Unwrap()
 
-				assert.IsType(t, interpreter.UnderflowError{}, err)
+				utils.RequireErrorAs(t, err, &interpreter.UnderflowError{})
 			})
 		}
 	})
@@ -393,15 +379,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				)
 
 				_, err := inter.Invoke("test")
-				require.Error(t, err)
 
-				require.IsType(t,
-					interpreter.Error{},
-					err,
-				)
-				err = err.(interpreter.Error).Unwrap()
-
-				assert.IsType(t, interpreter.OverflowError{}, err)
+				utils.RequireErrorAs(t, err, &interpreter.OverflowError{})
 			})
 		}
 	})
@@ -436,15 +415,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				)
 
 				_, err := inter.Invoke("test")
-				require.Error(t, err)
 
-				require.IsType(t,
-					interpreter.Error{},
-					err,
-				)
-				err = err.(interpreter.Error).Unwrap()
-
-				assert.IsType(t, interpreter.OverflowError{}, err)
+				utils.RequireErrorAs(t, err, &interpreter.OverflowError{})
 			})
 		}
 	})
@@ -481,13 +453,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
 
-				require.IsType(t,
-					interpreter.Error{},
-					err,
-				)
-				err = err.(interpreter.Error).Unwrap()
-
-				assert.IsType(t, interpreter.OverflowError{}, err)
+				utils.RequireErrorAs(t, err, &interpreter.OverflowError{})
 			})
 		}
 	})
@@ -524,13 +490,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
 
-				require.IsType(t,
-					interpreter.Error{},
-					err,
-				)
-				err = err.(interpreter.Error).Unwrap()
-
-				assert.IsType(t, interpreter.UnderflowError{}, err)
+				utils.RequireErrorAs(t, err, &interpreter.UnderflowError{})
 			})
 		}
 	})

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -297,6 +297,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
 		assert.IsType(t, interpreter.UnderflowError{}, err)
 	})
 
@@ -316,6 +322,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
 
 		assert.IsType(t, interpreter.OverflowError{}, err)
 	})
@@ -340,6 +352,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
+
+				require.IsType(t,
+					interpreter.Error{},
+					err,
+				)
+				err = err.(interpreter.Error).Unwrap()
 
 				assert.IsType(t, interpreter.UnderflowError{}, err)
 			})
@@ -376,6 +394,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
+
+				require.IsType(t,
+					interpreter.Error{},
+					err,
+				)
+				err = err.(interpreter.Error).Unwrap()
 
 				assert.IsType(t, interpreter.OverflowError{}, err)
 			})
@@ -414,6 +438,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
 
+				require.IsType(t,
+					interpreter.Error{},
+					err,
+				)
+				err = err.(interpreter.Error).Unwrap()
+
 				assert.IsType(t, interpreter.OverflowError{}, err)
 			})
 		}
@@ -451,6 +481,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
 
+				require.IsType(t,
+					interpreter.Error{},
+					err,
+				)
+				err = err.(interpreter.Error).Unwrap()
+
 				assert.IsType(t, interpreter.OverflowError{}, err)
 			})
 		}
@@ -487,6 +523,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
+
+				require.IsType(t,
+					interpreter.Error{},
+					err,
+				)
+				err = err.(interpreter.Error).Unwrap()
 
 				assert.IsType(t, interpreter.UnderflowError{}, err)
 			})

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -491,6 +491,17 @@ func TestInterpretInvalidArrayIndexing(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ArrayIndexOutOfBoundsError{},
+		err,
+	)
+
 	require.Equal(t,
 		interpreter.ArrayIndexOutOfBoundsError{
 			Index:    2,
@@ -647,11 +658,22 @@ func TestInterpretStringSlicing(t *testing.T) {
 			)
 
 			value, err := inter.Invoke("test")
-			assert.IsType(t, test.expectedError, err)
-			assert.Equal(t,
-				interpreter.NewStringValue(test.result),
-				value,
-			)
+			if test.expectedError == nil {
+				require.NoError(t, err)
+
+				assert.Equal(t,
+					interpreter.NewStringValue(test.result),
+					value,
+				)
+			} else {
+				require.IsType(t,
+					interpreter.Error{},
+					err,
+				)
+				err = err.(interpreter.Error).Unwrap()
+
+				assert.IsType(t, test.expectedError, err)
+			}
 		})
 	}
 }
@@ -1911,7 +1933,16 @@ func TestInterpretFunctionPreCondition(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -1938,7 +1969,16 @@ func TestInterpretFunctionPostCondition(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -1964,7 +2004,16 @@ func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -2042,11 +2091,21 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPreCondition(t *testing.
 
 	_, err := inter.Invoke("test")
 
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
+	conditionError := err.(interpreter.ConditionError)
 
 	assert.Equal(t,
 		ast.ConditionKindPre,
-		err.(interpreter.ConditionError).ConditionKind,
+		conditionError.ConditionKind,
 	)
 }
 
@@ -2070,11 +2129,21 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPostCondition(t *testing
 
 	_, err := inter.Invoke("test")
 
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
+	conditionError := err.(interpreter.ConditionError)
 
 	assert.Equal(t,
 		ast.ConditionKindPost,
-		err.(interpreter.ConditionError).ConditionKind,
+		conditionError.ConditionKind,
 	)
 }
 
@@ -2096,11 +2165,21 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
+	conditionError := err.(interpreter.ConditionError)
 
 	assert.Equal(t,
 		"y should be zero",
-		err.(interpreter.ConditionError).Message,
+		conditionError.Message,
 	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
@@ -2128,11 +2207,21 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
+	conditionError := err.(interpreter.ConditionError)
 
 	assert.Equal(t,
 		"return value",
-		err.(interpreter.ConditionError).Message,
+		conditionError.Message,
 	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
@@ -2159,11 +2248,21 @@ func TestInterpretFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
+	conditionError := err.(interpreter.ConditionError)
 
 	assert.Equal(t,
 		"parameter value",
-		err.(interpreter.ConditionError).Message,
+		conditionError.Message,
 	)
 }
 
@@ -2181,11 +2280,21 @@ func TestInterpretFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		err,
+	)
+	conditionError := err.(interpreter.ConditionError)
 
 	assert.Equal(t,
 		"parameter value",
-		err.(interpreter.ConditionError).Message,
+		conditionError.Message,
 	)
 }
 
@@ -3582,7 +3691,16 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			)
 
 			_, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(0))
-			assert.IsType(t, interpreter.ConditionError{}, err)
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
+
+			require.IsType(t,
+				interpreter.ConditionError{},
+				err,
+			)
 
 			value, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(1))
 			require.NoError(t, err)
@@ -3593,7 +3711,13 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			)
 
 			_, err = inter.Invoke("callTest", interpreter.NewIntValueFromInt64(2))
-			assert.IsType(t,
+			require.IsType(t,
+				interpreter.Error{},
+				err,
+			)
+			err = err.(interpreter.Error).Unwrap()
+
+			require.IsType(t,
 				interpreter.ConditionError{},
 				err,
 			)
@@ -3674,7 +3798,16 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 						if expectedError == nil {
 							require.NoError(t, err)
 						} else {
-							assert.IsType(t, expectedError, err)
+							require.IsType(t,
+								interpreter.Error{},
+								err,
+							)
+							err = err.(interpreter.Error).Unwrap()
+
+							require.IsType(t,
+								expectedError,
+								err,
+							)
 						}
 					}
 
@@ -3770,23 +3903,39 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	t.Run("-1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(-1))
 		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		require.IsType(t,
 			interpreter.ConditionError{},
 			err,
 		)
+		conditionError := err.(interpreter.ConditionError)
 
 		// NOTE: The type requirement condition (`Test.Nested`) is evaluated first,
 		//  before the type's conformances (`Also`)
 
-		assert.Equal(t, err.(interpreter.ConditionError).Message, "x >= 1")
+		assert.Equal(t, "x >= 1", conditionError.Message)
 	})
 
 	t.Run("0", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(0))
-		assert.IsType(t,
+
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		require.IsType(t,
 			interpreter.ConditionError{},
 			err,
 		)
-		assert.Equal(t, "x >= 1", err.(interpreter.ConditionError).Message)
+		conditionError := err.(interpreter.ConditionError)
+
+		assert.Equal(t, "x >= 1", conditionError.Message)
 	})
 
 	t.Run("1", func(t *testing.T) {
@@ -3801,9 +3950,15 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 
 	t.Run("2", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
-		assert.IsType(t,
-			interpreter.ConditionError{},
+		require.IsType(t,
+			interpreter.Error{},
 			err,
+		)
+		interpreterErr := err.(interpreter.Error)
+
+		require.IsType(t,
+			interpreter.ConditionError{},
+			interpreterErr.Err,
 		)
 	})
 }
@@ -3955,6 +4110,12 @@ func TestInterpretImportError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
+
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
 
 	assert.IsType(t, stdlib.PanicError{}, err)
 	assert.Equal(t,
@@ -5590,7 +5751,16 @@ func TestInterpretResourceDestroyExpressionResourceInterfaceCondition(t *testing
     `)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	interpreterErr := err.(interpreter.Error)
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		interpreterErr.Err,
+	)
 }
 
 // TestInterpretInterfaceInitializer tests that the interface's initializer
@@ -5617,7 +5787,16 @@ func TestInterpretInterfaceInitializer(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	interpreterErr := err.(interpreter.Error)
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		interpreterErr.Err,
+	)
 }
 
 func TestInterpretEmitEvent(t *testing.T) {
@@ -6099,7 +6278,16 @@ func TestInterpretReferenceDereferenceFailure(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
-	assert.IsType(t, interpreter.DestroyedCompositeError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	assert.IsType(t,
+		interpreter.DestroyedCompositeError{},
+		err,
+	)
 }
 
 func TestInterpretInvalidForwardReferenceCall(t *testing.T) {
@@ -6738,7 +6926,16 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	interpreterErr := err.(interpreter.Error)
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		interpreterErr.Err,
+	)
 }
 
 func TestInterpretFunctionPostConditionInInterface(t *testing.T) {
@@ -6793,7 +6990,16 @@ func TestInterpretFunctionPostConditionInInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test2")
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	interpreterErr := err.(interpreter.Error)
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		interpreterErr.Err,
+	)
 }
 
 func TestInterpretFunctionPostConditionWithBeforeInInterface(t *testing.T) {
@@ -6848,7 +7054,16 @@ func TestInterpretFunctionPostConditionWithBeforeInInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test2")
-	assert.IsType(t, interpreter.ConditionError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	interpreterErr := err.(interpreter.Error)
+
+	require.IsType(t,
+		interpreter.ConditionError{},
+		interpreterErr.Err,
+	)
 }
 
 func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
@@ -6928,8 +7143,19 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
 		require.Error(t, err)
 
-		require.IsType(t, interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid init", err.(interpreter.ConditionError).Message)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		interpreterErr := err.(interpreter.Error)
+
+		require.IsType(t,
+			interpreter.ConditionError{},
+			interpreterErr.Err,
+		)
+		conditionError := interpreterErr.Err.(interpreter.ConditionError)
+
+		assert.Equal(t, "invalid init", conditionError.Message)
 	})
 
 	t.Run("2", func(t *testing.T) {
@@ -6941,8 +7167,19 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(3))
 		require.Error(t, err)
 
-		require.IsType(t, interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid destroy", err.(interpreter.ConditionError).Message)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		interpreterErr := err.(interpreter.Error)
+
+		require.IsType(t,
+			interpreter.ConditionError{},
+			interpreterErr.Err,
+		)
+		conditionError := interpreterErr.Err.(interpreter.ConditionError)
+
+		assert.Equal(t, "invalid destroy", conditionError.Message)
 	})
 }
 
@@ -7000,8 +7237,19 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
 		require.Error(t, err)
 
-		require.IsType(t, interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid init", err.(interpreter.ConditionError).Message)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		interpreterErr := err.(interpreter.Error)
+
+		require.IsType(t,
+			interpreter.ConditionError{},
+			interpreterErr.Err,
+		)
+		conditionError := interpreterErr.Err.(interpreter.ConditionError)
+
+		assert.Equal(t, "invalid init", conditionError.Message)
 	})
 
 	t.Run("2", func(t *testing.T) {
@@ -7013,8 +7261,19 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(3))
 		require.Error(t, err)
 
-		require.IsType(t, interpreter.ConditionError{}, err)
-		assert.Equal(t, "invalid destroy", err.(interpreter.ConditionError).Message)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		interpreterErr := err.(interpreter.Error)
+
+		require.IsType(t,
+			interpreter.ConditionError{},
+			interpreterErr.Err,
+		)
+		conditionError := interpreterErr.Err.(interpreter.ConditionError)
+
+		assert.Equal(t, "invalid destroy", conditionError.Message)
 	})
 }
 
@@ -7084,7 +7343,16 @@ func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
 
-	assert.IsType(t, interpreter.DestroyedCompositeError{}, err)
+	require.IsType(t,
+		interpreter.Error{},
+		err,
+	)
+	err = err.(interpreter.Error).Unwrap()
+
+	assert.IsType(t,
+		interpreter.DestroyedCompositeError{},
+		err,
+	)
 }
 
 func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
@@ -7131,7 +7399,16 @@ func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
 		_, err := inter.Invoke("testNil")
 		require.Error(t, err)
 
-		assert.IsType(t, interpreter.DereferenceError{}, err)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		assert.IsType(t,
+			interpreter.DereferenceError{},
+			err,
+		)
 	})
 }
 
@@ -7460,7 +7737,16 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		assert.IsType(t, interpreter.ForceAssignmentToNonNilResourceError{}, err)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		assert.IsType(t,
+			interpreter.ForceAssignmentToNonNilResourceError{},
+			err,
+		)
 	})
 
 	t.Run("existing to nil", func(t *testing.T) {
@@ -7496,7 +7782,16 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		assert.IsType(t, interpreter.ForceAssignmentToNonNilResourceError{}, err)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		assert.IsType(t,
+			interpreter.ForceAssignmentToNonNilResourceError{},
+			err,
+		)
 	})
 }
 
@@ -7537,7 +7832,16 @@ func TestInterpretForce(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		assert.IsType(t, interpreter.ForceNilError{}, err)
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		require.IsType(t,
+			interpreter.ForceNilError{},
+			err,
+		)
 	})
 
 	t.Run("non-optional", func(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -491,16 +491,8 @@ func TestInterpretInvalidArrayIndexing(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
-
-	require.IsType(t,
-		interpreter.ArrayIndexOutOfBoundsError{},
-		err,
-	)
+	var indexErr interpreter.ArrayIndexOutOfBoundsError
+	RequireErrorAs(t, err, &indexErr)
 
 	require.Equal(t,
 		interpreter.ArrayIndexOutOfBoundsError{
@@ -514,7 +506,7 @@ func TestInterpretInvalidArrayIndexing(t *testing.T) {
 				},
 			},
 		},
-		err,
+		indexErr,
 	)
 }
 
@@ -1933,16 +1925,8 @@ func TestInterpretFunctionPreCondition(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
-
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -1969,16 +1953,8 @@ func TestInterpretFunctionPostCondition(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
-
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -2004,16 +1980,9 @@ func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
 
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	zero := interpreter.NewIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
@@ -2091,21 +2060,12 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPreCondition(t *testing.
 
 	_, err := inter.Invoke("test")
 
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
-
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
-	conditionError := err.(interpreter.ConditionError)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	assert.Equal(t,
 		ast.ConditionKindPre,
-		conditionError.ConditionKind,
+		conditionErr.ConditionKind,
 	)
 }
 
@@ -2129,21 +2089,12 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPostCondition(t *testing
 
 	_, err := inter.Invoke("test")
 
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
-
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
-	conditionError := err.(interpreter.ConditionError)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	assert.Equal(t,
 		ast.ConditionKindPost,
-		conditionError.ConditionKind,
+		conditionErr.ConditionKind,
 	)
 }
 
@@ -2165,21 +2116,13 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
 
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
-	conditionError := err.(interpreter.ConditionError)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	assert.Equal(t,
 		"y should be zero",
-		conditionError.Message,
+		conditionErr.Message,
 	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
@@ -2207,21 +2150,12 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 		"test",
 		interpreter.NewIntValueFromInt64(42),
 	)
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
-
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
-	conditionError := err.(interpreter.ConditionError)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	assert.Equal(t,
 		"return value",
-		conditionError.Message,
+		conditionErr.Message,
 	)
 
 	zero := interpreter.NewIntValueFromInt64(0)
@@ -2248,21 +2182,13 @@ func TestInterpretFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
 
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
-	conditionError := err.(interpreter.ConditionError)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	assert.Equal(t,
 		"parameter value",
-		conditionError.Message,
+		conditionErr.Message,
 	)
 }
 
@@ -2280,21 +2206,13 @@ func TestInterpretFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewStringValue("parameter value"))
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
 
-	require.IsType(t,
-		interpreter.ConditionError{},
-		err,
-	)
-	conditionError := err.(interpreter.ConditionError)
+	var conditionErr interpreter.ConditionError
+	RequireErrorAs(t, err, &conditionErr)
 
 	assert.Equal(t,
 		"parameter value",
-		conditionError.Message,
+		conditionErr.Message,
 	)
 }
 
@@ -3691,16 +3609,9 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			)
 
 			_, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(0))
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
 
-			require.IsType(t,
-				interpreter.ConditionError{},
-				err,
-			)
+			var conditionErr interpreter.ConditionError
+			RequireErrorAs(t, err, &conditionErr)
 
 			value, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(1))
 			require.NoError(t, err)
@@ -3711,16 +3622,8 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			)
 
 			_, err = inter.Invoke("callTest", interpreter.NewIntValueFromInt64(2))
-			require.IsType(t,
-				interpreter.Error{},
-				err,
-			)
-			err = err.(interpreter.Error).Unwrap()
 
-			require.IsType(t,
-				interpreter.ConditionError{},
-				err,
-			)
+			RequireErrorAs(t, err, &conditionErr)
 		})
 	}
 }
@@ -3902,40 +3805,23 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 
 	t.Run("-1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(-1))
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
 
-		require.IsType(t,
-			interpreter.ConditionError{},
-			err,
-		)
-		conditionError := err.(interpreter.ConditionError)
+		var conditionErr interpreter.ConditionError
+		RequireErrorAs(t, err, &conditionErr)
 
 		// NOTE: The type requirement condition (`Test.Nested`) is evaluated first,
 		//  before the type's conformances (`Also`)
 
-		assert.Equal(t, "x >= 1", conditionError.Message)
+		assert.Equal(t, "x >= 1", conditionErr.Message)
 	})
 
 	t.Run("0", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(0))
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
+		var conditionErr interpreter.ConditionError
+		RequireErrorAs(t, err, &conditionErr)
 
-		require.IsType(t,
-			interpreter.ConditionError{},
-			err,
-		)
-		conditionError := err.(interpreter.ConditionError)
-
-		assert.Equal(t, "x >= 1", conditionError.Message)
+		assert.Equal(t, "x >= 1", conditionErr.Message)
 	})
 
 	t.Run("1", func(t *testing.T) {
@@ -4111,16 +3997,12 @@ func TestInterpretImportError(t *testing.T) {
 
 	_, err = inter.Invoke("test")
 
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
+	var panicErr stdlib.PanicError
+	RequireErrorAs(t, err, &panicErr)
 
-	assert.IsType(t, stdlib.PanicError{}, err)
 	assert.Equal(t,
 		"?!",
-		err.(stdlib.PanicError).Message,
+		panicErr.Message,
 	)
 }
 
@@ -6278,16 +6160,8 @@ func TestInterpretReferenceDereferenceFailure(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
 
-	assert.IsType(t,
-		interpreter.DestroyedCompositeError{},
-		err,
-	)
+	RequireErrorAs(t, err, &interpreter.DestroyedCompositeError{})
 }
 
 func TestInterpretInvalidForwardReferenceCall(t *testing.T) {
@@ -7343,16 +7217,7 @@ func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
 
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	err = err.(interpreter.Error).Unwrap()
-
-	assert.IsType(t,
-		interpreter.DestroyedCompositeError{},
-		err,
-	)
+	RequireErrorAs(t, err, &interpreter.DestroyedCompositeError{})
 }
 
 func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
@@ -7399,16 +7264,7 @@ func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
 		_, err := inter.Invoke("testNil")
 		require.Error(t, err)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		assert.IsType(t,
-			interpreter.DereferenceError{},
-			err,
-		)
+		RequireErrorAs(t, err, &interpreter.DereferenceError{})
 	})
 }
 
@@ -7737,16 +7593,7 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		assert.IsType(t,
-			interpreter.ForceAssignmentToNonNilResourceError{},
-			err,
-		)
+		RequireErrorAs(t, err, &interpreter.ForceAssignmentToNonNilResourceError{})
 	})
 
 	t.Run("existing to nil", func(t *testing.T) {
@@ -7782,16 +7629,7 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		assert.IsType(t,
-			interpreter.ForceAssignmentToNonNilResourceError{},
-			err,
-		)
+		RequireErrorAs(t, err, &interpreter.ForceAssignmentToNonNilResourceError{})
 	})
 }
 
@@ -7832,16 +7670,7 @@ func TestInterpretForce(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		require.IsType(t,
-			interpreter.ForceNilError{},
-			err,
-		)
+		RequireErrorAs(t, err, &interpreter.ForceNilError{})
 	})
 
 	t.Run("non-optional", func(t *testing.T) {

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -111,7 +111,7 @@ func TestInterpretStatementHandler(t *testing.T) {
 
 				occurrences = append(occurrences, occurrence{
 					interpreterID: id,
-					line:          statement.Line,
+					line:          statement.Statement.StartPosition().Line,
 				})
 			},
 		),

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -104,8 +104,17 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(0)
-		require.IsType(t, interpreter.ConditionError{}, err)
 
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		require.IsType(t,
+			interpreter.ConditionError{},
+			err,
+		)
 		conditionErr := err.(interpreter.ConditionError)
 
 		assert.Equal(t, conditionErr.ConditionKind, ast.ConditionKindPre)
@@ -156,8 +165,17 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(0)
-		require.IsType(t, interpreter.ConditionError{}, err)
 
+		require.IsType(t,
+			interpreter.Error{},
+			err,
+		)
+		err = err.(interpreter.Error).Unwrap()
+
+		require.IsType(t,
+			interpreter.ConditionError{},
+			err,
+		)
 		conditionErr := err.(interpreter.ConditionError)
 
 		assert.Equal(t, conditionErr.ConditionKind, ast.ConditionKindPost)

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/tests/utils"
 	"github.com/onflow/cadence/runtime/trampoline"
 )
 
@@ -105,17 +106,8 @@ func TestInterpretTransactions(t *testing.T) {
 
 		err := inter.InvokeTransaction(0)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		require.IsType(t,
-			interpreter.ConditionError{},
-			err,
-		)
-		conditionErr := err.(interpreter.ConditionError)
+		var conditionErr interpreter.ConditionError
+		utils.RequireErrorAs(t, err, &conditionErr)
 
 		assert.Equal(t, conditionErr.ConditionKind, ast.ConditionKindPre)
 	})
@@ -166,17 +158,8 @@ func TestInterpretTransactions(t *testing.T) {
 
 		err := inter.InvokeTransaction(0)
 
-		require.IsType(t,
-			interpreter.Error{},
-			err,
-		)
-		err = err.(interpreter.Error).Unwrap()
-
-		require.IsType(t,
-			interpreter.ConditionError{},
-			err,
-		)
-		conditionErr := err.(interpreter.ConditionError)
+		var conditionErr interpreter.ConditionError
+		utils.RequireErrorAs(t, err, &conditionErr)
 
 		assert.Equal(t, conditionErr.ConditionKind, ast.ConditionKindPost)
 	})

--- a/runtime/tests/utils/utils.go
+++ b/runtime/tests/utils/utils.go
@@ -20,12 +20,14 @@ package utils
 
 import (
 	"encoding/hex"
+	errors2 "errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -93,4 +95,15 @@ func DeploymentTransaction(name string, contract []byte) []byte {
 		name,
 		hex.EncodeToString(contract),
 	))
+}
+
+// TODO: switch to require.ErrorAs once released:
+// https://github.com/stretchr/testify/commit/95a9d909e98735cd8211dfc5cbbb6b8b0b665915
+func RequireErrorAs(t *testing.T, err error, target interface{}) {
+	require.True(
+		t,
+		errors2.As(err, target),
+		"error chain must contain a %T",
+		target,
+	)
 }


### PR DESCRIPTION
Work towards dapperlabs/flow-go#2426

Improve fatal interpreter errors by wrapping them with position information.

- Before:

  <img width="288" alt="Screen Shot 2020-10-22 at 11 39 57 AM" src="https://user-images.githubusercontent.com/51661/96915640-583e7600-145b-11eb-9d5c-0db60a8a9b14.png">

- After:

  <img width="288" alt="Screen Shot 2020-10-22 at 11 37 15 AM" src="https://user-images.githubusercontent.com/51661/96915645-596fa300-145b-11eb-822d-35c02c9766af.png">
