### PR TITLE
Improve fixed-point multiplication and division

### DIFF
--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -3142,6 +3142,11 @@ func TestDivFix64(t *testing.T) {
 		Fix64Value(1).
 			Div(NewFix64ValueWithInteger(2))
 	})
+
+	assert.Equal(t,
+		Fix64Value(1535399),
+		NewFix64ValueWithInteger(1543219).Div(NewFix64ValueWithInteger(100509284)),
+	)
 }
 
 func TestModFix64(t *testing.T) {
@@ -3252,6 +3257,11 @@ func TestDivModUFix64(t *testing.T) {
 		UFix64Value(1).
 			Div(NewUFix64ValueWithInteger(2))
 	})
+
+	assert.Equal(t,
+		UFix64Value(1535399),
+		NewUFix64ValueWithInteger(1543219).Div(NewUFix64ValueWithInteger(100509284)),
+	)
 }
 
 // TestNegativeMod ensures that modulo uses the dividend's sign

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -3079,6 +3079,8 @@ func TestDivFix64(t *testing.T) {
 
 	t.Parallel()
 
+	const fix64MaxIntDividend = Fix64MaxValue / sema.Fix64Factor
+
 	tests := []struct {
 		a, b  int64
 		valid bool
@@ -3086,29 +3088,29 @@ func TestDivFix64(t *testing.T) {
 		{0, 0, false},
 		{1, 0, false},
 		{2, 0, false},
-		{Fix64MaxIntDividend, 0, false},
-		{Fix64MaxIntDividend + 1, 0, false},
+		{fix64MaxIntDividend, 0, false},
+		{fix64MaxIntDividend + 1, 0, false},
 		{-1, 0, false},
 
 		{0, 1, true},
 		{1, 1, true},
 		{2, 1, true},
-		{Fix64MaxIntDividend, 1, true},
-		{Fix64MaxIntDividend + 1, 1, false},
+		{fix64MaxIntDividend, 1, true},
+		{fix64MaxIntDividend + 1, 1, false},
 		{-1, 1, true},
 
 		{0, 2, true},
 		{1, 2, true},
 		{2, 2, true},
-		{Fix64MaxIntDividend, 2, true},
-		{Fix64MaxIntDividend + 1, 2, false},
+		{fix64MaxIntDividend, 2, true},
+		{fix64MaxIntDividend + 1, 2, false},
 		{-1, 2, true},
 
 		{0, -1, true},
 		{1, -1, true},
 		{2, -1, true},
-		{Fix64MaxIntDividend, -1, true},
-		{Fix64MaxIntDividend + 1, -1, false},
+		{fix64MaxIntDividend, -1, true},
+		{fix64MaxIntDividend + 1, -1, false},
 		{-1, -1, true},
 	}
 
@@ -3196,6 +3198,8 @@ func TestDivModUFix64(t *testing.T) {
 
 	t.Parallel()
 
+	const ufix64MaxIntDividend = UFix64MaxValue / sema.Fix64Factor
+
 	tests := []struct {
 		a, b  uint64
 		valid bool
@@ -3203,20 +3207,20 @@ func TestDivModUFix64(t *testing.T) {
 		{0, 0, false},
 		{1, 0, false},
 		{2, 0, false},
-		{UFix64MaxIntDividend, 0, false},
-		{UFix64MaxIntDividend + 1, 0, false},
+		{ufix64MaxIntDividend, 0, false},
+		{ufix64MaxIntDividend + 1, 0, false},
 
 		{0, 1, true},
 		{1, 1, true},
 		{2, 1, true},
-		{UFix64MaxIntDividend, 1, true},
-		{UFix64MaxIntDividend + 1, 1, false},
+		{ufix64MaxIntDividend, 1, true},
+		{ufix64MaxIntDividend + 1, 1, false},
 
 		{0, 2, true},
 		{1, 2, true},
 		{2, 2, true},
-		{UFix64MaxIntDividend, 2, true},
-		{UFix64MaxIntDividend + 1, 2, false},
+		{ufix64MaxIntDividend, 2, true},
+		{ufix64MaxIntDividend + 1, 2, false},
 	}
 
 	for _, test := range tests {

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -3075,60 +3075,6 @@ func TestModInt256(t *testing.T) {
 	}
 }
 
-func TestReciprocalFix64(t *testing.T) {
-
-	t.Parallel()
-
-	assert.PanicsWithValue(t,
-		DivisionByZeroError{},
-		func() {
-			Fix64Value(0).Reciprocal()
-		},
-	)
-
-	assert.Equal(t,
-		Fix64Value(sema.Fix64Factor),
-		Fix64Value(sema.Fix64Factor).Reciprocal(),
-	)
-
-	assert.Equal(t,
-		Fix64Value(1),
-		Fix64Value(Fix64MaxDivisorValue).Reciprocal(),
-	)
-
-	assert.Equal(t,
-		Fix64Value(0),
-		Fix64Value(2*Fix64MaxDivisorValue).Reciprocal(),
-	)
-}
-
-func TestReciprocalUFix64(t *testing.T) {
-
-	t.Parallel()
-
-	assert.PanicsWithValue(t,
-		DivisionByZeroError{},
-		func() {
-			UFix64Value(0).Reciprocal()
-		},
-	)
-
-	assert.Equal(t,
-		UFix64Value(sema.Fix64Factor),
-		UFix64Value(sema.Fix64Factor).Reciprocal(),
-	)
-
-	assert.Equal(t,
-		UFix64Value(1),
-		UFix64Value(Fix64MaxDivisorValue).Reciprocal(),
-	)
-
-	assert.Equal(t,
-		UFix64Value(0),
-		UFix64Value(2*Fix64MaxDivisorValue).Reciprocal(),
-	)
-}
-
 func TestDivFix64(t *testing.T) {
 
 	t.Parallel()
@@ -3184,12 +3130,17 @@ func TestDivFix64(t *testing.T) {
 	assert.Equal(t,
 		Fix64Value(1),
 		NewFix64ValueWithInteger(1).
-			Div(Fix64Value(Fix64MaxDivisorValue)),
+			Div(NewFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Panics(t, func() {
 		NewFix64ValueWithInteger(1).
-			Div(Fix64Value(Fix64MaxDivisorValue + 1))
+			Div(Fix64Value(Fix64MaxValue))
+	})
+
+	assert.Panics(t, func() {
+		Fix64Value(1).
+			Div(NewFix64ValueWithInteger(2))
 	})
 }
 
@@ -3289,12 +3240,17 @@ func TestDivModUFix64(t *testing.T) {
 	assert.Equal(t,
 		UFix64Value(1),
 		NewUFix64ValueWithInteger(1).
-			Div(UFix64Value(UFix64MaxDivisorValue)),
+			Div(NewUFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Panics(t, func() {
 		NewUFix64ValueWithInteger(1).
-			Div(UFix64Value(UFix64MaxDivisorValue + 1))
+			Div(UFix64Value(UFix64MaxValue))
+	})
+
+	assert.Panics(t, func() {
+		UFix64Value(1).
+			Div(NewUFix64ValueWithInteger(2))
 	})
 }
 

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -3133,15 +3133,17 @@ func TestDivFix64(t *testing.T) {
 			Div(NewFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
-	assert.Panics(t, func() {
+	assert.Equal(t,
+		Fix64Value(0),
 		NewFix64ValueWithInteger(1).
-			Div(Fix64Value(Fix64MaxValue))
-	})
+			Div(Fix64Value(Fix64MaxValue)),
+	)
 
-	assert.Panics(t, func() {
+	assert.Equal(t,
+		Fix64Value(0),
 		Fix64Value(1).
-			Div(NewFix64ValueWithInteger(2))
-	})
+			Div(NewFix64ValueWithInteger(2)),
+	)
 
 	assert.Equal(t,
 		Fix64Value(1535399),
@@ -3248,15 +3250,17 @@ func TestDivModUFix64(t *testing.T) {
 			Div(NewUFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
-	assert.Panics(t, func() {
+	assert.Equal(t,
+		UFix64Value(0),
 		NewUFix64ValueWithInteger(1).
-			Div(UFix64Value(UFix64MaxValue))
-	})
+			Div(UFix64Value(UFix64MaxValue)),
+	)
 
-	assert.Panics(t, func() {
+	assert.Equal(t,
+		UFix64Value(0),
 		UFix64Value(1).
-			Div(NewUFix64ValueWithInteger(2))
-	})
+			Div(NewUFix64ValueWithInteger(2)),
+	)
 
 	assert.Equal(t,
 		UFix64Value(1535399),

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4878,12 +4878,7 @@ func (v Fix64Value) Div(other NumberValue) NumberValue {
 		panic(OverflowError{})
 	}
 
-	res := result.Int64()
-	if res == 0 && v != 0 {
-		panic(OverflowError{})
-	}
-
-	return Fix64Value(res)
+	return Fix64Value(result.Int64())
 }
 
 func (v Fix64Value) Mod(other NumberValue) NumberValue {
@@ -5095,12 +5090,7 @@ func (v UFix64Value) Div(other NumberValue) NumberValue {
 		panic(OverflowError{})
 	}
 
-	res := result.Uint64()
-	if res == 0 && v != 0 {
-		panic(OverflowError{})
-	}
-
-	return UFix64Value(res)
+	return UFix64Value(result.Uint64())
 }
 
 func (v UFix64Value) Mod(other NumberValue) NumberValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4767,7 +4767,6 @@ func (v Word64Value) ToBigEndianBytes() []byte {
 type Fix64Value int64
 
 const Fix64MaxValue = math.MaxInt64
-const Fix64MaxIntDividend = Fix64MaxValue / sema.Fix64Factor
 
 func NewFix64ValueWithInteger(integer int64) Fix64Value {
 
@@ -4990,7 +4989,6 @@ func (v Fix64Value) ToBigEndianBytes() []byte {
 type UFix64Value uint64
 
 const UFix64MaxValue = math.MaxUint64
-const UFix64MaxIntDividend = UFix64MaxValue / sema.Fix64Factor
 
 func NewUFix64ValueWithInteger(integer uint64) UFix64Value {
 	if integer > sema.UFix64TypeMaxInt {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3030,6 +3030,8 @@ func (t *SignedFixedPointType) GetMembers() map[string]MemberResolver {
 const Fix64Scale = fixedpoint.Fix64Scale
 const Fix64Factor = fixedpoint.Fix64Factor
 
+var Fix64FactorBig = new(big.Int).SetUint64(uint64(Fix64Factor))
+
 // Fix64Type represents the 64-bit signed decimal fixed-point type `Fix64`
 // which has a scale of Fix64Scale, and checks for overflow and underflow
 type Fix64Type struct{}


### PR DESCRIPTION
Use `big.Int` to improve fixed-point multiplication and division.

See https://axiomzen.slack.com/archives/CG0B7CJAJ/p1607115540200500.