### PR TITLE
Refactor address locations, make composite decoding backwards-compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v1
+      - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.29

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build:
 
 .PHONY: install-tools
 install-tools:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.26.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.29.0
 
 .PHONY: lint
 lint:

--- a/languageserver/integration/resolving.go
+++ b/languageserver/integration/resolving.go
@@ -45,7 +45,7 @@ func resolveFileImport(mainPath string, location ast.StringLocation) (string, er
 }
 
 func (i *FlowIntegration) resolveAccountImport(location ast.AddressLocation) (string, error) {
-	accountAddr := location.ToAddress()
+	accountAddr := location.Address
 
 	acct, err := i.flowClient.GetAccount(context.Background(), flow.BytesToAddress(accountAddr[:]))
 	if err != nil {

--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
 )
 
 func TestIdentifierLocation_MarshalJSON(t *testing.T) {
@@ -70,7 +72,10 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 
 	t.Parallel()
 
-	loc := AddressLocation([]byte{1})
+	loc := AddressLocation{
+		Address: common.BytesToAddress([]byte{1}),
+		Name:    "A",
+	}
 
 	actual, err := json.Marshal(loc)
 	require.NoError(t, err)
@@ -79,7 +84,8 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 		`
         {
             "Type": "AddressLocation",
-            "Address": "0x1"
+            "Address": "0x1",
+            "Name": "A"
         }
         `,
 		string(actual),

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -58,7 +58,7 @@ func PrettyPrintError(writer io.Writer, err error, filename string, codes map[st
 				case ast.StringLocation:
 					filename = string(importLocation)
 				case ast.AddressLocation:
-					filename = importLocation.ToAddress().ShortHexWithPrefix()
+					filename = importLocation.Address.ShortHexWithPrefix()
 				case ast.IdentifierLocation:
 					filename = string(importLocation)
 				}

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -499,13 +499,13 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		},
 		resolveLocation: func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 
-			// Resolve each identifier as an address contract location
+			// Resolve each identifier as an address location
 
 			for _, identifier := range identifiers {
 				result = append(result, sema.ResolvedLocation{
-					Location: ast.AddressContractLocation{
-						AddressLocation: location.(ast.AddressLocation),
-						Name:            identifier.Identifier,
+					Location: ast.AddressLocation{
+						Address: location.(ast.AddressLocation).Address,
+						Name:    identifier.Identifier,
 					},
 					Identifiers: []ast.Identifier{
 						identifier,

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -26,7 +26,6 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 // Error is the containing type for all errors produced by the runtime.
@@ -223,15 +222,14 @@ func (e *TransactionParameterTypeNotStorableError) Error() string {
 // when a parsing or a checking error occurred
 //
 type ParsingCheckingError struct {
-	Err            error
-	RuntimeStorage *InterpreterRuntimeStorage
-	Functions      stdlib.StandardLibraryFunctions
-	Code           []byte
-	Location       Location
-	Options        []sema.Option
-	UseCache       bool
-	Program        *ast.Program
-	Checker        *sema.Checker
+	Err          error
+	StorageCache Cache
+	Code         []byte
+	Location     Location
+	Options      []sema.Option
+	UseCache     bool
+	Program      *ast.Program
+	Checker      *sema.Checker
 }
 
 func (e *ParsingCheckingError) ChildErrors() []error {

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -218,10 +218,10 @@ func (e *TransactionParameterTypeNotStorableError) Error() string {
 	)
 }
 
-// ExtendedParsingCheckingError is a special error which aids in debugging checking problems
-// by providing extra information about the state of the environment
-// Separate package to prevent cyclic imports with checker tests
-type ExtendedParsingCheckingError struct {
+// ParsingCheckingError provides extra information about the state of the environment
+// when a parsing or a checking error occurred
+//
+type ParsingCheckingError struct {
 	Err            error
 	RuntimeStorage *InterpreterRuntimeStorage
 	Functions      stdlib.StandardLibraryFunctions
@@ -232,14 +232,14 @@ type ExtendedParsingCheckingError struct {
 	Checker        *sema.Checker
 }
 
-func (e *ExtendedParsingCheckingError) ChildErrors() []error {
+func (e *ParsingCheckingError) ChildErrors() []error {
 	return []error{e.Err}
 }
 
-func (e *ExtendedParsingCheckingError) Error() string {
+func (e *ParsingCheckingError) Error() string {
 	return e.Err.Error()
 }
 
-func (e ExtendedParsingCheckingError) Unwrap() error {
+func (e ParsingCheckingError) Unwrap() error {
 	return e.Err
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 // Error is the containing type for all errors produced by the runtime.
@@ -200,12 +201,12 @@ func (e *ScriptParameterTypeNotStorableError) Error() string {
 	)
 }
 
-// TransactionParamterTypeNotStorableError is an error that is reported for
+// TransactionParameterTypeNotStorableError is an error that is reported for
 // transaction parameter types that are not storable.
 //
 // For example, the type `Int` is a storable type,
 // whereas a function type is not.
-
+//
 type TransactionParameterTypeNotStorableError struct {
 	Type sema.Type
 }
@@ -215,4 +216,30 @@ func (e *TransactionParameterTypeNotStorableError) Error() string {
 		"parameter type is non-storable type: `%s`",
 		e.Type.QualifiedString(),
 	)
+}
+
+// ExtendedParsingCheckingError is a special error which aids in debugging checking problems
+// by providing extra information about the state of the environment
+// Separate package to prevent cyclic imports with checker tests
+type ExtendedParsingCheckingError struct {
+	Err            error
+	RuntimeStorage *InterpreterRuntimeStorage
+	Functions      stdlib.StandardLibraryFunctions
+	Code           []byte
+	Location       Location
+	Options        []sema.Option
+	UseCache       bool
+	Checker        *sema.Checker
+}
+
+func (e *ExtendedParsingCheckingError) ChildErrors() []error {
+	return []error{e.Err}
+}
+
+func (e *ExtendedParsingCheckingError) Error() string {
+	return e.Err.Error()
+}
+
+func (e ExtendedParsingCheckingError) Unwrap() error {
+	return e.Err
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -229,6 +230,7 @@ type ParsingCheckingError struct {
 	Location       Location
 	Options        []sema.Option
 	UseCache       bool
+	Program        *ast.Program
 	Checker        *sema.Checker
 }
 

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -143,7 +143,7 @@ const (
 	cborTagAddressLocation
 	cborTagStringLocation
 	cborTagIdentifierLocation
-	cborTagAddressContractLocation
+	_
 	_
 	_
 	_
@@ -844,17 +844,12 @@ func (e *Encoder) prepareCapabilityValue(v CapabilityValue) (interface{}, error)
 
 // NOTE: NEVER change, only add/increment; ensure uint64
 const (
-	encodedAddressContractLocationAddressFieldKey uint64 = 0
-	encodedAddressContractLocationNameFieldKey    uint64 = 1
+	encodedAddressLocationAddressFieldKey uint64 = 0
+	encodedAddressLocationNameFieldKey    uint64 = 1
 )
 
 func (e *Encoder) prepareLocation(l ast.Location) (interface{}, error) {
 	switch l := l.(type) {
-	case ast.AddressLocation:
-		return cbor.Tag{
-			Number:  cborTagAddressLocation,
-			Content: l.ToAddress().Bytes(),
-		}, nil
 
 	case ast.StringLocation:
 		return cbor.Tag{
@@ -868,13 +863,21 @@ func (e *Encoder) prepareLocation(l ast.Location) (interface{}, error) {
 			Content: string(l),
 		}, nil
 
-	case ast.AddressContractLocation:
+	case ast.AddressLocation:
+		var content interface{}
+
+		if l.Name == "" {
+			content = l.Address.Bytes()
+		} else {
+			content = cborMap{
+				encodedAddressLocationAddressFieldKey: l.Address.Bytes(),
+				encodedAddressLocationNameFieldKey:    l.Name,
+			}
+		}
+
 		return cbor.Tag{
-			Number: cborTagAddressContractLocation,
-			Content: cborMap{
-				encodedAddressContractLocationAddressFieldKey: l.AddressLocation.ToAddress().Bytes(),
-				encodedAddressContractLocationNameFieldKey:    l.Name,
-			},
+			Number:  cborTagAddressLocation,
+			Content: content,
 		}, nil
 
 	default:

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3286,7 +3286,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					TargetPath: publicPathValue,
 					Type:       ConvertSemaToPrimitiveStaticType(&sema.BoolType{}),
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagPrimitiveStaticType,
 					0x6,
@@ -3304,7 +3305,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						Type: PrimitiveStaticTypeBool,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagOptionalStaticType,
 					// tag
@@ -3325,7 +3327,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						Location: utils.TestLocation,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagCompositeStaticType,
 					// map, 2 pairs of items follow
@@ -3351,6 +3354,47 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 		)
 	})
 
+	t.Run("composite, struct, address location without name", func(t *testing.T) {
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				decodeOnly: true,
+				decodedValue: LinkValue{
+					TargetPath: publicPathValue,
+					Type: CompositeStaticType{
+						TypeID: "A.0x1.SimpleStruct",
+						Location: ast.AddressLocation{
+							Address: common.BytesToAddress([]byte{0x1}),
+							Name:    "SimpleStruct",
+						},
+					},
+				},
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
+					// tag
+					0xd8, cborTagCompositeStaticType,
+					// map, 2 pairs of items follow
+					0xa2,
+					// key 0
+					0x0,
+					// tag
+					0xd8, cborTagAddressLocation,
+					// byte sequence, length 1
+					0x41,
+					// positive integer 1
+					0x1,
+					// key 1
+					0x1,
+					// UTF-8 string, length 18
+					0x72,
+					// A.0x1.SimpleStruct
+					0x41,
+					0x2E, 0x30, 0x78, 0x31,
+					0x2E, 0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+				),
+			},
+		)
+	})
+
 	t.Run("interface, struct", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -3361,7 +3405,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						Location: utils.TestLocation,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagInterfaceStaticType,
 					// map, 2 pairs of items follow
@@ -3387,6 +3432,47 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 		)
 	})
 
+	t.Run("interface, struct, address location without name", func(t *testing.T) {
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				decodeOnly: true,
+				decodedValue: LinkValue{
+					TargetPath: publicPathValue,
+					Type: InterfaceStaticType{
+						TypeID: "A.0x1.SimpleInterface",
+						Location: ast.AddressLocation{
+							Address: common.BytesToAddress([]byte{0x1}),
+							Name:    "SimpleInterface",
+						},
+					},
+				},
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
+					// tag
+					0xd8, cborTagInterfaceStaticType,
+					// map, 2 pairs of items follow
+					0xa2,
+					// key 0
+					0x0,
+					// tag
+					0xd8, cborTagAddressLocation,
+					// byte sequence, length 1
+					0x41,
+					// positive integer 1
+					0x1,
+					// key 1
+					0x1,
+					// UTF-8 string, length 21
+					0x75,
+					// A.0x1.SimpleInterface
+					0x41,
+					0x2E, 0x30, 0x78, 0x31,
+					0x2E, 0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
+				),
+			},
+		)
+	})
+
 	t.Run("variable-sized, bool", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -3396,7 +3482,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						Type: PrimitiveStaticTypeBool,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagVariableSizedStaticType,
 					// tag
@@ -3417,7 +3504,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						Size: 42,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagConstantSizedStaticType,
 					// map, 2 pairs of items follow
@@ -3446,7 +3534,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						Type:       PrimitiveStaticTypeBool,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagReferenceStaticType,
 					// map, 2 pairs of items follow
@@ -3475,7 +3564,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						Type:       PrimitiveStaticTypeBool,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagReferenceStaticType,
 					// map, 2 pairs of items follow
@@ -3504,7 +3594,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						ValueType: PrimitiveStaticTypeString,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagDictionaryStaticType,
 					// map, 2 pairs of items follow
@@ -3546,7 +3637,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						},
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagRestrictedStaticType,
 					// map, 2 pairs of items follow
@@ -3623,7 +3715,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					TargetPath: publicPathValue,
 					Type:       CapabilityStaticType{},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagCapabilityStaticType,
 					// null
@@ -3642,7 +3735,8 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 						BorrowType: PrimitiveStaticTypeBool,
 					},
 				},
-				encoded: append(expectedLinkEncodingPrefix[:],
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagCapabilityStaticType,
 					// tag

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -461,9 +461,14 @@ func TestEncodeDecodeComposite(t *testing.T) {
 	})
 
 	t.Run("empty, address location", func(t *testing.T) {
+
 		expected := NewCompositeValue(
-			ast.AddressLocation{0x1},
-			"A.0x1.TestStruct",
+			ast.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x1}),
+				// NOTE: not stored, inferred from type ID
+				Name: "TestContract",
+			},
+			"A.0x1.TestContract.TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -472,7 +477,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: expected,
+				decodedValue: expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -488,10 +493,12 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x1,
 					// key 1
 					0x1,
-					// UTF-8 string, length 16
-					0x70,
-					0x41, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54, 0x65,
-					0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+					// UTF-8 string, length 29
+					0x78, 0x1D,
+					0x41,
+					0x2e, 0x30, 0x78, 0x31,
+					0x2e, 0x54, 0x65, 0x73, 0x74, 0x43, 0x6F, 0x6E, 0x74, 0x72, 0x61, 0x63, 0x74,
+					0x2e, 0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
 					// positive integer 1
@@ -501,6 +508,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// map, 0 pairs of items follow
 					0xa0,
 				},
+				decodeOnly: true,
 			},
 		)
 	})
@@ -545,11 +553,11 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 	t.Run("empty, address location", func(t *testing.T) {
 		expected := NewCompositeValue(
-			ast.AddressContractLocation{
-				AddressLocation: ast.AddressLocation{0x1},
-				Name:            "TestStruct",
+			ast.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x1}),
+				Name:    "TestStruct",
 			},
-			"AC.0x1.TestStruct",
+			"A.0x1.TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -567,7 +575,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 0
 					0x0,
 					// tag
-					0xd8, cborTagAddressContractLocation,
+					0xd8, cborTagAddressLocation,
 					// map, 4 pairs of items follow
 					0xa2,
 					// key 0
@@ -585,8 +593,8 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 1
 					0x1,
 					// UTF-8 string, length 17
-					0x71,
-					0x41, 0x43, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54,
+					0x70,
+					0x41, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54,
 					0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
@@ -601,7 +609,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("empty, address contract location, address too long", func(t *testing.T) {
+	t.Run("empty, address location, address too long", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
@@ -612,7 +620,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 0
 					0x0,
 					// tag
-					0xd8, cborTagAddressContractLocation,
+					0xd8, cborTagAddressLocation,
 					// map, 4 pairs of items follow
 					0xa2,
 					// key 0
@@ -730,7 +738,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 					// byte string, length 1
 					0x41,
 					// `-42` in decimal is is `0x2a` in hex.
-					// CBOR requires negative values to be encoded as `-1-n`, which is `-n - 1`, 
+					// CBOR requires negative values to be encoded as `-1-n`, which is `-n - 1`,
 					// which is `0x2a - 0x01`, which equals to `0x29`.
 					0x29,
 				},

--- a/runtime/locations.go
+++ b/runtime/locations.go
@@ -20,26 +20,26 @@ package runtime
 
 import (
 	"encoding/hex"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
 )
 
 type (
-	Location                = ast.Location
-	LocationID              = ast.LocationID
-	StringLocation          = ast.StringLocation
-	AddressLocation         = ast.AddressLocation
-	AddressContractLocation = ast.AddressContractLocation
-	Identifier              = ast.Identifier
+	Location        = ast.Location
+	LocationID      = ast.LocationID
+	TypeID          = ast.TypeID
+	StringLocation  = ast.StringLocation
+	AddressLocation = ast.AddressLocation
+	Identifier      = ast.Identifier
 )
 
 const (
-	IdentifierLocationPrefix      = ast.IdentifierLocationPrefix
-	StringLocationPrefix          = ast.StringLocationPrefix
-	AddressLocationPrefix         = ast.AddressLocationPrefix
-	AddressContractLocationPrefix = ast.AddressContractLocationPrefix
-	TransactionLocationPrefix     = "t"
-	ScriptLocationPrefix          = "s"
+	IdentifierLocationPrefix  = ast.IdentifierLocationPrefix
+	StringLocationPrefix      = ast.StringLocationPrefix
+	AddressLocationPrefix     = ast.AddressLocationPrefix
+	TransactionLocationPrefix = "t"
+	ScriptLocationPrefix      = "s"
 )
 
 // TransactionLocation
@@ -47,7 +47,28 @@ const (
 type TransactionLocation []byte
 
 func (l TransactionLocation) ID() ast.LocationID {
-	return ast.NewLocationID(TransactionLocationPrefix, l.String())
+	return ast.NewLocationID(
+		TransactionLocationPrefix,
+		l.String(),
+	)
+}
+
+func (l TransactionLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		TransactionLocationPrefix,
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l TransactionLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 3)
+
+	if len(pieces) < 3 {
+		return ""
+	}
+
+	return pieces[2]
 }
 
 func (l TransactionLocation) String() string {
@@ -59,7 +80,28 @@ func (l TransactionLocation) String() string {
 type ScriptLocation []byte
 
 func (l ScriptLocation) ID() ast.LocationID {
-	return ast.NewLocationID(ScriptLocationPrefix, l.String())
+	return ast.NewLocationID(
+		ScriptLocationPrefix,
+		l.String(),
+	)
+}
+
+func (l ScriptLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		ScriptLocationPrefix,
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l ScriptLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 3)
+
+	if len(pieces) < 3 {
+		return ""
+	}
+
+	return pieces[2]
 }
 
 func (l ScriptLocation) String() string {
@@ -74,6 +116,23 @@ func (l FileLocation) ID() ast.LocationID {
 	return LocationID(l.String())
 }
 
+func (l FileLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l FileLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
+}
+
 func (l FileLocation) String() string {
 	return string(l)
 }
@@ -84,6 +143,23 @@ type REPLLocation struct{}
 
 func (l REPLLocation) ID() LocationID {
 	return LocationID(l.String())
+}
+
+func (l REPLLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l REPLLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
 }
 
 func (l REPLLocation) String() string {

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -578,7 +578,9 @@ func parseHexadecimalLocation(literal string) ast.AddressLocation {
 		panic(err)
 	}
 
-	return address
+	return ast.AddressLocation{
+		Address: common.BytesToAddress(address),
+	}
 }
 
 // parseEventDeclaration parses an event declaration.

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -1225,7 +1225,9 @@ func TestParseImportDeclaration(t *testing.T) {
 			[]ast.Declaration{
 				&ast.ImportDeclaration{
 					Identifiers: nil,
-					Location:    ast.AddressLocation{0x42},
+					Location: ast.AddressLocation{
+						Address: common.BytesToAddress([]byte{0x42}),
+					},
 					LocationPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -1338,7 +1340,9 @@ func TestParseImportDeclaration(t *testing.T) {
 							Pos:        ast.Position{Line: 1, Column: 20, Offset: 20},
 						},
 					},
-					Location:    ast.AddressLocation{0x42},
+					Location: ast.AddressLocation{
+						Address: common.BytesToAddress([]byte{0x42}),
+					},
 					LocationPos: ast.Position{Line: 1, Column: 29, Offset: 29},
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -2198,4 +2202,5 @@ func TestParseTransactionDeclaration(t *testing.T) {
 			result,
 		)
 	})
+
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -287,12 +287,12 @@ func (r *interpreterRuntime) ExecuteTransaction(
 
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
-		ee, is := err.(*ExtendedParsingCheckingError)
-		if is {
-			ee.RuntimeStorage = runtimeStorage
-			ee.Functions = functions
-			return newError(ee)
+		if err, ok := err.(*ExtendedParsingCheckingError); ok {
+			err.RuntimeStorage = runtimeStorage
+			err.Functions = functions
+			return newError(err)
 		}
+
 		return newError(err)
 	}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -511,14 +511,13 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 
 	wrapError := func(err error) error {
 		return &ParsingCheckingError{
-			Err:       err,
-			Code:      code,
-			Location:  location,
-			Functions: functions,
-			Options:   options,
-			UseCache:  useCache,
-			Checker:   checker,
-			Program:   program,
+			Err:      err,
+			Code:     code,
+			Location: location,
+			Options:  options,
+			UseCache: useCache,
+			Checker:  checker,
+			Program:  program,
 		}
 	}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -82,7 +82,7 @@ func validTopLevelDeclarations(location ast.Location) []common.DeclarationKind {
 	switch location.(type) {
 	case TransactionLocation:
 		return validTopLevelDeclarationsInTransaction
-	case AddressLocation, AddressContractLocation:
+	case AddressLocation:
 		return validTopLevelDeclarationsInAccountCode
 	}
 
@@ -106,8 +106,6 @@ func reportMetric(
 
 	report(metrics, elapsed)
 }
-
-const contractKey = "contract"
 
 // interpreterRuntime is a interpreter-based version of the Flow runtime.
 type interpreterRuntime struct{}
@@ -708,9 +706,7 @@ func (r *interpreterRuntime) injectedCompositeFieldsHandler(
 
 				switch location := location.(type) {
 				case AddressLocation:
-					address = location.ToAddress()
-				case AddressContractLocation:
-					address = location.AddressLocation.ToAddress()
+					address = location.Address
 				default:
 					panic(runtimeErrors.NewUnreachableError())
 				}
@@ -824,11 +820,11 @@ func (r *interpreterRuntime) importResolver(runtimeInterface Interface) ImportRe
 		}
 
 		var code []byte
-		if addressContractLocation, ok := location.(AddressContractLocation); ok {
+		if addressLocation, ok := location.(AddressLocation); ok {
 			wrapPanic(func() {
 				code, err = runtimeInterface.GetAccountContractCode(
-					addressContractLocation.AddressLocation.ToAddress(),
-					addressContractLocation.Name,
+					addressLocation.Address,
+					addressLocation.Name,
 				)
 			})
 		} else {
@@ -1053,7 +1049,6 @@ func (r *interpreterRuntime) writeContract(
 	name string,
 	contractValue interpreter.OptionalValue,
 ) {
-
 	runtimeStorage.writeValue(
 		addressValue.ToAddress(),
 		formatContractKey(name),
@@ -1062,12 +1057,9 @@ func (r *interpreterRuntime) writeContract(
 }
 
 func formatContractKey(name string) string {
-	if name == "" {
-		return contractKey
-	}
+	const contractKey = "contract"
 
 	// \x1F = Information Separator One
-
 	return fmt.Sprintf("%s\x1F%s", contractKey, name)
 }
 
@@ -1099,18 +1091,10 @@ func (r *interpreterRuntime) loadContract(
 		var storedValue interpreter.OptionalValue = interpreter.NilValue{}
 
 		switch location := compositeType.Location.(type) {
-		case AddressLocation:
-			address := location.ToAddress()
-			storedValue = runtimeStorage.readValue(
-				address,
-				contractKey,
-				false,
-			)
 
-		case AddressContractLocation:
-			address := location.AddressLocation.ToAddress()
+		case AddressLocation:
 			storedValue = runtimeStorage.readValue(
-				address,
+				location.Address,
 				formatContractKey(location.Name),
 				false,
 			)
@@ -1400,9 +1384,9 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 
 			// Check the code
 
-			location := AddressContractLocation{
-				AddressLocation: addressValue[:],
-				Name:            nameArgument,
+			location := AddressLocation{
+				Address: address,
+				Name:    nameArgument,
 			}
 
 			// NOTE: do NOT use the cache!
@@ -1529,7 +1513,7 @@ func (r *interpreterRuntime) updateAccountContractCode(
 	name string,
 	code []byte,
 	addressValue interpreter.AddressValue,
-	location AddressContractLocation,
+	location AddressLocation,
 	checker *sema.Checker,
 	contractType *sema.CompositeType,
 	constructorArguments []interpreter.Value,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -291,7 +291,6 @@ func (r *interpreterRuntime) ExecuteTransaction(
 		if is {
 			ee.RuntimeStorage = runtimeStorage
 			ee.Functions = functions
-			//return newError(ee.Err)
 			return newError(ee)
 		}
 		return newError(err)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -287,7 +287,7 @@ func (r *interpreterRuntime) ExecuteTransaction(
 
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
-		if err, ok := err.(*ExtendedParsingCheckingError); ok {
+		if err, ok := err.(*ParsingCheckingError); ok {
 			err.RuntimeStorage = runtimeStorage
 			err.Functions = functions
 			return newError(err)
@@ -511,7 +511,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 			program, err = runtimeInterface.GetCachedProgram(location)
 		})
 		if err != nil {
-			return nil, &ExtendedParsingCheckingError{
+			return nil, &ParsingCheckingError{
 				Err:       err,
 				Code:      code,
 				Location:  location,
@@ -525,7 +525,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 	if program == nil {
 		program, err = r.parse(location, code, runtimeInterface)
 		if err != nil {
-			return nil, &ExtendedParsingCheckingError{
+			return nil, &ParsingCheckingError{
 				Err:       err,
 				Code:      code,
 				Location:  location,
@@ -592,7 +592,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 		)...,
 	)
 	if err != nil {
-		return nil, &ExtendedParsingCheckingError{
+		return nil, &ParsingCheckingError{
 			Err:       err,
 			Code:      code,
 			Location:  location,
@@ -605,7 +605,7 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 
 	err = checker.Check()
 	if err != nil {
-		return nil, &ExtendedParsingCheckingError{
+		return nil, &ParsingCheckingError{
 			Err:       err,
 			Code:      code,
 			Location:  location,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -287,6 +287,13 @@ func (r *interpreterRuntime) ExecuteTransaction(
 
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
+		ee, is := err.(*ExtendedParsingCheckingError)
+		if is {
+			ee.RuntimeStorage = runtimeStorage
+			ee.Functions = functions
+			//return newError(ee.Err)
+			return newError(ee)
+		}
 		return newError(err)
 	}
 
@@ -505,14 +512,28 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 			program, err = runtimeInterface.GetCachedProgram(location)
 		})
 		if err != nil {
-			return nil, err
+			return nil, &ExtendedParsingCheckingError{
+				Err:       err,
+				Code:      code,
+				Location:  location,
+				Functions: functions,
+				Options:   options,
+				UseCache:  useCache,
+			}
 		}
 	}
 
 	if program == nil {
 		program, err = r.parse(location, code, runtimeInterface)
 		if err != nil {
-			return nil, err
+			return nil, &ExtendedParsingCheckingError{
+				Err:       err,
+				Code:      code,
+				Location:  location,
+				Functions: functions,
+				Options:   options,
+				UseCache:  useCache,
+			}
 		}
 	}
 
@@ -572,12 +593,28 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 		)...,
 	)
 	if err != nil {
-		return nil, err
+		return nil, &ExtendedParsingCheckingError{
+			Err:       err,
+			Code:      code,
+			Location:  location,
+			Functions: functions,
+			Options:   options,
+			UseCache:  useCache,
+			Checker:   checker,
+		}
 	}
 
 	err = checker.Check()
 	if err != nil {
-		return nil, err
+		return nil, &ExtendedParsingCheckingError{
+			Err:       err,
+			Code:      code,
+			Location:  location,
+			Functions: functions,
+			Options:   options,
+			UseCache:  useCache,
+			Checker:   checker,
+		}
 	}
 
 	// After the program has passed semantic analysis, cache the program AST.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -288,8 +288,7 @@ func (r *interpreterRuntime) ExecuteTransaction(
 	checker, err := r.parseAndCheckProgram(script, runtimeInterface, location, functions, nil, false)
 	if err != nil {
 		if err, ok := err.(*ParsingCheckingError); ok {
-			err.RuntimeStorage = runtimeStorage
-			err.Functions = functions
+			err.StorageCache = runtimeStorage.cache
 			return newError(err)
 		}
 
@@ -299,7 +298,9 @@ func (r *interpreterRuntime) ExecuteTransaction(
 	transactions := checker.TransactionTypes
 	transactionCount := len(transactions)
 	if transactionCount != 1 {
-		return newError(InvalidTransactionCountError{Count: transactionCount})
+		return newError(InvalidTransactionCountError{
+			Count: transactionCount,
+		})
 	}
 
 	transactionType := transactions[0]

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -505,41 +505,42 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 ) (*sema.Checker, error) {
 
 	var program *ast.Program
+	var checker *sema.Checker
 	var err error
+
+	wrapError := func(err error) error {
+		return &ParsingCheckingError{
+			Err:       err,
+			Code:      code,
+			Location:  location,
+			Functions: functions,
+			Options:   options,
+			UseCache:  useCache,
+			Checker:   checker,
+			Program:   program,
+		}
+	}
+
 	if useCache {
 		wrapPanic(func() {
 			program, err = runtimeInterface.GetCachedProgram(location)
 		})
 		if err != nil {
-			return nil, &ParsingCheckingError{
-				Err:       err,
-				Code:      code,
-				Location:  location,
-				Functions: functions,
-				Options:   options,
-				UseCache:  useCache,
-			}
+			return nil, wrapError(err)
 		}
 	}
 
 	if program == nil {
 		program, err = r.parse(location, code, runtimeInterface)
 		if err != nil {
-			return nil, &ParsingCheckingError{
-				Err:       err,
-				Code:      code,
-				Location:  location,
-				Functions: functions,
-				Options:   options,
-				UseCache:  useCache,
-			}
+			return nil, wrapError(err)
 		}
 	}
 
 	importResolver := r.importResolver(runtimeInterface)
 	valueDeclarations := functions.ToValueDeclarations()
 
-	checker, err := sema.NewChecker(
+	checker, err = sema.NewChecker(
 		program,
 		location,
 		append(
@@ -592,28 +593,12 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 		)...,
 	)
 	if err != nil {
-		return nil, &ParsingCheckingError{
-			Err:       err,
-			Code:      code,
-			Location:  location,
-			Functions: functions,
-			Options:   options,
-			UseCache:  useCache,
-			Checker:   checker,
-		}
+		return nil, wrapError(err)
 	}
 
 	err = checker.Check()
 	if err != nil {
-		return nil, &ParsingCheckingError{
-			Err:       err,
-			Code:      code,
-			Location:  location,
-			Functions: functions,
-			Options:   options,
-			UseCache:  useCache,
-			Checker:   checker,
-		}
+		return nil, wrapError(err)
 	}
 
 	// After the program has passed semantic analysis, cache the program AST.

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -27,27 +27,26 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 )
 
-type storageKey struct {
-	address common.Address
-	key     string
+type StorageKey struct {
+	Address common.Address
+	Key     string
 }
 
-type cacheEntry struct {
+type Cache map[StorageKey]CacheEntry
+
+type CacheEntry struct {
 	// true indicates that the value definitely must be written, independent of the value.
 	// false indicates that the value may has to be written if the value is modified.
-	mustWrite bool
-	value     interpreter.Value
+	MustWrite bool
+	Value     interpreter.Value
 }
 
 type interpreterRuntimeStorage struct {
 	runtimeInterface        Interface
 	highLevelStorageEnabled bool
 	highLevelStorage        HighLevelStorage
-	cache                   map[storageKey]cacheEntry
+	cache                   Cache
 }
-
-// temporary export the type for usage in ParsingCheckingError
-type InterpreterRuntimeStorage = interpreterRuntimeStorage
 
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {
 	highLevelStorageEnabled := false
@@ -58,7 +57,7 @@ func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntim
 
 	return &interpreterRuntimeStorage{
 		runtimeInterface:        runtimeInterface,
-		cache:                   map[storageKey]cacheEntry{},
+		cache:                   Cache{},
 		highLevelStorage:        highLevelStorage,
 		highLevelStorageEnabled: highLevelStorageEnabled,
 	}
@@ -77,15 +76,15 @@ func (s *interpreterRuntimeStorage) valueExists(
 	key string,
 ) bool {
 
-	fullKey := storageKey{
-		address: address,
-		key:     key,
+	fullKey := StorageKey{
+		Address: address,
+		Key:     key,
 	}
 
 	// Check cache
 
 	if entry, ok := s.cache[fullKey]; ok {
-		return entry.value != nil
+		return entry.Value != nil
 	}
 
 	// Cache miss: Ask interface
@@ -100,9 +99,9 @@ func (s *interpreterRuntimeStorage) valueExists(
 	}
 
 	if !exists {
-		s.cache[fullKey] = cacheEntry{
-			mustWrite: false,
-			value:     nil,
+		s.cache[fullKey] = CacheEntry{
+			MustWrite: false,
+			Value:     nil,
 		}
 	}
 
@@ -123,19 +122,19 @@ func (s *interpreterRuntimeStorage) readValue(
 	deferred bool,
 ) interpreter.OptionalValue {
 
-	fullKey := storageKey{
-		address: address,
-		key:     key,
+	fullKey := StorageKey{
+		Address: address,
+		Key:     key,
 	}
 
 	// Check cache. Return cached value, if any
 
 	if entry, ok := s.cache[fullKey]; ok {
-		if entry.value == nil {
+		if entry.Value == nil {
 			return interpreter.NilValue{}
 		}
 
-		return interpreter.NewSomeValueOwningNonCopying(entry.value)
+		return interpreter.NewSomeValueOwningNonCopying(entry.Value)
 	}
 
 	// Cache miss: Load and deserialize the stored value (if any)
@@ -154,9 +153,9 @@ func (s *interpreterRuntimeStorage) readValue(
 	storedData, version = interpreter.StripMagic(storedData)
 
 	if len(storedData) == 0 {
-		s.cache[fullKey] = cacheEntry{
-			mustWrite: false,
-			value:     nil,
+		s.cache[fullKey] = CacheEntry{
+			MustWrite: false,
+			Value:     nil,
 		}
 		return interpreter.NilValue{}
 	}
@@ -177,9 +176,9 @@ func (s *interpreterRuntimeStorage) readValue(
 	}
 
 	if !deferred {
-		s.cache[fullKey] = cacheEntry{
-			mustWrite: false,
-			value:     storedValue,
+		s.cache[fullKey] = CacheEntry{
+			MustWrite: false,
+			Value:     storedValue,
 		}
 	}
 
@@ -198,23 +197,23 @@ func (s *interpreterRuntimeStorage) writeValue(
 	key string,
 	value interpreter.OptionalValue,
 ) {
-	fullKey := storageKey{
-		address: address,
-		key:     key,
+	fullKey := StorageKey{
+		Address: address,
+		Key:     key,
 	}
 
 	// Only write the value to the cache.
 	// The Cache is finally written back through the runtime interface in `writeCached`
 
 	entry := s.cache[fullKey]
-	entry.mustWrite = true
+	entry.MustWrite = true
 
 	switch typedValue := value.(type) {
 	case *interpreter.SomeValue:
-		entry.value = typedValue.Value
+		entry.Value = typedValue.Value
 
 	case interpreter.NilValue:
-		entry.value = nil
+		entry.Value = nil
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -228,7 +227,7 @@ func (s *interpreterRuntimeStorage) writeValue(
 func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) {
 
 	type writeItem struct {
-		storageKey storageKey
+		storageKey StorageKey
 		value      interpreter.Value
 	}
 
@@ -236,25 +235,25 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 
 	for fullKey, entry := range s.cache {
 
-		if !entry.mustWrite && entry.value != nil && !entry.value.IsModified() {
+		if !entry.MustWrite && entry.Value != nil && !entry.Value.IsModified() {
 			continue
 		}
 
 		items = append(items, writeItem{
 			storageKey: fullKey,
-			value:      entry.value,
+			value:      entry.Value,
 		})
 
 		if s.highLevelStorageEnabled {
 			var err error
 
 			var value cadence.Value
-			if entry.value != nil {
-				value = exportValueWithInterpreter(entry.value, inter)
+			if entry.Value != nil {
+				value = exportValueWithInterpreter(entry.Value, inter)
 			}
 
 			wrapPanic(func() {
-				err = s.highLevelStorage.SetCadenceValue(fullKey.address, fullKey.key, value)
+				err = s.highLevelStorage.SetCadenceValue(fullKey.Address, fullKey.Key, value)
 			})
 			if err != nil {
 				panic(err)
@@ -271,16 +270,16 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 		if item.value != nil {
 			var deferrals *interpreter.EncodingDeferrals
 			var err error
-			newData, deferrals, err = s.encodeValue(item.value, item.storageKey.key)
+			newData, deferrals, err = s.encodeValue(item.value, item.storageKey.Key)
 			if err != nil {
 				panic(err)
 			}
 
 			for deferredKey, deferredValue := range deferrals.Values {
 
-				deferredStorageKey := storageKey{
-					address: item.storageKey.address,
-					key:     deferredKey,
+				deferredStorageKey := StorageKey{
+					Address: item.storageKey.Address,
+					Key:     deferredKey,
 				}
 
 				if !deferredValue.IsModified() {
@@ -311,8 +310,8 @@ func (s *interpreterRuntimeStorage) writeCached(inter *interpreter.Interpreter) 
 		var err error
 		wrapPanic(func() {
 			err = s.runtimeInterface.SetValue(
-				item.storageKey.address[:],
-				[]byte(item.storageKey.key),
+				item.storageKey.Address[:],
+				[]byte(item.storageKey.Key),
 				newData,
 			)
 		})

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -48,9 +48,6 @@ type interpreterRuntimeStorage struct {
 	cache                   Cache
 }
 
-// temporary export the type for usage in ParsingCheckingError
-type InterpreterRuntimeStorage = interpreterRuntimeStorage
-
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {
 	highLevelStorageEnabled := false
 	highLevelStorage, ok := runtimeInterface.(HighLevelStorage)

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -46,7 +46,7 @@ type interpreterRuntimeStorage struct {
 	cache                   map[storageKey]cacheEntry
 }
 
-// temporary export the type for usage in ExtendedParsingCheckingError
+// temporary export the type for usage in ParsingCheckingError
 type InterpreterRuntimeStorage = interpreterRuntimeStorage
 
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -48,7 +48,7 @@ type interpreterRuntimeStorage struct {
 	cache                   Cache
 }
 
-// temporary export the type for usage in ExtendedParsingCheckingError
+// temporary export the type for usage in ParsingCheckingError
 type InterpreterRuntimeStorage = interpreterRuntimeStorage
 
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -48,6 +48,9 @@ type interpreterRuntimeStorage struct {
 	cache                   Cache
 }
 
+// temporary export the type for usage in ExtendedParsingCheckingError
+type InterpreterRuntimeStorage = interpreterRuntimeStorage
+
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {
 	highLevelStorageEnabled := false
 	highLevelStorage, ok := runtimeInterface.(HighLevelStorage)

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -46,6 +46,9 @@ type interpreterRuntimeStorage struct {
 	cache                   map[storageKey]cacheEntry
 }
 
+// temporary export the type for usage in ExtendedParsingCheckingError
+type InterpreterRuntimeStorage = interpreterRuntimeStorage
+
 func newInterpreterRuntimeStorage(runtimeInterface Interface) *interpreterRuntimeStorage {
 	highLevelStorageEnabled := false
 	highLevelStorage, ok := runtimeInterface.(HighLevelStorage)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -3342,7 +3341,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 		require.IsType(t, Error{}, err)
 		err = err.(Error).Unwrap()
 
-		errs := checker.ExpectCheckerErrors(t, err, 1)
+		errs := ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidTopLevelDeclarationError{}, errs[0])
 	})
@@ -5051,4 +5050,39 @@ func singleIdentifierLocationResolver(t *testing.T) func(identifiers []Identifie
 			},
 		}
 	}
+}
+
+// Copied to prevent import cycle while importing from tests/checker package
+// while using ExtendedParsingCheckingError
+// This now required `runtime` to get access `ExtendedParsingCheckingError`
+// which in turns requires `runtime` so any import of original function from
+// any other module will introduce cycle
+// If we decide to keep extended debug functionality beyond original
+// debug possible race condition, this would need to be refactored
+func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
+	if count <= 0 && err == nil {
+		return nil
+	}
+
+	require.Error(t, err)
+
+	// Temporary to help catch checking error
+	ee, is := err.(*ExtendedParsingCheckingError)
+	if is {
+		err = ee.Unwrap()
+	}
+
+	assert.IsType(t, &sema.CheckerError{}, err)
+
+	errs := err.(*sema.CheckerError).Errors
+
+	require.Len(t, errs, count)
+
+	// Get the error message, to check that it can be successfully generated
+
+	for _, checkerErr := range errs {
+		_ = checkerErr.Error()
+	}
+
+	return errs
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2860,12 +2860,20 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 			return []Address{signerAccount}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
-			key := string(AddressLocation(address[:]).ID())
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -2975,12 +2983,20 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 			return []Address{signerAccount}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) (err error) {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3108,12 +3124,20 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 			return []Address{{0x1}}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3478,12 +3502,20 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 			return []Address{address}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3624,13 +3656,21 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{address}
 		},
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3777,12 +3817,20 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 			return []Address{address}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4431,12 +4479,20 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4545,12 +4601,20 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4678,12 +4742,20 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4720,7 +4792,7 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
-			"AC.0100000000000000.HelloWorld",
+			"A.0100000000000000.HelloWorld",
 		},
 		cacheHits,
 	)
@@ -4823,9 +4895,9 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 			return []ResolvedLocation{
 				{
-					Location: AddressContractLocation{
-						AddressLocation: location.(AddressLocation),
-						Name:            "Test",
+					Location: AddressLocation{
+						Address: location.(AddressLocation).Address,
+						Name:    "Test",
 					},
 					Identifiers: []ast.Identifier{
 						{
@@ -4971,9 +5043,9 @@ func singleIdentifierLocationResolver(t *testing.T) func(identifiers []Identifie
 
 		return []ResolvedLocation{
 			{
-				Location: AddressContractLocation{
-					AddressLocation: location.(AddressLocation),
-					Name:            identifiers[0].Identifier,
+				Location: AddressLocation{
+					Address: location.(AddressLocation).Address,
+					Name:    identifiers[0].Identifier,
 				},
 				Identifiers: identifiers,
 			},

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -3341,7 +3342,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 		require.IsType(t, Error{}, err)
 		err = err.(Error).Unwrap()
 
-		errs := ExpectCheckerErrors(t, err, 1)
+		errs := checker.ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidTopLevelDeclarationError{}, errs[0])
 	})
@@ -5050,39 +5051,4 @@ func singleIdentifierLocationResolver(t *testing.T) func(identifiers []Identifie
 			},
 		}
 	}
-}
-
-// Copied to prevent import cycle while importing from tests/checker package
-// while using ExtendedParsingCheckingError
-// This now required `runtime` to get access `ExtendedParsingCheckingError`
-// which in turns requires `runtime` so any import of original function from
-// any other module will introduce cycle
-// If we decide to keep extended debug functionality beyond original
-// debug possible race condition, this would need to be refactored
-func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
-	if count <= 0 && err == nil {
-		return nil
-	}
-
-	require.Error(t, err)
-
-	// Temporary to help catch checking error
-	ee, is := err.(*ExtendedParsingCheckingError)
-	if is {
-		err = ee.Unwrap()
-	}
-
-	assert.IsType(t, &sema.CheckerError{}, err)
-
-	errs := err.(*sema.CheckerError).Errors
-
-	require.Len(t, errs, count)
-
-	// Get the error message, to check that it can be successfully generated
-
-	for _, checkerErr := range errs {
-		_ = checkerErr.Error()
-	}
-
-	return errs
 }

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -28,12 +28,12 @@ import (
 // 1. Resolution of the import statement.
 //
 //     The default case is that one location is resolved to one location (itself),
-//     though e.g. an address location may also be resolved into multiple "address contract" locations.
+//     though e.g. an address location may also be resolved into multiple address locations.
 //
 //     For example, an import declaration `import a, b from 0x1` specifies the import of the declarations with
 //     the identifiers `a` and `b` from the address location `0x1`.
 //     This import declaration might be resolved into just the location itself, i.e. the address location `0x1`,
-//     but could also be resolved into multiple locations, e.g. the address contract locations `0x1.a` and `0x1.b`.
+//     but could also be resolved into multiple locations, e.g. the address locations `0x1.a` and `0x1.b`.
 //
 // 2. Acquiring the programs for the resolved imports. For each resolved import a separate program can be returned.
 //

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -615,7 +615,7 @@ type InvalidVariableKindError struct {
 
 func (e *InvalidVariableKindError) Error() string {
 	if e.Kind == ast.VariableKindNotSpecified {
-		return fmt.Sprintf("missing variable kind")
+		return "missing variable kind"
 	}
 	return fmt.Sprintf("invalid variable kind: `%s`", e.Kind.Name())
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -63,7 +63,7 @@ func qualifiedIdentifier(identifier string, containerType Type) string {
 	return sb.String()
 }
 
-type TypeID string
+type TypeID = ast.TypeID
 
 type Type interface {
 	IsType()
@@ -4809,7 +4809,7 @@ func (t *CompositeType) QualifiedIdentifier() string {
 }
 
 func (t *CompositeType) ID() TypeID {
-	return TypeID(fmt.Sprintf("%s.%s", t.Location.ID(), t.QualifiedIdentifier()))
+	return t.Location.TypeID(t.QualifiedIdentifier())
 }
 
 func (t *CompositeType) Equal(other Type) bool {
@@ -5711,7 +5711,7 @@ func (t *InterfaceType) QualifiedIdentifier() string {
 }
 
 func (t *InterfaceType) ID() TypeID {
-	return TypeID(fmt.Sprintf("%s.%s", t.Location.ID(), t.QualifiedIdentifier()))
+	return t.Location.TypeID(t.QualifiedIdentifier())
 }
 
 func (t *InterfaceType) Equal(other Type) bool {

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -21,6 +21,7 @@ package stdlib
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -181,6 +182,23 @@ const flowLocationID = "flow"
 
 func (l FlowLocation) ID() ast.LocationID {
 	return ast.NewLocationID(flowLocationID)
+}
+
+func (l FlowLocation) TypeID(qualifiedIdentifier string) ast.TypeID {
+	return ast.NewTypeID(
+		flowLocationID,
+		qualifiedIdentifier,
+	)
+}
+
+func (l FlowLocation) QualifiedIdentifier(typeID ast.TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
 }
 
 // built-in event types

--- a/runtime/stdlib/internal/contracts.gen.go
+++ b/runtime/stdlib/internal/contracts.gen.go
@@ -228,8 +228,8 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"contracts": &bintree{nil, map[string]*bintree{
-		"crypto.cdc": &bintree{contractsCryptoCdc, map[string]*bintree{}},
+	"contracts": {nil, map[string]*bintree{
+		"crypto.cdc": {contractsCryptoCdc, map[string]*bintree{}},
 	}},
 }}
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -136,7 +136,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 	assert.NotNil(t, accountCode)
 
 	rType := &cadence.ResourceType{
-		TypeID:     "AC.000000000000cade.Test.Test.R",
+		TypeID:     "A.000000000000cade.Test.R",
 		Identifier: "R",
 		Fields: []cadence.Field{
 			{
@@ -156,7 +156,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 				address,
 				"contract\x1fTest",
 				cadence.NewContract([]cadence.Value{}).WithType(&cadence.ContractType{
-					TypeID:       "AC.000000000000cade.Test.Test",
+					TypeID:       "A.000000000000cade.Test",
 					Identifier:   "Test",
 					Fields:       []cadence.Field{},
 					Initializers: nil,

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -87,7 +87,7 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddressLocation := ast.AddressLocation{0x1}
+	importedAddress := common.BytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`
@@ -98,9 +98,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
           pub let x = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "x",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "x",
 			},
 		},
 	)
@@ -115,9 +115,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
           pub let y = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "y",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "y",
 			},
 		},
 	)
@@ -134,9 +134,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 					func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 						for _, identifier := range identifiers {
 							result = append(result, sema.ResolvedLocation{
-								Location: ast.AddressContractLocation{
-									AddressLocation: importedAddressLocation,
-									Name:            identifier.Identifier,
+								Location: ast.AddressLocation{
+									Address: importedAddress,
+									Name:    identifier.Identifier,
 								},
 								Identifiers: []ast.Identifier{
 									identifier,
@@ -148,9 +148,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 				),
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
-						addressContractLocation := location.(ast.AddressContractLocation)
+						addressLocation := location.(ast.AddressLocation)
 						var importedChecker *sema.Checker
-						switch addressContractLocation.Name {
+						switch addressLocation.Name {
 						case "x":
 							importedChecker = importedCheckerX
 						case "y":
@@ -210,7 +210,7 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddressLocation := ast.AddressLocation{0x1}
+	importedAddress := common.BytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`
@@ -221,9 +221,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
           pub let x = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "x",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "x",
 			},
 		},
 	)
@@ -238,9 +238,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
           pub let y = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "y",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "y",
 			},
 		},
 	)
@@ -256,9 +256,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 					func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 						for _, identifier := range identifiers {
 							result = append(result, sema.ResolvedLocation{
-								Location: ast.AddressContractLocation{
-									AddressLocation: importedAddressLocation,
-									Name:            identifier.Identifier,
+								Location: ast.AddressLocation{
+									Address: importedAddress,
+									Name:    identifier.Identifier,
 								},
 								Identifiers: []ast.Identifier{
 									identifier,
@@ -270,9 +270,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 				),
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
-						addressContractLocation := location.(ast.AddressContractLocation)
+						addressLocation := location.(ast.AddressLocation)
 						var importedChecker *sema.Checker
-						switch addressContractLocation.Name {
+						switch addressLocation.Name {
 						case "x":
 							importedChecker = importedCheckerX
 						case "y":

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser2"
@@ -83,6 +84,12 @@ func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
 	}
 
 	require.Error(t, err)
+
+	// Temporary to help catch checking error
+	ee, is := err.(*runtime.ExtendedParsingCheckingError)
+	if is {
+		err = ee.Unwrap()
+	}
 
 	assert.IsType(t, &sema.CheckerError{}, err)
 

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser2"
@@ -85,15 +84,10 @@ func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
 
 	require.Error(t, err)
 
-	// Temporary to help catch checking error
-	ee, is := err.(*runtime.ExtendedParsingCheckingError)
-	if is {
-		err = ee.Unwrap()
-	}
+	var checkerErr *sema.CheckerError
+	utils.RequireErrorAs(t, err, &checkerErr)
 
-	assert.IsType(t, &sema.CheckerError{}, err)
-
-	errs := err.(*sema.CheckerError).Errors
+	errs := checkerErr.Errors
 
 	require.Len(t, errs, count)
 

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -4383,7 +4383,9 @@ func TestParseImportWithAddress(t *testing.T) {
 		[]Declaration{
 			&ImportDeclaration{
 				Identifiers: nil,
-				Location:    AddressLocation{18, 52},
+				Location: AddressLocation{
+					Address: common.BytesToAddress([]byte{18, 52}),
+				},
 				Range: Range{
 					StartPos: Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   Position{Offset: 21, Line: 2, Column: 20},
@@ -4418,7 +4420,9 @@ func TestParseImportWithIdentifiers(t *testing.T) {
 						Pos:        Position{Offset: 19, Line: 2, Column: 18},
 					},
 				},
-				Location: AddressLocation{0},
+				Location: AddressLocation{
+					Address: common.BytesToAddress([]byte{0}),
+				},
 				Range: Range{
 					StartPos: Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   Position{Offset: 28, Line: 2, Column: 27},
@@ -4515,7 +4519,9 @@ func TestParseImportWithFromIdentifier(t *testing.T) {
 						Pos:        Position{Offset: 16, Line: 2, Column: 15},
 					},
 				},
-				Location: AddressLocation{0},
+				Location: AddressLocation{
+					Address: common.BytesToAddress([]byte{0}),
+				},
 				Range: Range{
 					StartPos: Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   Position{Offset: 28, Line: 2, Column: 27},

--- a/runtime/tests/utils/utils.go
+++ b/runtime/tests/utils/utils.go
@@ -20,12 +20,14 @@ package utils
 
 import (
 	"encoding/hex"
+	errors2 "errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -108,4 +110,15 @@ func UpdateTransaction(name string, contract []byte) []byte {
 		name,
 		hex.EncodeToString(contract),
 	))
+}
+
+// TODO: switch to require.ErrorAs once released:
+// https://github.com/stretchr/testify/commit/95a9d909e98735cd8211dfc5cbbb6b8b0b665915
+func RequireErrorAs(t *testing.T, err error, target interface{}) {
+	require.True(
+		t,
+		errors2.As(err, target),
+		"error chain must contain a %T",
+		target,
+	)
 }

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.10.0"
+const Version = "v0.10.1"


### PR DESCRIPTION
Same as #457, backported to v0.10 (for more info, see the description in the referenced PR)

