### PR TITLE
Improve the parsing / checking error

### DIFF
--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -77,7 +77,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 		require.Equal(t, expectedCodeHash[:], actualCodeHash)
 	}
 
-	expectFailure := func(expectedErrorMessage string) expectation {
+	expectFailure := func(expectedProgramCount int, expectedErrorMessage string) expectation {
 		return func(t *testing.T, err error, accountCode []byte, events []cadence.Event, _ cadence.Type) {
 			var runtimeErr Error
 			utils.RequireErrorAs(t, err, &runtimeErr)
@@ -85,6 +85,9 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			println(runtimeErr.Error())
 
 			assert.EqualError(t, runtimeErr, expectedErrorMessage)
+
+			assert.Len(t, runtimeErr.Codes, 2)
+			assert.Len(t, runtimeErr.Programs, expectedProgramCount)
 
 			assert.Nil(t, accountCode)
 			assert.Len(t, events, 0)
@@ -96,118 +99,209 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 	}
 
 	type testCase struct {
-		name      string
 		contract  string
 		arguments []argument
 		check     func(t *testing.T, err error, accountCode []byte, events []cadence.Event, expectedEventType cadence.Type)
 	}
 
-	tests := []testCase{
-		{
-			name: "no arguments",
+	test := func(t *testing.T, test testCase) {
+
+		t.Parallel()
+
+		contractArrayCode := fmt.Sprintf(
+			`"%s".decodeHex()`,
+			hex.EncodeToString([]byte(test.contract)),
+		)
+
+		argumentCodes := make([]string, len(test.arguments))
+
+		for i, argument := range test.arguments {
+			argumentCodes[i] = argument.String()
+		}
+
+		argumentCode := strings.Join(argumentCodes, ", ")
+		if len(test.arguments) > 0 {
+			argumentCode = ", " + argumentCode
+		}
+
+		script := []byte(fmt.Sprintf(
+			`
+              transaction {
+
+                  prepare(signer: AuthAccount) {
+                      signer.contracts.add(name: "Test", code: %s%s)
+                  }
+              }
+            `,
+			contractArrayCode,
+			argumentCode,
+		))
+
+		runtime := NewInterpreterRuntime()
+
+		var accountCode []byte
+		var events []cadence.Event
+
+		runtimeInterface := &testRuntimeInterface{
+			storage: newTestStorage(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{{42}}, nil
+			},
+			getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+				return accountCode, nil
+			},
+			updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+				accountCode = code
+				return nil
+			},
+			emitEvent: func(event cadence.Event) error {
+				events = append(events, event)
+				return nil
+			},
+		}
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		exportedEventType := ExportType(
+			stdlib.AccountContractAddedEventType,
+			map[sema.TypeID]cadence.Type{},
+		)
+		test.check(t, err, accountCode, events, exportedEventType)
+	}
+
+	t.Run("no arguments", func(t *testing.T) {
+		test(t, testCase{
 			contract: `
-		     pub contract Test {}
-		   `,
+              pub contract Test {}
+            `,
 			arguments: []argument{},
 			check:     expectSuccess,
-		},
-		{
-			name: "with argument",
+		})
+	})
+
+	t.Run("with argument", func(t *testing.T) {
+		test(t, testCase{
 			contract: `
-		     pub contract Test {
-		         init(_ x: Int) {}
-		     }
-		   `,
+              pub contract Test {
+                  init(_ x: Int) {}
+              }
+            `,
 			arguments: []argument{
 				interpreter.NewIntValueFromInt64(1),
 			},
 			check: expectSuccess,
-		},
-		{
-			name: "with incorrect argument",
+		})
+	})
+
+	t.Run("with incorrect argument", func(t *testing.T) {
+		test(t, testCase{
 			contract: `
-		     pub contract Test {
-		         init(_ x: Int) {}
-		     }
-		   `,
+              pub contract Test {
+                  init(_ x: Int) {}
+              }
+            `,
 			arguments: []argument{
 				interpreter.BoolValue(true),
 			},
-			check: expectFailure("Execution failed:\n" +
-				"error: invalid argument 0: expected type `Int`, got `Bool`\n" +
-				" --> 00:5:26\n" +
-				"  |\n" +
-				"5 |                           signer.contracts.add(name: \"Test\", code: \"0a0909202020202070756220636f6e74726163742054657374207b0a0909202020202020202020696e6974285f20783a20496e7429207b7d0a090920202020207d0a0909202020\".decodeHex(), true)\n" +
-				"  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+			check: expectFailure(
+				2,
+				"Execution failed:\n"+
+					"error: invalid argument 0: expected type `Int`, got `Bool`\n"+
+					" --> 00:5:22\n"+
+					"  |\n"+
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b0a202020202020202020202020202020202020696e6974285f20783a20496e7429207b7d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex(), true)\n"+
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
 			),
-		},
-		{
-			name: "additional argument",
+		})
+	})
+
+	t.Run("additional argument", func(t *testing.T) {
+		test(t, testCase{
 			contract: `
-		     pub contract Test {}
-		   `,
+              pub contract Test {}
+            `,
 			arguments: []argument{
 				interpreter.NewIntValueFromInt64(1),
 			},
-			check: expectFailure("Execution failed:\n" +
-				"error: invalid argument count, too many arguments: expected 0, got 1\n" +
-				" --> 00:5:26\n" +
-				"  |\n" +
-				"5 |                           signer.contracts.add(name: \"Test\", code: \"0a0909202020202070756220636f6e74726163742054657374207b7d0a0909202020\".decodeHex(), 1)\n" +
-				"  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+			check: expectFailure(
+				2,
+				"Execution failed:\n"+
+					"error: invalid argument count, too many arguments: expected 0, got 1\n"+
+					" --> 00:5:22\n"+
+					"  |\n"+
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b7d0a202020202020202020202020\".decodeHex(), 1)\n"+
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
 			),
-		},
-		{
-			name: "additional code which is invalid at top-level",
+		})
+	})
+
+	t.Run("additional code which is invalid at top-level", func(t *testing.T) {
+		test(t, testCase{
 			contract: `
-		     pub contract Test {}
-		
-		     fun testCase() {}
-		   `,
+              pub contract Test {}
+
+              fun testCase() {}
+            `,
 			arguments: []argument{},
-			check: expectFailure("Execution failed:\n" +
-				"error: cannot deploy invalid contract\n" +
-				" --> 00:5:26\n" +
-				"  |\n" +
-				"5 |                           signer.contracts.add(name: \"Test\", code: \"0a0909202020202070756220636f6e74726163742054657374207b7d0a09090a0909202020202066756e2074657374436173652829207b7d0a0909202020\".decodeHex())\n" +
-				"  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-				"\n" +
-				"error: function declarations are not valid at the top-level\n" +
-				" --> 2a00000000000000.Test:4:11\n" +
-				"  |\n" +
-				"4 | \t\t     fun testCase() {}\n" +
-				"  |            ^^^^^^^^\n" +
-				"\n" +
-				"error: missing access modifier for function\n" +
-				" --> 2a00000000000000.Test:4:7\n" +
-				"  |\n" +
-				"4 | \t\t     fun testCase() {}\n" +
-				"  |        ^\n",
+			check: expectFailure(
+				2,
+				"Execution failed:\n"+
+					"error: cannot deploy invalid contract\n"+
+					" --> 00:5:22\n"+
+					"  |\n"+
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b7d0a0a202020202020202020202020202066756e2074657374436173652829207b7d0a202020202020202020202020\".decodeHex())\n"+
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
+					"\n"+
+					"error: function declarations are not valid at the top-level\n"+
+					" --> 2a00000000000000.Test:4:18\n"+
+					"  |\n"+
+					"4 |               fun testCase() {}\n"+
+					"  |                   ^^^^^^^^\n"+
+					"\n"+
+					"error: missing access modifier for function\n"+
+					" --> 2a00000000000000.Test:4:14\n"+
+					"  |\n"+
+					"4 |               fun testCase() {}\n"+
+					"  |               ^\n",
 			),
-		},
-		{
-			name: "invalid contract, parsing error",
+		})
+	})
+
+	t.Run("invalid contract, parsing error", func(t *testing.T) {
+		test(t, testCase{
 			contract: `
               X
             `,
 			arguments: []argument{},
 			check: expectFailure(
-				"Execution failed:\n" +
-					"error: cannot deploy invalid contract\n" +
-					" --> 00:5:26\n" +
-					"  |\n" +
-					"5 |                           signer.contracts.add(name: \"Test\", code: \"0a2020202020202020202020202020580a202020202020202020202020\".decodeHex())\n" +
-					"  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-					"\n" +
-					"error: unexpected token: identifier\n" +
-					" --> 2a00000000000000.Test:2:14\n" +
-					"  |\n" +
-					"2 |               X\n" +
+				1,
+				"Execution failed:\n"+
+					"error: cannot deploy invalid contract\n"+
+					" --> 00:5:22\n"+
+					"  |\n"+
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a2020202020202020202020202020580a202020202020202020202020\".decodeHex())\n"+
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
+					"\n"+
+					"error: unexpected token: identifier\n"+
+					" --> 2a00000000000000.Test:2:14\n"+
+					"  |\n"+
+					"2 |               X\n"+
 					"  |               ^\n",
 			),
-		},
-		{
-			name: "invalid contract, checking error",
+		})
+	})
+
+	t.Run("invalid contract, checking error", func(t *testing.T) {
+		test(t, testCase{
 			contract: `
               pub contract Test {
                   pub fun test() { X }
@@ -215,100 +309,21 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
             `,
 			arguments: []argument{},
 			check: expectFailure(
-				"Execution failed:\n" +
-					"error: cannot deploy invalid contract\n" +
-					" --> 00:5:26\n" +
-					"  |\n" +
-					"5 |                           signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b0a2020202020202020202020202020202020207075622066756e20746573742829207b2058207d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex())\n" +
-					"  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-					"\n" +
-					"error: cannot find variable in this scope: `X`\n" +
-					" --> 2a00000000000000.Test:3:35\n" +
-					"  |\n" +
-					"3 |                   pub fun test() { X }\n" +
+				2,
+				"Execution failed:\n"+
+					"error: cannot deploy invalid contract\n"+
+					" --> 00:5:22\n"+
+					"  |\n"+
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b0a2020202020202020202020202020202020207075622066756e20746573742829207b2058207d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex())\n"+
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
+					"\n"+
+					"error: cannot find variable in this scope: `X`\n"+
+					" --> 2a00000000000000.Test:3:35\n"+
+					"  |\n"+
+					"3 |                   pub fun test() { X }\n"+
 					"  |                                    ^ not found in this scope\n",
 			),
-		},
-	}
-
-	test := func(test testCase) {
-
-		t.Run(test.name, func(t *testing.T) {
-
-			t.Parallel()
-
-			contractArrayCode := fmt.Sprintf(
-				`"%s".decodeHex()`,
-				hex.EncodeToString([]byte(test.contract)),
-			)
-
-			argumentCodes := make([]string, len(test.arguments))
-
-			for i, argument := range test.arguments {
-				argumentCodes[i] = argument.String()
-			}
-
-			argumentCode := strings.Join(argumentCodes, ", ")
-			if len(test.arguments) > 0 {
-				argumentCode = ", " + argumentCode
-			}
-
-			script := []byte(fmt.Sprintf(
-				`
-                  transaction {
-
-                      prepare(signer: AuthAccount) {
-                          signer.contracts.add(name: "Test", code: %s%s)
-                      }
-                  }
-                `,
-				contractArrayCode,
-				argumentCode,
-			))
-
-			runtime := NewInterpreterRuntime()
-
-			var accountCode []byte
-			var events []cadence.Event
-
-			runtimeInterface := &testRuntimeInterface{
-				storage: newTestStorage(nil, nil),
-				getSigningAccounts: func() ([]Address, error) {
-					return []Address{{42}}, nil
-				},
-				getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
-					return accountCode, nil
-				},
-				updateAccountContractCode: func(_ Address, _ string, code []byte) error {
-					accountCode = code
-					return nil
-				},
-				emitEvent: func(event cadence.Event) error {
-					events = append(events, event)
-					return nil
-				},
-			}
-
-			nextTransactionLocation := newTransactionLocationGenerator()
-
-			err := runtime.ExecuteTransaction(
-				Script{
-					Source: script,
-				},
-				Context{
-					Interface: runtimeInterface,
-					Location:  nextTransactionLocation(),
-				},
-			)
-			exportedEventType := ExportType(
-				stdlib.AccountContractAddedEventType,
-				map[sema.TypeID]cadence.Type{},
-			)
-			test.check(t, err, accountCode, events, exportedEventType)
 		})
-	}
+	})
 
-	for _, testCase := range tests {
-		test(testCase)
-	}
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -34,6 +34,7 @@ type Error struct {
 	Err      error
 	Location common.Location
 	Codes    map[common.LocationID]string
+	Programs map[common.LocationID]*ast.Program
 }
 
 func newError(err error, context Context) Error {
@@ -41,6 +42,7 @@ func newError(err error, context Context) Error {
 		Err:      err,
 		Location: context.Location,
 		Codes:    context.codes,
+		Programs: context.programs,
 	}
 }
 
@@ -189,18 +191,12 @@ func (e *ScriptParameterTypeNotStorableError) Error() string {
 	)
 }
 
-// ParsingCheckingError provides extra information about the state of the environment
-// when a parsing or a checking error occurred
+// ParsingCheckingError is an error wrapper
+// for a parsing or a checking error at a specific location
 //
 type ParsingCheckingError struct {
-	Err          error
-	StorageCache Cache
-	Code         []byte
-	Location     common.Location
-	Options      []sema.Option
-	UseCache     bool
-	Program      *ast.Program
-	Checker      *sema.Checker
+	Err      error
+	Location common.Location
 }
 
 func (e *ParsingCheckingError) ChildErrors() []error {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3959,10 +3959,10 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 		)
 		require.Error(t, err)
 
-		require.IsType(t, Error{}, err)
-		err = err.(Error).Unwrap()
+		var checkerErr *sema.CheckerError
+		utils.RequireErrorAs(t, err, &checkerErr)
 
-		errs := checker.ExpectCheckerErrors(t, err, 1)
+		errs := checker.ExpectCheckerErrors(t, checkerErr, 1)
 
 		assert.IsType(t, &sema.InvalidTopLevelDeclarationError{}, errs[0])
 	})


### PR DESCRIPTION
## Description

The parsing / checking error currently contains fields that were intended to be logged by the [FVM](https://github.com/onflow/flow-go/blob/14e4d157b2365b024b1014f519434001d7eb5145/fvm/transaction.go#L103) when a checking / parsing error for deployed contracts occurs.

However, the values may contain cyclic pointers, which can't be encoded using JSON, spew, etc.
Remove the unused fields and actually include the interesting part, the program ASTs in the runtime error, just like the source codes of all programs already are included in the runtime error.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
