### PR TITLE
Language Server: Parse pragma arguments declarations and show codelenses

### DIFF
--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/mapstructure v1.3.3
-	github.com/onflow/cadence v0.12.3
+	github.com/onflow/cadence v0.12.4
 	github.com/onflow/flow-go-sdk v0.14.0
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20191222043438-96c4efab7ee2
 	github.com/stretchr/testify v1.5.1

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -204,8 +204,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.1/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
-github.com/onflow/cadence v0.12.3 h1:TLC34jmFJZgM7sBUIGjWAY5Tf6EeXVcUxCVFC9nb4cI=
-github.com/onflow/cadence v0.12.3/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
+github.com/onflow/cadence v0.12.4 h1:Ws0IROGEl1541ciBUsCBvaSJbP9X0XVYBuHcJk/wim0=
+github.com/onflow/cadence v0.12.4/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
 github.com/onflow/flow-go-sdk v0.14.0 h1:P83cCi7SkqPUvl87k+9CDG1TMGbFOGvtrwQY9M/tKb4=
 github.com/onflow/flow-go-sdk v0.14.0/go.mod h1:h3FkeOdsmT+2t3dTvV0fhtw3Y2S2m4jvccZeHbg/i8Y=
 github.com/onflow/flow/protobuf/go/flow v0.1.8 h1:jBR8aXEL0MOh3gVJmCr0KYXmtG3JUBhzADonKkYE6oI=

--- a/languageserver/integration/codelenses.go
+++ b/languageserver/integration/codelenses.go
@@ -142,7 +142,6 @@ func (i *FlowIntegration) showDeployContractInterfaceAction(
 // entryPointActions shows an execute button when there is exactly one valid entry point
 // (valid script function or transaction declaration) and no other actionable declarations.
 //
-// NOTE: requires
 //
 func (i *FlowIntegration) entryPointActions(
 	uri protocol.DocumentUri,

--- a/languageserver/integration/diagnostics.go
+++ b/languageserver/integration/diagnostics.go
@@ -33,12 +33,12 @@ import (
 //
 func (i *FlowIntegration) diagnostics(
 	_ protocol.DocumentUri,
+	_ float64,
 	checker *sema.Checker,
 ) (
 	diagnostics []protocol.Diagnostic,
 	err error,
 ) {
-
 	diagnostics = append(diagnostics, i.transactionDeclarationCountDiagnostics(checker)...)
 	diagnostics = append(diagnostics, i.compositeOrInterfaceDeclarationCountDiagnostics(checker)...)
 

--- a/languageserver/integration/entrypoint.go
+++ b/languageserver/integration/entrypoint.go
@@ -1,0 +1,111 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/languageserver/protocol"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/parser2"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+type entryPointKind uint8
+
+const (
+	entryPointKindUnknown entryPointKind = iota
+	entryPointKindScript
+	entryPointKindTransaction
+)
+
+type entryPointInfo struct {
+	documentVersion       float64
+	startPos              *ast.Position
+	kind                  entryPointKind
+	parameters            []*sema.Parameter
+	pragmaArgumentStrings []string
+	pragmaArguments       [][]cadence.Value
+}
+
+func (i *FlowIntegration) updateEntryPointInfoIfNeeded(
+	uri protocol.DocumentUri,
+	version float64,
+	checker *sema.Checker,
+) {
+	if i.entryPointInfo[uri].documentVersion == version {
+		return
+	}
+
+	var startPos *ast.Position
+	var kind entryPointKind
+	var docString string
+	var parameters []*sema.Parameter
+
+	transactionDeclaration := checker.Program.SoleTransactionDeclaration()
+	if transactionDeclaration != nil {
+		startPos = &transactionDeclaration.StartPos
+		kind = entryPointKindTransaction
+		docString = transactionDeclaration.DocString
+		transactionType := checker.Elaboration.TransactionDeclarationTypes[transactionDeclaration]
+		parameters = transactionType.Parameters
+	} else {
+
+		functionDeclaration := sema.FunctionEntryPointDeclaration(checker.Program)
+		if functionDeclaration != nil {
+			startPos = &functionDeclaration.StartPos
+			kind = entryPointKindScript
+			docString = functionDeclaration.DocString
+			functionType := checker.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+			parameters = functionType.Parameters
+		}
+	}
+
+	var pragmaArgumentStrings []string
+	var pragmaArguments [][]cadence.Value
+
+	if startPos != nil {
+
+		parameterTypes := make([]sema.Type, len(parameters))
+
+		for i, parameter := range parameters {
+			parameterTypes[i] = parameter.TypeAnnotation.Type
+		}
+
+		for _, pragmaArgumentString := range parser2.ParseDocstringPragmaArguments(docString) {
+			arguments, err := runtime.ParseLiteralArgumentList(pragmaArgumentString, parameterTypes)
+			// TODO: record error and show diagnostic
+			if err != nil {
+				continue
+			}
+
+			pragmaArgumentStrings = append(pragmaArgumentStrings, pragmaArgumentString)
+			pragmaArguments = append(pragmaArguments, arguments)
+		}
+	}
+
+	i.entryPointInfo[uri] = entryPointInfo{
+		documentVersion:       version,
+		startPos:              startPos,
+		kind:                  kind,
+		parameters:            parameters,
+		pragmaArgumentStrings: pragmaArgumentStrings,
+		pragmaArguments:       pragmaArguments,
+	}
+}

--- a/languageserver/integration/integration.go
+++ b/languageserver/integration/integration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
 
+	"github.com/onflow/cadence/languageserver/protocol"
 	"github.com/onflow/cadence/languageserver/server"
 )
 
@@ -32,12 +33,14 @@ type FlowIntegration struct {
 	accounts       map[flow.Address]AccountPrivateKey
 	activeAddress  flow.Address
 	serviceAddress flow.Address
+	entryPointInfo map[protocol.DocumentUri]entryPointInfo
 }
 
 func NewFlowIntegration(s *server.Server, enableFlowClient bool) (*FlowIntegration, error) {
 	integration := &FlowIntegration{
-		server:   s,
-		accounts: make(map[flow.Address]AccountPrivateKey),
+		server:         s,
+		accounts:       make(map[flow.Address]AccountPrivateKey),
+		entryPointInfo: map[protocol.DocumentUri]entryPointInfo{},
 	}
 
 	options := []server.Option{

--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -24,7 +24,16 @@ async function withConnection(f: (connection: ProtocolConnection) => Promise<voi
     ['-enableFlowClient=false']
   )
 
+  let stderr = ""
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (data) => {
+    stderr += data
+  });
+
   child.on('exit', (code) => {
+    if (code !== 0) {
+      console.error(stderr)
+    }
     expect(code).toBe(0)
   })
 


### PR DESCRIPTION
Closes #431

- Parse docstring for transactions and retain it in the AST element
- Improve tests for language server: log error of language server when it exits unsuccessfully
- Add a function to parse an argument list where all arguments are literals, e.g. `(1, true)`
- Add a function to parse all `pragma arguments` declarations in a docstring, e.g. `/// pragma arguments (1, true)`
- Refactor codelenses for transactions and scripts: consider pragma arguments declarations, show one codelens per argument list. Include the arguments in the command sent from the client to the server
- Accept arguments in the script execution command and the transaction submission command

Examples:

- Script:
  <img width="271" alt="Screen Shot 2020-10-29 at 6 42 12 PM" src="https://user-images.githubusercontent.com/51661/97652049-c4504980-1a1a-11eb-8e14-6f5ed4da83c0.png">

- Tranaction:
  <img width="653" alt="Screen Shot 2020-10-29 at 6 41 18 PM" src="https://user-images.githubusercontent.com/51661/97652058-c74b3a00-1a1a-11eb-936e-ebb2a780e663.png">
