### PR TITLE
WebAssembly package improvements

### DIFF
--- a/runtime/compiler/wasm/buf.go
+++ b/runtime/compiler/wasm/buf.go
@@ -24,14 +24,14 @@ import (
 
 type offset int
 
-// buf is a byte buffer, which allows reading and writing.
+// Buffer is a byte buffer, which allows reading and writing.
 //
-type buf struct {
+type Buffer struct {
 	data   []byte
 	offset offset
 }
 
-func (buf *buf) WriteByte(b byte) error {
+func (buf *Buffer) WriteByte(b byte) error {
 	if buf.offset < offset(len(buf.data)) {
 		buf.data[buf.offset] = b
 	} else {
@@ -41,7 +41,7 @@ func (buf *buf) WriteByte(b byte) error {
 	return nil
 }
 
-func (buf *buf) WriteBytes(data []byte) error {
+func (buf *Buffer) WriteBytes(data []byte) error {
 	for _, b := range data {
 		err := buf.WriteByte(b)
 		if err != nil {
@@ -51,7 +51,7 @@ func (buf *buf) WriteBytes(data []byte) error {
 	return nil
 }
 
-func (buf *buf) Read(data []byte) (int, error) {
+func (buf *Buffer) Read(data []byte) (int, error) {
 	n := copy(data, buf.data[buf.offset:])
 	if n == 0 && len(data) != 0 {
 		return 0, io.EOF
@@ -60,7 +60,7 @@ func (buf *buf) Read(data []byte) (int, error) {
 	return n, nil
 }
 
-func (buf *buf) ReadByte() (byte, error) {
+func (buf *Buffer) ReadByte() (byte, error) {
 	if buf.offset >= offset(len(buf.data)) {
 		return 0, io.EOF
 	}
@@ -69,7 +69,7 @@ func (buf *buf) ReadByte() (byte, error) {
 	return b, nil
 }
 
-func (buf *buf) PeekByte() (byte, error) {
+func (buf *Buffer) PeekByte() (byte, error) {
 	if buf.offset >= offset(len(buf.data)) {
 		return 0, io.EOF
 	}
@@ -77,7 +77,7 @@ func (buf *buf) PeekByte() (byte, error) {
 	return b, nil
 }
 
-func (buf *buf) ReadBytesEqual(expected []byte) (bool, error) {
+func (buf *Buffer) ReadBytesEqual(expected []byte) (bool, error) {
 	off := buf.offset
 	for _, b := range expected {
 		if off >= offset(len(buf.data)) {
@@ -90,4 +90,8 @@ func (buf *buf) ReadBytesEqual(expected []byte) (bool, error) {
 	}
 	buf.offset = off
 	return true, nil
+}
+
+func (buf *Buffer) Bytes() []byte {
+	return buf.data
 }

--- a/runtime/compiler/wasm/errors.go
+++ b/runtime/compiler/wasm/errors.go
@@ -97,6 +97,22 @@ func (e InvalidDuplicateSectionError) Error() string {
 	)
 }
 
+// InvalidSectionOrderError is returned when the WASM binary specifies
+// a non-custom section out-of-order
+//
+type InvalidSectionOrderError struct {
+	Offset    int
+	SectionID sectionID
+}
+
+func (e InvalidSectionOrderError) Error() string {
+	return fmt.Sprintf(
+		"out-of-order section with ID %d at offset %d",
+		e.SectionID,
+		e.Offset,
+	)
+}
+
 // InvalidSectionSizeError is returned when the WASM binary specifies
 // an invalid section size
 //
@@ -371,6 +387,20 @@ func (e InvalidFunctionSectionTypeIndexError) Error() string {
 
 func (e InvalidFunctionSectionTypeIndexError) Unwrap() error {
 	return e.ReadError
+}
+
+// FunctionCountMismatchError is returned when the WASM binary specifies
+// information for a different number of functions than previously specified
+//
+type FunctionCountMismatchError struct {
+	Offset int
+}
+
+func (e FunctionCountMismatchError) Error() string {
+	return fmt.Sprintf(
+		"function count mismatch at offset %d",
+		e.Offset,
+	)
 }
 
 // InvalidExportSectionExportCountError is returned when the WASM binary specifies

--- a/runtime/compiler/wasm/leb128.go
+++ b/runtime/compiler/wasm/leb128.go
@@ -43,7 +43,7 @@ const max64bitLEB128ByteCount = 10
 // writeUint32LEB128 encodes and writes the given unsigned 32-bit integer
 // in canonical (with fewest bytes possible) unsigned little endian base 128 format
 //
-func (buf *buf) writeUint32LEB128(v uint32) error {
+func (buf *Buffer) writeUint32LEB128(v uint32) error {
 	if v < 128 {
 		err := buf.WriteByte(uint8(v))
 		if err != nil {
@@ -74,7 +74,7 @@ func (buf *buf) writeUint32LEB128(v uint32) error {
 // writeUint64LEB128 encodes and writes the given unsigned 64-bit integer
 // in canonical (with fewest bytes possible) unsigned little endian base 128 format
 //
-func (buf *buf) writeUint64LEB128(v uint64) error {
+func (buf *Buffer) writeUint64LEB128(v uint64) error {
 	if v < 128 {
 		err := buf.WriteByte(uint8(v))
 		if err != nil {
@@ -106,7 +106,7 @@ func (buf *buf) writeUint64LEB128(v uint64) error {
 // in non-canonical (fixed-size, instead of with fewest bytes possible)
 // unsigned little endian base 128 format
 //
-func (buf *buf) writeUint32LEB128FixedLength(v uint32, length int) error {
+func (buf *Buffer) writeUint32LEB128FixedLength(v uint32, length int) error {
 	for i := 0; i < length; i++ {
 		c := uint8(v & 0x7f)
 		v >>= 7
@@ -126,7 +126,7 @@ func (buf *buf) writeUint32LEB128FixedLength(v uint32, length int) error {
 
 // readUint32LEB128 reads and decodes an unsigned 32-bit integer
 //
-func (buf *buf) readUint32LEB128() (uint32, error) {
+func (buf *Buffer) readUint32LEB128() (uint32, error) {
 	var result uint32
 	var shift, i uint
 	// only read up to maximum number of bytes
@@ -148,7 +148,7 @@ func (buf *buf) readUint32LEB128() (uint32, error) {
 
 // readUint64LEB128 reads and decodes an unsigned 32-bit integer
 //
-func (buf *buf) readUint64LEB128() (uint64, error) {
+func (buf *Buffer) readUint64LEB128() (uint64, error) {
 	var result uint64
 	var shift, i uint
 	// only read up to maximum number of bytes
@@ -171,7 +171,7 @@ func (buf *buf) readUint64LEB128() (uint64, error) {
 // writeInt32LEB128 encodes and writes the given signed 32-bit integer
 // in canonical (with fewest bytes possible) signed little endian base 128 format
 //
-func (buf *buf) writeInt32LEB128(v int32) error {
+func (buf *Buffer) writeInt32LEB128(v int32) error {
 	more := true
 	for more {
 		// low order 7 bits of value
@@ -193,7 +193,7 @@ func (buf *buf) writeInt32LEB128(v int32) error {
 // writeInt64LEB128 encodes and writes the given signed 64-bit integer
 // in canonical (with fewest bytes possible) signed little endian base 128 format
 //
-func (buf *buf) writeInt64LEB128(v int64) error {
+func (buf *Buffer) writeInt64LEB128(v int64) error {
 	more := true
 	for more {
 		// low order 7 bits of value
@@ -214,7 +214,7 @@ func (buf *buf) writeInt64LEB128(v int64) error {
 
 // readInt32LEB128 reads and decodes a signed 32-bit integer
 //
-func (buf *buf) readInt32LEB128() (int32, error) {
+func (buf *Buffer) readInt32LEB128() (int32, error) {
 	var result int32
 	var i uint
 	var b byte = 0x80
@@ -237,7 +237,7 @@ func (buf *buf) readInt32LEB128() (int32, error) {
 
 // readInt64LEB128 reads and decodes a signed 64-bit integer
 //
-func (buf *buf) readInt64LEB128() (int64, error) {
+func (buf *Buffer) readInt64LEB128() (int64, error) {
 	var result int64
 	var i uint
 	var b byte = 0x80
@@ -261,7 +261,7 @@ func (buf *buf) readInt64LEB128() (int64, error) {
 // writeFixedUint32LEB128Space writes a non-canonical 5-byte fixed-size space
 // (instead of the minimal size if canonical encoding would be used)
 //
-func (buf *buf) writeFixedUint32LEB128Space() (offset, error) {
+func (buf *Buffer) writeFixedUint32LEB128Space() (offset, error) {
 	off := buf.offset
 	for i := 0; i < max32bitLEB128ByteCount; i++ {
 		err := buf.WriteByte(0)
@@ -278,7 +278,7 @@ func (buf *buf) writeFixedUint32LEB128Space() (offset, error) {
 // (instead of the minimal size if canonical encoding would be used)
 // at the given offset
 //
-func (buf *buf) writeUint32LEB128SizeAt(off offset) error {
+func (buf *Buffer) writeUint32LEB128SizeAt(off offset) error {
 	currentOff := buf.offset
 	if currentOff < max32bitLEB128ByteCount || currentOff-max32bitLEB128ByteCount < off {
 		return fmt.Errorf("writeUint32LEB128SizeAt: invalid offset: %d", off)

--- a/runtime/compiler/wasm/leb128_test.go
+++ b/runtime/compiler/wasm/leb128_test.go
@@ -51,7 +51,7 @@ func TestBuf_Uint32LEB128(t *testing.T) {
 			0xff:  {0xff, 0x01},
 			12857: {57 + 0x80, 100},
 		} {
-			var b buf
+			var b Buffer
 			err := b.writeUint32LEB128(v)
 			require.NoError(t, err)
 			require.Equal(t, expected, b.data)
@@ -72,7 +72,7 @@ func TestBuf_Uint32LEB128(t *testing.T) {
 		// when writing a LEB128-encoded 32-bit number (see max32bitLEB128ByteCount),
 		// i.e. test that only up to 5 bytes are written.
 
-		var b buf
+		var b Buffer
 		err := b.writeUint32LEB128(math.MaxUint32)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, max32bitLEB128ByteCount, len(b.data))
@@ -87,7 +87,7 @@ func TestBuf_Uint32LEB128(t *testing.T) {
 		// i.e. test that only 5 of the 8 given bytes are read,
 		// to ensure the LEB128 parser doesn't keep reading infinitely.
 
-		b := buf{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
+		b := Buffer{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
 		_, err := b.readUint32LEB128()
 		require.NoError(t, err)
 		require.Equal(t, offset(max32bitLEB128ByteCount), b.offset)
@@ -120,7 +120,7 @@ func TestBuf_Uint64LEB128(t *testing.T) {
 			0xff:  {0xff, 0x01},
 			12857: {57 + 0x80, 100},
 		} {
-			var b buf
+			var b Buffer
 			err := b.writeUint64LEB128(v)
 			require.NoError(t, err)
 			require.Equal(t, expected, b.data)
@@ -137,7 +137,7 @@ func TestBuf_Uint64LEB128(t *testing.T) {
 
 		t.Parallel()
 
-		var b buf
+		var b Buffer
 		err := b.writeUint64LEB128(math.MaxUint64)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, max64bitLEB128ByteCount, len(b.data))
@@ -147,7 +147,7 @@ func TestBuf_Uint64LEB128(t *testing.T) {
 
 		t.Parallel()
 
-		b := buf{data: []byte{
+		b := Buffer{data: []byte{
 			0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88,
 			0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90,
 		}}
@@ -186,7 +186,7 @@ func TestBuf_Int32LEB128(t *testing.T) {
 			-129:   {0x7f + 0x80, 0x7e},
 			-12345: {0xc7, 0x9f, 0x7f},
 		} {
-			var b buf
+			var b Buffer
 			err := b.writeInt32LEB128(v)
 			require.NoError(t, err)
 			require.Equal(t, expected, b.data)
@@ -207,12 +207,12 @@ func TestBuf_Int32LEB128(t *testing.T) {
 		// when writing a LEB128-encoded 32-bit number (see max32bitLEB128ByteCount),
 		// i.e. test that only up to 5 bytes are written.
 
-		var b buf
+		var b Buffer
 		err := b.writeInt32LEB128(math.MaxInt32)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, max32bitLEB128ByteCount, len(b.data))
 
-		var b2 buf
+		var b2 Buffer
 		err = b2.writeInt32LEB128(math.MinInt32)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, max32bitLEB128ByteCount, len(b.data))
@@ -227,7 +227,7 @@ func TestBuf_Int32LEB128(t *testing.T) {
 		// i.e. test that only 5 of the 8 given bytes are read,
 		// to ensure the LEB128 parser doesn't keep reading infinitely.
 
-		b := buf{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
+		b := Buffer{data: []byte{0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88}}
 		_, err := b.readInt32LEB128()
 		require.NoError(t, err)
 		require.Equal(t, offset(max32bitLEB128ByteCount), b.offset)
@@ -263,7 +263,7 @@ func TestBuf_Int64LEB128(t *testing.T) {
 			-129:   {0x7f + 0x80, 0x7e},
 			-12345: {0xc7, 0x9f, 0x7f},
 		} {
-			var b buf
+			var b Buffer
 			err := b.writeInt64LEB128(v)
 			require.NoError(t, err)
 			require.Equal(t, expected, b.data)
@@ -280,12 +280,12 @@ func TestBuf_Int64LEB128(t *testing.T) {
 
 		t.Parallel()
 
-		var b buf
+		var b Buffer
 		err := b.writeInt64LEB128(math.MaxInt64)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, max64bitLEB128ByteCount, len(b.data))
 
-		var b2 buf
+		var b2 Buffer
 		err = b2.writeInt64LEB128(math.MinInt64)
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, max64bitLEB128ByteCount, len(b.data))
@@ -295,7 +295,7 @@ func TestBuf_Int64LEB128(t *testing.T) {
 
 		t.Parallel()
 
-		b := buf{data: []byte{
+		b := Buffer{data: []byte{
 			0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88,
 			0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90,
 		}}
@@ -309,7 +309,7 @@ func TestBuf_WriteSpaceAndSize(t *testing.T) {
 
 	t.Parallel()
 
-	var b buf
+	var b Buffer
 
 	err := b.WriteByte(101)
 	require.NoError(t, err)

--- a/runtime/compiler/wasm/module.go
+++ b/runtime/compiler/wasm/module.go
@@ -21,11 +21,33 @@ package wasm
 // Module represents a module
 //
 type Module struct {
-	Types []*FunctionType
-	// The type indices of all functions
-	functionTypeIndices []uint32
-	// The bodies of all functions
-	functionBodies []*Code
-	Imports        []*Import
-	Exports        []*Export
+	Name      string
+	Types     []*FunctionType
+	Functions []*Function
+	Imports   []*Import
+	Exports   []*Export
+}
+
+type ModuleBuilder struct {
+	types     []*FunctionType
+	functions []*Function
+}
+
+func (b *ModuleBuilder) AddFunction(name string, functionType *FunctionType, code *Code) {
+	typeIndex := uint32(len(b.types))
+	b.types = append(b.types, functionType)
+	b.functions = append(b.functions,
+		&Function{
+			Name:      name,
+			TypeIndex: typeIndex,
+			Code:      code,
+		},
+	)
+}
+
+func (b *ModuleBuilder) Build() *Module {
+	return &Module{
+		Types:     b.types,
+		Functions: b.functions,
+	}
 }

--- a/runtime/compiler/wasm/reader.go
+++ b/runtime/compiler/wasm/reader.go
@@ -19,6 +19,7 @@
 package wasm
 
 import (
+	"io"
 	"math"
 	"unicode/utf8"
 )
@@ -26,8 +27,17 @@ import (
 // WASMReader allows reading WASM binaries
 //
 type WASMReader struct {
-	buf    *buf
-	Module Module
+	buf              *Buffer
+	Module           Module
+	lastSectionID    sectionID
+	didReadFunctions bool
+	didReadCode      bool
+}
+
+func NewWASMReader(buf *Buffer) *WASMReader {
+	return &WASMReader{
+		buf: buf,
+	}
 }
 
 // readMagicAndVersion reads the magic byte sequence and version at the beginning of the WASM binary
@@ -83,6 +93,16 @@ func (r *WASMReader) readSection() error {
 		}
 	}
 
+	// "Custom sections may be inserted at any place in this sequence,
+	// while other sections must occur at most once and in the prescribed order."
+
+	if sectionID > 0 && sectionID <= r.lastSectionID {
+		return InvalidSectionOrderError{
+			SectionID: sectionID,
+			Offset:    int(sectionIDOffset),
+		}
+	}
+
 	switch sectionID {
 	case sectionIDCustom:
 		err = r.readCustomSection()
@@ -111,7 +131,7 @@ func (r *WASMReader) readSection() error {
 		}
 
 	case sectionIDFunction:
-		if r.Module.functionTypeIndices != nil {
+		if r.didReadFunctions {
 			return invalidDuplicateSectionError()
 		}
 
@@ -119,6 +139,9 @@ func (r *WASMReader) readSection() error {
 		if err != nil {
 			return err
 		}
+
+		r.didReadFunctions = true
+
 	case sectionIDExport:
 		if r.Module.Exports != nil {
 			return invalidDuplicateSectionError()
@@ -130,7 +153,7 @@ func (r *WASMReader) readSection() error {
 		}
 
 	case sectionIDCode:
-		if r.Module.functionBodies != nil {
+		if r.didReadCode {
 			return invalidDuplicateSectionError()
 		}
 
@@ -139,11 +162,20 @@ func (r *WASMReader) readSection() error {
 			return err
 		}
 
+		r.didReadCode = true
+
 	default:
 		return InvalidSectionIDError{
 			SectionID: sectionID,
 			Offset:    int(sectionIDOffset),
 		}
+	}
+
+	// Keep track of the last read non-custom section ID:
+	// non-custom sections must appear in order
+
+	if sectionID > 0 {
+		r.lastSectionID = sectionID
 	}
 
 	return nil
@@ -420,9 +452,30 @@ func (r *WASMReader) readFunctionSection() error {
 		functionTypeIndices[i] = typeIndex
 	}
 
-	r.Module.functionTypeIndices = functionTypeIndices
+	if !r.ensureModuleFunctions(len(functionTypeIndices)) {
+		return FunctionCountMismatchError{
+			Offset: int(r.buf.offset),
+		}
+	}
+
+	for i, functionTypeIndex := range functionTypeIndices {
+		r.Module.Functions[i].TypeIndex = functionTypeIndex
+	}
 
 	return nil
+}
+
+func (r *WASMReader) ensureModuleFunctions(count int) bool {
+	if r.Module.Functions != nil {
+		return len(r.Module.Functions) == count
+	}
+
+	r.Module.Functions = make([]*Function, count)
+	for i := 0; i < count; i++ {
+		r.Module.Functions[i] = &Function{}
+	}
+
+	return true
 }
 
 // readExportSection reads the section that declares the exports
@@ -539,7 +592,15 @@ func (r *WASMReader) readCodeSection() error {
 		functionBodies[i] = functionBody
 	}
 
-	r.Module.functionBodies = functionBodies
+	if !r.ensureModuleFunctions(len(functionBodies)) {
+		return FunctionCountMismatchError{
+			Offset: int(r.buf.offset),
+		}
+	}
+
+	for i, functionBody := range functionBodies {
+		r.Module.Functions[i].Code = functionBody
+	}
 
 	return nil
 }
@@ -903,4 +964,25 @@ func (r *WASMReader) readNameSection(size uint32) error {
 	r.buf.offset += offset(size)
 
 	return nil
+}
+
+func (r *WASMReader) ReadModule() error {
+	if err := r.readMagicAndVersion(); err != nil {
+		return err
+	}
+
+	for {
+		_, err := r.buf.PeekByte()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+
+			return err
+		}
+
+		if err = r.readSection(); err != nil {
+			return err
+		}
+	}
 }

--- a/runtime/compiler/wasm/writer.go
+++ b/runtime/compiler/wasm/writer.go
@@ -25,7 +25,14 @@ import (
 // WASMWriter allows writing WASM binaries
 //
 type WASMWriter struct {
-	buf *buf
+	buf        *Buffer
+	WriteNames bool
+}
+
+func NewWASMWriter(buf *Buffer) *WASMWriter {
+	return &WASMWriter{
+		buf: buf,
+	}
 }
 
 // writeMagicAndVersion writes the magic byte sequence and version at the beginning of the WASM binary
@@ -533,4 +540,38 @@ func (w *WASMWriter) writeNameSectionFunctionNamesSubSection(imports []*Import, 
 
 		return nil
 	})
+}
+
+func (w *WASMWriter) WriteModule(module *Module) error {
+	if err := w.writeMagicAndVersion(); err != nil {
+		return err
+	}
+
+	if err := w.writeTypeSection(module.Types); err != nil {
+		return err
+	}
+	if err := w.writeImportSection(module.Imports); err != nil {
+		return err
+	}
+	if err := w.writeFunctionSection(module.Functions); err != nil {
+		return err
+	}
+	if err := w.writeExportSection(module.Exports); err != nil {
+		return err
+	}
+	if err := w.writeCodeSection(module.Functions); err != nil {
+		return err
+	}
+
+	if w.WriteNames {
+		if err := w.writeNameSection(
+			module.Name,
+			module.Imports,
+			module.Functions,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/runtime/compiler/wasm/writer_test.go
+++ b/runtime/compiler/wasm/writer_test.go
@@ -234,7 +234,7 @@ func TestWASMWriter_writeExportSection(t *testing.T) {
 			0x66, 0x6f, 0x6f,
 			// type indicator: function = 0
 			0x0,
-			// index of function: 0
+			// index of function: 1
 			0x1,
 		},
 		b.data,


### PR DESCRIPTION
## Description

- Export functions and types, so the reader and writer can be used outside of the package
- Add support for writing and reading whole modules

(Accidentally closed #407 by merging the PR that it was depending on. Rebased on master now)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
