### PR TITLE
Declare new contract's nested values before evaluating initializer

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2620,6 +2620,11 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 				// needs to be available for nested declarations
 
 				variable.Value = value
+
+				// Also, immediately set the nested values,
+				// as the initializer of the contract may use nested declarations
+
+				value.NestedValues = members
 			}
 
 			var initializationTrampoline Trampoline = Done{}

--- a/runtime/tests/interpreter/nesting_test.go
+++ b/runtime/tests/interpreter/nesting_test.go
@@ -1,0 +1,48 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+)
+
+func TestInterpretContractWithNestedDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	_ = parseCheckAndInterpretWithOptions(t,
+		`
+	      contract C {
+
+	          struct S {}
+
+	          init() {
+	              C.S()
+	          }
+	      }
+	    `,
+		ParseCheckAndInterpretOptions{
+			Options: []interpreter.Option{
+				makeContractValueHandler(nil, nil, nil),
+			},
+		},
+	)
+}


### PR DESCRIPTION
The initializer of a contract may already refer and use nested declarations.

Set the new contract value's nested values before evaluating the contract initializer.

Reported by @orodio 🙏 