### PR TITLE
Prevent resource loss in failable downcasts

### DIFF
--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -59,6 +59,14 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 					},
 				)
 			}
+
+			if _, ok := expression.Expression.(*ast.IdentifierExpression); !ok {
+				checker.report(
+					&InvalidNonIdentifierFailableResourceDowncast{
+						Range: ast.NewRangeFromPositioned(expression.Expression),
+					},
+				)
+			}
 		}
 	}
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2221,6 +2221,22 @@ func (e *InvalidFailableResourceDowncastOutsideOptionalBindingError) Error() str
 
 func (*InvalidFailableResourceDowncastOutsideOptionalBindingError) isSemanticError() {}
 
+// InvalidNonIdentifierFailableResourceDowncast
+
+type InvalidNonIdentifierFailableResourceDowncast struct {
+	ast.Range
+}
+
+func (e *InvalidNonIdentifierFailableResourceDowncast) Error() string {
+	return "cannot failably downcast non-identifier resource"
+}
+
+func (e *InvalidNonIdentifierFailableResourceDowncast) SecondaryError() string {
+	return "consider declaring a variable for this expression"
+}
+
+func (*InvalidNonIdentifierFailableResourceDowncast) isSemanticError() {}
+
 // ReadOnlyTargetAssignmentError
 
 type ReadOnlyTargetAssignmentError struct {


### PR DESCRIPTION
Requiring failable downcasts of resources to be in an optional binding is not enough to prevent a resource loss: If the casted expression is not an identifier, the resource will still be lost if the cast fails.