### PR TITLE
Optimize composite and interface static types

### DIFF
--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -721,8 +721,8 @@ func TestExportCapabilityValue(t *testing.T) {
 				Identifier: "foo",
 			},
 			BorrowType: interpreter.CompositeStaticType{
-				TypeID:   utils.TestLocation.TypeID("S"),
-				Location: utils.TestLocation,
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "S",
 			},
 		}
 		actual := exportValueWithInterpreter(capability, inter, exportResults{})
@@ -784,8 +784,8 @@ func TestExportLinkValue(t *testing.T) {
 				Identifier: "foo",
 			},
 			Type: interpreter.CompositeStaticType{
-				TypeID:   utils.TestLocation.TypeID("S"),
-				Location: utils.TestLocation,
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "S",
 			},
 		}
 		actual := exportValueWithInterpreter(capability, inter, exportResults{})

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -963,8 +963,9 @@ func (e *Encoder) prepareOptionalStaticType(v OptionalStaticType) (interface{}, 
 
 // NOTE: NEVER change, only add/increment; ensure uint64
 const (
-	encodedCompositeStaticTypeLocationFieldKey uint64 = 0
-	encodedCompositeStaticTypeTypeIDFieldKey   uint64 = 1
+	encodedCompositeStaticTypeLocationFieldKey            uint64 = 0
+	encodedCompositeStaticTypeTypeIDFieldKey              uint64 = 1
+	encodedCompositeStaticTypeQualifiedIdentifierFieldKey uint64 = 2
 )
 
 func (e *Encoder) prepareCompositeStaticType(v CompositeStaticType) (interface{}, error) {
@@ -973,20 +974,20 @@ func (e *Encoder) prepareCompositeStaticType(v CompositeStaticType) (interface{}
 		return nil, err
 	}
 
-	// TODO: optimize, decode location from type ID
 	return cbor.Tag{
 		Number: cborTagCompositeStaticType,
 		Content: cborMap{
-			encodedCompositeStaticTypeLocationFieldKey: location,
-			encodedCompositeStaticTypeTypeIDFieldKey:   string(v.TypeID),
+			encodedCompositeStaticTypeLocationFieldKey:            location,
+			encodedCompositeStaticTypeQualifiedIdentifierFieldKey: v.QualifiedIdentifier,
 		},
 	}, nil
 }
 
 // NOTE: NEVER change, only add/increment; ensure uint64
 const (
-	encodedInterfaceStaticTypeLocationFieldKey uint64 = 0
-	encodedInterfaceStaticTypeTypeIDFieldKey   uint64 = 1
+	encodedInterfaceStaticTypeLocationFieldKey            uint64 = 0
+	encodedInterfaceStaticTypeTypeIDFieldKey              uint64 = 1
+	encodedInterfaceStaticTypeQualifiedIdentifierFieldKey uint64 = 2
 )
 
 func (e *Encoder) prepareInterfaceStaticType(v InterfaceStaticType) (interface{}, error) {
@@ -995,12 +996,11 @@ func (e *Encoder) prepareInterfaceStaticType(v InterfaceStaticType) (interface{}
 		return nil, err
 	}
 
-	// TODO: optimize, decode location from type ID
 	return cbor.Tag{
 		Number: cborTagInterfaceStaticType,
 		Content: cborMap{
-			encodedInterfaceStaticTypeLocationFieldKey: location,
-			encodedInterfaceStaticTypeTypeIDFieldKey:   string(v.TypeID),
+			encodedInterfaceStaticTypeLocationFieldKey:            location,
+			encodedInterfaceStaticTypeQualifiedIdentifierFieldKey: v.QualifiedIdentifier,
 		},
 	}, nil
 }

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3484,14 +3484,50 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 		)
 	})
 
-	t.Run("composite, struct", func(t *testing.T) {
+	t.Run("composite, struct, qualified identifier", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				value: LinkValue{
 					TargetPath: publicPathValue,
 					Type: CompositeStaticType{
-						TypeID:   "S.test.SimpleStruct",
-						Location: utils.TestLocation,
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "SimpleStruct",
+					},
+				},
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
+					// tag
+					0xd8, cborTagCompositeStaticType,
+					// map, 2 pairs of items follow
+					0xa2,
+					// key 0
+					0x0,
+					// tag
+					0xd8, cborTagStringLocation,
+					// UTF-8 string, length 4
+					0x64,
+					// t, e, s, t
+					0x74, 0x65, 0x73, 0x74,
+					// key 1
+					0x2,
+					// UTF-8 string, length 12
+					0x6c,
+					// SimpleStruct
+					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+				),
+			},
+		)
+	})
+
+	t.Run("composite, struct, type ID", func(t *testing.T) {
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				decodeOnly: true,
+				decodedValue: LinkValue{
+					TargetPath: publicPathValue,
+					Type: CompositeStaticType{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "SimpleStruct",
 					},
 				},
 				encoded: append(
@@ -3528,11 +3564,11 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: CompositeStaticType{
-						TypeID: "A.0000000000000001.SimpleStruct",
 						Location: common.AddressLocation{
 							Address: common.BytesToAddress([]byte{0x1}),
 							Name:    "SimpleStruct",
 						},
+						QualifiedIdentifier: "SimpleStruct",
 					},
 				},
 				encoded: append(
@@ -3565,14 +3601,50 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 		)
 	})
 
-	t.Run("interface, struct", func(t *testing.T) {
+	t.Run("interface, struct, qualified identifier", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				value: LinkValue{
 					TargetPath: publicPathValue,
 					Type: InterfaceStaticType{
-						TypeID:   "S.test.SimpleInterface",
-						Location: utils.TestLocation,
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "SimpleInterface",
+					},
+				},
+				encoded: append(
+					expectedLinkEncodingPrefix[:],
+					// tag
+					0xd8, cborTagInterfaceStaticType,
+					// map, 2 pairs of items follow
+					0xa2,
+					// key 0
+					0x0,
+					// tag
+					0xd8, cborTagStringLocation,
+					// UTF-8 string, length 4
+					0x64,
+					// t, e, s, t
+					0x74, 0x65, 0x73, 0x74,
+					// key 1
+					0x2,
+					// UTF-8 string, length 22
+					0x6F,
+					// SimpleInterface
+					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
+				),
+			},
+		)
+	})
+
+	t.Run("interface, struct, type ID", func(t *testing.T) {
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				decodeOnly: true,
+				decodedValue: LinkValue{
+					TargetPath: publicPathValue,
+					Type: InterfaceStaticType{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "SimpleInterface",
 					},
 				},
 				encoded: append(
@@ -3611,11 +3683,11 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: InterfaceStaticType{
-						TypeID: "A.0000000000000001.SimpleInterface",
 						Location: common.AddressLocation{
 							Address: common.BytesToAddress([]byte{0x1}),
 							Name:    "SimpleInterface",
 						},
+						QualifiedIdentifier: "SimpleInterface",
 					},
 				},
 				encoded: append(
@@ -3797,17 +3869,17 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					TargetPath: publicPathValue,
 					Type: RestrictedStaticType{
 						Type: CompositeStaticType{
-							TypeID:   "S.test.S",
-							Location: utils.TestLocation,
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "S",
 						},
 						Restrictions: []InterfaceStaticType{
 							{
-								TypeID:   "S.test.I1",
-								Location: utils.TestLocation,
+								Location:            utils.TestLocation,
+								QualifiedIdentifier: "I1",
 							},
 							{
-								TypeID:   "S.test.I2",
-								Location: utils.TestLocation,
+								Location:            utils.TestLocation,
+								QualifiedIdentifier: "I2",
 							},
 						},
 					},
@@ -3832,12 +3904,12 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					0x64,
 					// t, e, s, t
 					0x74, 0x65, 0x73, 0x74,
-					// key 1
-					0x1,
-					// UTF-8 string, length 8
-					0x68,
-					// S.test.S
-					0x53, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x53,
+					// key 2
+					0x2,
+					// UTF-8 string, length 1
+					0x61,
+					// S
+					0x53,
 					// key 1
 					0x1,
 					// array, length 2
@@ -3854,12 +3926,12 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					0x64,
 					// t, e, s, t
 					0x74, 0x65, 0x73, 0x74,
-					// key 1
-					0x1,
-					// UTF-8 string, length 9
-					0x69,
-					// S.test.I1
-					0x53, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x49, 0x31,
+					// key 2
+					0x2,
+					// UTF-8 string, length 2
+					0x62,
+					// I1
+					0x49, 0x31,
 					// tag
 					0xd8, cborTagInterfaceStaticType,
 					// map, 2 pairs of items follow
@@ -3872,12 +3944,12 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					0x64,
 					// t, e, s, t
 					0x74, 0x65, 0x73, 0x74,
-					// key 1
-					0x1,
-					// UTF-8 string, length 9
-					0x69,
-					// S.test.I2
-					0x53, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x49, 0x32,
+					// key 2
+					0x2,
+					// UTF-8 string, length 2
+					0x62,
+					// I2
+					0x49, 0x32,
 				),
 			},
 		)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4417,11 +4417,11 @@ func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
 func (interpreter *Interpreter) ConvertStaticToSemaType(staticType StaticType) sema.Type {
 	return ConvertStaticToSemaType(
 		staticType,
-		func(location common.Location, typeID sema.TypeID) *sema.InterfaceType {
-			return interpreter.getInterfaceType(location, typeID)
+		func(location common.Location, qualifiedIdentifier string) *sema.InterfaceType {
+			return interpreter.getInterfaceType(location, qualifiedIdentifier)
 		},
-		func(location common.Location, typeID sema.TypeID) *sema.CompositeType {
-			return interpreter.getCompositeType(location, typeID)
+		func(location common.Location, qualifiedIdentifier string) *sema.CompositeType {
+			return interpreter.getCompositeType(location, qualifiedIdentifier)
 		},
 	)
 }
@@ -4447,13 +4447,15 @@ func (interpreter *Interpreter) getElaboration(location common.Location) *sema.E
 	return checker.Elaboration
 }
 
-func (interpreter *Interpreter) getCompositeType(location common.Location, typeID sema.TypeID) *sema.CompositeType {
+func (interpreter *Interpreter) getCompositeType(location common.Location, qualifiedIdentifier string) *sema.CompositeType {
 	elaboration := interpreter.getElaboration(location)
+	typeID := location.TypeID(qualifiedIdentifier)
 	return elaboration.CompositeTypes[typeID]
 }
 
-func (interpreter *Interpreter) getInterfaceType(location common.Location, typeID sema.TypeID) *sema.InterfaceType {
+func (interpreter *Interpreter) getInterfaceType(location common.Location, qualifiedIdentifier string) *sema.InterfaceType {
 	elaboration := interpreter.getElaboration(location)
+	typeID := location.TypeID(qualifiedIdentifier)
 	return elaboration.InterfaceTypes[typeID]
 }
 

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -42,34 +42,34 @@ type StaticType interface {
 // CompositeStaticType
 
 type CompositeStaticType struct {
-	Location common.Location
-	TypeID   sema.TypeID
+	Location            common.Location
+	QualifiedIdentifier string
 }
 
 func (CompositeStaticType) isStaticType() {}
 
 func (t CompositeStaticType) String() string {
 	return fmt.Sprintf(
-		"CompositeStaticType(Location: %s, TypeID: %s)",
+		"CompositeStaticType(Location: %s, QualifiedIdentifier: %s)",
 		t.Location,
-		t.TypeID,
+		t.QualifiedIdentifier,
 	)
 }
 
 // InterfaceStaticType
 
 type InterfaceStaticType struct {
-	Location common.Location
-	TypeID   sema.TypeID
+	Location            common.Location
+	QualifiedIdentifier string
 }
 
 func (InterfaceStaticType) isStaticType() {}
 
 func (t InterfaceStaticType) String() string {
 	return fmt.Sprintf(
-		"InterfaceStaticType(Location: %s, TypeID: %s)",
+		"InterfaceStaticType(Location: %s, QualifiedIdentifier: %s)",
 		t.Location,
-		t.TypeID,
+		t.QualifiedIdentifier,
 	)
 }
 
@@ -181,8 +181,8 @@ func ConvertSemaToStaticType(t sema.Type) StaticType {
 	switch t := t.(type) {
 	case *sema.CompositeType:
 		return CompositeStaticType{
-			Location: t.Location,
-			TypeID:   t.ID(),
+			Location:            t.Location,
+			QualifiedIdentifier: t.QualifiedIdentifier(),
 		}
 
 	case *sema.InterfaceType:
@@ -249,22 +249,22 @@ func convertSemaReferenceToStaticReferenceType(t *sema.ReferenceType) ReferenceS
 
 func convertToInterfaceStaticType(t *sema.InterfaceType) InterfaceStaticType {
 	return InterfaceStaticType{
-		Location: t.Location,
-		TypeID:   t.ID(),
+		Location:            t.Location,
+		QualifiedIdentifier: t.QualifiedIdentifier(),
 	}
 }
 
 func ConvertStaticToSemaType(
 	typ StaticType,
-	getInterface func(location common.Location, id sema.TypeID) *sema.InterfaceType,
-	getComposite func(location common.Location, id sema.TypeID) *sema.CompositeType,
+	getInterface func(location common.Location, qualifiedIdentifier string) *sema.InterfaceType,
+	getComposite func(location common.Location, qualifiedIdentifier string) *sema.CompositeType,
 ) sema.Type {
 	switch t := typ.(type) {
 	case CompositeStaticType:
-		return getComposite(t.Location, t.TypeID)
+		return getComposite(t.Location, t.QualifiedIdentifier)
 
 	case InterfaceStaticType:
-		return getInterface(t.Location, t.TypeID)
+		return getInterface(t.Location, t.QualifiedIdentifier)
 
 	case VariableSizedStaticType:
 		return &sema.VariableSizedType{
@@ -292,7 +292,7 @@ func ConvertStaticToSemaType(
 		restrictions := make([]*sema.InterfaceType, len(t.Restrictions))
 
 		for i, restriction := range t.Restrictions {
-			restrictions[i] = getInterface(restriction.Location, restriction.TypeID)
+			restrictions[i] = getInterface(restriction.Location, restriction.QualifiedIdentifier)
 		}
 
 		return &sema.RestrictedType{

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5281,7 +5281,7 @@ func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (v *CompositeValue) DynamicType(interpreter *Interpreter) DynamicType {
-	staticType := interpreter.getCompositeType(v.Location, v.TypeID())
+	staticType := interpreter.getCompositeType(v.Location, v.QualifiedIdentifier)
 	return CompositeDynamicType{
 		StaticType: staticType,
 	}


### PR DESCRIPTION
Only store the qualified identifier in composite and interface static types, not the full type ID.
The static types already stores the location, so it was duplicated in the type ID.