### PR TITLE
Revert "always find the declared variable (#408)"

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -915,6 +915,7 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 
 	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]
 
+	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
 	variable := interpreter.findOrDeclareVariable(identifier)
 
 	// lexical scope: variables in functions are bound to what is visible at declaration time
@@ -2433,6 +2434,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 	value Value,
 ) {
 	identifier := declaration.Identifier.Identifier
+	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
 	variable := interpreter.findOrDeclareVariable(identifier)
 
 	// Make the value available in the initializer
@@ -2675,6 +2677,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 	value Value,
 ) {
 	identifier := declaration.Identifier.Identifier
+	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
 	variable := interpreter.findOrDeclareVariable(identifier)
 
 	lexicalScope = lexicalScope.Insert(identifier, variable)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -552,6 +552,14 @@ func (interpreter *Interpreter) findVariable(name string) *Variable {
 	return result.(*Variable)
 }
 
+func (interpreter *Interpreter) findOrDeclareVariable(name string) *Variable {
+	variable := interpreter.findVariable(name)
+	if variable == nil {
+		variable = interpreter.declareVariable(name, nil)
+	}
+	return variable
+}
+
 func (interpreter *Interpreter) setVariable(name string, variable *Variable) {
 	interpreter.activations.Set(name, variable)
 }
@@ -907,10 +915,7 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 
 	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]
 
-	variable := interpreter.findVariable(identifier)
-	if variable == nil {
-		panic(errors.NewUnreachableError())
-	}
+	variable := interpreter.findOrDeclareVariable(identifier)
 
 	// lexical scope: variables in functions are bound to what is visible at declaration time
 	lexicalScope := interpreter.activations.CurrentOrNew()
@@ -2428,11 +2433,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 	value Value,
 ) {
 	identifier := declaration.Identifier.Identifier
-
-	variable := interpreter.findVariable(identifier)
-	if variable == nil {
-		panic(errors.NewUnreachableError())
-	}
+	variable := interpreter.findOrDeclareVariable(identifier)
 
 	// Make the value available in the initializer
 	lexicalScope = lexicalScope.Insert(identifier, variable)
@@ -2674,10 +2675,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 	value Value,
 ) {
 	identifier := declaration.Identifier.Identifier
-	variable := interpreter.findVariable(identifier)
-	if variable == nil {
-		panic(errors.NewUnreachableError())
-	}
+	variable := interpreter.findOrDeclareVariable(identifier)
 
 	lexicalScope = lexicalScope.Insert(identifier, variable)
 


### PR DESCRIPTION
## Description

This reverts PR #408 (commit 5df4e54ced5262e69aebc117c9d660332c2448db).

I realized that this optimization cannot be made, as this breaks the REPL.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
