### PR TITLE
Fix nested enum declarations

### DIFF
--- a/runtime/tests/checker/enum_test.go
+++ b/runtime/tests/checker/enum_test.go
@@ -218,3 +218,25 @@ func TestCheckEnumConstructor(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestCheckEnumInContract(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      contract C {
+          enum E: UInt8 {
+              pub case a
+              pub case b
+          }
+
+          var e: E
+
+          init() {
+              self.e = E.a
+          }
+      }
+    `)
+
+	require.NoError(t, err)
+}

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -202,8 +202,16 @@ func TestInterpretEnumInContract(t *testing.T) {
 		},
 	)
 
+	c := inter.Globals["C"].Value
+	require.IsType(t, &interpreter.CompositeValue{}, c)
+	contract := c.(*interpreter.CompositeValue)
+
+	e := contract.Fields["e"]
+	require.IsType(t, &interpreter.CompositeValue{}, c)
+	enumCase := e.(*interpreter.CompositeValue)
+
 	require.Equal(t,
-		nil,
-		inter.Globals["C"].Value,
+		interpreter.UInt8Value(0),
+		enumCase.Fields["rawValue"],
 	)
 }

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -207,7 +207,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 	contract := c.(*interpreter.CompositeValue)
 
 	e := contract.Fields["e"]
-	require.IsType(t, &interpreter.CompositeValue{}, c)
+	require.IsType(t, &interpreter.CompositeValue{}, e)
 	enumCase := e.(*interpreter.CompositeValue)
 
 	require.Equal(t,

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -175,3 +175,35 @@ func TestInterpretEnumInstance(t *testing.T) {
 		inter.Globals["res"].Value,
 	)
 }
+
+func TestInterpretEnumInContract(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpretWithOptions(t,
+		`
+          contract C {
+              enum E: UInt8 {
+                  pub case a
+                  pub case b
+              }
+
+              var e: E
+
+              init() {
+                  self.e = E.a
+              }
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Options: []interpreter.Option{
+				makeContractValueHandler(nil, nil, nil),
+			},
+		},
+	)
+
+	require.Equal(t,
+		nil,
+		inter.Globals["C"].Value,
+	)
+}


### PR DESCRIPTION
Closes #548 

## Description

When re-declaring the constructor for a nested composite declaration (e.g. an enum in a contract), then declare the constructor function appropriate for the composite kind.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
