### PR TITLE
Permit storage path expressions to contain dots

### DIFF
--- a/docs/language/accounts.md
+++ b/docs/language/accounts.md
@@ -122,7 +122,7 @@ Objects are stored under paths.
 Paths consist of a domain and an identifier.
 
 Paths start with the character `/`, followed by the domain, the path separator `/`,
-and finally the identifier.
+and finally the identifier. Path identifiers can consist of alphanumeric characters in addition to the `_` and `.` characters.
 For example, the path `/storage/test` has the domain `storage` and the identifier `test`.
 
 There are only three valid domains: `storage`, `private`, and `public`.

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1007,9 +1007,9 @@ func (e *ForceExpression) MarshalJSON() ([]byte, error) {
 // PathExpression
 
 type PathExpression struct {
-	StartPos   Position `json:"-"`
-	Domain     Identifier
-	Identifier Identifier
+	StartPos    Position `json:"-"`
+	Domain      Identifier
+	Identifiers []Identifier
 }
 
 func (*PathExpression) isExpression() {}
@@ -1024,8 +1024,16 @@ func (e *PathExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitPathExpression(e)
 }
 
+func (e *PathExpression) Identifier() string {
+	var idents []string
+	for _, ident := range e.Identifiers {
+		idents = append(idents, ident.Identifier)
+	}
+	return strings.Join(idents, ".")
+}
+
 func (e *PathExpression) String() string {
-	return fmt.Sprintf("/%s/%s", e.Domain, e.Identifier)
+	return fmt.Sprintf("/%s/%s", e.Domain, e.Identifier())
 }
 
 func (e *PathExpression) StartPosition() Position {
@@ -1033,7 +1041,8 @@ func (e *PathExpression) StartPosition() Position {
 }
 
 func (e *PathExpression) EndPosition() Position {
-	return e.Identifier.EndPosition()
+	// Return the final identifier's EndPosition
+	return e.Identifiers[len(e.Identifiers)-1].EndPosition()
 }
 
 func (e *PathExpression) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -318,9 +318,11 @@ func TestPathExpression_MarshalJSON(t *testing.T) {
 			Identifier: "storage",
 			Pos:        Position{Offset: 4, Line: 5, Column: 6},
 		},
-		Identifier: Identifier{
-			Identifier: "foobar",
-			Pos:        Position{Offset: 7, Line: 8, Column: 9},
+		Identifiers: []Identifier{
+			{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 7, Line: 8, Column: 9},
+			},
 		},
 	}
 
@@ -336,11 +338,11 @@ func TestPathExpression_MarshalJSON(t *testing.T) {
                 "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
                 "EndPos": {"Offset": 10, "Line": 5, "Column": 12}
             },
-            "Identifier": {
+            "Identifiers": [{
                 "Identifier": "foobar",
                 "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
                 "EndPos": {"Offset": 12, "Line": 8, "Column": 14}
-            },
+            }],
             "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
             "EndPos": {"Offset": 12, "Line": 8, "Column": 14}
         }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3597,7 +3597,7 @@ func (interpreter *Interpreter) VisitPathExpression(expression *ast.PathExpressi
 	return Done{
 		Result: PathValue{
 			Domain:     domain,
-			Identifier: expression.Identifier.Identifier,
+			Identifier: expression.Identifier(),
 		},
 	}
 }

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -78,7 +78,7 @@ func pathLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, e
 
 	return cadence.Path{
 		Domain:     pathExpression.Domain.Identifier,
-		Identifier: pathExpression.Identifier.Identifier,
+		Identifier: pathExpression.Identifier(),
 	}, nil
 }
 

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -629,8 +629,8 @@ func defineLessThanOrTypeArgumentsExpression() {
 		})
 }
 
-// defineGreaterThanOrBitwiseRightShiftExpression parses 
-// the greater-than expression (operator `>`, e.g. `1 > 2`) 
+// defineGreaterThanOrBitwiseRightShiftExpression parses
+// the greater-than expression (operator `>`, e.g. `1 > 2`)
 // and the bitwise right shift expression (operator `>>`, e.g. `1 >> 3`).
 //
 // The `>>` operator consists of two `>` tokens, instead of one dedicated `>>` token,
@@ -1046,11 +1046,18 @@ func definePathExpression() {
 		func(p *parser, token lexer.Token) ast.Expression {
 			domain := mustIdentifier(p)
 			p.mustOne(lexer.TokenSlash)
-			identifier := mustIdentifier(p)
+
+			var idents []ast.Identifier
+			idents = append(idents, mustIdentifier(p))
+			for p.current.Is(lexer.TokenDot) {
+				p.next()
+				idents = append(idents, mustIdentifier(p))
+			}
+
 			return &ast.PathExpression{
-				Domain:     domain,
-				Identifier: identifier,
-				StartPos:   token.StartPos,
+				Domain:      domain,
+				Identifiers: idents,
+				StartPos:    token.StartPos,
 			}
 		},
 	)

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -708,9 +708,40 @@ func TestParsePath(t *testing.T) {
 				Identifier: "foo",
 				Pos:        ast.Position{Line: 1, Column: 1, Offset: 1},
 			},
-			Identifier: ast.Identifier{
-				Identifier: "bar",
-				Pos:        ast.Position{Line: 1, Column: 5, Offset: 5},
+			Identifiers: []ast.Identifier{
+				{
+					Identifier: "bar",
+					Pos:        ast.Position{Line: 1, Column: 5, Offset: 5},
+				},
+			},
+			StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+		},
+		result,
+	)
+}
+
+func TestParsePathWithDots(t *testing.T) {
+
+	t.Parallel()
+
+	result, errs := ParseExpression("/foo/bar.baz")
+	require.Empty(t, errs)
+
+	utils.AssertEqualWithDiff(t,
+		&ast.PathExpression{
+			Domain: ast.Identifier{
+				Identifier: "foo",
+				Pos:        ast.Position{Line: 1, Column: 1, Offset: 1},
+			},
+			Identifiers: []ast.Identifier{
+				{
+					Identifier: "bar",
+					Pos:        ast.Position{Line: 1, Column: 5, Offset: 5},
+				},
+				{
+					Identifier: "baz",
+					Pos:        ast.Position{Line: 1, Column: 9, Offset: 9},
+				},
 			},
 			StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 		},
@@ -5362,9 +5393,11 @@ func TestParsePathLiteral(t *testing.T) {
 						Identifier: "foo",
 						Pos:        ast.Position{Offset: 15, Line: 2, Column: 14},
 					},
-					Identifier: ast.Identifier{
-						Identifier: "bar",
-						Pos:        ast.Position{Offset: 19, Line: 2, Column: 18},
+					Identifiers: []ast.Identifier{
+						{
+							Identifier: "bar",
+							Pos:        ast.Position{Offset: 19, Line: 2, Column: 18},
+						},
 					},
 				},
 				StartPos: ast.Position{Offset: 6, Line: 2, Column: 5},


### PR DESCRIPTION
Closes #419.

## Description

Hey Bastian! 👋 Hope things are going well in Cadence-land! 🎶 Quick little PR:

Parse the `TokenDot` as a valid character within a `PathExpression`. Update relevant tests and add an additional test.

I exposed the sub-identifiers (identifiers delimited by `TokenDot`) to the interpreter, however on second thought I could consolidate them at the parser level if that is preferred -- let me know if you would prefer that and I can revise!

This approach probably makes less sense if dots have no significance but I thought it would be good to get your take before I simplify!
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
