### PR TITLE
Add a visitor for interpreter values

### DIFF
--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -92,6 +92,30 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestAddressContractLocation_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	loc := AddressContractLocation{
+		AddressLocation: AddressLocation([]byte{1}),
+		Name:            "A",
+	}
+
+	actual, err := json.Marshal(loc)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "AddressContractLocation",
+            "Address": "0x1",
+            "Name": "A"
+        }
+        `,
+		string(actual),
+	)
+}
+
 func TestImportDeclaration_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -92,30 +92,6 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 	)
 }
 
-func TestAddressContractLocation_MarshalJSON(t *testing.T) {
-
-	t.Parallel()
-
-	loc := AddressContractLocation{
-		AddressLocation: AddressLocation([]byte{1}),
-		Name:            "A",
-	}
-
-	actual, err := json.Marshal(loc)
-	require.NoError(t, err)
-
-	assert.JSONEq(t,
-		`
-        {
-            "Type": "AddressContractLocation",
-            "Address": "0x1",
-            "Name": "A"
-        }
-        `,
-		string(actual),
-	)
-}
-
 func TestImportDeclaration_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -39,6 +39,10 @@ type AuthAccountContractsValue struct {
 
 func (AuthAccountContractsValue) IsValue() {}
 
+func (v AuthAccountContractsValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitAuthAccountContractsValue(interpreter, v)
+}
+
 func (AuthAccountContractsValue) DynamicType(_ *Interpreter) DynamicType {
 	return AuthAccountContractsDynamicType{}
 }

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -37,6 +37,10 @@ type DeployedContractValue struct {
 
 func (DeployedContractValue) IsValue() {}
 
+func (v DeployedContractValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitDeployedContractValue(interpreter, v)
+}
+
 func (DeployedContractValue) DynamicType(_ *Interpreter) DynamicType {
 	return DeployedContractDynamicType{}
 }

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -68,6 +68,10 @@ func (f InterpretedFunctionValue) String() string {
 
 func (InterpretedFunctionValue) IsValue() {}
 
+func (v InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInterpretedFunctionValue(interpreter, v)
+}
+
 func (InterpretedFunctionValue) DynamicType(_ *Interpreter) DynamicType {
 	return FunctionDynamicType{}
 }
@@ -123,6 +127,10 @@ func NewHostFunctionValue(
 
 func (HostFunctionValue) IsValue() {}
 
+func (v HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitHostFunctionValue(interpreter, v)
+}
+
 func (HostFunctionValue) DynamicType(_ *Interpreter) DynamicType {
 	return FunctionDynamicType{}
 }
@@ -174,6 +182,10 @@ func (f BoundFunctionValue) String() string {
 }
 
 func (BoundFunctionValue) IsValue() {}
+
+func (v BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitBoundFunctionValue(interpreter, v)
+}
 
 func (BoundFunctionValue) DynamicType(_ *Interpreter) DynamicType {
 	return FunctionDynamicType{}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -43,6 +43,7 @@ import (
 type Value interface {
 	fmt.Stringer
 	IsValue()
+	Accept(interpreter *Interpreter, visitor Visitor)
 	DynamicType(interpreter *Interpreter) DynamicType
 	Copy() Value
 	GetOwner() *common.Address
@@ -97,6 +98,10 @@ type TypeValue struct {
 }
 
 func (TypeValue) IsValue() {}
+
+func (v TypeValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitTypeValue(interpreter, v)
+}
 
 func (TypeValue) DynamicType(_ *Interpreter) DynamicType {
 	return MetaTypeDynamicType{}
@@ -159,6 +164,10 @@ type VoidValue struct{}
 
 func (VoidValue) IsValue() {}
 
+func (v VoidValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitVoidValue(interpreter, v)
+}
+
 func (VoidValue) DynamicType(_ *Interpreter) DynamicType {
 	return VoidDynamicType{}
 }
@@ -193,6 +202,10 @@ func (VoidValue) String() string {
 type BoolValue bool
 
 func (BoolValue) IsValue() {}
+
+func (v BoolValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitBoolValue(interpreter, v)
+}
 
 func (BoolValue) DynamicType(_ *Interpreter) DynamicType {
 	return BoolDynamicType{}
@@ -254,6 +267,10 @@ func NewStringValue(str string) *StringValue {
 }
 
 func (*StringValue) IsValue() {}
+
+func (v *StringValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitStringValue(interpreter, v)
+}
 
 func (*StringValue) DynamicType(_ *Interpreter) DynamicType {
 	return StringDynamicType{}
@@ -455,6 +472,17 @@ func NewArrayValueUnownedNonCopying(values ...Value) *ArrayValue {
 }
 
 func (*ArrayValue) IsValue() {}
+
+func (v *ArrayValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	descend := visitor.VisitArrayValue(interpreter, v)
+	if !descend {
+		return
+	}
+
+	for _, value := range v.Values {
+		value.Accept(interpreter, visitor)
+	}
+}
 
 func (v *ArrayValue) DynamicType(interpreter *Interpreter) DynamicType {
 	elementTypes := make([]DynamicType, len(v.Values))
@@ -768,6 +796,10 @@ func ConvertInt(value Value, _ *Interpreter) Value {
 
 func (v IntValue) IsValue() {}
 
+func (v IntValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitIntValue(interpreter, v)
+}
+
 func (IntValue) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.IntType{}}
 }
@@ -969,6 +1001,10 @@ func (v IntValue) ToBigEndianBytes() []byte {
 type Int8Value int8
 
 func (Int8Value) IsValue() {}
+
+func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInt8Value(interpreter, v)
+}
 
 func (Int8Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int8Type{}}
@@ -1199,6 +1235,10 @@ func (v Int8Value) ToBigEndianBytes() []byte {
 type Int16Value int16
 
 func (Int16Value) IsValue() {}
+
+func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInt16Value(interpreter, v)
+}
 
 func (Int16Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int16Type{}}
@@ -1432,6 +1472,10 @@ type Int32Value int32
 
 func (Int32Value) IsValue() {}
 
+func (v Int32Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInt32Value(interpreter, v)
+}
+
 func (Int32Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int32Type{}}
 }
@@ -1663,6 +1707,10 @@ func (v Int32Value) ToBigEndianBytes() []byte {
 type Int64Value int64
 
 func (Int64Value) IsValue() {}
+
+func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInt64Value(interpreter, v)
+}
 
 func (Int64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int64Type{}}
@@ -1903,6 +1951,10 @@ func NewInt128ValueFromBigInt(value *big.Int) Int128Value {
 	return Int128Value{BigInt: value}
 }
 func (v Int128Value) IsValue() {}
+
+func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInt128Value(interpreter, v)
+}
 
 func (Int128Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int128Type{}}
@@ -2193,6 +2245,10 @@ func NewInt256ValueFromBigInt(value *big.Int) Int256Value {
 }
 
 func (v Int256Value) IsValue() {}
+
+func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInt256Value(interpreter, v)
+}
 
 func (Int256Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int256Type{}}
@@ -2505,6 +2561,10 @@ func ConvertUInt(value Value, _ *Interpreter) Value {
 
 func (v UIntValue) IsValue() {}
 
+func (v UIntValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUIntValue(interpreter, v)
+}
+
 func (UIntValue) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UIntType{}}
 }
@@ -2710,6 +2770,10 @@ type UInt8Value uint8
 
 func (UInt8Value) IsValue() {}
 
+func (v UInt8Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUInt8Value(interpreter, v)
+}
+
 func (UInt8Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt8Type{}}
 }
@@ -2908,6 +2972,10 @@ type UInt16Value uint16
 
 func (UInt16Value) IsValue() {}
 
+func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUInt16Value(interpreter, v)
+}
+
 func (UInt16Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt16Type{}}
 }
@@ -3105,6 +3173,10 @@ func (v UInt16Value) ToBigEndianBytes() []byte {
 type UInt32Value uint32
 
 func (UInt32Value) IsValue() {}
+
+func (v UInt32Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUInt32Value(interpreter, v)
+}
 
 func (UInt32Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt32Type{}}
@@ -3305,6 +3377,10 @@ func (v UInt32Value) ToBigEndianBytes() []byte {
 type UInt64Value uint64
 
 func (UInt64Value) IsValue() {}
+
+func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUInt64Value(interpreter, v)
+}
 
 func (UInt64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt64Type{}}
@@ -3518,6 +3594,10 @@ func NewUInt128ValueFromBigInt(value *big.Int) UInt128Value {
 }
 
 func (v UInt128Value) IsValue() {}
+
+func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUInt128Value(interpreter, v)
+}
 
 func (UInt128Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt128Type{}}
@@ -3778,6 +3858,10 @@ func NewUInt256ValueFromBigInt(value *big.Int) UInt256Value {
 
 func (v UInt256Value) IsValue() {}
 
+func (v UInt256Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUInt256Value(interpreter, v)
+}
+
 func (UInt256Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt256Type{}}
 }
@@ -4028,6 +4112,10 @@ type Word8Value uint8
 
 func (Word8Value) IsValue() {}
 
+func (v Word8Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitWord8Value(interpreter, v)
+}
+
 func (Word8Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word8Type{}}
 }
@@ -4187,6 +4275,10 @@ type Word16Value uint16
 
 func (Word16Value) IsValue() {}
 
+func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitWord16Value(interpreter, v)
+}
+
 func (Word16Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word16Type{}}
 }
@@ -4345,6 +4437,10 @@ func (v Word16Value) ToBigEndianBytes() []byte {
 type Word32Value uint32
 
 func (Word32Value) IsValue() {}
+
+func (v Word32Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitWord32Value(interpreter, v)
+}
 
 func (Word32Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word32Type{}}
@@ -4506,6 +4602,10 @@ func (v Word32Value) ToBigEndianBytes() []byte {
 type Word64Value uint64
 
 func (Word64Value) IsValue() {}
+
+func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitWord64Value(interpreter, v)
+}
 
 func (Word64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word64Type{}}
@@ -4684,6 +4784,10 @@ func NewFix64ValueWithInteger(integer int64) Fix64Value {
 }
 
 func (Fix64Value) IsValue() {}
+
+func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitFix64Value(interpreter, v)
+}
 
 func (Fix64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Fix64Type{}}
@@ -4928,6 +5032,10 @@ func NewUFix64ValueWithInteger(integer uint64) UFix64Value {
 }
 
 func (UFix64Value) IsValue() {}
+
+func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitUFix64Value(interpreter, v)
+}
 
 func (UFix64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UFix64Type{}}
@@ -5227,6 +5335,16 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, locationRange Locatio
 
 func (*CompositeValue) IsValue() {}
 
+func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	descend := visitor.VisitCompositeValue(interpreter, v)
+	if !descend {
+		return
+	}
+	for _, value := range v.Fields {
+		value.Accept(interpreter, visitor)
+	}
+}
+
 func (v *CompositeValue) DynamicType(interpreter *Interpreter) DynamicType {
 	staticType := interpreter.getCompositeType(v.Location, v.TypeID)
 	return CompositeDynamicType{
@@ -5416,14 +5534,17 @@ func (v *CompositeValue) SetMember(_ *Interpreter, locationRange LocationRange, 
 }
 
 func (v *CompositeValue) String() string {
-	fields := make([]struct{Name string; Value string}, 0, len(v.Fields))
+	fields := make([]struct {
+		Name  string
+		Value string
+	}, 0, len(v.Fields))
 	for name, value := range v.Fields {
 		fields = append(fields,
 			struct {
 				Name  string
 				Value string
 			}{
-				Name: name,
+				Name:  name,
 				Value: value.String(),
 			},
 		)
@@ -5508,6 +5629,20 @@ func NewDictionaryValueUnownedNonCopying(keysAndValues ...Value) *DictionaryValu
 }
 
 func (*DictionaryValue) IsValue() {}
+
+func (v *DictionaryValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	descend := visitor.VisitDictionaryValue(interpreter, v)
+	if !descend {
+		return
+	}
+	for _, key := range v.Keys.Values {
+		key.Accept(interpreter, visitor)
+
+		// NOTE: Force unwrap. This is safe because we are iterating over the keys.
+		value := v.Get(interpreter, LocationRange{}, key).(*SomeValue).Value
+		value.Accept(interpreter, visitor)
+	}
+}
 
 func (v *DictionaryValue) DynamicType(interpreter *Interpreter) DynamicType {
 	entryTypes := make([]struct{ KeyType, ValueType DynamicType }, len(v.Keys.Values))
@@ -5681,13 +5816,19 @@ func (v *DictionaryValue) Set(inter *Interpreter, locationRange LocationRange, k
 }
 
 func (v *DictionaryValue) String() string {
-	pairs := make([]struct{Key string; Value string}, len(v.Keys.Values))
+	pairs := make([]struct {
+		Key   string
+		Value string
+	}, len(v.Keys.Values))
 
 	for i, keyValue := range v.Keys.Values {
 		key := dictionaryKey(keyValue)
 		value := v.Entries[key]
-		pairs[i] = struct{Key string;Value string}{
-			Key: keyValue.String(),
+		pairs[i] = struct {
+			Key   string
+			Value string
+		}{
+			Key:   keyValue.String(),
 			Value: value.String(),
 		}
 	}
@@ -5853,6 +5994,10 @@ type NilValue struct{}
 
 func (NilValue) IsValue() {}
 
+func (v NilValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitNilValue(interpreter, v)
+}
+
 func (NilValue) DynamicType(_ *Interpreter) DynamicType {
 	return NilDynamicType{}
 }
@@ -5922,6 +6067,14 @@ func NewSomeValueOwningNonCopying(value Value) *SomeValue {
 }
 
 func (*SomeValue) IsValue() {}
+
+func (v *SomeValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	descend := visitor.VisitSomeValue(interpreter, v)
+	if !descend {
+		return
+	}
+	v.Value.Accept(interpreter, visitor)
+}
 
 func (v *SomeValue) DynamicType(interpreter *Interpreter) DynamicType {
 	innerType := v.Value.DynamicType(interpreter)
@@ -6009,6 +6162,10 @@ type StorageReferenceValue struct {
 }
 
 func (*StorageReferenceValue) IsValue() {}
+
+func (v *StorageReferenceValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitStorageReferenceValue(interpreter, v)
+}
 
 func (v *StorageReferenceValue) String() string {
 	return "StorageReference()"
@@ -6129,6 +6286,10 @@ type EphemeralReferenceValue struct {
 }
 
 func (*EphemeralReferenceValue) IsValue() {}
+
+func (v *EphemeralReferenceValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitEphemeralReferenceValue(interpreter, v)
+}
 
 func (v *EphemeralReferenceValue) String() string {
 	return v.Value.String()
@@ -6273,6 +6434,10 @@ func ConvertAddress(value Value, _ *Interpreter) Value {
 
 func (AddressValue) IsValue() {}
 
+func (v AddressValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitAddressValue(interpreter, v)
+}
+
 func (AddressValue) DynamicType(_ *Interpreter) DynamicType {
 	return AddressDynamicType{}
 }
@@ -6386,6 +6551,10 @@ func NewAuthAccountValue(
 }
 
 func (AuthAccountValue) IsValue() {}
+
+func (v AuthAccountValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitAuthAccountValue(interpreter, v)
+}
 
 func (AuthAccountValue) isAccountValue() {}
 
@@ -6538,6 +6707,10 @@ func NewPublicAccountValue(
 
 func (PublicAccountValue) IsValue() {}
 
+func (v PublicAccountValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitPublicAccountValue(interpreter, v)
+}
+
 func (PublicAccountValue) isAccountValue() {}
 
 func (v PublicAccountValue) AddressValue() AddressValue {
@@ -6611,6 +6784,10 @@ type PathValue struct {
 
 func (PathValue) IsValue() {}
 
+func (v PathValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitPathValue(interpreter, v)
+}
+
 func (v PathValue) DynamicType(_ *Interpreter) DynamicType {
 	switch v.Domain {
 	case common.PathDomainStorage:
@@ -6665,6 +6842,10 @@ type CapabilityValue struct {
 }
 
 func (CapabilityValue) IsValue() {}
+
+func (v CapabilityValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitCapabilityValue(interpreter, v)
+}
 
 func (v CapabilityValue) DynamicType(inter *Interpreter) DynamicType {
 	var borrowType *sema.ReferenceType
@@ -6743,6 +6924,10 @@ type LinkValue struct {
 }
 
 func (LinkValue) IsValue() {}
+
+func (v LinkValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitLinkValue(interpreter, v)
+}
 
 func (LinkValue) DynamicType(_ *Interpreter) DynamicType {
 	panic(errors.NewUnreachableError())

--- a/runtime/interpreter/visitor.go
+++ b/runtime/interpreter/visitor.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package interpreter
 
 type Visitor interface {

--- a/runtime/interpreter/visitor.go
+++ b/runtime/interpreter/visitor.go
@@ -1,0 +1,394 @@
+package interpreter
+
+type Visitor interface {
+	VisitValue(interpreter *Interpreter, value Value)
+	VisitTypeValue(interpreter *Interpreter, value TypeValue)
+	VisitVoidValue(interpreter *Interpreter, value VoidValue)
+	VisitBoolValue(interpreter *Interpreter, value BoolValue)
+	VisitStringValue(interpreter *Interpreter, value *StringValue)
+	VisitArrayValue(interpreter *Interpreter, value *ArrayValue) bool
+	VisitIntValue(interpreter *Interpreter, value IntValue)
+	VisitInt8Value(interpreter *Interpreter, value Int8Value)
+	VisitInt16Value(interpreter *Interpreter, value Int16Value)
+	VisitInt32Value(interpreter *Interpreter, value Int32Value)
+	VisitInt64Value(interpreter *Interpreter, value Int64Value)
+	VisitInt128Value(interpreter *Interpreter, value Int128Value)
+	VisitInt256Value(interpreter *Interpreter, value Int256Value)
+	VisitUIntValue(interpreter *Interpreter, value UIntValue)
+	VisitUInt8Value(interpreter *Interpreter, value UInt8Value)
+	VisitUInt16Value(interpreter *Interpreter, value UInt16Value)
+	VisitUInt32Value(interpreter *Interpreter, value UInt32Value)
+	VisitUInt64Value(interpreter *Interpreter, value UInt64Value)
+	VisitUInt128Value(interpreter *Interpreter, value UInt128Value)
+	VisitUInt256Value(interpreter *Interpreter, value UInt256Value)
+	VisitWord8Value(interpreter *Interpreter, value Word8Value)
+	VisitWord16Value(interpreter *Interpreter, value Word16Value)
+	VisitWord32Value(interpreter *Interpreter, value Word32Value)
+	VisitWord64Value(interpreter *Interpreter, value Word64Value)
+	VisitFix64Value(interpreter *Interpreter, value Fix64Value)
+	VisitUFix64Value(interpreter *Interpreter, value UFix64Value)
+	VisitCompositeValue(interpreter *Interpreter, value *CompositeValue) bool
+	VisitDictionaryValue(interpreter *Interpreter, value *DictionaryValue) bool
+	VisitNilValue(interpreter *Interpreter, value NilValue)
+	VisitSomeValue(interpreter *Interpreter, value *SomeValue) bool
+	VisitStorageReferenceValue(interpreter *Interpreter, value *StorageReferenceValue)
+	VisitEphemeralReferenceValue(interpreter *Interpreter, value *EphemeralReferenceValue)
+	VisitAddressValue(interpreter *Interpreter, value AddressValue)
+	VisitAuthAccountValue(interpreter *Interpreter, value AuthAccountValue)
+	VisitPublicAccountValue(interpreter *Interpreter, value PublicAccountValue)
+	VisitPathValue(interpreter *Interpreter, value PathValue)
+	VisitCapabilityValue(interpreter *Interpreter, value CapabilityValue)
+	VisitLinkValue(interpreter *Interpreter, value LinkValue)
+	VisitInterpretedFunctionValue(interpreter *Interpreter, value InterpretedFunctionValue)
+	VisitHostFunctionValue(interpreter *Interpreter, value HostFunctionValue)
+	VisitBoundFunctionValue(interpreter *Interpreter, value BoundFunctionValue)
+	VisitAuthAccountContractsValue(interpreter *Interpreter, value AuthAccountContractsValue)
+	VisitDeployedContractValue(interpreter *Interpreter, value DeployedContractValue)
+}
+
+type EmptyVisitor struct {
+	ValueVisitor                     func(interpreter *Interpreter, value Value)
+	TypeValueVisitor                 func(interpreter *Interpreter, value TypeValue)
+	VoidValueVisitor                 func(interpreter *Interpreter, value VoidValue)
+	BoolValueVisitor                 func(interpreter *Interpreter, value BoolValue)
+	StringValueVisitor               func(interpreter *Interpreter, value *StringValue)
+	ArrayValueVisitor                func(interpreter *Interpreter, value *ArrayValue) bool
+	IntValueVisitor                  func(interpreter *Interpreter, value IntValue)
+	Int8ValueVisitor                 func(interpreter *Interpreter, value Int8Value)
+	Int16ValueVisitor                func(interpreter *Interpreter, value Int16Value)
+	Int32ValueVisitor                func(interpreter *Interpreter, value Int32Value)
+	Int64ValueVisitor                func(interpreter *Interpreter, value Int64Value)
+	Int128ValueVisitor               func(interpreter *Interpreter, value Int128Value)
+	Int256ValueVisitor               func(interpreter *Interpreter, value Int256Value)
+	UIntValueVisitor                 func(interpreter *Interpreter, value UIntValue)
+	UInt8ValueVisitor                func(interpreter *Interpreter, value UInt8Value)
+	UInt16ValueVisitor               func(interpreter *Interpreter, value UInt16Value)
+	UInt32ValueVisitor               func(interpreter *Interpreter, value UInt32Value)
+	UInt64ValueVisitor               func(interpreter *Interpreter, value UInt64Value)
+	UInt128ValueVisitor              func(interpreter *Interpreter, value UInt128Value)
+	UInt256ValueVisitor              func(interpreter *Interpreter, value UInt256Value)
+	Word8ValueVisitor                func(interpreter *Interpreter, value Word8Value)
+	Word16ValueVisitor               func(interpreter *Interpreter, value Word16Value)
+	Word32ValueVisitor               func(interpreter *Interpreter, value Word32Value)
+	Word64ValueVisitor               func(interpreter *Interpreter, value Word64Value)
+	Fix64ValueVisitor                func(interpreter *Interpreter, value Fix64Value)
+	UFix64ValueVisitor               func(interpreter *Interpreter, value UFix64Value)
+	CompositeValueVisitor            func(interpreter *Interpreter, value *CompositeValue) bool
+	DictionaryValueVisitor           func(interpreter *Interpreter, value *DictionaryValue) bool
+	NilValueVisitor                  func(interpreter *Interpreter, value NilValue)
+	SomeValueVisitor                 func(interpreter *Interpreter, value *SomeValue) bool
+	StorageReferenceValueVisitor     func(interpreter *Interpreter, value *StorageReferenceValue)
+	EphemeralReferenceValueVisitor   func(interpreter *Interpreter, value *EphemeralReferenceValue)
+	AddressValueVisitor              func(interpreter *Interpreter, value AddressValue)
+	AuthAccountValueVisitor          func(interpreter *Interpreter, value AuthAccountValue)
+	PublicAccountValueVisitor        func(interpreter *Interpreter, value PublicAccountValue)
+	PathValueVisitor                 func(interpreter *Interpreter, value PathValue)
+	CapabilityValueVisitor           func(interpreter *Interpreter, value CapabilityValue)
+	LinkValueVisitor                 func(interpreter *Interpreter, value LinkValue)
+	InterpretedFunctionValueVisitor  func(interpreter *Interpreter, value InterpretedFunctionValue)
+	HostFunctionValueVisitor         func(interpreter *Interpreter, value HostFunctionValue)
+	BoundFunctionValueVisitor        func(interpreter *Interpreter, value BoundFunctionValue)
+	AuthAccountContractsValueVisitor func(interpreter *Interpreter, value AuthAccountContractsValue)
+	DeployedContractValueVisitor     func(interpreter *Interpreter, value DeployedContractValue)
+}
+
+func (v EmptyVisitor) VisitValue(interpreter *Interpreter, value Value) {
+	if v.ValueVisitor == nil {
+		return
+	}
+	v.ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitTypeValue(interpreter *Interpreter, value TypeValue) {
+	if v.TypeValueVisitor == nil {
+		return
+	}
+	v.TypeValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitVoidValue(interpreter *Interpreter, value VoidValue) {
+	if v.VoidValueVisitor == nil {
+		return
+	}
+	v.VoidValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitBoolValue(interpreter *Interpreter, value BoolValue) {
+	if v.BoolValueVisitor == nil {
+		return
+	}
+	v.BoolValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitStringValue(interpreter *Interpreter, value *StringValue) {
+	if v.StringValueVisitor == nil {
+		return
+	}
+	v.StringValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitArrayValue(interpreter *Interpreter, value *ArrayValue) bool {
+	if v.ArrayValueVisitor == nil {
+		return true
+	}
+	return v.ArrayValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitIntValue(interpreter *Interpreter, value IntValue) {
+	if v.IntValueVisitor == nil {
+		return
+	}
+	v.IntValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitInt8Value(interpreter *Interpreter, value Int8Value) {
+	if v.Int8ValueVisitor == nil {
+		return
+	}
+	v.Int8ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitInt16Value(interpreter *Interpreter, value Int16Value) {
+	if v.Int16ValueVisitor == nil {
+		return
+	}
+	v.Int16ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitInt32Value(interpreter *Interpreter, value Int32Value) {
+	if v.Int32ValueVisitor == nil {
+		return
+	}
+	v.Int32ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitInt64Value(interpreter *Interpreter, value Int64Value) {
+	if v.Int64ValueVisitor == nil {
+		return
+	}
+	v.Int64ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitInt128Value(interpreter *Interpreter, value Int128Value) {
+	if v.Int128ValueVisitor == nil {
+		return
+	}
+	v.Int128ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitInt256Value(interpreter *Interpreter, value Int256Value) {
+	if v.Int256ValueVisitor == nil {
+		return
+	}
+	v.Int256ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUIntValue(interpreter *Interpreter, value UIntValue) {
+	if v.UIntValueVisitor == nil {
+		return
+	}
+	v.UIntValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUInt8Value(interpreter *Interpreter, value UInt8Value) {
+	if v.UInt8ValueVisitor == nil {
+		return
+	}
+	v.UInt8ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUInt16Value(interpreter *Interpreter, value UInt16Value) {
+	if v.UInt16ValueVisitor == nil {
+		return
+	}
+	v.UInt16ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUInt32Value(interpreter *Interpreter, value UInt32Value) {
+	if v.UInt32ValueVisitor == nil {
+		return
+	}
+	v.UInt32ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUInt64Value(interpreter *Interpreter, value UInt64Value) {
+	if v.UInt64ValueVisitor == nil {
+		return
+	}
+	v.UInt64ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUInt128Value(interpreter *Interpreter, value UInt128Value) {
+	if v.UInt128ValueVisitor == nil {
+		return
+	}
+	v.UInt128ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUInt256Value(interpreter *Interpreter, value UInt256Value) {
+	if v.UInt256ValueVisitor == nil {
+		return
+	}
+	v.UInt256ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitWord8Value(interpreter *Interpreter, value Word8Value) {
+	if v.Word8ValueVisitor == nil {
+		return
+	}
+	v.Word8ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitWord16Value(interpreter *Interpreter, value Word16Value) {
+	if v.Word16ValueVisitor == nil {
+		return
+	}
+	v.Word16ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitWord32Value(interpreter *Interpreter, value Word32Value) {
+	if v.Word32ValueVisitor == nil {
+		return
+	}
+	v.Word32ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitWord64Value(interpreter *Interpreter, value Word64Value) {
+	if v.Word64ValueVisitor == nil {
+		return
+	}
+	v.Word64ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitFix64Value(interpreter *Interpreter, value Fix64Value) {
+	if v.Fix64ValueVisitor == nil {
+		return
+	}
+	v.Fix64ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitUFix64Value(interpreter *Interpreter, value UFix64Value) {
+	if v.UFix64ValueVisitor == nil {
+		return
+	}
+	v.UFix64ValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitCompositeValue(interpreter *Interpreter, value *CompositeValue) bool {
+	if v.CompositeValueVisitor == nil {
+		return true
+	}
+	return v.CompositeValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitDictionaryValue(interpreter *Interpreter, value *DictionaryValue) bool {
+	if v.DictionaryValueVisitor == nil {
+		return true
+	}
+	return v.DictionaryValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitNilValue(interpreter *Interpreter, value NilValue) {
+	if v.NilValueVisitor == nil {
+		return
+	}
+	v.NilValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitSomeValue(interpreter *Interpreter, value *SomeValue) bool {
+	if v.SomeValueVisitor == nil {
+		return true
+	}
+	return v.SomeValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitStorageReferenceValue(interpreter *Interpreter, value *StorageReferenceValue) {
+	if v.StorageReferenceValueVisitor == nil {
+		return
+	}
+	v.StorageReferenceValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitEphemeralReferenceValue(interpreter *Interpreter, value *EphemeralReferenceValue) {
+	if v.EphemeralReferenceValueVisitor == nil {
+		return
+	}
+	v.EphemeralReferenceValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitAddressValue(interpreter *Interpreter, value AddressValue) {
+	if v.AddressValueVisitor == nil {
+		return
+	}
+	v.AddressValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitAuthAccountValue(interpreter *Interpreter, value AuthAccountValue) {
+	if v.AuthAccountValueVisitor == nil {
+		return
+	}
+	v.AuthAccountValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitPublicAccountValue(interpreter *Interpreter, value PublicAccountValue) {
+	if v.PublicAccountValueVisitor == nil {
+		return
+	}
+	v.PublicAccountValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitPathValue(interpreter *Interpreter, value PathValue) {
+	if v.PathValueVisitor == nil {
+		return
+	}
+	v.PathValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitCapabilityValue(interpreter *Interpreter, value CapabilityValue) {
+	if v.CapabilityValueVisitor == nil {
+		return
+	}
+	v.CapabilityValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitLinkValue(interpreter *Interpreter, value LinkValue) {
+	if v.LinkValueVisitor == nil {
+		return
+	}
+	v.LinkValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitInterpretedFunctionValue(interpreter *Interpreter, value InterpretedFunctionValue) {
+	if v.InterpretedFunctionValueVisitor == nil {
+		return
+	}
+	v.InterpretedFunctionValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitHostFunctionValue(interpreter *Interpreter, value HostFunctionValue) {
+	if v.HostFunctionValueVisitor == nil {
+		return
+	}
+	v.HostFunctionValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitBoundFunctionValue(interpreter *Interpreter, value BoundFunctionValue) {
+	if v.BoundFunctionValueVisitor == nil {
+		return
+	}
+	v.BoundFunctionValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitAuthAccountContractsValue(interpreter *Interpreter, value AuthAccountContractsValue) {
+	if v.AuthAccountContractsValueVisitor == nil {
+		return
+	}
+	v.AuthAccountContractsValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitDeployedContractValue(interpreter *Interpreter, value DeployedContractValue) {
+	if v.DeployedContractValueVisitor == nil {
+		return
+	}
+	v.DeployedContractValueVisitor(interpreter, value)
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1808,6 +1808,10 @@ func NewBlockValue(block Block) BlockValue {
 
 func (BlockValue) IsValue() {}
 
+func (v BlockValue) Accept(interpreter *interpreter.Interpreter, visitor interpreter.Visitor) {
+	visitor.VisitValue(interpreter, v)
+}
+
 func (BlockValue) DynamicType(*interpreter.Interpreter) interpreter.DynamicType {
 	return nil
 }


### PR DESCRIPTION
Work towards #84

Add a visitor which allows traversing a whole interpreter object tree. This can e.g. be used for data migration.