### PR TITLE
Language Server: Don't panic when notifications fail

### DIFF
--- a/languageserver/cmd/languageserver/main_wasm.go
+++ b/languageserver/cmd/languageserver/main_wasm.go
@@ -27,8 +27,9 @@ import (
 	"sync"
 	"syscall/js"
 
-	"github.com/onflow/cadence/languageserver/server"
 	"github.com/onflow/cadence/runtime/common"
+
+	"github.com/onflow/cadence/languageserver/server"
 )
 
 const globalFunctionNamePrefix = "CADENCE_LANGUAGE_SERVER"

--- a/languageserver/conversion/conversion.go
+++ b/languageserver/conversion/conversion.go
@@ -19,9 +19,10 @@
 package conversion
 
 import (
-	"github.com/onflow/cadence/languageserver/protocol"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/sema"
+
+	"github.com/onflow/cadence/languageserver/protocol"
 )
 
 // ASTToProtocolPosition converts an AST position to a LSP position

--- a/languageserver/integration/codelenses.go
+++ b/languageserver/integration/codelenses.go
@@ -25,10 +25,11 @@ import (
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
-	"github.com/onflow/cadence/languageserver/conversion"
-	"github.com/onflow/cadence/languageserver/protocol"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/sema"
+
+	"github.com/onflow/cadence/languageserver/conversion"
+	"github.com/onflow/cadence/languageserver/protocol"
 )
 
 func (i *FlowIntegration) codeLenses(

--- a/languageserver/integration/commands.go
+++ b/languageserver/integration/commands.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
+
 	"github.com/onflow/cadence/languageserver/protocol"
 	"github.com/onflow/cadence/languageserver/server"
 )
@@ -217,7 +218,7 @@ func (i *FlowIntegration) executeScript(conn protocol.Conn, args ...interface{})
 //
 // There should be exactly 1 argument:
 //   * the address of the new active account
-func (i *FlowIntegration) switchActiveAccount(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) switchActiveAccount(_ protocol.Conn, args ...interface{}) (interface{}, error) {
 
 	err := server.CheckCommandArgumentCount(args, 1)
 	if err != nil {

--- a/languageserver/integration/diagnostics.go
+++ b/languageserver/integration/diagnostics.go
@@ -19,11 +19,12 @@
 package integration
 
 import (
-	"github.com/onflow/cadence/languageserver/conversion"
-	"github.com/onflow/cadence/languageserver/protocol"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
+
+	"github.com/onflow/cadence/languageserver/conversion"
+	"github.com/onflow/cadence/languageserver/protocol"
 )
 
 // diagnostics gets extra non-error diagnostics based on a checker.

--- a/languageserver/jsonrpc2/server.go
+++ b/languageserver/jsonrpc2/server.go
@@ -91,11 +91,8 @@ func (server *Server) Start(stream ObjectStream) <-chan struct{} {
 	return server.conn.DisconnectNotify()
 }
 
-func (server *Server) Notify(method string, params interface{}) {
-	err := server.conn.Notify(context.Background(), method, params)
-	if err != nil {
-		panic(err)
-	}
+func (server *Server) Notify(method string, params interface{}) error {
+	return server.conn.Notify(context.Background(), method, params)
 }
 
 func (server *Server) Call(method string, params interface{}) error {

--- a/languageserver/protocol/server.go
+++ b/languageserver/protocol/server.go
@@ -36,10 +36,10 @@ type Server struct {
 // the language server to push various types of messages to the client.
 // https://microsoft.github.io/language-server-protocol/specifications/specification-3-14
 type Conn interface {
-	Notify(method string, params interface{})
+	Notify(method string, params interface{}) error
 	ShowMessage(params *ShowMessageParams)
 	LogMessage(params *LogMessageParams)
-	PublishDiagnostics(params *PublishDiagnosticsParams)
+	PublishDiagnostics(params *PublishDiagnosticsParams) error
 	RegisterCapability(params *RegistrationParams) error
 }
 
@@ -50,24 +50,24 @@ type connection struct {
 // ShowMessage displays a notification message to the client. It is visible to
 // the user.
 func (conn *connection) ShowMessage(params *ShowMessageParams) {
-	conn.Notify("window/showMessage", params)
+	_ = conn.Notify("window/showMessage", params)
 }
 
 // LogMessage logs a message to the Cadence terminal in VS Code. It isn't
 // visible to the user unless they go looking for it.
 func (conn *connection) LogMessage(params *LogMessageParams) {
-	conn.Notify("window/logMessage", params)
+	_ = conn.Notify("window/logMessage", params)
 }
 
 // PublishDiagnostics is used to report errors for a document, typically syntax
 // or semantic errors in the code.
-func (conn *connection) PublishDiagnostics(params *PublishDiagnosticsParams) {
-	conn.Notify("textDocument/publishDiagnostics", params)
+func (conn *connection) PublishDiagnostics(params *PublishDiagnosticsParams) error {
+	return conn.Notify("textDocument/publishDiagnostics", params)
 }
 
 // Notify sends a notification to the client.
-func (conn *connection) Notify(method string, params interface{}) {
-	conn.jsonrpc2Server.Notify(method, params)
+func (conn *connection) Notify(method string, params interface{}) error {
+	return conn.jsonrpc2Server.Notify(method, params)
 }
 
 // RegisterCapability is used to dynamically inform the client that the server

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -30,8 +30,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/onflow/cadence/encoding/json"
-	"github.com/onflow/cadence/languageserver/conversion"
-	"github.com/onflow/cadence/languageserver/jsonrpc2"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -39,6 +37,9 @@ import (
 	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+
+	"github.com/onflow/cadence/languageserver/conversion"
+	"github.com/onflow/cadence/languageserver/jsonrpc2"
 
 	"github.com/onflow/cadence/languageserver/protocol"
 )

--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -1,16 +1,16 @@
 import {
+  createProtocolConnection,
+  DidOpenTextDocumentNotification,
+  ExecuteCommandRequest,
+  ExitNotification,
+  InitializeRequest,
+  ProtocolConnection,
   StreamMessageReader,
   StreamMessageWriter,
-  ProtocolConnection,
-  createProtocolConnection,
-  InitializeRequest,
-  ExitNotification,
-  ExecuteCommandRequest,
-  DidOpenTextDocumentNotification,
   TextDocumentItem
 } from "vscode-languageserver-protocol"
 
-import { spawn, execSync } from 'child_process'
+import {execSync, spawn} from 'child_process'
 import * as path from "path"
 
 beforeAll(() => {


### PR DESCRIPTION
## Description

It is common for notifications to fail, e.g. when the connection is already closed.
Given that notifications are just informative, don't panic.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
