### PR TITLE
Refactor address locations, make composite decoding backwards-compatible

### DIFF
--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
 )
 
 func TestIdentifierLocation_MarshalJSON(t *testing.T) {
@@ -70,7 +72,10 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 
 	t.Parallel()
 
-	loc := AddressLocation([]byte{1})
+	loc := AddressLocation{
+		Address: common.BytesToAddress([]byte{1}),
+		Name:    "A",
+	}
 
 	actual, err := json.Marshal(loc)
 	require.NoError(t, err)
@@ -79,7 +84,8 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 		`
         {
             "Type": "AddressLocation",
-            "Address": "0x1"
+            "Address": "0x1",
+            "Name": "A"
         }
         `,
 		string(actual),

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -77,7 +77,7 @@ func importLocationFileName(importLocation ast.Location) string {
 	case ast.StringLocation:
 		return string(importLocation)
 	case ast.AddressLocation:
-		return importLocation.ToAddress().ShortHexWithPrefix()
+		return importLocation.Address.ShortHexWithPrefix()
 	case ast.IdentifierLocation:
 		return string(importLocation)
 	case runtime.FileLocation:

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -499,13 +499,13 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		},
 		resolveLocation: func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 
-			// Resolve each identifier as an address contract location
+			// Resolve each identifier as an address location
 
 			for _, identifier := range identifiers {
 				result = append(result, sema.ResolvedLocation{
-					Location: ast.AddressContractLocation{
-						AddressLocation: location.(ast.AddressLocation),
-						Name:            identifier.Identifier,
+					Location: ast.AddressLocation{
+						Address: location.(ast.AddressLocation).Address,
+						Name:    identifier.Identifier,
 					},
 					Identifiers: []ast.Identifier{
 						identifier,

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -143,7 +143,7 @@ const (
 	cborTagAddressLocation
 	cborTagStringLocation
 	cborTagIdentifierLocation
-	cborTagAddressContractLocation
+	_
 	_
 	_
 	_
@@ -844,17 +844,12 @@ func (e *Encoder) prepareCapabilityValue(v CapabilityValue) (interface{}, error)
 
 // NOTE: NEVER change, only add/increment; ensure uint64
 const (
-	encodedAddressContractLocationAddressFieldKey uint64 = 0
-	encodedAddressContractLocationNameFieldKey    uint64 = 1
+	encodedAddressLocationAddressFieldKey uint64 = 0
+	encodedAddressLocationNameFieldKey    uint64 = 1
 )
 
 func (e *Encoder) prepareLocation(l ast.Location) (interface{}, error) {
 	switch l := l.(type) {
-	case ast.AddressLocation:
-		return cbor.Tag{
-			Number:  cborTagAddressLocation,
-			Content: l.ToAddress().Bytes(),
-		}, nil
 
 	case ast.StringLocation:
 		return cbor.Tag{
@@ -868,13 +863,21 @@ func (e *Encoder) prepareLocation(l ast.Location) (interface{}, error) {
 			Content: string(l),
 		}, nil
 
-	case ast.AddressContractLocation:
+	case ast.AddressLocation:
+		var content interface{}
+
+		if l.Name == "" {
+			content = l.Address.Bytes()
+		} else {
+			content = cborMap{
+				encodedAddressLocationAddressFieldKey: l.Address.Bytes(),
+				encodedAddressLocationNameFieldKey:    l.Name,
+			}
+		}
+
 		return cbor.Tag{
-			Number: cborTagAddressContractLocation,
-			Content: cborMap{
-				encodedAddressContractLocationAddressFieldKey: l.AddressLocation.ToAddress().Bytes(),
-				encodedAddressContractLocationNameFieldKey:    l.Name,
-			},
+			Number:  cborTagAddressLocation,
+			Content: content,
 		}, nil
 
 	default:

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -461,9 +461,14 @@ func TestEncodeDecodeComposite(t *testing.T) {
 	})
 
 	t.Run("empty, address location", func(t *testing.T) {
+
 		expected := NewCompositeValue(
-			ast.AddressLocation{0x1},
-			"A.0x1.TestStruct",
+			ast.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x1}),
+				// NOTE: not stored, inferred from type ID
+				Name: "TestContract",
+			},
+			"A.0x1.TestContract.TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -472,7 +477,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: expected,
+				decodedValue: expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -488,10 +493,12 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x1,
 					// key 1
 					0x1,
-					// UTF-8 string, length 16
-					0x70,
-					0x41, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54, 0x65,
-					0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+					// UTF-8 string, length 29
+					0x78, 0x1D,
+					0x41,
+					0x2e, 0x30, 0x78, 0x31,
+					0x2e, 0x54, 0x65, 0x73, 0x74, 0x43, 0x6F, 0x6E, 0x74, 0x72, 0x61, 0x63, 0x74,
+					0x2e, 0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
 					// positive integer 1
@@ -501,6 +508,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// map, 0 pairs of items follow
 					0xa0,
 				},
+				decodeOnly: true,
 			},
 		)
 	})
@@ -545,11 +553,11 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 	t.Run("empty, address location", func(t *testing.T) {
 		expected := NewCompositeValue(
-			ast.AddressContractLocation{
-				AddressLocation: ast.AddressLocation{0x1},
-				Name:            "TestStruct",
+			ast.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x1}),
+				Name:    "TestStruct",
 			},
-			"AC.0x1.TestStruct",
+			"A.0x1.TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -567,7 +575,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 0
 					0x0,
 					// tag
-					0xd8, cborTagAddressContractLocation,
+					0xd8, cborTagAddressLocation,
 					// map, 4 pairs of items follow
 					0xa2,
 					// key 0
@@ -585,8 +593,8 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 1
 					0x1,
 					// UTF-8 string, length 17
-					0x71,
-					0x41, 0x43, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54,
+					0x70,
+					0x41, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54,
 					0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
@@ -601,7 +609,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("empty, address contract location, address too long", func(t *testing.T) {
+	t.Run("empty, address location, address too long", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
@@ -612,7 +620,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 0
 					0x0,
 					// tag
-					0xd8, cborTagAddressContractLocation,
+					0xd8, cborTagAddressLocation,
 					// map, 4 pairs of items follow
 					0xa2,
 					// key 0
@@ -730,7 +738,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 					// byte string, length 1
 					0x41,
 					// `-42` in decimal is is `0x2a` in hex.
-					// CBOR requires negative values to be encoded as `-1-n`, which is `-n - 1`, 
+					// CBOR requires negative values to be encoded as `-1-n`, which is `-n - 1`,
 					// which is `0x2a - 0x01`, which equals to `0x29`.
 					0x29,
 				},

--- a/runtime/locations.go
+++ b/runtime/locations.go
@@ -20,26 +20,26 @@ package runtime
 
 import (
 	"encoding/hex"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
 )
 
 type (
-	Location                = ast.Location
-	LocationID              = ast.LocationID
-	StringLocation          = ast.StringLocation
-	AddressLocation         = ast.AddressLocation
-	AddressContractLocation = ast.AddressContractLocation
-	Identifier              = ast.Identifier
+	Location        = ast.Location
+	LocationID      = ast.LocationID
+	TypeID          = ast.TypeID
+	StringLocation  = ast.StringLocation
+	AddressLocation = ast.AddressLocation
+	Identifier      = ast.Identifier
 )
 
 const (
-	IdentifierLocationPrefix      = ast.IdentifierLocationPrefix
-	StringLocationPrefix          = ast.StringLocationPrefix
-	AddressLocationPrefix         = ast.AddressLocationPrefix
-	AddressContractLocationPrefix = ast.AddressContractLocationPrefix
-	TransactionLocationPrefix     = "t"
-	ScriptLocationPrefix          = "s"
+	IdentifierLocationPrefix  = ast.IdentifierLocationPrefix
+	StringLocationPrefix      = ast.StringLocationPrefix
+	AddressLocationPrefix     = ast.AddressLocationPrefix
+	TransactionLocationPrefix = "t"
+	ScriptLocationPrefix      = "s"
 )
 
 // TransactionLocation
@@ -47,7 +47,28 @@ const (
 type TransactionLocation []byte
 
 func (l TransactionLocation) ID() ast.LocationID {
-	return ast.NewLocationID(TransactionLocationPrefix, l.String())
+	return ast.NewLocationID(
+		TransactionLocationPrefix,
+		l.String(),
+	)
+}
+
+func (l TransactionLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		TransactionLocationPrefix,
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l TransactionLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 3)
+
+	if len(pieces) < 3 {
+		return ""
+	}
+
+	return pieces[2]
 }
 
 func (l TransactionLocation) String() string {
@@ -59,7 +80,28 @@ func (l TransactionLocation) String() string {
 type ScriptLocation []byte
 
 func (l ScriptLocation) ID() ast.LocationID {
-	return ast.NewLocationID(ScriptLocationPrefix, l.String())
+	return ast.NewLocationID(
+		ScriptLocationPrefix,
+		l.String(),
+	)
+}
+
+func (l ScriptLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		ScriptLocationPrefix,
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l ScriptLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 3)
+
+	if len(pieces) < 3 {
+		return ""
+	}
+
+	return pieces[2]
 }
 
 func (l ScriptLocation) String() string {
@@ -74,6 +116,23 @@ func (l FileLocation) ID() ast.LocationID {
 	return LocationID(l.String())
 }
 
+func (l FileLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l FileLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
+}
+
 func (l FileLocation) String() string {
 	return string(l)
 }
@@ -84,6 +143,23 @@ type REPLLocation struct{}
 
 func (l REPLLocation) ID() LocationID {
 	return LocationID(l.String())
+}
+
+func (l REPLLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l REPLLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
 }
 
 func (l REPLLocation) String() string {

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -578,7 +578,9 @@ func parseHexadecimalLocation(literal string) ast.AddressLocation {
 		panic(err)
 	}
 
-	return address
+	return ast.AddressLocation{
+		Address: common.BytesToAddress(address),
+	}
 }
 
 // parseEventDeclaration parses an event declaration.

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -1226,7 +1226,9 @@ func TestParseImportDeclaration(t *testing.T) {
 			[]ast.Declaration{
 				&ast.ImportDeclaration{
 					Identifiers: nil,
-					Location:    ast.AddressLocation{0x42},
+					Location: ast.AddressLocation{
+						Address: common.BytesToAddress([]byte{0x42}),
+					},
 					LocationPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -1339,7 +1341,9 @@ func TestParseImportDeclaration(t *testing.T) {
 							Pos:        ast.Position{Line: 1, Column: 20, Offset: 20},
 						},
 					},
-					Location:    ast.AddressLocation{0x42},
+					Location: ast.AddressLocation{
+						Address: common.BytesToAddress([]byte{0x42}),
+					},
 					LocationPos: ast.Position{Line: 1, Column: 29, Offset: 29},
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -3823,7 +3827,9 @@ func TestParseImportWithAddress(t *testing.T) {
 		[]ast.Declaration{
 			&ast.ImportDeclaration{
 				Identifiers: nil,
-				Location:    ast.AddressLocation{18, 52},
+				Location: ast.AddressLocation{
+					Address: common.BytesToAddress([]byte{0x12, 0x34}),
+				},
 				Range: ast.Range{
 					StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   ast.Position{Offset: 21, Line: 2, Column: 20},
@@ -3840,7 +3846,7 @@ func TestParseImportWithIdentifiers(t *testing.T) {
 	t.Parallel()
 
 	result, errs := ParseProgram(`
-        import A, b from 0x0
+        import A, b from 0x1
 	`)
 	require.Empty(t, errs)
 
@@ -3857,7 +3863,9 @@ func TestParseImportWithIdentifiers(t *testing.T) {
 						Pos:        ast.Position{Offset: 19, Line: 2, Column: 18},
 					},
 				},
-				Location: ast.AddressLocation{0},
+				Location: ast.AddressLocation{
+					Address: common.BytesToAddress([]byte{0x1}),
+				},
 				Range: ast.Range{
 					StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   ast.Position{Offset: 28, Line: 2, Column: 27},
@@ -3939,7 +3947,7 @@ func TestParseImportWithFromIdentifier(t *testing.T) {
 	t.Parallel()
 
 	result, errs := ParseProgram(`
-        import from from 0x0
+        import from from 0x1
 	`)
 	require.Empty(t, errs)
 
@@ -3952,7 +3960,9 @@ func TestParseImportWithFromIdentifier(t *testing.T) {
 						Pos:        ast.Position{Offset: 16, Line: 2, Column: 15},
 					},
 				},
-				Location: ast.AddressLocation{0},
+				Location: ast.AddressLocation{
+					Address: common.BytesToAddress([]byte{0x1}),
+				},
 				Range: ast.Range{
 					StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   ast.Position{Offset: 28, Line: 2, Column: 27},

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -82,7 +82,7 @@ func validTopLevelDeclarations(location ast.Location) []common.DeclarationKind {
 	switch location.(type) {
 	case TransactionLocation:
 		return validTopLevelDeclarationsInTransaction
-	case AddressLocation, AddressContractLocation:
+	case AddressLocation:
 		return validTopLevelDeclarationsInAccountCode
 	}
 
@@ -106,8 +106,6 @@ func reportMetric(
 
 	report(metrics, elapsed)
 }
-
-const contractKey = "contract"
 
 // interpreterRuntime is a interpreter-based version of the Flow runtime.
 type interpreterRuntime struct{}
@@ -689,9 +687,7 @@ func (r *interpreterRuntime) injectedCompositeFieldsHandler(
 
 				switch location := location.(type) {
 				case AddressLocation:
-					address = location.ToAddress()
-				case AddressContractLocation:
-					address = location.AddressLocation.ToAddress()
+					address = location.Address
 				default:
 					panic(runtimeErrors.NewUnreachableError())
 				}
@@ -805,11 +801,11 @@ func (r *interpreterRuntime) importResolver(runtimeInterface Interface) ImportRe
 		}
 
 		var code []byte
-		if addressContractLocation, ok := location.(AddressContractLocation); ok {
+		if addressLocation, ok := location.(AddressLocation); ok {
 			wrapPanic(func() {
 				code, err = runtimeInterface.GetAccountContractCode(
-					addressContractLocation.AddressLocation.ToAddress(),
-					addressContractLocation.Name,
+					addressLocation.Address,
+					addressLocation.Name,
 				)
 			})
 		} else {
@@ -1063,7 +1059,6 @@ func (r *interpreterRuntime) writeContract(
 	name string,
 	contractValue interpreter.OptionalValue,
 ) {
-
 	runtimeStorage.writeValue(
 		addressValue.ToAddress(),
 		formatContractKey(name),
@@ -1072,12 +1067,9 @@ func (r *interpreterRuntime) writeContract(
 }
 
 func formatContractKey(name string) string {
-	if name == "" {
-		return contractKey
-	}
+	const contractKey = "contract"
 
 	// \x1F = Information Separator One
-
 	return fmt.Sprintf("%s\x1F%s", contractKey, name)
 }
 
@@ -1109,18 +1101,10 @@ func (r *interpreterRuntime) loadContract(
 		var storedValue interpreter.OptionalValue = interpreter.NilValue{}
 
 		switch location := compositeType.Location.(type) {
-		case AddressLocation:
-			address := location.ToAddress()
-			storedValue = runtimeStorage.readValue(
-				address,
-				contractKey,
-				false,
-			)
 
-		case AddressContractLocation:
-			address := location.AddressLocation.ToAddress()
+		case AddressLocation:
 			storedValue = runtimeStorage.readValue(
-				address,
+				location.Address,
 				formatContractKey(location.Name),
 				false,
 			)
@@ -1413,9 +1397,9 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 
 			// Check the code
 
-			location := AddressContractLocation{
-				AddressLocation: addressValue[:],
-				Name:            nameArgument,
+			location := AddressLocation{
+				Address: address,
+				Name:    nameArgument,
 			}
 
 			// NOTE: do NOT use the cache!
@@ -1542,7 +1526,7 @@ func (r *interpreterRuntime) updateAccountContractCode(
 	name string,
 	code []byte,
 	addressValue interpreter.AddressValue,
-	location AddressContractLocation,
+	location AddressLocation,
 	checker *sema.Checker,
 	contractType *sema.CompositeType,
 	constructorArguments []interpreter.Value,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2907,12 +2907,20 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 			return []Address{signerAccount}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
-			key := string(AddressLocation(address[:]).ID())
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3022,12 +3030,20 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 			return []Address{signerAccount}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) (err error) {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3155,12 +3171,20 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 			return []Address{{0x1}}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3525,12 +3549,20 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 			return []Address{address}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3671,13 +3703,21 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{address}
 		},
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3824,12 +3864,20 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 			return []Address{address}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4481,12 +4529,20 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4595,12 +4651,20 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4728,12 +4792,20 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4770,7 +4842,7 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
-			"AC.0100000000000000.HelloWorld",
+			"A.0100000000000000.HelloWorld",
 		},
 		cacheHits,
 	)
@@ -4873,9 +4945,9 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 			return []ResolvedLocation{
 				{
-					Location: AddressContractLocation{
-						AddressLocation: location.(AddressLocation),
-						Name:            "Test",
+					Location: AddressLocation{
+						Address: location.(AddressLocation).Address,
+						Name:    "Test",
 					},
 					Identifiers: []ast.Identifier{
 						{
@@ -5021,9 +5093,9 @@ func singleIdentifierLocationResolver(t *testing.T) func(identifiers []Identifie
 
 		return []ResolvedLocation{
 			{
-				Location: AddressContractLocation{
-					AddressLocation: location.(AddressLocation),
-					Name:            identifiers[0].Identifier,
+				Location: AddressLocation{
+					Address: location.(AddressLocation).Address,
+					Name:    identifiers[0].Identifier,
 				},
 				Identifiers: identifiers,
 			},

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -28,12 +28,12 @@ import (
 // 1. Resolution of the import statement.
 //
 //     The default case is that one location is resolved to one location (itself),
-//     though e.g. an address location may also be resolved into multiple "address contract" locations.
+//     though e.g. an address location may also be resolved into multiple address locations.
 //
 //     For example, an import declaration `import a, b from 0x1` specifies the import of the declarations with
 //     the identifiers `a` and `b` from the address location `0x1`.
 //     This import declaration might be resolved into just the location itself, i.e. the address location `0x1`,
-//     but could also be resolved into multiple locations, e.g. the address contract locations `0x1.a` and `0x1.b`.
+//     but could also be resolved into multiple locations, e.g. the address locations `0x1.a` and `0x1.b`.
 //
 // 2. Acquiring the programs for the resolved imports. For each resolved import a separate program can be returned.
 //

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -63,7 +63,7 @@ func qualifiedIdentifier(identifier string, containerType Type) string {
 	return sb.String()
 }
 
-type TypeID string
+type TypeID = ast.TypeID
 
 type Type interface {
 	IsType()
@@ -4804,7 +4804,7 @@ func (t *CompositeType) QualifiedIdentifier() string {
 }
 
 func (t *CompositeType) ID() TypeID {
-	return TypeID(fmt.Sprintf("%s.%s", t.Location.ID(), t.QualifiedIdentifier()))
+	return t.Location.TypeID(t.QualifiedIdentifier())
 }
 
 func (t *CompositeType) Equal(other Type) bool {
@@ -5840,7 +5840,7 @@ func (t *InterfaceType) QualifiedIdentifier() string {
 }
 
 func (t *InterfaceType) ID() TypeID {
-	return TypeID(fmt.Sprintf("%s.%s", t.Location.ID(), t.QualifiedIdentifier()))
+	return t.Location.TypeID(t.QualifiedIdentifier())
 }
 
 func (t *InterfaceType) Equal(other Type) bool {

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -21,6 +21,7 @@ package stdlib
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -181,6 +182,23 @@ const flowLocationID = "flow"
 
 func (l FlowLocation) ID() ast.LocationID {
 	return ast.NewLocationID(flowLocationID)
+}
+
+func (l FlowLocation) TypeID(qualifiedIdentifier string) ast.TypeID {
+	return ast.NewTypeID(
+		flowLocationID,
+		qualifiedIdentifier,
+	)
+}
+
+func (l FlowLocation) QualifiedIdentifier(typeID ast.TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
 }
 
 // built-in event types

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -136,7 +136,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 	assert.NotNil(t, accountCode)
 
 	rType := &cadence.ResourceType{
-		TypeID:     "AC.000000000000cade.Test.Test.R",
+		TypeID:     "A.000000000000cade.Test.R",
 		Identifier: "R",
 		Fields: []cadence.Field{
 			{
@@ -156,7 +156,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 				address,
 				"contract\x1fTest",
 				cadence.NewContract([]cadence.Value{}).WithType(&cadence.ContractType{
-					TypeID:       "AC.000000000000cade.Test.Test",
+					TypeID:       "A.000000000000cade.Test",
 					Identifier:   "Test",
 					Fields:       []cadence.Field{},
 					Initializers: nil,

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -87,7 +87,7 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddressLocation := ast.AddressLocation{0x1}
+	importedAddress := common.BytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`
@@ -98,9 +98,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
           pub let x = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "x",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "x",
 			},
 		},
 	)
@@ -115,9 +115,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
           pub let y = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "y",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "y",
 			},
 		},
 	)
@@ -134,9 +134,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 					func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 						for _, identifier := range identifiers {
 							result = append(result, sema.ResolvedLocation{
-								Location: ast.AddressContractLocation{
-									AddressLocation: importedAddressLocation,
-									Name:            identifier.Identifier,
+								Location: ast.AddressLocation{
+									Address: importedAddress,
+									Name:    identifier.Identifier,
 								},
 								Identifiers: []ast.Identifier{
 									identifier,
@@ -148,9 +148,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 				),
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
-						addressContractLocation := location.(ast.AddressContractLocation)
+						addressLocation := location.(ast.AddressLocation)
 						var importedChecker *sema.Checker
-						switch addressContractLocation.Name {
+						switch addressLocation.Name {
 						case "x":
 							importedChecker = importedCheckerX
 						case "y":
@@ -210,7 +210,7 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddressLocation := ast.AddressLocation{0x1}
+	importedAddress := common.BytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`
@@ -221,9 +221,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
           pub let x = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "x",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "x",
 			},
 		},
 	)
@@ -238,9 +238,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
           pub let y = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "y",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "y",
 			},
 		},
 	)
@@ -256,9 +256,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 					func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 						for _, identifier := range identifiers {
 							result = append(result, sema.ResolvedLocation{
-								Location: ast.AddressContractLocation{
-									AddressLocation: importedAddressLocation,
-									Name:            identifier.Identifier,
+								Location: ast.AddressLocation{
+									Address: importedAddress,
+									Name:    identifier.Identifier,
 								},
 								Identifiers: []ast.Identifier{
 									identifier,
@@ -270,9 +270,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 				),
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
-						addressContractLocation := location.(ast.AddressContractLocation)
+						addressLocation := location.(ast.AddressLocation)
 						var importedChecker *sema.Checker
-						switch addressContractLocation.Name {
+						switch addressLocation.Name {
 						case "x":
 							importedChecker = importedCheckerX
 						case "y":


### PR DESCRIPTION
Closes onflow/flow#84

[Cadence v0.10](https://github.com/onflow/cadence/releases/tag/v0.10.0) added support for multiple contracts per account.

Along with the changes to the contract management API, this also introduced a breaking change to how values are stored: Composite values are stored with a location and type identifier, which allows the interpreter to load the code related to the type. 

Previously, the location was an address location, which has for example an ID like `A.0x1`, which indicates the code for the type is the code deployed in account `0x1` (the whole code of the account, as there was only one code associated with an account).

In v0.10, address contract locations were introduced: Each contract of an account has a distinct identifier, e.g `AC.0x1.SomeContract`, which indicates the code for the type is specifically the code of the "SomeContract" contract deployed to account `0x1`. This was a breaking change, as we did not add support for decoding values stored with plain address locations. Instead, we planned to migrate all existing data of the existing networks to the new format (see #84). This would have worked, but would have been a breaking change for users: Many developers have started using type identifiers (e.g. directly comparison to expected values), for example to detect certain events (events are also composite values).

This PR reverts the breaking change, i.e. the introduction of address contract locations, by merging them with the existing address location, and adding backwards-compatibility to the composite value decoding: When a composite value is decoded and it is stored in the old format, i.e. it only has a plain address location, then infer the contract name from the type identifier, to reconstruct an address location with name, just like it is generated now by new code.

Once this PR is merged to master, I'll open another PR against v0.10.1, then release v0.10.2, and update all downstream dependencies.