### PR TITLE
Optimize composite values

### DIFF
--- a/runtime/common/addresslocation_test.go
+++ b/runtime/common/addresslocation_test.go
@@ -74,7 +74,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeAddressLocationTypeID("A.01")
+		_, _, err := decodeAddressLocationTypeID("A.0000000000000001")
 		require.EqualError(t, err, "invalid address location type ID: missing qualified identifier")
 	})
 
@@ -82,7 +82,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeAddressLocationTypeID("X.01.T")
+		_, _, err := decodeAddressLocationTypeID("X.0000000000000001.T")
 		require.EqualError(t, err, "invalid address location type ID: invalid prefix: expected \"A\", got \"X\"")
 	})
 
@@ -90,7 +90,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeAddressLocationTypeID("A.01.T")
+		location, qualifiedIdentifier, err := decodeAddressLocationTypeID("A.0000000000000001.T")
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -107,7 +107,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeAddressLocationTypeID("A.01.T.U")
+		location, qualifiedIdentifier, err := decodeAddressLocationTypeID("A.0000000000000001.T.U")
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -418,7 +418,7 @@ func importCompositeValue(
 
 	return interpreter.NewCompositeValue(
 		location,
-		location.TypeID(qualifiedIdentifier),
+		qualifiedIdentifier,
 		kind,
 		fields,
 		nil,

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -710,10 +710,11 @@ func (e *Encoder) prepareDictionaryValue(
 
 // NOTE: NEVER change, only add/increment; ensure uint64
 const (
-	encodedCompositeValueLocationFieldKey uint64 = 0
-	encodedCompositeValueTypeIDFieldKey   uint64 = 1
-	encodedCompositeValueKindFieldKey     uint64 = 2
-	encodedCompositeValueFieldsFieldKey   uint64 = 3
+	encodedCompositeValueLocationFieldKey            uint64 = 0
+	encodedCompositeValueTypeIDFieldKey              uint64 = 1
+	encodedCompositeValueKindFieldKey                uint64 = 2
+	encodedCompositeValueFieldsFieldKey              uint64 = 3
+	encodedCompositeValueQualifiedIdentifierFieldKey uint64 = 4
 )
 
 func (e *Encoder) prepareCompositeValue(
@@ -744,10 +745,10 @@ func (e *Encoder) prepareCompositeValue(
 	return cbor.Tag{
 		Number: cborTagCompositeValue,
 		Content: cborMap{
-			encodedCompositeValueLocationFieldKey: location,
-			encodedCompositeValueTypeIDFieldKey:   string(v.TypeID),
-			encodedCompositeValueKindFieldKey:     uint(v.Kind),
-			encodedCompositeValueFieldsFieldKey:   fields,
+			encodedCompositeValueLocationFieldKey:            location,
+			encodedCompositeValueKindFieldKey:                uint(v.Kind),
+			encodedCompositeValueFieldsFieldKey:              fields,
+			encodedCompositeValueQualifiedIdentifierFieldKey: v.QualifiedIdentifier,
 		},
 	}, nil
 }

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -345,10 +345,10 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("empty structure, string location", func(t *testing.T) {
+	t.Run("empty structure, string location, qualified identifier", func(t *testing.T) {
 		expected := NewCompositeValue(
 			utils.TestLocation,
-			"S.test.TestStruct",
+			"TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -358,6 +358,51 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				value: expected,
+				encoded: []byte{
+					// tag
+					0xd8, cborTagCompositeValue,
+					// map, 4 pairs of items follow
+					0xa4,
+					// key 0
+					0x0,
+					// tag
+					0xd8, cborTagStringLocation,
+					// UTF-8 string, length 4
+					0x64,
+					// t, e, s, t
+					0x74, 0x65, 0x73, 0x74,
+					// key 2
+					0x2,
+					// positive integer 1
+					0x1,
+					// key 3
+					0x3,
+					// map, 0 pairs of items follow
+					0xa0,
+					// key 4
+					0x4,
+					// UTF-8 string, length 10
+					0x6a,
+					0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+				},
+			},
+		)
+	})
+
+	t.Run("empty structure, string location, type ID", func(t *testing.T) {
+		expected := NewCompositeValue(
+			utils.TestLocation,
+			"TestStruct",
+			common.CompositeKindStructure,
+			map[string]Value{},
+			nil,
+		)
+		expected.modified = false
+
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				decodeOnly:   true,
+				decodedValue: expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -399,7 +444,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 				Address: common.BytesToAddress([]byte{0x1}),
 				Name:    "SimpleStruct",
 			},
-			"A.0x1.SimpleStruct",
+			"SimpleStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -425,12 +470,15 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x1,
 					// key 1
 					0x1,
-					// UTF-8 string, length 18
-					0x72,
-					// A.0x1.SimpleStruct
+					// UTF-8 string, length 31
+					0x78, 0x1F,
+					// A.0000000000000001.SimpleStruct
 					0x41,
-					0x2E, 0x30, 0x78, 0x31,
-					0x2E, 0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+					0x2E,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x31,
+					0x2E,
+					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
 					// positive integer 1
@@ -444,13 +492,13 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("non-empty resource", func(t *testing.T) {
+	t.Run("non-empty resource, qualified identifier", func(t *testing.T) {
 		stringValue := NewStringValue("test")
 		stringValue.modified = false
 
 		expected := NewCompositeValue(
 			utils.TestLocation,
-			"S.test.TestResource",
+			"TestResource",
 			common.CompositeKindResource,
 			map[string]Value{
 				"true":   BoolValue(true),
@@ -463,6 +511,71 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				value: expected,
+				encoded: []byte{
+					// tag
+					0xd8, cborTagCompositeValue,
+					// map, 4 pairs of items follow
+					0xa4,
+					// key 0
+					0x0,
+					// tag
+					0xd8, cborTagStringLocation,
+					// UTF-8 string, length 4
+					0x64,
+					// t, e, s, t
+					0x74, 0x65, 0x73, 0x74,
+					// key 2
+					0x2,
+					// positive integer 2
+					0x2,
+					// key 3
+					0x3,
+					// map, 2 pairs of items follow
+					0xa2,
+					// UTF-8 string, length 4
+					0x64,
+					// t, r, u, e
+					0x74, 0x72, 0x75, 0x65,
+					// true
+					0xf5,
+					// UTF-8 string, length 6
+					0x66,
+					// s, t, r, i, n, g
+					0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+					// UTF-8 string, length 4
+					0x64,
+					// t, e, s, t
+					0x74, 0x65, 0x73, 0x74,
+					// key 4
+					0x4,
+					// UTF-8 string, length 12
+					0x6c,
+					0x54, 0x65, 0x73, 0x74, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65,
+				},
+			},
+		)
+	})
+
+	t.Run("non-empty resource, type ID", func(t *testing.T) {
+		stringValue := NewStringValue("test")
+		stringValue.modified = false
+
+		expected := NewCompositeValue(
+			utils.TestLocation,
+			"TestResource",
+			common.CompositeKindResource,
+			map[string]Value{
+				"true":   BoolValue(true),
+				"string": stringValue,
+			},
+			nil,
+		)
+		expected.modified = false
+
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				decodeOnly:   true,
+				decodedValue: expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -510,7 +623,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("empty, address location", func(t *testing.T) {
+	t.Run("empty, address location, nested", func(t *testing.T) {
 
 		expected := NewCompositeValue(
 			common.AddressLocation{
@@ -518,7 +631,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 				// NOTE: not stored, inferred from type ID
 				Name: "TestContract",
 			},
-			"A.0x1.TestContract.TestStruct",
+			"TestContract.TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -543,12 +656,16 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x1,
 					// key 1
 					0x1,
-					// UTF-8 string, length 29
-					0x78, 0x1D,
+					// UTF-8 string, length 42
+					0x78, 0x2a,
 					0x41,
-					0x2e, 0x30, 0x78, 0x31,
-					0x2e, 0x54, 0x65, 0x73, 0x74, 0x43, 0x6F, 0x6E, 0x74, 0x72, 0x61, 0x63, 0x74,
-					0x2e, 0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+					0x2e,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x31,
+					0x2e,
+					0x54, 0x65, 0x73, 0x74, 0x43, 0x6F, 0x6E, 0x74, 0x72, 0x61, 0x63, 0x74,
+					0x2e,
+					0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
 					// positive integer 1
@@ -607,7 +724,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 				Address: common.BytesToAddress([]byte{0x1}),
 				Name:    "TestStruct",
 			},
-			"A.0x1.TestStruct",
+			"TestStruct",
 			common.CompositeKindStructure,
 			map[string]Value{},
 			nil,
@@ -640,12 +757,6 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x6a,
 					0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
 					0x63, 0x74,
-					// key 1
-					0x1,
-					// UTF-8 string, length 17
-					0x70,
-					0x41, 0x2e, 0x30, 0x78, 0x31, 0x2e, 0x54,
-					0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 					// key 2
 					0x2,
 					// positive integer 1
@@ -654,6 +765,12 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x3,
 					// map, 0 pairs of items follow
 					0xa0,
+					// key 4
+					0x4,
+					// UTF-8 string, length 10
+					0x6a,
+					0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
+					0x63, 0x74,
 				},
 			},
 		)
@@ -3411,7 +3528,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: CompositeStaticType{
-						TypeID: "A.0x1.SimpleStruct",
+						TypeID: "A.0000000000000001.SimpleStruct",
 						Location: common.AddressLocation{
 							Address: common.BytesToAddress([]byte{0x1}),
 							Name:    "SimpleStruct",
@@ -3434,12 +3551,15 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					0x1,
 					// key 1
 					0x1,
-					// UTF-8 string, length 18
-					0x72,
-					// A.0x1.SimpleStruct
+					// UTF-8 string, length 31
+					0x78, 0x1F,
+					// A.0000000000000001.SimpleStruct
 					0x41,
-					0x2E, 0x30, 0x78, 0x31,
-					0x2E, 0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+					0x2E,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x31,
+					0x2E,
+					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
 				),
 			},
 		)
@@ -3474,9 +3594,11 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					// UTF-8 string, length 22
 					0x76,
 					// S.test.SimpleInterface
-					0x53, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x53,
-					0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74,
-					0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
+					0x53,
+					0x2e,
+					0x74, 0x65, 0x73, 0x74,
+					0x2e,
+					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
 				),
 			},
 		)
@@ -3489,7 +3611,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: InterfaceStaticType{
-						TypeID: "A.0x1.SimpleInterface",
+						TypeID: "A.0000000000000001.SimpleInterface",
 						Location: common.AddressLocation{
 							Address: common.BytesToAddress([]byte{0x1}),
 							Name:    "SimpleInterface",
@@ -3512,12 +3634,15 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					0x1,
 					// key 1
 					0x1,
-					// UTF-8 string, length 21
-					0x75,
-					// A.0x1.SimpleInterface
+					// UTF-8 string, length 34
+					0x78, 0x22,
+					// A.0000000000000001.SimpleInterface
 					0x41,
-					0x2E, 0x30, 0x78, 0x31,
-					0x2E, 0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
+					0x2E,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
+					0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x31,
+					0x2E,
+					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
 				),
 			},
 		)
@@ -3806,7 +3931,7 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 		key1.modified = false
 		value1 := NewCompositeValue(
 			utils.TestLocation,
-			"S.test.R",
+			"R",
 			common.CompositeKindResource,
 			map[string]Value{},
 			nil,
@@ -3816,7 +3941,7 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 		key2 := BoolValue(true)
 		value2 := NewCompositeValue(
 			utils.TestLocation,
-			"S.test.R2",
+			"R2",
 			common.CompositeKindResource,
 			map[string]Value{},
 			nil,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -139,7 +139,7 @@ type StorageKeyHandlerFunc func(
 type InjectedCompositeFieldsHandlerFunc func(
 	inter *Interpreter,
 	location common.Location,
-	typeID sema.TypeID,
+	qualifiedIdentifier string,
 	compositeKind common.CompositeKind,
 ) map[string]Value
 
@@ -2484,7 +2484,6 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 	})()
 
 	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
-	typeID := compositeType.ID()
 
 	var initializerFunction FunctionValue
 	if declaration.CompositeKind == common.CompositeKindEvent {
@@ -2567,6 +2566,8 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 
 	location := interpreter.Checker.Location
 
+	qualifiedIdentifier := compositeType.QualifiedIdentifier()
+
 	constructor := NewHostFunctionValue(
 		func(invocation Invocation) Trampoline {
 
@@ -2576,7 +2577,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 				injectedFields = interpreter.injectedCompositeFieldsHandler(
 					interpreter,
 					location,
-					typeID,
+					qualifiedIdentifier,
 					declaration.CompositeKind,
 				)
 			}
@@ -2600,13 +2601,13 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			}
 
 			value := &CompositeValue{
-				Location:       location,
-				TypeID:         typeID,
-				Kind:           declaration.CompositeKind,
-				Fields:         fields,
-				InjectedFields: injectedFields,
-				Functions:      functions,
-				Destructor:     destructorFunction,
+				Location:            location,
+				QualifiedIdentifier: qualifiedIdentifier,
+				Kind:                declaration.CompositeKind,
+				Fields:              fields,
+				InjectedFields:      injectedFields,
+				Functions:           functions,
+				Destructor:          destructorFunction,
 				// NOTE: new value has no owner
 				Owner:    nil,
 				modified: true,
@@ -2674,7 +2675,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 	lexicalScope = lexicalScope.Insert(identifier, variable)
 
 	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
-	typeID := compositeType.ID()
+	qualifiedIdentifier := compositeType.QualifiedIdentifier()
 
 	location := interpreter.Checker.Location
 
@@ -2699,10 +2700,10 @@ func (interpreter *Interpreter) declareEnumConstructor(
 		}
 
 		caseValue := &CompositeValue{
-			Location: location,
-			TypeID:   typeID,
-			Kind:     declaration.CompositeKind,
-			Fields:   caseValueFields,
+			Location:            location,
+			QualifiedIdentifier: qualifiedIdentifier,
+			Kind:                declaration.CompositeKind,
+			Fields:              caseValueFields,
 			// NOTE: new value has no owner
 			Owner:    nil,
 			modified: true,

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -31,7 +31,7 @@ import (
 func newTestCompositeValue(owner common.Address) *CompositeValue {
 	return NewCompositeValue(
 		utils.TestLocation,
-		"S.test.Test",
+		"Test",
 		common.CompositeKindStructure,
 		map[string]Value{},
 		&owner,
@@ -532,7 +532,7 @@ func TestStringer(t *testing.T) {
 		"composite": {
 			value: NewCompositeValue(
 				utils.TestLocation,
-				"S.test.Foo",
+				"Foo",
 				common.CompositeKindResource,
 				map[string]Value{
 					"y": NewStringValue("bar"),
@@ -613,7 +613,7 @@ func TestVisitor(t *testing.T) {
 	value = NewDictionaryValueUnownedNonCopying(NewStringValue("42"), value)
 	value = NewCompositeValue(
 		utils.TestLocation,
-		"S.test.Foo",
+		"Foo",
 		common.CompositeKindStructure,
 		map[string]Value{
 			"foo": value,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -763,7 +763,7 @@ func (r *interpreterRuntime) injectedCompositeFieldsHandler(
 	return func(
 		_ *interpreter.Interpreter,
 		location Location,
-		_ sema.TypeID,
+		_ string,
 		compositeKind common.CompositeKind,
 	) map[string]interpreter.Value {
 

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -142,12 +142,13 @@ func newCryptoContractVerifySignatureFunction(signatureVerifier CryptoSignatureV
 }
 
 func newCryptoContractSignatureVerifier(signatureVerifier CryptoSignatureVerifier) *interpreter.CompositeValue {
-	implementationTypeID :=
-		sema.TypeID(string(cryptoContractInitializerTypes[0].ID()) + "Impl")
+	implIdentifier := CryptoChecker.Location.
+		QualifiedIdentifier(cryptoContractInitializerTypes[0].ID()) +
+		"Impl"
 
 	result := interpreter.NewCompositeValue(
 		CryptoChecker.Location,
-		implementationTypeID,
+		implIdentifier,
 		common.CompositeKindStructure,
 		nil,
 		nil,
@@ -188,12 +189,13 @@ func newCryptoContractHashFunction(hasher CryptoHasher) interpreter.FunctionValu
 }
 
 func newCryptoContractHasher(hasher CryptoHasher) *interpreter.CompositeValue {
-	implementationTypeID :=
-		sema.TypeID(string(cryptoContractInitializerTypes[1].ID()) + "Impl")
+	implIdentifier := CryptoChecker.Location.
+		QualifiedIdentifier(cryptoContractInitializerTypes[1].ID()) +
+		"Impl"
 
 	result := interpreter.NewCompositeValue(
 		CryptoChecker.Location,
-		implementationTypeID,
+		implIdentifier,
 		common.CompositeKindStructure,
 		nil,
 		nil,

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -74,9 +74,9 @@ func TestInterpretVirtualImport(t *testing.T) {
 						return interpreter.VirtualImport{
 							Globals: map[string]interpreter.Value{
 								"Foo": &interpreter.CompositeValue{
-									Location: location,
-									TypeID:   "I.Foo.Foo",
-									Kind:     common.CompositeKindContract,
+									Location:            location,
+									QualifiedIdentifier: "Foo",
+									Kind:                common.CompositeKindContract,
 									Functions: map[string]interpreter.FunctionValue{
 										"bar": interpreter.NewHostFunctionValue(
 											func(invocation interpreter.Invocation) trampoline.Trampoline {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -5722,7 +5722,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 	expectedEvents := []*interpreter.CompositeValue{
 		interpreter.NewCompositeValue(
 			TestLocation,
-			transferEventType.ID(),
+			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
 			map[string]interpreter.Value{
 				"to":   interpreter.NewIntValueFromInt64(1),
@@ -5732,7 +5732,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 		),
 		interpreter.NewCompositeValue(
 			TestLocation,
-			transferEventType.ID(),
+			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
 			map[string]interpreter.Value{
 				"to":   interpreter.NewIntValueFromInt64(3),
@@ -5742,7 +5742,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 		),
 		interpreter.NewCompositeValue(
 			TestLocation,
-			transferAmountEventType.ID(),
+			TestLocation.QualifiedIdentifier(transferAmountEventType.ID()),
 			common.CompositeKindEvent,
 			map[string]interpreter.Value{
 				"to":     interpreter.NewIntValueFromInt64(1),
@@ -5816,7 +5816,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			value: func() interpreter.Value {
 				v := interpreter.NewCompositeValue(
 					TestLocation,
-					"S.test.S",
+					"S",
 					common.CompositeKindStructure,
 					map[string]interpreter.Value{},
 					nil,
@@ -5917,10 +5917,11 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			_, err := inter.Invoke("test")
 			require.NoError(t, err)
 
+			testType := inter.Checker.GlobalTypes["Test"].Type
 			expectedEvents := []*interpreter.CompositeValue{
 				interpreter.NewCompositeValue(
 					TestLocation,
-					inter.Checker.GlobalTypes["Test"].Type.ID(),
+					TestLocation.QualifiedIdentifier(testType.ID()),
 					common.CompositeKindEvent,
 					map[string]interpreter.Value{
 						"value": value.value,
@@ -6561,7 +6562,7 @@ func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) 
 
 	assert.Equal(t,
 		sema.TypeID("S.test.Test.X"),
-		x1.(*interpreter.CompositeValue).TypeID,
+		x1.(*interpreter.CompositeValue).TypeID(),
 	)
 
 	require.IsType(t,
@@ -6571,7 +6572,7 @@ func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) 
 
 	assert.Equal(t,
 		sema.TypeID("S.test.Test.X"),
-		x2.(*interpreter.CompositeValue).TypeID,
+		x2.(*interpreter.CompositeValue).TypeID(),
 	)
 }
 
@@ -6604,7 +6605,7 @@ func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
 
 	assert.Equal(t,
 		sema.TypeID("S.test.Test.X"),
-		x.(*interpreter.CompositeValue).TypeID,
+		x.(*interpreter.CompositeValue).TypeID(),
 	)
 }
 
@@ -6705,7 +6706,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 					func(
 						_ *interpreter.Interpreter,
 						_ common.Location,
-						_ sema.TypeID,
+						_ string,
 						_ common.CompositeKind,
 					) map[string]interpreter.Value {
 						panicFunction := interpreter.NewHostFunctionValue(func(invocation interpreter.Invocation) trampoline.Trampoline {


### PR DESCRIPTION
Only store the qualified identifier of a composite value, not the full type ID.
The composite value already stores the location, so it was duplicated in the type ID.

