### PR TITLE
Add support for coverage reports

### DIFF
--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -1,0 +1,61 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+)
+
+// LocationCoverage records coverage information for a location
+//
+type LocationCoverage struct {
+	LineHits map[int]int `json:"line_hits"`
+}
+
+func (c *LocationCoverage) AddLineHit(line int) {
+	c.LineHits[line]++
+}
+
+func NewLocationCoverage() *LocationCoverage {
+	return &LocationCoverage{
+		LineHits: map[int]int{},
+	}
+}
+
+// CoverageReport is a collection of coverage per location
+//
+type CoverageReport struct {
+	Coverage map[ast.LocationID]*LocationCoverage `json:"coverage"`
+}
+
+func (r *CoverageReport) AddLineHit(location ast.Location, line int) {
+	locationID := location.ID()
+	locationCoverage := r.Coverage[locationID]
+	if locationCoverage == nil {
+		locationCoverage = NewLocationCoverage()
+		r.Coverage[locationID] = locationCoverage
+	}
+	locationCoverage.AddLineHit(line)
+}
+
+func NewCoverageReport() *CoverageReport {
+	return &CoverageReport{
+		Coverage: map[ast.LocationID]*LocationCoverage{},
+	}
+}

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -1,0 +1,109 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+)
+
+func TestRuntimeCoverage(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewInterpreterRuntime()
+
+	importedScript := []byte(`
+      pub fun answer(): Int {
+        var i = 0
+        while i < 42 {
+          i = i + 1
+        }
+        return i
+      }
+    `)
+
+	script := []byte(`
+      import "imported"
+
+      pub fun main(): Int {
+          let answer = answer()
+          if answer != 42 {
+            panic("?!")
+          }
+          return answer
+        }
+    `)
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(location Location) (bytes []byte, err error) {
+			switch location {
+			case StringLocation("imported"):
+				return importedScript, nil
+			default:
+				return nil, fmt.Errorf("unknown import location: %s", location)
+			}
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	coverageReport := NewCoverageReport()
+
+	runtime.SetCoverageReport(coverageReport)
+
+	value, err := runtime.ExecuteScript(script, nil, runtimeInterface, nextTransactionLocation())
+	require.NoError(t, err)
+
+	assert.Equal(t, cadence.NewInt(42), value)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		`
+        {
+          "coverage": {
+            "S.imported": {
+              "line_hits": {
+                "3": 1,
+                "4": 1,
+                "5": 42,
+                "7": 1
+              }
+            },
+            "t.00": {
+              "line_hits": {
+                "5": 1,
+                "6": 1,
+                "9": 1
+              }
+            }
+          }
+        }
+        `,
+		string(actual),
+	)
+}


### PR DESCRIPTION
When running tests it is useful to know what parts of the program where covered. Add support for a coverage to the interpreter. Start with measuring line hits. This can be extended in the future.