### PR TITLE
Allow host environment to predeclare values, predicated on location

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1265,10 +1265,14 @@ func convertValueFromScript(t *testing.T, script string) cadence.Value {
 	rt := runtime.NewInterpreterRuntime()
 
 	value, err := rt.ExecuteScript(
-		[]byte(script),
-		nil,
-		&runtime.EmptyRuntimeInterface{},
-		runtime.StringLocation("test"),
+		runtime.Script{
+			Source:    []byte(script),
+			Arguments: nil,
+		},
+		runtime.Context{
+			Interface: &runtime.EmptyRuntimeInterface{},
+			Location:  runtime.StringLocation("test"),
+		},
 	)
 
 	require.NoError(t, err)

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -136,7 +136,7 @@ func PrepareChecker(program *ast.Program, filename string, codes map[string]stri
 	checker, err := sema.NewChecker(
 		program,
 		location,
-		sema.WithPredeclaredValues(valueDeclarations.ToValueDeclarations()),
+		sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 		sema.WithPredeclaredTypes(typeDeclarations),
 		sema.WithImportHandler(
 			func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
@@ -187,7 +187,7 @@ func PrepareInterpreter(filename string) (*interpreter.Interpreter, *sema.Checke
 
 	inter, err := interpreter.NewInterpreter(
 		checker,
-		interpreter.WithPredefinedValues(valueDeclarations.ToValues()),
+		interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
 		interpreter.WithUUIDHandler(func() (uint64, error) {
 			defer func() { uuid++ }()
 			return uuid, nil

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -178,7 +178,16 @@ func TestRuntimeContract(t *testing.T) {
 
 		t.Run("add", func(t *testing.T) {
 
-			err := runtime.ExecuteTransaction(addTx, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source:    addTx,
+					Arguments: nil,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 
 			if tc.valid {
 				require.NoError(t, err)
@@ -231,7 +240,15 @@ func TestRuntimeContract(t *testing.T) {
 			loggedMessages = nil
 			events = nil
 
-			err := runtime.ExecuteTransaction(addTx, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source: addTx,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 			require.Error(t, err)
 
 			// the deployed code should not have been updated,
@@ -250,7 +267,15 @@ func TestRuntimeContract(t *testing.T) {
 			loggedMessages = nil
 			events = nil
 
-			err := runtime.ExecuteTransaction(updateTx, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source: updateTx,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 			require.NoError(t, err)
 
 			require.Equal(t, []byte(tc.code2), deployedCode)
@@ -287,7 +312,15 @@ func TestRuntimeContract(t *testing.T) {
 			loggedMessages = nil
 			events = nil
 
-			err := runtime.ExecuteTransaction(removeTx, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source: removeTx,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 			require.NoError(t, err)
 
 			require.Empty(t, deployedCode)
@@ -535,7 +568,14 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		{"C", contractC},
 	} {
 		tx := addTx(contract.name, contract.code)
-		err := runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: tx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			})
 		require.NoError(t, err)
 	}
 
@@ -552,7 +592,15 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 
 		loggedMessages = nil
 
-		err := runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: tx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		require.NoError(t, err)
 	})
 
@@ -569,7 +617,15 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 
 		loggedMessages = nil
 
-		err := runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: tx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		require.NoError(t, err)
 	})
 
@@ -586,8 +642,15 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 
 		loggedMessages = nil
 
-		err := runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: tx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		require.NoError(t, err)
 	})
-
 }

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -593,10 +593,13 @@ func exportEventFromScript(t *testing.T, script string) cadence.Event {
 	inter := &eventCapturingInterface{}
 
 	_, err := rt.ExecuteScript(
-		[]byte(script),
-		nil,
-		inter,
-		utils.TestLocation,
+		Script{
+			Source: []byte(script),
+		},
+		Context{
+			Interface: inter,
+			Location:  utils.TestLocation,
+		},
 	)
 
 	require.NoError(t, err)
@@ -611,10 +614,13 @@ func exportValueFromScript(t *testing.T, script string) cadence.Value {
 	rt := NewInterpreterRuntime()
 
 	value, err := rt.ExecuteScript(
-		[]byte(script),
-		nil,
-		&EmptyRuntimeInterface{},
-		utils.TestLocation,
+		Script{
+			Source: []byte(script),
+		},
+		Context{
+			Interface: &EmptyRuntimeInterface{},
+			Location:  utils.TestLocation,
+		},
 	)
 
 	require.NoError(t, err)

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -74,7 +74,15 @@ func TestRuntimeCoverage(t *testing.T) {
 
 	runtime.SetCoverageReport(coverageReport)
 
-	value, err := runtime.ExecuteScript(script, nil, runtimeInterface, nextTransactionLocation())
+	value, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, cadence.NewInt(42), value)

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -44,7 +44,15 @@ func TestRuntimeCrypto_import(t *testing.T) {
 
 	runtimeInterface := &testRuntimeInterface{}
 
-	result, err := runtime.ExecuteScript(script, nil, runtimeInterface, utils.TestLocation)
+	result, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  utils.TestLocation,
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -111,7 +119,15 @@ func TestRuntimeCrypto_verify(t *testing.T) {
 		},
 	}
 
-	result, err := runtime.ExecuteScript(script, nil, runtimeInterface, utils.TestLocation)
+	result, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  utils.TestLocation,
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -156,7 +172,15 @@ func TestRuntimeCrypto_hash(t *testing.T) {
 		},
 	}
 
-	_, err := runtime.ExecuteScript(script, nil, runtimeInterface, utils.TestLocation)
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  utils.TestLocation,
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,

--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -157,7 +157,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	nextTransactionLocation := newTransactionLocationGenerator()
 
 	clearReadsAndWrites()
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
@@ -165,7 +173,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	assert.Len(t, writes, 1)
 
 	clearReadsAndWrites()
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, writes, 1)
@@ -186,7 +202,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
     `)
 
 	clearReadsAndWrites()
-	err = runtime.ExecuteTransaction(insertTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: insertTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	cStorageKey := []byte("storage\x1fc")
@@ -225,7 +249,14 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: readTx},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"2", "2"}, loggedMessages)
@@ -265,7 +296,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(updateTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: updateTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"3"}, loggedMessages)
@@ -318,7 +357,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(replaceTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: replaceTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -379,7 +426,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(removeTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: removeTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -425,7 +480,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: readTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"nil", "nil"}, loggedMessages)
@@ -466,7 +529,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(destroyTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: destroyTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -642,7 +713,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 	nextTransactionLocation := newTransactionLocationGenerator()
 
 	clearReadsAndWrites()
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
@@ -650,7 +729,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 	assert.Len(t, writes, 1)
 
 	clearReadsAndWrites()
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, writes, 1)
@@ -673,7 +760,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
     `)
 
 	clearReadsAndWrites()
-	err = runtime.ExecuteTransaction(insertTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: insertTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	cStorageKey := []byte("storage\x1fc")
@@ -715,7 +810,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: readTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"2"}, loggedMessages)
@@ -882,7 +985,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 	nextTransactionLocation := newTransactionLocationGenerator()
 
 	clearReadsAndWrites()
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
@@ -890,7 +1001,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 	assert.Len(t, writes, 1)
 
 	clearReadsAndWrites()
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	cStorageKey := []byte("storage\x1fc")
@@ -929,7 +1048,15 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 	clearReadsAndWrites()
 	loggedMessages = nil
 
-	err = runtime.ExecuteTransaction(transferTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: transferTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	require.Len(t, writes, 7)
@@ -1035,16 +1162,48 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Removal(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(borrowTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: borrowTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(loadTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: loadTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -1117,13 +1276,38 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Destruction(t *testing.T
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(testTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: testTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -1233,16 +1417,48 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Insertion(t *testing.T) 
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(borrowTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: borrowTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(loadTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: loadTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -1353,26 +1569,74 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_ValueTransferAndDestroy(
 	nextTransactionLocation := newTransactionLocationGenerator()
 
 	signers = []Address{signer1}
-	err := runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	signers = []Address{signer2}
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	signers = []Address{signer3}
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	signers = []Address{signer2}
-	err = runtime.ExecuteTransaction(mintTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: mintTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	signers = []Address{signer2, signer3}
-	err = runtime.ExecuteTransaction(transferTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: transferTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	signers = []Address{signer3}
-	err = runtime.ExecuteTransaction(destroyTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: destroyTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }

--- a/runtime/interpreter/valuedeclaration.go
+++ b/runtime/interpreter/valuedeclaration.go
@@ -16,26 +16,14 @@
  * limitations under the License.
  */
 
-package sema
+package interpreter
 
 import (
 	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
 )
 
 type ValueDeclaration interface {
 	ValueDeclarationName() string
-	ValueDeclarationType() Type
-	ValueDeclarationKind() common.DeclarationKind
-	ValueDeclarationPosition() ast.Position
-	ValueDeclarationIsConstant() bool
-	ValueDeclarationArgumentLabels() []string
+	ValueDeclarationValue() Value
 	ValueDeclarationAvailable(ast.Location) bool
-}
-
-type TypeDeclaration interface {
-	TypeDeclarationName() string
-	TypeDeclarationType() Type
-	TypeDeclarationKind() common.DeclarationKind
-	TypeDeclarationPosition() ast.Position
 }

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -1,0 +1,150 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/checker"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestRuntimePredeclaredValues(t *testing.T) {
+
+	t.Parallel()
+
+	// Declare four programs.
+	// Program 0x1 imports 0x2, 0x3, and 0x4.
+	// All programs attempt to call a function 'foo'.
+	// Only predeclare a function 'foo' for 0x2 and 0x4.
+	// Both functions have the same name, but different types.
+
+	address2 := common.BytesToAddress([]byte{0x2})
+	address3 := common.BytesToAddress([]byte{0x3})
+	address4 := common.BytesToAddress([]byte{0x4})
+
+	valueDeclaration1 := ValueDeclaration{
+		Name: "foo",
+		Type: &sema.FunctionType{
+			ReturnTypeAnnotation: &sema.TypeAnnotation{
+				Type: sema.VoidType,
+			},
+		},
+		Kind:           common.DeclarationKindFunction,
+		IsConstant:     true,
+		ArgumentLabels: nil,
+		Available: func(location ast.Location) bool {
+			addressLocation, ok := location.(ast.AddressLocation)
+			return ok && addressLocation.Address == address2
+		},
+		Value: nil,
+	}
+
+	valueDeclaration2 := ValueDeclaration{
+		Name: "foo",
+		Type: &sema.FunctionType{
+			Parameters: []*sema.Parameter{
+				{
+					Label:          sema.ArgumentLabelNotRequired,
+					Identifier:     "n",
+					TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+				},
+			},
+			ReturnTypeAnnotation: &sema.TypeAnnotation{
+				Type: sema.VoidType,
+			},
+		},
+		Kind:           common.DeclarationKindFunction,
+		IsConstant:     true,
+		ArgumentLabels: nil,
+		Available: func(location ast.Location) bool {
+			addressLocation, ok := location.(ast.AddressLocation)
+			return ok && addressLocation.Address == address4
+		},
+		Value: nil,
+	}
+
+	program2 := []byte(`pub contract C2 { pub fun main() { foo() } }`)
+	program3 := []byte(`pub contract C3 { pub fun main() { foo() } }`)
+	program4 := []byte(`pub contract C4 { pub fun main() { foo(1) } }`)
+
+	program1 := []byte(`
+	  import 0x2
+	  import 0x3
+	  import 0x4
+
+	  pub fun main() {
+		  foo()
+	  }
+	`)
+
+	runtime := NewInterpreterRuntime()
+
+	runtimeInterface := &testRuntimeInterface{
+		getAccountContractCode: func(address Address, name string) (bytes []byte, err error) {
+			switch address {
+			case address2:
+				return program2, nil
+			case address3:
+				return program3, nil
+			case address4:
+				return program4, nil
+			default:
+				return nil, fmt.Errorf("unknown address: %s", address.ShortHexWithPrefix())
+			}
+		},
+	}
+
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: program1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  ScriptLocation{},
+			PredeclaredValues: []ValueDeclaration{
+				valueDeclaration1,
+				valueDeclaration2,
+			},
+		},
+	)
+
+	var checkerErr *sema.CheckerError
+	utils.RequireErrorAs(t, err, &checkerErr)
+
+	errs := checker.ExpectCheckerErrors(t, err, 2)
+
+	// The illegal use of 'foo' in 0x3 should be reported
+
+	var importedProgramError *sema.ImportedProgramError
+	utils.RequireErrorAs(t, errs[0], &importedProgramError)
+	//require.Equal(t, location3, importedProgramError.ImportLocation)
+	importedErrs := checker.ExpectCheckerErrors(t, importedProgramError.CheckerError, 1)
+	require.IsType(t, &sema.NotDeclaredError{}, importedErrs[0])
+
+	// The illegal use of 'foo' in 0x1 should be reported
+
+	require.IsType(t, &sema.NotDeclaredError{}, errs[1])
+}

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -46,7 +46,7 @@ func NewREPL(onError func(error), onResult func(interpreter.Value), checkerOptio
 
 	checkerOptions = append(
 		[]sema.Option{
-			sema.WithPredeclaredValues(valueDeclarations.ToValueDeclarations()),
+			sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 			sema.WithPredeclaredTypes(typeDeclarations),
 			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
 		},
@@ -62,13 +62,13 @@ func NewREPL(onError func(error), onResult func(interpreter.Value), checkerOptio
 		return nil, err
 	}
 
-	values := valueDeclarations.ToValues()
+	values := valueDeclarations.ToInterpreterValueDeclarations()
 
 	var uuid uint64
 
 	inter, err := interpreter.NewInterpreter(
 		checker,
-		interpreter.WithPredefinedValues(values),
+		interpreter.WithPredeclaredValues(values),
 		interpreter.WithUUIDHandler(func() (uint64, error) {
 			defer func() { uuid++ }()
 			return uuid, nil

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -378,7 +378,15 @@ func TestRuntimeImport(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	value, err := runtime.ExecuteScript(script, nil, runtimeInterface, nextTransactionLocation())
+	value, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, cadence.NewInt(42), value)
@@ -436,7 +444,13 @@ func TestRuntimeProgramCache(t *testing.T) {
 		scriptLocation := ast.StringLocation("placeholder")
 
 		// Initial call, should parse script, store result in cache.
-		_, err := runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
+		_, err := runtime.ParseAndCheckProgram(
+			script,
+			Context{
+				Interface: runtimeInterface,
+				Location:  scriptLocation,
+			},
+		)
 		assert.NoError(t, err)
 
 		// Program was added to cache.
@@ -461,7 +475,13 @@ func TestRuntimeProgramCache(t *testing.T) {
 		scriptLocation := ast.StringLocation("placeholder")
 
 		// Call a second time to hit the cache
-		_, err := runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
+		_, err := runtime.ParseAndCheckProgram(
+			script,
+			Context{
+				Interface: runtimeInterface,
+				Location:  scriptLocation,
+			},
+		)
 		assert.NoError(t, err)
 
 		// Script was in cache.
@@ -481,7 +501,13 @@ func TestRuntimeProgramCache(t *testing.T) {
 		scriptLocation := ast.StringLocation("placeholder")
 
 		// Call a second time to hit the cache
-		_, err := runtime.ParseAndCheckProgram(script, runtimeInterface, scriptLocation)
+		_, err := runtime.ParseAndCheckProgram(
+			script,
+			Context{
+				Interface: runtimeInterface,
+				Location:  scriptLocation,
+			},
+		)
 		assert.NoError(t, err)
 
 		// Script was in cache.
@@ -520,7 +546,15 @@ func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	assert.Error(t, err)
 }
 
@@ -553,7 +587,15 @@ func TestRuntimeTransactionWithAccount(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, "0x2a", loggedMessage)
@@ -837,10 +879,14 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			}
 
 			err := rt.ExecuteTransaction(
-				[]byte(tt.script),
-				tt.args,
-				runtimeInterface,
-				utils.TestLocation,
+				Script{
+					Source:    []byte(tt.script),
+					Arguments: tt.args,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  utils.TestLocation,
+				},
 			)
 
 			if tt.check != nil {
@@ -1111,10 +1157,14 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			}
 
 			_, err := rt.ExecuteScript(
-				[]byte(tt.script),
-				tt.args,
-				runtimeInterface,
-				utils.TestLocation,
+				Script{
+					Source:    []byte(tt.script),
+					Arguments: tt.args,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  utils.TestLocation,
+				},
 			)
 
 			if tt.check != nil {
@@ -1149,7 +1199,15 @@ func TestRuntimeProgramWithNoTransaction(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 
 	utils.RequireErrorAs(t, err, &InvalidTransactionCountError{})
 }
@@ -1173,7 +1231,15 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 
 	utils.RequireErrorAs(t, err, &InvalidTransactionCountError{})
 }
@@ -1287,7 +1353,15 @@ func TestRuntimeStorage(t *testing.T) {
 
 			nextTransactionLocation := newTransactionLocationGenerator()
 
-			err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source: script,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 			require.NoError(t, err)
 
 			assert.Equal(t, []string{"true", "true"}, loggedMessages)
@@ -1382,13 +1456,37 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script3, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script3,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -1458,10 +1556,26 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Contains(t, loggedMessages, "42")
@@ -1534,10 +1648,26 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Contains(t, loggedMessages, "42")
@@ -1608,10 +1738,26 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -1678,10 +1824,26 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"\"x!\""}, loggedMessages)
@@ -1753,10 +1915,26 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"\"x!\""}, loggedMessages)
@@ -1842,10 +2020,26 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"\"x!\""}, loggedMessages)
@@ -1863,7 +2057,13 @@ func TestParseAndCheckProgram(t *testing.T) {
 
 		nextTransactionLocation := newTransactionLocationGenerator()
 
-		_, err := runtime.ParseAndCheckProgram(script, runtimeInterface, nextTransactionLocation())
+		_, err := runtime.ParseAndCheckProgram(
+			script,
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		assert.NoError(t, err)
 	})
 
@@ -1875,7 +2075,13 @@ func TestParseAndCheckProgram(t *testing.T) {
 
 		nextTransactionLocation := newTransactionLocationGenerator()
 
-		_, err := runtime.ParseAndCheckProgram(script, runtimeInterface, nextTransactionLocation())
+		_, err := runtime.ParseAndCheckProgram(
+			script,
+			Context{
+				runtimeInterface,
+				nextTransactionLocation(),
+			},
+		)
 		assert.NotNil(t, err)
 	})
 
@@ -1887,7 +2093,13 @@ func TestParseAndCheckProgram(t *testing.T) {
 
 		nextTransactionLocation := newTransactionLocationGenerator()
 
-		_, err := runtime.ParseAndCheckProgram(script, runtimeInterface, nextTransactionLocation())
+		_, err := runtime.ParseAndCheckProgram(
+			script,
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		assert.NotNil(t, err)
 	})
 }
@@ -1908,7 +2120,15 @@ func TestScriptReturnTypeNotReturnableError(t *testing.T) {
 
 		nextTransactionLocation := newTransactionLocationGenerator()
 
-		actual, err := runtime.ExecuteScript([]byte(code), nil, runtimeInterface, nextTransactionLocation())
+		actual, err := runtime.ExecuteScript(
+			Script{
+				Source: []byte(code),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 
 		if expected == nil {
 			require.IsType(t, &InvalidScriptReturnTypeError{}, err)
@@ -1990,7 +2210,15 @@ func TestScriptParameterTypeNotStorableError(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	_, err := runtime.ExecuteScript(script, nil, runtimeInterface, nextTransactionLocation())
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	assert.IsType(t, &ScriptParameterTypeNotStorableError{}, err)
 }
 
@@ -2014,7 +2242,15 @@ func TestRuntimeSyntaxError(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	_, err := runtime.ExecuteScript(script, nil, runtimeInterface, nextTransactionLocation())
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	assert.Error(t, err)
 }
 
@@ -2084,10 +2320,26 @@ func TestRuntimeStorageChanges(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"1"}, loggedMessages)
@@ -2122,7 +2374,15 @@ func TestRuntimeAccountAddress(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"0x2a"}, loggedMessages)
@@ -2157,7 +2417,15 @@ func TestRuntimePublicAccountAddress(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{fmt.Sprint(address)}, loggedMessages)
@@ -2232,10 +2500,26 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(script2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"42"}, loggedMessages)
@@ -2273,7 +2557,15 @@ func TestRuntimeTransaction_CreateAccount(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	require.Len(t, events, 1)
@@ -2375,7 +2667,16 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 				}
 			}
 
-			err := runtime.ExecuteTransaction([]byte(tt.code), args, runtimeInterface, utils.TestLocation)
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source:    []byte(tt.code),
+					Arguments: args,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  utils.TestLocation,
+				},
+			)
 			require.NoError(t, err)
 			assert.Len(t, events, tt.keyCount+1)
 			assert.Len(t, keys, tt.keyCount)
@@ -2563,7 +2864,15 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 			nextTransactionLocation := newTransactionLocationGenerator()
 
-			err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source: script,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 			exportedEventType := ExportType(
 				stdlib.AccountContractAddedEventType,
 				map[sema.TypeID]cadence.Type{},
@@ -2648,20 +2957,44 @@ func TestRuntimeContractAccount(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
 
 	t.Run("", func(t *testing.T) {
-		value, err := runtime.ExecuteScript(script1, nil, runtimeInterface, nextTransactionLocation())
+		value, err := runtime.ExecuteScript(
+			Script{
+				Source: script1,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		require.NoError(t, err)
 
 		assert.Equal(t, addressValue, value)
 	})
 
 	t.Run("", func(t *testing.T) {
-		value, err := runtime.ExecuteScript(script2, nil, runtimeInterface, nextTransactionLocation())
+		value, err := runtime.ExecuteScript(
+			Script{
+				Source: script2,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		require.NoError(t, err)
 
 		assert.Equal(t, addressValue, value)
@@ -2723,7 +3056,7 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(address Address, _ string, code []byte) error {
+		updateAccountContractCode: func(addess Address, _ string, code []byte) error {
 			accountCode = code
 			return nil
 		},
@@ -2735,12 +3068,28 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
 
-	err = runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, `"Hello World!"`, loggedMessage)
@@ -2941,15 +3290,39 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(setup1Transaction, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setup1Transaction,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	signerAccount = address2Value
 
-	err = runtime.ExecuteTransaction(setup2Transaction, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setup2Transaction,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -3065,13 +3438,37 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(setup1Transaction, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setup1Transaction,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(setup2Transaction, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setup2Transaction,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -3207,27 +3604,38 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
+	deployTransaction := makeDeployTransaction("TestContractInterface", contractInterfaceCode)
 	err := runtime.ExecuteTransaction(
-		makeDeployTransaction("TestContractInterface", contractInterfaceCode),
-		nil,
-		runtimeInterface,
-		nextTransactionLocation(),
+		Script{
+			Source: deployTransaction,
+		},
+		Context{
+			runtimeInterface,
+			nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	deployTransaction = makeDeployTransaction("TestContract", contractCode)
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: deployTransaction,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
 	)
 	require.NoError(t, err)
 
 	err = runtime.ExecuteTransaction(
-		makeDeployTransaction("TestContract", contractCode),
-		nil,
-		runtimeInterface,
-		nextTransactionLocation(),
-	)
-	require.NoError(t, err)
-
-	err = runtime.ExecuteTransaction(
-		setupCode,
-		nil,
-		runtimeInterface,
-		nextTransactionLocation(),
+		Script{
+			Source: setupCode,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
 	)
 	require.NoError(t, err)
 
@@ -3237,10 +3645,13 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 			t.Run(fmt.Sprintf("%d/%d", a, b), func(t *testing.T) {
 
 				err = runtime.ExecuteTransaction(
-					makeUseCode(a, b),
-					nil,
-					runtimeInterface,
-					nextTransactionLocation(),
+					Script{
+						Source: makeUseCode(a, b),
+					},
+					Context{
+						Interface: runtimeInterface,
+						Location:  nextTransactionLocation(),
+					},
 				)
 
 				if a == 2 && b == 2 {
@@ -3294,7 +3705,15 @@ func TestRuntimeBlock(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3342,7 +3761,15 @@ func TestUnsafeRandom(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3374,7 +3801,15 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 
 		nextTransactionLocation := newTransactionLocationGenerator()
 
-		err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		require.NoError(t, err)
 	})
 
@@ -3395,7 +3830,15 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 
 		nextTransactionLocation := newTransactionLocationGenerator()
 
-		err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
 		require.Error(t, err)
 
 		require.IsType(t, Error{}, err)
@@ -3467,7 +3910,15 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 
 			nextTransactionLocation := newTransactionLocationGenerator()
 
-			err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source: deploy,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 			require.NoError(t, err)
 
 			assert.NotNil(t, accountCode)
@@ -3590,10 +4041,26 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3606,7 +4073,15 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 	)
 
 	loggedMessages = nil
-	err = runtime.ExecuteTransaction(tx2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3746,10 +4221,26 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3765,7 +4256,15 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 	)
 
 	loggedMessages = nil
-	err = runtime.ExecuteTransaction(tx2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3907,10 +4406,26 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -3926,7 +4441,15 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 	)
 
 	loggedMessages = nil
-	err = runtime.ExecuteTransaction(tx2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -4014,7 +4537,15 @@ func TestRuntimeComputationLimit(t *testing.T) {
 
 			nextTransactionLocation := newTransactionLocationGenerator()
 
-			err := runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+			err := runtime.ExecuteTransaction(
+				Script{
+					Source: script,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 			if test.ok {
 				require.NoError(t, err)
 			} else {
@@ -4139,7 +4670,15 @@ func TestRuntimeMetrics(t *testing.T) {
 	nextTransactionLocation := newTransactionLocationGenerator()
 
 	transactionLocation := nextTransactionLocation()
-	err := runtime.ExecuteTransaction(script1, nil, i1, transactionLocation)
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: i1,
+			Location:  transactionLocation,
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -4169,7 +4708,15 @@ func TestRuntimeMetrics(t *testing.T) {
 
 	transactionLocation = nextTransactionLocation()
 
-	err = runtime.ExecuteTransaction(script2, nil, i2, transactionLocation)
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: i2,
+			Location:  transactionLocation,
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -4295,19 +4842,43 @@ func TestRuntimeContractWriteback(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
 
 	assert.Len(t, writes, 1)
 
-	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: readTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, writes, 1)
 
-	err = runtime.ExecuteTransaction(writeTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: writeTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, writes, 2)
@@ -4393,14 +4964,30 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(deploy, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
 
 	assert.Len(t, writes, 1)
 
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, writes, 2)
@@ -4416,7 +5003,15 @@ func TestRuntimeStorageWriteback(t *testing.T) {
       }
     `)
 
-	err = runtime.ExecuteTransaction(readTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: readTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, writes, 2)
@@ -4433,7 +5028,15 @@ func TestRuntimeStorageWriteback(t *testing.T) {
       }
     `)
 
-	err = runtime.ExecuteTransaction(writeTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: writeTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Len(t, writes, 3)
@@ -4471,7 +5074,15 @@ func TestRuntimeExternalError(t *testing.T) {
 			Recovered: logPanic{},
 		},
 		func() {
-			_ = runtime.ExecuteTransaction(script, nil, runtimeInterface, nextTransactionLocation())
+			_ = runtime.ExecuteTransaction(
+				Script{
+					Source: script,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
 		},
 	)
 }
@@ -4576,21 +5187,45 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 
 	signerAddresses = []Address{{accountCounter}}
 
-	err := runtime.ExecuteTransaction(createAccountTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: createAccountTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	// deploy the contract
 
 	signerAddresses = []Address{{accountCounter}}
 
-	err = runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	// call the hello function
 
 	callTx := []byte(fmt.Sprintf(callHelloTxTemplate, Address{accountCounter}))
 
-	err = runtime.ExecuteTransaction(callTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: callTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -4699,7 +5334,15 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	signerAddresses = []Address{{accountCounter}}
 
-	err := runtime.ExecuteTransaction(createAccountTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: createAccountTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	// deploy the contract
@@ -4708,7 +5351,15 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	signerAddresses = []Address{{accountCounter}}
 
-	err = runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 	require.Empty(t, cacheHits)
 
@@ -4716,7 +5367,15 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	callScript := []byte(fmt.Sprintf(callHelloScriptTemplate, Address{accountCounter}))
 
-	result1, err := runtime.ExecuteScript(callScript, nil, runtimeInterface, nextTransactionLocation())
+	result1, err := runtime.ExecuteScript(
+		Script{
+			Source: callScript,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 	require.Equal(t, cadence.NewString("1"), result1)
 
@@ -4724,13 +5383,29 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	cacheHits = nil
 
-	err = runtime.ExecuteTransaction(updateTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: updateTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 	require.Empty(t, cacheHits)
 
 	// call the new hello function
 
-	result2, err := runtime.ExecuteScript(callScript, nil, runtimeInterface, nextTransactionLocation())
+	result2, err := runtime.ExecuteScript(
+		Script{
+			Source: callScript,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 	require.Equal(t, cadence.NewString("2"), result2)
 }
@@ -4841,19 +5516,43 @@ func TestRuntimeNoCacheHitForToplevelPrograms(t *testing.T) {
 
 	// create the account
 
-	err := runtime.ExecuteTransaction(createAccountTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: createAccountTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	signerAddresses = []Address{{accountCounter}}
 
-	err = runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	// call the function
 
 	callTx := []byte(fmt.Sprintf(callHelloTxTemplate, Address{accountCounter}))
 
-	err = runtime.ExecuteTransaction(callTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: callTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	// We should only receive a cache hit for the imported program, not the transactions/scripts.
@@ -4995,7 +5694,15 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 	deployTx1 := newDeployTransaction("add", "Test", contract1)
 
-	err := runtime.ExecuteTransaction(deployTx1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	script1 := []byte(`
@@ -5014,12 +5721,28 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
       }
     `)
 
-	_, err = runtime.ExecuteScript(script1, nil, runtimeInterface, nextTransactionLocation())
+	_, err = runtime.ExecuteScript(
+		Script{
+			Source: script1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	deployTx2 := newDeployTransaction("update__experimental", "Test", contract2)
 
-	err = runtime.ExecuteTransaction(deployTx2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	script2 := []byte(`
@@ -5039,7 +5762,15 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
       }
     `)
 
-	_, err = runtime.ExecuteScript(script2, nil, runtimeInterface, nextTransactionLocation())
+	_, err = runtime.ExecuteScript(
+		Script{
+			Source: script2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 }
 
@@ -5070,7 +5801,16 @@ func TestRuntime(t *testing.T) {
 
 			t.Parallel()
 
-			_, err := runtime.ExecuteScript(script, tc.arguments, runtimeInterface, ScriptLocation{0x1})
+			_, err := runtime.ExecuteScript(
+				Script{
+					Source:    script,
+					Arguments: tc.arguments,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  ScriptLocation{0x1},
+				},
+			)
 
 			if tc.valid {
 				require.NoError(t, err)
@@ -5145,6 +5885,14 @@ func TestPanics(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	_, err := runtime.ExecuteScript(script, nil, runtimeInterface, nextTransactionLocation())
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	assert.Error(t, err)
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2078,8 +2078,8 @@ func TestParseAndCheckProgram(t *testing.T) {
 		_, err := runtime.ParseAndCheckProgram(
 			script,
 			Context{
-				runtimeInterface,
-				nextTransactionLocation(),
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
 			},
 		)
 		assert.NotNil(t, err)
@@ -3610,8 +3610,8 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 			Source: deployTransaction,
 		},
 		Context{
-			runtimeInterface,
-			nextTransactionLocation(),
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/sema/basefunction.go
+++ b/runtime/sema/basefunction.go
@@ -1,0 +1,54 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+type baseFunction struct {
+	name           string
+	invokableType  InvokableType
+	argumentLabels []string
+}
+
+func (f baseFunction) ValueDeclarationType() Type {
+	return f.invokableType
+}
+
+func (baseFunction) ValueDeclarationKind() common.DeclarationKind {
+	return common.DeclarationKindFunction
+}
+
+func (baseFunction) ValueDeclarationPosition() ast.Position {
+	return ast.Position{}
+}
+
+func (baseFunction) ValueDeclarationIsConstant() bool {
+	return true
+}
+
+func (baseFunction) ValueDeclarationAvailable(_ ast.Location) bool {
+	return true
+}
+
+func (f baseFunction) ValueDeclarationArgumentLabels() []string {
+	return f.argumentLabels
+}

--- a/runtime/sema/basefunction.go
+++ b/runtime/sema/basefunction.go
@@ -29,6 +29,10 @@ type baseFunction struct {
 	argumentLabels []string
 }
 
+func (f baseFunction) ValueDeclarationName() string {
+	return f.name
+}
+
 func (f baseFunction) ValueDeclarationType() Type {
 	return f.invokableType
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -122,7 +122,10 @@ func WithPredeclaredValues(predeclaredValues map[string]ValueDeclaration) Option
 		checker.PredeclaredValues = predeclaredValues
 
 		for name, declaration := range predeclaredValues {
-			checker.declareValue(name, declaration)
+			variable := checker.declareValue(name, declaration)
+			if variable == nil {
+				continue
+			}
 			checker.declareGlobalValue(name)
 		}
 
@@ -282,12 +285,20 @@ func (checker *Checker) SetAllCheckers(allCheckers map[ast.LocationID]*Checker) 
 func (checker *Checker) declareBaseValues() {
 	for name, declaration := range BaseValues {
 		variable := checker.declareValue(name, declaration)
+		if variable == nil {
+			continue
+		}
 		variable.IsBaseValue = true
 		checker.declareGlobalValue(name)
 	}
 }
 
 func (checker *Checker) declareValue(name string, declaration ValueDeclaration) *Variable {
+
+	if !declaration.ValueDeclarationAvailable(checker.Location) {
+		return nil
+	}
+
 	variable, err := checker.valueActivations.Declare(variableDeclaration{
 		identifier: name,
 		ty:         declaration.ValueDeclarationType(),

--- a/runtime/sema/declarations.go
+++ b/runtime/sema/declarations.go
@@ -29,6 +29,7 @@ type ValueDeclaration interface {
 	ValueDeclarationPosition() ast.Position
 	ValueDeclarationIsConstant() bool
 	ValueDeclarationArgumentLabels() []string
+	ValueDeclarationAvailable(ast.Location) bool
 }
 
 type TypeDeclaration interface {

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -66,12 +66,11 @@ func (i CheckerImport) AllValueElements() map[string]ImportElement {
 }
 
 func (i CheckerImport) IsImportableValue(name string) bool {
-	_, isBaseValue := BaseValues[name]
-	if isBaseValue {
+	if _, ok := BaseValues[name]; ok {
 		return false
 	}
 
-	_, isPredeclaredValue := i.Checker.PredeclaredValues[name]
+	_, isPredeclaredValue := i.Checker.effectivePredeclaredValues[name]
 	return !isPredeclaredValue
 }
 
@@ -80,7 +79,11 @@ func (i CheckerImport) AllTypeElements() map[string]ImportElement {
 }
 
 func (i CheckerImport) IsImportableType(name string) bool {
-	_, isPredeclaredType := i.Checker.PredeclaredTypes[name]
+	if _, ok := baseTypes[name]; ok {
+		return false
+	}
+
+	_, isPredeclaredType := i.Checker.effectivePredeclaredTypes[name]
 	return !isPredeclaredType
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4518,6 +4518,9 @@ func init() {
 }
 
 func init() {
+
+	// Declare a conversion function for the address type
+
 	addressType := &AddressType{}
 	typeName := addressType.String()
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4411,35 +4411,9 @@ func init() {
 	}
 }
 
-// baseValues are the values available in programs
-
+// BaseValues are the values available in programs
+//
 var BaseValues = map[string]ValueDeclaration{}
-
-type baseFunction struct {
-	name           string
-	invokableType  InvokableType
-	argumentLabels []string
-}
-
-func (f baseFunction) ValueDeclarationType() Type {
-	return f.invokableType
-}
-
-func (baseFunction) ValueDeclarationKind() common.DeclarationKind {
-	return common.DeclarationKindFunction
-}
-
-func (baseFunction) ValueDeclarationPosition() ast.Position {
-	return ast.Position{}
-}
-
-func (baseFunction) ValueDeclarationIsConstant() bool {
-	return true
-}
-
-func (f baseFunction) ValueDeclarationArgumentLabels() []string {
-	return f.argumentLabels
-}
 
 var AllSignedFixedPointTypes = []Type{
 	&Fix64Type{},

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -39,13 +39,13 @@ func TestAssert(t *testing.T) {
 	checker, err := sema.NewChecker(
 		program,
 		utils.TestLocation,
-		sema.WithPredeclaredValues(BuiltinFunctions.ToValueDeclarations()),
+		sema.WithPredeclaredValues(BuiltinFunctions.ToSemaValueDeclarations()),
 	)
 	require.Nil(t, err)
 
 	inter, err := interpreter.NewInterpreter(
 		checker,
-		interpreter.WithPredefinedValues(BuiltinFunctions.ToValues()),
+		interpreter.WithPredeclaredValues(BuiltinFunctions.ToInterpreterValueDeclarations()),
 	)
 	require.Nil(t, err)
 
@@ -88,13 +88,13 @@ func TestPanic(t *testing.T) {
 	checker, err := sema.NewChecker(
 		&ast.Program{},
 		utils.TestLocation,
-		sema.WithPredeclaredValues(BuiltinFunctions.ToValueDeclarations()),
+		sema.WithPredeclaredValues(BuiltinFunctions.ToSemaValueDeclarations()),
 	)
 	require.Nil(t, err)
 
 	inter, err := interpreter.NewInterpreter(
 		checker,
-		interpreter.WithPredefinedValues(BuiltinFunctions.ToValues()),
+		interpreter.WithPredeclaredValues(BuiltinFunctions.ToInterpreterValueDeclarations()),
 	)
 	require.Nil(t, err)
 

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -46,7 +46,7 @@ var CryptoChecker = func() *sema.Checker {
 	checker, err = sema.NewChecker(
 		program,
 		location,
-		sema.WithPredeclaredValues(BuiltinFunctions.ToValueDeclarations()),
+		sema.WithPredeclaredValues(BuiltinFunctions.ToSemaValueDeclarations()),
 		sema.WithPredeclaredTypes(BuiltinTypes.ToTypeDeclarations()),
 	)
 	if err != nil {

--- a/runtime/stdlib/functions.go
+++ b/runtime/stdlib/functions.go
@@ -37,6 +37,14 @@ type StandardLibraryFunction struct {
 	Available      func(ast.Location) bool
 }
 
+func (f StandardLibraryFunction) ValueDeclarationName() string {
+	return f.Name
+}
+
+func (f StandardLibraryFunction) ValueDeclarationValue() interpreter.Value {
+	return f.Function
+}
+
 func (f StandardLibraryFunction) ValueDeclarationType() sema.Type {
 	return f.Type
 }
@@ -91,20 +99,20 @@ func NewStandardLibraryFunction(
 
 type StandardLibraryFunctions []StandardLibraryFunction
 
-func (functions StandardLibraryFunctions) ToValueDeclarations() map[string]sema.ValueDeclaration {
-	valueDeclarations := make(map[string]sema.ValueDeclaration, len(functions))
-	for _, function := range functions {
-		valueDeclarations[function.Name] = function
+func (functions StandardLibraryFunctions) ToSemaValueDeclarations() []sema.ValueDeclaration {
+	valueDeclarations := make([]sema.ValueDeclaration, len(functions))
+	for i, function := range functions {
+		valueDeclarations[i] = function
 	}
 	return valueDeclarations
 }
 
-func (functions StandardLibraryFunctions) ToValues() map[string]interpreter.Value {
-	values := make(map[string]interpreter.Value, len(functions))
-	for _, function := range functions {
-		values[function.Name] = function.Function
+func (functions StandardLibraryFunctions) ToInterpreterValueDeclarations() []interpreter.ValueDeclaration {
+	valueDeclarations := make([]interpreter.ValueDeclaration, len(functions))
+	for i, function := range functions {
+		valueDeclarations[i] = function
 	}
-	return values
+	return valueDeclarations
 }
 
 // AssertionError

--- a/runtime/stdlib/functions.go
+++ b/runtime/stdlib/functions.go
@@ -34,6 +34,7 @@ type StandardLibraryFunction struct {
 	Type           sema.InvokableType
 	Function       interpreter.HostFunctionValue
 	ArgumentLabels []string
+	Available      func(ast.Location) bool
 }
 
 func (f StandardLibraryFunction) ValueDeclarationType() sema.Type {
@@ -50,6 +51,13 @@ func (StandardLibraryFunction) ValueDeclarationPosition() ast.Position {
 
 func (StandardLibraryFunction) ValueDeclarationIsConstant() bool {
 	return true
+}
+
+func (f StandardLibraryFunction) ValueDeclarationAvailable(location ast.Location) bool {
+	if f.Available == nil {
+		return true
+	}
+	return f.Available(location)
 }
 
 func (f StandardLibraryFunction) ValueDeclarationArgumentLabels() []string {

--- a/runtime/stdlib/types.go
+++ b/runtime/stdlib/types.go
@@ -30,6 +30,10 @@ type StandardLibraryType struct {
 	Kind common.DeclarationKind
 }
 
+func (t StandardLibraryType) TypeDeclarationName() string {
+	return t.Name
+}
+
 func (t StandardLibraryType) TypeDeclarationType() sema.Type {
 	return t.Type
 }
@@ -46,10 +50,10 @@ func (StandardLibraryType) TypeDeclarationPosition() ast.Position {
 
 type StandardLibraryTypes []StandardLibraryType
 
-func (types StandardLibraryTypes) ToTypeDeclarations() map[string]sema.TypeDeclaration {
-	valueDeclarations := make(map[string]sema.TypeDeclaration, len(types))
-	for _, ty := range types {
-		valueDeclarations[ty.Name] = ty
+func (types StandardLibraryTypes) ToTypeDeclarations() []sema.TypeDeclaration {
+	valueDeclarations := make([]sema.TypeDeclaration, len(types))
+	for i, ty := range types {
+		valueDeclarations[i] = ty
 	}
 	return valueDeclarations
 }

--- a/runtime/stdlib/value.go
+++ b/runtime/stdlib/value.go
@@ -29,6 +29,7 @@ type StandardLibraryValue struct {
 	Type       sema.Type
 	Kind       common.DeclarationKind
 	IsConstant bool
+	Available  func(ast.Location) bool
 }
 
 func (v StandardLibraryValue) ValueDeclarationType() sema.Type {
@@ -48,6 +49,13 @@ func (StandardLibraryValue) ValueDeclarationPosition() ast.Position {
 
 func (v StandardLibraryValue) ValueDeclarationIsConstant() bool {
 	return v.IsConstant
+}
+
+func (f StandardLibraryValue) ValueDeclarationAvailable(location ast.Location) bool {
+	if f.Available == nil {
+		return true
+	}
+	return f.Available(location)
 }
 
 func (StandardLibraryValue) ValueDeclarationArgumentLabels() []string {

--- a/runtime/stdlib/value.go
+++ b/runtime/stdlib/value.go
@@ -21,15 +21,25 @@ package stdlib
 import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
 type StandardLibraryValue struct {
 	Name       string
 	Type       sema.Type
+	Value      interpreter.Value
 	Kind       common.DeclarationKind
 	IsConstant bool
 	Available  func(ast.Location) bool
+}
+
+func (v StandardLibraryValue) ValueDeclarationName() string {
+	return v.Name
+}
+
+func (v StandardLibraryValue) ValueDeclarationValue() interpreter.Value {
+	return v.Value
 }
 
 func (v StandardLibraryValue) ValueDeclarationType() sema.Type {
@@ -51,11 +61,11 @@ func (v StandardLibraryValue) ValueDeclarationIsConstant() bool {
 	return v.IsConstant
 }
 
-func (f StandardLibraryValue) ValueDeclarationAvailable(location ast.Location) bool {
-	if f.Available == nil {
+func (v StandardLibraryValue) ValueDeclarationAvailable(location ast.Location) bool {
+	if v.Available == nil {
 		return true
 	}
-	return f.Available(location)
+	return v.Available(location)
 }
 
 func (StandardLibraryValue) ValueDeclarationArgumentLabels() []string {
@@ -66,10 +76,18 @@ func (StandardLibraryValue) ValueDeclarationArgumentLabels() []string {
 
 type StandardLibraryValues []StandardLibraryValue
 
-func (functions StandardLibraryValues) ToValueDeclarations() map[string]sema.ValueDeclaration {
-	valueDeclarations := make(map[string]sema.ValueDeclaration, len(functions))
-	for _, function := range functions {
-		valueDeclarations[function.Name] = function
+func (values StandardLibraryValues) ToSemaValueDeclarations() []sema.ValueDeclaration {
+	valueDeclarations := make([]sema.ValueDeclaration, len(values))
+	for i, function := range values {
+		valueDeclarations[i] = function
+	}
+	return valueDeclarations
+}
+
+func (values StandardLibraryValues) ToInterpreterValueDeclarations() []interpreter.ValueDeclaration {
+	valueDeclarations := make([]interpreter.ValueDeclaration, len(values))
+	for i, function := range values {
+		valueDeclarations[i] = function
 	}
 	return valueDeclarations
 }

--- a/runtime/stdlib/value.go
+++ b/runtime/stdlib/value.go
@@ -26,12 +26,11 @@ import (
 )
 
 type StandardLibraryValue struct {
-	Name       string
-	Type       sema.Type
-	Value      interpreter.Value
-	Kind       common.DeclarationKind
-	IsConstant bool
-	Available  func(ast.Location) bool
+	Name      string
+	Type      sema.Type
+	Value     interpreter.Value
+	Kind      common.DeclarationKind
+	Available func(ast.Location) bool
 }
 
 func (v StandardLibraryValue) ValueDeclarationName() string {
@@ -47,10 +46,7 @@ func (v StandardLibraryValue) ValueDeclarationType() sema.Type {
 }
 
 func (v StandardLibraryValue) ValueDeclarationKind() common.DeclarationKind {
-	if v.IsConstant {
-		return common.DeclarationKindConstant
-	}
-	return common.DeclarationKindVariable
+	return v.Kind
 }
 
 func (StandardLibraryValue) ValueDeclarationPosition() ast.Position {
@@ -58,7 +54,7 @@ func (StandardLibraryValue) ValueDeclarationPosition() ast.Position {
 }
 
 func (v StandardLibraryValue) ValueDeclarationIsConstant() bool {
-	return v.IsConstant
+	return v.Kind != common.DeclarationKindVariable
 }
 
 func (v StandardLibraryValue) ValueDeclarationAvailable(location ast.Location) bool {

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -131,7 +131,15 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 
 	writes = nil
 
-	err := runtime.ExecuteTransaction(deployTx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deployTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.NotNil(t, accountCode)
@@ -169,7 +177,15 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 
 	writes = nil
 
-	err = runtime.ExecuteTransaction(setupTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: setupTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -200,7 +216,15 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 
 	writes = nil
 
-	err = runtime.ExecuteTransaction(changeTx, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: changeTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -265,7 +289,15 @@ func TestRuntimeMagic(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(tx, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: tx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t,

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -45,9 +45,9 @@ func ParseAndCheckAccount(t *testing.T, code string) (*sema.Checker, error) {
 		code,
 		ParseAndCheckOptions{
 			Options: []sema.Option{
-				sema.WithPredeclaredValues(map[string]sema.ValueDeclaration{
-					"authAccount":   constantDeclaration("authAccount", &sema.AuthAccountType{}),
-					"publicAccount": constantDeclaration("publicAccount", &sema.PublicAccountType{}),
+				sema.WithPredeclaredValues([]sema.ValueDeclaration{
+					constantDeclaration("authAccount", &sema.AuthAccountType{}),
+					constantDeclaration("publicAccount", &sema.PublicAccountType{}),
 				}),
 			},
 		},

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -34,10 +34,9 @@ func ParseAndCheckAccount(t *testing.T, code string) (*sema.Checker, error) {
 
 	constantDeclaration := func(name string, ty sema.Type) stdlib.StandardLibraryValue {
 		return stdlib.StandardLibraryValue{
-			Name:       name,
-			Type:       ty,
-			Kind:       common.DeclarationKindConstant,
-			IsConstant: true,
+			Name: name,
+			Type: ty,
+			Kind: common.DeclarationKindConstant,
 		}
 	}
 

--- a/runtime/tests/checker/assert_test.go
+++ b/runtime/tests/checker/assert_test.go
@@ -42,7 +42,7 @@ func TestCheckAssertWithoutMessage(t *testing.T) {
 				sema.WithPredeclaredValues(
 					stdlib.StandardLibraryFunctions{
 						stdlib.AssertFunction,
-					}.ToValueDeclarations(),
+					}.ToSemaValueDeclarations(),
 				),
 			},
 		},
@@ -66,7 +66,7 @@ func TestCheckAssertWithMessage(t *testing.T) {
 				sema.WithPredeclaredValues(
 					stdlib.StandardLibraryFunctions{
 						stdlib.AssertFunction,
-					}.ToValueDeclarations(),
+					}.ToSemaValueDeclarations(),
 				),
 			},
 		},

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -38,10 +38,9 @@ func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.
 			Options: []sema.Option{
 				sema.WithPredeclaredValues([]sema.ValueDeclaration{
 					stdlib.StandardLibraryValue{
-						Name:       "test",
-						Type:       ty,
-						Kind:       common.DeclarationKindConstant,
-						IsConstant: true,
+						Name: "test",
+						Type: ty,
+						Kind: common.DeclarationKindConstant,
 					},
 				}),
 			},

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -36,8 +36,8 @@ func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.
 		code,
 		ParseAndCheckOptions{
 			Options: []sema.Option{
-				sema.WithPredeclaredValues(map[string]sema.ValueDeclaration{
-					"test": stdlib.StandardLibraryValue{
+				sema.WithPredeclaredValues([]sema.ValueDeclaration{
+					stdlib.StandardLibraryValue{
 						Name:       "test",
 						Type:       ty,
 						Kind:       common.DeclarationKindConstant,

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -59,7 +59,6 @@ func TestCheckRepeatedImport(t *testing.T) {
 			Location: utils.ImportedLocation,
 		},
 	)
-
 	require.NoError(t, err)
 
 	_, err = ParseAndCheckWithOptions(t,
@@ -79,7 +78,6 @@ func TestCheckRepeatedImport(t *testing.T) {
 			},
 		},
 	)
-
 	require.NoError(t, err)
 }
 

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -335,7 +335,7 @@ func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
 								}(),
 							},
 						},
-					}.ToValueDeclarations(),
+					}.ToSemaValueDeclarations(),
 				),
 			},
 		},

--- a/runtime/tests/checker/predeclaredvalues_test.go
+++ b/runtime/tests/checker/predeclaredvalues_test.go
@@ -1,0 +1,195 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package checker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/parser2"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestCheckPredeclaredValues(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("simple", func(t *testing.T) {
+
+		valueDeclaration := stdlib.StandardLibraryFunction{
+			Name: "foo",
+			Type: &sema.FunctionType{
+				ReturnTypeAnnotation: &sema.TypeAnnotation{
+					Type: sema.VoidType,
+				},
+			},
+		}
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+            pub fun test() {
+                foo()
+            }
+        `,
+			ParseAndCheckOptions{
+				Options: []sema.Option{
+					sema.WithPredeclaredValues(
+						[]sema.ValueDeclaration{
+							valueDeclaration,
+						},
+					),
+				},
+			},
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("predicated", func(t *testing.T) {
+
+		// Declare four programs.
+		// Program 0x1 imports 0x2, 0x3, and 0x4.
+		// All programs attempt to call a function 'foo'.
+		// Only predeclare a function 'foo' for 0x2 and 0x4.
+		// Both functions have the same name, but different types.
+
+		location1 := ast.AddressLocation{
+			Address: common.BytesToAddress([]byte{0x1}),
+		}
+
+		location2 := ast.AddressLocation{
+			Address: common.BytesToAddress([]byte{0x2}),
+		}
+
+		location3 := ast.AddressLocation{
+			Address: common.BytesToAddress([]byte{0x3}),
+		}
+
+		location4 := ast.AddressLocation{
+			Address: common.BytesToAddress([]byte{0x4}),
+		}
+
+		valueDeclaration1 := stdlib.StandardLibraryFunction{
+			Name: "foo",
+			Type: &sema.FunctionType{
+				ReturnTypeAnnotation: &sema.TypeAnnotation{
+					Type: sema.VoidType,
+				},
+			},
+			Available: func(location ast.Location) bool {
+				addressLocation, ok := location.(ast.AddressLocation)
+				return ok && addressLocation == location2
+			},
+		}
+
+		valueDeclaration2 := stdlib.StandardLibraryFunction{
+			Name: "foo",
+			Type: &sema.FunctionType{
+				Parameters: []*sema.Parameter{
+					{
+						Label:          sema.ArgumentLabelNotRequired,
+						Identifier:     "n",
+						TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+					},
+				},
+				ReturnTypeAnnotation: &sema.TypeAnnotation{
+					Type: sema.VoidType,
+				},
+			},
+			Available: func(location ast.Location) bool {
+				addressLocation, ok := location.(ast.AddressLocation)
+				return ok && addressLocation == location4
+			},
+		}
+
+		program2, err := parser2.ParseProgram(`let x = foo()`)
+		require.NoError(t, err)
+
+		program3, err := parser2.ParseProgram(`let y = foo()`)
+		require.NoError(t, err)
+
+		program4, err := parser2.ParseProgram(`let z = foo(1)`)
+		require.NoError(t, err)
+
+		_, err = ParseAndCheckWithOptions(t,
+			`
+              import 0x2
+              import 0x3
+              import 0x4
+
+              fun main() {
+                  foo()
+              }
+            `,
+			ParseAndCheckOptions{
+				Location: location1,
+				Options: []sema.Option{
+					sema.WithPredeclaredValues(
+						[]sema.ValueDeclaration{
+							valueDeclaration1,
+							valueDeclaration2,
+						},
+					),
+					sema.WithImportHandler(
+						func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
+							checker, err := checker.EnsureLoaded(location, func() *ast.Program {
+								switch location {
+								case location2:
+									return program2
+								case location3:
+									return program3
+								case location4:
+									return program4
+								default:
+									t.Fatal("invalid location", location)
+									return nil
+								}
+							})
+							if err != nil {
+								return nil, err
+							}
+							return sema.CheckerImport{
+								Checker: checker,
+							}, nil
+						},
+					),
+				},
+			},
+		)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+
+		// The illegal use of 'foo' in 0x3 should be reported
+
+		var importedProgramError *sema.ImportedProgramError
+		utils.RequireErrorAs(t, errs[0], &importedProgramError)
+		require.Equal(t, location3, importedProgramError.ImportLocation)
+		importedErrs := ExpectCheckerErrors(t, importedProgramError.CheckerError, 1)
+		require.IsType(t, &sema.NotDeclaredError{}, importedErrs[0])
+
+		// The illegal use of 'foo' in 0x1 should be reported
+
+		require.IsType(t, &sema.NotDeclaredError{}, errs[1])
+	})
+}

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -188,7 +188,7 @@ func TestCheckInvalidMissingReturnStatementStructFunction(t *testing.T) {
 type exitTest struct {
 	body              string
 	exits             bool
-	valueDeclarations map[string]sema.ValueDeclaration
+	valueDeclarations []sema.ValueDeclaration
 	errors            []error
 }
 
@@ -421,7 +421,7 @@ func TestCheckNeverInvocationExits(t *testing.T) {
 
 	valueDeclarations := stdlib.StandardLibraryFunctions{
 		stdlib.PanicFunction,
-	}.ToValueDeclarations()
+	}.ToSemaValueDeclarations()
 
 	testExits(
 		t,

--- a/runtime/tests/checker/utils_test.go
+++ b/runtime/tests/checker/utils_test.go
@@ -34,7 +34,7 @@ func ParseAndCheckWithPanic(t *testing.T, code string) (*sema.Checker, error) {
 				sema.WithPredeclaredValues(
 					stdlib.StandardLibraryFunctions{
 						stdlib.PanicFunction,
-					}.ToValueDeclarations(),
+					}.ToSemaValueDeclarations(),
 				),
 			},
 		},
@@ -45,8 +45,8 @@ func ParseAndCheckWithAny(t *testing.T, code string) (*sema.Checker, error) {
 		code,
 		ParseAndCheckOptions{
 			Options: []sema.Option{
-				sema.WithPredeclaredTypes(map[string]sema.TypeDeclaration{
-					"Any": stdlib.StandardLibraryType{
+				sema.WithPredeclaredTypes([]sema.TypeDeclaration{
+					stdlib.StandardLibraryType{
 						Name: "Any",
 						Type: &sema.AnyType{},
 						Kind: common.DeclarationKindType,

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -57,8 +57,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 			panicFunction,
 			interpreter.AuthAccountContractsValue{},
 		),
-		Kind:       common.DeclarationKindConstant,
-		IsConstant: true,
+		Kind: common.DeclarationKindConstant,
 	}
 	valueDeclarations = append(valueDeclarations, authAccountValueDeclaration)
 
@@ -72,8 +71,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 			returnZero,
 			returnZero,
 		),
-		Kind:       common.DeclarationKindConstant,
-		IsConstant: true,
+		Kind: common.DeclarationKindConstant,
 	}
 	valueDeclarations = append(valueDeclarations, pubAccountValueDeclaration)
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3340,9 +3340,8 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 				Type: structType,
 			},
 		},
-		Value:      capabilityValue,
-		Kind:       common.DeclarationKindConstant,
-		IsConstant: true,
+		Value: capabilityValue,
+		Kind:  common.DeclarationKindConstant,
 	}
 
 	options := ParseCheckAndInterpretOptions{

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3333,25 +3333,27 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 			},
 		),
 	}
+	capabilityValueDeclaration := stdlib.StandardLibraryValue{
+		Name: "cap",
+		Type: &sema.CapabilityType{
+			BorrowType: &sema.ReferenceType{
+				Type: structType,
+			},
+		},
+		Value:      capabilityValue,
+		Kind:       common.DeclarationKindConstant,
+		IsConstant: true,
+	}
 
 	options := ParseCheckAndInterpretOptions{
 		CheckerOptions: []sema.Option{
-			sema.WithPredeclaredValues(map[string]sema.ValueDeclaration{
-				"cap": stdlib.StandardLibraryValue{
-					Name: "cap",
-					Type: &sema.CapabilityType{
-						BorrowType: &sema.ReferenceType{
-							Type: structType,
-						},
-					},
-					Kind:       common.DeclarationKindConstant,
-					IsConstant: true,
-				},
+			sema.WithPredeclaredValues([]sema.ValueDeclaration{
+				capabilityValueDeclaration,
 			}),
 		},
 		Options: []interpreter.Option{
-			interpreter.WithPredefinedValues(map[string]interpreter.Value{
-				"cap": capabilityValue,
+			interpreter.WithPredeclaredValues([]interpreter.ValueDeclaration{
+				capabilityValueDeclaration,
 			}),
 		},
 	}

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -37,6 +37,22 @@ func TestInterpretEquality(t *testing.T) {
 
 		t.Parallel()
 
+		capabilityValue := interpreter.CapabilityValue{
+			Address: interpreter.NewAddressValue(common.BytesToAddress([]byte{0x1})),
+			Path: interpreter.PathValue{
+				Domain:     common.PathDomainStorage,
+				Identifier: "something",
+			},
+		}
+
+		capabilityValueDeclarartion := stdlib.StandardLibraryValue{
+			Name:       "cap",
+			Type:       &sema.CapabilityType{},
+			Value:      capabilityValue,
+			Kind:       common.DeclarationKindConstant,
+			IsConstant: true,
+		}
+
 		inter := parseCheckAndInterpretWithOptions(t,
 			`
               let maybeCapNonNil: Capability? = cap
@@ -46,24 +62,13 @@ func TestInterpretEquality(t *testing.T) {
 		    `,
 			ParseCheckAndInterpretOptions{
 				Options: []interpreter.Option{
-					interpreter.WithPredefinedValues(map[string]interpreter.Value{
-						"cap": interpreter.CapabilityValue{
-							Address: interpreter.NewAddressValue(common.BytesToAddress([]byte{0x1})),
-							Path: interpreter.PathValue{
-								Domain:     common.PathDomainStorage,
-								Identifier: "something",
-							},
-						},
+					interpreter.WithPredeclaredValues([]interpreter.ValueDeclaration{
+						capabilityValueDeclarartion,
 					}),
 				},
 				CheckerOptions: []sema.Option{
-					sema.WithPredeclaredValues(map[string]sema.ValueDeclaration{
-						"cap": stdlib.StandardLibraryValue{
-							Name:       "cap",
-							Type:       &sema.CapabilityType{},
-							Kind:       common.DeclarationKindConstant,
-							IsConstant: true,
-						},
+					sema.WithPredeclaredValues([]sema.ValueDeclaration{
+						capabilityValueDeclarartion,
 					}),
 				},
 			},

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -45,12 +45,11 @@ func TestInterpretEquality(t *testing.T) {
 			},
 		}
 
-		capabilityValueDeclarartion := stdlib.StandardLibraryValue{
-			Name:       "cap",
-			Type:       &sema.CapabilityType{},
-			Value:      capabilityValue,
-			Kind:       common.DeclarationKindConstant,
-			IsConstant: true,
+		capabilityValueDeclaration := stdlib.StandardLibraryValue{
+			Name:  "cap",
+			Type:  &sema.CapabilityType{},
+			Value: capabilityValue,
+			Kind:  common.DeclarationKindConstant,
 		}
 
 		inter := parseCheckAndInterpretWithOptions(t,
@@ -63,12 +62,12 @@ func TestInterpretEquality(t *testing.T) {
 			ParseCheckAndInterpretOptions{
 				Options: []interpreter.Option{
 					interpreter.WithPredeclaredValues([]interpreter.ValueDeclaration{
-						capabilityValueDeclarartion,
+						capabilityValueDeclaration,
 					}),
 				},
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues([]sema.ValueDeclaration{
-						capabilityValueDeclarartion,
+						capabilityValueDeclaration,
 					}),
 				},
 			},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7523,8 +7523,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 			panicFunction,
 			interpreter.AuthAccountContractsValue{},
 		),
-		Kind:       common.DeclarationKindConstant,
-		IsConstant: true,
+		Kind: common.DeclarationKindConstant,
 	}
 
 	inter := parseCheckAndInterpretWithOptions(t,

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -66,10 +66,26 @@ func TestRuntimeTypeStorage(t *testing.T) {
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	err := runtime.ExecuteTransaction(tx1, nil, runtimeInterface, nextTransactionLocation())
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: tx1,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
-	err = runtime.ExecuteTransaction(tx2, nil, runtimeInterface, nextTransactionLocation())
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx2,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, `"Int"`, loggedMessage)

--- a/runtime/valuedeclaration.go
+++ b/runtime/valuedeclaration.go
@@ -1,0 +1,71 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+type ValueDeclaration struct {
+	Name           string
+	Type           sema.Type
+	Kind           common.DeclarationKind
+	IsConstant     bool
+	ArgumentLabels []string
+	Available      func(ast.Location) bool
+	Value          interpreter.Value
+}
+
+func (v ValueDeclaration) ValueDeclarationName() string {
+	return v.Name
+}
+
+func (v ValueDeclaration) ValueDeclarationType() sema.Type {
+	return v.Type
+}
+
+func (v ValueDeclaration) ValueDeclarationValue() interpreter.Value {
+	return v.Value
+}
+
+func (v ValueDeclaration) ValueDeclarationKind() common.DeclarationKind {
+	return v.Kind
+}
+
+func (v ValueDeclaration) ValueDeclarationPosition() ast.Position {
+	return ast.Position{}
+}
+
+func (v ValueDeclaration) ValueDeclarationIsConstant() bool {
+	return v.IsConstant
+}
+
+func (v ValueDeclaration) ValueDeclarationArgumentLabels() []string {
+	return v.ArgumentLabels
+}
+
+func (v ValueDeclaration) ValueDeclarationAvailable(location ast.Location) bool {
+	if v.Available == nil {
+		return true
+	}
+	return v.Available(location)
+}


### PR DESCRIPTION
Closes #471

- Refactor/bundle the parameters of the runtime interface main functions for script and transaction execution, introduce `Script` and `Context`
- Allow the host environment to provide predeclared values. The value declarations are passed to all  checkers and interpreters.
- However, value declarations may have a predicate function, which determines if the value should be declared in the given location