### PR TITLE
Extended debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v1
+      - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.29

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build:
 
 .PHONY: install-tools
 install-tools:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.26.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.29.0
 
 .PHONY: lint
 lint:

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -439,6 +439,7 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -203,13 +203,8 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/onflow/cadence/languageserver v0.9.1/go.mod h1:pnsGwScKufVurrYqRKzrBVmYZjLhQhsqKUW1MU87its=
-github.com/onflow/flow-go-sdk v0.9.0 h1:eK40f6RU+cjh9ASGOPzsE38gO8VQhy3x52rnUGEWY6k=
-github.com/onflow/flow-go-sdk v0.9.0/go.mod h1:FVVYKmWmUjfa1A4eIeZfBC+vFg0VmCf1TUaBowx+3AM=
 github.com/onflow/flow-go-sdk v0.11.0 h1:hsUcgFZN7TZFUcP45HTF3oJKsM36ZffpZBmz2L9jnYk=
 github.com/onflow/flow-go-sdk v0.11.0/go.mod h1:BKb9/8NtCDuwy91eLnv7TJMAsWR64s3EZhKp6mc790o=
-github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27 h1:ZZ8njaFTOz7JyBpQwXGfFUUOc9l2urVAxQ7FpMUpfnc=
-github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onflow/flow/protobuf/go/flow v0.1.7 h1:BaZVc1XWkI1vx/+qvdkXnKjsWk4UFRBAg7vvfQ/u5Pk=
 github.com/onflow/flow/protobuf/go/flow v0.1.7/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -26,7 +26,6 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 // Error is the containing type for all errors produced by the runtime.
@@ -223,15 +222,14 @@ func (e *TransactionParameterTypeNotStorableError) Error() string {
 // when a parsing or a checking error occurred
 //
 type ParsingCheckingError struct {
-	Err            error
-	RuntimeStorage *InterpreterRuntimeStorage
-	Functions      stdlib.StandardLibraryFunctions
-	Code           []byte
-	Location       Location
-	Options        []sema.Option
-	UseCache       bool
-	Program        *ast.Program
-	Checker        *sema.Checker
+	Err          error
+	StorageCache Cache
+	Code         []byte
+	Location     Location
+	Options      []sema.Option
+	UseCache     bool
+	Program      *ast.Program
+	Checker      *sema.Checker
 }
 
 func (e *ParsingCheckingError) ChildErrors() []error {

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -218,10 +218,10 @@ func (e *TransactionParameterTypeNotStorableError) Error() string {
 	)
 }
 
-// ExtendedParsingCheckingError is a special error which aids in debugging checking problems
-// by providing extra information about the state of the environment
-// Separate package to prevent cyclic imports with checker tests
-type ExtendedParsingCheckingError struct {
+// ParsingCheckingError provides extra information about the state of the environment
+// when a parsing or a checking error occurred
+//
+type ParsingCheckingError struct {
 	Err            error
 	RuntimeStorage *InterpreterRuntimeStorage
 	Functions      stdlib.StandardLibraryFunctions
@@ -232,14 +232,14 @@ type ExtendedParsingCheckingError struct {
 	Checker        *sema.Checker
 }
 
-func (e *ExtendedParsingCheckingError) ChildErrors() []error {
+func (e *ParsingCheckingError) ChildErrors() []error {
 	return []error{e.Err}
 }
 
-func (e *ExtendedParsingCheckingError) Error() string {
+func (e *ParsingCheckingError) Error() string {
 	return e.Err.Error()
 }
 
-func (e ExtendedParsingCheckingError) Unwrap() error {
+func (e ParsingCheckingError) Unwrap() error {
 	return e.Err
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -229,6 +230,7 @@ type ParsingCheckingError struct {
 	Location       Location
 	Options        []sema.Option
 	UseCache       bool
+	Program        *ast.Program
 	Checker        *sema.Checker
 }
 

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 // Error is the containing type for all errors produced by the runtime.
@@ -215,4 +216,30 @@ func (e *TransactionParameterTypeNotStorableError) Error() string {
 		"parameter type is non-storable type: `%s`",
 		e.Type.QualifiedString(),
 	)
+}
+
+// ExtendedParsingCheckingError is a special error which aids in debugging checking problems
+// by providing extra information about the state of the environment
+// Separate package to prevent cyclic imports with checker tests
+type ExtendedParsingCheckingError struct {
+	Err            error
+	RuntimeStorage *InterpreterRuntimeStorage
+	Functions      stdlib.StandardLibraryFunctions
+	Code           []byte
+	Location       Location
+	Options        []sema.Option
+	UseCache       bool
+	Checker        *sema.Checker
+}
+
+func (e *ExtendedParsingCheckingError) ChildErrors() []error {
+	return []error{e.Err}
+}
+
+func (e *ExtendedParsingCheckingError) Error() string {
+	return e.Err.Error()
+}
+
+func (e ExtendedParsingCheckingError) Unwrap() error {
+	return e.Err
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -298,12 +298,12 @@ func (r *interpreterRuntime) ExecuteTransaction(
 
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
-		ee, is := err.(*ExtendedParsingCheckingError)
-		if is {
-			ee.RuntimeStorage = runtimeStorage
-			ee.Functions = functions
-			return newError(ee)
+		if err, ok := err.(*ExtendedParsingCheckingError); ok {
+			err.RuntimeStorage = runtimeStorage
+			err.Functions = functions
+			return newError(err)
 		}
+
 		return newError(err)
 	}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -298,6 +298,13 @@ func (r *interpreterRuntime) ExecuteTransaction(
 
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
+		ee, is := err.(*ExtendedParsingCheckingError)
+		if is {
+			ee.RuntimeStorage = runtimeStorage
+			ee.Functions = functions
+			//return newError(ee.Err)
+			return newError(ee)
+		}
 		return newError(err)
 	}
 
@@ -516,21 +523,42 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 			program, err = runtimeInterface.GetCachedProgram(location)
 		})
 		if err != nil {
-			return nil, err
+			return nil, &ExtendedParsingCheckingError{
+				Err:       err,
+				Code:      code,
+				Location:  location,
+				Functions: functions,
+				Options:   options,
+				UseCache:  useCache,
+			}
 		}
 	}
 
 	if program == nil {
 		program, err = r.parse(location, code, runtimeInterface)
 		if err != nil {
-			return nil, err
+			return nil, &ExtendedParsingCheckingError{
+				Err:       err,
+				Code:      code,
+				Location:  location,
+				Functions: functions,
+				Options:   options,
+				UseCache:  useCache,
+			}
 		}
 	}
 
 	importResolver := r.importResolver(runtimeInterface)
 	err = program.ResolveImports(importResolver)
 	if err != nil {
-		return nil, err
+		return nil, &ExtendedParsingCheckingError{
+			Err:       err,
+			Code:      code,
+			Location:  location,
+			Functions: functions,
+			Options:   options,
+			UseCache:  useCache,
+		}
 	}
 
 	valueDeclarations := functions.ToValueDeclarations()
@@ -568,12 +596,28 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 		)...,
 	)
 	if err != nil {
-		return nil, err
+		return nil, &ExtendedParsingCheckingError{
+			Err:       err,
+			Code:      code,
+			Location:  location,
+			Functions: functions,
+			Options:   options,
+			UseCache:  useCache,
+			Checker:   checker,
+		}
 	}
 
 	err = checker.Check()
 	if err != nil {
-		return nil, err
+		return nil, &ExtendedParsingCheckingError{
+			Err:       err,
+			Code:      code,
+			Location:  location,
+			Functions: functions,
+			Options:   options,
+			UseCache:  useCache,
+			Checker:   checker,
+		}
 	}
 
 	// After the program has passed semantic analysis, cache the program AST.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -298,7 +298,7 @@ func (r *interpreterRuntime) ExecuteTransaction(
 
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
-		if err, ok := err.(*ExtendedParsingCheckingError); ok {
+		if err, ok := err.(*ParsingCheckingError); ok {
 			err.RuntimeStorage = runtimeStorage
 			err.Functions = functions
 			return newError(err)
@@ -522,7 +522,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 			program, err = runtimeInterface.GetCachedProgram(location)
 		})
 		if err != nil {
-			return nil, &ExtendedParsingCheckingError{
+			return nil, &ParsingCheckingError{
 				Err:       err,
 				Code:      code,
 				Location:  location,
@@ -536,7 +536,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 	if program == nil {
 		program, err = r.parse(location, code, runtimeInterface)
 		if err != nil {
-			return nil, &ExtendedParsingCheckingError{
+			return nil, &ParsingCheckingError{
 				Err:       err,
 				Code:      code,
 				Location:  location,
@@ -550,7 +550,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 	importResolver := r.importResolver(runtimeInterface)
 	err = program.ResolveImports(importResolver)
 	if err != nil {
-		return nil, &ExtendedParsingCheckingError{
+		return nil, &ParsingCheckingError{
 			Err:       err,
 			Code:      code,
 			Location:  location,
@@ -595,7 +595,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 		)...,
 	)
 	if err != nil {
-		return nil, &ExtendedParsingCheckingError{
+		return nil, &ParsingCheckingError{
 			Err:       err,
 			Code:      code,
 			Location:  location,
@@ -608,7 +608,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 
 	err = checker.Check()
 	if err != nil {
-		return nil, &ExtendedParsingCheckingError{
+		return nil, &ParsingCheckingError{
 			Err:       err,
 			Code:      code,
 			Location:  location,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -302,7 +302,6 @@ func (r *interpreterRuntime) ExecuteTransaction(
 		if is {
 			ee.RuntimeStorage = runtimeStorage
 			ee.Functions = functions
-			//return newError(ee.Err)
 			return newError(ee)
 		}
 		return newError(err)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -522,14 +522,13 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 
 	wrapError := func(err error) error {
 		return &ParsingCheckingError{
-			Err:       err,
-			Code:      code,
-			Location:  location,
-			Functions: functions,
-			Options:   options,
-			UseCache:  useCache,
-			Checker:   checker,
-			Program:   program,
+			Err:      err,
+			Code:     code,
+			Location: location,
+			Options:  options,
+			UseCache: useCache,
+			Checker:  checker,
+			Program:  program,
 		}
 	}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -299,8 +299,7 @@ func (r *interpreterRuntime) ExecuteTransaction(
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
 		if err, ok := err.(*ParsingCheckingError); ok {
-			err.RuntimeStorage = runtimeStorage
-			err.Functions = functions
+			err.StorageCache = runtimeStorage.cache
 			return newError(err)
 		}
 
@@ -310,7 +309,9 @@ func (r *interpreterRuntime) ExecuteTransaction(
 	transactions := checker.TransactionTypes
 	transactionCount := len(transactions)
 	if transactionCount != 1 {
-		return newError(InvalidTransactionCountError{Count: transactionCount})
+		return newError(InvalidTransactionCountError{
+			Count: transactionCount,
+		})
 	}
 
 	transactionType := transactions[0]

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -997,7 +997,7 @@ func (r *interpreterRuntime) newAddPublicKeyFunction(
 
 			publicKey, err := interpreter.ByteArrayValueToByteSlice(publicKeyValue)
 			if err != nil {
-				panic(fmt.Sprintf("addPublicKey requires the first parameter to be an array"))
+				panic("addPublicKey requires the first parameter to be an array")
 			}
 
 			wrapPanic(func() {
@@ -1072,7 +1072,7 @@ func (r *interpreterRuntime) newSetCodeFunction(
 
 			code, err := interpreter.ByteArrayValueToByteSlice(invocation.Arguments[0])
 			if err != nil {
-				panic(fmt.Sprintf("setCode requires the first parameter to be an array of bytes ([Int])"))
+				panic("setCode requires the first parameter to be an array of bytes ([Int])")
 			}
 
 			constructorArguments := invocation.Arguments[requiredArgumentCount:]
@@ -1146,7 +1146,7 @@ func (r *interpreterRuntime) updateAccountCode(
 	}
 
 	if len(contractTypes) > 1 {
-		panic(fmt.Sprintf("code declares more than one contract"))
+		panic("code declares more than one contract")
 	}
 
 	// If the code declares a contract, instantiate it and store it

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -46,7 +46,7 @@ type interpreterRuntimeStorage struct {
 	cache                   map[storageKey]cacheEntry
 }
 
-// temporary export the type for usage in ExtendedParsingCheckingError
+// temporary export the type for usage in ParsingCheckingError
 type InterpreterRuntimeStorage = interpreterRuntimeStorage
 
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -27,27 +27,26 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 )
 
-type storageKey struct {
-	address common.Address
-	key     string
+type StorageKey struct {
+	Address common.Address
+	Key     string
 }
 
-type cacheEntry struct {
+type Cache map[StorageKey]CacheEntry
+
+type CacheEntry struct {
 	// true indicates that the value definitely must be written, independent of the value.
 	// false indicates that the value may has to be written if the value is modified.
-	mustWrite bool
-	value     interpreter.Value
+	MustWrite bool
+	Value     interpreter.Value
 }
 
 type interpreterRuntimeStorage struct {
 	runtimeInterface        Interface
 	highLevelStorageEnabled bool
 	highLevelStorage        HighLevelStorage
-	cache                   map[storageKey]cacheEntry
+	cache                   Cache
 }
-
-// temporary export the type for usage in ParsingCheckingError
-type InterpreterRuntimeStorage = interpreterRuntimeStorage
 
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {
 	highLevelStorageEnabled := false
@@ -58,7 +57,7 @@ func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntim
 
 	return &interpreterRuntimeStorage{
 		runtimeInterface:        runtimeInterface,
-		cache:                   map[storageKey]cacheEntry{},
+		cache:                   Cache{},
 		highLevelStorage:        highLevelStorage,
 		highLevelStorageEnabled: highLevelStorageEnabled,
 	}
@@ -77,15 +76,15 @@ func (s *interpreterRuntimeStorage) valueExists(
 	key string,
 ) bool {
 
-	fullKey := storageKey{
-		address: address,
-		key:     key,
+	fullKey := StorageKey{
+		Address: address,
+		Key:     key,
 	}
 
 	// Check cache
 
 	if entry, ok := s.cache[fullKey]; ok {
-		return entry.value != nil
+		return entry.Value != nil
 	}
 
 	// Cache miss: Ask interface
@@ -100,9 +99,9 @@ func (s *interpreterRuntimeStorage) valueExists(
 	}
 
 	if !exists {
-		s.cache[fullKey] = cacheEntry{
-			mustWrite: false,
-			value:     nil,
+		s.cache[fullKey] = CacheEntry{
+			MustWrite: false,
+			Value:     nil,
 		}
 	}
 
@@ -123,19 +122,19 @@ func (s *interpreterRuntimeStorage) readValue(
 	deferred bool,
 ) interpreter.OptionalValue {
 
-	fullKey := storageKey{
-		address: address,
-		key:     key,
+	fullKey := StorageKey{
+		Address: address,
+		Key:     key,
 	}
 
 	// Check cache. Return cached value, if any
 
 	if entry, ok := s.cache[fullKey]; ok {
-		if entry.value == nil {
+		if entry.Value == nil {
 			return interpreter.NilValue{}
 		}
 
-		return interpreter.NewSomeValueOwningNonCopying(entry.value)
+		return interpreter.NewSomeValueOwningNonCopying(entry.Value)
 	}
 
 	// Cache miss: Load and deserialize the stored value (if any)
@@ -153,9 +152,9 @@ func (s *interpreterRuntimeStorage) readValue(
 	storedData = interpreter.StripMagic(storedData)
 
 	if len(storedData) == 0 {
-		s.cache[fullKey] = cacheEntry{
-			mustWrite: false,
-			value:     nil,
+		s.cache[fullKey] = CacheEntry{
+			MustWrite: false,
+			Value:     nil,
 		}
 		return interpreter.NilValue{}
 	}
@@ -176,9 +175,9 @@ func (s *interpreterRuntimeStorage) readValue(
 	}
 
 	if !deferred {
-		s.cache[fullKey] = cacheEntry{
-			mustWrite: false,
-			value:     storedValue,
+		s.cache[fullKey] = CacheEntry{
+			MustWrite: false,
+			Value:     storedValue,
 		}
 	}
 
@@ -197,23 +196,23 @@ func (s *interpreterRuntimeStorage) writeValue(
 	key string,
 	value interpreter.OptionalValue,
 ) {
-	fullKey := storageKey{
-		address: address,
-		key:     key,
+	fullKey := StorageKey{
+		Address: address,
+		Key:     key,
 	}
 
 	// Only write the value to the cache.
 	// The Cache is finally written back through the runtime interface in `writeCached`
 
 	entry := s.cache[fullKey]
-	entry.mustWrite = true
+	entry.MustWrite = true
 
 	switch typedValue := value.(type) {
 	case *interpreter.SomeValue:
-		entry.value = typedValue.Value
+		entry.Value = typedValue.Value
 
 	case interpreter.NilValue:
-		entry.value = nil
+		entry.Value = nil
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -227,7 +226,7 @@ func (s *interpreterRuntimeStorage) writeValue(
 func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) {
 
 	type writeItem struct {
-		storageKey storageKey
+		storageKey StorageKey
 		value      interpreter.Value
 	}
 
@@ -235,25 +234,25 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 
 	for fullKey, entry := range s.cache {
 
-		if !entry.mustWrite && entry.value != nil && !entry.value.IsModified() {
+		if !entry.MustWrite && entry.Value != nil && !entry.Value.IsModified() {
 			continue
 		}
 
 		items = append(items, writeItem{
 			storageKey: fullKey,
-			value:      entry.value,
+			value:      entry.Value,
 		})
 
 		if s.highLevelStorageEnabled {
 			var err error
 
 			var value cadence.Value
-			if entry.value != nil {
-				value = exportValueWithInterpreter(entry.value, inter)
+			if entry.Value != nil {
+				value = exportValueWithInterpreter(entry.Value, inter)
 			}
 
 			wrapPanic(func() {
-				err = s.highLevelStorage.SetCadenceValue(fullKey.address, fullKey.key, value)
+				err = s.highLevelStorage.SetCadenceValue(fullKey.Address, fullKey.Key, value)
 			})
 			if err != nil {
 				panic(err)
@@ -270,16 +269,16 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 		if item.value != nil {
 			var deferrals *interpreter.EncodingDeferrals
 			var err error
-			newData, deferrals, err = s.encodeValue(item.value, item.storageKey.key)
+			newData, deferrals, err = s.encodeValue(item.value, item.storageKey.Key)
 			if err != nil {
 				panic(err)
 			}
 
 			for deferredKey, deferredValue := range deferrals.Values {
 
-				deferredStorageKey := storageKey{
-					address: item.storageKey.address,
-					key:     deferredKey,
+				deferredStorageKey := StorageKey{
+					Address: item.storageKey.Address,
+					Key:     deferredKey,
 				}
 
 				if !deferredValue.IsModified() {
@@ -310,8 +309,8 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 		var err error
 		wrapPanic(func() {
 			err = s.runtimeInterface.SetValue(
-				item.storageKey.address[:],
-				[]byte(item.storageKey.key),
+				item.storageKey.Address[:],
+				[]byte(item.storageKey.Key),
 				newData,
 			)
 		})

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -46,6 +46,9 @@ type interpreterRuntimeStorage struct {
 	cache                   map[storageKey]cacheEntry
 }
 
+// temporary export the type for usage in ExtendedParsingCheckingError
+type InterpreterRuntimeStorage = interpreterRuntimeStorage
+
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {
 	highLevelStorageEnabled := false
 	highLevelStorage, ok := runtimeInterface.(HighLevelStorage)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -2377,7 +2376,14 @@ func TestRuntimeCyclicImport(t *testing.T) {
 
 	require.Error(t, err)
 	require.IsType(t, Error{}, err)
-	assert.IsType(t, ast.CyclicImportsError{}, err.(Error).Unwrap())
+
+	// Temporary to help catch checking error
+	ee := err.(Error).Unwrap()
+
+	require.IsType(t, &ExtendedParsingCheckingError{}, ee)
+	eee := ee.(*ExtendedParsingCheckingError)
+
+	assert.IsType(t, ast.CyclicImportsError{}, eee.Unwrap())
 }
 
 func ArrayValueFromBytes(bytes []byte) *interpreter.ArrayValue {
@@ -3338,7 +3344,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 		require.IsType(t, Error{}, err)
 		err = err.(Error).Unwrap()
 
-		errs := checker.ExpectCheckerErrors(t, err, 1)
+		errs := ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidTopLevelDeclarationError{}, errs[0])
 	})
@@ -4773,4 +4779,39 @@ func TestRuntime(t *testing.T) {
 	} {
 		test(testCase)
 	}
+}
+
+// Copied to prevent import cycle while importing from tests/checker package
+// while using ExtendedParsingCheckingError
+// This now required `runtime` to get access `ExtendedParsingCheckingError`
+// which in turns requires `runtime` so any import of original function from
+// any other module will introduce cycle
+// If we decide to keep extended debug functionality beyond original
+// debug possible race condition, this would need to be refactored
+func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
+	if count <= 0 && err == nil {
+		return nil
+	}
+
+	require.Error(t, err)
+
+	// Temporary to help catch checking error
+	ee, is := err.(*ExtendedParsingCheckingError)
+	if is {
+		err = ee.Unwrap()
+	}
+
+	assert.IsType(t, &sema.CheckerError{}, err)
+
+	errs := err.(*sema.CheckerError).Errors
+
+	require.Len(t, errs, count)
+
+	// Get the error message, to check that it can be successfully generated
+
+	for _, checkerErr := range errs {
+		_ = checkerErr.Error()
+	}
+
+	return errs
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -2377,13 +2378,7 @@ func TestRuntimeCyclicImport(t *testing.T) {
 	require.Error(t, err)
 	require.IsType(t, Error{}, err)
 
-	// Temporary to help catch checking error
-	ee := err.(Error).Unwrap()
-
-	require.IsType(t, &ExtendedParsingCheckingError{}, ee)
-	eee := ee.(*ExtendedParsingCheckingError)
-
-	assert.IsType(t, ast.CyclicImportsError{}, eee.Unwrap())
+	utils.RequireErrorAs(t, err, &ast.CyclicImportsError{})
 }
 
 func ArrayValueFromBytes(bytes []byte) *interpreter.ArrayValue {
@@ -3344,7 +3339,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 		require.IsType(t, Error{}, err)
 		err = err.(Error).Unwrap()
 
-		errs := ExpectCheckerErrors(t, err, 1)
+		errs := checker.ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidTopLevelDeclarationError{}, errs[0])
 	})
@@ -4779,39 +4774,4 @@ func TestRuntime(t *testing.T) {
 	} {
 		test(testCase)
 	}
-}
-
-// Copied to prevent import cycle while importing from tests/checker package
-// while using ExtendedParsingCheckingError
-// This now required `runtime` to get access `ExtendedParsingCheckingError`
-// which in turns requires `runtime` so any import of original function from
-// any other module will introduce cycle
-// If we decide to keep extended debug functionality beyond original
-// debug possible race condition, this would need to be refactored
-func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
-	if count <= 0 && err == nil {
-		return nil
-	}
-
-	require.Error(t, err)
-
-	// Temporary to help catch checking error
-	ee, is := err.(*ExtendedParsingCheckingError)
-	if is {
-		err = ee.Unwrap()
-	}
-
-	assert.IsType(t, &sema.CheckerError{}, err)
-
-	errs := err.(*sema.CheckerError).Errors
-
-	require.Len(t, errs, count)
-
-	// Get the error message, to check that it can be successfully generated
-
-	for _, checkerErr := range errs {
-		_ = checkerErr.Error()
-	}
-
-	return errs
 }

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -611,7 +611,7 @@ type InvalidVariableKindError struct {
 
 func (e *InvalidVariableKindError) Error() string {
 	if e.Kind == ast.VariableKindNotSpecified {
-		return fmt.Sprintf("missing variable kind")
+		return "missing variable kind"
 	}
 	return fmt.Sprintf("invalid variable kind: `%s`", e.Kind.Name())
 }

--- a/runtime/stdlib/internal/contracts.gen.go
+++ b/runtime/stdlib/internal/contracts.gen.go
@@ -228,8 +228,8 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"contracts": &bintree{nil, map[string]*bintree{
-		"crypto.cdc": &bintree{contractsCryptoCdc, map[string]*bintree{}},
+	"contracts": {nil, map[string]*bintree{
+		"crypto.cdc": {contractsCryptoCdc, map[string]*bintree{}},
 	}},
 }}
 

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser2"
@@ -93,15 +92,10 @@ func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
 
 	require.Error(t, err)
 
-	// Temporary to help catch checking error
-	ee, is := err.(*runtime.ExtendedParsingCheckingError)
-	if is {
-		err = ee.Unwrap()
-	}
+	var checkerErr *sema.CheckerError
+	utils.RequireErrorAs(t, err, &checkerErr)
 
-	assert.IsType(t, &sema.CheckerError{}, err)
-
-	errs := err.(*sema.CheckerError).Errors
+	errs := checkerErr.Errors
 
 	require.Len(t, errs, count)
 

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser2"
@@ -91,6 +92,12 @@ func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
 	}
 
 	require.Error(t, err)
+
+	// Temporary to help catch checking error
+	ee, is := err.(*runtime.ExtendedParsingCheckingError)
+	if is {
+		err = ee.Unwrap()
+	}
 
 	assert.IsType(t, &sema.CheckerError{}, err)
 

--- a/runtime/tests/utils/utils.go
+++ b/runtime/tests/utils/utils.go
@@ -20,12 +20,14 @@ package utils
 
 import (
 	"encoding/hex"
+	errors2 "errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -92,4 +94,15 @@ func DeploymentTransaction(contract []byte) []byte {
         `,
 		hex.EncodeToString(contract),
 	))
+}
+
+// TODO: switch to require.ErrorAs once released:
+// https://github.com/stretchr/testify/commit/95a9d909e98735cd8211dfc5cbbb6b8b0b665915
+func RequireErrorAs(t *testing.T, err error, target interface{}) {
+	require.True(
+		t,
+		errors2.As(err, target),
+		"error chain must contain a %T",
+		target,
+	)
 }


### PR DESCRIPTION
Part of changes to support dapperlabs/flow-go#1291

It's not the most elegant solution, but I assume this code is temporary anyway.
It supports returning extended information on case of execution errors so they can be recorded by the caller - currently if TopShot contract fails.
It was started from v0.9.2 branch as it was the latest one we use in Flow-go - I plan to update this PR accordingly once more mature version of Cadence is used in Flow-go