### PR TITLE
Improve error pretty printing

### DIFF
--- a/check-headers.sh
+++ b/check-headers.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files=$(find . -name \*.go -type f -print0 | xargs -0 egrep -L '(Licensed under the Apache License)|(Code generated from|by)')
+files=$(find . -name \*.go -type f -print0 | xargs -0 grep -L -E '(Licensed under the Apache License)|(Code generated (from|by))')
 if [ -n "$files" ]; then
   echo "Missing license header in:"
   echo "$files"

--- a/runtime/cmd/check/main.go
+++ b/runtime/cmd/check/main.go
@@ -178,7 +178,7 @@ func runPath(path string, bench bool, useColor bool) (res result, succeeded bool
 	var program *ast.Program
 	var must func(error)
 
-	codes := map[common.Location]string{}
+	codes := map[common.LocationID]string{}
 
 	location := common.StringLocation(path)
 

--- a/runtime/cmd/check/main.go
+++ b/runtime/cmd/check/main.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/cmd"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -194,7 +194,7 @@ func runPath(path string, bench bool, useColor bool) (res result, succeeded bool
 		err = checker.Check()
 		if err != nil {
 			var builder strings.Builder
-			printErr := print2.NewErrorPrettyPrinter(&builder, useColor).
+			printErr := pretty.NewErrorPrettyPrinter(&builder, useColor).
 				PrettyPrintError(err, path, codes)
 			if printErr != nil {
 				panic(printErr)

--- a/runtime/cmd/check/main.go
+++ b/runtime/cmd/check/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/cmd"
+	print2 "github.com/onflow/cadence/runtime/print"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -145,8 +146,10 @@ func run(paths []string, bench bool, json bool) {
 		out = newStdoutOutput()
 	}
 
+	useColor := !json
+
 	for _, path := range paths {
-		res, runSucceeded := runPath(path, bench)
+		res, runSucceeded := runPath(path, bench, useColor)
 		if !runSucceeded {
 			allSucceeded = false
 		}
@@ -161,7 +164,7 @@ func run(paths []string, bench bool, json bool) {
 	}
 }
 
-func runPath(path string, bench bool) (res result, succeeded bool) {
+func runPath(path string, bench bool, useColor bool) (res result, succeeded bool) {
 	res = result{
 		Path: path,
 	}
@@ -191,7 +194,11 @@ func runPath(path string, bench bool) (res result, succeeded bool) {
 		err = checker.Check()
 		if err != nil {
 			var builder strings.Builder
-			cmd.PrettyPrintError(&builder, err, path, codes)
+			printErr := print2.NewErrorPrettyPrinter(&builder, useColor).
+				PrettyPrintError(err, path, codes)
+			if printErr != nil {
+				panic(printErr)
+			}
 			res.Error = builder.String()
 		}
 	}()

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -27,7 +27,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/parser2"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -36,7 +36,7 @@ func must(err error, filename string, codes map[string]string) {
 	if err == nil {
 		return
 	}
-	printErr := print2.NewErrorPrettyPrinter(os.Stderr, true).
+	printErr := pretty.NewErrorPrettyPrinter(os.Stderr, true).
 		PrettyPrintError(err, filename, codes)
 	if printErr != nil {
 		panic(printErr)
@@ -151,6 +151,6 @@ func PrepareInterpreter(filename string) (*interpreter.Interpreter, *sema.Checke
 }
 
 func ExitWithError(message string) {
-	print(print2.FormatErrorMessage(message, true))
+	println(pretty.FormatErrorMessage(message, true))
 	os.Exit(1)
 }

--- a/runtime/cmd/execute/repl.go
+++ b/runtime/cmd/execute/repl.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -47,7 +47,7 @@ func RunREPL() {
 
 	codes := map[string]string{}
 
-	errorPrettyPrinter := print2.NewErrorPrettyPrinter(os.Stderr, true)
+	errorPrettyPrinter := pretty.NewErrorPrettyPrinter(os.Stderr, true)
 
 	repl, err := runtime.NewREPL(
 		func(err error) {

--- a/runtime/cmd/execute/repl.go
+++ b/runtime/cmd/execute/repl.go
@@ -36,8 +36,6 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-const replLocation = "REPL"
-
 func RunREPL() {
 	printWelcome()
 
@@ -45,9 +43,11 @@ func RunREPL() {
 	lineIsContinuation := false
 	code := ""
 
-	codes := map[string]string{}
+	codes := map[common.Location]string{}
 
 	errorPrettyPrinter := pretty.NewErrorPrettyPrinter(os.Stderr, true)
+
+	replLocation := common.REPLLocation{}
 
 	repl, err := runtime.NewREPL(
 		func(err error) {
@@ -80,8 +80,7 @@ func RunREPL() {
 					importChecker, err := checker.EnsureLoaded(
 						location,
 						func() *ast.Program {
-							filename := string(stringLocation)
-							imported, _ := cmd.PrepareProgramFromFile(filename, codes)
+							imported, _ := cmd.PrepareProgramFromFile(stringLocation, codes)
 							return imported
 						},
 					)

--- a/runtime/cmd/execute/repl.go
+++ b/runtime/cmd/execute/repl.go
@@ -32,10 +32,11 @@ import (
 	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	print2 "github.com/onflow/cadence/runtime/print"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-const replFilename = "REPL"
+const replLocation = "REPL"
 
 func RunREPL() {
 	printWelcome()
@@ -46,10 +47,15 @@ func RunREPL() {
 
 	codes := map[string]string{}
 
+	errorPrettyPrinter := print2.NewErrorPrettyPrinter(os.Stderr, true)
+
 	repl, err := runtime.NewREPL(
 		func(err error) {
-			// TODO: handle imports
-			cmd.PrettyPrintError(os.Stderr, err, replFilename, map[string]string{replFilename: code})
+			codes[replLocation] = code
+			printErr := errorPrettyPrinter.PrettyPrintError(err, replLocation, codes)
+			if printErr != nil {
+				panic(printErr)
+			}
 		},
 		func(value interpreter.Value) {
 			if _, isVoid := value.(*interpreter.VoidValue); isVoid || value == nil {

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -32,8 +32,8 @@ import (
 	"time"
 
 	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/parser2"
+	print2 "github.com/onflow/cadence/runtime/print"
 )
 
 var benchFlag = flag.Bool("bench", false, "benchmark the parser")
@@ -104,7 +104,11 @@ func (s stdoutOutput) Append(r result) {
 	}
 
 	if r.Error != nil {
-		cmd.PrettyPrintError(os.Stdout, r.Error, r.Path, map[string]string{r.Path: r.Code})
+		printErr := print2.NewErrorPrettyPrinter(os.Stdout, true).
+			PrettyPrintError(r.Error, r.Path, map[string]string{r.Path: r.Code})
+		if printErr != nil {
+			panic(printErr)
+		}
 	}
 
 	if len(r.BenchStr) > 0 {

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -107,7 +107,7 @@ func (s stdoutOutput) Append(r result) {
 	if r.Error != nil {
 		location := common.StringLocation(r.Path)
 		printErr := pretty.NewErrorPrettyPrinter(os.Stdout, true).
-			PrettyPrintError(r.Error, location, map[common.Location]string{location: r.Code})
+			PrettyPrintError(r.Error, location, map[common.LocationID]string{location.ID(): r.Code})
 		if printErr != nil {
 			panic(printErr)
 		}

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/pretty"
 )
@@ -104,8 +105,9 @@ func (s stdoutOutput) Append(r result) {
 	}
 
 	if r.Error != nil {
+		location := common.StringLocation(r.Path)
 		printErr := pretty.NewErrorPrettyPrinter(os.Stdout, true).
-			PrettyPrintError(r.Error, r.Path, map[string]string{r.Path: r.Code})
+			PrettyPrintError(r.Error, location, map[common.Location]string{location: r.Code})
 		if printErr != nil {
 			panic(printErr)
 		}

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/parser2"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 )
 
 var benchFlag = flag.Bool("bench", false, "benchmark the parser")
@@ -104,7 +104,7 @@ func (s stdoutOutput) Append(r result) {
 	}
 
 	if r.Error != nil {
-		printErr := print2.NewErrorPrettyPrinter(os.Stdout, true).
+		printErr := pretty.NewErrorPrettyPrinter(os.Stdout, true).
 			PrettyPrintError(r.Error, r.Path, map[string]string{r.Path: r.Code})
 		if printErr != nil {
 			panic(printErr)

--- a/runtime/common/identifierlocation.go
+++ b/runtime/common/identifierlocation.go
@@ -55,6 +55,10 @@ func (l IdentifierLocation) QualifiedIdentifier(typeID TypeID) string {
 	return pieces[2]
 }
 
+func (l IdentifierLocation) String() string {
+	return string(l)
+}
+
 func (l IdentifierLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type       string

--- a/runtime/common/location.go
+++ b/runtime/common/location.go
@@ -28,6 +28,7 @@ import (
 // This could be a file, a transaction, or a smart contract.
 //
 type Location interface {
+	fmt.Stringer
 	// ID returns the canonical ID for this import location.
 	ID() LocationID
 	// TypeID returns a type ID for the given qualified identifier

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -55,6 +55,10 @@ func (l StringLocation) QualifiedIdentifier(typeID TypeID) string {
 	return pieces[2]
 }
 
+func (l StringLocation) String() string {
+	return string(l)
+}
+
 func (l StringLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type   string

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -1,0 +1,279 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+)
+
+func TestRuntimeError(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("parse error", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime()
+
+		script := []byte(`X`)
+
+		runtimeInterface := &testRuntimeInterface{}
+
+		location := common.ScriptLocation{0x1}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  location,
+			},
+		)
+		require.EqualError(
+			t,
+			err,
+			"Execution failed:\nerror: unexpected token: identifier\n"+
+				" --> 01:1:0\n"+
+				"  |\n"+
+				"1 | X\n"+
+				"  | ^\n",
+		)
+	})
+
+	t.Run("checking error", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime()
+
+		script := []byte(`fun test() {}`)
+
+		runtimeInterface := &testRuntimeInterface{}
+
+		location := common.ScriptLocation{0x1}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  location,
+			},
+		)
+		require.EqualError(
+			t,
+			err,
+			"Execution failed:\n"+
+				"error: missing access modifier for function\n"+
+				" --> 01:1:0\n"+
+				"  |\n"+
+				"1 | fun test() {}\n"+
+				"  | ^\n",
+		)
+	})
+
+	t.Run("execution error", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime()
+
+		script := []byte(`
+            pub fun main() {
+                let a: UInt8 = 255
+                let b: UInt8 = 1
+                a + b
+            }
+        `)
+
+		runtimeInterface := &testRuntimeInterface{}
+
+		location := common.ScriptLocation{0x1}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  location,
+			},
+		)
+		require.EqualError(
+			t,
+			err,
+			"Execution failed:\nerror: overflow\n"+
+				" --> 01:5:16\n"+
+				"  |\n"+
+				"5 |                 a + b\n"+
+				"  |                 ^^^^^\n",
+		)
+	})
+
+	t.Run("parse error in import", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime()
+
+		importedScript := []byte(`X`)
+
+		script := []byte(`import "imported"`)
+
+		runtimeInterface := &testRuntimeInterface{
+			getCode: func(location Location) (bytes []byte, err error) {
+				switch location {
+				case common.StringLocation("imported"):
+					return importedScript, nil
+				default:
+					return nil, fmt.Errorf("unknown import location: %s", location)
+				}
+			},
+		}
+
+		location := common.ScriptLocation{0x1}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  location,
+			},
+		)
+		require.EqualError(
+			t,
+			err,
+			"Execution failed:\nerror: unexpected token: identifier\n"+
+				" --> imported:1:0\n"+
+				"  |\n"+
+				"1 | X\n"+
+				"  | ^\n",
+		)
+	})
+
+	t.Run("checking error in import", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime()
+
+		importedScript := []byte(`fun test() {}`)
+
+		script := []byte(`import "imported"`)
+
+		runtimeInterface := &testRuntimeInterface{
+			getCode: func(location Location) (bytes []byte, err error) {
+				switch location {
+				case common.StringLocation("imported"):
+					return importedScript, nil
+				default:
+					return nil, fmt.Errorf("unknown import location: %s", location)
+				}
+			},
+		}
+
+		location := common.ScriptLocation{0x1}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  location,
+			},
+		)
+		require.EqualError(
+			t,
+			err,
+			"Execution failed:\n"+
+				"error: missing access modifier for function\n"+
+				" --> imported:1:0\n"+
+				"  |\n"+
+				"1 | fun test() {}\n"+
+				"  | ^\n",
+		)
+	})
+
+	t.Run("execution error in import", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime()
+
+		importedScript := []byte(`
+            pub fun add() {
+                let a: UInt8 = 255
+                let b: UInt8 = 1
+                a + b
+            }
+        `)
+
+		script := []byte(`
+            import add from "imported"
+
+            pub fun main() {
+                add()
+            }
+        `)
+
+		runtimeInterface := &testRuntimeInterface{
+			getCode: func(location Location) (bytes []byte, err error) {
+				switch location {
+				case common.StringLocation("imported"):
+					return importedScript, nil
+				default:
+					return nil, fmt.Errorf("unknown import location: %s", location)
+				}
+			},
+		}
+
+		location := common.ScriptLocation{0x1}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  location,
+			},
+		)
+		require.EqualError(
+			t,
+			err,
+			"Execution failed:\nerror: overflow\n"+
+				" --> imported:5:16\n"+
+				"  |\n"+
+				"5 |                 a + b\n"+
+				"  |                 ^^^^^\n",
+		)
+	})
+
+}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -47,7 +47,7 @@ func (e Error) Error() string {
 	sb.WriteString("Execution failed:\n")
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
 		// TODO: capture codes in error and include in codes argument
-		PrettyPrintError(e, "", map[string]string{})
+		PrettyPrintError(e, nil, map[common.Location]string{})
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -47,7 +47,7 @@ func (e Error) Error() string {
 	sb.WriteString("Execution failed:\n")
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
 		// TODO: capture codes in error and include in codes argument
-		PrettyPrintError(e, nil, map[common.Location]string{})
+		PrettyPrintError(e, nil, map[common.LocationID]string{})
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
+	print2 "github.com/onflow/cadence/runtime/print"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -45,8 +45,12 @@ func (e Error) Unwrap() error {
 func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Execution failed:\n")
-	sb.WriteString(errors.UnrollChildErrors(e.Err))
-	sb.WriteString("\n")
+	printErr := print2.NewErrorPrettyPrinter(&sb, false).
+		// TODO: capture codes in error and include in codes argument
+		PrettyPrintError(e, "", map[string]string{})
+	if printErr != nil {
+		panic(printErr)
+	}
 	return sb.String()
 }
 

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -31,11 +31,17 @@ import (
 
 // Error is the containing type for all errors produced by the runtime.
 type Error struct {
-	Err error
+	Err      error
+	Location common.Location
+	Codes    map[common.LocationID]string
 }
 
-func newError(err error) Error {
-	return Error{Err: err}
+func newError(err error, context Context) Error {
+	return Error{
+		Err:      err,
+		Location: context.Location,
+		Codes:    context.codes,
+	}
 }
 
 func (e Error) Unwrap() error {
@@ -46,8 +52,7 @@ func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Execution failed:\n")
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
-		// TODO: capture codes in error and include in codes argument
-		PrettyPrintError(e, nil, map[common.LocationID]string{})
+		PrettyPrintError(e.Err, e.Location, e.Codes)
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -45,7 +45,7 @@ func (e Error) Unwrap() error {
 func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Execution failed:\n")
-	printErr := print2.NewErrorPrettyPrinter(&sb, false).
+	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
 		// TODO: capture codes in error and include in codes argument
 		PrettyPrintError(e, "", map[string]string{})
 	if printErr != nil {

--- a/runtime/errors/errors.go
+++ b/runtime/errors/errors.go
@@ -21,7 +21,6 @@ package errors
 import (
 	"fmt"
 	"runtime/debug"
-	"strings"
 )
 
 // UnreachableError
@@ -66,35 +65,4 @@ type ErrorNote interface {
 type ParentError interface {
 	error
 	ChildErrors() []error
-}
-
-// UnrollChildErrors recursively combines all child errors into a single error message.
-func UnrollChildErrors(err error) string {
-	var sb strings.Builder
-	unrollChildErrors(&sb, 0, err)
-	return sb.String()
-}
-
-func unrollChildErrors(sb *strings.Builder, level int, err error) {
-	var indent = strings.Repeat("    ", level)
-
-	sb.WriteString(indent)
-	sb.WriteString(err.Error())
-
-	if err, ok := err.(SecondaryError); ok {
-		sb.WriteString(". ")
-		sb.WriteString(err.SecondaryError())
-	}
-
-	if err, ok := err.(ParentError); ok {
-		childErrors := err.ChildErrors()
-		if len(childErrors) > 0 {
-			sb.WriteString(":")
-		}
-
-		for _, childErr := range childErrors {
-			sb.WriteString("\n")
-			unrollChildErrors(sb, level+1, childErr)
-		}
-	}
 }

--- a/runtime/interpreter/big.go
+++ b/runtime/interpreter/big.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package interpreter
 
 import (

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -641,7 +641,7 @@ func (interpreter *Interpreter) runAllStatements(t Trampoline) interface{} {
 
 		panic(Error{
 			Err:           internalErr,
-			LocationRange: interpreter.locationRange(posInfo),
+			LocationRange: statement.Interpreter.locationRange(posInfo),
 		})
 	})
 

--- a/runtime/interpreter/magic.go
+++ b/runtime/interpreter/magic.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package interpreter
 
 import (

--- a/runtime/interpreter/magic_test.go
+++ b/runtime/interpreter/magic_test.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package interpreter
 
 import (

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -37,6 +37,7 @@ func ParseLiteral(literal string, ty sema.Type) (cadence.Value, error) {
 	expression, errs := parser2.ParseExpression(literal)
 	if len(errs) > 0 {
 		return nil, parser2.Error{
+			Code:   literal,
 			Errors: errs,
 		}
 	}

--- a/runtime/parser2/errors.go
+++ b/runtime/parser2/errors.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 )
 
 // Error
@@ -36,9 +36,9 @@ type Error struct {
 func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Parsing failed:\n")
-	printErr := print2.NewErrorPrettyPrinter(&sb, false).
 		// TODO: capture code in error and include in codes argument
 		PrettyPrintError(e, "", map[string]string{})
+	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/parser2/errors.go
+++ b/runtime/parser2/errors.go
@@ -39,7 +39,7 @@ func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Parsing failed:\n")
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
-		PrettyPrintError(e, nil, map[common.Location]string{nil: e.Code})
+		PrettyPrintError(e, nil, map[common.LocationID]string{"": e.Code})
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/parser2/errors.go
+++ b/runtime/parser2/errors.go
@@ -30,15 +30,15 @@ import (
 // Error
 
 type Error struct {
+	Code   string
 	Errors []error
 }
 
 func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Parsing failed:\n")
-		// TODO: capture code in error and include in codes argument
-		PrettyPrintError(e, "", map[string]string{})
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
+		PrettyPrintError(e, "", map[string]string{"": e.Code})
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/parser2/errors.go
+++ b/runtime/parser2/errors.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
+	print2 "github.com/onflow/cadence/runtime/print"
 )
 
 // Error
@@ -35,13 +36,11 @@ type Error struct {
 func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Parsing failed:\n")
-	for _, err := range e.Errors {
-		sb.WriteString(err.Error())
-		if err, ok := err.(errors.SecondaryError); ok {
-			sb.WriteString(". ")
-			sb.WriteString(err.SecondaryError())
-		}
-		sb.WriteString("\n")
+	printErr := print2.NewErrorPrettyPrinter(&sb, false).
+		// TODO: capture code in error and include in codes argument
+		PrettyPrintError(e, "", map[string]string{})
+	if printErr != nil {
+		panic(printErr)
 	}
 	return sb.String()
 }

--- a/runtime/parser2/errors.go
+++ b/runtime/parser2/errors.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/pretty"
 )
@@ -38,7 +39,7 @@ func (e Error) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Parsing failed:\n")
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
-		PrettyPrintError(e, "", map[string]string{"": e.Code})
+		PrettyPrintError(e, nil, map[common.Location]string{nil: e.Code})
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -4680,7 +4680,6 @@ func TestParseExpression(t *testing.T) {
 			Errors: errs,
 		}
 	}
-
 	require.NoError(t, err)
 
 	expected := &ast.BinaryExpression{

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -415,6 +415,7 @@ func ParseProgram(input string) (program *ast.Program, err error) {
 	})
 	if len(errs) > 0 {
 		err = Error{
+			Code:   input,
 			Errors: errs,
 		}
 	}

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -39,8 +39,8 @@ func TestParseInvalid(t *testing.T) {
 
 	t.Parallel()
 
-	_, errs := ParseExpression("#")
-	require.NotEmpty(t, errs)
+	_, err := ParseProgram("X")
+	require.EqualError(t, err, "Parsing failed:\nerror: unexpected token: identifier\n --> :1:0\n  |\n1 | X\n  | ^\n")
 }
 
 func TestParseBuffering(t *testing.T) {

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -1,4 +1,4 @@
-package print
+package pretty
 
 import (
 	"fmt"

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -112,7 +112,7 @@ func (p ErrorPrettyPrinter) writeString(str string) {
 	}
 }
 
-func (p ErrorPrettyPrinter) PrettyPrintError(err error, location common.Location, codes map[common.Location]string) error {
+func (p ErrorPrettyPrinter) PrettyPrintError(err error, location common.Location, codes map[common.LocationID]string) error {
 
 	// writeString panics when the write to the writer fails, so recover those errors and return them.
 	// This way we don't need to if-err for every single writer write
@@ -164,7 +164,13 @@ func (p ErrorPrettyPrinter) PrettyPrintError(err error, location common.Location
 		if i > 0 {
 			p.writeString("\n")
 		}
-		p.prettyPrintError(err, location, codes[location])
+
+		var locationID common.LocationID
+		if location != nil {
+			locationID = location.ID()
+		}
+
+		p.prettyPrintError(err, location, codes[locationID])
 		i++
 		return nil
 	}

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pretty
 
 import (

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -125,6 +125,7 @@ func (r *REPL) Accept(code string) (inputIsComplete bool) {
 	result, errs := parser2.ParseStatements(code)
 	if len(errs) > 0 {
 		err = parser2.Error{
+			Code:   code,
 			Errors: errs,
 		}
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2131,7 +2131,8 @@ func TestScriptReturnTypeNotReturnableError(t *testing.T) {
 		)
 
 		if expected == nil {
-			require.IsType(t, &InvalidScriptReturnTypeError{}, err)
+			var subErr *InvalidScriptReturnTypeError
+			utils.RequireErrorAs(t, err, &subErr)
 		} else {
 			require.NoError(t, err)
 			require.Equal(t, expected, actual)
@@ -2219,7 +2220,9 @@ func TestScriptParameterTypeNotStorableError(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
-	assert.IsType(t, &ScriptParameterTypeNotStorableError{}, err)
+
+	var subErr *ScriptParameterTypeNotStorableError
+	utils.RequireErrorAs(t, err, &subErr)
 }
 
 func TestRuntimeSyntaxError(t *testing.T) {

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -98,9 +98,9 @@ func (checker *Checker) importResolvedLocation(resolvedLocation ResolvedLocation
 		if err != nil {
 			checker.report(
 				&ImportedProgramError{
-					CheckerError:   err,
-					ImportLocation: location,
-					Range:          locationRange,
+					CheckerError: err,
+					Location:     location,
+					Range:        locationRange,
 				},
 			)
 			return

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -376,7 +376,8 @@ func (checker *Checker) Check() error {
 func (checker *Checker) CheckerError() *CheckerError {
 	if len(checker.errors) > 0 {
 		return &CheckerError{
-			Errors: checker.errors,
+			Location: checker.Location,
+			Errors:   checker.errors,
 		}
 	}
 	return nil

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -79,6 +79,8 @@ func (e *MissingLocationError) Error() string {
 // CheckerError
 
 type CheckerError struct {
+	//Location common.Location
+	//Codes map[string]
 	Errors []error
 }
 
@@ -87,7 +89,7 @@ func (e CheckerError) Error() string {
 	sb.WriteString("Checking failed:\n")
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
 		// TODO: capture codes in error and include in codes argument
-		PrettyPrintError(e, "", map[string]string{})
+		PrettyPrintError(e, nil, map[common.Location]string{})
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -79,17 +79,20 @@ func (e *MissingLocationError) Error() string {
 // CheckerError
 
 type CheckerError struct {
-	//Location common.Location
-	//Codes map[string]
-	Errors []error
+	Location common.Location
+	Codes    map[common.LocationID]string
+	Errors   []error
 }
 
 func (e CheckerError) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Checking failed:\n")
+	codes := e.Codes
+	if codes == nil {
+		codes = map[common.LocationID]string{}
+	}
 	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
-		// TODO: capture codes in error and include in codes argument
-		PrettyPrintError(e, nil, map[common.Location]string{})
+		PrettyPrintError(e, e.Location, codes)
 	if printErr != nil {
 		panic(printErr)
 	}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 )
 
 // astTypeConversionError
@@ -85,7 +85,7 @@ type CheckerError struct {
 func (e CheckerError) Error() string {
 	var sb strings.Builder
 	sb.WriteString("Checking failed:\n")
-	printErr := print2.NewErrorPrettyPrinter(&sb, false).
+	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
 		// TODO: capture codes in error and include in codes argument
 		PrettyPrintError(e, "", map[string]string{})
 	if printErr != nil {

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package stdlib
 
 import (

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -202,6 +202,10 @@ func (l FlowLocation) QualifiedIdentifier(typeID common.TypeID) string {
 	return pieces[1]
 }
 
+func (l FlowLocation) String() string {
+	return "flow"
+}
+
 func (l FlowLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type string

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -22,13 +22,11 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
@@ -739,10 +737,7 @@ func TestCheckArraySubtyping(t *testing.T) {
 					interfaceType,
 				),
 			)
-
-			if !assert.NoError(t, err) {
-				cmd.PrettyPrintError(os.Stdout, err, "", map[string]string{"": ""})
-			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/runtime/tests/checker/composite_test.go
+++ b/runtime/tests/checker/composite_test.go
@@ -20,13 +20,11 @@ package checker
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/sema"
@@ -2196,9 +2194,7 @@ func TestCheckMutualTypeUseTopLevel(t *testing.T) {
 
 						_, err := ParseAndCheck(t, code)
 
-						if !assert.NoError(t, err) {
-							cmd.PrettyPrintError(os.Stdout, err, "", map[string]string{"": code})
-						}
+						require.NoError(t, err)
 					})
 				}
 			}

--- a/runtime/tests/checker/contract_test.go
+++ b/runtime/tests/checker/contract_test.go
@@ -20,13 +20,11 @@ package checker
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 )
@@ -630,9 +628,7 @@ func TestCheckContractNestedDeclarationsComplex(t *testing.T) {
 							)
 							_, err := ParseAndCheck(t, code)
 
-							if !assert.NoError(t, err) {
-								cmd.PrettyPrintError(os.Stdout, err, "", map[string]string{"": code})
-							}
+							require.NoError(t, err)
 						})
 					}
 				}

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -20,13 +20,11 @@ package checker
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/sema"
@@ -1836,11 +1834,9 @@ func TestCheckContractInterfaceFungibleToken(t *testing.T) {
 	t.Parallel()
 
 	const code = examples.FungibleTokenContractInterface
-	_, err := ParseAndCheck(t, code)
 
-	if !assert.NoError(t, err) {
-		cmd.PrettyPrintError(os.Stdout, err, "", map[string]string{"": code})
-	}
+	_, err := ParseAndCheck(t, code)
+	require.NoError(t, err)
 }
 
 func TestCheckContractInterfaceFungibleTokenConformance(t *testing.T) {
@@ -1850,10 +1846,7 @@ func TestCheckContractInterfaceFungibleTokenConformance(t *testing.T) {
 	code := examples.FungibleTokenContractInterface + "\n" + examples.ExampleFungibleTokenContract
 
 	_, err := ParseAndCheckWithPanic(t, code)
-
-	if !assert.NoError(t, err) {
-		cmd.PrettyPrintError(os.Stdout, err, "", map[string]string{"": code})
-	}
+	require.NoError(t, err)
 }
 
 func TestCheckContractInterfaceFungibleTokenUse(t *testing.T) {
@@ -1882,9 +1875,7 @@ func TestCheckContractInterfaceFungibleTokenUse(t *testing.T) {
 
 	_, err := ParseAndCheckWithPanic(t, code)
 
-	if !assert.NoError(t, err) {
-		cmd.PrettyPrintError(os.Stdout, err, "", map[string]string{"": code})
-	}
+	require.NoError(t, err)
 }
 
 // TestCheckInvalidInterfaceUseAsTypeSuggestion tests that an interface

--- a/runtime/tests/checker/predeclaredvalues_test.go
+++ b/runtime/tests/checker/predeclaredvalues_test.go
@@ -184,7 +184,7 @@ func TestCheckPredeclaredValues(t *testing.T) {
 
 		var importedProgramError *sema.ImportedProgramError
 		utils.RequireErrorAs(t, errs[0], &importedProgramError)
-		require.Equal(t, location3, importedProgramError.ImportLocation)
+		require.Equal(t, location3, importedProgramError.Location)
 		importedErrs := ExpectCheckerErrors(t, importedProgramError.CheckerError, 1)
 		require.IsType(t, &sema.NotDeclaredError{}, importedErrs[0])
 

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser2"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -56,7 +56,7 @@ func ParseAndCheckWithOptions(
 	if !options.IgnoreParseError && !assert.NoError(t, err) {
 		var sb strings.Builder
 		location := options.Location.String()
-		printErr := print2.NewErrorPrettyPrinter(&sb, true).
+		printErr := pretty.NewErrorPrettyPrinter(&sb, true).
 			PrettyPrintError(err, location, map[string]string{location: code})
 		if printErr != nil {
 			panic(printErr)

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -55,8 +55,9 @@ func ParseAndCheckWithOptions(
 	program, err := parser2.ParseProgram(code)
 	if !options.IgnoreParseError && !assert.NoError(t, err) {
 		var sb strings.Builder
+		locationID := options.Location.ID()
 		printErr := pretty.NewErrorPrettyPrinter(&sb, true).
-			PrettyPrintError(err, options.Location, map[common.Location]string{options.Location: code})
+			PrettyPrintError(err, options.Location, map[common.LocationID]string{locationID: code})
 		if printErr != nil {
 			panic(printErr)
 		}

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -55,9 +55,8 @@ func ParseAndCheckWithOptions(
 	program, err := parser2.ParseProgram(code)
 	if !options.IgnoreParseError && !assert.NoError(t, err) {
 		var sb strings.Builder
-		location := options.Location.String()
 		printErr := pretty.NewErrorPrettyPrinter(&sb, true).
-			PrettyPrintError(err, location, map[string]string{location: code})
+			PrettyPrintError(err, options.Location, map[common.Location]string{options.Location: code})
 		if printErr != nil {
 			panic(printErr)
 		}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/parser2"
-	print2 "github.com/onflow/cadence/runtime/print"
+	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/onflow/cadence/runtime/tests/checker"
@@ -71,7 +71,7 @@ func parseCheckAndInterpretWithOptions(
 		if !assert.NoError(t, err) {
 			var sb strings.Builder
 			location := checker.Location.String()
-			printErr := print2.NewErrorPrettyPrinter(&sb, true).
+			printErr := pretty.NewErrorPrettyPrinter(&sb, true).
 				PrettyPrintError(err, location, map[string]string{location: code})
 			if printErr != nil {
 				panic(printErr)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -70,9 +70,8 @@ func parseCheckAndInterpretWithOptions(
 	} else {
 		if !assert.NoError(t, err) {
 			var sb strings.Builder
-			location := checker.Location.String()
 			printErr := pretty.NewErrorPrettyPrinter(&sb, true).
-				PrettyPrintError(err, location, map[string]string{location: code})
+				PrettyPrintError(err, checker.Location, map[common.Location]string{checker.Location: code})
 			if printErr != nil {
 				panic(printErr)
 			}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -70,8 +70,9 @@ func parseCheckAndInterpretWithOptions(
 	} else {
 		if !assert.NoError(t, err) {
 			var sb strings.Builder
+			locationID := checker.Location.ID()
 			printErr := pretty.NewErrorPrettyPrinter(&sb, true).
-				PrettyPrintError(err, checker.Location, map[common.Location]string{checker.Location: code})
+				PrettyPrintError(err, checker.Location, map[common.LocationID]string{locationID: code})
 			if printErr != nil {
 				panic(printErr)
 			}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/parser2"
+	print2 "github.com/onflow/cadence/runtime/print"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/onflow/cadence/runtime/tests/checker"
@@ -68,7 +69,14 @@ func parseCheckAndInterpretWithOptions(
 		options.HandleCheckerError(err)
 	} else {
 		if !assert.NoError(t, err) {
-			assert.FailNow(t, errors.UnrollChildErrors(err))
+			var sb strings.Builder
+			location := checker.Location.String()
+			printErr := print2.NewErrorPrettyPrinter(&sb, true).
+				PrettyPrintError(err, location, map[string]string{location: code})
+			if printErr != nil {
+				panic(printErr)
+			}
+			assert.FailNow(t, sb.String())
 			return nil
 		}
 	}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -67,18 +67,16 @@ func parseCheckAndInterpretWithOptions(
 
 	if options.HandleCheckerError != nil {
 		options.HandleCheckerError(err)
-	} else {
-		if !assert.NoError(t, err) {
-			var sb strings.Builder
-			locationID := checker.Location.ID()
-			printErr := pretty.NewErrorPrettyPrinter(&sb, true).
-				PrettyPrintError(err, checker.Location, map[common.LocationID]string{locationID: code})
-			if printErr != nil {
-				panic(printErr)
-			}
-			assert.FailNow(t, sb.String())
-			return nil
+	} else if !assert.NoError(t, err) {
+		var sb strings.Builder
+		locationID := checker.Location.ID()
+		printErr := pretty.NewErrorPrettyPrinter(&sb, true).
+			PrettyPrintError(err, checker.Location, map[common.LocationID]string{locationID: code})
+		if printErr != nil {
+			panic(printErr)
 		}
+		assert.FailNow(t, sb.String())
+		return nil
 	}
 
 	var uuid uint64 = 0

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -19,13 +19,11 @@
 package interpreter
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime/cmd"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -81,11 +79,6 @@ func TestInterpretResourceUUID(t *testing.T) {
 			},
 		},
 	)
-
-	if err != nil {
-		cmd.PrettyPrintError(os.Stdout, err, "", map[string]string{"": ""})
-	}
-
 	require.NoError(t, err)
 
 	var uuid uint64

--- a/values_test.go
+++ b/values_test.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cadence
 
 import (


### PR DESCRIPTION
Closes #437

This PR
- Refactors error printing into one place: it was split up, with one part only in the command line,  and was tightly coupled to parser and checker error. Make it generic so that any error can be pretty printed, based on the `HasImportLocation` and `ParentErrors` interfaces
- Pretty prints runtime errors (which may be parsing, checking, or execution errors). Support imports bu keep track of all imported programs (codes)
- Fixes the location info in interpreter errors: We need to use the interpreter of the executed statement to get the position information, not the interpreter that runs the trampoline