### PR TITLE
Move global values, global types, and transaction types to elaboration

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -761,7 +761,7 @@ func (interpreter *Interpreter) prepareInvokeVariable(
 		}
 	}
 
-	ty := interpreter.Checker.GlobalValues[functionName].Type
+	ty := interpreter.Program.Elaboration.GlobalValues[functionName].Type
 
 	// function must be invokable
 	invokableType, ok := ty.(sema.InvokableType)
@@ -787,7 +787,7 @@ func (interpreter *Interpreter) prepareInvokeTransaction(
 
 	functionValue := interpreter.Transactions[index]
 
-	transactionType := interpreter.Checker.TransactionTypes[index]
+	transactionType := interpreter.Program.Elaboration.TransactionTypes[index]
 	functionType := transactionType.EntryPointFunctionType()
 
 	return interpreter.prepareInvoke(functionValue, functionType, arguments)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -761,7 +761,7 @@ func (interpreter *Interpreter) prepareInvokeVariable(
 		}
 	}
 
-	ty := interpreter.Program.Elaboration.GlobalValues[functionName].Type
+	ty := interpreter.Checker.Elaboration.GlobalValues[functionName].Type
 
 	// function must be invokable
 	invokableType, ok := ty.(sema.InvokableType)
@@ -787,7 +787,7 @@ func (interpreter *Interpreter) prepareInvokeTransaction(
 
 	functionValue := interpreter.Transactions[index]
 
-	transactionType := interpreter.Program.Elaboration.TransactionTypes[index]
+	transactionType := interpreter.Checker.Elaboration.TransactionTypes[index]
 	functionType := transactionType.EntryPointFunctionType()
 
 	return interpreter.prepareInvoke(functionValue, functionType, arguments)
@@ -3404,7 +3404,7 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 
 		// don't import predeclared values
 		if subInterpreter.Checker != nil {
-			if subInterpreter.Checker.HasEffectivePredeclaredValue(name) {
+			if _, ok := subInterpreter.Checker.Elaboration.EffectivePredeclaredValues[name]; ok {
 				continue
 			}
 		}

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -178,7 +178,7 @@ type REPLSuggestion struct {
 func (r *REPL) Suggestions() (result []REPLSuggestion) {
 	names := map[string]string{}
 
-	for name, variable := range r.checker.GlobalValues {
+	for name, variable := range r.checker.Elaboration.GlobalValues {
 		if names[name] != "" {
 			continue
 		}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -331,7 +331,7 @@ func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) 
 		return newError(err, context)
 	}
 
-	transactions := checker.TransactionTypes
+	transactions := checker.Elaboration.TransactionTypes
 	transactionCount := len(transactions)
 	if transactionCount != 1 {
 		err = InvalidTransactionCountError{
@@ -1570,7 +1570,7 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 			var contractTypes []*sema.CompositeType
 			var contractInterfaceTypes []*sema.InterfaceType
 
-			for _, variable := range checker.GlobalTypes {
+			for _, variable := range checker.Elaboration.GlobalTypes {
 				switch ty := variable.Type.(type) {
 				case *sema.CompositeType:
 					if ty.Kind == common.CompositeKindContract {

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -283,5 +283,5 @@ func (checker *Checker) declareTransactionDeclaration(declaration *ast.Transacti
 	}
 
 	checker.Elaboration.TransactionDeclarationTypes[declaration] = transactionType
-	checker.TransactionTypes = append(checker.TransactionTypes, transactionType)
+	checker.Elaboration.TransactionTypes = append(checker.Elaboration.TransactionTypes, transactionType)
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -82,9 +82,7 @@ type Checker struct {
 	Program                            *ast.Program
 	Location                           common.Location
 	PredeclaredValues                  []ValueDeclaration
-	effectivePredeclaredValues         map[string]ValueDeclaration
 	PredeclaredTypes                   []TypeDeclaration
-	effectivePredeclaredTypes          map[string]TypeDeclaration
 	AllCheckers                        map[common.LocationID]*Checker
 	accessCheckMode                    AccessCheckMode
 	errors                             []error
@@ -126,7 +124,7 @@ func WithPredeclaredValues(predeclaredValues []ValueDeclaration) Option {
 				continue
 			}
 			checker.Elaboration.GlobalValues[variable.Identifier] = variable
-			checker.effectivePredeclaredValues[variable.Identifier] = declaration
+			checker.Elaboration.EffectivePredeclaredValues[variable.Identifier] = declaration
 		}
 
 		return nil
@@ -141,7 +139,7 @@ func WithPredeclaredTypes(predeclaredTypes []TypeDeclaration) Option {
 			checker.declareTypeDeclaration(declaration)
 
 			name := declaration.TypeDeclarationName()
-			checker.effectivePredeclaredTypes[name] = declaration
+			checker.Elaboration.EffectivePredeclaredTypes[name] = declaration
 		}
 
 		return nil
@@ -237,20 +235,18 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 	}
 
 	checker := &Checker{
-		Program:                    program,
-		Location:                   location,
-		valueActivations:           NewValueActivations(),
-		resources:                  &Resources{},
-		typeActivations:            typeActivations,
-		functionActivations:        functionActivations,
-		Occurrences:                NewOccurrences(),
-		MemberAccesses:             NewMemberAccesses(),
-		containerTypes:             map[Type]bool{},
-		variableOrigins:            map[*Variable]*Origin{},
-		memberOrigins:              map[Type]map[string]*Origin{},
-		Elaboration:                NewElaboration(),
-		effectivePredeclaredValues: map[string]ValueDeclaration{},
-		effectivePredeclaredTypes:  map[string]TypeDeclaration{},
+		Program:             program,
+		Location:            location,
+		valueActivations:    NewValueActivations(),
+		resources:           &Resources{},
+		typeActivations:     typeActivations,
+		functionActivations: functionActivations,
+		Occurrences:         NewOccurrences(),
+		MemberAccesses:      NewMemberAccesses(),
+		containerTypes:      map[Type]bool{},
+		variableOrigins:     map[*Variable]*Origin{},
+		memberOrigins:       map[Type]map[string]*Origin{},
+		Elaboration:         NewElaboration(),
 	}
 
 	checker.beforeExtractor = NewBeforeExtractor(checker.report)
@@ -397,11 +393,11 @@ func (checker *Checker) UserDefinedValues() map[string]*Variable {
 			continue
 		}
 
-		if _, ok := checker.effectivePredeclaredValues[key]; ok {
+		if _, ok := checker.Elaboration.EffectivePredeclaredValues[key]; ok {
 			continue
 		}
 
-		if _, ok := checker.effectivePredeclaredTypes[key]; ok {
+		if _, ok := checker.Elaboration.EffectivePredeclaredTypes[key]; ok {
 			continue
 		}
 
@@ -2299,9 +2295,4 @@ func (checker *Checker) convertInstantiationType(t *ast.InstantiationType) Type 
 
 func (checker *Checker) Hints() []Hint {
 	return checker.hints
-}
-
-func (checker *Checker) HasEffectivePredeclaredValue(name string) bool {
-	_, ok := checker.effectivePredeclaredValues[name]
-	return ok
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -94,9 +94,6 @@ type Checker struct {
 	typeActivations                    *VariableActivations
 	containerTypes                     map[Type]bool
 	functionActivations                *FunctionActivations
-	GlobalValues                       map[string]*Variable
-	GlobalTypes                        map[string]*Variable
-	TransactionTypes                   []*TransactionType
 	inCondition                        bool
 	Occurrences                        *Occurrences
 	MemberAccesses                     *MemberAccesses
@@ -128,7 +125,7 @@ func WithPredeclaredValues(predeclaredValues []ValueDeclaration) Option {
 			if variable == nil {
 				continue
 			}
-			checker.GlobalValues[variable.Identifier] = variable
+			checker.Elaboration.GlobalValues[variable.Identifier] = variable
 			checker.effectivePredeclaredValues[variable.Identifier] = declaration
 		}
 
@@ -246,8 +243,6 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 		resources:                  &Resources{},
 		typeActivations:            typeActivations,
 		functionActivations:        functionActivations,
-		GlobalValues:               map[string]*Variable{},
-		GlobalTypes:                map[string]*Variable{},
 		Occurrences:                NewOccurrences(),
 		MemberAccesses:             NewMemberAccesses(),
 		containerTypes:             map[Type]bool{},
@@ -297,7 +292,7 @@ func (checker *Checker) declareBaseValues() {
 			continue
 		}
 		variable.IsBaseValue = true
-		checker.GlobalValues[variable.Identifier] = variable
+		checker.Elaboration.GlobalValues[variable.Identifier] = variable
 	}
 }
 
@@ -397,7 +392,7 @@ func (checker *Checker) hint(hint Hint) {
 func (checker *Checker) UserDefinedValues() map[string]*Variable {
 	variables := map[string]*Variable{}
 
-	for key, value := range checker.GlobalValues {
+	for key, value := range checker.Elaboration.GlobalValues {
 		if value.IsBaseValue {
 			continue
 		}
@@ -410,7 +405,7 @@ func (checker *Checker) UserDefinedValues() map[string]*Variable {
 			continue
 		}
 
-		if typeValue, ok := checker.GlobalTypes[key]; ok {
+		if typeValue, ok := checker.Elaboration.GlobalTypes[key]; ok {
 			variables[key] = typeValue
 			continue
 		}
@@ -817,7 +812,7 @@ func (checker *Checker) declareGlobalValue(name string) {
 	if variable == nil {
 		return
 	}
-	checker.GlobalValues[name] = variable
+	checker.Elaboration.GlobalValues[name] = variable
 }
 
 func (checker *Checker) declareGlobalType(name string) {
@@ -825,7 +820,7 @@ func (checker *Checker) declareGlobalType(name string) {
 	if ty == nil {
 		return
 	}
-	checker.GlobalTypes[name] = ty
+	checker.Elaboration.GlobalTypes[name] = ty
 }
 
 func (checker *Checker) checkResourceMoveOperation(valueExpression ast.Expression, valueType Type) {

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -65,6 +65,9 @@ type Elaboration struct {
 	InvocationExpressionTypeArguments   map[*ast.InvocationExpression]map[*TypeParameter]Type
 	IdentifierInInvocationTypes         map[*ast.IdentifierExpression]Type
 	ImportDeclarationsResolvedLocations map[*ast.ImportDeclaration][]ResolvedLocation
+	GlobalValues                        map[string]*Variable
+	GlobalTypes                         map[string]*Variable
+	TransactionTypes                    []*TransactionType
 }
 
 func NewElaboration() *Elaboration {
@@ -106,5 +109,7 @@ func NewElaboration() *Elaboration {
 		InvocationExpressionTypeArguments:      map[*ast.InvocationExpression]map[*TypeParameter]Type{},
 		IdentifierInInvocationTypes:            map[*ast.IdentifierExpression]Type{},
 		ImportDeclarationsResolvedLocations:    map[*ast.ImportDeclaration][]ResolvedLocation{},
+		GlobalValues:                           map[string]*Variable{},
+		GlobalTypes:                            map[string]*Variable{},
 	}
 }

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -68,6 +68,8 @@ type Elaboration struct {
 	GlobalValues                        map[string]*Variable
 	GlobalTypes                         map[string]*Variable
 	TransactionTypes                    []*TransactionType
+	EffectivePredeclaredValues          map[string]ValueDeclaration
+	EffectivePredeclaredTypes           map[string]TypeDeclaration
 }
 
 func NewElaboration() *Elaboration {
@@ -111,5 +113,7 @@ func NewElaboration() *Elaboration {
 		ImportDeclarationsResolvedLocations:    map[*ast.ImportDeclaration][]ResolvedLocation{},
 		GlobalValues:                           map[string]*Variable{},
 		GlobalTypes:                            map[string]*Variable{},
+		EffectivePredeclaredValues:             map[string]ValueDeclaration{},
+		EffectivePredeclaredTypes:              map[string]TypeDeclaration{},
 	}
 }

--- a/runtime/sema/entrypoint.go
+++ b/runtime/sema/entrypoint.go
@@ -30,7 +30,7 @@ const FunctionEntryPointName = "main"
 //
 func (checker *Checker) FunctionEntryPointType() (*FunctionType, error) {
 
-	entryPointValue, ok := checker.GlobalValues[FunctionEntryPointName]
+	entryPointValue, ok := checker.Elaboration.GlobalValues[FunctionEntryPointName]
 	if !ok {
 		return nil, &MissingEntryPointError{
 			Expected: FunctionEntryPointName,

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -70,7 +70,7 @@ func (i CheckerImport) IsImportableValue(name string) bool {
 		return false
 	}
 
-	_, isPredeclaredValue := i.Checker.effectivePredeclaredValues[name]
+	_, isPredeclaredValue := i.Checker.Elaboration.EffectivePredeclaredValues[name]
 	return !isPredeclaredValue
 }
 
@@ -83,7 +83,7 @@ func (i CheckerImport) IsImportableType(name string) bool {
 		return false
 	}
 
-	_, isPredeclaredType := i.Checker.effectivePredeclaredTypes[name]
+	_, isPredeclaredType := i.Checker.Elaboration.EffectivePredeclaredTypes[name]
 	return !isPredeclaredType
 }
 

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -62,7 +62,7 @@ func variablesToImportElements(variables map[string]*Variable) map[string]Import
 }
 
 func (i CheckerImport) AllValueElements() map[string]ImportElement {
-	return variablesToImportElements(i.Checker.GlobalValues)
+	return variablesToImportElements(i.Checker.Elaboration.GlobalValues)
 }
 
 func (i CheckerImport) IsImportableValue(name string) bool {
@@ -75,7 +75,7 @@ func (i CheckerImport) IsImportableValue(name string) bool {
 }
 
 func (i CheckerImport) AllTypeElements() map[string]ImportElement {
-	return variablesToImportElements(i.Checker.GlobalTypes)
+	return variablesToImportElements(i.Checker.Elaboration.GlobalTypes)
 }
 
 func (i CheckerImport) IsImportableType(name string) bool {

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -79,7 +79,7 @@ var CryptoChecker = func() *sema.Checker {
 	return checker
 }()
 
-var cryptoContractType = CryptoChecker.GlobalTypes["Crypto"].Type.(*sema.CompositeType)
+var cryptoContractType = CryptoChecker.Elaboration.GlobalTypes["Crypto"].Type.(*sema.CompositeType)
 
 var cryptoContractInitializerTypes = func() (result []sema.Type) {
 	result = make([]sema.Type, len(cryptoContractType.ConstructorParameters))

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -429,9 +429,9 @@ func TestCheckAccount_load(t *testing.T) {
 
 					require.NoError(t, err)
 
-					rType := checker.GlobalTypes["R"].Type
+					rType := checker.Elaboration.GlobalTypes["R"].Type
 
-					rValueType := checker.GlobalValues["r"].Type
+					rValueType := checker.Elaboration.GlobalValues["r"].Type
 
 					require.Equal(t,
 						&sema.OptionalType{
@@ -466,9 +466,9 @@ func TestCheckAccount_load(t *testing.T) {
 
 					require.NoError(t, err)
 
-					sType := checker.GlobalTypes["S"].Type
+					sType := checker.Elaboration.GlobalTypes["S"].Type
 
-					sValueType := checker.GlobalValues["s"].Type
+					sValueType := checker.Elaboration.GlobalValues["s"].Type
 
 					require.Equal(t,
 						&sema.OptionalType{
@@ -560,9 +560,9 @@ func TestCheckAccount_copy(t *testing.T) {
 				if domain == common.PathDomainStorage {
 					require.NoError(t, err)
 
-					sType := checker.GlobalTypes["S"].Type
+					sType := checker.Elaboration.GlobalTypes["S"].Type
 
-					sValueType := checker.GlobalValues["s"].Type
+					sValueType := checker.Elaboration.GlobalValues["s"].Type
 
 					require.Equal(t,
 						&sema.OptionalType{
@@ -720,9 +720,9 @@ func TestCheckAccount_borrow(t *testing.T) {
 
 					require.NoError(t, err)
 
-					rType := checker.GlobalTypes["R"].Type
+					rType := checker.Elaboration.GlobalTypes["R"].Type
 
-					rValueType := checker.GlobalValues["r"].Type
+					rValueType := checker.Elaboration.GlobalValues["r"].Type
 
 					require.Equal(t,
 						&sema.OptionalType{
@@ -759,9 +759,9 @@ func TestCheckAccount_borrow(t *testing.T) {
 				if domain == common.PathDomainStorage {
 					require.NoError(t, err)
 
-					sType := checker.GlobalTypes["S"].Type
+					sType := checker.Elaboration.GlobalTypes["S"].Type
 
-					sValueType := checker.GlobalValues["s"].Type
+					sValueType := checker.Elaboration.GlobalValues["s"].Type
 
 					require.Equal(t,
 						&sema.OptionalType{
@@ -1234,7 +1234,7 @@ func TestCheckAccount_getCapability(t *testing.T) {
 				}
 			}
 
-			capType := checker.GlobalValues["cap"].Type
+			capType := checker.Elaboration.GlobalValues["cap"].Type
 			assert.Equal(t,
 				&sema.CapabilityType{
 					BorrowType: expectedBorrowType,
@@ -1297,7 +1297,7 @@ func TestCheckAccount_StorageFields(t *testing.T) {
 				)
 
 				require.NoError(t, err)
-				amountType := checker.GlobalValues["amount"].Type
+				amountType := checker.Elaboration.GlobalValues["amount"].Type
 				assert.Equal(t, &sema.UInt64Type{}, amountType)
 			})
 		}

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -132,7 +132,7 @@ func TestCheckDictionaryIndexingString(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.OptionalType{Type: &sema.IntType{}},
-		checker.GlobalValues["y"].Type,
+		checker.Elaboration.GlobalValues["y"].Type,
 	)
 }
 
@@ -264,7 +264,7 @@ func TestCheckDictionaryKeys(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.VariableSizedType{Type: &sema.StringType{}},
-		checker.GlobalValues["keys"].Type,
+		checker.Elaboration.GlobalValues["keys"].Type,
 	)
 }
 
@@ -280,7 +280,7 @@ func TestCheckDictionaryValues(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.VariableSizedType{Type: &sema.IntType{}},
-		checker.GlobalValues["values"].Type,
+		checker.Elaboration.GlobalValues["values"].Type,
 	)
 }
 

--- a/runtime/tests/checker/boolean_test.go
+++ b/runtime/tests/checker/boolean_test.go
@@ -39,6 +39,6 @@ func TestCheckBoolean(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.BoolType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 }

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -53,7 +53,7 @@ func TestCheckToString(t *testing.T) {
 
 			assert.Equal(t,
 				&sema.StringType{},
-				checker.GlobalValues["res"].Type,
+				checker.Elaboration.GlobalValues["res"].Type,
 			)
 		})
 	}
@@ -78,7 +78,7 @@ func TestCheckToBytes(t *testing.T) {
 			&sema.VariableSizedType{
 				Type: &sema.UInt8Type{},
 			},
-			checker.GlobalValues["res"].Type,
+			checker.Elaboration.GlobalValues["res"].Type,
 		)
 	})
 }
@@ -102,7 +102,7 @@ func TestCheckToBigEndianBytes(t *testing.T) {
 				&sema.VariableSizedType{
 					Type: &sema.UInt8Type{},
 				},
-				checker.GlobalValues["res"].Type,
+				checker.Elaboration.GlobalValues["res"].Type,
 			)
 		})
 	}

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -44,7 +44,7 @@ func TestCheckCapability(t *testing.T) {
 
 		assert.IsType(t,
 			&sema.CapabilityType{},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 	})
 
@@ -62,7 +62,7 @@ func TestCheckCapability(t *testing.T) {
 			&sema.CapabilityType{
 				BorrowType: &sema.IntType{},
 			},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 	})
 }
@@ -116,9 +116,9 @@ func TestCheckCapability_borrow(t *testing.T) {
 
 				require.NoError(t, err)
 
-				rType := checker.GlobalTypes["R"].Type
+				rType := checker.Elaboration.GlobalTypes["R"].Type
 
-				rValueType := checker.GlobalValues["r"].Type
+				rValueType := checker.Elaboration.GlobalValues["r"].Type
 
 				require.Equal(t,
 					&sema.OptionalType{
@@ -148,9 +148,9 @@ func TestCheckCapability_borrow(t *testing.T) {
 
 				require.NoError(t, err)
 
-				rType := checker.GlobalTypes["R"].Type
+				rType := checker.Elaboration.GlobalTypes["R"].Type
 
-				rValueType := checker.GlobalValues["r"].Type
+				rValueType := checker.Elaboration.GlobalValues["r"].Type
 
 				require.Equal(t,
 					&sema.OptionalType{
@@ -180,9 +180,9 @@ func TestCheckCapability_borrow(t *testing.T) {
 
 				require.NoError(t, err)
 
-				sType := checker.GlobalTypes["S"].Type
+				sType := checker.Elaboration.GlobalTypes["S"].Type
 
-				sValueType := checker.GlobalValues["s"].Type
+				sValueType := checker.Elaboration.GlobalValues["s"].Type
 
 				require.Equal(t,
 					&sema.OptionalType{
@@ -212,9 +212,9 @@ func TestCheckCapability_borrow(t *testing.T) {
 
 				require.NoError(t, err)
 
-				sType := checker.GlobalTypes["S"].Type
+				sType := checker.Elaboration.GlobalTypes["S"].Type
 
-				sValueType := checker.GlobalValues["s"].Type
+				sValueType := checker.Elaboration.GlobalValues["s"].Type
 
 				require.Equal(t,
 					&sema.OptionalType{
@@ -316,7 +316,7 @@ func TestCheckCapability_check(t *testing.T) {
 
 				require.Equal(t,
 					&sema.BoolType{},
-					checker.GlobalValues["ok"].Type,
+					checker.Elaboration.GlobalValues["ok"].Type,
 				)
 			})
 
@@ -339,7 +339,7 @@ func TestCheckCapability_check(t *testing.T) {
 
 				require.Equal(t,
 					&sema.BoolType{},
-					checker.GlobalValues["ok"].Type,
+					checker.Elaboration.GlobalValues["ok"].Type,
 				)
 			})
 
@@ -362,7 +362,7 @@ func TestCheckCapability_check(t *testing.T) {
 
 				require.Equal(t,
 					&sema.BoolType{},
-					checker.GlobalValues["ok"].Type,
+					checker.Elaboration.GlobalValues["ok"].Type,
 				)
 			})
 
@@ -385,7 +385,7 @@ func TestCheckCapability_check(t *testing.T) {
 
 				require.Equal(t,
 					&sema.BoolType{},
-					checker.GlobalValues["ok"].Type,
+					checker.Elaboration.GlobalValues["ok"].Type,
 				)
 			})
 		})

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -51,7 +51,7 @@ func TestCheckCastingIntLiteralToIntegerType(t *testing.T) {
 
 			assert.Equal(t,
 				integerType,
-				checker.GlobalValues["x"].Type,
+				checker.Elaboration.GlobalValues["x"].Type,
 			)
 
 			assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
@@ -88,7 +88,7 @@ func TestCheckCastingIntLiteralToAnyStruct(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.AnyStructType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 
 	assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
@@ -157,7 +157,7 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			r2Type := checker.GlobalValues["r2"].Type
+			r2Type := checker.Elaboration.GlobalValues["r2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{},
@@ -206,7 +206,7 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			r2Type := checker.GlobalValues["r2"].Type
+			r2Type := checker.Elaboration.GlobalValues["r2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{},
@@ -299,7 +299,7 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			r2Type := checker.GlobalValues["r2"].Type
+			r2Type := checker.Elaboration.GlobalValues["r2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{},
@@ -531,7 +531,7 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			r2Type := checker.GlobalValues["r2"].Type
+			r2Type := checker.Elaboration.GlobalValues["r2"].Type
 
 			require.IsType(t,
 				&sema.CompositeType{},
@@ -843,11 +843,11 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			iType := checker.GlobalTypes["I"].Type
+			iType := checker.Elaboration.GlobalTypes["I"].Type
 
 			require.IsType(t, &sema.InterfaceType{}, iType)
 
-			r2Type := checker.GlobalValues["r2"].Type
+			r2Type := checker.Elaboration.GlobalValues["r2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{
@@ -901,11 +901,11 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			i2Type := checker.GlobalTypes["I2"].Type
+			i2Type := checker.Elaboration.GlobalTypes["I2"].Type
 
 			require.IsType(t, &sema.InterfaceType{}, i2Type)
 
-			r2Type := checker.GlobalValues["r2"].Type
+			r2Type := checker.Elaboration.GlobalValues["r2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{
@@ -1307,7 +1307,7 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			s2Type := checker.GlobalValues["s2"].Type
+			s2Type := checker.Elaboration.GlobalValues["s2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{},
@@ -1326,7 +1326,7 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			s2Type := checker.GlobalValues["s2"].Type
+			s2Type := checker.Elaboration.GlobalValues["s2"].Type
 
 			require.IsType(t,
 				&sema.OptionalType{
@@ -1358,7 +1358,7 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			s2Type := checker.GlobalValues["s2"].Type
+			s2Type := checker.Elaboration.GlobalValues["s2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{},
@@ -1437,7 +1437,7 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			s2Type := checker.GlobalValues["s2"].Type
+			s2Type := checker.Elaboration.GlobalValues["s2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{},
@@ -1632,7 +1632,7 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			s2Type := checker.GlobalValues["s2"].Type
+			s2Type := checker.Elaboration.GlobalValues["s2"].Type
 
 			require.IsType(t,
 				&sema.CompositeType{},
@@ -1895,11 +1895,11 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			iType := checker.GlobalTypes["I"].Type
+			iType := checker.Elaboration.GlobalTypes["I"].Type
 
 			require.IsType(t, &sema.InterfaceType{}, iType)
 
-			s2Type := checker.GlobalValues["s2"].Type
+			s2Type := checker.Elaboration.GlobalValues["s2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{
@@ -1946,11 +1946,11 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			i2Type := checker.GlobalTypes["I2"].Type
+			i2Type := checker.Elaboration.GlobalTypes["I2"].Type
 
 			require.IsType(t, &sema.InterfaceType{}, i2Type)
 
-			s2Type := checker.GlobalValues["s2"].Type
+			s2Type := checker.Elaboration.GlobalValues["s2"].Type
 
 			require.IsType(t,
 				&sema.RestrictedType{

--- a/runtime/tests/checker/character_test.go
+++ b/runtime/tests/checker/character_test.go
@@ -39,7 +39,7 @@ func TestCheckCharacterLiteral(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.CharacterType{},
-		checker.GlobalValues["a"].Type,
+		checker.Elaboration.GlobalValues["a"].Type,
 	)
 }
 

--- a/runtime/tests/checker/composite_test.go
+++ b/runtime/tests/checker/composite_test.go
@@ -1733,7 +1733,7 @@ func TestCheckCompositeConstructorUseInInitializerAndFunction(t *testing.T) {
 
 			require.NoError(t, err)
 
-			testType := checker.GlobalTypes["Test"].Type
+			testType := checker.Elaboration.GlobalTypes["Test"].Type
 
 			assert.IsType(t, &sema.CompositeType{}, testType)
 
@@ -2232,7 +2232,7 @@ func TestCheckCompositeFieldOrder(t *testing.T) {
 
 			require.NoError(t, err)
 
-			testType := checker.GlobalTypes["Test"].Type.(*sema.CompositeType)
+			testType := checker.Elaboration.GlobalTypes["Test"].Type.(*sema.CompositeType)
 
 			switch kind {
 			case common.CompositeKindContract:

--- a/runtime/tests/checker/declaration_test.go
+++ b/runtime/tests/checker/declaration_test.go
@@ -42,12 +42,12 @@ func TestCheckConstantAndVariableDeclarations(t *testing.T) {
 
 	assert.IsType(t,
 		&sema.IntType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 
 	assert.IsType(t,
 		&sema.IntType{},
-		checker.GlobalValues["y"].Type,
+		checker.Elaboration.GlobalValues["y"].Type,
 	)
 }
 
@@ -388,22 +388,22 @@ func TestCheckVariableDeclarationSecondValue(t *testing.T) {
 
 	assert.IsType(t,
 		&sema.CompositeType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 
 	assert.IsType(t,
 		&sema.CompositeType{},
-		checker.GlobalValues["y"].Type,
+		checker.Elaboration.GlobalValues["y"].Type,
 	)
 
 	assert.IsType(t,
 		&sema.CompositeType{},
-		checker.GlobalValues["z"].Type,
+		checker.Elaboration.GlobalValues["z"].Type,
 	)
 
 	assert.IsType(t,
 		&sema.CompositeType{},
-		checker.GlobalValues["r"].Type,
+		checker.Elaboration.GlobalValues["r"].Type,
 	)
 }
 
@@ -427,22 +427,22 @@ func TestCheckVariableDeclarationSecondValueDictionary(t *testing.T) {
 
 	assert.IsType(t,
 		&sema.CompositeType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 
 	assert.IsType(t,
 		&sema.DictionaryType{},
-		checker.GlobalValues["ys"].Type,
+		checker.Elaboration.GlobalValues["ys"].Type,
 	)
 
 	assert.IsType(t,
 		&sema.OptionalType{},
-		checker.GlobalValues["z"].Type,
+		checker.Elaboration.GlobalValues["z"].Type,
 	)
 
 	assert.IsType(t,
 		&sema.OptionalType{},
-		checker.GlobalValues["r"].Type,
+		checker.Elaboration.GlobalValues["r"].Type,
 	)
 }
 

--- a/runtime/tests/checker/dictionary_test.go
+++ b/runtime/tests/checker/dictionary_test.go
@@ -47,6 +47,6 @@ func TestCheckIncompleteDictionaryType(t *testing.T) {
 			KeyType:   &sema.IntType{},
 			ValueType: sema.InvalidType,
 		},
-		checker.GlobalValues["dict"].Type,
+		checker.Elaboration.GlobalValues["dict"].Type,
 	)
 }

--- a/runtime/tests/checker/fixedpoint_test.go
+++ b/runtime/tests/checker/fixedpoint_test.go
@@ -58,7 +58,7 @@ func TestCheckFixedPointLiteralTypeConversionInVariableDeclaration(t *testing.T)
 
 				assert.Equal(t,
 					ty,
-					checker.GlobalValues["x"].Type,
+					checker.Elaboration.GlobalValues["x"].Type,
 				)
 			})
 		}
@@ -94,7 +94,7 @@ func TestCheckFixedPointLiteralTypeConversionInAssignment(t *testing.T) {
 
 				assert.Equal(t,
 					ty,
-					checker.GlobalValues["x"].Type,
+					checker.Elaboration.GlobalValues["x"].Type,
 				)
 			})
 		}
@@ -119,7 +119,7 @@ func TestCheckFixedPointLiteralRanges(t *testing.T) {
 			),
 		)
 
-		return checker.GlobalValues["x"].Type
+		return checker.Elaboration.GlobalValues["x"].Type
 	}
 
 	for _, ty := range sema.AllFixedPointTypes {

--- a/runtime/tests/checker/force_test.go
+++ b/runtime/tests/checker/force_test.go
@@ -42,12 +42,12 @@ func TestCheckForce(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.OptionalType{Type: &sema.IntType{}},
-			checker.GlobalValues["x"].Type,
+			checker.Elaboration.GlobalValues["x"].Type,
 		)
 
 		assert.Equal(t,
 			&sema.IntType{},
-			checker.GlobalValues["y"].Type,
+			checker.Elaboration.GlobalValues["y"].Type,
 		)
 
 	})
@@ -63,12 +63,12 @@ func TestCheckForce(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.IntType{},
-			checker.GlobalValues["x"].Type,
+			checker.Elaboration.GlobalValues["x"].Type,
 		)
 
 		assert.Equal(t,
 			&sema.IntType{},
-			checker.GlobalValues["y"].Type,
+			checker.Elaboration.GlobalValues["y"].Type,
 		)
 
 		hints := checker.Hints()

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -75,7 +75,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 			assert.Equal(t,
 				sema.VoidType,
-				checker.GlobalValues["res"].Type,
+				checker.Elaboration.GlobalValues["res"].Type,
 			)
 		}
 	})
@@ -521,7 +521,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		assert.IsType(t,
 			&sema.IntType{},
-			checker.GlobalValues["res"].Type,
+			checker.Elaboration.GlobalValues["res"].Type,
 		)
 	})
 
@@ -581,7 +581,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		assert.IsType(t,
 			&sema.IntType{},
-			checker.GlobalValues["res"].Type,
+			checker.Elaboration.GlobalValues["res"].Type,
 		)
 	})
 
@@ -769,7 +769,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 				assert.Equal(t,
 					test.generateType(&sema.IntType{}),
-					checker.GlobalValues["res"].Type,
+					checker.Elaboration.GlobalValues["res"].Type,
 				)
 			})
 		}
@@ -877,7 +877,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 				assert.Equal(t,
 					test.generateType(&sema.IntType{}),
-					checker.GlobalValues["res"].Type,
+					checker.Elaboration.GlobalValues["res"].Type,
 				)
 			})
 		}

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -61,7 +61,7 @@ func TestCheckIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {
 
 				assert.Equal(t,
 					ty,
-					checker.GlobalValues["x"].Type,
+					checker.Elaboration.GlobalValues["x"].Type,
 				)
 			})
 		}
@@ -97,7 +97,7 @@ func TestCheckIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 
 				assert.Equal(t,
 					ty,
-					checker.GlobalValues["x"].Type,
+					checker.Elaboration.GlobalValues["x"].Type,
 				)
 			})
 		}

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -445,8 +445,8 @@ func TestCheckInvalidInterfaceConformanceIncompatibleCompositeKinds(t *testing.T
 
 				require.NotNil(t, checker)
 
-				testType := checker.GlobalTypes["Test"].Type
-				testImplType := checker.GlobalTypes["TestImpl"].Type
+				testType := checker.Elaboration.GlobalTypes["Test"].Type
+				testImplType := checker.Elaboration.GlobalTypes["TestImpl"].Type
 
 				assert.False(t, sema.IsSubType(testImplType, testType))
 			})
@@ -511,8 +511,8 @@ func TestCheckInvalidInterfaceConformanceUndeclared(t *testing.T) {
 
 			require.NotNil(t, checker)
 
-			testType := checker.GlobalTypes["Test"].Type
-			testImplType := checker.GlobalTypes["TestImpl"].Type
+			testType := checker.Elaboration.GlobalTypes["Test"].Type
+			testImplType := checker.Elaboration.GlobalTypes["TestImpl"].Type
 
 			assert.False(t, sema.IsSubType(testImplType, testType))
 		})
@@ -1895,7 +1895,7 @@ func TestCheckInvalidInterfaceUseAsTypeSuggestion(t *testing.T) {
 
 	require.IsType(t, &sema.InvalidInterfaceTypeError{}, errs[0])
 
-	iType := checker.GlobalTypes["I"].Type.(*sema.InterfaceType)
+	iType := checker.Elaboration.GlobalTypes["I"].Type.(*sema.InterfaceType)
 
 	assert.Equal(t,
 		&sema.FunctionType{

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -48,7 +48,7 @@ func TestCheckOptionalChainingNonOptionalFieldRead(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.OptionalType{Type: &sema.IntType{}},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 }
 
@@ -73,7 +73,7 @@ func TestCheckOptionalChainingOptionalFieldRead(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.OptionalType{Type: &sema.IntType{}},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 }
 
@@ -95,7 +95,7 @@ func TestCheckOptionalChainingFunctionRead(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t,
-		checker.GlobalValues["x"].Type.Equal(
+		checker.Elaboration.GlobalValues["x"].Type.Equal(
 			&sema.OptionalType{
 				Type: &sema.FunctionType{
 					ReturnTypeAnnotation: &sema.TypeAnnotation{
@@ -125,7 +125,7 @@ func TestCheckOptionalChainingFunctionCall(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t,
-		checker.GlobalValues["x"].Type.Equal(
+		checker.Elaboration.GlobalValues["x"].Type.Equal(
 			&sema.OptionalType{Type: &sema.IntType{}},
 		),
 	)

--- a/runtime/tests/checker/metatype_test.go
+++ b/runtime/tests/checker/metatype_test.go
@@ -43,7 +43,7 @@ func TestCheckMetaType(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.MetaType{},
-			checker.GlobalValues["type"].Type,
+			checker.Elaboration.GlobalValues["type"].Type,
 		)
 	})
 
@@ -60,7 +60,7 @@ func TestCheckMetaType(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.MetaType{},
-			checker.GlobalValues["type"].Type,
+			checker.Elaboration.GlobalValues["type"].Type,
 		)
 	})
 }
@@ -131,7 +131,7 @@ func TestCheckIsInstance(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t,
 					&sema.BoolType{},
-					checker.GlobalValues["result"].Type,
+					checker.Elaboration.GlobalValues["result"].Type,
 				)
 			} else {
 				require.Error(t, err)
@@ -193,7 +193,7 @@ func TestCheckGetType(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t,
 				&sema.MetaType{},
-				checker.GlobalValues["result"].Type,
+				checker.Elaboration.GlobalValues["result"].Type,
 			)
 		})
 	}

--- a/runtime/tests/checker/nil_coalescing_test.go
+++ b/runtime/tests/checker/nil_coalescing_test.go
@@ -193,7 +193,7 @@ func TestCheckNilCoalescingOptionalRightHandSide(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.IsType(t, &sema.OptionalType{Type: &sema.IntType{}}, checker.GlobalValues["z"].Type)
+	assert.IsType(t, &sema.OptionalType{Type: &sema.IntType{}}, checker.Elaboration.GlobalValues["z"].Type)
 }
 
 func TestCheckNilCoalescingBothOptional(t *testing.T) {
@@ -208,7 +208,7 @@ func TestCheckNilCoalescingBothOptional(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.IsType(t, &sema.OptionalType{Type: &sema.IntType{}}, checker.GlobalValues["z"].Type)
+	assert.IsType(t, &sema.OptionalType{Type: &sema.IntType{}}, checker.Elaboration.GlobalValues["z"].Type)
 }
 
 func TestCheckNilCoalescingWithNever(t *testing.T) {

--- a/runtime/tests/checker/path_test.go
+++ b/runtime/tests/checker/path_test.go
@@ -59,7 +59,7 @@ func TestCheckPath(t *testing.T) {
 
 			assert.IsType(t,
 				domainTypes[domain],
-				checker.GlobalValues["x"].Type,
+				checker.Elaboration.GlobalValues["x"].Type,
 			)
 		})
 	}

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -182,7 +182,7 @@ func TestCheckReferenceExpressionWithNonCompositeResultType(t *testing.T) {
 
 	require.NoError(t, err)
 
-	refValueType := checker.GlobalValues["ref"].Type
+	refValueType := checker.Elaboration.GlobalValues["ref"].Type
 
 	assert.Equal(t,
 		&sema.ReferenceType{
@@ -209,9 +209,9 @@ func TestCheckReferenceExpressionWithCompositeResultType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		rType := checker.GlobalTypes["R"].Type
+		rType := checker.Elaboration.GlobalTypes["R"].Type
 
-		refValueType := checker.GlobalValues["ref"].Type
+		refValueType := checker.Elaboration.GlobalValues["ref"].Type
 
 		assert.Equal(t,
 			&sema.ReferenceType{
@@ -234,9 +234,9 @@ func TestCheckReferenceExpressionWithCompositeResultType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		sType := checker.GlobalTypes["S"].Type
+		sType := checker.Elaboration.GlobalTypes["S"].Type
 
-		refValueType := checker.GlobalValues["ref"].Type
+		refValueType := checker.Elaboration.GlobalValues["ref"].Type
 
 		assert.Equal(t,
 			&sema.ReferenceType{
@@ -926,9 +926,9 @@ func TestCheckReferenceExpressionReferenceType(t *testing.T) {
 
 			require.NoError(t, err)
 
-			tType := checker.GlobalTypes["T"].Type
+			tType := checker.Elaboration.GlobalTypes["T"].Type
 
-			refValueType := checker.GlobalValues["ref"].Type
+			refValueType := checker.Elaboration.GlobalValues["ref"].Type
 
 			require.Equal(t,
 				&sema.ReferenceType{

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -840,7 +840,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		rType := checker.GlobalValues["r"].Type
+		rType := checker.Elaboration.GlobalValues["r"].Type
 		require.IsType(t, &sema.RestrictedType{}, rType)
 
 		ty := rType.(*sema.RestrictedType)
@@ -849,7 +849,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 	})
@@ -864,7 +864,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		rType := checker.GlobalValues["s"].Type
+		rType := checker.Elaboration.GlobalValues["s"].Type
 		require.IsType(t, &sema.RestrictedType{}, rType)
 
 		ty := rType.(*sema.RestrictedType)
@@ -873,7 +873,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 	})
@@ -888,7 +888,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		rType := checker.GlobalValues["r"].Type
+		rType := checker.Elaboration.GlobalValues["r"].Type
 		require.IsType(t, &sema.RestrictedType{}, rType)
 
 		ty := rType.(*sema.RestrictedType)
@@ -897,11 +897,11 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 		assert.Same(t,
-			checker.GlobalTypes["I2"].Type,
+			checker.Elaboration.GlobalTypes["I2"].Type,
 			ty.Restrictions[1],
 		)
 	})
@@ -916,7 +916,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		rType := checker.GlobalValues["s"].Type
+		rType := checker.Elaboration.GlobalValues["s"].Type
 		require.IsType(t, &sema.RestrictedType{}, rType)
 
 		ty := rType.(*sema.RestrictedType)
@@ -925,11 +925,11 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 		assert.Same(t,
-			checker.GlobalTypes["I2"].Type,
+			checker.Elaboration.GlobalTypes["I2"].Type,
 			ty.Restrictions[1],
 		)
 	})
@@ -957,7 +957,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		refType := checker.GlobalValues["ref"].Type
+		refType := checker.Elaboration.GlobalValues["ref"].Type
 		require.IsType(t, &sema.ReferenceType{}, refType)
 
 		rType := refType.(*sema.ReferenceType).Type
@@ -969,7 +969,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 	})
@@ -984,7 +984,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		refType := checker.GlobalValues["ref"].Type
+		refType := checker.Elaboration.GlobalValues["ref"].Type
 		require.IsType(t, &sema.ReferenceType{}, refType)
 
 		rType := refType.(*sema.ReferenceType).Type
@@ -996,7 +996,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 	})
@@ -1011,7 +1011,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		refType := checker.GlobalValues["ref"].Type
+		refType := checker.Elaboration.GlobalValues["ref"].Type
 		require.IsType(t, &sema.ReferenceType{}, refType)
 
 		rType := refType.(*sema.ReferenceType).Type
@@ -1023,11 +1023,11 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 		assert.Same(t,
-			checker.GlobalTypes["I2"].Type,
+			checker.Elaboration.GlobalTypes["I2"].Type,
 			ty.Restrictions[1],
 		)
 	})
@@ -1042,7 +1042,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.NoError(t, err)
 
-		refType := checker.GlobalValues["ref"].Type
+		refType := checker.Elaboration.GlobalValues["ref"].Type
 		require.IsType(t, &sema.ReferenceType{}, refType)
 
 		rType := refType.(*sema.ReferenceType).Type
@@ -1054,11 +1054,11 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,
-			checker.GlobalTypes["I1"].Type,
+			checker.Elaboration.GlobalTypes["I1"].Type,
 			ty.Restrictions[0],
 		)
 		assert.Same(t,
-			checker.GlobalTypes["I2"].Type,
+			checker.Elaboration.GlobalTypes["I2"].Type,
 			ty.Restrictions[1],
 		)
 	})

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -39,7 +39,7 @@ func TestCheckCharacter(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.CharacterType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 }
 
@@ -55,7 +55,7 @@ func TestCheckCharacterUnicodeScalar(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.CharacterType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 }
 
@@ -71,7 +71,7 @@ func TestCheckString(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.StringType{},
-		checker.GlobalValues["x"].Type,
+		checker.Elaboration.GlobalValues["x"].Type,
 	)
 }
 

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -46,7 +46,7 @@ func TestCheckTypeArguments(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.CapabilityType{},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 	})
 
@@ -88,7 +88,7 @@ func TestCheckTypeArguments(t *testing.T) {
 					Type: &sema.IntType{},
 				},
 			},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 	})
 
@@ -154,12 +154,12 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 					Type: &sema.IntType{},
 				},
 			},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 
 		assert.Equal(t,
 			&sema.CapabilityType{},
-			checker.GlobalValues["cap2"].Type,
+			checker.Elaboration.GlobalValues["cap2"].Type,
 		)
 	})
 
@@ -187,7 +187,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 					Type: &sema.IntType{},
 				},
 			},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 
 		assert.Equal(t,
@@ -196,7 +196,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 					Type: &sema.IntType{},
 				},
 			},
-			checker.GlobalValues["cap2"].Type,
+			checker.Elaboration.GlobalValues["cap2"].Type,
 		)
 	})
 
@@ -214,7 +214,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.CapabilityType{},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 
 		assert.Equal(t,
@@ -223,7 +223,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 					Type: &sema.IntType{},
 				},
 			},
-			checker.GlobalValues["cap2"].Type,
+			checker.Elaboration.GlobalValues["cap2"].Type,
 		)
 
 		errs := ExpectCheckerErrors(t, err, 1)
@@ -255,7 +255,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 					Type: &sema.StringType{},
 				},
 			},
-			checker.GlobalValues["cap"].Type,
+			checker.Elaboration.GlobalValues["cap"].Type,
 		)
 
 		assert.Equal(t,
@@ -264,7 +264,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 					Type: &sema.IntType{},
 				},
 			},
-			checker.GlobalValues["cap2"].Type,
+			checker.Elaboration.GlobalValues["cap2"].Type,
 		)
 
 		errs := ExpectCheckerErrors(t, err, 1)

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -756,7 +756,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					rType := inter.Program.Elaboration.GlobalTypes["R"].Type
+					rType := inter.Checker.Elaboration.GlobalTypes["R"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -798,7 +798,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					r2Type := inter.Program.Elaboration.GlobalTypes["R2"].Type
+					r2Type := inter.Checker.Elaboration.GlobalTypes["R2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -891,7 +891,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					sType := inter.Program.Elaboration.GlobalTypes["S"].Type
+					sType := inter.Checker.Elaboration.GlobalTypes["S"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -933,7 +933,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					s2Type := inter.Program.Elaboration.GlobalTypes["S2"].Type
+					s2Type := inter.Checker.Elaboration.GlobalTypes["S2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -756,7 +756,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					rType := inter.Checker.GlobalTypes["R"].Type
+					rType := inter.Program.Elaboration.GlobalTypes["R"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -798,7 +798,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					r2Type := inter.Checker.GlobalTypes["R2"].Type
+					r2Type := inter.Program.Elaboration.GlobalTypes["R2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -891,7 +891,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					sType := inter.Checker.GlobalTypes["S"].Type
+					sType := inter.Program.Elaboration.GlobalTypes["S"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -933,7 +933,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					s2Type := inter.Checker.GlobalTypes["S2"].Type
+					s2Type := inter.Program.Elaboration.GlobalTypes["S2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -5721,8 +5721,8 @@ func TestInterpretEmitEvent(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	transferEventType := inter.Checker.GlobalTypes["Transfer"].Type
-	transferAmountEventType := inter.Checker.GlobalTypes["TransferAmount"].Type
+	transferEventType := inter.Checker.Elaboration.GlobalTypes["Transfer"].Type
+	transferAmountEventType := inter.Checker.Elaboration.GlobalTypes["TransferAmount"].Type
 
 	expectedEvents := []*interpreter.CompositeValue{
 		interpreter.NewCompositeValue(
@@ -5922,7 +5922,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			_, err := inter.Invoke("test")
 			require.NoError(t, err)
 
-			testType := inter.Checker.GlobalTypes["Test"].Type
+			testType := inter.Checker.Elaboration.GlobalTypes["Test"].Type
 			expectedEvents := []*interpreter.CompositeValue{
 				interpreter.NewCompositeValue(
 					TestLocation,


### PR DESCRIPTION
## Description

Move checking results that are currently stored in the checker to the elaboration:
- Global values
- Global types
- Transaction types

This is pre-work to eventually have the interpreter just consume an elaboration instead of a whole checker.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
