### PR TITLE
Optionally run checker tests concurrently

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@
 
 This will automatically recompile the language server every time it is started.
 
-## How can data races in the checker be detected?
+## How is it possible to detect non-determinism and data races in the checker?
 
 Run the checker tests with the `cadence.checkConcurrently` flag, e.g.
 
@@ -24,3 +24,4 @@ go test -race -v ./runtime/tests/checker -cadence.checkConcurrently=10
 
 This runs each check of a checker test 10 times, concurrently,
 and asserts that the checker errors of all checks are equal.
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,3 +13,14 @@
 - Restart Visual Studio Code
 
 This will automatically recompile the language server every time it is started.
+
+## How can data races in the checker be detected?
+
+Run the checker tests with the `cadence.checkConcurrently` flag, e.g.
+
+```shell
+go test -race -v ./runtime/tests/checker -cadence.checkConcurrently=10
+```
+
+This runs each check of a checker test 10 times, concurrently,
+and asserts that the checker errors of all checks are equal.

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -19,9 +19,12 @@
 package checker
 
 import (
+	"flag"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,6 +35,10 @@ import (
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
+func init() {
+	deep.MaxDepth = 20
+}
+
 func ParseAndCheck(t *testing.T, code string) (*sema.Checker, error) {
 	return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{})
 }
@@ -41,6 +48,12 @@ type ParseAndCheckOptions struct {
 	IgnoreParseError bool
 	Options          []sema.Option
 }
+
+var checkConcurrently = flag.Int(
+	"cadence.checkConcurrently",
+	0,
+	"check programs N times, concurrently. useful for detecting data races with the -race flag",
+)
 
 func ParseAndCheckWithOptions(
 	t *testing.T,
@@ -65,23 +78,77 @@ func ParseAndCheckWithOptions(
 		return nil, err
 	}
 
-	checkerOptions := append(
-		[]sema.Option{
-			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
-		},
-		options.Options...,
-	)
+	check := func() (*sema.Checker, error) {
 
-	checker, err := sema.NewChecker(
-		program,
-		options.Location,
-		checkerOptions...,
-	)
-	if err != nil {
+		checkerOptions := append(
+			[]sema.Option{
+				sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
+			},
+			options.Options...,
+		)
+
+		checker, err := sema.NewChecker(
+			program,
+			options.Location,
+			checkerOptions...,
+		)
+		if err != nil {
+			return checker, err
+		}
+
+		err = checker.Check()
+
 		return checker, err
 	}
 
-	err = checker.Check()
+	var checker *sema.Checker
+
+	if *checkConcurrently > 1 {
+
+		// Run 10 additional checks in parallel,
+		// and ensure all reported errors are equal.
+		//
+		// This is useful when combined with Go testing's race detector,
+		// which allows detecting data race conditions.
+
+		concurrency := *checkConcurrently
+
+		type result struct {
+			checker *sema.Checker
+			err     error
+		}
+
+		var wg sync.WaitGroup
+		results := make(chan result, concurrency)
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				checker, err := check()
+				results <- result{
+					checker: checker,
+					err:     err,
+				}
+			}()
+		}
+		wg.Wait()
+		close(results)
+
+		firstResult := <-results
+		checker = firstResult.checker
+		err = firstResult.err
+
+		for otherResult := range results {
+			diff := deep.Equal(err, otherResult.err)
+			if diff != nil {
+				t.Error(diff)
+			}
+		}
+
+	} else {
+		checker, err = check()
+	}
+
 	return checker, err
 }
 

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -52,7 +52,7 @@ type ParseAndCheckOptions struct {
 var checkConcurrently = flag.Int(
 	"cadence.checkConcurrently",
 	0,
-	"check programs N times, concurrently. useful for detecting data races with the -race flag",
+	"check programs N times, concurrently. useful for detecting non-determinism, and data races with the -race flag",
 )
 
 func ParseAndCheckWithOptions(
@@ -108,8 +108,9 @@ func ParseAndCheckWithOptions(
 		// Run 10 additional checks in parallel,
 		// and ensure all reported errors are equal.
 		//
-		// This is useful when combined with Go testing's race detector,
-		// which allows detecting data race conditions.
+		// This is useful to detect non-determinism ,
+		// and when combined with Go testing's race detector,
+		// allows detecting data race conditions.
 
 		concurrency := *checkConcurrently
 


### PR DESCRIPTION
## Description

Add a flag to the checker tests which runs each check of a test multiple times, concurrently.
This allows the detection of data races (e.g. in the AST or elaboration) and non-determinism (order of checker errors).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
