### PR TITLE
Add support for multiple contracts per account to the language server 

### DIFF
--- a/languageserver/integration/codelenses.go
+++ b/languageserver/integration/codelenses.go
@@ -100,6 +100,10 @@ func (i *FlowIntegration) showDeployContractAction(
 
 	contract := program.SoleContractDeclaration()
 
+	if contract == nil {
+		return nil
+	}
+
 	name := contract.Identifier.Identifier
 
 	position := contract.StartPosition()

--- a/languageserver/integration/commands.go
+++ b/languageserver/integration/commands.go
@@ -404,7 +404,7 @@ func (i *FlowIntegration) sendTransactionHelper(
 
 	conn.LogMessage(&protocol.LogMessageParams{
 		Type:    protocol.Info,
-		Message: fmt.Sprintf("submitting transaction %d", tx.ID()),
+		Message: fmt.Sprintf("submitting transaction %s", tx.ID().Hex()),
 	})
 
 	err = i.flowClient.SendTransaction(context.Background(), *tx)
@@ -494,6 +494,11 @@ func (i *FlowIntegration) createAccountHelper(conn protocol.Conn) (addr flow.Add
 	}
 
 	i.accounts[addr] = i.config.ServiceAccountKey
+
+	conn.LogMessage(&protocol.LogMessageParams{
+		Type:    protocol.Info,
+		Message: fmt.Sprintf("Created account with address: %s", addr.Hex()),
+	})
 
 	return addr, nil
 }

--- a/languageserver/integration/integration.go
+++ b/languageserver/integration/integration.go
@@ -49,7 +49,8 @@ func NewFlowIntegration(s *server.Server, enableFlowClient bool) (*FlowIntegrati
 		options = append(options,
 			server.WithInitializationOptionsHandler(integration.initialize),
 			server.WithCodeLensProvider(integration.codeLenses),
-			server.WithAddressImportResolver(integration.resolveAccountImport),
+			server.WithAddressImportResolver(integration.resolveAddressImport),
+			server.WithAddressContractNamesResolver(integration.resolveAddressContractNames),
 		)
 
 		for _, command := range integration.commands() {

--- a/languageserver/run.sh
+++ b/languageserver/run.sh
@@ -2,4 +2,10 @@
 
 SCRIPTPATH=$(dirname "$0")
 
-(cd "$SCRIPTPATH" && /usr/local/bin/go run ./cmd/languageserver/main.go "$@")
+
+if [ $1 == "cadence" -a $2 == "language-server" ] ; then
+	(cd "$SCRIPTPATH" && /usr/local/bin/go run ./cmd/languageserver/main.go "$@");
+else
+	flow "$@"
+fi
+


### PR DESCRIPTION
Closes #517

## Description

The language server was not supporting multiple contracts properly. The language server was still fetching account information and the deprecated `Code` field, which used to contain all code of an account, but is now empty.

Properly implement the two stage process of first resolving address locations + optional identifiers of the import statement to  multiple address locations. If the developer didn't specify any identifiers in the import statements (e.g. `import 0x1`), fetch all deployed contract names from the network. Finally, use the new `Contracts` field of the account instead of the deprecated `Code` field.

Also fix a crasher where the deployment codelens assumed that a contract declaration always exists, which is not the case (e.g. an empty program does not).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
