### PR TITLE
Fix the export of static types

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -678,15 +678,15 @@ func TestEncodeResource(t *testing.T) {
 		t.Parallel()
 
 		script := `
-			access(all) resource Foo {
-				access(all) let bar: Int
+			pub resource Foo {
+				pub let bar: Int
 	
 				init(bar: Int) {
 					self.bar = bar
 				}
 			}
 	
-			access(all) fun main(): @Foo {
+			pub fun main(): @Foo {
 				return <- create Foo(bar: 42)
 			}
 		`
@@ -703,8 +703,8 @@ func TestEncodeResource(t *testing.T) {
 		t.Parallel()
 
 		script := `
-			access(all) resource Foo {
-				access(all) let bar: Int
+			pub resource Foo {
+				pub let bar: Int
 	
 				pub fun foo(): String {
 					return "foo"
@@ -715,7 +715,7 @@ func TestEncodeResource(t *testing.T) {
 				}
 			}
 	
-			access(all) fun main(): @Foo {
+			pub fun main(): @Foo {
 				return <- create Foo(bar: 42)
 			}
 		`
@@ -736,16 +736,16 @@ func TestEncodeResource(t *testing.T) {
 		t.Parallel()
 
 		script := `
-			access(all) resource Bar {
-				access(all) let x: Int
+			pub resource Bar {
+				pub let x: Int
 	
 				init(x: Int) {
 					self.x = x
 				}
 			}
 	
-			access(all) resource Foo {
-				access(all) let bar: @Bar
+			pub resource Foo {
+				pub let bar: @Bar
 	
 				init(bar: @Bar) {
 					self.bar <- bar
@@ -756,7 +756,7 @@ func TestEncodeResource(t *testing.T) {
 				}
 			}
 	
-			access(all) fun main(): @Foo {
+			pub fun main(): @Foo {
 				return <- create Foo(bar: <- create Bar(x: 42))
 			}
 		`

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -251,7 +251,7 @@ func exportDictionaryValue(
 
 func exportLinkValue(v interpreter.LinkValue, inter *interpreter.Interpreter) cadence.Link {
 	path := exportPathValue(v.TargetPath)
-	ty := inter.ConvertStaticToSemaType(v.Type).QualifiedString()
+	ty := string(inter.ConvertStaticToSemaType(v.Type).ID())
 	return cadence.NewLink(path, ty)
 }
 
@@ -263,14 +263,14 @@ func exportPathValue(v interpreter.PathValue) cadence.Path {
 }
 
 func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) cadence.TypeValue {
-	ty := inter.ConvertStaticToSemaType(v.Type).QualifiedString()
+	ty := string(inter.ConvertStaticToSemaType(v.Type).ID())
 	return cadence.TypeValue{
 		StaticType: ty,
 	}
 }
 
 func exportCapabilityValue(v interpreter.CapabilityValue, inter *interpreter.Interpreter) cadence.Capability {
-	borrowType := inter.ConvertStaticToSemaType(v.BorrowType).QualifiedString()
+	borrowType := string(inter.ConvertStaticToSemaType(v.BorrowType).ID())
 	return cadence.Capability{
 		Path:       exportPathValue(v.Path),
 		Address:    cadence.NewAddress(v.Address),


### PR DESCRIPTION
Static types are currently only exported as a string. However, only the qualified identifier is used (e.g. any type `S` in `C` has qualified identifier `C.S`), which is not unique. 
Use the full type ID instead (e.g. type `S` in `C`, deployed to account 0x1, has ID `A.0x1.C.S`).

Also, add more tests (export of static types which are not primitive)