### PR TITLE
Fix the export of type values with restricted static types

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1429,7 +1429,7 @@ func (d *Decoder) decodeRestrictedStaticType(v interface{}) (StaticType, error) 
 		restrictions[i] = restriction
 	}
 
-	return RestrictedStaticType{
+	return &RestrictedStaticType{
 		Type:         restrictedType,
 		Restrictions: restrictions,
 	}, nil

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -931,7 +931,7 @@ func (e *Encoder) prepareStaticType(t StaticType) (interface{}, error) {
 	case DictionaryStaticType:
 		return e.prepareDictionaryStaticType(v)
 
-	case RestrictedStaticType:
+	case *RestrictedStaticType:
 		return e.prepareRestrictedStaticType(v)
 
 	case CapabilityStaticType:
@@ -1091,7 +1091,7 @@ const (
 	encodedRestrictedStaticTypeRestrictionsFieldKey uint64 = 1
 )
 
-func (e *Encoder) prepareRestrictedStaticType(v RestrictedStaticType) (interface{}, error) {
+func (e *Encoder) prepareRestrictedStaticType(v *RestrictedStaticType) (interface{}, error) {
 	restrictedType, err := e.prepareStaticType(v.Type)
 	if err != nil {
 		return nil, err

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3867,7 +3867,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 			encodeDecodeTest{
 				value: LinkValue{
 					TargetPath: publicPathValue,
-					Type: RestrictedStaticType{
+					Type: &RestrictedStaticType{
 						Type: CompositeStaticType{
 							Location:            utils.TestLocation,
 							QualifiedIdentifier: "S",

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -130,9 +130,14 @@ type RestrictedStaticType struct {
 	Restrictions []InterfaceStaticType
 }
 
-func (RestrictedStaticType) IsStaticType() {}
+// NOTE: must be pointer receiver, as static types get used in type values,
+// which are used as keys in maps when exporting.
+// Key types in Go maps must be (transitively) hashable types,
+// and slices are not, but `Restrictions` is one.
+//
+func (*RestrictedStaticType) IsStaticType() {}
 
-func (t RestrictedStaticType) String() string {
+func (t *RestrictedStaticType) String() string {
 	restrictions := make([]string, len(t.Restrictions))
 
 	for i, restriction := range t.Restrictions {
@@ -217,7 +222,7 @@ func ConvertSemaToStaticType(t sema.Type) StaticType {
 			restrictions[i] = convertToInterfaceStaticType(restriction)
 		}
 
-		return RestrictedStaticType{
+		return &RestrictedStaticType{
 			Type:         ConvertSemaToStaticType(t.Type),
 			Restrictions: restrictions,
 		}
@@ -288,7 +293,7 @@ func ConvertStaticToSemaType(
 			Type: ConvertStaticToSemaType(t.Type, getInterface, getComposite),
 		}
 
-	case RestrictedStaticType:
+	case *RestrictedStaticType:
 		restrictions := make([]*sema.InterfaceType, len(t.Restrictions))
 
 		for i, restriction := range t.Restrictions {


### PR DESCRIPTION
## Description

Exporting a type value with a restricted static type caused a crasher:

```
runtime error: hash of unhashable type interpreter.RestrictedStaticType

goroutine 102 [running]:
runtime/debug.Stack(0x1, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.5/libexec/src/runtime/debug/stack.go:24 +0x9d
runtime/debug.PrintStack()
	/usr/local/Cellar/go/1.14.5/libexec/src/runtime/debug/stack.go:16 +0x22
github.com/99designs/gqlgen/graphql.DefaultRecover(0x52d1840, 0xc000b97140, 0x4db6220, 0xc00079c830, 0xc000800100, 0x100000000000000)
	/Users/bastian/go/pkg/mod/github.com/99designs/gqlgen@v0.10.2/graphql/recovery.go:16 +0xa7
github.com/dapperlabs/flow-playground-api.(*executionContext)._Mutation_updateAccount.func1(0xc0009aaae0, 0xc0009aab10, 0xc00066ac70)
	/Users/bastian/Documents/work/flow-playground-api/generated.go:1676 +0xac
panic(0x4db6220, 0xc00079c830)
	/usr/local/Cellar/go/1.14.5/libexec/src/runtime/panic.go:969 +0x166
github.com/onflow/cadence/runtime.exportValueWithInterpreter(0x52e12c0, 0xc000beb350, 0xc000c54000, 0xc000669300, 0x3, 0xc0004dd9a0)
	/Users/bastian/go/pkg/mod/github.com/onflow/cadence@v0.12.3/runtime/convertValues.go:68 +0x59
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
