### PR TITLE
Export all checkers

### DIFF
--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -232,7 +232,7 @@ func (checker *Checker) EnsureLoaded(location common.Location, loadProgram func(
 
 	locationID := location.ID()
 
-	subChecker, ok := checker.allCheckers[locationID]
+	subChecker, ok := checker.AllCheckers[locationID]
 	if ok {
 		return subChecker, nil
 	}
@@ -246,13 +246,13 @@ func (checker *Checker) EnsureLoaded(location common.Location, loadProgram func(
 			WithPredeclaredTypes(checker.PredeclaredTypes),
 			WithAccessCheckMode(checker.accessCheckMode),
 			WithValidTopLevelDeclarationsHandler(checker.validTopLevelDeclarationsHandler),
-			WithAllCheckers(checker.allCheckers),
+			WithAllCheckers(checker.AllCheckers),
 			WithCheckHandler(checker.checkHandler),
 			WithImportHandler(checker.importHandler),
 			WithLocationHandler(checker.locationHandler),
 		)
 		if err == nil {
-			checker.allCheckers[locationID] = subChecker
+			checker.AllCheckers[locationID] = subChecker
 		}
 	}
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -85,7 +85,7 @@ type Checker struct {
 	effectivePredeclaredValues         map[string]ValueDeclaration
 	PredeclaredTypes                   []TypeDeclaration
 	effectivePredeclaredTypes          map[string]TypeDeclaration
-	allCheckers                        map[common.LocationID]*Checker
+	AllCheckers                        map[common.LocationID]*Checker
 	accessCheckMode                    AccessCheckMode
 	errors                             []error
 	hints                              []Hint
@@ -284,10 +284,10 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 // SetAllCheckers sets the given map of checkers as the map of all checkers.
 //
 func (checker *Checker) SetAllCheckers(allCheckers map[common.LocationID]*Checker) {
-	checker.allCheckers = allCheckers
+	checker.AllCheckers = allCheckers
 
 	// Register self
-	checker.allCheckers[checker.Location.ID()] = checker
+	checker.AllCheckers[checker.Location.ID()] = checker
 }
 
 func (checker *Checker) declareBaseValues() {


### PR DESCRIPTION
## Description

Allow access to all checkers. This is useful when working with parsing/checking errors, which only point to the checker in which the error occurred. Exporting the field allows access the checkers of all imported programs. 

There is already an exported setter for this field.

This will be used in the [FVM](https://github.com/onflow/flow-go/blob/14e4d157b2365b024b1014f519434001d7eb5145/fvm/transaction.go#L103)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
