### PR TITLE
Add getType function 

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -598,8 +598,15 @@ func decodePath(valueJSON interface{}) cadence.Path {
 func decodeTypeValue(valueJSON interface{}) cadence.TypeValue {
 	obj := toObject(valueJSON)
 
+	var staticType string
+
+	staticTypeProperty, ok := obj[staticTypeKey]
+	if ok && staticTypeProperty != nil {
+		staticType = toString(staticTypeProperty)
+	}
+
 	return cadence.TypeValue{
-		StaticType: obj.GetString(staticTypeKey),
+		StaticType: staticType,
 	}
 }
 

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -976,13 +976,29 @@ func TestEncodeType(t *testing.T) {
 
 	t.Parallel()
 
-	testEncodeAndDecode(
-		t,
-		cadence.TypeValue{
-			StaticType: "Int",
-		},
-		`{"type":"Type","value":{"staticType":"Int"}}`,
-	)
+	t.Run("with static type", func(t *testing.T) {
+
+		t.Parallel()
+
+		testEncodeAndDecode(
+			t,
+			cadence.TypeValue{
+				StaticType: "Int",
+			},
+			`{"type":"Type","value":{"staticType":"Int"}}`,
+		)
+
+	})
+	t.Run("without static type", func(t *testing.T) {
+
+		t.Parallel()
+
+		testEncodeAndDecode(
+			t,
+			cadence.TypeValue{},
+			`{"type":"Type","value":{"staticType":""}}`,
+		)
+	})
 }
 
 func TestEncodeCapability(t *testing.T) {

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -24,7 +24,6 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 // ExportType converts a runtime type to its corresponding Go representation.
@@ -123,7 +122,7 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return exportReferenceType(t, results)
 		case *sema.RestrictedType:
 			return exportRestrictedType(t, results)
-		case *stdlib.BlockType:
+		case *sema.BlockType:
 			return cadence.BlockType{}
 		case *sema.CheckedFunctionType:
 			return exportFunctionType(t.FunctionType, results)

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -263,9 +263,13 @@ func exportPathValue(v interpreter.PathValue) cadence.Path {
 }
 
 func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) cadence.TypeValue {
-	ty := string(inter.ConvertStaticToSemaType(v.Type).ID())
+	var typeID string
+	staticType := v.Type
+	if staticType != nil {
+		typeID = string(inter.ConvertStaticToSemaType(staticType).ID())
+	}
 	return cadence.TypeValue{
-		StaticType: ty,
+		StaticType: typeID,
 	}
 }
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -670,6 +670,21 @@ func TestExportTypeValue(t *testing.T) {
 
 		assert.Equal(t, expected, actual)
 	})
+
+	t.Run("without static type", func(t *testing.T) {
+
+		t.Parallel()
+
+		value := interpreter.TypeValue{
+			Type: nil,
+		}
+		actual := exportValueWithInterpreter(value, nil, exportResults{})
+		expected := cadence.TypeValue{
+			StaticType: "",
+		}
+
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestExportCapabilityValue(t *testing.T) {

--- a/runtime/format/type.go
+++ b/runtime/format/type.go
@@ -23,5 +23,8 @@ import (
 )
 
 func TypeValue(ty string) string {
+	if ty == "" {
+		return "Type()"
+	}
 	return fmt.Sprintf("Type<%s>()", ty)
 }

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -47,6 +47,10 @@ func (AuthAccountContractsValue) DynamicType(_ *Interpreter) DynamicType {
 	return AuthAccountContractsDynamicType{}
 }
 
+func (AuthAccountContractsValue) StaticType() StaticType {
+	return PrimitiveStaticTypeAuthAccountContracts
+}
+
 func (v AuthAccountContractsValue) Copy() Value {
 	return v
 }

--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package interpreter
 
 import (

--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -1,0 +1,93 @@
+package interpreter
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/common"
+	runtimeErrors "github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+// Block
+
+type BlockValue struct {
+	Height    UInt64Value
+	View      UInt64Value
+	ID        *ArrayValue
+	Timestamp Fix64Value
+}
+
+func (BlockValue) IsValue() {}
+
+func (v BlockValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitValue(interpreter, v)
+}
+
+func (BlockValue) DynamicType(_ *Interpreter) DynamicType {
+	return BlockDynamicType{}
+}
+
+func (BlockValue) StaticType() StaticType {
+	return PrimitiveStaticTypeBlock
+}
+
+func (v BlockValue) Copy() Value {
+	return v
+}
+
+func (BlockValue) GetOwner() *common.Address {
+	// value is never owned
+	return nil
+}
+
+func (BlockValue) SetOwner(_ *common.Address) {
+	// NO-OP: value cannot be owned
+}
+
+func (BlockValue) IsModified() bool {
+	return false
+}
+
+func (BlockValue) SetModified(_ bool) {
+	// NO-OP
+}
+
+func (v BlockValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+	switch name {
+	case "height":
+		return v.Height
+
+	case "view":
+		return v.View
+
+	case "id":
+		return v.ID
+
+	case "timestamp":
+		return v.Timestamp
+	}
+
+	return nil
+}
+
+func (v BlockValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
+	panic(runtimeErrors.NewUnreachableError())
+}
+
+func (v BlockValue) IDAsByteArray() [sema.BlockIDSize]byte {
+	var byteArray [sema.BlockIDSize]byte
+	for i, b := range v.ID.Values {
+		byteArray[i] = byte(b.(UInt8Value))
+	}
+	return byteArray
+}
+
+func (v BlockValue) String() string {
+	return fmt.Sprintf(
+		"Block(height: %s, view: %s, id: 0x%x, timestamp: %s)",
+		v.Height,
+		v.View,
+		v.IDAsByteArray(),
+		v.Timestamp,
+	)
+}

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1436,19 +1436,25 @@ func (d *Decoder) decodeRestrictedStaticType(v interface{}) (StaticType, error) 
 }
 
 func (d *Decoder) decodeType(v interface{}) (TypeValue, error) {
+
 	encoded, ok := v.(map[interface{}]interface{})
 	if !ok {
 		return TypeValue{}, fmt.Errorf("invalid type encoding")
 	}
 
-	decodedStaticType, err := d.decodeStaticType(encoded[encodedTypeValueTypeFieldKey])
-	if err != nil {
-		return TypeValue{}, fmt.Errorf("invalid type encoding: %w", err)
-	}
+	var staticType StaticType
 
-	staticType, ok := decodedStaticType.(StaticType)
-	if !ok {
-		return TypeValue{}, fmt.Errorf("invalid type encoding: %T", decodedStaticType)
+	staticTypeField, ok := encoded[encodedTypeValueTypeFieldKey]
+	if ok {
+		decodedStaticType, err := d.decodeStaticType(staticTypeField)
+		if err != nil {
+			return TypeValue{}, fmt.Errorf("invalid type encoding: %w", err)
+		}
+
+		staticType, ok = decodedStaticType.(StaticType)
+		if !ok {
+			return TypeValue{}, fmt.Errorf("invalid type encoding: %T", decodedStaticType)
+		}
 	}
 
 	return TypeValue{

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -45,6 +45,10 @@ func (DeployedContractValue) DynamicType(_ *Interpreter) DynamicType {
 	return DeployedContractDynamicType{}
 }
 
+func (DeployedContractValue) StaticType() StaticType {
+	return PrimitiveStaticTypeDeployedContract
+}
+
 func (v DeployedContractValue) Copy() Value {
 	return v
 }

--- a/runtime/interpreter/dynamictype.go
+++ b/runtime/interpreter/dynamictype.go
@@ -202,3 +202,9 @@ func (DeployedContractDynamicType) IsDynamicType() {}
 type AuthAccountContractsDynamicType struct{}
 
 func (AuthAccountContractsDynamicType) IsDynamicType() {}
+
+// BlockDynamicType
+
+type BlockDynamicType struct{}
+
+func (BlockDynamicType) IsDynamicType() {}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1122,15 +1122,22 @@ const (
 )
 
 func (e *Encoder) prepareTypeValue(v TypeValue) (interface{}, error) {
-	staticType, err := e.prepareStaticType(v.Type)
-	if err != nil {
-		return nil, err
+
+	content := cborMap{}
+
+	staticType := v.Type
+	if staticType != nil {
+		preparedStaticType, err := e.prepareStaticType(staticType)
+		if err != nil {
+			return nil, err
+		}
+
+		content[encodedTypeValueTypeFieldKey] = preparedStaticType
 	}
+
 	return cbor.Tag{
-		Number: cborTagTypeValue,
-		Content: cborMap{
-			encodedTypeValueTypeFieldKey: staticType,
-		},
+		Number:  cborTagTypeValue,
+		Content: content,
 	}, nil
 }
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -4178,4 +4178,20 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("without static type", func(t *testing.T) {
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				value: TypeValue{
+					Type: nil,
+				},
+				encoded: []byte{
+					// tag
+					0xd8, cborTagTypeValue,
+					// map, 0 pairs of items follow
+					0xa0,
+				},
+			},
+		)
+	})
 }

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -68,12 +68,17 @@ func (f InterpretedFunctionValue) String() string {
 
 func (InterpretedFunctionValue) IsValue() {}
 
-func (v InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
-	visitor.VisitInterpretedFunctionValue(interpreter, v)
+func (f InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitInterpretedFunctionValue(interpreter, f)
 }
 
 func (InterpretedFunctionValue) DynamicType(_ *Interpreter) DynamicType {
 	return FunctionDynamicType{}
+}
+
+func (f InterpretedFunctionValue) StaticType() StaticType {
+	// TODO: add function static type, convert f.Type
+	return nil
 }
 
 func (f InterpretedFunctionValue) Copy() Value {
@@ -127,12 +132,17 @@ func NewHostFunctionValue(
 
 func (HostFunctionValue) IsValue() {}
 
-func (v HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
-	visitor.VisitHostFunctionValue(interpreter, v)
+func (f HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitHostFunctionValue(interpreter, f)
 }
 
 func (HostFunctionValue) DynamicType(_ *Interpreter) DynamicType {
 	return FunctionDynamicType{}
+}
+
+func (HostFunctionValue) StaticType() StaticType {
+	// TODO: add function static type, store static type in host function value
+	return nil
 }
 
 func (f HostFunctionValue) Copy() Value {
@@ -183,12 +193,16 @@ func (f BoundFunctionValue) String() string {
 
 func (BoundFunctionValue) IsValue() {}
 
-func (v BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
-	visitor.VisitBoundFunctionValue(interpreter, v)
+func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitBoundFunctionValue(interpreter, f)
 }
 
 func (BoundFunctionValue) DynamicType(_ *Interpreter) DynamicType {
 	return FunctionDynamicType{}
+}
+
+func (f BoundFunctionValue) StaticType() StaticType {
+	return f.Function.StaticType()
 }
 
 func (f BoundFunctionValue) Copy() Value {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4006,6 +4006,15 @@ func IsSubType(subType DynamicType, superType sema.Type) bool {
 		default:
 			return false
 		}
+
+	case BlockDynamicType:
+		switch superType.(type) {
+		case *sema.BlockType, *sema.AnyStructType:
+			return true
+
+		default:
+			return false
+		}
 	}
 
 	return false
@@ -4491,31 +4500,48 @@ func (interpreter *Interpreter) getMember(self Value, locationRange LocationRang
 	if result == nil {
 		switch identifier {
 		case sema.IsInstanceFunctionName:
-			return NewHostFunctionValue(
-				func(invocation Invocation) Trampoline {
-					firstArgument := invocation.Arguments[0]
-					typeValue := firstArgument.(TypeValue)
-
-					staticType := typeValue.Type
-
-					// Values are never instances of unknown types
-					if staticType == nil {
-						return Done{Result: BoolValue(false)}
-					}
-
-					semaType := interpreter.ConvertStaticToSemaType(staticType)
-					// NOTE: not invocation.Self, as that is only set for composite values
-					dynamicType := self.DynamicType(interpreter)
-					result := IsSubType(dynamicType, semaType)
-					return Done{Result: BoolValue(result)}
-				},
-			)
+			return interpreter.isInstanceFunction(self)
+		case sema.GetTypeFunctionName:
+			return interpreter.getTypeFunction(self)
 		}
 	}
 	if result == nil {
 		panic(errors.NewUnreachableError())
 	}
 	return result
+}
+
+func (interpreter *Interpreter) isInstanceFunction(self Value) HostFunctionValue {
+	return NewHostFunctionValue(
+		func(invocation Invocation) Trampoline {
+			firstArgument := invocation.Arguments[0]
+			typeValue := firstArgument.(TypeValue)
+
+			staticType := typeValue.Type
+
+			// Values are never instances of unknown types
+			if staticType == nil {
+				return Done{Result: BoolValue(false)}
+			}
+
+			semaType := interpreter.ConvertStaticToSemaType(staticType)
+			// NOTE: not invocation.Self, as that is only set for composite values
+			dynamicType := self.DynamicType(interpreter)
+			result := IsSubType(dynamicType, semaType)
+			return Done{Result: BoolValue(result)}
+		},
+	)
+}
+
+func (interpreter *Interpreter) getTypeFunction(self Value) HostFunctionValue {
+	return NewHostFunctionValue(
+		func(invocation Invocation) Trampoline {
+			result := TypeValue{
+				Type: self.StaticType(),
+			}
+			return Done{Result: result}
+		},
+	)
 }
 
 func (interpreter *Interpreter) setMember(self Value, locationRange LocationRange, identifier string, value Value) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4494,13 +4494,19 @@ func (interpreter *Interpreter) getMember(self Value, locationRange LocationRang
 			return NewHostFunctionValue(
 				func(invocation Invocation) Trampoline {
 					firstArgument := invocation.Arguments[0]
+					typeValue := firstArgument.(TypeValue)
 
+					staticType := typeValue.Type
+
+					// Values are never instances of unknown types
+					if staticType == nil {
+						return Done{Result: BoolValue(false)}
+					}
+
+					semaType := interpreter.ConvertStaticToSemaType(staticType)
 					// NOTE: not invocation.Self, as that is only set for composite values
 					dynamicType := self.DynamicType(interpreter)
-					ty := interpreter.ConvertStaticToSemaType(
-						firstArgument.(TypeValue).Type,
-					)
-					result := IsSubType(dynamicType, ty)
+					result := IsSubType(dynamicType, semaType)
 					return Done{Result: BoolValue(result)}
 				},
 			)

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -52,8 +52,8 @@ const (
 	PrimitiveStaticTypeAddress
 	PrimitiveStaticTypeString
 	PrimitiveStaticTypeCharacter
-	_
-	_
+	PrimitiveStaticTypeMetaType
+	PrimitiveStaticTypeBlock
 	_
 	_
 	_
@@ -105,7 +105,7 @@ const (
 	PrimitiveStaticTypeUInt256
 	_
 
-	// Word *
+	// Word*
 	_
 	PrimitiveStaticTypeWord8
 	PrimitiveStaticTypeWord16
@@ -143,9 +143,22 @@ const (
 	PrimitiveStaticTypeCapabilityPath
 	PrimitiveStaticTypePublicPath
 	PrimitiveStaticTypePrivatePath
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	PrimitiveStaticTypeAuthAccount
+	PrimitiveStaticTypePublicAccount
+	PrimitiveStaticTypeDeployedContract
+	PrimitiveStaticTypeAuthAccountContracts
+	_
 )
 
-func (PrimitiveStaticType) isStaticType() {}
+func (PrimitiveStaticType) IsStaticType() {}
 
 func (i PrimitiveStaticType) SemaType() sema.Type {
 	switch i {
@@ -175,6 +188,12 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 
 	case PrimitiveStaticTypeCharacter:
 		return &sema.CharacterType{}
+
+	case PrimitiveStaticTypeMetaType:
+		return &sema.MetaType{}
+
+	case PrimitiveStaticTypeBlock:
+		return &sema.BlockType{}
 
 	// Number
 
@@ -260,6 +279,14 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return sema.PrivatePathType
 	case PrimitiveStaticTypeCapability:
 		return &sema.CapabilityType{}
+	case PrimitiveStaticTypeAuthAccount:
+		return &sema.AuthAccountType{}
+	case PrimitiveStaticTypePublicAccount:
+		return &sema.PublicAccountType{}
+	case PrimitiveStaticTypeDeployedContract:
+		return &sema.DeployedContractType{}
+	case PrimitiveStaticTypeAuthAccountContracts:
+		return &sema.AuthAccountContractsType{}
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -292,6 +319,12 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 
 	case *sema.CharacterType:
 		return PrimitiveStaticTypeCharacter
+
+	case *sema.MetaType:
+		return PrimitiveStaticTypeMetaType
+
+	case *sema.BlockType:
+		return PrimitiveStaticTypeBlock
 
 	// Number
 
@@ -344,7 +377,7 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	case *sema.UInt256Type:
 		return PrimitiveStaticTypeUInt256
 
-	// Word *
+	// Word*
 
 	case *sema.Word8Type:
 		return PrimitiveStaticTypeWord8
@@ -367,6 +400,14 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 
 	case *sema.CapabilityType:
 		return PrimitiveStaticTypeCapability
+	case *sema.AuthAccountType:
+		return PrimitiveStaticTypeAuthAccount
+	case *sema.PublicAccountType:
+		return PrimitiveStaticTypePublicAccount
+	case *sema.DeployedContractType:
+		return PrimitiveStaticTypeDeployedContract
+	case *sema.AuthAccountContractsType:
+		return PrimitiveStaticTypeAuthAccountContracts
 	}
 
 	switch t {

--- a/runtime/interpreter/primitivestatictype_string.go
+++ b/runtime/interpreter/primitivestatictype_string.go
@@ -18,6 +18,8 @@ func _() {
 	_ = x[PrimitiveStaticTypeAddress-7]
 	_ = x[PrimitiveStaticTypeString-8]
 	_ = x[PrimitiveStaticTypeCharacter-9]
+	_ = x[PrimitiveStaticTypeMetaType-10]
+	_ = x[PrimitiveStaticTypeBlock-11]
 	_ = x[PrimitiveStaticTypeNumber-18]
 	_ = x[PrimitiveStaticTypeSignedNumber-19]
 	_ = x[PrimitiveStaticTypeInteger-24]
@@ -50,62 +52,68 @@ func _() {
 	_ = x[PrimitiveStaticTypeCapabilityPath-79]
 	_ = x[PrimitiveStaticTypePublicPath-80]
 	_ = x[PrimitiveStaticTypePrivatePath-81]
+	_ = x[PrimitiveStaticTypeAuthAccount-90]
+	_ = x[PrimitiveStaticTypePublicAccount-91]
+	_ = x[PrimitiveStaticTypeDeployedContract-92]
+	_ = x[PrimitiveStaticTypeAuthAccountContracts-93]
 }
 
-const (
-	_PrimitiveStaticType_name_0 = "UnknownVoidAnyNeverAnyStructAnyResourceBoolAddressStringCharacter"
-	_PrimitiveStaticType_name_1 = "NumberSignedNumber"
-	_PrimitiveStaticType_name_2 = "IntegerSignedInteger"
-	_PrimitiveStaticType_name_3 = "FixedPointSignedFixedPoint"
-	_PrimitiveStaticType_name_4 = "IntInt8Int16Int32Int64Int128Int256"
-	_PrimitiveStaticType_name_5 = "UIntUInt8UInt16UInt32UInt64UInt128UInt256"
-	_PrimitiveStaticType_name_6 = "Word8Word16Word32Word64"
-	_PrimitiveStaticType_name_7 = "Fix64"
-	_PrimitiveStaticType_name_8 = "UFix64"
-	_PrimitiveStaticType_name_9 = "PathCapabilityStoragePathCapabilityPathPublicPathPrivatePath"
-)
+const _PrimitiveStaticType_name = "UnknownVoidAnyNeverAnyStructAnyResourceBoolAddressStringCharacterMetaTypeBlockNumberSignedNumberIntegerSignedIntegerFixedPointSignedFixedPointIntInt8Int16Int32Int64Int128Int256UIntUInt8UInt16UInt32UInt64UInt128UInt256Word8Word16Word32Word64Fix64UFix64PathCapabilityStoragePathCapabilityPathPublicPathPrivatePathAuthAccountPublicAccountDeployedContractAuthAccountContracts"
 
-var (
-	_PrimitiveStaticType_index_0 = [...]uint8{0, 7, 11, 14, 19, 28, 39, 43, 50, 56, 65}
-	_PrimitiveStaticType_index_1 = [...]uint8{0, 6, 18}
-	_PrimitiveStaticType_index_2 = [...]uint8{0, 7, 20}
-	_PrimitiveStaticType_index_3 = [...]uint8{0, 10, 26}
-	_PrimitiveStaticType_index_4 = [...]uint8{0, 3, 7, 12, 17, 22, 28, 34}
-	_PrimitiveStaticType_index_5 = [...]uint8{0, 4, 9, 15, 21, 27, 34, 41}
-	_PrimitiveStaticType_index_6 = [...]uint8{0, 5, 11, 17, 23}
-	_PrimitiveStaticType_index_9 = [...]uint8{0, 4, 14, 25, 39, 49, 60}
-)
+var _PrimitiveStaticType_map = map[PrimitiveStaticType]string{
+	0:  _PrimitiveStaticType_name[0:7],
+	1:  _PrimitiveStaticType_name[7:11],
+	2:  _PrimitiveStaticType_name[11:14],
+	3:  _PrimitiveStaticType_name[14:19],
+	4:  _PrimitiveStaticType_name[19:28],
+	5:  _PrimitiveStaticType_name[28:39],
+	6:  _PrimitiveStaticType_name[39:43],
+	7:  _PrimitiveStaticType_name[43:50],
+	8:  _PrimitiveStaticType_name[50:56],
+	9:  _PrimitiveStaticType_name[56:65],
+	10: _PrimitiveStaticType_name[65:73],
+	11: _PrimitiveStaticType_name[73:78],
+	18: _PrimitiveStaticType_name[78:84],
+	19: _PrimitiveStaticType_name[84:96],
+	24: _PrimitiveStaticType_name[96:103],
+	25: _PrimitiveStaticType_name[103:116],
+	30: _PrimitiveStaticType_name[116:126],
+	31: _PrimitiveStaticType_name[126:142],
+	36: _PrimitiveStaticType_name[142:145],
+	37: _PrimitiveStaticType_name[145:149],
+	38: _PrimitiveStaticType_name[149:154],
+	39: _PrimitiveStaticType_name[154:159],
+	40: _PrimitiveStaticType_name[159:164],
+	41: _PrimitiveStaticType_name[164:170],
+	42: _PrimitiveStaticType_name[170:176],
+	44: _PrimitiveStaticType_name[176:180],
+	45: _PrimitiveStaticType_name[180:185],
+	46: _PrimitiveStaticType_name[185:191],
+	47: _PrimitiveStaticType_name[191:197],
+	48: _PrimitiveStaticType_name[197:203],
+	49: _PrimitiveStaticType_name[203:210],
+	50: _PrimitiveStaticType_name[210:217],
+	53: _PrimitiveStaticType_name[217:222],
+	54: _PrimitiveStaticType_name[222:228],
+	55: _PrimitiveStaticType_name[228:234],
+	56: _PrimitiveStaticType_name[234:240],
+	64: _PrimitiveStaticType_name[240:245],
+	72: _PrimitiveStaticType_name[245:251],
+	76: _PrimitiveStaticType_name[251:255],
+	77: _PrimitiveStaticType_name[255:265],
+	78: _PrimitiveStaticType_name[265:276],
+	79: _PrimitiveStaticType_name[276:290],
+	80: _PrimitiveStaticType_name[290:300],
+	81: _PrimitiveStaticType_name[300:311],
+	90: _PrimitiveStaticType_name[311:322],
+	91: _PrimitiveStaticType_name[322:335],
+	92: _PrimitiveStaticType_name[335:351],
+	93: _PrimitiveStaticType_name[351:371],
+}
 
 func (i PrimitiveStaticType) String() string {
-	switch {
-	case i <= 9:
-		return _PrimitiveStaticType_name_0[_PrimitiveStaticType_index_0[i]:_PrimitiveStaticType_index_0[i+1]]
-	case 18 <= i && i <= 19:
-		i -= 18
-		return _PrimitiveStaticType_name_1[_PrimitiveStaticType_index_1[i]:_PrimitiveStaticType_index_1[i+1]]
-	case 24 <= i && i <= 25:
-		i -= 24
-		return _PrimitiveStaticType_name_2[_PrimitiveStaticType_index_2[i]:_PrimitiveStaticType_index_2[i+1]]
-	case 30 <= i && i <= 31:
-		i -= 30
-		return _PrimitiveStaticType_name_3[_PrimitiveStaticType_index_3[i]:_PrimitiveStaticType_index_3[i+1]]
-	case 36 <= i && i <= 42:
-		i -= 36
-		return _PrimitiveStaticType_name_4[_PrimitiveStaticType_index_4[i]:_PrimitiveStaticType_index_4[i+1]]
-	case 44 <= i && i <= 50:
-		i -= 44
-		return _PrimitiveStaticType_name_5[_PrimitiveStaticType_index_5[i]:_PrimitiveStaticType_index_5[i+1]]
-	case 53 <= i && i <= 56:
-		i -= 53
-		return _PrimitiveStaticType_name_6[_PrimitiveStaticType_index_6[i]:_PrimitiveStaticType_index_6[i+1]]
-	case i == 64:
-		return _PrimitiveStaticType_name_7
-	case i == 72:
-		return _PrimitiveStaticType_name_8
-	case 76 <= i && i <= 81:
-		i -= 76
-		return _PrimitiveStaticType_name_9[_PrimitiveStaticType_index_9[i]:_PrimitiveStaticType_index_9[i+1]]
-	default:
-		return "PrimitiveStaticType(" + strconv.FormatInt(int64(i), 10) + ")"
+	if str, ok := _PrimitiveStaticType_map[i]; ok {
+		return str
 	}
+	return "PrimitiveStaticType(" + strconv.FormatInt(int64(i), 10) + ")"
 }

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -36,7 +36,7 @@ import (
 //
 type StaticType interface {
 	fmt.Stringer
-	isStaticType()
+	IsStaticType()
 }
 
 // CompositeStaticType
@@ -46,7 +46,7 @@ type CompositeStaticType struct {
 	QualifiedIdentifier string
 }
 
-func (CompositeStaticType) isStaticType() {}
+func (CompositeStaticType) IsStaticType() {}
 
 func (t CompositeStaticType) String() string {
 	return fmt.Sprintf(
@@ -63,7 +63,7 @@ type InterfaceStaticType struct {
 	QualifiedIdentifier string
 }
 
-func (InterfaceStaticType) isStaticType() {}
+func (InterfaceStaticType) IsStaticType() {}
 
 func (t InterfaceStaticType) String() string {
 	return fmt.Sprintf(
@@ -79,7 +79,7 @@ type VariableSizedStaticType struct {
 	Type StaticType
 }
 
-func (VariableSizedStaticType) isStaticType() {}
+func (VariableSizedStaticType) IsStaticType() {}
 
 func (t VariableSizedStaticType) String() string {
 	return fmt.Sprintf("[%s]", t.Type)
@@ -92,7 +92,7 @@ type ConstantSizedStaticType struct {
 	Size int64
 }
 
-func (ConstantSizedStaticType) isStaticType() {}
+func (ConstantSizedStaticType) IsStaticType() {}
 
 func (t ConstantSizedStaticType) String() string {
 	return fmt.Sprintf("[%s; %d]", t.Type, t.Size)
@@ -105,7 +105,7 @@ type DictionaryStaticType struct {
 	ValueType StaticType
 }
 
-func (DictionaryStaticType) isStaticType() {}
+func (DictionaryStaticType) IsStaticType() {}
 
 func (t DictionaryStaticType) String() string {
 	return fmt.Sprintf("{%s: %s}", t.KeyType, t.ValueType)
@@ -117,7 +117,7 @@ type OptionalStaticType struct {
 	Type StaticType
 }
 
-func (OptionalStaticType) isStaticType() {}
+func (OptionalStaticType) IsStaticType() {}
 
 func (t OptionalStaticType) String() string {
 	return fmt.Sprintf("%s?", t.Type)
@@ -130,7 +130,7 @@ type RestrictedStaticType struct {
 	Restrictions []InterfaceStaticType
 }
 
-func (RestrictedStaticType) isStaticType() {}
+func (RestrictedStaticType) IsStaticType() {}
 
 func (t RestrictedStaticType) String() string {
 	restrictions := make([]string, len(t.Restrictions))
@@ -149,7 +149,7 @@ type ReferenceStaticType struct {
 	Type       StaticType
 }
 
-func (ReferenceStaticType) isStaticType() {}
+func (ReferenceStaticType) IsStaticType() {}
 
 func (t ReferenceStaticType) String() string {
 	auth := ""
@@ -166,7 +166,7 @@ type CapabilityStaticType struct {
 	BorrowType StaticType
 }
 
-func (CapabilityStaticType) isStaticType() {}
+func (CapabilityStaticType) IsStaticType() {}
 
 func (t CapabilityStaticType) String() string {
 	if t.BorrowType != nil {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -128,17 +128,31 @@ func (TypeValue) SetModified(_ bool) {
 }
 
 func (v TypeValue) String() string {
-	return format.TypeValue(v.Type.String())
+	var typeString string
+	staticType := v.Type
+	if staticType != nil {
+		typeString = staticType.String()
+	}
+	return format.TypeValue(typeString)
 }
 
 func (v TypeValue) Equal(inter *Interpreter, other Value) BoolValue {
-	otherMetaType, ok := other.(TypeValue)
+	otherTypeValue, ok := other.(TypeValue)
 	if !ok {
 		return false
 	}
 
-	ty := inter.ConvertStaticToSemaType(v.Type)
-	otherTy := inter.ConvertStaticToSemaType(otherMetaType.Type)
+	// Unknown types are never equal to another type
+
+	staticType := v.Type
+	otherStaticType := otherTypeValue.Type
+
+	if staticType == nil || otherStaticType == nil {
+		return false
+	}
+
+	ty := inter.ConvertStaticToSemaType(staticType)
+	otherTy := inter.ConvertStaticToSemaType(otherStaticType)
 
 	return BoolValue(ty.Equal(otherTy))
 }
@@ -146,8 +160,12 @@ func (v TypeValue) Equal(inter *Interpreter, other Value) BoolValue {
 func (v TypeValue) GetMember(inter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case "identifier":
-		ty := inter.ConvertStaticToSemaType(v.Type)
-		return NewStringValue(ty.QualifiedString())
+		var typeID string
+		staticType := v.Type
+		if staticType != nil {
+			typeID = string(inter.ConvertStaticToSemaType(staticType).ID())
+		}
+		return NewStringValue(typeID)
 	}
 
 	return nil

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5412,8 +5412,8 @@ func (v *CompositeValue) DynamicType(interpreter *Interpreter) DynamicType {
 
 func (v *CompositeValue) StaticType() StaticType {
 	return CompositeStaticType{
-		Location: v.Location,
-		TypeID:   v.TypeID(),
+		Location:            v.Location,
+		QualifiedIdentifier: v.QualifiedIdentifier,
 	}
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -49,6 +49,7 @@ type Value interface {
 	SetOwner(address *common.Address)
 	IsModified() bool
 	SetModified(modified bool)
+	StaticType() StaticType
 }
 
 // ValueIndexableValue
@@ -104,6 +105,10 @@ func (v TypeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (TypeValue) DynamicType(_ *Interpreter) DynamicType {
 	return MetaTypeDynamicType{}
+}
+
+func (TypeValue) StaticType() StaticType {
+	return PrimitiveStaticTypeMetaType
 }
 
 func (v TypeValue) Copy() Value {
@@ -189,6 +194,10 @@ func (VoidValue) DynamicType(_ *Interpreter) DynamicType {
 	return VoidDynamicType{}
 }
 
+func (VoidValue) StaticType() StaticType {
+	return PrimitiveStaticTypeVoid
+}
+
 func (v VoidValue) Copy() Value {
 	return v
 }
@@ -226,6 +235,10 @@ func (v BoolValue) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (BoolValue) DynamicType(_ *Interpreter) DynamicType {
 	return BoolDynamicType{}
+}
+
+func (BoolValue) StaticType() StaticType {
+	return PrimitiveStaticTypeBool
 }
 
 func (v BoolValue) Copy() Value {
@@ -294,6 +307,10 @@ func (v *StringValue) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (*StringValue) DynamicType(_ *Interpreter) DynamicType {
 	return StringDynamicType{}
+}
+
+func (StringValue) StaticType() StaticType {
+	return PrimitiveStaticTypeString
 }
 
 func (v *StringValue) Copy() Value {
@@ -514,6 +531,11 @@ func (v *ArrayValue) DynamicType(interpreter *Interpreter) DynamicType {
 	return ArrayDynamicType{
 		ElementTypes: elementTypes,
 	}
+}
+
+func (v *ArrayValue) StaticType() StaticType {
+	// TODO: store static type in array values
+	return nil
 }
 
 func (v *ArrayValue) Copy() Value {
@@ -824,6 +846,10 @@ func (IntValue) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.IntType{}}
 }
 
+func (IntValue) StaticType() StaticType {
+	return PrimitiveStaticTypeInt
+}
+
 func (v IntValue) Copy() Value {
 	return IntValue{new(big.Int).Set(v.BigInt)}
 }
@@ -1028,6 +1054,10 @@ func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Int8Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int8Type{}}
+}
+
+func (Int8Value) StaticType() StaticType {
+	return PrimitiveStaticTypeInt8
 }
 
 func (v Int8Value) Copy() Value {
@@ -1262,6 +1292,10 @@ func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Int16Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int16Type{}}
+}
+
+func (Int16Value) StaticType() StaticType {
+	return PrimitiveStaticTypeInt16
 }
 
 func (v Int16Value) Copy() Value {
@@ -1500,6 +1534,10 @@ func (Int32Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int32Type{}}
 }
 
+func (Int32Value) StaticType() StaticType {
+	return PrimitiveStaticTypeInt32
+}
+
 func (v Int32Value) Copy() Value {
 	return v
 }
@@ -1734,6 +1772,10 @@ func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Int64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int64Type{}}
+}
+
+func (Int64Value) StaticType() StaticType {
+	return PrimitiveStaticTypeInt64
 }
 
 func (v Int64Value) Copy() Value {
@@ -1978,6 +2020,10 @@ func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Int128Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int128Type{}}
+}
+
+func (Int128Value) StaticType() StaticType {
+	return PrimitiveStaticTypeInt128
 }
 
 func (v Int128Value) Copy() Value {
@@ -2272,6 +2318,10 @@ func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Int256Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Int256Type{}}
+}
+
+func (Int256Value) StaticType() StaticType {
+	return PrimitiveStaticTypeInt256
 }
 
 func (v Int256Value) Copy() Value {
@@ -2589,6 +2639,10 @@ func (UIntValue) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UIntType{}}
 }
 
+func (UIntValue) StaticType() StaticType {
+	return PrimitiveStaticTypeUInt
+}
+
 func (v UIntValue) Copy() Value {
 	return UIntValue{new(big.Int).Set(v.BigInt)}
 }
@@ -2798,6 +2852,10 @@ func (UInt8Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt8Type{}}
 }
 
+func (UInt8Value) StaticType() StaticType {
+	return PrimitiveStaticTypeUInt8
+}
+
 func (v UInt8Value) Copy() Value {
 	return v
 }
@@ -2998,6 +3056,10 @@ func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (UInt16Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt16Type{}}
+}
+
+func (UInt16Value) StaticType() StaticType {
+	return PrimitiveStaticTypeUInt16
 }
 
 func (v UInt16Value) Copy() Value {
@@ -3202,6 +3264,10 @@ func (UInt32Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt32Type{}}
 }
 
+func (UInt32Value) StaticType() StaticType {
+	return PrimitiveStaticTypeUInt32
+}
+
 func (v UInt32Value) Copy() Value {
 	return v
 }
@@ -3404,6 +3470,10 @@ func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (UInt64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt64Type{}}
+}
+
+func (UInt64Value) StaticType() StaticType {
+	return PrimitiveStaticTypeUInt64
 }
 
 func (v UInt64Value) Copy() Value {
@@ -3621,6 +3691,10 @@ func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (UInt128Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt128Type{}}
+}
+
+func (UInt128Value) StaticType() StaticType {
+	return PrimitiveStaticTypeUInt128
 }
 
 func (v UInt128Value) Copy() Value {
@@ -3886,6 +3960,10 @@ func (UInt256Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UInt256Type{}}
 }
 
+func (UInt256Value) StaticType() StaticType {
+	return PrimitiveStaticTypeUInt256
+}
+
 func (v UInt256Value) Copy() Value {
 	return UInt256Value{new(big.Int).Set(v.BigInt)}
 }
@@ -4140,6 +4218,10 @@ func (Word8Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word8Type{}}
 }
 
+func (Word8Value) StaticType() StaticType {
+	return PrimitiveStaticTypeWord8
+}
+
 func (v Word8Value) Copy() Value {
 	return v
 }
@@ -4301,6 +4383,10 @@ func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Word16Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word16Type{}}
+}
+
+func (Word16Value) StaticType() StaticType {
+	return PrimitiveStaticTypeWord16
 }
 
 func (v Word16Value) Copy() Value {
@@ -4466,6 +4552,10 @@ func (Word32Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word32Type{}}
 }
 
+func (Word32Value) StaticType() StaticType {
+	return PrimitiveStaticTypeWord32
+}
+
 func (v Word32Value) Copy() Value {
 	return v
 }
@@ -4629,6 +4719,10 @@ func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Word64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Word64Type{}}
+}
+
+func (Word64Value) StaticType() StaticType {
+	return PrimitiveStaticTypeWord64
 }
 
 func (v Word64Value) Copy() Value {
@@ -4809,6 +4903,10 @@ func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (Fix64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.Fix64Type{}}
+}
+
+func (Fix64Value) StaticType() StaticType {
+	return PrimitiveStaticTypeFix64
 }
 
 func (v Fix64Value) Copy() Value {
@@ -5026,6 +5124,10 @@ func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 
 func (UFix64Value) DynamicType(_ *Interpreter) DynamicType {
 	return NumberDynamicType{&sema.UFix64Type{}}
+}
+
+func (UFix64Value) StaticType() StaticType {
+	return PrimitiveStaticTypeUFix64
 }
 
 func (v UFix64Value) Copy() Value {
@@ -5305,6 +5407,13 @@ func (v *CompositeValue) DynamicType(interpreter *Interpreter) DynamicType {
 	staticType := interpreter.getCompositeType(v.Location, v.QualifiedIdentifier)
 	return CompositeDynamicType{
 		StaticType: staticType,
+	}
+}
+
+func (v *CompositeValue) StaticType() StaticType {
+	return CompositeStaticType{
+		Location: v.Location,
+		TypeID:   v.TypeID(),
 	}
 }
 
@@ -5621,6 +5730,11 @@ func (v *DictionaryValue) DynamicType(interpreter *Interpreter) DynamicType {
 	return DictionaryDynamicType{
 		EntryTypes: entryTypes,
 	}
+}
+
+func (v *DictionaryValue) StaticType() StaticType {
+	// TODO: store static type in dictionary values
+	return nil
 }
 
 func (v *DictionaryValue) Copy() Value {
@@ -5962,6 +6076,12 @@ func (NilValue) DynamicType(_ *Interpreter) DynamicType {
 	return NilDynamicType{}
 }
 
+func (NilValue) StaticType() StaticType {
+	return OptionalStaticType{
+		Type: PrimitiveStaticTypeNever,
+	}
+}
+
 func (NilValue) isOptionalValue() {}
 
 func (v NilValue) Copy() Value {
@@ -6039,6 +6159,16 @@ func (v *SomeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 func (v *SomeValue) DynamicType(interpreter *Interpreter) DynamicType {
 	innerType := v.Value.DynamicType(interpreter)
 	return SomeDynamicType{InnerType: innerType}
+}
+
+func (v *SomeValue) StaticType() StaticType {
+	innerType := v.Value.StaticType()
+	if innerType == nil {
+		return nil
+	}
+	return OptionalStaticType{
+		Type: innerType,
+	}
 }
 
 func (*SomeValue) isOptionalValue() {}
@@ -6143,6 +6273,11 @@ func (v *StorageReferenceValue) DynamicType(interpreter *Interpreter) DynamicTyp
 		authorized: v.Authorized,
 		innerType:  innerType,
 	}
+}
+
+func (v *StorageReferenceValue) StaticType() StaticType {
+	// TODO:
+	return nil
 }
 
 func (v *StorageReferenceValue) Copy() Value {
@@ -6267,6 +6402,11 @@ func (v *EphemeralReferenceValue) DynamicType(interpreter *Interpreter) DynamicT
 		authorized: v.Authorized,
 		innerType:  innerType,
 	}
+}
+
+func (v *EphemeralReferenceValue) StaticType() StaticType {
+	// TODO:
+	return nil
 }
 
 func (v *EphemeralReferenceValue) Copy() Value {
@@ -6402,6 +6542,10 @@ func (AddressValue) DynamicType(_ *Interpreter) DynamicType {
 	return AddressDynamicType{}
 }
 
+func (AddressValue) StaticType() StaticType {
+	return PrimitiveStaticTypeAddress
+}
+
 func (v AddressValue) Copy() Value {
 	return v
 }
@@ -6524,6 +6668,10 @@ func (v AuthAccountValue) AddressValue() AddressValue {
 
 func (AuthAccountValue) DynamicType(_ *Interpreter) DynamicType {
 	return AuthAccountDynamicType{}
+}
+
+func (AuthAccountValue) StaticType() StaticType {
+	return PrimitiveStaticTypeAuthAccount
 }
 
 func (v AuthAccountValue) Copy() Value {
@@ -6681,6 +6829,10 @@ func (PublicAccountValue) DynamicType(_ *Interpreter) DynamicType {
 	return PublicAccountDynamicType{}
 }
 
+func (PublicAccountValue) StaticType() StaticType {
+	return PrimitiveStaticTypePublicAccount
+}
+
 func (v PublicAccountValue) Copy() Value {
 	return v
 }
@@ -6761,6 +6913,19 @@ func (v PathValue) DynamicType(_ *Interpreter) DynamicType {
 	}
 }
 
+func (v PathValue) StaticType() StaticType {
+	switch v.Domain {
+	case common.PathDomainStorage:
+		return PrimitiveStaticTypeStoragePath
+	case common.PathDomainPublic:
+		return PrimitiveStaticTypePublicPath
+	case common.PathDomainPrivate:
+		return PrimitiveStaticTypePrivatePath
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
 func (v PathValue) Copy() Value {
 	return v
 }
@@ -6823,6 +6988,12 @@ func (v CapabilityValue) DynamicType(inter *Interpreter) DynamicType {
 
 	return CapabilityDynamicType{
 		BorrowType: borrowType,
+	}
+}
+
+func (v CapabilityValue) StaticType() StaticType {
+	return CapabilityStaticType{
+		BorrowType: v.BorrowType,
 	}
 }
 
@@ -6898,7 +7069,11 @@ func (v LinkValue) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (LinkValue) DynamicType(_ *Interpreter) DynamicType {
-	panic(errors.NewUnreachableError())
+	return nil
+}
+
+func (LinkValue) StaticType() StaticType {
+	return nil
 }
 
 func (v LinkValue) Copy() Value {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -279,7 +279,7 @@ func (i *testRuntimeInterface) GetBlockAtHeight(height uint64) (block Block, exi
 
 	encoded := buf.Bytes()
 	var hash BlockHash
-	copy(hash[stdlib.BlockIDSize-len(encoded):], encoded)
+	copy(hash[sema.BlockIDSize-len(encoded):], encoded)
 
 	block = Block{
 		Height:    height,

--- a/runtime/sema/block.go
+++ b/runtime/sema/block.go
@@ -1,0 +1,164 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+// BlockType
+
+type BlockType struct{}
+
+func (*BlockType) IsType() {}
+
+func (*BlockType) String() string {
+	return "Block"
+}
+
+func (*BlockType) QualifiedString() string {
+	return "Block"
+}
+
+func (*BlockType) ID() TypeID {
+	return "Block"
+}
+
+func (*BlockType) Equal(other Type) bool {
+	_, ok := other.(*BlockType)
+	return ok
+}
+
+func (*BlockType) IsResourceType() bool {
+	return false
+}
+
+func (*BlockType) TypeAnnotationState() TypeAnnotationState {
+	return TypeAnnotationStateValid
+}
+
+func (*BlockType) IsInvalidType() bool {
+	return false
+}
+
+func (*BlockType) IsStorable(_ map[*Member]bool) bool {
+	return false
+}
+
+func (*BlockType) IsExternallyReturnable(_ map[*Member]bool) bool {
+	return false
+}
+
+func (*BlockType) IsEquatable() bool {
+	// TODO:
+	return false
+}
+
+func (t *BlockType) RewriteWithRestrictedTypes() (Type, bool) {
+	return t, false
+}
+
+const BlockIDSize = 32
+
+var blockIDFieldType = &ConstantSizedType{
+	Type: &UInt8Type{},
+	Size: BlockIDSize,
+}
+
+const blockTypeHeightFieldDocString = `
+The height of the block.
+
+If the blockchain is viewed as a tree with the genesis block at the root, the height of a node is the number of edges between the node and the genesis block
+`
+
+const blockTypeViewFieldDocString = `
+The view of the block.
+
+It is a detail of the consensus algorithm. It is a monotonically increasing integer and counts rounds in the consensus algorithm. Since not all rounds result in a finalized block, the view number is strictly greater than or equal to the block height
+`
+
+const blockTypeTimestampFieldDocString = `
+The ID of the block.
+
+It is essentially the hash of the block
+`
+
+const blockTypeIdFieldDocString = `
+The timestamp of the block.
+
+It is the local clock time of the block proposer when it generates the block
+`
+
+func (t *BlockType) GetMembers() map[string]MemberResolver {
+	return map[string]MemberResolver{
+		"height": {
+			Kind: common.DeclarationKindField,
+			Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
+				return NewPublicConstantFieldMember(
+					t,
+					identifier,
+					&UInt64Type{},
+					blockTypeHeightFieldDocString,
+				)
+			},
+		},
+		"view": {
+			Kind: common.DeclarationKindField,
+			Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
+				return NewPublicConstantFieldMember(
+					t,
+					identifier,
+					&UInt64Type{},
+					blockTypeViewFieldDocString,
+				)
+			},
+		},
+		"timestamp": {
+			Kind: common.DeclarationKindField,
+			Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
+				return NewPublicConstantFieldMember(
+					t,
+					identifier,
+					&UFix64Type{},
+					blockTypeTimestampFieldDocString,
+				)
+			},
+		},
+		"id": {
+			Kind: common.DeclarationKindField,
+			Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
+				return NewPublicConstantFieldMember(
+					t,
+					identifier,
+					blockIDFieldType,
+					blockTypeIdFieldDocString,
+				)
+			},
+		},
+	}
+}
+
+func (t *BlockType) Unify(_ Type, _ map[*TypeParameter]Type, _ func(err error), _ ast.Range) bool {
+	return false
+}
+
+func (t *BlockType) Resolve(_ map[*TypeParameter]Type) Type {
+	return t
+}

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -77,10 +77,11 @@ func IsValidEventParameterType(t Type) bool {
 			return false
 		}
 		for _, member := range t.Members {
-			if member.DeclarationKind == common.DeclarationKindField {
-				if !IsValidEventParameterType(member.TypeAnnotation.Type) {
-					return false
-				}
+			if member.DeclarationKind == common.DeclarationKindField &&
+				!member.IgnoreInSerialization &&
+				!IsValidEventParameterType(member.TypeAnnotation.Type) {
+
+				return false
 			}
 		}
 		return true

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1991,7 +1991,7 @@ func (checker *Checker) predeclaredMembers(containerType Type) []*Member {
 	// All types have a predeclared member `fun getType(): Type`
 
 	addPredeclaredMember(
-		getTypeFunctionName,
+		GetTypeFunctionName,
 		getTypeFunctionType,
 		common.DeclarationKindFunction,
 		ast.AccessPublic,

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1988,6 +1988,17 @@ func (checker *Checker) predeclaredMembers(containerType Type) []*Member {
 		isInstanceFunctionDocString,
 	)
 
+	// All types have a predeclared member `fun getType(): Type`
+
+	addPredeclaredMember(
+		getTypeFunctionName,
+		getTypeFunctionType,
+		common.DeclarationKindFunction,
+		ast.AccessPublic,
+		true,
+		getTypeFunctionDocString,
+	)
+
 	if compositeKindedType, ok := containerType.(CompositeKindedType); ok {
 
 		switch compositeKindedType.GetCompositeKind() {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -293,6 +293,20 @@ const isInstanceFunctionDocString = `
 Returns true if the object conforms to the given type at runtime
 `
 
+// getType
+
+const getTypeFunctionName = "getType"
+
+var getTypeFunctionType = &FunctionType{
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&MetaType{},
+	),
+}
+
+const getTypeFunctionDocString = `
+Returns the type of the value
+`
+
 // toString
 
 const ToStringFunctionName = "toString"
@@ -338,6 +352,20 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 				identifier,
 				isInstanceFunctionType,
 				isInstanceFunctionDocString,
+			)
+		},
+	}
+
+	// All types have a predeclared member `fun getType(): Type`
+
+	members[getTypeFunctionName] = MemberResolver{
+		Kind: common.DeclarationKindFunction,
+		Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
+			return NewPublicFunctionMember(
+				ty,
+				identifier,
+				getTypeFunctionType,
+				getTypeFunctionDocString,
 			)
 		},
 	}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -295,7 +295,7 @@ Returns true if the object conforms to the given type at runtime
 
 // getType
 
-const getTypeFunctionName = "getType"
+const GetTypeFunctionName = "getType"
 
 var getTypeFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
@@ -358,7 +358,7 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 
 	// All types have a predeclared member `fun getType(): Type`
 
-	members[getTypeFunctionName] = MemberResolver{
+	members[GetTypeFunctionName] = MemberResolver{
 		Kind: common.DeclarationKindFunction,
 		Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
 			return NewPublicFunctionMember(
@@ -4422,6 +4422,7 @@ func init() {
 		PublicPathType,
 		&CapabilityType{},
 		&DeployedContractType{},
+		&BlockType{},
 	}
 
 	types := append(

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -24,7 +24,6 @@ import (
 	"math/rand"
 	"strings"
 
-	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -80,7 +79,7 @@ var logFunctionType = &sema.FunctionType{
 }
 
 var getCurrentBlockFunctionType = &sema.FunctionType{
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(&BlockType{}),
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.BlockType{}),
 }
 
 var getBlockFunctionType = &sema.FunctionType{
@@ -95,7 +94,7 @@ var getBlockFunctionType = &sema.FunctionType{
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		&sema.OptionalType{
-			Type: &BlockType{},
+			Type: &sema.BlockType{},
 		},
 	),
 }
@@ -372,150 +371,4 @@ var AccountContractRemovedEventType = newFlowEventType(
 	AccountEventContractParameter,
 )
 
-// BlockType
-
-type BlockType struct{}
-
-func (*BlockType) IsType() {}
-
-func (*BlockType) String() string {
-	return "Block"
-}
-
-func (*BlockType) QualifiedString() string {
-	return "Block"
-}
-
-func (*BlockType) ID() sema.TypeID {
-	return "Block"
-}
-
-func (*BlockType) Equal(other sema.Type) bool {
-	_, ok := other.(*BlockType)
-	return ok
-}
-
-func (*BlockType) IsResourceType() bool {
-	return false
-}
-
-func (*BlockType) TypeAnnotationState() sema.TypeAnnotationState {
-	return sema.TypeAnnotationStateValid
-}
-
-func (*BlockType) IsInvalidType() bool {
-	return false
-}
-
-func (*BlockType) IsStorable(_ map[*sema.Member]bool) bool {
-	return false
-}
-
-func (*BlockType) IsExternallyReturnable(_ map[*sema.Member]bool) bool {
-	return false
-}
-
-func (*BlockType) IsEquatable() bool {
-	// TODO:
-	return false
-}
-
-func (t *BlockType) RewriteWithRestrictedTypes() (sema.Type, bool) {
-	return t, false
-}
-
-const BlockIDSize = 32
-
-var blockIDFieldType = &sema.ConstantSizedType{
-	Type: &sema.UInt8Type{},
-	Size: BlockIDSize,
-}
-
-const blockTypeHeightFieldDocString = `
-The height of the block.
-
-If the blockchain is viewed as a tree with the genesis block at the root, the height of a node is the number of edges between the node and the genesis block
-`
-
-const blockTypeViewFieldDocString = `
-The view of the block.
-
-It is a detail of the consensus algorithm. It is a monotonically increasing integer and counts rounds in the consensus algorithm. Since not all rounds result in a finalized block, the view number is strictly greater than or equal to the block height
-`
-
-const blockTypeTimestampFieldDocString = `
-The ID of the block.
-
-It is essentially the hash of the block
-`
-
-const blockTypeIdFieldDocString = `
-The timestamp of the block.
-
-It is the local clock time of the block proposer when it generates the block
-`
-
-func (t *BlockType) GetMembers() map[string]sema.MemberResolver {
-	return map[string]sema.MemberResolver{
-		"height": {
-			Kind: common.DeclarationKindField,
-			Resolve: func(identifier string, _ ast.Range, _ func(error)) *sema.Member {
-				return sema.NewPublicConstantFieldMember(
-					t,
-					identifier,
-					&sema.UInt64Type{},
-					blockTypeHeightFieldDocString,
-				)
-			},
-		},
-		"view": {
-			Kind: common.DeclarationKindField,
-			Resolve: func(identifier string, _ ast.Range, _ func(error)) *sema.Member {
-				return sema.NewPublicConstantFieldMember(
-					t,
-					identifier,
-					&sema.UInt64Type{},
-					blockTypeViewFieldDocString,
-				)
-			},
-		},
-		"timestamp": {
-			Kind: common.DeclarationKindField,
-			Resolve: func(identifier string, _ ast.Range, _ func(error)) *sema.Member {
-				return sema.NewPublicConstantFieldMember(
-					t,
-					identifier,
-					&sema.UFix64Type{},
-					blockTypeTimestampFieldDocString,
-				)
-			},
-		},
-		"id": {
-			Kind: common.DeclarationKindField,
-			Resolve: func(identifier string, _ ast.Range, _ func(error)) *sema.Member {
-				return sema.NewPublicConstantFieldMember(
-					t,
-					identifier,
-					blockIDFieldType,
-					blockTypeIdFieldDocString,
-				)
-			},
-		},
-	}
-}
-
-func (t *BlockType) Unify(_ sema.Type, _ map[*sema.TypeParameter]sema.Type, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *BlockType) Resolve(_ map[*sema.TypeParameter]sema.Type) sema.Type {
-	return t
-}
-
-var FlowBuiltInTypes = StandardLibraryTypes{
-	StandardLibraryType{
-		Name: "Block",
-		Type: &BlockType{},
-		Kind: common.DeclarationKindType,
-	},
-}
+var FlowBuiltInTypes StandardLibraryTypes

--- a/runtime/stdlib/types.go
+++ b/runtime/stdlib/types.go
@@ -60,4 +60,4 @@ func (types StandardLibraryTypes) ToTypeDeclarations() []sema.TypeDeclaration {
 
 // BuiltinTypes
 
-var BuiltinTypes = StandardLibraryTypes{}
+var BuiltinTypes StandardLibraryTypes

--- a/runtime/tests/checker/metatype_test.go
+++ b/runtime/tests/checker/metatype_test.go
@@ -66,61 +66,68 @@ func TestCheckMetaType(t *testing.T) {
 }
 
 func TestCheckIsInstance(t *testing.T) {
+
 	t.Parallel()
 
-	cases := map[string]struct {
+	cases := []struct {
+		name  string
 		code  string
 		valid bool
 	}{
-		"string is an instance of string": {
-			`
-          let stringType = Type<String>()
-          let result = "abc".isInstance(stringType)
-			`,
-			true,
+		{
+			name: "string is an instance of string",
+			code: `
+              let stringType = Type<String>()
+              let result = "abc".isInstance(stringType)
+            `,
+			valid: true,
 		},
-		"int is an instance of int": {
+		{
+			name: "int is an instance of int",
+			code: `
+              let intType = Type<Int>()
+              let result = (1).isInstance(intType)
+            `,
+			valid: true,
+		},
+		{
+			name: "resource is an instance of resource",
+			code: `
+              resource R {}
 
-			`
-          let intType = Type<Int>()
-          let result = (1).isInstance(intType)
-			`,
-			true,
+              let r <- create R()
+              let rType = Type<@R>()
+              let result = r.isInstance(rType)
+            `,
+			valid: true,
 		},
-		"resource is an instance of resource": {
-			`
-          resource R {}
-
-          let r <- create R()
-          let rType = Type<@R>()
-          let result = r.isInstance(rType)
-			`,
-			true,
+		{
+			name: "1 is an instance of Int?",
+			code: `
+              let result = (1).isInstance(Type<Int?>())
+            `,
+			valid: true,
 		},
-		"1 is an instance of Int?": {
-			`
-				let result = (1).isInstance(Type<Int?>())
-			`,
-			true,
+		{
+			name: "isInstance must take a type",
+			code: `
+              let result = (1).isInstance(3)
+            `,
+			valid: false,
 		},
-		"isInstance must take a type": {
-			`
-				let result = (1).isInstance(3)
-			`,
-			false,
-		},
-		"nil is not a type": {
-			`
-				let result = (1).isInstance(nil)
-			`,
-			false,
+		{
+			name: "nil is not a type",
+			code: `
+              let result = (1).isInstance(nil)
+            `,
+			valid: false,
 		},
 	}
 
-	for name, cases := range cases {
-		t.Run(name, func(t *testing.T) {
-			checker, err := ParseAndCheck(t, cases.code)
-			if cases.valid {
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			checker, err := ParseAndCheck(t, testCase.code)
+			if testCase.valid {
 				require.NoError(t, err)
 				assert.Equal(t,
 					&sema.BoolType{},
@@ -131,7 +138,6 @@ func TestCheckIsInstance(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestCheckIsInstance_Redeclaration(t *testing.T) {
@@ -147,4 +153,48 @@ func TestCheckIsInstance_Redeclaration(t *testing.T) {
 	errs := ExpectCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.InvalidDeclarationError{}, errs[0])
+}
+
+func TestCheckGetType(t *testing.T) {
+
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		code string
+	}{
+		{
+			name: "String",
+			code: `
+              let result = "abc".getType()
+            `,
+		},
+		{
+			name: "Int",
+			code: `
+              let result = (1).getType()
+            `,
+		},
+		{
+			name: "resource",
+			code: `
+              resource R {}
+
+              let r <- create R()
+              let result = r.getType()
+            `,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			checker, err := ParseAndCheck(t, testCase.code)
+
+			require.NoError(t, err)
+			assert.Equal(t,
+				&sema.MetaType{},
+				checker.GlobalValues["result"].Type,
+			)
+		})
+	}
 }

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -23,51 +23,176 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
 )
 
-func TestInterpretMetaType(t *testing.T) {
+func TestInterpretMetaTypeEquality(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("constructor", func(t *testing.T) {
+	t.Run("Int == Int", func(t *testing.T) {
+
 		t.Parallel()
 
 		inter := parseCheckAndInterpret(t, `
-           let intInt = Type<Int>() == Type<Int>()
-           let intString = Type<Int>() == Type<String>()
-           let intOptional = Type<Int>() == Type<Int?>()
-           let intIntRef = Type<&Int>() == Type<&Int>()
-           let intStringRef = Type<&Int>() == Type<&String>()
+           let result = Type<Int>() == Type<Int>()
         `)
 
 		assert.Equal(t,
 			interpreter.BoolValue(true),
-			inter.Globals["intInt"].Value,
-		)
-
-		assert.Equal(t,
-			interpreter.BoolValue(false),
-			inter.Globals["intString"].Value,
-		)
-
-		assert.Equal(t,
-			interpreter.BoolValue(false),
-			inter.Globals["intOptional"].Value,
-		)
-
-		assert.Equal(t,
-			interpreter.BoolValue(true),
-			inter.Globals["intIntRef"].Value,
-		)
-
-		assert.Equal(t,
-			interpreter.BoolValue(false),
-			inter.Globals["intStringRef"].Value,
+			inter.Globals["result"].Value,
 		)
 	})
 
-	t.Run("identifier", func(t *testing.T) {
+	t.Run("Int != String", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+           let result = Type<Int>() == Type<String>()
+        `)
+
+		assert.Equal(t,
+			interpreter.BoolValue(false),
+			inter.Globals["result"].Value,
+		)
+	})
+
+	t.Run("Int != Int?", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+           let result = Type<Int>() == Type<Int?>()
+        `)
+
+		assert.Equal(t,
+			interpreter.BoolValue(false),
+			inter.Globals["result"].Value,
+		)
+	})
+
+	t.Run("&Int == &Int", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+           let result = Type<&Int>() == Type<&Int>()
+        `)
+
+		assert.Equal(t,
+			interpreter.BoolValue(true),
+			inter.Globals["result"].Value,
+		)
+	})
+
+	t.Run("&Int != &String", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+           let result = Type<&Int>() == Type<&String>()
+        `)
+
+		assert.Equal(t,
+			interpreter.BoolValue(false),
+			inter.Globals["result"].Value,
+		)
+	})
+
+	t.Run("Int != unknownType", func(t *testing.T) {
+
+		t.Parallel()
+
+		valueDeclarations := stdlib.StandardLibraryValues{
+			{
+				Name: "unknownType",
+				Type: &sema.MetaType{},
+				Value: interpreter.TypeValue{
+					Type: nil,
+				},
+				Kind: common.DeclarationKindConstant,
+			},
+		}
+
+		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
+		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
+
+		inter := parseCheckAndInterpretWithOptions(t,
+			`
+              let result = Type<Int>() == unknownType
+            `,
+			ParseCheckAndInterpretOptions{
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(semaValueDeclarations),
+				},
+				Options: []interpreter.Option{
+					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				},
+			},
+		)
+
+		assert.Equal(t,
+			interpreter.BoolValue(false),
+			inter.Globals["result"].Value,
+		)
+	})
+
+	t.Run("unknownType1 != unknownType2", func(t *testing.T) {
+
+		t.Parallel()
+
+		valueDeclarations := stdlib.StandardLibraryValues{
+			{
+				Name: "unknownType1",
+				Type: &sema.MetaType{},
+				Value: interpreter.TypeValue{
+					Type: nil,
+				},
+				Kind: common.DeclarationKindConstant,
+			},
+			{
+				Name: "unknownType2",
+				Type: &sema.MetaType{},
+				Value: interpreter.TypeValue{
+					Type: nil,
+				},
+				Kind: common.DeclarationKindConstant,
+			},
+		}
+
+		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
+		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
+
+		inter := parseCheckAndInterpretWithOptions(t,
+			`
+              let result = unknownType1 == unknownType2
+            `,
+			ParseCheckAndInterpretOptions{
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(semaValueDeclarations),
+				},
+				Options: []interpreter.Option{
+					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				},
+			},
+		)
+
+		assert.Equal(t,
+			interpreter.BoolValue(false),
+			inter.Globals["result"].Value,
+		)
+	})
+}
+
+func TestInterpretMetaTypeIdentifier(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("identifier, Int", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -81,85 +206,179 @@ func TestInterpretMetaType(t *testing.T) {
 			inter.Globals["identifier"].Value,
 		)
 	})
+
+	t.Run("identifier, struct", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          struct S {}
+
+          let type = Type<S>()
+          let identifier = type.identifier
+        `)
+
+		assert.Equal(t,
+			interpreter.NewStringValue("S.test.S"),
+			inter.Globals["identifier"].Value,
+		)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+
+		t.Parallel()
+
+		valueDeclarations := stdlib.StandardLibraryValues{
+			{
+				Name: "unknownType",
+				Type: &sema.MetaType{},
+				Value: interpreter.TypeValue{
+					Type: nil,
+				},
+				Kind: common.DeclarationKindConstant,
+			},
+		}
+
+		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
+		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
+
+		inter := parseCheckAndInterpretWithOptions(t,
+			`
+              let identifier = unknownType.identifier
+            `,
+			ParseCheckAndInterpretOptions{
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(semaValueDeclarations),
+				},
+				Options: []interpreter.Option{
+					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				},
+			},
+		)
+
+		assert.Equal(t,
+			interpreter.NewStringValue(""),
+			inter.Globals["identifier"].Value,
+		)
+	})
 }
 
 func TestInterpretIsInstance(t *testing.T) {
 
 	t.Parallel()
 
-	cases := map[string]struct {
+	cases := []struct {
+		name   string
 		code   string
 		result bool
 	}{
-		"string is an instance of string": {
-			`
-          let stringType = Type<String>()
-          let result = "abc".isInstance(stringType)
-			`,
-			true,
+		{
+			name: "string is an instance of string",
+			code: `
+              let stringType = Type<String>()
+              let result = "abc".isInstance(stringType)
+            `,
+			result: true,
 		},
-		"int is an instance of int": {
-			`
-          let intType = Type<Int>()
-          let result = (1).isInstance(intType)
-			`,
-			true,
+		{
+			name: "int is an instance of int",
+			code: `
+              let intType = Type<Int>()
+              let result = (1).isInstance(intType)
+            `,
+			result: true,
 		},
-		"resource is an instance of resource": {
-			`
-          resource R {}
+		{
+			name: "resource is an instance of resource",
+			code: `
+              resource R {}
 
-          let r <- create R()
-          let rType = Type<@R>()
-          let result = r.isInstance(rType)
-			`,
-			true,
+              let r <- create R()
+              let rType = Type<@R>()
+              let result = r.isInstance(rType)
+            `,
+			result: true,
 		},
-		"int is not an instance of string": {
-			`
-          let stringType = Type<String>()
-          let result = (1).isInstance(stringType)
-			`,
-			false,
+		{
+			name: "int is not an instance of string",
+			code: `
+              let stringType = Type<String>()
+              let result = (1).isInstance(stringType)
+            `,
+			result: false,
 		},
-		"int is not an instance of resource": {
-			`
-          resource R {}
+		{
+			name: "int is not an instance of resource",
+			code: `
+              resource R {}
 
-          let rType = Type<@R>()
-          let result = (1).isInstance(rType)
-			`,
-			false,
+              let rType = Type<@R>()
+              let result = (1).isInstance(rType)
+            `,
+			result: false,
 		},
-		"resource is not an instance of string": {
-			`
-          resource R {}
+		{
+			name: "resource is not an instance of string",
+			code: `
+              resource R {}
 
-          let r <- create R()
-          let stringType = Type<String>()
-          let result = (r).isInstance(stringType)
-			`,
-			false,
+              let r <- create R()
+              let stringType = Type<String>()
+              let result = r.isInstance(stringType)
+            `,
+			result: false,
 		},
-		"resource R is not an instance of resource S": {
-			`
-          resource R {}
-          resource S {}
+		{
+			name: "resource R is not an instance of resource S",
+			code: `
+              resource R {}
+              resource S {}
 
-          let r <- create R()
-          let sType = Type<@S>()
-          let result = (r).isInstance(sType)
-			`,
-			false,
+              let r <- create R()
+              let sType = Type<@S>()
+              let result = r.isInstance(sType)
+            `,
+			result: false,
+		},
+		{
+			name: "struct S is not an instance of an unknown type",
+			code: `
+              struct S {}
+
+              let s = S()
+              let result = s.isInstance(unknownType)
+            `,
+			result: false,
 		},
 	}
 
-	for name, cases := range cases {
-		t.Run(name, func(t *testing.T) {
-			inter := parseCheckAndInterpret(t, cases.code)
+	valueDeclarations := stdlib.StandardLibraryValues{
+		{
+			Name: "unknownType",
+			Type: &sema.MetaType{},
+			Value: interpreter.TypeValue{
+				Type: nil,
+			},
+			Kind: common.DeclarationKindConstant,
+		},
+	}
+
+	semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
+	interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			inter := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(semaValueDeclarations),
+				},
+				Options: []interpreter.Option{
+					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				},
+			})
 
 			assert.Equal(t,
-				interpreter.BoolValue(cases.result),
+				interpreter.BoolValue(testCase.result),
 				inter.Globals["result"].Value,
 			)
 		})

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -423,8 +423,8 @@ func TestInterpretGetType(t *testing.T) {
             `,
 			result: interpreter.TypeValue{
 				Type: interpreter.CompositeStaticType{
-					Location: utils.TestLocation,
-					TypeID:   "S.test.R",
+					Location:            utils.TestLocation,
+					QualifiedIdentifier: "R",
 				},
 			},
 		},


### PR DESCRIPTION
Closes #195 

Add a function `fun getType(): Type` to all values. Implement it for values where a static type is known – for some values it is not currently possible to return a static type (e.g. arrays, dictionaries)

1. Make the static type in type value optional to support the case where a value has no known static type
2. Refactor the `Block` type to `sema`, and the value to `interpreter`. Add the missing dynamic type. This is only temporary – we should move it out of Cadence and inject it in the FVM package.
3. Add the missing static types (`AuthAccount`, `PublicAccount`, `DeployedContract`, etc.)