### PR TITLE
Cache programs before checking succeeded, properly wrap returned error

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -561,6 +561,13 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 			return nil, wrapError(err)
 		}
 		context.SetProgram(context.Location, program)
+
+		wrapPanic(func() {
+			err = context.Interface.CacheProgram(context.Location, program)
+		})
+		if err != nil {
+			return nil, wrapError(err)
+		}
 	}
 
 	importResolver := r.importResolver(context)
@@ -640,14 +647,6 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 	err = checker.Check()
 	if err != nil {
 		return nil, wrapError(err)
-	}
-
-	// After the program has passed semantic analysis, cache the program AST.
-	wrapPanic(func() {
-		err = context.Interface.CacheProgram(context.Location, program)
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	return checker, nil


### PR DESCRIPTION
## Description

Parsed programs should always be cached, even if checking fails.
Also, properly wrap the returned error using the helper function, just like in all other return cases.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
