### PR TITLE
Argument list parsing and transaction declaration docstrings

### DIFF
--- a/runtime/ast/transaction_declaration.go
+++ b/runtime/ast/transaction_declaration.go
@@ -31,6 +31,7 @@ type TransactionDeclaration struct {
 	PreConditions  *Conditions
 	PostConditions *Conditions
 	Execute        *SpecialFunctionDeclaration
+	DocString      string
 	Range
 }
 

--- a/runtime/ast/transaction_declaration_test.go
+++ b/runtime/ast/transaction_declaration_test.go
@@ -42,6 +42,7 @@ func TestTransactionDeclaration_MarshalJSON(t *testing.T) {
 		Prepare:        nil,
 		PreConditions:  &Conditions{},
 		PostConditions: &Conditions{},
+		DocString:      "test",
 		Execute:        nil,
 		Range: Range{
 			StartPos: Position{Offset: 7, Line: 8, Column: 9},
@@ -66,6 +67,7 @@ func TestTransactionDeclaration_MarshalJSON(t *testing.T) {
 		    "PreConditions":  [],
 		    "PostConditions": [],
 		    "Execute":        null,
+            "DocString":      "test",
             "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
             "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
         }

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -50,7 +50,7 @@ func ParseLiteral(literal string, ty sema.Type) (cadence.Value, error) {
 	return LiteralValue(expression, ty)
 }
 
-// ParseLiteralArgumrntList parses an argument list with literals, that should have the given types.
+// ParseLiteralArgumentList parses an argument list with literals, that should have the given types.
 //
 // Returns an error if the code is not a valid argument list, or the arguments are not literals.
 //

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -89,7 +89,7 @@ func parseDeclaration(p *parser, docString string) ast.Declaration {
 				if access != ast.AccessNotSpecified {
 					panic(fmt.Errorf("invalid access modifier for transaction"))
 				}
-				return parseTransactionDeclaration(p)
+				return parseTransactionDeclaration(p, docString)
 
 			case keywordPriv, keywordPub, keywordAccess:
 				if access != ast.AccessNotSpecified {

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -85,7 +85,7 @@ func parseDeclaration(p *parser, docString string) ast.Declaration {
 			case keywordStruct, keywordResource, keywordContract, keywordEnum:
 				return parseCompositeOrInterfaceDeclaration(p, access, accessPos, docString)
 
-			case keywordTransaction:
+			case KeywordTransaction:
 				if access != ast.AccessNotSpecified {
 					panic(fmt.Errorf("invalid access modifier for transaction"))
 				}

--- a/runtime/parser2/docstring.go
+++ b/runtime/parser2/docstring.go
@@ -1,0 +1,47 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser2
+
+import (
+	"regexp"
+	"strings"
+)
+
+var pragmaArgumentRegexp = regexp.MustCompile(`^\s+pragma\s+arguments\s+(.*)(?:\n|$)`)
+
+// ParseDocstringPragmaArguments parses the docstring and returns the values of all pragma arguments declarations.
+//
+// A pragma arguments declaration has the form `pragma arguments <argument-list>`,
+// where <argument-list> is a Cadence argument list.
+//
+// The validity of the argument list is NOT checked by this function.
+//
+func ParseDocstringPragmaArguments(docString string) []string {
+	var pragmaArguments []string
+
+	for _, line := range strings.Split(docString, "\n") {
+		match := pragmaArgumentRegexp.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		pragmaArguments = append(pragmaArguments, match[1])
+	}
+
+	return pragmaArguments
+}

--- a/runtime/parser2/docstring_test.go
+++ b/runtime/parser2/docstring_test.go
@@ -1,0 +1,45 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDocstringPragmaArguments(t *testing.T) {
+
+	actual := ParseDocstringPragmaArguments(`
+      pragma arguments (a: 1)
+      other stuff
+
+      pragma arguments   (b: 2)  
+
+      pragma arguments  ( a: 1 ,  b:   2)`)
+
+	require.Equal(t,
+		[]string{
+			"(a: 1)",
+			"(b: 2)  ",
+			"( a: 1 ,  b:   2)",
+		},
+		actual,
+	)
+}

--- a/runtime/parser2/keyword.go
+++ b/runtime/parser2/keyword.go
@@ -55,7 +55,7 @@ const (
 	keywordStruct      = "struct"
 	keywordResource    = "resource"
 	keywordInterface   = "interface"
-	keywordTransaction = "transaction"
+	KeywordTransaction = "transaction"
 	keywordPrepare     = "prepare"
 	keywordExecute     = "execute"
 	keywordCase        = "case"

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -407,6 +407,22 @@ func ParseDeclarations(input string) (declarations []ast.Declaration, errors []e
 	return
 }
 
+func ParseArgumentList(input string) (arguments ast.Arguments, errors []error) {
+	var res interface{}
+	res, errors = Parse(input, func(p *parser) interface{} {
+		p.skipSpaceAndComments(true)
+		p.mustOne(lexer.TokenParenOpen)
+		arguments, _ := parseArgumentListRemainder(p)
+		return arguments
+	})
+	if res == nil {
+		arguments = nil
+		return
+	}
+	arguments = res.([]*ast.Argument)
+	return
+}
+
 func ParseProgram(input string) (program *ast.Program, err error) {
 	var res interface{}
 	var errs []error

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -20,6 +20,7 @@ package parser2
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -322,4 +323,101 @@ func TestParseNames(t *testing.T) {
 			assert.IsType(t, Error{}, err)
 		}
 	}
+}
+
+func TestParseArgumentList(t *testing.T) {
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+
+		_, errs := ParseArgumentList(`xyz`)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected token '('",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		result, errs := ParseArgumentList(`()`)
+		require.Empty(t, errs)
+
+		var expected ast.Arguments
+
+		utils.AssertEqualWithDiff(t,
+			expected,
+			result,
+		)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		result, errs := ParseArgumentList(`(1, b: true)`)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			ast.Arguments{
+				{
+					Label:         "",
+					LabelStartPos: nil,
+					LabelEndPos:   nil,
+					Expression: &ast.IntegerExpression{
+						Value: big.NewInt(1),
+						Base:  10,
+						Range: ast.Range{
+							StartPos: ast.Position{
+								Offset: 1,
+								Line:   1,
+								Column: 1,
+							},
+							EndPos: ast.Position{
+								Offset: 1,
+								Line:   1,
+								Column: 1,
+							},
+						},
+					},
+				},
+				{
+					Label: "b",
+					LabelStartPos: &ast.Position{
+						Offset: 4,
+						Line:   1,
+						Column: 4,
+					},
+					LabelEndPos: &ast.Position{
+						Offset: 4,
+						Line:   1,
+						Column: 4,
+					},
+					Expression: &ast.BoolExpression{
+						Value: true,
+						Range: ast.Range{
+							StartPos: ast.Position{
+								Offset: 7,
+								Line:   1,
+								Column: 7,
+							},
+							EndPos: ast.Position{
+								Offset: 10,
+								Line:   1,
+								Column: 10,
+							},
+						},
+					},
+				},
+			},
+			result,
+		)
+	})
+
 }

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -331,8 +331,6 @@ func TestParseArgumentList(t *testing.T) {
 		t.Parallel()
 
 		_, errs := ParseArgumentList(`xyz`)
-		require.Empty(t, errs)
-
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{

--- a/runtime/parser2/transaction.go
+++ b/runtime/parser2/transaction.go
@@ -42,7 +42,7 @@ import (
 //         )
 //         '}'
 //
-func parseTransactionDeclaration(p *parser) *ast.TransactionDeclaration {
+func parseTransactionDeclaration(p *parser, docString string) *ast.TransactionDeclaration {
 
 	startPos := p.current.StartPos
 
@@ -164,6 +164,7 @@ func parseTransactionDeclaration(p *parser) *ast.TransactionDeclaration {
 		PreConditions:  preConditions,
 		PostConditions: postConditions,
 		Execute:        execute,
+		DocString:      docString,
 		Range: ast.Range{
 			StartPos: startPos,
 			EndPos:   endPos,


### PR DESCRIPTION
Work towards #431

## Description

- Parse docstring for transactions and retain it in the AST element
- Add a function to parse an argument list where all arguments are literals, e.g. `(1, true)`
- Add a function to parse all `pragma arguments` declarations in a docstring, e.g. `/// pragma arguments (1, true)`

(This part of #431 was previously aleady opened as #432)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
