### PR TITLE
Refactor address locations, make composite decoding backwards-compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v1
+      - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.29

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build:
 
 .PHONY: install-tools
 install-tools:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.26.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.29.0
 
 .PHONY: lint
 lint:

--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
 )
 
 func TestIdentifierLocation_MarshalJSON(t *testing.T) {
@@ -70,7 +72,10 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 
 	t.Parallel()
 
-	loc := AddressLocation([]byte{1})
+	loc := AddressLocation{
+		Address: common.BytesToAddress([]byte{1}),
+		Name:    "A",
+	}
 
 	actual, err := json.Marshal(loc)
 	require.NoError(t, err)
@@ -79,7 +84,8 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 		`
         {
             "Type": "AddressLocation",
-            "Address": "0x1"
+            "Address": "0x1",
+            "Name": "A"
         }
         `,
 		string(actual),

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -58,7 +58,7 @@ func PrettyPrintError(writer io.Writer, err error, filename string, codes map[st
 				case ast.StringLocation:
 					filename = string(importLocation)
 				case ast.AddressLocation:
-					filename = importLocation.ToAddress().ShortHexWithPrefix()
+					filename = importLocation.Address.ShortHexWithPrefix()
 				case ast.IdentifierLocation:
 					filename = string(importLocation)
 				}

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -499,13 +499,13 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		},
 		resolveLocation: func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 
-			// Resolve each identifier as an address contract location
+			// Resolve each identifier as an address location
 
 			for _, identifier := range identifiers {
 				result = append(result, sema.ResolvedLocation{
-					Location: ast.AddressContractLocation{
-						AddressLocation: location.(ast.AddressLocation),
-						Name:            identifier.Identifier,
+					Location: ast.AddressLocation{
+						Address: location.(ast.AddressLocation).Address,
+						Name:    identifier.Identifier,
 					},
 					Identifiers: []ast.Identifier{
 						identifier,

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -143,7 +143,7 @@ const (
 	cborTagAddressLocation
 	cborTagStringLocation
 	cborTagIdentifierLocation
-	cborTagAddressContractLocation
+	_
 	_
 	_
 	_
@@ -844,17 +844,12 @@ func (e *Encoder) prepareCapabilityValue(v CapabilityValue) (interface{}, error)
 
 // NOTE: NEVER change, only add/increment; ensure uint64
 const (
-	encodedAddressContractLocationAddressFieldKey uint64 = 0
-	encodedAddressContractLocationNameFieldKey    uint64 = 1
+	encodedAddressLocationAddressFieldKey uint64 = 0
+	encodedAddressLocationNameFieldKey    uint64 = 1
 )
 
 func (e *Encoder) prepareLocation(l ast.Location) (interface{}, error) {
 	switch l := l.(type) {
-	case ast.AddressLocation:
-		return cbor.Tag{
-			Number:  cborTagAddressLocation,
-			Content: l.ToAddress().Bytes(),
-		}, nil
 
 	case ast.StringLocation:
 		return cbor.Tag{
@@ -868,13 +863,21 @@ func (e *Encoder) prepareLocation(l ast.Location) (interface{}, error) {
 			Content: string(l),
 		}, nil
 
-	case ast.AddressContractLocation:
+	case ast.AddressLocation:
+		var content interface{}
+
+		if l.Name == "" {
+			content = l.Address.Bytes()
+		} else {
+			content = cborMap{
+				encodedAddressLocationAddressFieldKey: l.Address.Bytes(),
+				encodedAddressLocationNameFieldKey:    l.Name,
+			}
+		}
+
 		return cbor.Tag{
-			Number: cborTagAddressContractLocation,
-			Content: cborMap{
-				encodedAddressContractLocationAddressFieldKey: l.AddressLocation.ToAddress().Bytes(),
-				encodedAddressContractLocationNameFieldKey:    l.Name,
-			},
+			Number:  cborTagAddressLocation,
+			Content: content,
 		}, nil
 
 	default:

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -461,9 +461,14 @@ func TestEncodeDecodeComposite(t *testing.T) {
 	})
 
 	t.Run("empty, address location", func(t *testing.T) {
+
 		expected := NewCompositeValue(
-			ast.AddressLocation{0x1},
-			"A.0x1.TestStruct",
+			ast.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x1}),
+				// NOTE: not stored, inferred from type ID
+				Name: "TestContract",
+			},
+			"A.0x1.TestContract.TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -472,7 +477,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: expected,
+				decodedValue: expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -488,10 +493,12 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x1,
 					// key 1
 					0x1,
-					// UTF-8 string, length 16
-					0x70,
-					0x41, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54, 0x65,
-					0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+					// UTF-8 string, length 29
+					0x78, 0x1D,
+					0x41,
+					0x2e, 0x30, 0x78, 0x31,
+					0x2e, 0x54, 0x65, 0x73, 0x74, 0x43, 0x6F, 0x6E, 0x74, 0x72, 0x61, 0x63, 0x74,
+					0x2e, 0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
 					// positive integer 1
@@ -501,6 +508,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// map, 0 pairs of items follow
 					0xa0,
 				},
+				decodeOnly: true,
 			},
 		)
 	})
@@ -545,11 +553,11 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 	t.Run("empty, address location", func(t *testing.T) {
 		expected := NewCompositeValue(
-			ast.AddressContractLocation{
-				AddressLocation: ast.AddressLocation{0x1},
-				Name:            "TestStruct",
+			ast.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x1}),
+				Name:    "TestStruct",
 			},
-			"AC.0x1.TestStruct",
+			"A.0x1.TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -567,7 +575,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 0
 					0x0,
 					// tag
-					0xd8, cborTagAddressContractLocation,
+					0xd8, cborTagAddressLocation,
 					// map, 4 pairs of items follow
 					0xa2,
 					// key 0
@@ -585,8 +593,8 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 1
 					0x1,
 					// UTF-8 string, length 17
-					0x71,
-					0x41, 0x43, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54,
+					0x70,
+					0x41, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54,
 					0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
@@ -601,7 +609,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("empty, address contract location, address too long", func(t *testing.T) {
+	t.Run("empty, address location, address too long", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
@@ -612,7 +620,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// key 0
 					0x0,
 					// tag
-					0xd8, cborTagAddressContractLocation,
+					0xd8, cborTagAddressLocation,
 					// map, 4 pairs of items follow
 					0xa2,
 					// key 0
@@ -730,7 +738,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 					// byte string, length 1
 					0x41,
 					// `-42` in decimal is is `0x2a` in hex.
-					// CBOR requires negative values to be encoded as `-1-n`, which is `-n - 1`, 
+					// CBOR requires negative values to be encoded as `-1-n`, which is `-n - 1`,
 					// which is `0x2a - 0x01`, which equals to `0x29`.
 					0x29,
 				},

--- a/runtime/locations.go
+++ b/runtime/locations.go
@@ -20,26 +20,26 @@ package runtime
 
 import (
 	"encoding/hex"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
 )
 
 type (
-	Location                = ast.Location
-	LocationID              = ast.LocationID
-	StringLocation          = ast.StringLocation
-	AddressLocation         = ast.AddressLocation
-	AddressContractLocation = ast.AddressContractLocation
-	Identifier              = ast.Identifier
+	Location        = ast.Location
+	LocationID      = ast.LocationID
+	TypeID          = ast.TypeID
+	StringLocation  = ast.StringLocation
+	AddressLocation = ast.AddressLocation
+	Identifier      = ast.Identifier
 )
 
 const (
-	IdentifierLocationPrefix      = ast.IdentifierLocationPrefix
-	StringLocationPrefix          = ast.StringLocationPrefix
-	AddressLocationPrefix         = ast.AddressLocationPrefix
-	AddressContractLocationPrefix = ast.AddressContractLocationPrefix
-	TransactionLocationPrefix     = "t"
-	ScriptLocationPrefix          = "s"
+	IdentifierLocationPrefix  = ast.IdentifierLocationPrefix
+	StringLocationPrefix      = ast.StringLocationPrefix
+	AddressLocationPrefix     = ast.AddressLocationPrefix
+	TransactionLocationPrefix = "t"
+	ScriptLocationPrefix      = "s"
 )
 
 // TransactionLocation
@@ -47,7 +47,28 @@ const (
 type TransactionLocation []byte
 
 func (l TransactionLocation) ID() ast.LocationID {
-	return ast.NewLocationID(TransactionLocationPrefix, l.String())
+	return ast.NewLocationID(
+		TransactionLocationPrefix,
+		l.String(),
+	)
+}
+
+func (l TransactionLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		TransactionLocationPrefix,
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l TransactionLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 3)
+
+	if len(pieces) < 3 {
+		return ""
+	}
+
+	return pieces[2]
 }
 
 func (l TransactionLocation) String() string {
@@ -59,7 +80,28 @@ func (l TransactionLocation) String() string {
 type ScriptLocation []byte
 
 func (l ScriptLocation) ID() ast.LocationID {
-	return ast.NewLocationID(ScriptLocationPrefix, l.String())
+	return ast.NewLocationID(
+		ScriptLocationPrefix,
+		l.String(),
+	)
+}
+
+func (l ScriptLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		ScriptLocationPrefix,
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l ScriptLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 3)
+
+	if len(pieces) < 3 {
+		return ""
+	}
+
+	return pieces[2]
 }
 
 func (l ScriptLocation) String() string {
@@ -74,6 +116,23 @@ func (l FileLocation) ID() ast.LocationID {
 	return LocationID(l.String())
 }
 
+func (l FileLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l FileLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
+}
+
 func (l FileLocation) String() string {
 	return string(l)
 }
@@ -84,6 +143,23 @@ type REPLLocation struct{}
 
 func (l REPLLocation) ID() LocationID {
 	return LocationID(l.String())
+}
+
+func (l REPLLocation) TypeID(qualifiedIdentifier string) TypeID {
+	return ast.NewTypeID(
+		l.String(),
+		qualifiedIdentifier,
+	)
+}
+
+func (l REPLLocation) QualifiedIdentifier(typeID TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
 }
 
 func (l REPLLocation) String() string {

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -578,7 +578,9 @@ func parseHexadecimalLocation(literal string) ast.AddressLocation {
 		panic(err)
 	}
 
-	return address
+	return ast.AddressLocation{
+		Address: common.BytesToAddress(address),
+	}
 }
 
 // parseEventDeclaration parses an event declaration.

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -1225,7 +1225,9 @@ func TestParseImportDeclaration(t *testing.T) {
 			[]ast.Declaration{
 				&ast.ImportDeclaration{
 					Identifiers: nil,
-					Location:    ast.AddressLocation{0x42},
+					Location: ast.AddressLocation{
+						Address: common.BytesToAddress([]byte{0x42}),
+					},
 					LocationPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
@@ -1338,7 +1340,9 @@ func TestParseImportDeclaration(t *testing.T) {
 							Pos:        ast.Position{Line: 1, Column: 20, Offset: 20},
 						},
 					},
-					Location:    ast.AddressLocation{0x42},
+					Location: ast.AddressLocation{
+						Address: common.BytesToAddress([]byte{0x42}),
+					},
 					LocationPos: ast.Position{Line: 1, Column: 29, Offset: 29},
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2901,12 +2901,20 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 			return []Address{signerAccount}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
-			key := string(AddressLocation(address[:]).ID())
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3016,12 +3024,20 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 			return []Address{signerAccount}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) (err error) {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3149,12 +3165,20 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 			return []Address{{0x1}}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3519,12 +3543,20 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 			return []Address{address}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3665,13 +3697,21 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 		getSigningAccounts: func() []Address {
 			return []Address{address}
 		},
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -3818,12 +3858,20 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 			return []Address{address}
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4472,12 +4520,20 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4586,12 +4642,20 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4719,12 +4783,20 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 			return signerAddresses
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, _ string) (code []byte, err error) {
-			key := string(AddressLocation(address[:]).ID())
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			return accountCodes[key], nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
-			key := string(AddressLocation(address[:]).ID())
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			key := string(location.ID())
 			accountCodes[key] = code
 			return nil
 		},
@@ -4761,7 +4833,7 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
-			"AC.0100000000000000.HelloWorld",
+			"A.0100000000000000.HelloWorld",
 		},
 		cacheHits,
 	)
@@ -4864,9 +4936,9 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 			return []ResolvedLocation{
 				{
-					Location: AddressContractLocation{
-						AddressLocation: location.(AddressLocation),
-						Name:            "Test",
+					Location: AddressLocation{
+						Address: location.(AddressLocation).Address,
+						Name:    "Test",
 					},
 					Identifiers: []ast.Identifier{
 						{
@@ -5012,9 +5084,9 @@ func singleIdentifierLocationResolver(t *testing.T) func(identifiers []Identifie
 
 		return []ResolvedLocation{
 			{
-				Location: AddressContractLocation{
-					AddressLocation: location.(AddressLocation),
-					Name:            identifiers[0].Identifier,
+				Location: AddressLocation{
+					Address: location.(AddressLocation).Address,
+					Name:    identifiers[0].Identifier,
 				},
 				Identifiers: identifiers,
 			},

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -28,12 +28,12 @@ import (
 // 1. Resolution of the import statement.
 //
 //     The default case is that one location is resolved to one location (itself),
-//     though e.g. an address location may also be resolved into multiple "address contract" locations.
+//     though e.g. an address location may also be resolved into multiple address locations.
 //
 //     For example, an import declaration `import a, b from 0x1` specifies the import of the declarations with
 //     the identifiers `a` and `b` from the address location `0x1`.
 //     This import declaration might be resolved into just the location itself, i.e. the address location `0x1`,
-//     but could also be resolved into multiple locations, e.g. the address contract locations `0x1.a` and `0x1.b`.
+//     but could also be resolved into multiple locations, e.g. the address locations `0x1.a` and `0x1.b`.
 //
 // 2. Acquiring the programs for the resolved imports. For each resolved import a separate program can be returned.
 //

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -615,7 +615,7 @@ type InvalidVariableKindError struct {
 
 func (e *InvalidVariableKindError) Error() string {
 	if e.Kind == ast.VariableKindNotSpecified {
-		return fmt.Sprintf("missing variable kind")
+		return "missing variable kind"
 	}
 	return fmt.Sprintf("invalid variable kind: `%s`", e.Kind.Name())
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -63,7 +63,7 @@ func qualifiedIdentifier(identifier string, containerType Type) string {
 	return sb.String()
 }
 
-type TypeID string
+type TypeID = ast.TypeID
 
 type Type interface {
 	IsType()
@@ -4804,7 +4804,7 @@ func (t *CompositeType) QualifiedIdentifier() string {
 }
 
 func (t *CompositeType) ID() TypeID {
-	return TypeID(fmt.Sprintf("%s.%s", t.Location.ID(), t.QualifiedIdentifier()))
+	return t.Location.TypeID(t.QualifiedIdentifier())
 }
 
 func (t *CompositeType) Equal(other Type) bool {
@@ -5788,7 +5788,7 @@ func (t *InterfaceType) QualifiedIdentifier() string {
 }
 
 func (t *InterfaceType) ID() TypeID {
-	return TypeID(fmt.Sprintf("%s.%s", t.Location.ID(), t.QualifiedIdentifier()))
+	return t.Location.TypeID(t.QualifiedIdentifier())
 }
 
 func (t *InterfaceType) Equal(other Type) bool {

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -21,6 +21,7 @@ package stdlib
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -181,6 +182,23 @@ const flowLocationID = "flow"
 
 func (l FlowLocation) ID() ast.LocationID {
 	return ast.NewLocationID(flowLocationID)
+}
+
+func (l FlowLocation) TypeID(qualifiedIdentifier string) ast.TypeID {
+	return ast.NewTypeID(
+		flowLocationID,
+		qualifiedIdentifier,
+	)
+}
+
+func (l FlowLocation) QualifiedIdentifier(typeID ast.TypeID) string {
+	pieces := strings.SplitN(string(typeID), ".", 2)
+
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return pieces[1]
 }
 
 // built-in event types

--- a/runtime/stdlib/internal/contracts.gen.go
+++ b/runtime/stdlib/internal/contracts.gen.go
@@ -228,8 +228,8 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"contracts": &bintree{nil, map[string]*bintree{
-		"crypto.cdc": &bintree{contractsCryptoCdc, map[string]*bintree{}},
+	"contracts": {nil, map[string]*bintree{
+		"crypto.cdc": {contractsCryptoCdc, map[string]*bintree{}},
 	}},
 }}
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -136,7 +136,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 	assert.NotNil(t, accountCode)
 
 	rType := &cadence.ResourceType{
-		TypeID:     "AC.000000000000cade.Test.Test.R",
+		TypeID:     "A.000000000000cade.Test.R",
 		Identifier: "R",
 		Fields: []cadence.Field{
 			{
@@ -156,7 +156,7 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 				address,
 				"contract\x1fTest",
 				cadence.NewContract([]cadence.Value{}).WithType(&cadence.ContractType{
-					TypeID:       "AC.000000000000cade.Test.Test",
+					TypeID:       "A.000000000000cade.Test",
 					Identifier:   "Test",
 					Fields:       []cadence.Field{},
 					Initializers: nil,

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -87,7 +87,7 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddressLocation := ast.AddressLocation{0x1}
+	importedAddress := common.BytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`
@@ -98,9 +98,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
           pub let x = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "x",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "x",
 			},
 		},
 	)
@@ -115,9 +115,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
           pub let y = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "y",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "y",
 			},
 		},
 	)
@@ -134,9 +134,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 					func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 						for _, identifier := range identifiers {
 							result = append(result, sema.ResolvedLocation{
-								Location: ast.AddressContractLocation{
-									AddressLocation: importedAddressLocation,
-									Name:            identifier.Identifier,
+								Location: ast.AddressLocation{
+									Address: importedAddress,
+									Name:    identifier.Identifier,
 								},
 								Identifiers: []ast.Identifier{
 									identifier,
@@ -148,9 +148,9 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 				),
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
-						addressContractLocation := location.(ast.AddressContractLocation)
+						addressLocation := location.(ast.AddressLocation)
 						var importedChecker *sema.Checker
-						switch addressContractLocation.Name {
+						switch addressLocation.Name {
 						case "x":
 							importedChecker = importedCheckerX
 						case "y":
@@ -210,7 +210,7 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddressLocation := ast.AddressLocation{0x1}
+	importedAddress := common.BytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`
@@ -221,9 +221,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
           pub let x = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "x",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "x",
 			},
 		},
 	)
@@ -238,9 +238,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
           pub let y = test()
         `,
 		ParseAndCheckOptions{
-			Location: ast.AddressContractLocation{
-				AddressLocation: importedAddressLocation,
-				Name:            "y",
+			Location: ast.AddressLocation{
+				Address: importedAddress,
+				Name:    "y",
 			},
 		},
 	)
@@ -256,9 +256,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 					func(identifiers []ast.Identifier, location ast.Location) (result []sema.ResolvedLocation) {
 						for _, identifier := range identifiers {
 							result = append(result, sema.ResolvedLocation{
-								Location: ast.AddressContractLocation{
-									AddressLocation: importedAddressLocation,
-									Name:            identifier.Identifier,
+								Location: ast.AddressLocation{
+									Address: importedAddress,
+									Name:    identifier.Identifier,
 								},
 								Identifiers: []ast.Identifier{
 									identifier,
@@ -270,9 +270,9 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 				),
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
-						addressContractLocation := location.(ast.AddressContractLocation)
+						addressLocation := location.(ast.AddressLocation)
 						var importedChecker *sema.Checker
-						switch addressContractLocation.Name {
+						switch addressLocation.Name {
 						case "x":
 							importedChecker = importedCheckerX
 						case "y":

--- a/runtime/tests/parser/parser_test.go
+++ b/runtime/tests/parser/parser_test.go
@@ -4383,7 +4383,9 @@ func TestParseImportWithAddress(t *testing.T) {
 		[]Declaration{
 			&ImportDeclaration{
 				Identifiers: nil,
-				Location:    AddressLocation{18, 52},
+				Location: AddressLocation{
+					Address: common.BytesToAddress([]byte{18, 52}),
+				},
 				Range: Range{
 					StartPos: Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   Position{Offset: 21, Line: 2, Column: 20},
@@ -4418,7 +4420,9 @@ func TestParseImportWithIdentifiers(t *testing.T) {
 						Pos:        Position{Offset: 19, Line: 2, Column: 18},
 					},
 				},
-				Location: AddressLocation{0},
+				Location: AddressLocation{
+					Address: common.BytesToAddress([]byte{0}),
+				},
 				Range: Range{
 					StartPos: Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   Position{Offset: 28, Line: 2, Column: 27},
@@ -4515,7 +4519,9 @@ func TestParseImportWithFromIdentifier(t *testing.T) {
 						Pos:        Position{Offset: 16, Line: 2, Column: 15},
 					},
 				},
-				Location: AddressLocation{0},
+				Location: AddressLocation{
+					Address: common.BytesToAddress([]byte{0}),
+				},
 				Range: Range{
 					StartPos: Position{Offset: 9, Line: 2, Column: 8},
 					EndPos:   Position{Offset: 28, Line: 2, Column: 27},

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.11.0"
+const Version = "v0.11.1"


### PR DESCRIPTION
Same as #457, backported to v0.11 (for more info, see the description in the referenced PR)

