### PR TITLE
Adding error to emit event

### DIFF
--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -163,8 +163,9 @@ func TestRuntimeContract(t *testing.T) {
 
 				return nil
 			},
-			emitEvent: func(event cadence.Event) {
+			emitEvent: func(event cadence.Event) error {
 				events = append(events, event)
+				return nil
 			},
 		}
 
@@ -518,8 +519,9 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error{
 			events = append(events, event)
+			return nil
 		},
 	}
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -582,8 +582,9 @@ type eventCapturingInterface struct {
 	events []cadence.Event
 }
 
-func (t *eventCapturingInterface) EmitEvent(event cadence.Event) {
+func (t *eventCapturingInterface) EmitEvent(event cadence.Event) error {
 	t.events = append(t.events, event)
+	return nil
 }
 
 func exportEventFromScript(t *testing.T, script string) cadence.Event {

--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -145,8 +145,9 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -629,8 +630,9 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -868,8 +870,9 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -1021,8 +1024,9 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Removal(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -1102,8 +1106,9 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Destruction(t *testing.T
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -1217,8 +1222,9 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Insertion(t *testing.T) 
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -1335,8 +1341,9 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_ValueTransferAndDestroy(
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -67,9 +67,9 @@ type Interface interface {
 	// GetSigningAccounts returns the signing accounts.
 	GetSigningAccounts() []Address
 	// Log logs a string.
-	Log(string)
+	Log(string) error
 	// EmitEvent is called when an event is emitted by the runtime.
-	EmitEvent(cadence.Event)
+	EmitEvent(cadence.Event) (err error)
 	// ValueExists returns true if the given key exists in the storage, owned by the given account.
 	ValueExists(owner, key []byte) (exists bool, err error)
 	// GenerateUUID is called to generate a UUID.
@@ -194,7 +194,7 @@ func (i *EmptyRuntimeInterface) GetSigningAccounts() []Address {
 
 func (i *EmptyRuntimeInterface) Log(_ string) {}
 
-func (i *EmptyRuntimeInterface) EmitEvent(_ cadence.Event) {}
+func (i *EmptyRuntimeInterface) EmitEvent(_ cadence.Event) error {}
 
 func (i *EmptyRuntimeInterface) GenerateUUID() uint64 {
 	return 0

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -67,7 +67,7 @@ type Interface interface {
 	// GetSigningAccounts returns the signing accounts.
 	GetSigningAccounts() []Address
 	// Log logs a string.
-	Log(string) error
+	Log(string)
 	// EmitEvent is called when an event is emitted by the runtime.
 	EmitEvent(cadence.Event) (err error)
 	// ValueExists returns true if the given key exists in the storage, owned by the given account.

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -194,7 +194,7 @@ func (i *EmptyRuntimeInterface) GetSigningAccounts() []Address {
 
 func (i *EmptyRuntimeInterface) Log(_ string) {}
 
-func (i *EmptyRuntimeInterface) EmitEvent(_ cadence.Event) error {}
+func (i *EmptyRuntimeInterface) EmitEvent(_ cadence.Event) error {return nil}
 
 func (i *EmptyRuntimeInterface) GenerateUUID() uint64 {
 	return 0

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -194,7 +194,9 @@ func (i *EmptyRuntimeInterface) GetSigningAccounts() []Address {
 
 func (i *EmptyRuntimeInterface) Log(_ string) {}
 
-func (i *EmptyRuntimeInterface) EmitEvent(_ cadence.Event) error {return nil}
+func (i *EmptyRuntimeInterface) EmitEvent(_ cadence.Event) error {
+	return nil
+}
 
 func (i *EmptyRuntimeInterface) GenerateUUID() uint64 {
 	return 0

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -899,10 +899,14 @@ func (r *interpreterRuntime) emitEvent(
 		Fields: fields,
 	}
 
+	var err error
 	exportedEvent := exportEvent(eventValue)
 	wrapPanic(func() {
-		runtimeInterface.EmitEvent(exportedEvent)
+		err = runtimeInterface.EmitEvent(exportedEvent)
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (r *interpreterRuntime) emitAccountEvent(
@@ -927,10 +931,14 @@ func (r *interpreterRuntime) emitAccountEvent(
 		))
 	}
 
+	var err error
 	exportedEvent := exportEvent(eventValue)
 	wrapPanic(func() {
-		runtimeInterface.EmitEvent(exportedEvent)
+		err = runtimeInterface.EmitEvent(exportedEvent)
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 func CodeToHashValue(code []byte) *interpreter.ArrayValue {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -100,7 +100,7 @@ type testRuntimeInterface struct {
 	removeAccountContractCode func(address Address, name string) (err error)
 	getSigningAccounts        func() []Address
 	log                       func(string)
-	emitEvent                 func(cadence.Event)
+	emitEvent                 func(cadence.Event) error
 	generateUUID              func() uint64
 	computationLimit          uint64
 	decodeArgument            func(b []byte, t cadence.Type) (cadence.Value, error)
@@ -206,8 +206,8 @@ func (i *testRuntimeInterface) Log(message string) {
 	i.log(message)
 }
 
-func (i *testRuntimeInterface) EmitEvent(event cadence.Event) {
-	i.emitEvent(event)
+func (i *testRuntimeInterface) EmitEvent(event cadence.Event) error {
+	return i.emitEvent(event)
 }
 
 func (i *testRuntimeInterface) GenerateUUID() uint64 {
@@ -2260,8 +2260,9 @@ func TestRuntimeTransaction_CreateAccount(t *testing.T) {
 		createAccount: func(payer Address) (address Address, err error) {
 			return Address{42}, nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -2350,8 +2351,9 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 				keys = append(keys, publicKey)
 				return nil
 			},
-			emitEvent: func(event cadence.Event) {
+			emitEvent: func(event cadence.Event) error {
 				events = append(events, event)
+				return nil
 			},
 			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return jsoncdc.Decode(b)
@@ -2548,8 +2550,9 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 					accountCode = code
 					return nil
 				},
-				emitEvent: func(event cadence.Event) {
+				emitEvent: func(event cadence.Event) error {
 					events = append(events, event)
+					return nil
 				},
 			}
 
@@ -2632,8 +2635,9 @@ func TestRuntimeContractAccount(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -2718,7 +2722,7 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {},
+		emitEvent: func(event cadence.Event) error {return nil},
 		log: func(message string) {
 			loggedMessage = message
 		},
@@ -2924,8 +2928,9 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -3047,8 +3052,9 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -3188,8 +3194,9 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -3447,8 +3454,9 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 					accountCode = code
 					return nil
 				},
-				emitEvent: func(event cadence.Event) {
+				emitEvent: func(event cadence.Event) error {
 					events = append(events, event)
+					return nil
 				},
 			}
 
@@ -3566,8 +3574,9 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -3721,8 +3730,9 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -3881,8 +3891,9 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error{
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -4268,8 +4279,9 @@ func TestRuntimeContractWriteback(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error{
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -4365,8 +4377,9 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
@@ -4546,8 +4559,9 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -4668,8 +4682,9 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error{
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -4809,8 +4824,9 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 			accountCodes[key] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -4964,8 +4980,9 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 	}
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -113,8 +113,9 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) {
+		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
+			return nil
 		},
 		setCadenceValue: func(owner Address, key string, value cadence.Value) (err error) {
 			writes = append(writes, write{


### PR DESCRIPTION
## Description

This PR updates the interface to return errors for emitEvent method, this functionality is needed for the environment to enforce event limit sizes.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to the spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
