### PR TITLE
Gracefully handle type loading failure

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -332,3 +332,13 @@ type UUIDUnavailableError struct {
 func (e UUIDUnavailableError) Error() string {
 	return "cannot get UUID: unavailable"
 }
+
+// TypeLoadingError
+
+type TypeLoadingError struct {
+	TypeID common.TypeID
+}
+
+func (e TypeLoadingError) Error() string {
+	return fmt.Sprintf("failed to load type: %s", e.TypeID)
+}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4464,13 +4464,25 @@ func (interpreter *Interpreter) getElaboration(location common.Location) *sema.E
 func (interpreter *Interpreter) getCompositeType(location common.Location, qualifiedIdentifier string) *sema.CompositeType {
 	elaboration := interpreter.getElaboration(location)
 	typeID := location.TypeID(qualifiedIdentifier)
-	return elaboration.CompositeTypes[typeID]
+	ty := elaboration.CompositeTypes[typeID]
+	if ty == nil {
+		panic(TypeLoadingError{
+			TypeID: typeID,
+		})
+	}
+	return ty
 }
 
 func (interpreter *Interpreter) getInterfaceType(location common.Location, qualifiedIdentifier string) *sema.InterfaceType {
 	elaboration := interpreter.getElaboration(location)
 	typeID := location.TypeID(qualifiedIdentifier)
-	return elaboration.InterfaceTypes[typeID]
+	ty := elaboration.InterfaceTypes[typeID]
+	if ty == nil {
+		panic(TypeLoadingError{
+			TypeID: typeID,
+		})
+	}
+	return ty
 }
 
 func (interpreter *Interpreter) reportLoopIteration(pos ast.HasPosition) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -916,9 +916,6 @@ func (r *interpreterRuntime) importResolver(startContext Context) ImportResolver
 		if err != nil {
 			return nil, err
 		}
-		if code == nil {
-			return nil, nil
-		}
 
 		context.SetCode(location, string(code))
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3288,6 +3288,127 @@ func TestRuntimeStorageLoadedDestructionAnyResource(t *testing.T) {
 	assert.Equal(t, `"destroyed"`, loggedMessage)
 }
 
+func TestRuntimeStorageLoadedDestructionAfterRemoval(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewInterpreterRuntime()
+
+	addressValue := Address{
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+	}
+
+	contract := []byte(`
+        pub contract Test {
+            pub resource R {
+                // test that the destructor is linked back into the nested resource
+                // after being loaded from storage
+                destroy() {
+                    log("destroyed")
+                }
+            }
+
+            init() {
+                // store nested resource in account on deployment
+                self.account.save(<-create R(), to: /storage/r)
+            }
+        }
+    `)
+
+	tx := []byte(`
+        // NOTE: *not* importing concrete implementation.
+        //   Should be imported automatically when loading the value from storage
+
+		transaction {
+
+			prepare(acct: AuthAccount) {
+                let r <- acct.load<@AnyResource>(from: /storage/r)
+				destroy r
+			}
+		}
+	`)
+
+	deploy := utils.DeploymentTransaction("Test", contract)
+	removal := utils.RemovalTransaction("Test")
+
+	var accountCode []byte
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(_ Location) (bytes []byte, err error) {
+			return accountCode, nil
+		},
+		storage: newTestStorage(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{addressValue}, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+			return accountCode, nil
+		},
+		updateAccountContractCode: func(address Address, _ string, code []byte) error {
+			accountCode = code
+			return nil
+		},
+		removeAccountContractCode: func(_ Address, _ string) (err error) {
+			accountCode = nil
+			return nil
+		},
+		emitEvent: func(event cadence.Event) error { return nil },
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	// Deploy the contract
+
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	assert.NotNil(t, accountCode)
+
+	// Remove the contract
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: removal,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Nil(t, accountCode)
+
+	// Destroy
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: tx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+
+	var typeLoadingErr interpreter.TypeLoadingError
+	utils.RequireErrorAs(t, err, &typeLoadingErr)
+
+	require.Equal(t,
+		common.AddressLocation{Address: addressValue}.TypeID("Test.R"),
+		typeLoadingErr.TypeID,
+	)
+}
+
 const fungibleTokenContract = `
 pub contract FungibleToken {
 

--- a/runtime/tests/utils/utils.go
+++ b/runtime/tests/utils/utils.go
@@ -96,6 +96,20 @@ func DeploymentTransaction(name string, contract []byte) []byte {
 	))
 }
 
+func RemovalTransaction(name string) []byte {
+	return []byte(fmt.Sprintf(
+		`
+          transaction {
+
+              prepare(signer: AuthAccount) {
+                  signer.contracts.remove(name: "%s")
+              }
+          }
+        `,
+		name,
+	))
+}
+
 func UpdateTransaction(name string, contract []byte) []byte {
 	return []byte(fmt.Sprintf(
 		`


### PR DESCRIPTION
Work towards dapperlabs/flow-go#5150

When the code for a composite type or interface type cannot be loaded (because it was potentially removed), then treat it as a user error instead of an implementation error.

Also, when a destructor is invoked, explicitly ensure the code for the type is loaded. This was already done previously, but implicitly: When the value is loaded/borrowed from storage, a dynamic type check is performed, which checks if the value's type matches the requested type (the type parameter of the `load`/`borrow` functions). As part of this check the code of the type is loaded.

Add tests that ensure the following three scenarios are handled properly:
- A value is loaded from storage, by it's concrete type / an explicit import of the contract code, and it is destroyed: the value's destructor should be called, which requires loading the type's code.
- A value is loaded from storage, through a non-concrete type (here, `AnyResource`), i.e. there is no explicit import of thee contract code, and it is destroyed: the value's destructor should be called, which requires loading the type's code.
- Deploy a contract, save a value, remove the contract, load the value: The type does not exist anymore, and this is a user error instead of an implementation error
