### PR TITLE
Use elaborations instead of checkers

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1287,7 +1287,7 @@ func convertValueFromScript(t *testing.T, script string) cadence.Value {
 			Arguments: nil,
 		},
 		runtime.Context{
-			Interface: &runtime.EmptyRuntimeInterface{},
+			Interface: runtime.NewEmptyRuntimeInterface(),
 			Location:  utils.TestLocation,
 		},
 	)

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -1,0 +1,1 @@
+package runtime

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -1,1 +1,56 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package runtime
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+type Context struct {
+	Interface         Interface
+	Location          Location
+	PredeclaredValues []ValueDeclaration
+	codes             map[common.LocationID]string
+	programs          map[common.LocationID]*ast.Program
+}
+
+func (c Context) SetCode(location common.Location, code string) {
+	c.codes[location.ID()] = code
+}
+
+func (c Context) SetProgram(location common.Location, program *ast.Program) {
+	c.programs[location.ID()] = program
+}
+
+func (c Context) WithLocation(location common.Location) Context {
+	result := c
+	result.Location = location
+	return result
+}
+
+func (c *Context) InitializeCodesAndPrograms() {
+	if c.codes == nil {
+		c.codes = map[common.LocationID]string{}
+	}
+
+	if c.programs == nil {
+		c.programs = map[common.LocationID]*ast.Program{}
+	}
+}

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -132,6 +132,8 @@ func TestRuntimeContract(t *testing.T) {
 
 		storage := newTestStorage(nil, nil)
 
+		programs := map[common.LocationID]*interpreter.Program{}
+
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
 			getSigningAccounts: func() ([]Address, error) {
@@ -139,6 +141,13 @@ func TestRuntimeContract(t *testing.T) {
 			},
 			log: func(message string) {
 				loggedMessages = append(loggedMessages, message)
+			},
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
 			},
 			updateAccountContractCode: func(address Address, name string, code []byte) error {
 				require.Equal(t, tc.name, name)
@@ -501,11 +510,19 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 
 	var events []cadence.Event
 	var loggedMessages []string
+	programs := map[common.LocationID]*interpreter.Program{}
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{common.BytesToAddress([]byte{0x1})}, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			key := contractKey{

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -579,7 +579,7 @@ func TestExportEventValue(t *testing.T) {
 
 // mock runtime.Interface to capture events
 type eventCapturingInterface struct {
-	EmptyRuntimeInterface
+	emptyRuntimeInterface
 	events []cadence.Event
 }
 
@@ -592,6 +592,7 @@ func exportEventFromScript(t *testing.T, script string) cadence.Event {
 	rt := NewInterpreterRuntime()
 
 	inter := &eventCapturingInterface{}
+	inter.programs = map[common.LocationID]*interpreter.Program{}
 
 	_, err := rt.ExecuteScript(
 		Script{
@@ -619,7 +620,7 @@ func exportValueFromScript(t *testing.T, script string) cadence.Value {
 			Source: []byte(script),
 		},
 		Context{
-			Interface: &EmptyRuntimeInterface{},
+			Interface: NewEmptyRuntimeInterface(),
 			Location:  utils.TestLocation,
 		},
 	)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -704,7 +704,10 @@ func TestExportTypeValue(t *testing.T) {
 		err = checker.Check()
 		require.NoError(t, err)
 
-		inter, err := interpreter.NewInterpreter(checker)
+		inter, err := interpreter.NewInterpreter(
+			interpreter.ProgramFromChecker(checker),
+			checker.Location,
+		)
 		require.NoError(t, err)
 
 		ty := interpreter.TypeValue{
@@ -771,7 +774,10 @@ func TestExportCapabilityValue(t *testing.T) {
 		err = checker.Check()
 		require.NoError(t, err)
 
-		inter, err := interpreter.NewInterpreter(checker)
+		inter, err := interpreter.NewInterpreter(
+			interpreter.ProgramFromChecker(checker),
+			checker.Location,
+		)
 		require.NoError(t, err)
 
 		capability := interpreter.CapabilityValue{
@@ -835,7 +841,10 @@ func TestExportLinkValue(t *testing.T) {
 		err = checker.Check()
 		require.NoError(t, err)
 
-		inter, err := interpreter.NewInterpreter(checker)
+		inter, err := interpreter.NewInterpreter(
+			interpreter.ProgramFromChecker(checker),
+			checker.Location,
+		)
 		require.NoError(t, err)
 
 		capability := interpreter.LinkValue{

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 )
 
 func TestRuntimeCoverage(t *testing.T) {
@@ -58,6 +59,8 @@ func TestRuntimeCoverage(t *testing.T) {
         }
     `)
 
+	programs := map[common.LocationID]*interpreter.Program{}
+
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
@@ -66,6 +69,13 @@ func TestRuntimeCoverage(t *testing.T) {
 			default:
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 	}
 

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -42,7 +44,17 @@ func TestRuntimeCrypto_import(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{}
+	programs := map[common.LocationID]*interpreter.Program{}
+
+	runtimeInterface := &testRuntimeInterface{
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
+		},
+	}
 
 	result, err := runtime.ExecuteScript(
 		Script{
@@ -99,6 +111,8 @@ func TestRuntimeCrypto_verify(t *testing.T) {
 
 	called := false
 
+	programs := map[common.LocationID]*interpreter.Program{}
+
 	runtimeInterface := &testRuntimeInterface{
 		verifySignature: func(
 			signature []byte,
@@ -116,6 +130,13 @@ func TestRuntimeCrypto_verify(t *testing.T) {
 			assert.Equal(t, "ECDSA_P256", signatureAlgorithm)
 			assert.Equal(t, "SHA3_256", hashAlgorithm)
 			return true, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 	}
 
@@ -156,6 +177,7 @@ func TestRuntimeCrypto_hash(t *testing.T) {
 	called := false
 
 	var loggedMessages []string
+	programs := map[common.LocationID]*interpreter.Program{}
 
 	runtimeInterface := &testRuntimeInterface{
 		hash: func(
@@ -169,6 +191,13 @@ func TestRuntimeCrypto_hash(t *testing.T) {
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 	}
 

--- a/runtime/deferral_test.go
+++ b/runtime/deferral_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -106,6 +107,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
        }
     `)
 
+	programs := map[common.LocationID]*interpreter.Program{}
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -136,6 +138,13 @@ func TestRuntimeStorageDeferredResourceDictionaryValues(t *testing.T) {
 		resolveLocation: singleIdentifierLocationResolver(t),
 		getAccountContractCode: func(_ Address, _ string) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: newTestStorage(onRead, onWrite),
 		getSigningAccounts: func() ([]Address, error) {
@@ -659,6 +668,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
        }
     `)
 
+	programs := map[common.LocationID]*interpreter.Program{}
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -692,6 +702,13 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Nested(t *testing.T) {
 		},
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: newTestStorage(onRead, onWrite),
 		getSigningAccounts: func() ([]Address, error) {
@@ -915,6 +932,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
        }
     `)
 
+	programs := map[common.LocationID]*interpreter.Program{}
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -957,6 +975,13 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_DictionaryTransfer(t *te
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: newTestStorage(onRead, onWrite),
 		getSigningAccounts: func() ([]Address, error) {
@@ -1129,6 +1154,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Removal(t *testing.T) {
       }
     `)
 
+	programs := map[common.LocationID]*interpreter.Program{}
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -1138,6 +1164,13 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Removal(t *testing.T) {
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -1243,6 +1276,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Destruction(t *testing.T
       }
     `)
 
+	programs := map[common.LocationID]*interpreter.Program{}
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -1252,6 +1286,13 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Destruction(t *testing.T
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -1384,6 +1425,7 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Insertion(t *testing.T) 
       }
     `)
 
+	programs := map[common.LocationID]*interpreter.Program{}
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -1393,6 +1435,13 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_Insertion(t *testing.T) 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -1538,12 +1587,20 @@ func TestRuntimeStorageDeferredResourceDictionaryValues_ValueTransferAndDestroy(
 	signer3 := common.BytesToAddress([]byte{0x3})
 
 	var signers []Address
+	programs := map[common.LocationID]*interpreter.Program{}
 
 	testStorage := newTestStorage(nil, nil)
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: testStorage,
 		getSigningAccounts: func() ([]Address, error) {

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
@@ -139,6 +140,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 		runtime := NewInterpreterRuntime()
 
+		programs := map[common.LocationID]*interpreter.Program{}
 		var accountCode []byte
 		var events []cadence.Event
 
@@ -146,6 +148,13 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			storage: newTestStorage(nil, nil),
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
+			},
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
 			},
 			getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
 				return accountCode, nil

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 )
 
 func TestRuntimeError(t *testing.T) {
@@ -39,7 +40,17 @@ func TestRuntimeError(t *testing.T) {
 
 		script := []byte(`X`)
 
-		runtimeInterface := &testRuntimeInterface{}
+		programs := map[common.LocationID]*interpreter.Program{}
+
+		runtimeInterface := &testRuntimeInterface{
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
+			},
+		}
 
 		location := common.ScriptLocation{0x1}
 
@@ -71,7 +82,17 @@ func TestRuntimeError(t *testing.T) {
 
 		script := []byte(`fun test() {}`)
 
-		runtimeInterface := &testRuntimeInterface{}
+		programs := map[common.LocationID]*interpreter.Program{}
+
+		runtimeInterface := &testRuntimeInterface{
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
+			},
+		}
 
 		location := common.ScriptLocation{0x1}
 
@@ -110,7 +131,17 @@ func TestRuntimeError(t *testing.T) {
             }
         `)
 
-		runtimeInterface := &testRuntimeInterface{}
+		programs := map[common.LocationID]*interpreter.Program{}
+
+		runtimeInterface := &testRuntimeInterface{
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
+			},
+		}
 
 		location := common.ScriptLocation{0x1}
 
@@ -144,6 +175,8 @@ func TestRuntimeError(t *testing.T) {
 
 		script := []byte(`import "imported"`)
 
+		programs := map[common.LocationID]*interpreter.Program{}
+
 		runtimeInterface := &testRuntimeInterface{
 			getCode: func(location Location) (bytes []byte, err error) {
 				switch location {
@@ -152,6 +185,13 @@ func TestRuntimeError(t *testing.T) {
 				default:
 					return nil, fmt.Errorf("unknown import location: %s", location)
 				}
+			},
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
 			},
 		}
 
@@ -187,6 +227,8 @@ func TestRuntimeError(t *testing.T) {
 
 		script := []byte(`import "imported"`)
 
+		programs := map[common.LocationID]*interpreter.Program{}
+
 		runtimeInterface := &testRuntimeInterface{
 			getCode: func(location Location) (bytes []byte, err error) {
 				switch location {
@@ -195,6 +237,13 @@ func TestRuntimeError(t *testing.T) {
 				default:
 					return nil, fmt.Errorf("unknown import location: %s", location)
 				}
+			},
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
 			},
 		}
 
@@ -243,6 +292,8 @@ func TestRuntimeError(t *testing.T) {
             }
         `)
 
+		programs := map[common.LocationID]*interpreter.Program{}
+
 		runtimeInterface := &testRuntimeInterface{
 			getCode: func(location Location) (bytes []byte, err error) {
 				switch location {
@@ -251,6 +302,13 @@ func TestRuntimeError(t *testing.T) {
 				default:
 					return nil, fmt.Errorf("unknown import location: %s", location)
 				}
+			},
+			setProgram: func(location Location, program *interpreter.Program) error {
+				programs[location.ID()] = program
+				return nil
+			},
+			getProgram: func(location Location) (*interpreter.Program, error) {
+				return programs[location.ID()], nil
 			},
 		}
 

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -47,10 +47,17 @@ type Interface interface {
 	ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
 	// GetCode returns the code at a given location
 	GetCode(location Location) ([]byte, error)
+
 	// GetCachedProgram attempts to get a parsed program from a cache.
 	GetCachedProgram(Location) (*ast.Program, error)
 	// CacheProgram adds a parsed program to a cache.
 	CacheProgram(Location, *ast.Program) error
+
+	// GetCachedElaboration attempts to get an elaboration from a cache.
+	GetCachedElaboration(Location) (*sema.Elaboration, error)
+	// CacheElaboration adds an elaboration to a cache.
+	CacheElaboration(Location, *sema.Elaboration) error
+
 	// GetValue gets a value for the given key in the storage, owned by the given account.
 	GetValue(owner, key []byte) (value []byte, err error)
 	// SetValue sets a value for the given key in the storage, owned by the given account.
@@ -150,6 +157,14 @@ func (i *EmptyRuntimeInterface) GetCachedProgram(_ Location) (*ast.Program, erro
 }
 
 func (i *EmptyRuntimeInterface) CacheProgram(_ Location, _ *ast.Program) error {
+	return nil
+}
+
+func (i *EmptyRuntimeInterface) GetCachedElaboration(Location) (*sema.Elaboration, error) {
+	return nil, nil
+}
+
+func (i *EmptyRuntimeInterface) CacheElaboration(Location, *sema.Elaboration) error {
 	return nil
 }
 

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -47,17 +48,21 @@ type Interface interface {
 	ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
 	// GetCode returns the code at a given location
 	GetCode(location Location) ([]byte, error)
-
-	// GetCachedProgram attempts to get a parsed program from a cache.
-	GetCachedProgram(Location) (*ast.Program, error)
-	// CacheProgram adds a parsed program to a cache.
-	CacheProgram(Location, *ast.Program) error
-
-	// GetCachedElaboration attempts to get an elaboration from a cache.
-	GetCachedElaboration(Location) (*sema.Elaboration, error)
-	// CacheElaboration adds an elaboration to a cache.
-	CacheElaboration(Location, *sema.Elaboration) error
-
+	// GetProgram attempts gets the program for the given location, if available.
+	//
+	// NOTE: During execution, this function must always return the *same* program,
+	// i.e. it may NOT return a different program,
+	// an elaboration in the program that is not annotating the AST in the program;
+	// or a program/elaboration and then nothing in a subsequent call.
+	//
+	// This function must also return what was set using SetProgram,
+	// it may NOT return something different or nothing (!) after SetProgram was called.
+	//
+	// This is not a caching function!
+	//
+	GetProgram(Location) (*interpreter.Program, error)
+	// SetProgram sets the program for the given location.
+	SetProgram(Location, *interpreter.Program) error
 	// GetValue gets a value for the given key in the storage, owned by the given account.
 	GetValue(owner, key []byte) (value []byte, err error)
 	// SetValue sets a value for the given key in the storage, owned by the given account.
@@ -135,11 +140,20 @@ type Metrics interface {
 	ValueDecoded(duration time.Duration)
 }
 
-type EmptyRuntimeInterface struct{}
+type emptyRuntimeInterface struct {
+	programs map[common.LocationID]*interpreter.Program
+}
 
-var _ Interface = &EmptyRuntimeInterface{}
+// emptyRuntimeInterface should implement Interface
+var _ Interface = &emptyRuntimeInterface{}
 
-func (i *EmptyRuntimeInterface) ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
+func NewEmptyRuntimeInterface() Interface {
+	return &emptyRuntimeInterface{
+		programs: map[common.LocationID]*interpreter.Program{},
+	}
+}
+
+func (i *emptyRuntimeInterface) ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
 	return []ResolvedLocation{
 		{
 			Location:    location,
@@ -148,107 +162,101 @@ func (i *EmptyRuntimeInterface) ResolveLocation(identifiers []Identifier, locati
 	}, nil
 }
 
-func (i *EmptyRuntimeInterface) GetCode(_ Location) ([]byte, error) {
-	return nil, nil
-}
+func (i *emptyRuntimeInterface) SetProgram(location Location, program *interpreter.Program) error {
+	i.programs[location.ID()] = program
 
-func (i *EmptyRuntimeInterface) GetCachedProgram(_ Location) (*ast.Program, error) {
-	return nil, nil
-}
-
-func (i *EmptyRuntimeInterface) CacheProgram(_ Location, _ *ast.Program) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) GetCachedElaboration(Location) (*sema.Elaboration, error) {
+func (i *emptyRuntimeInterface) GetProgram(location Location) (*interpreter.Program, error) {
+	return i.programs[location.ID()], nil
+}
+
+func (i *emptyRuntimeInterface) GetCode(_ Location) ([]byte, error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) CacheElaboration(Location, *sema.Elaboration) error {
-	return nil
-}
-
-func (i *EmptyRuntimeInterface) ValueExists(_, _ []byte) (exists bool, err error) {
+func (i *emptyRuntimeInterface) ValueExists(_, _ []byte) (exists bool, err error) {
 	return false, nil
 }
 
-func (i *EmptyRuntimeInterface) GetValue(_, _ []byte) (value []byte, err error) {
+func (i *emptyRuntimeInterface) GetValue(_, _ []byte) (value []byte, err error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) SetValue(_, _, _ []byte) error {
+func (i *emptyRuntimeInterface) SetValue(_, _, _ []byte) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) CreateAccount(_ Address) (address Address, err error) {
+func (i *emptyRuntimeInterface) CreateAccount(_ Address) (address Address, err error) {
 	return Address{}, nil
 }
 
-func (i *EmptyRuntimeInterface) AddAccountKey(_ Address, _ []byte) error {
+func (i *emptyRuntimeInterface) AddAccountKey(_ Address, _ []byte) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) RemoveAccountKey(_ Address, _ int) (publicKey []byte, err error) {
+func (i *emptyRuntimeInterface) RemoveAccountKey(_ Address, _ int) (publicKey []byte, err error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) UpdateAccountCode(_ Address, _ []byte) error {
+func (i *emptyRuntimeInterface) UpdateAccountCode(_ Address, _ []byte) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) UpdateAccountContractCode(_ Address, _ string, _ []byte) (err error) {
+func (i *emptyRuntimeInterface) UpdateAccountContractCode(_ Address, _ string, _ []byte) (err error) {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) GetAccountContractCode(_ Address, _ string) (code []byte, err error) {
+func (i *emptyRuntimeInterface) GetAccountContractCode(_ Address, _ string) (code []byte, err error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) RemoveAccountContractCode(_ Address, _ string) (err error) {
+func (i *emptyRuntimeInterface) RemoveAccountContractCode(_ Address, _ string) (err error) {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) GetSigningAccounts() ([]Address, error) {
+func (i *emptyRuntimeInterface) GetSigningAccounts() ([]Address, error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) Log(_ string) error {
+func (i *emptyRuntimeInterface) Log(_ string) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) EmitEvent(_ cadence.Event) error {
+func (i *emptyRuntimeInterface) EmitEvent(_ cadence.Event) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) GenerateUUID() (uint64, error) {
+func (i *emptyRuntimeInterface) GenerateUUID() (uint64, error) {
 	return 0, nil
 }
 
-func (i *EmptyRuntimeInterface) GetComputationLimit() uint64 {
+func (i *emptyRuntimeInterface) GetComputationLimit() uint64 {
 	return 0
 }
 
-func (i *EmptyRuntimeInterface) SetComputationUsed(uint64) error {
+func (i *emptyRuntimeInterface) SetComputationUsed(uint64) error {
 	return nil
 }
 
-func (i *EmptyRuntimeInterface) DecodeArgument(_ []byte, _ cadence.Type) (cadence.Value, error) {
+func (i *emptyRuntimeInterface) DecodeArgument(_ []byte, _ cadence.Type) (cadence.Value, error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) GetCurrentBlockHeight() (uint64, error) {
+func (i *emptyRuntimeInterface) GetCurrentBlockHeight() (uint64, error) {
 	return 0, nil
 }
 
-func (i *EmptyRuntimeInterface) GetBlockAtHeight(_ uint64) (block Block, exists bool, err error) {
+func (i *emptyRuntimeInterface) GetBlockAtHeight(_ uint64) (block Block, exists bool, err error) {
 	return
 }
 
-func (i *EmptyRuntimeInterface) UnsafeRandom() (uint64, error) {
+func (i *emptyRuntimeInterface) UnsafeRandom() (uint64, error) {
 	return 0, nil
 }
 
-func (i *EmptyRuntimeInterface) VerifySignature(
+func (i *emptyRuntimeInterface) VerifySignature(
 	_ []byte,
 	_ string,
 	_ []byte,
@@ -259,17 +267,17 @@ func (i *EmptyRuntimeInterface) VerifySignature(
 	return false, nil
 }
 
-func (i *EmptyRuntimeInterface) Hash(
+func (i *emptyRuntimeInterface) Hash(
 	_ []byte,
 	_ string,
 ) ([]byte, error) {
 	return nil, nil
 }
 
-func (i EmptyRuntimeInterface) GetStorageUsed(_ Address) (uint64, error) {
+func (i emptyRuntimeInterface) GetStorageUsed(_ Address) (uint64, error) {
 	return 0, nil
 }
 
-func (i EmptyRuntimeInterface) GetStorageCapacity(_ Address) (uint64, error) {
+func (i emptyRuntimeInterface) GetStorageCapacity(_ Address) (uint64, error) {
 	return 0, nil
 }

--- a/runtime/interpreter/import.go
+++ b/runtime/interpreter/import.go
@@ -18,10 +18,6 @@
 
 package interpreter
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-)
-
 // Import
 
 type Import interface {
@@ -37,10 +33,10 @@ type VirtualImport struct {
 
 func (VirtualImport) isImport() {}
 
-// ProgramImport
+// InterpreterImport
 
-type ProgramImport struct {
-	Program *ast.Program
+type InterpreterImport struct {
+	Interpreter *Interpreter
 }
 
-func (ProgramImport) isImport() {}
+func (InterpreterImport) isImport() {}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4459,20 +4459,35 @@ func (interpreter *Interpreter) getElaboration(location common.Location) *sema.E
 }
 
 func (interpreter *Interpreter) getCompositeType(location common.Location, qualifiedIdentifier string) *sema.CompositeType {
-	elaboration := interpreter.getElaboration(location)
 	typeID := location.TypeID(qualifiedIdentifier)
+
+	elaboration := interpreter.getElaboration(location)
+	if elaboration == nil {
+		panic(TypeLoadingError{
+			TypeID: typeID,
+		})
+	}
+
 	ty := elaboration.CompositeTypes[typeID]
 	if ty == nil {
 		panic(TypeLoadingError{
 			TypeID: typeID,
 		})
 	}
+
 	return ty
 }
 
 func (interpreter *Interpreter) getInterfaceType(location common.Location, qualifiedIdentifier string) *sema.InterfaceType {
-	elaboration := interpreter.getElaboration(location)
 	typeID := location.TypeID(qualifiedIdentifier)
+
+	elaboration := interpreter.getElaboration(location)
+	if elaboration == nil {
+		panic(TypeLoadingError{
+			TypeID: typeID,
+		})
+	}
+
 	ty := elaboration.InterfaceTypes[typeID]
 	if ty == nil {
 		panic(TypeLoadingError{

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -212,13 +212,13 @@ func (c TypeCodes) Merge(codes TypeCodes) {
 }
 
 type Interpreter struct {
-	Checker                        *sema.Checker
+	Program                        *Program
+	Location                       common.Location
 	PredeclaredValues              []ValueDeclaration
 	effectivePredeclaredValues     map[string]ValueDeclaration
 	activations                    *activations.Activations
 	Globals                        map[string]*Variable
 	allInterpreters                map[common.LocationID]*Interpreter
-	allCheckers                    map[common.LocationID]*sema.Checker
 	typeCodes                      TypeCodes
 	Transactions                   []*HostFunctionValue
 	onEventEmitted                 OnEventEmittedFunc
@@ -233,6 +233,7 @@ type Interpreter struct {
 	contractValueHandler           ContractValueHandlerFunc
 	importLocationHandler          ImportLocationHandlerFunc
 	uuidHandler                    UUIDHandlerFunc
+	interpreted                    bool
 }
 
 type Option func(*Interpreter) error
@@ -388,16 +389,6 @@ func WithAllInterpreters(allInterpreters map[common.LocationID]*Interpreter) Opt
 	}
 }
 
-// WithAllCheckers returns an interpreter option which sets
-// the given map of checkers as the map of all checkers.
-//
-func WithAllCheckers(allCheckers map[common.LocationID]*sema.Checker) Option {
-	return func(interpreter *Interpreter) error {
-		interpreter.SetAllCheckers(allCheckers)
-		return nil
-	}
-}
-
 // withTypeCodes returns an interpreter option which sets the type codes.
 //
 func withTypeCodes(typeCodes TypeCodes) Option {
@@ -407,9 +398,11 @@ func withTypeCodes(typeCodes TypeCodes) Option {
 	}
 }
 
-func NewInterpreter(checker *sema.Checker, options ...Option) (*Interpreter, error) {
+func NewInterpreter(program *Program, location common.Location, options ...Option) (*Interpreter, error) {
+
 	interpreter := &Interpreter{
-		Checker:                    checker,
+		Program:                    program,
+		Location:                   location,
 		activations:                &activations.Activations{},
 		Globals:                    map[string]*Variable{},
 		effectivePredeclaredValues: map[string]ValueDeclaration{},
@@ -417,7 +410,6 @@ func NewInterpreter(checker *sema.Checker, options ...Option) (*Interpreter, err
 
 	defaultOptions := []Option{
 		WithAllInterpreters(map[common.LocationID]*Interpreter{}),
-		WithAllCheckers(map[common.LocationID]*sema.Checker{}),
 		withTypeCodes(TypeCodes{
 			CompositeCodes:       map[sema.TypeID]CompositeTypeCode{},
 			InterfaceCodes:       map[sema.TypeID]WrapperCode{},
@@ -516,17 +508,7 @@ func (interpreter *Interpreter) SetAllInterpreters(allInterpreters map[common.Lo
 	interpreter.allInterpreters = allInterpreters
 
 	// Register self
-	interpreter.allInterpreters[interpreter.Checker.Location.ID()] = interpreter
-}
-
-// SetAllCheckers sets the given map of checkers as the map of all checkers.
-//
-func (interpreter *Interpreter) SetAllCheckers(allCheckers map[common.LocationID]*sema.Checker) {
-	interpreter.allCheckers = allCheckers
-
-	// Register self
-	checker := interpreter.Checker
-	interpreter.allCheckers[checker.Location.ID()] = checker
+	interpreter.allInterpreters[interpreter.Location.ID()] = interpreter
 }
 
 // setTypeCodes sets the type codes.
@@ -539,7 +521,7 @@ func (interpreter *Interpreter) setTypeCodes(typeCodes TypeCodes) {
 //
 func (interpreter *Interpreter) locationRange(hasPosition ast.HasPosition) LocationRange {
 	return LocationRange{
-		Location: interpreter.Checker.Location,
+		Location: interpreter.Location,
 		Range:    ast.NewRangeFromPositioned(hasPosition),
 	}
 }
@@ -565,13 +547,18 @@ func (interpreter *Interpreter) setVariable(name string, variable *Variable) {
 }
 
 func (interpreter *Interpreter) Interpret() (err error) {
+	if interpreter.interpreted {
+		return
+	}
+
 	// recover internal panics and return them as an error
 	defer recoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
-	// declare all declarations and then run all statements
 	interpreter.runAllStatements(interpreter.interpret())
+
+	interpreter.interpreted = true
 
 	return nil
 }
@@ -642,7 +629,7 @@ func (interpreter *Interpreter) runAllStatements(t Trampoline) interface{} {
 
 		panic(Error{
 			Err:      internalErr,
-			Location: statement.Interpreter.Checker.Location,
+			Location: statement.Interpreter.Location,
 		})
 	})
 
@@ -683,11 +670,11 @@ func getStatement(t Trampoline) *StatementTrampoline {
 // interpret returns a Trampoline that is done when all top-level declarations
 // have been declared and evaluated.
 func (interpreter *Interpreter) interpret() Trampoline {
-	return interpreter.Checker.Program.Accept(interpreter).(Trampoline)
+	return interpreter.Program.Program.Accept(interpreter).(Trampoline)
 }
 
 func (interpreter *Interpreter) prepareInterpretation() {
-	program := interpreter.Checker.Program
+	program := interpreter.Program.Program
 
 	// Pre-declare empty variables for all interfaces, composites, and function declarations
 	for _, declaration := range program.InterfaceDeclarations() {
@@ -769,7 +756,7 @@ func (interpreter *Interpreter) prepareInvokeVariable(
 		}
 	}
 
-	ty := interpreter.Checker.Elaboration.GlobalValues[functionName].Type
+	ty := interpreter.Program.Elaboration.GlobalValues[functionName].Type
 
 	// function must be invokable
 	invokableType, ok := ty.(sema.InvokableType)
@@ -795,7 +782,7 @@ func (interpreter *Interpreter) prepareInvokeTransaction(
 
 	functionValue := interpreter.Transactions[index]
 
-	transactionType := interpreter.Checker.Elaboration.TransactionTypes[index]
+	transactionType := interpreter.Program.Elaboration.TransactionTypes[index]
 	functionType := transactionType.EntryPointFunctionType()
 
 	return interpreter.prepareInvoke(functionValue, functionType, arguments)
@@ -913,7 +900,7 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 
 	identifier := declaration.Identifier.Identifier
 
-	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]
+	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[declaration]
 
 	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
 	variable := interpreter.findOrDeclareVariable(identifier)
@@ -950,7 +937,7 @@ func (interpreter *Interpreter) functionDeclarationValue(
 
 	if declaration.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
 
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
 		beforeStatements = postConditionsRewrite.BeforeStatements
@@ -1129,8 +1116,8 @@ func (interpreter *Interpreter) VisitReturnStatement(statement *ast.ReturnStatem
 		Map(func(result interface{}) interface{} {
 			value := result.(Value)
 
-			valueType := interpreter.Checker.Elaboration.ReturnStatementValueTypes[statement]
-			returnType := interpreter.Checker.Elaboration.ReturnStatementReturnTypes[statement]
+			valueType := interpreter.Program.Elaboration.ReturnStatementValueTypes[statement]
+			returnType := interpreter.Program.Elaboration.ReturnStatementReturnTypes[statement]
 
 			// NOTE: copy on return
 			value = interpreter.copyAndConvert(value, valueType, returnType)
@@ -1187,8 +1174,8 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 
 			if someValue, ok := result.(*SomeValue); ok {
 
-				targetType := interpreter.Checker.Elaboration.VariableDeclarationTargetTypes[declaration]
-				valueType := interpreter.Checker.Elaboration.VariableDeclarationValueTypes[declaration]
+				targetType := interpreter.Program.Elaboration.VariableDeclarationTargetTypes[declaration]
+				valueType := interpreter.Program.Elaboration.VariableDeclarationValueTypes[declaration]
 				unwrappedValueCopy := interpreter.copyAndConvert(someValue.Value, valueType, targetType)
 
 				interpreter.activations.PushCurrent()
@@ -1381,9 +1368,9 @@ func (interpreter *Interpreter) visitPotentialStorageRemoval(expression ast.Expr
 // then declares the variable with the name bound to the value
 func (interpreter *Interpreter) VisitVariableDeclaration(declaration *ast.VariableDeclaration) ast.Repr {
 
-	targetType := interpreter.Checker.Elaboration.VariableDeclarationTargetTypes[declaration]
-	valueType := interpreter.Checker.Elaboration.VariableDeclarationValueTypes[declaration]
-	secondValueType := interpreter.Checker.Elaboration.VariableDeclarationSecondValueTypes[declaration]
+	targetType := interpreter.Program.Elaboration.VariableDeclarationTargetTypes[declaration]
+	valueType := interpreter.Program.Elaboration.VariableDeclarationValueTypes[declaration]
+	secondValueType := interpreter.Program.Elaboration.VariableDeclarationSecondValueTypes[declaration]
 
 	return interpreter.visitPotentialStorageRemoval(declaration.Value).
 		FlatMap(func(result interface{}) Trampoline {
@@ -1413,7 +1400,7 @@ func (interpreter *Interpreter) VisitVariableDeclaration(declaration *ast.Variab
 
 func (interpreter *Interpreter) movingStorageIndexExpression(expression ast.Expression) *ast.IndexExpression {
 	indexExpression, ok := expression.(*ast.IndexExpression)
-	if !ok || !interpreter.Checker.Elaboration.IsResourceMovingStorageIndexExpression[indexExpression] {
+	if !ok || !interpreter.Program.Elaboration.IsResourceMovingStorageIndexExpression[indexExpression] {
 		return nil
 	}
 
@@ -1422,7 +1409,7 @@ func (interpreter *Interpreter) movingStorageIndexExpression(expression ast.Expr
 
 func (interpreter *Interpreter) declareValue(declaration ValueDeclaration) *Variable {
 
-	if !declaration.ValueDeclarationAvailable(interpreter.Checker.Location) {
+	if !declaration.ValueDeclarationAvailable(interpreter.Location) {
 		return nil
 	}
 
@@ -1442,8 +1429,8 @@ func (interpreter *Interpreter) declareVariable(identifier string, value Value) 
 }
 
 func (interpreter *Interpreter) VisitAssignmentStatement(assignment *ast.AssignmentStatement) ast.Repr {
-	targetType := interpreter.Checker.Elaboration.AssignmentStatementTargetTypes[assignment]
-	valueType := interpreter.Checker.Elaboration.AssignmentStatementValueTypes[assignment]
+	targetType := interpreter.Program.Elaboration.AssignmentStatementTargetTypes[assignment]
+	valueType := interpreter.Program.Elaboration.AssignmentStatementValueTypes[assignment]
 
 	target := assignment.Target
 	value := assignment.Value
@@ -1498,8 +1485,8 @@ func (interpreter *Interpreter) visitAssignment(
 
 func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) ast.Repr {
 
-	leftType := interpreter.Checker.Elaboration.SwapStatementLeftTypes[swap]
-	rightType := interpreter.Checker.Elaboration.SwapStatementRightTypes[swap]
+	leftType := interpreter.Program.Elaboration.SwapStatementLeftTypes[swap]
+	rightType := interpreter.Program.Elaboration.SwapStatementRightTypes[swap]
 
 	// Evaluate the left expression
 	return interpreter.assignmentGetterSetter(swap.Left).
@@ -1841,8 +1828,8 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 						Map(func(result interface{}) interface{} {
 							value := result.(Value)
 
-							rightType := interpreter.Checker.Elaboration.BinaryExpressionRightTypes[expression]
-							resultType := interpreter.Checker.Elaboration.BinaryExpressionResultTypes[expression]
+							rightType := interpreter.Program.Elaboration.BinaryExpressionRightTypes[expression]
+							resultType := interpreter.Program.Elaboration.BinaryExpressionResultTypes[expression]
 
 							// NOTE: important to convert both any and optional
 							return interpreter.convertAndBox(value, rightType, resultType)
@@ -1979,8 +1966,8 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 		FlatMap(func(result interface{}) Trampoline {
 			values := result.(*ArrayValue)
 
-			argumentTypes := interpreter.Checker.Elaboration.ArrayExpressionArgumentTypes[expression]
-			elementType := interpreter.Checker.Elaboration.ArrayExpressionElementType[expression]
+			argumentTypes := interpreter.Program.Elaboration.ArrayExpressionArgumentTypes[expression]
+			elementType := interpreter.Program.Elaboration.ArrayExpressionElementType[expression]
 
 			copies := make([]Value, len(values.Values))
 			for i, argument := range values.Values {
@@ -1996,8 +1983,8 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 	return interpreter.visitEntries(expression.Entries).
 		FlatMap(func(result interface{}) Trampoline {
 
-			entryTypes := interpreter.Checker.Elaboration.DictionaryExpressionEntryTypes[expression]
-			dictionaryType := interpreter.Checker.Elaboration.DictionaryExpressionType[expression]
+			entryTypes := interpreter.Program.Elaboration.DictionaryExpressionEntryTypes[expression]
+			dictionaryType := interpreter.Program.Elaboration.DictionaryExpressionType[expression]
 
 			newDictionary := NewDictionaryValueUnownedNonCopying()
 			for i, dictionaryEntryValues := range result.([]DictionaryEntryValues) {
@@ -2128,11 +2115,11 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 					arguments := result.(*ArrayValue).Values
 
 					typeParameterTypes :=
-						interpreter.Checker.Elaboration.InvocationExpressionTypeArguments[invocationExpression]
+						interpreter.Program.Elaboration.InvocationExpressionTypeArguments[invocationExpression]
 					argumentTypes :=
-						interpreter.Checker.Elaboration.InvocationExpressionArgumentTypes[invocationExpression]
+						interpreter.Program.Elaboration.InvocationExpressionArgumentTypes[invocationExpression]
 					parameterTypes :=
-						interpreter.Checker.Elaboration.InvocationExpressionParameterTypes[invocationExpression]
+						interpreter.Program.Elaboration.InvocationExpressionParameterTypes[invocationExpression]
 
 					invocation := interpreter.functionValueInvocationTrampoline(
 						function,
@@ -2212,7 +2199,7 @@ func (interpreter *Interpreter) functionValueInvocationTrampoline(
 	// TODO: optimize: only potentially used by host-functions
 
 	locationRange := LocationRange{
-		Location: interpreter.Checker.Location,
+		Location: interpreter.Location,
 		Range:    invocationRange,
 	}
 
@@ -2349,7 +2336,7 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 	// lexical scope: variables in functions are bound to what is visible at declaration time
 	lexicalScope := interpreter.activations.CurrentOrNew()
 
-	functionType := interpreter.Checker.Elaboration.FunctionExpressionFunctionType[expression]
+	functionType := interpreter.Program.Elaboration.FunctionExpressionFunctionType[expression]
 
 	var preConditions ast.Conditions
 	if expression.FunctionBlock.PreConditions != nil {
@@ -2361,7 +2348,7 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 
 	if expression.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[expression.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[expression.FunctionBlock.PostConditions]
 
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
 		beforeStatements = postConditionsRewrite.BeforeStatements
@@ -2485,7 +2472,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 		}
 	})()
 
-	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
 
 	var initializerFunction FunctionValue
 	if declaration.CompositeKind == common.CompositeKindEvent {
@@ -2566,7 +2553,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 		CompositeFunctions: functions,
 	}
 
-	location := interpreter.Checker.Location
+	location := interpreter.Location
 
 	qualifiedIdentifier := compositeType.QualifiedIdentifier()
 
@@ -2682,10 +2669,10 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 	lexicalScope = lexicalScope.Insert(identifier, variable)
 
-	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
 	qualifiedIdentifier := compositeType.QualifiedIdentifier()
 
-	location := interpreter.Checker.Location
+	location := interpreter.Location
 
 	intType := &sema.IntType{}
 
@@ -2758,7 +2745,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 	}
 
 	initializer = initializers[0]
-	functionType := interpreter.Checker.Elaboration.SpecialFunctionTypes[initializer].FunctionType
+	functionType := interpreter.Program.Elaboration.SpecialFunctionTypes[initializer].FunctionType
 
 	parameterList := initializer.FunctionDeclaration.ParameterList
 
@@ -2775,7 +2762,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 	postConditions := initializer.FunctionDeclaration.FunctionBlock.PostConditions
 	if postConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[postConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[postConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -2818,7 +2805,7 @@ func (interpreter *Interpreter) compositeDestructorFunction(
 	postConditions := destructor.FunctionDeclaration.FunctionBlock.PostConditions
 	if postConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[postConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[postConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -2863,7 +2850,7 @@ func (interpreter *Interpreter) functionWrappers(
 
 	for _, functionDeclaration := range members.Functions() {
 
-		functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+		functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
 
 		name := functionDeclaration.Identifier.Identifier
 		functionWrapper := interpreter.functionConditionsWrapper(
@@ -2885,7 +2872,7 @@ func (interpreter *Interpreter) compositeFunction(
 	lexicalScope activations.Activation,
 ) InterpretedFunctionValue {
 
-	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
 
 	var preConditions ast.Conditions
 
@@ -2899,7 +2886,7 @@ func (interpreter *Interpreter) compositeFunction(
 	if functionDeclaration.FunctionBlock.PostConditions != nil {
 
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[functionDeclaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[functionDeclaration.FunctionBlock.PostConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		postConditions = postConditionsRewrite.RewrittenPostConditions
@@ -3101,7 +3088,7 @@ func (interpreter *Interpreter) declareInterface(
 		}
 	})()
 
-	interfaceType := interpreter.Checker.Elaboration.InterfaceDeclarationTypes[declaration]
+	interfaceType := interpreter.Program.Elaboration.InterfaceDeclarationTypes[declaration]
 	typeID := interfaceType.ID()
 
 	initializerFunctionWrapper := interpreter.initializerFunctionWrapper(declaration.Members, lexicalScope)
@@ -3135,7 +3122,7 @@ func (interpreter *Interpreter) declareTypeRequirement(
 		}
 	})()
 
-	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
 	typeID := compositeType.ID()
 
 	initializerFunctionWrapper := interpreter.initializerFunctionWrapper(declaration.Members, lexicalScope)
@@ -3211,7 +3198,7 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 	if declaration.FunctionBlock.PostConditions != nil {
 
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -3274,49 +3261,72 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 func (interpreter *Interpreter) ensureLoaded(
 	location common.Location,
 	loadLocation func() Import,
-) (subInterpreter *Interpreter) {
+) *Interpreter {
 
 	locationID := location.ID()
 
 	// If a sub-interpreter already exists, return it
 
-	subInterpreter = interpreter.allInterpreters[locationID]
+	subInterpreter := interpreter.allInterpreters[locationID]
 	if subInterpreter != nil {
 		return subInterpreter
 	}
 
-	// Create a sub-checker and sub-interpreter
-
-	var importedChecker *sema.Checker
+	// Load the import
 
 	var virtualImport *VirtualImport
 
-	var checkerErr *sema.CheckerError
-	importedChecker, checkerErr = interpreter.Checker.EnsureLoaded(location, func() *ast.Program {
-		imported := loadLocation()
+	imported := loadLocation()
 
-		switch imported := imported.(type) {
-		case VirtualImport:
-			virtualImport = &imported
-			return nil
-
-		case ProgramImport:
-			return imported.Program
-
-		default:
-			panic(errors.NewUnreachableError())
+	switch imported := imported.(type) {
+	case InterpreterImport:
+		subInterpreter = imported.Interpreter
+		err := subInterpreter.Interpret()
+		if err != nil {
+			panic(err)
 		}
-	})
-	if importedChecker == nil {
-		panic("missing checker")
-	}
-	if checkerErr != nil {
-		panic(checkerErr)
-	}
 
-	var err error
-	subInterpreter, err = NewInterpreter(
-		importedChecker,
+		return subInterpreter
+
+	case VirtualImport:
+		virtualImport = &imported
+
+		var err error
+		// NOTE: virtual import, no program
+		subInterpreter, err = interpreter.NewSubInterpreter(nil, location)
+		if err != nil {
+			panic(err)
+		}
+
+		// If the imported location is a virtual import,
+		// prepare the interpreter
+
+		for name, value := range virtualImport.Globals {
+			variable := NewVariable(value, 0)
+			subInterpreter.setVariable(name, variable)
+			subInterpreter.Globals[name] = variable
+		}
+
+		subInterpreter.typeCodes.
+			Merge(virtualImport.TypeCodes)
+
+		return subInterpreter
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (interpreter *Interpreter) NewSubInterpreter(
+	program *Program,
+	location common.Location,
+	options ...Option,
+) (
+	*Interpreter,
+	error,
+) {
+
+	defaultOptions := []Option{
 		WithPredeclaredValues(interpreter.PredeclaredValues),
 		WithOnEventEmittedHandler(interpreter.onEventEmitted),
 		WithOnStatementHandler(interpreter.onStatement),
@@ -3331,34 +3341,17 @@ func (interpreter *Interpreter) ensureLoaded(
 		WithImportLocationHandler(interpreter.importLocationHandler),
 		WithUUIDHandler(interpreter.uuidHandler),
 		WithAllInterpreters(interpreter.allInterpreters),
-		WithAllCheckers(interpreter.allCheckers),
 		withTypeCodes(interpreter.typeCodes),
+	}
+
+	return NewInterpreter(
+		program,
+		location,
+		append(
+			defaultOptions,
+			options...,
+		)...,
 	)
-	if err != nil {
-		panic(err)
-	}
-
-	if virtualImport != nil {
-		// If the imported location is a virtual import,
-		// prepare the interpreter
-
-		for name, value := range virtualImport.Globals {
-			variable := NewVariable(value, 0)
-			subInterpreter.setVariable(name, variable)
-			subInterpreter.Globals[name] = variable
-		}
-
-		subInterpreter.typeCodes.
-			Merge(virtualImport.TypeCodes)
-
-	} else {
-		// If the imported location is an interpreted program,
-		// evaluate its top-level declarations
-
-		subInterpreter.runAllStatements(subInterpreter.interpret())
-	}
-
-	return subInterpreter
 }
 
 func (interpreter *Interpreter) VisitPragmaDeclaration(_ *ast.PragmaDeclaration) ast.Repr {
@@ -3367,7 +3360,7 @@ func (interpreter *Interpreter) VisitPragmaDeclaration(_ *ast.PragmaDeclaration)
 
 func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDeclaration) ast.Repr {
 
-	resolvedLocations := interpreter.Checker.Elaboration.ImportDeclarationsResolvedLocations[declaration]
+	resolvedLocations := interpreter.Program.Elaboration.ImportDeclarationsResolvedLocations[declaration]
 
 	for _, resolvedLocation := range resolvedLocations {
 		interpreter.importResolvedLocation(resolvedLocation)
@@ -3404,8 +3397,8 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 	for name, variable := range variables {
 
 		// don't import predeclared values
-		if subInterpreter.Checker != nil {
-			if _, ok := subInterpreter.Checker.Elaboration.EffectivePredeclaredValues[name]; ok {
+		if subInterpreter.Program != nil {
+			if _, ok := subInterpreter.Program.Elaboration.EffectivePredeclaredValues[name]; ok {
 				continue
 			}
 		}
@@ -3428,7 +3421,7 @@ func (interpreter *Interpreter) VisitTransactionDeclaration(declaration *ast.Tra
 }
 
 func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.TransactionDeclaration) {
-	transactionType := interpreter.Checker.Elaboration.TransactionDeclarationTypes[declaration]
+	transactionType := interpreter.Program.Elaboration.TransactionDeclarationTypes[declaration]
 
 	lexicalScope := interpreter.activations.CurrentOrNew()
 
@@ -3447,10 +3440,10 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 	}
 
 	postConditionsRewrite :=
-		interpreter.Checker.Elaboration.PostConditionsRewrite[declaration.PostConditions]
+		interpreter.Program.Elaboration.PostConditionsRewrite[declaration.PostConditions]
 
 	self := &CompositeValue{
-		Location: interpreter.Checker.Location,
+		Location: interpreter.Location,
 		Fields:   map[string]Value{},
 		modified: true,
 	}
@@ -3534,7 +3527,7 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 		FlatMap(func(result interface{}) Trampoline {
 			event := result.(*CompositeValue)
 
-			eventType := interpreter.Checker.Elaboration.EmitStatementEventTypes[statement]
+			eventType := interpreter.Program.Elaboration.EmitStatementEventTypes[statement]
 
 			if interpreter.onEventEmitted == nil {
 				panic(EventEmissionUnavailableError{
@@ -3557,7 +3550,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		Map(func(result interface{}) interface{} {
 			value := result.(Value)
 
-			expectedType := interpreter.Checker.Elaboration.CastingTargetTypes[expression]
+			expectedType := interpreter.Program.Elaboration.CastingTargetTypes[expression]
 
 			switch expression.Operation {
 			case ast.OperationFailableCast, ast.OperationForceCast:
@@ -3589,7 +3582,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 				}
 
 			case ast.OperationCast:
-				staticValueType := interpreter.Checker.Elaboration.CastingStaticValueTypes[expression]
+				staticValueType := interpreter.Program.Elaboration.CastingStaticValueTypes[expression]
 				return interpreter.convertAndBox(value, staticValueType, expectedType)
 
 			default:
@@ -4457,11 +4450,12 @@ func (interpreter *Interpreter) getElaboration(location common.Location) *sema.E
 
 	locationID := location.ID()
 
-	checker := inter.allCheckers[locationID]
-	if checker == nil {
+	subInterpreter := inter.allInterpreters[locationID]
+	if subInterpreter == nil || subInterpreter.Program == nil {
 		return nil
 	}
-	return checker.Elaboration
+
+	return subInterpreter.Program.Elaboration
 }
 
 func (interpreter *Interpreter) getCompositeType(location common.Location, qualifiedIdentifier string) *sema.CompositeType {

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -36,7 +36,9 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	checker, err := sema.NewChecker(nil, utils.TestLocation)
 	require.NoError(t, err)
 
-	inter, err := NewInterpreter(checker)
+	program := ProgramFromChecker(checker)
+
+	inter, err := NewInterpreter(program, checker.Location)
 	require.NoError(t, err)
 
 	t.Run("Bool to Bool?", func(t *testing.T) {
@@ -111,7 +113,9 @@ func TestInterpreterBoxing(t *testing.T) {
 	checker, err := sema.NewChecker(nil, utils.TestLocation)
 	require.NoError(t, err)
 
-	inter, err := NewInterpreter(checker)
+	program := ProgramFromChecker(checker)
+
+	inter, err := NewInterpreter(program, checker.Location)
 	require.NoError(t, err)
 
 	for _, anyType := range []sema.Type{

--- a/runtime/interpreter/program.go
+++ b/runtime/interpreter/program.go
@@ -1,0 +1,36 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+type Program struct {
+	Program     *ast.Program
+	Elaboration *sema.Elaboration
+}
+
+func ProgramFromChecker(checker *sema.Checker) *Program {
+	return &Program{
+		Program:     checker.Program,
+		Elaboration: checker.Elaboration,
+	}
+}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5565,7 +5565,7 @@ func (v *CompositeValue) getInterpreter(interpreter *Interpreter) *Interpreter {
 	// Get the correct interpreter. The program code might need to be loaded.
 	// NOTE: standard library values have no location
 
-	if v.Location == nil || common.LocationsMatch(interpreter.Checker.Location, v.Location) {
+	if v.Location == nil || common.LocationsMatch(interpreter.Location, v.Location) {
 		return interpreter
 	}
 

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -140,7 +140,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 	var importedProgramError *sema.ImportedProgramError
 	utils.RequireErrorAs(t, errs[0], &importedProgramError)
 	//require.Equal(t, location3, importedProgramError.ImportLocation)
-	importedErrs := checker.ExpectCheckerErrors(t, importedProgramError.CheckerError, 1)
+	importedErrs := checker.ExpectCheckerErrors(t, importedProgramError.Err, 1)
 	require.IsType(t, &sema.NotDeclaredError{}, importedErrs[0])
 
 	// The illegal use of 'foo' in 0x1 should be reported

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
@@ -101,6 +102,8 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 
 	runtime := NewInterpreterRuntime()
 
+	programs := map[common.LocationID]*interpreter.Program{}
+
 	runtimeInterface := &testRuntimeInterface{
 		getAccountContractCode: func(address Address, name string) (bytes []byte, err error) {
 			switch address {
@@ -113,6 +116,13 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 			default:
 				return nil, fmt.Errorf("unknown address: %s", address.ShortHexWithPrefix())
 			}
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 	}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -181,7 +181,7 @@ func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (cade
 		return nil, newError(err, context)
 	}
 
-	functionEntryPointType, err := checker.FunctionEntryPointType()
+	functionEntryPointType, err := checker.Elaboration.FunctionEntryPointType()
 	if err != nil {
 		return nil, newError(err, context)
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -60,7 +60,7 @@ type Runtime interface {
 	// ParseAndCheckProgram parses and checks the given code without executing the program.
 	//
 	// This function returns an error if the program contains any syntax or semantic errors.
-	ParseAndCheckProgram(source []byte, context Context) (*sema.Checker, error)
+	ParseAndCheckProgram(source []byte, context Context) (*interpreter.Program, error)
 
 	// SetCoverageReport activates reporting coverage in the given report.
 	// Passing nil disables coverage reporting (default).
@@ -142,14 +142,17 @@ func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (cade
 
 	runtimeStorage := newRuntimeStorage(context.Interface)
 
-	functions := r.standardLibraryFunctions(context, runtimeStorage)
+	var checkerOptions []sema.Option
+	var interpreterOptions []interpreter.Option
 
-	checker, err := r.parseAndCheckProgram(script.Source, context, functions, nil, false)
+	functions := r.standardLibraryFunctions(context, runtimeStorage, interpreterOptions, checkerOptions)
+
+	program, err := r.parseAndCheckProgram(script.Source, context, functions, checkerOptions, false)
 	if err != nil {
 		return nil, newError(err, context)
 	}
 
-	functionEntryPointType, err := checker.Elaboration.FunctionEntryPointType()
+	functionEntryPointType, err := program.Elaboration.FunctionEntryPointType()
 	if err != nil {
 		return nil, newError(err, context)
 	}
@@ -181,11 +184,12 @@ func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (cade
 	)
 
 	value, inter, err := r.interpret(
+		program,
 		context,
 		runtimeStorage,
-		checker,
 		functions,
-		nil,
+		interpreterOptions,
+		checkerOptions,
 		interpret,
 	)
 	if err != nil {
@@ -223,11 +227,12 @@ func scriptExecutionFunction(
 }
 
 func (r *interpreterRuntime) interpret(
+	program *interpreter.Program,
 	context Context,
 	runtimeStorage *runtimeStorage,
-	checker *sema.Checker,
 	functions stdlib.StandardLibraryFunctions,
-	options []interpreter.Option,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 	f interpretFunc,
 ) (
 	exportableValue,
@@ -235,7 +240,14 @@ func (r *interpreterRuntime) interpret(
 	error,
 ) {
 
-	inter, err := r.newInterpreter(checker, context, functions, runtimeStorage, options)
+	inter, err := r.newInterpreter(
+		program,
+		context,
+		functions,
+		runtimeStorage,
+		interpreterOptions,
+		checkerOptions,
+	)
 	if err != nil {
 		return exportableValue{}, nil, err
 	}
@@ -272,6 +284,8 @@ func (r *interpreterRuntime) newAuthAccountValue(
 	addressValue interpreter.AddressValue,
 	context Context,
 	runtimeStorage *runtimeStorage,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 ) interpreter.AuthAccountValue {
 	return interpreter.NewAuthAccountValue(
 		addressValue,
@@ -283,6 +297,8 @@ func (r *interpreterRuntime) newAuthAccountValue(
 			addressValue,
 			context,
 			runtimeStorage,
+			interpreterOptions,
+			checkerOptions,
 		),
 	)
 }
@@ -292,14 +308,17 @@ func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) 
 
 	runtimeStorage := newRuntimeStorage(context.Interface)
 
-	functions := r.standardLibraryFunctions(context, runtimeStorage)
+	var interpreterOptions []interpreter.Option
+	var checkerOptions []sema.Option
 
-	checker, err := r.parseAndCheckProgram(script.Source, context, functions, nil, false)
+	functions := r.standardLibraryFunctions(context, runtimeStorage, interpreterOptions, checkerOptions)
+
+	program, err := r.parseAndCheckProgram(script.Source, context, functions, checkerOptions, false)
 	if err != nil {
 		return newError(err, context)
 	}
 
-	transactions := checker.Elaboration.TransactionTypes
+	transactions := program.Elaboration.TransactionTypes
 	transactionCount := len(transactions)
 	if transactionCount != 1 {
 		err = InvalidTransactionCountError{
@@ -349,15 +368,18 @@ func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) 
 			interpreter.NewAddressValue(address),
 			context,
 			runtimeStorage,
+			interpreterOptions,
+			checkerOptions,
 		)
 	}
 
 	_, inter, err := r.interpret(
+		program,
 		context,
 		runtimeStorage,
-		checker,
 		functions,
-		nil,
+		interpreterOptions,
+		checkerOptions,
 		r.transactionExecutionFunction(
 			transactionType.Parameters,
 			script.Arguments,
@@ -479,18 +501,22 @@ func validateArgumentParams(
 }
 
 // ParseAndCheckProgram parses the given script and runs type check.
-func (r *interpreterRuntime) ParseAndCheckProgram(code []byte, context Context) (*sema.Checker, error) {
+func (r *interpreterRuntime) ParseAndCheckProgram(code []byte, context Context) (*interpreter.Program, error) {
 	context.InitializeCodesAndPrograms()
 
 	runtimeStorage := newRuntimeStorage(context.Interface)
-	functions := r.standardLibraryFunctions(context, runtimeStorage)
 
-	checker, err := r.parseAndCheckProgram(code, context, functions, nil, true)
+	var interpreterOptions []interpreter.Option
+	var checkerOptions []sema.Option
+
+	functions := r.standardLibraryFunctions(context, runtimeStorage, interpreterOptions, checkerOptions)
+
+	program, err := r.parseAndCheckProgram(code, context, functions, checkerOptions, true)
 	if err != nil {
 		return nil, newError(err, context)
 	}
 
-	return checker, nil
+	return program, nil
 }
 
 func (r *interpreterRuntime) parseAndCheckProgram(
@@ -499,11 +525,35 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 	functions stdlib.StandardLibraryFunctions,
 	options []sema.Option,
 	useCache bool,
-) (*sema.Checker, error) {
+) (
+	*interpreter.Program,
+	error,
+) {
 
-	var program *ast.Program
-	var checker *sema.Checker
-	var err error
+	parsed, err := r.parseCode(code, context, useCache)
+	if err != nil {
+		return nil, err
+	}
+
+	elaboration, err := r.check(parsed, context, functions, options, useCache)
+	if err != nil {
+		return nil, err
+	}
+
+	return &interpreter.Program{
+		Program:     parsed,
+		Elaboration: elaboration,
+	}, nil
+}
+
+func (r *interpreterRuntime) parseCode(
+	code []byte,
+	context Context,
+	useCache bool,
+) (
+	program *ast.Program,
+	err error,
+) {
 
 	wrapError := func(err error) error {
 		return &ParsingCheckingError{
@@ -521,33 +571,99 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 		if err != nil {
 			return nil, wrapError(err)
 		}
+		if program != nil {
+			return program, nil
+		}
 	}
 
-	if program == nil {
-		program, err = r.parse(code, context)
-		if err != nil {
-			return nil, wrapError(err)
-		}
-		context.SetProgram(context.Location, program)
+	reportMetric(
+		func() {
+			program, err = parser2.ParseProgram(string(code))
+		},
+		context.Interface,
+		func(metrics Metrics, duration time.Duration) {
+			metrics.ProgramParsed(context.Location, duration)
+		},
+	)
+	if err != nil {
+		return nil, wrapError(err)
+	}
 
+	context.SetProgram(context.Location, program)
+
+	wrapPanic(func() {
+		err = context.Interface.CacheProgram(context.Location, program)
+	})
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
+	return program, nil
+}
+
+func (r *interpreterRuntime) parseLocation(
+	context Context,
+	useCache bool,
+) (
+	program *ast.Program,
+	err error,
+) {
+	if useCache {
 		wrapPanic(func() {
-			err = context.Interface.CacheProgram(context.Location, program)
+			program, err = context.Interface.GetCachedProgram(context.Location)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	code, err := r.getCode(context)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.parseCode(code, context, useCache)
+}
+
+func (r *interpreterRuntime) check(
+	program *ast.Program,
+	startContext Context,
+	functions stdlib.StandardLibraryFunctions,
+	options []sema.Option,
+	useCache bool,
+) (
+	elaboration *sema.Elaboration,
+	err error,
+) {
+
+	wrapError := func(err error) error {
+		return &ParsingCheckingError{
+			Err:      err,
+			Location: startContext.Location,
+		}
+	}
+
+	if useCache {
+		wrapPanic(func() {
+			elaboration, err = startContext.Interface.GetCachedElaboration(startContext.Location)
 		})
 		if err != nil {
 			return nil, wrapError(err)
 		}
+		if elaboration != nil {
+			return elaboration, nil
+		}
 	}
 
-	importResolver := r.importResolver(context)
 	valueDeclarations := functions.ToSemaValueDeclarations()
 
-	for _, predeclaredValue := range context.PredeclaredValues {
+	for _, predeclaredValue := range startContext.PredeclaredValues {
 		valueDeclarations = append(valueDeclarations, predeclaredValue)
 	}
 
-	checker, err = sema.NewChecker(
+	checker, err := sema.NewChecker(
 		program,
-		context.Location,
+		startContext.Location,
 		append(
 			[]sema.Option{
 				sema.WithPredeclaredValues(valueDeclarations),
@@ -556,49 +672,36 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 				sema.WithLocationHandler(
 					func(identifiers []Identifier, location Location) (res []ResolvedLocation, err error) {
 						wrapPanic(func() {
-							res, err = context.Interface.ResolveLocation(identifiers, location)
+							res, err = startContext.Interface.ResolveLocation(identifiers, location)
 						})
 						return
 					},
 				),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						switch location {
 						case stdlib.CryptoChecker.Location:
-							return sema.CheckerImport{
-								Checker: stdlib.CryptoChecker,
-							}, nil
+							elaboration = stdlib.CryptoChecker.Elaboration
 
 						default:
-							var program *ast.Program
-							var err error
-							checker, checkerErr := checker.EnsureLoaded(location, func() *ast.Program {
-								program, err = importResolver(location)
-								return program
-							})
-							// TODO: improve
+							context := startContext.WithLocation(location)
+							program, err := r.checkLocation(context, functions, options, true)
 							if err != nil {
-								return nil, &sema.CheckerError{
-									Errors:   []error{err},
-									Location: location,
-									Codes:    context.codes,
-								}
+								return nil, err
 							}
-							if checkerErr != nil {
-								return nil, checkerErr
-							}
-							return sema.CheckerImport{
-								Checker: checker,
-							}, nil
+
+							elaboration = program.Elaboration
 						}
+
+						return sema.ElaborationImport{
+							Elaboration: elaboration,
+						}, nil
 					},
 				),
 				sema.WithCheckHandler(func(location common.Location, check func()) {
 					reportMetric(
-						func() {
-							check()
-						},
-						context.Interface,
+						check,
+						startContext.Interface,
 						func(metrics Metrics, duration time.Duration) {
 							metrics.ProgramChecked(location, duration)
 						},
@@ -612,20 +715,73 @@ func (r *interpreterRuntime) parseAndCheckProgram(
 		return nil, wrapError(err)
 	}
 
+	// NOTE: cache elaboration *before* checking,
+	// so it is returned when there is a cyclic import
+
+	elaboration = checker.Elaboration
+
+	wrapPanic(func() {
+		err = startContext.Interface.CacheElaboration(startContext.Location, elaboration)
+	})
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
 	err = checker.Check()
 	if err != nil {
 		return nil, wrapError(err)
 	}
 
-	return checker, nil
+	return elaboration, nil
+}
+
+func (r *interpreterRuntime) checkLocation(
+	context Context,
+	functions stdlib.StandardLibraryFunctions,
+	options []sema.Option,
+	useCache bool,
+) (
+	*interpreter.Program,
+	error,
+) {
+	var err error
+	var program *ast.Program
+	program, err = r.parseLocation(context, useCache)
+	if err != nil {
+		return nil, err
+	}
+
+	var elaboration *sema.Elaboration
+
+	if useCache {
+		wrapPanic(func() {
+			elaboration, err = context.Interface.GetCachedElaboration(context.Location)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if elaboration == nil {
+		elaboration, err = r.check(program, context, functions, options, useCache)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &interpreter.Program{
+		Program:     program,
+		Elaboration: elaboration,
+	}, nil
 }
 
 func (r *interpreterRuntime) newInterpreter(
-	checker *sema.Checker,
+	program *interpreter.Program,
 	context Context,
 	functions stdlib.StandardLibraryFunctions,
 	runtimeStorage *runtimeStorage,
-	options []interpreter.Option,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 ) (*interpreter.Interpreter, error) {
 
 	values := functions.ToInterpreterValueDeclarations()
@@ -651,7 +807,7 @@ func (r *interpreterRuntime) newInterpreter(
 			},
 		),
 		interpreter.WithInjectedCompositeFieldsHandler(
-			r.injectedCompositeFieldsHandler(context, runtimeStorage),
+			r.injectedCompositeFieldsHandler(context, runtimeStorage, interpreterOptions, checkerOptions),
 		),
 		interpreter.WithUUIDHandler(func() (uuid uint64, err error) {
 			wrapPanic(func() {
@@ -678,7 +834,7 @@ func (r *interpreterRuntime) newInterpreter(
 			},
 		),
 		interpreter.WithImportLocationHandler(
-			r.importLocationHandler(context),
+			r.importLocationHandler(context, functions, checkerOptions),
 		),
 		interpreter.WithOnStatementHandler(
 			r.onStatementHandler(),
@@ -694,30 +850,46 @@ func (r *interpreterRuntime) newInterpreter(
 	)
 
 	return interpreter.NewInterpreter(
-		checker,
-		append(defaultOptions, options...)...,
+		program,
+		context.Location,
+		append(
+			defaultOptions,
+			interpreterOptions...,
+		)...,
 	)
 }
 
-func (r *interpreterRuntime) importLocationHandler(context Context) interpreter.ImportLocationHandlerFunc {
-
-	importResolver := r.importResolver(context)
+func (r *interpreterRuntime) importLocationHandler(
+	startContext Context,
+	functions stdlib.StandardLibraryFunctions,
+	checkerOptions []sema.Option,
+) interpreter.ImportLocationHandlerFunc {
 
 	return func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 		switch location {
 		case stdlib.CryptoChecker.Location:
-			return interpreter.ProgramImport{
-				Program: stdlib.CryptoChecker.Program,
+			program := interpreter.ProgramFromChecker(stdlib.CryptoChecker)
+			subInterpreter, err := inter.NewSubInterpreter(program, location)
+			if err != nil {
+				panic(err)
+			}
+			return interpreter.InterpreterImport{
+				Interpreter: subInterpreter,
 			}
 
 		default:
-			program, err := importResolver(location)
+			context := startContext.WithLocation(location)
+			program, err := r.checkLocation(context, functions, checkerOptions, true)
 			if err != nil {
 				panic(err)
 			}
 
-			return interpreter.ProgramImport{
-				Program: program,
+			subInterpreter, err := inter.NewSubInterpreter(program, location)
+			if err != nil {
+				panic(err)
+			}
+			return interpreter.InterpreterImport{
+				Interpreter: subInterpreter,
 			}
 		}
 	}
@@ -726,6 +898,8 @@ func (r *interpreterRuntime) importLocationHandler(context Context) interpreter.
 func (r *interpreterRuntime) injectedCompositeFieldsHandler(
 	context Context,
 	runtimeStorage *runtimeStorage,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 ) interpreter.InjectedCompositeFieldsHandlerFunc {
 	return func(
 		_ *interpreter.Interpreter,
@@ -753,7 +927,13 @@ func (r *interpreterRuntime) injectedCompositeFieldsHandler(
 				addressValue := interpreter.NewAddressValue(address)
 
 				return map[string]interpreter.Value{
-					"account": r.newAuthAccountValue(addressValue, context, runtimeStorage),
+					"account": r.newAuthAccountValue(
+						addressValue,
+						context,
+						runtimeStorage,
+						interpreterOptions,
+						checkerOptions,
+					),
 				}
 			}
 		}
@@ -838,10 +1018,12 @@ func (r *interpreterRuntime) meteringInterpreterOptions(runtimeInterface Interfa
 func (r *interpreterRuntime) standardLibraryFunctions(
 	context Context,
 	runtimeStorage *runtimeStorage,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 ) stdlib.StandardLibraryFunctions {
 	return append(
 		stdlib.FlowBuiltInFunctions(stdlib.FlowBuiltinImpls{
-			CreateAccount:   r.newCreateAccountFunction(context, runtimeStorage),
+			CreateAccount:   r.newCreateAccountFunction(context, runtimeStorage, interpreterOptions, checkerOptions),
 			GetAccount:      r.newGetAccountFunction(context.Interface, runtimeStorage),
 			Log:             r.newLogFunction(context.Interface),
 			GetCurrentBlock: r.newGetCurrentBlockFunction(context.Interface),
@@ -852,79 +1034,24 @@ func (r *interpreterRuntime) standardLibraryFunctions(
 	)
 }
 
-func (r *interpreterRuntime) importResolver(startContext Context) ImportResolver {
-	return func(location Location) (program *ast.Program, err error) {
-
-		context := startContext.WithLocation(location)
-
+func (r *interpreterRuntime) getCode(context Context) (code []byte, err error) {
+	if addressLocation, ok := context.Location.(common.AddressLocation); ok {
 		wrapPanic(func() {
-			program, err = context.Interface.GetCachedProgram(location)
+			code, err = context.Interface.GetAccountContractCode(
+				addressLocation.Address,
+				addressLocation.Name,
+			)
 		})
-		if err != nil {
-			return nil, err
-		}
-		if program != nil {
-			return program, nil
-		}
-
-		var code []byte
-		if addressLocation, ok := location.(common.AddressLocation); ok {
-			wrapPanic(func() {
-				code, err = context.Interface.GetAccountContractCode(
-					addressLocation.Address,
-					addressLocation.Name,
-				)
-			})
-		} else {
-			wrapPanic(func() {
-				code, err = context.Interface.GetCode(location)
-			})
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		context.SetCode(location, string(code))
-
-		program, err = r.parse(code, context)
-		if err != nil {
-			return nil, err
-		}
-
-		context.SetProgram(location, program)
-
+	} else {
 		wrapPanic(func() {
-			err = context.Interface.CacheProgram(location, program)
+			code, err = context.Interface.GetCode(context.Location)
 		})
-		if err != nil {
-			return nil, err
-		}
-
-		return program, nil
 	}
-}
-
-func (r *interpreterRuntime) parse(
-	script []byte,
-	context Context,
-) (
-	program *ast.Program,
-	err error,
-) {
-
-	parse := func() {
-		program, err = parser2.ParseProgram(string(script))
+	if err != nil {
+		return nil, err
 	}
 
-	reportMetric(
-		parse,
-		context.Interface,
-		func(metrics Metrics, duration time.Duration) {
-			metrics.ProgramParsed(context.Location, duration)
-		},
-	)
-
-	return
+	return code, nil
 }
 
 // emitEvent converts an event value to native Go types and emits it to the runtime interface.
@@ -993,6 +1120,8 @@ func CodeToHashValue(code []byte) *interpreter.ArrayValue {
 func (r *interpreterRuntime) newCreateAccountFunction(
 	context Context,
 	runtimeStorage *runtimeStorage,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 ) interpreter.HostFunction {
 	return func(invocation interpreter.Invocation) trampoline.Trampoline {
 		payer, ok := invocation.Arguments[0].(interpreter.AuthAccountValue)
@@ -1022,7 +1151,13 @@ func (r *interpreterRuntime) newCreateAccountFunction(
 			},
 		)
 
-		account := r.newAuthAccountValue(addressValue, context, runtimeStorage)
+		account := r.newAuthAccountValue(
+			addressValue,
+			context,
+			runtimeStorage,
+			interpreterOptions,
+			checkerOptions,
+		)
 
 		return trampoline.Done{Result: account}
 	}
@@ -1204,13 +1339,15 @@ func (r *interpreterRuntime) loadContract(
 }
 
 func (r *interpreterRuntime) instantiateContract(
+	program *interpreter.Program,
 	context Context,
 	contractType *sema.CompositeType,
 	constructorArguments []interpreter.Value,
 	argumentTypes []sema.Type,
 	runtimeStorage *runtimeStorage,
-	checker *sema.Checker,
 	functions stdlib.StandardLibraryFunctions,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 	invocationRange ast.Range,
 ) (
 	interpreter.Value,
@@ -1268,7 +1405,8 @@ func (r *interpreterRuntime) instantiateContract(
 
 	var contract *interpreter.CompositeValue
 
-	interpreterOptions := []interpreter.Option{
+	allInterpreterOptions := append(
+		interpreterOptions[:],
 		interpreter.WithContractValueHandler(
 			func(
 				inter *interpreter.Interpreter,
@@ -1309,14 +1447,15 @@ func (r *interpreterRuntime) instantiateContract(
 				)
 			},
 		),
-	}
+	)
 
 	_, _, err := r.interpret(
+		program,
 		context,
 		runtimeStorage,
-		checker,
 		functions,
-		interpreterOptions,
+		allInterpreterOptions,
+		checkerOptions,
 		nil,
 	)
 
@@ -1436,20 +1575,49 @@ func (r *interpreterRuntime) newAuthAccountContracts(
 	addressValue interpreter.AddressValue,
 	context Context,
 	runtimeStorage *runtimeStorage,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 ) interpreter.AuthAccountContractsValue {
 	return interpreter.AuthAccountContractsValue{
-		Address:        addressValue,
-		AddFunction:    r.newAuthAccountContractsChangeFunction(addressValue, context, runtimeStorage, false),
-		UpdateFunction: r.newAuthAccountContractsChangeFunction(addressValue, context, runtimeStorage, true),
-		GetFunction:    r.newAuthAccountContractsGetFunction(addressValue, context.Interface),
-		RemoveFunction: r.newAuthAccountContractsRemoveFunction(addressValue, context.Interface, runtimeStorage),
+		Address: addressValue,
+		AddFunction: r.newAuthAccountContractsChangeFunction(
+			addressValue,
+			context,
+			runtimeStorage,
+			interpreterOptions,
+			checkerOptions,
+			false,
+		),
+		UpdateFunction: r.newAuthAccountContractsChangeFunction(
+			addressValue,
+			context,
+			runtimeStorage,
+			interpreterOptions,
+			checkerOptions,
+			true,
+		),
+		GetFunction: r.newAuthAccountContractsGetFunction(
+			addressValue,
+			context.Interface,
+		),
+		RemoveFunction: r.newAuthAccountContractsRemoveFunction(
+			addressValue,
+			context.Interface,
+			runtimeStorage,
+		),
 	}
 }
 
+// newAuthAccountContractsChangeFunction called when e.g.
+// - adding: `AuthAccount.contracts.add(name: "Foo", code: [...])` (isUpdate = false)
+// - updating: `AuthAccount.contracts.update__experimental(name: "Foo", code: [...])` (isUpdate = true)
+//
 func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 	addressValue interpreter.AddressValue,
 	startContext Context,
 	runtimeStorage *runtimeStorage,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 	isUpdate bool,
 ) interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
@@ -1523,9 +1691,9 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 
 			const useCache = false
 
-			functions := r.standardLibraryFunctions(context, runtimeStorage)
+			functions := r.standardLibraryFunctions(context, runtimeStorage, interpreterOptions, checkerOptions)
 
-			checker, err := r.parseAndCheckProgram(code, context, functions, nil, useCache)
+			program, err := r.parseAndCheckProgram(code, context, functions, checkerOptions, useCache)
 			if err != nil {
 				panic(&InvalidContractDeploymentError{
 					Err:           err,
@@ -1538,7 +1706,7 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 			var contractTypes []*sema.CompositeType
 			var contractInterfaceTypes []*sema.InterfaceType
 
-			for _, variable := range checker.Elaboration.GlobalTypes {
+			for _, variable := range program.Elaboration.GlobalTypes {
 				switch ty := variable.Type.(type) {
 				case *sema.CompositeType:
 					if ty.Kind == common.CompositeKindContract {
@@ -1592,16 +1760,18 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 			}
 
 			r.updateAccountContractCode(
+				program,
 				context,
 				runtimeStorage,
 				declaredName,
 				code,
 				addressValue,
-				checker,
 				contractType,
 				constructorArguments,
 				constructorArgumentTypes,
 				invocation.LocationRange.Range,
+				interpreterOptions,
+				checkerOptions,
 				updateAccountContractCodeOptions{
 					createContract: !isUpdate,
 				},
@@ -1648,16 +1818,18 @@ type updateAccountContractCodeOptions struct {
 // This function is only used for the new account code/contract API.
 //
 func (r *interpreterRuntime) updateAccountContractCode(
+	program *interpreter.Program,
 	context Context,
 	runtimeStorage *runtimeStorage,
 	name string,
 	code []byte,
 	addressValue interpreter.AddressValue,
-	checker *sema.Checker,
 	contractType *sema.CompositeType,
 	constructorArguments []interpreter.Value,
 	constructorArgumentTypes []sema.Type,
 	invocationRange ast.Range,
+	interpreterOptions []interpreter.Option,
+	checkerOptions []sema.Option,
 	options updateAccountContractCodeOptions,
 ) {
 	// If the code declares a contract, instantiate it and store it.
@@ -1680,16 +1852,18 @@ func (r *interpreterRuntime) updateAccountContractCode(
 
 	if createContract {
 
-		functions := r.standardLibraryFunctions(context, runtimeStorage)
+		functions := r.standardLibraryFunctions(context, runtimeStorage, interpreterOptions, checkerOptions)
 
 		contract, err := r.instantiateContract(
+			program,
 			context,
 			contractType,
 			constructorArguments,
 			constructorArgumentTypes,
 			runtimeStorage,
-			checker,
 			functions,
+			interpreterOptions,
+			checkerOptions,
 			invocationRange,
 		)
 
@@ -1824,7 +1998,7 @@ func (r *interpreterRuntime) onStatementHandler() interpreter.OnStatementFunc {
 	}
 
 	return func(statement *interpreter.Statement) {
-		location := statement.Interpreter.Checker.Location
+		location := statement.Interpreter.Location
 		line := statement.Statement.StartPosition().Line
 		r.coverageReport.AddLineHit(location, line)
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -679,6 +679,7 @@ func (r *interpreterRuntime) check(
 				),
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+						var elaboration *sema.Elaboration
 						switch location {
 						case stdlib.CryptoChecker.Location:
 							elaboration = stdlib.CryptoChecker.Elaboration

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -43,38 +43,6 @@ type Script struct {
 	Arguments [][]byte
 }
 
-type Context struct {
-	Interface         Interface
-	Location          Location
-	PredeclaredValues []ValueDeclaration
-	codes             map[common.LocationID]string
-	programs          map[common.LocationID]*ast.Program
-}
-
-func (c Context) SetCode(location common.Location, code string) {
-	c.codes[location.ID()] = code
-}
-
-func (c Context) SetProgram(location common.Location, program *ast.Program) {
-	c.programs[location.ID()] = program
-}
-
-func (c Context) WithLocation(location common.Location) Context {
-	result := c
-	result.Location = location
-	return result
-}
-
-func (c *Context) InitializeCodesAndPrograms() {
-	if c.codes == nil {
-		c.codes = map[common.LocationID]string{}
-	}
-
-	if c.programs == nil {
-		c.programs = map[common.LocationID]*ast.Program{}
-	}
-}
-
 // Runtime is a runtime capable of executing Cadence.
 type Runtime interface {
 	// ExecuteScript executes the given script.

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -90,6 +90,8 @@ type testRuntimeInterface struct {
 	getCode                   func(_ Location) ([]byte, error)
 	getCachedProgram          func(Location) (*ast.Program, error)
 	cacheProgram              func(Location, *ast.Program) error
+	getCachedElaboration      func(Location) (*sema.Elaboration, error)
+	cacheElaboration          func(Location, *sema.Elaboration) error
 	storage                   testRuntimeInterfaceStorage
 	createAccount             func(payer Address) (address Address, err error)
 	addAccountKey             func(address Address, publicKey []byte) error
@@ -156,6 +158,20 @@ func (i *testRuntimeInterface) CacheProgram(location Location, program *ast.Prog
 		return nil
 	}
 	return i.cacheProgram(location, program)
+}
+
+func (i *testRuntimeInterface) GetCachedElaboration(location Location) (*sema.Elaboration, error) {
+	if i.getCachedElaboration == nil {
+		return nil, nil
+	}
+	return i.getCachedElaboration(location)
+}
+
+func (i *testRuntimeInterface) CacheElaboration(location Location, elaboration *sema.Elaboration) error {
+	if i.cacheElaboration == nil {
+		return nil
+	}
+	return i.cacheElaboration(location, elaboration)
 }
 
 func (i *testRuntimeInterface) ValueExists(owner, key []byte) (exists bool, err error) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -730,14 +730,16 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 
 	t.Parallel()
 
-	var tests = []struct {
+	type testCase struct {
 		label        string
 		script       string
 		args         [][]byte
 		authorizers  []Address
 		expectedLogs []string
 		check        func(t *testing.T, err error)
-	}{
+	}
+
+	var tests = []testCase{
 		{
 			label: "Single argument",
 			script: `
@@ -987,8 +989,10 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.label, func(t *testing.T) {
+	test := func(tc testCase) {
+
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
 			rt := NewInterpreterRuntime()
 
 			var loggedMessages []string
@@ -996,7 +1000,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			programs := map[common.LocationID]*interpreter.Program{}
 
 			runtimeInterface := &testRuntimeInterface{
-				getSigningAccounts: func() ([]Address, error) { return tt.authorizers, nil },
+				getSigningAccounts: func() ([]Address, error) {
+					return tc.authorizers, nil
+				},
 				decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
 					return jsoncdc.Decode(b)
 				},
@@ -1014,8 +1020,8 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 
 			err := rt.ExecuteTransaction(
 				Script{
-					Source:    []byte(tt.script),
-					Arguments: tt.args,
+					Source:    []byte(tc.script),
+					Arguments: tc.args,
 				},
 				Context{
 					Interface: runtimeInterface,
@@ -1023,17 +1029,21 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 				},
 			)
 
-			if tt.check != nil {
-				tt.check(t, err)
+			if tc.check != nil {
+				tc.check(t, err)
 			} else {
 				if !assert.NoError(t, err) {
 					for err := err; err != nil; err = errors.Unwrap(err) {
 						t.Log(err)
 					}
 				}
-				assert.ElementsMatch(t, tt.expectedLogs, loggedMessages)
+				assert.ElementsMatch(t, tc.expectedLogs, loggedMessages)
 			}
 		})
+	}
+
+	for _, tt := range tests {
+		test(tt)
 	}
 }
 
@@ -6440,7 +6450,8 @@ func TestRuntime(t *testing.T) {
 	test := func(tc testCase) {
 		t.Run(tc.name, func(t *testing.T) {
 
-			t.Parallel()
+			// NOTE: to parallelize this sub-test,
+			// access to `programs` must be made thread-safe first
 
 			_, err := runtime.ExecuteScript(
 				Script{

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -4751,6 +4751,9 @@ func TestRuntimeMetrics(t *testing.T) {
 		valueDecoded       int
 	}
 
+	cachedPrograms := map[common.LocationID]*ast.Program{}
+	cachedElaborations := map[common.LocationID]*sema.Elaboration{}
+
 	newRuntimeInterface := func() (runtimeInterface Interface, r *reports) {
 
 		r = &reports{
@@ -4788,6 +4791,21 @@ func TestRuntimeMetrics(t *testing.T) {
 			},
 			valueDecoded: func(duration time.Duration) {
 				r.valueDecoded++
+			},
+			cacheProgram: func(location Location, program *ast.Program) error {
+				cachedPrograms[location.ID()] = program
+				return nil
+			},
+			getCachedProgram: func(location Location) (*ast.Program, error) {
+				return cachedPrograms[location.ID()], nil
+			},
+
+			cacheElaboration: func(location Location, elaboration *sema.Elaboration) error {
+				cachedElaborations[location.ID()] = elaboration
+				return nil
+			},
+			getCachedElaboration: func(location Location) (*sema.Elaboration, error) {
+				return cachedElaborations[location.ID()], nil
 			},
 		}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -25,6 +25,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -349,7 +351,7 @@ func TestRuntimeImport(t *testing.T) {
 
 	importedScript := []byte(`
       pub fun answer(): Int {
-        return 42
+          return 42
       }
     `)
 
@@ -365,6 +367,7 @@ func TestRuntimeImport(t *testing.T) {
         }
     `)
 
+	var checkCount int
 	programs := map[common.LocationID]*interpreter.Program{}
 
 	runtimeInterface := &testRuntimeInterface{
@@ -376,6 +379,9 @@ func TestRuntimeImport(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
+		programChecked: func(location common.Location, duration time.Duration) {
+			checkCount += 1
+		},
 		setProgram: func(location Location, program *interpreter.Program) error {
 			programs[location.ID()] = program
 			return nil
@@ -385,20 +391,112 @@ func TestRuntimeImport(t *testing.T) {
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	const transactionCount = 10
+	for i := 0; i < transactionCount; i++ {
 
-	value, err := runtime.ExecuteScript(
-		Script{
-			Source: script,
-		},
-		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-		},
-	)
-	require.NoError(t, err)
+		nextTransactionLocation := newTransactionLocationGenerator()
 
-	assert.Equal(t, cadence.NewInt(42), value)
+		value, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, cadence.NewInt(42), value)
+	}
+	require.Equal(t, transactionCount+1, checkCount)
+}
+
+func TestRuntimeConcurrentImport(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewInterpreterRuntime()
+
+	importedScript := []byte(`
+      pub fun answer(): Int {
+          return 42
+      }
+    `)
+
+	script := []byte(`
+      import "imported"
+
+      pub fun main(): Int {
+          let answer = answer()
+          if answer != 42 {
+            panic("?!")
+          }
+          return answer
+        }
+    `)
+
+	var checkCount uint64
+	var programsLock sync.RWMutex
+	programs := map[common.LocationID]*interpreter.Program{}
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(location Location) (bytes []byte, err error) {
+			switch location {
+			case common.StringLocation("imported"):
+				return importedScript, nil
+			default:
+				return nil, fmt.Errorf("unknown import location: %s", location)
+			}
+		},
+		programChecked: func(location common.Location, duration time.Duration) {
+			atomic.AddUint64(&checkCount, 1)
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programsLock.Lock()
+			defer programsLock.Unlock()
+
+			programs[location.ID()] = program
+
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			programsLock.RLock()
+			defer programsLock.RUnlock()
+
+			program := programs[location.ID()]
+
+			return program, nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	const concurrency uint64 = 10
+	for i := uint64(0); i < concurrency; i++ {
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			value, err := runtime.ExecuteScript(
+				Script{
+					Source: script,
+				},
+				Context{
+					Interface: runtimeInterface,
+					Location:  nextTransactionLocation(),
+				},
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, cadence.NewInt(42), value)
+		}()
+	}
+	wg.Wait()
+
+	//TODO:
+	//require.Equal(t, concurrency+1, checkCount)
 }
 
 func TestRuntimeProgramSetAndGet(t *testing.T) {

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -93,14 +93,14 @@ func (checker *Checker) importResolvedLocation(resolvedLocation ResolvedLocation
 	var imp Import
 
 	if checker.importHandler != nil {
-		var err *CheckerError
+		var err error
 		imp, err = checker.importHandler(checker, location)
 		if err != nil {
 			checker.report(
 				&ImportedProgramError{
-					CheckerError: err,
-					Location:     location,
-					Range:        locationRange,
+					Err:      err,
+					Location: location,
+					Range:    locationRange,
 				},
 			)
 			return
@@ -224,49 +224,6 @@ func (checker *Checker) importResolvedLocation(resolvedLocation ResolvedLocation
 
 		checker.handleMissingImports(missing, available, location)
 	}
-}
-
-// EnsureLoaded finds or create a checker for the imported program and checks it.
-//
-func (checker *Checker) EnsureLoaded(location common.Location, loadProgram func() *ast.Program) (*Checker, *CheckerError) {
-
-	locationID := location.ID()
-
-	subChecker, ok := checker.AllCheckers[locationID]
-	if ok {
-		return subChecker, nil
-	}
-
-	if !ok || subChecker == nil {
-		var err error
-		subChecker, err = NewChecker(
-			loadProgram(),
-			location,
-			WithPredeclaredValues(checker.PredeclaredValues),
-			WithPredeclaredTypes(checker.PredeclaredTypes),
-			WithAccessCheckMode(checker.accessCheckMode),
-			WithValidTopLevelDeclarationsHandler(checker.validTopLevelDeclarationsHandler),
-			WithAllCheckers(checker.AllCheckers),
-			WithCheckHandler(checker.checkHandler),
-			WithImportHandler(checker.importHandler),
-			WithLocationHandler(checker.locationHandler),
-		)
-		if err == nil {
-			checker.AllCheckers[locationID] = subChecker
-		}
-	}
-
-	// Check the imported program, if any.
-
-	var checkerErr *CheckerError
-	if subChecker.Program != nil {
-		// NOTE: ignore generic `error`-typed result, get internal `*CheckerError`
-
-		_ = subChecker.Check()
-		checkerErr = subChecker.CheckerError()
-	}
-
-	return subChecker, checkerErr
 }
 
 func (checker *Checker) handleMissingImports(missing []ast.Identifier, available []string, importLocation common.Location) {

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -333,7 +333,7 @@ func (checker *Checker) IsChecked() bool {
 
 func (checker *Checker) Check() error {
 	if !checker.IsChecked() {
-		checker.Elaboration.IsChecking = true
+		checker.Elaboration.setIsChecking(true)
 		checker.errors = nil
 		check := func() {
 			checker.Program.Accept(checker)
@@ -343,7 +343,7 @@ func (checker *Checker) Check() error {
 		} else {
 			check()
 		}
-		checker.Elaboration.IsChecking = false
+		checker.Elaboration.setIsChecking(false)
 		checker.isChecked = true
 	}
 	err := checker.CheckerError()

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -256,6 +256,20 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 	return checker, nil
 }
 
+func (checker *Checker) SubChecker(program *ast.Program, location common.Location) (*Checker, error) {
+	return NewChecker(
+		program,
+		location,
+		WithPredeclaredValues(checker.PredeclaredValues),
+		WithPredeclaredTypes(checker.PredeclaredTypes),
+		WithAccessCheckMode(checker.accessCheckMode),
+		WithValidTopLevelDeclarationsHandler(checker.validTopLevelDeclarationsHandler),
+		WithCheckHandler(checker.checkHandler),
+		WithImportHandler(checker.importHandler),
+		WithLocationHandler(checker.locationHandler),
+	)
+}
+
 func (checker *Checker) declareBaseValues() {
 	for _, declaration := range BaseValues {
 		variable := checker.declareValue(declaration)

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -74,7 +74,7 @@ type ResolvedLocation struct {
 
 type LocationHandlerFunc func(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
 
-type ImportHandlerFunc func(checker *Checker, location common.Location) (Import, *CheckerError)
+type ImportHandlerFunc func(checker *Checker, location common.Location) (Import, error)
 
 // Checker
 
@@ -83,7 +83,6 @@ type Checker struct {
 	Location                           common.Location
 	PredeclaredValues                  []ValueDeclaration
 	PredeclaredTypes                   []TypeDeclaration
-	AllCheckers                        map[common.LocationID]*Checker
 	accessCheckMode                    AccessCheckMode
 	errors                             []error
 	hints                              []Hint
@@ -109,7 +108,6 @@ type Checker struct {
 	locationHandler                    LocationHandlerFunc
 	importHandler                      ImportHandlerFunc
 	checkHandler                       CheckHandlerFunc
-	isChecking                         bool
 }
 
 type Option func(*Checker) error
@@ -164,16 +162,6 @@ func WithAccessCheckMode(mode AccessCheckMode) Option {
 func WithValidTopLevelDeclarationsHandler(handler ValidTopLevelDeclarationsHandlerFunc) Option {
 	return func(checker *Checker) error {
 		checker.validTopLevelDeclarationsHandler = handler
-		return nil
-	}
-}
-
-// WithAllCheckers returns a checker option which sets
-// the given map of checkers as the map of all checkers.
-//
-func WithAllCheckers(allCheckers map[common.LocationID]*Checker) Option {
-	return func(checker *Checker) error {
-		checker.SetAllCheckers(allCheckers)
 		return nil
 	}
 }
@@ -253,11 +241,7 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 
 	checker.declareBaseValues()
 
-	defaultOptions := []Option{
-		WithAllCheckers(map[common.LocationID]*Checker{}),
-	}
-
-	for _, option := range append(defaultOptions, options...) {
+	for _, option := range options {
 		err := option(checker)
 		if err != nil {
 			return nil, err
@@ -270,15 +254,6 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 	}
 
 	return checker, nil
-}
-
-// SetAllCheckers sets the given map of checkers as the map of all checkers.
-//
-func (checker *Checker) SetAllCheckers(allCheckers map[common.LocationID]*Checker) {
-	checker.AllCheckers = allCheckers
-
-	// Register self
-	checker.AllCheckers[checker.Location.ID()] = checker
 }
 
 func (checker *Checker) declareBaseValues() {
@@ -344,7 +319,7 @@ func (checker *Checker) IsChecked() bool {
 
 func (checker *Checker) Check() error {
 	if !checker.IsChecked() {
-		checker.isChecking = true
+		checker.Elaboration.IsChecking = true
 		checker.errors = nil
 		check := func() {
 			checker.Program.Accept(checker)
@@ -354,7 +329,7 @@ func (checker *Checker) Check() error {
 		} else {
 			check()
 		}
-		checker.isChecking = false
+		checker.Elaboration.IsChecking = false
 		checker.isChecked = true
 	}
 	err := checker.CheckerError()

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -18,7 +18,11 @@
 
 package sema
 
-import "github.com/onflow/cadence/runtime/ast"
+import (
+	"sync"
+
+	"github.com/onflow/cadence/runtime/ast"
+)
 
 type MemberInfo struct {
 	Member       *Member
@@ -27,6 +31,7 @@ type MemberInfo struct {
 }
 
 type Elaboration struct {
+	lock                                   *sync.RWMutex
 	FunctionDeclarationFunctionTypes       map[*ast.FunctionDeclaration]*FunctionType
 	VariableDeclarationValueTypes          map[*ast.VariableDeclaration]Type
 	VariableDeclarationSecondValueTypes    map[*ast.VariableDeclaration]Type
@@ -70,11 +75,12 @@ type Elaboration struct {
 	TransactionTypes                    []*TransactionType
 	EffectivePredeclaredValues          map[string]ValueDeclaration
 	EffectivePredeclaredTypes           map[string]TypeDeclaration
-	IsChecking                          bool
+	isChecking                          bool
 }
 
 func NewElaboration() *Elaboration {
 	return &Elaboration{
+		lock:                                   new(sync.RWMutex),
 		FunctionDeclarationFunctionTypes:       map[*ast.FunctionDeclaration]*FunctionType{},
 		VariableDeclarationValueTypes:          map[*ast.VariableDeclaration]Type{},
 		VariableDeclarationSecondValueTypes:    map[*ast.VariableDeclaration]Type{},
@@ -117,6 +123,18 @@ func NewElaboration() *Elaboration {
 		EffectivePredeclaredValues:             map[string]ValueDeclaration{},
 		EffectivePredeclaredTypes:              map[string]TypeDeclaration{},
 	}
+}
+
+func (e *Elaboration) IsChecking() bool {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+	return e.isChecking
+}
+
+func (e *Elaboration) setIsChecking(isChecking bool) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.isChecking = isChecking
 }
 
 // FunctionEntryPointType returns the type of the entry point function declaration, if any.

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -118,3 +118,27 @@ func NewElaboration() *Elaboration {
 		EffectivePredeclaredTypes:              map[string]TypeDeclaration{},
 	}
 }
+
+// FunctionEntryPointType returns the type of the entry point function declaration, if any.
+//
+// Returns an error if no valid entry point function declaration exists.
+//
+func (e *Elaboration) FunctionEntryPointType() (*FunctionType, error) {
+
+	entryPointValue, ok := e.GlobalValues[FunctionEntryPointName]
+	if !ok {
+		return nil, &MissingEntryPointError{
+			Expected: FunctionEntryPointName,
+		}
+	}
+
+	invokableType, ok := entryPointValue.Type.(InvokableType)
+	if !ok {
+		return nil, &InvalidEntryPointTypeError{
+			Type: entryPointValue.Type,
+		}
+	}
+
+	functionType := invokableType.InvocationFunctionType()
+	return functionType, nil
+}

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -70,6 +70,7 @@ type Elaboration struct {
 	TransactionTypes                    []*TransactionType
 	EffectivePredeclaredValues          map[string]ValueDeclaration
 	EffectivePredeclaredTypes           map[string]TypeDeclaration
+	IsChecking                          bool
 }
 
 func NewElaboration() *Elaboration {

--- a/runtime/sema/entrypoint.go
+++ b/runtime/sema/entrypoint.go
@@ -24,30 +24,6 @@ import (
 
 const FunctionEntryPointName = "main"
 
-// FunctionEntryPointType returns the type of the entry point function declaration, if any.
-//
-// Returns an error if no valid entry point function declaration exists.
-//
-func (checker *Checker) FunctionEntryPointType() (*FunctionType, error) {
-
-	entryPointValue, ok := checker.Elaboration.GlobalValues[FunctionEntryPointName]
-	if !ok {
-		return nil, &MissingEntryPointError{
-			Expected: FunctionEntryPointName,
-		}
-	}
-
-	invokableType, ok := entryPointValue.Type.(InvokableType)
-	if !ok {
-		return nil, &InvalidEntryPointTypeError{
-			Type: entryPointValue.Type,
-		}
-	}
-
-	functionType := invokableType.InvocationFunctionType()
-	return functionType, nil
-}
-
 // FunctionEntryPointDeclaration returns the entry point function declaration, if any.
 //
 // Returns nil if there are multiple function declarations with the same function entry point name, or any other top-level declarations.

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1114,8 +1114,8 @@ func (e *NotExportedError) EndPosition() ast.Position {
 // ImportedProgramError
 
 type ImportedProgramError struct {
-	CheckerError *CheckerError
-	Location     common.Location
+	Err      error
+	Location common.Location
 	ast.Range
 }
 
@@ -1131,7 +1131,11 @@ func (e *ImportedProgramError) ImportLocation() common.Location {
 }
 
 func (e *ImportedProgramError) ChildErrors() []error {
-	return e.CheckerError.Errors
+	parentErr, ok := e.Err.(errors.ParentError)
+	if !ok {
+		return nil
+	}
+	return parentErr.ChildErrors()
 }
 
 func (*ImportedProgramError) isSemanticError() {}

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -34,7 +34,7 @@ type Import interface {
 }
 
 // ImportElement
-
+//
 type ImportElement struct {
 	DeclarationKind common.DeclarationKind
 	Access          ast.Access
@@ -42,10 +42,10 @@ type ImportElement struct {
 	ArgumentLabels  []string
 }
 
-// CheckerImport
-
-type CheckerImport struct {
-	Checker *Checker
+// ElaborationImport
+//
+type ElaborationImport struct {
+	Elaboration *Elaboration
 }
 
 func variablesToImportElements(variables map[string]*Variable) map[string]ImportElement {
@@ -61,34 +61,34 @@ func variablesToImportElements(variables map[string]*Variable) map[string]Import
 	return elements
 }
 
-func (i CheckerImport) AllValueElements() map[string]ImportElement {
-	return variablesToImportElements(i.Checker.Elaboration.GlobalValues)
+func (i ElaborationImport) AllValueElements() map[string]ImportElement {
+	return variablesToImportElements(i.Elaboration.GlobalValues)
 }
 
-func (i CheckerImport) IsImportableValue(name string) bool {
+func (i ElaborationImport) IsImportableValue(name string) bool {
 	if _, ok := BaseValues[name]; ok {
 		return false
 	}
 
-	_, isPredeclaredValue := i.Checker.Elaboration.EffectivePredeclaredValues[name]
+	_, isPredeclaredValue := i.Elaboration.EffectivePredeclaredValues[name]
 	return !isPredeclaredValue
 }
 
-func (i CheckerImport) AllTypeElements() map[string]ImportElement {
-	return variablesToImportElements(i.Checker.Elaboration.GlobalTypes)
+func (i ElaborationImport) AllTypeElements() map[string]ImportElement {
+	return variablesToImportElements(i.Elaboration.GlobalTypes)
 }
 
-func (i CheckerImport) IsImportableType(name string) bool {
+func (i ElaborationImport) IsImportableType(name string) bool {
 	if _, ok := baseTypes[name]; ok {
 		return false
 	}
 
-	_, isPredeclaredType := i.Checker.Elaboration.EffectivePredeclaredTypes[name]
+	_, isPredeclaredType := i.Elaboration.EffectivePredeclaredTypes[name]
 	return !isPredeclaredType
 }
 
-func (i CheckerImport) IsChecking() bool {
-	return i.Checker.isChecking
+func (i ElaborationImport) IsChecking() bool {
+	return i.Elaboration.IsChecking
 }
 
 // VirtualImport

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -88,7 +88,7 @@ func (i ElaborationImport) IsImportableType(name string) bool {
 }
 
 func (i ElaborationImport) IsChecking() bool {
-	return i.Elaboration.IsChecking
+	return i.Elaboration.IsChecking()
 }
 
 // VirtualImport

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -44,8 +44,11 @@ func TestAssert(t *testing.T) {
 	require.Nil(t, err)
 
 	inter, err := interpreter.NewInterpreter(
-		checker,
-		interpreter.WithPredeclaredValues(BuiltinFunctions.ToInterpreterValueDeclarations()),
+		interpreter.ProgramFromChecker(checker),
+		checker.Location,
+		interpreter.WithPredeclaredValues(
+			BuiltinFunctions.ToInterpreterValueDeclarations(),
+		),
 	)
 	require.Nil(t, err)
 
@@ -93,7 +96,8 @@ func TestPanic(t *testing.T) {
 	require.Nil(t, err)
 
 	inter, err := interpreter.NewInterpreter(
-		checker,
+		interpreter.ProgramFromChecker(checker),
+		checker.Location,
 		interpreter.WithPredeclaredValues(BuiltinFunctions.ToInterpreterValueDeclarations()),
 	)
 	require.Nil(t, err)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -97,9 +98,18 @@ func TestRuntimeHighLevelStorage(t *testing.T) {
 
 	var writes []write
 
+	programs := map[common.LocationID]*interpreter.Program{}
+
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -286,10 +296,19 @@ func TestRuntimeMagic(t *testing.T) {
 		})
 	}
 
+	programs := map[common.LocationID]*interpreter.Program{}
+
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestStorage(nil, onWrite),
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 	}
 
@@ -344,6 +363,7 @@ func TestAccountStorageStorage(t *testing.T) {
     `)
 
 	var loggedMessages []string
+	programs := map[common.LocationID]*interpreter.Program{}
 
 	storage := newTestStorage(nil, nil)
 
@@ -351,6 +371,13 @@ func TestAccountStorageStorage(t *testing.T) {
 		storage: storage,
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 		getStorageUsed: func(_ Address) (uint64, error) {
 			var amount uint64 = 0

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -626,132 +625,6 @@ func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
 				}
 			}
 		}
-	}
-}
-
-func TestCheckAccessImportGlobalValue(t *testing.T) {
-
-	t.Parallel()
-
-	checkModeTests := map[sema.AccessCheckMode]func(*testing.T, error){
-		sema.AccessCheckModeStrict: func(t *testing.T, err error) {
-			errs := ExpectCheckerErrors(t, err, 2)
-
-			require.IsType(t, &sema.InvalidAccessError{}, errs[0])
-			assert.Equal(t,
-				"a",
-				errs[0].(*sema.InvalidAccessError).Name,
-			)
-
-			require.IsType(t, &sema.InvalidAccessError{}, errs[1])
-			assert.Equal(t,
-				"c",
-				errs[1].(*sema.InvalidAccessError).Name,
-			)
-		},
-		sema.AccessCheckModeNotSpecifiedRestricted: func(t *testing.T, err error) {
-			errs := ExpectCheckerErrors(t, err, 2)
-
-			require.IsType(t, &sema.InvalidAccessError{}, errs[0])
-			assert.Equal(t,
-				"a",
-				errs[0].(*sema.InvalidAccessError).Name,
-			)
-
-			require.IsType(t, &sema.InvalidAccessError{}, errs[1])
-			assert.Equal(t,
-				"c",
-				errs[1].(*sema.InvalidAccessError).Name,
-			)
-		},
-		sema.AccessCheckModeNotSpecifiedUnrestricted: func(t *testing.T, err error) {
-			errs := ExpectCheckerErrors(t, err, 1)
-
-			require.IsType(t, &sema.InvalidAccessError{}, errs[0])
-			assert.Equal(t,
-				"a",
-				errs[0].(*sema.InvalidAccessError).Name,
-			)
-		},
-		sema.AccessCheckModeNone: expectSuccess,
-	}
-
-	require.Len(t, checkModeTests, len(sema.AccessCheckModes))
-
-	for checkMode, check := range checkModeTests {
-
-		t.Run(checkMode.String(), func(t *testing.T) {
-
-			lastAccessModifier := ""
-			if checkMode == sema.AccessCheckModeStrict {
-				lastAccessModifier = "priv"
-			}
-
-			tests := []string{
-				fmt.Sprintf(
-					`
-                      priv fun a() {}
-                      pub fun b() {}
-                      %s fun c() {}
-                    `,
-					lastAccessModifier,
-				),
-			}
-
-			for _, variableKind := range ast.VariableKinds {
-
-				tests = append(tests,
-					fmt.Sprintf(
-						`
-                           priv %[1]s a = 1
-                           pub %[1]s b = 2
-                           %[2]s %[1]s c = 3
-                        `,
-						variableKind.Keyword(),
-						lastAccessModifier,
-					),
-				)
-			}
-
-			for _, test := range tests {
-				// NOTE: only parse, don't check imported program.
-				// will be checked by checker checking importing program
-
-				imported, err := parser2.ParseProgram(test)
-
-				require.NoError(t, err)
-
-				_, err = ParseAndCheckWithOptions(t,
-					`
-                       import a, b, c from "imported"
-                    `,
-					ParseAndCheckOptions{
-						Options: []sema.Option{
-							sema.WithAccessCheckMode(checkMode),
-							sema.WithImportHandler(
-								func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
-									importChecker, err := checker.EnsureLoaded(
-										location,
-										func() *ast.Program {
-											return imported
-										},
-									)
-									if err != nil {
-										return nil, err
-									}
-
-									return sema.CheckerImport{
-										Checker: importChecker,
-									}, nil
-								},
-							),
-						},
-					},
-				)
-
-				check(t, err)
-			}
-		})
 	}
 }
 
@@ -1823,28 +1696,12 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
 
 		t.Run(checkMode.String(), func(t *testing.T) {
 
-			// NOTE: only parse, don't check imported program.
-			// will be checked by checker checking importing program
-
 			lastAccessModifier := ""
 			if checkMode == sema.AccessCheckModeStrict {
 				lastAccessModifier = "priv"
 			}
 
-			imported, err := parser2.ParseProgram(
-				fmt.Sprintf(
-					`
-                       priv var a = 1
-                       pub var b = 2
-                       %s var c = 3
-                    `,
-					lastAccessModifier,
-				),
-			)
-
-			require.NoError(t, err)
-
-			_, err = ParseAndCheckWithOptions(t,
+			_, err := ParseAndCheckWithOptions(t,
 				`
                   import a, b, c from "imported"
 
@@ -1867,19 +1724,22 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
 					Options: []sema.Option{
 						sema.WithAccessCheckMode(checkMode),
 						sema.WithImportHandler(
-							func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
-								importChecker, err := checker.EnsureLoaded(
-									location,
-									func() *ast.Program {
-										return imported
-									},
-								)
-								if err != nil {
-									return nil, err
-								}
+							func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 
-								return sema.CheckerImport{
-									Checker: importChecker,
+								imported, err := ParseAndCheck(t,
+									fmt.Sprintf(
+										`
+                                           priv var a = 1
+                                           pub var b = 2
+                                           %s var c = 3
+                                        `,
+										lastAccessModifier,
+									),
+								)
+								require.NoError(t, err)
+
+								return sema.ElaborationImport{
+									Elaboration: imported.Elaboration,
 								}, nil
 							},
 						),
@@ -1896,23 +1756,7 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
 
 	t.Parallel()
 
-	// NOTE: only parse, don't check imported program.
-	// will be checked by checker checking importing program
-
-	imported, err := parser2.ParseProgram(`
-       pub resource R {}
-
-       pub fun createR(): @R {
-           return <-create R()
-       }
-
-       priv var x <- createR()
-       pub var y <- createR()
-    `)
-
-	require.NoError(t, err)
-
-	_, err = ParseAndCheckWithOptions(t,
+	_, err := ParseAndCheckWithOptions(t,
 		`
            import x, y, createR from "imported"
 
@@ -1927,19 +1771,22 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
-						importChecker, err := checker.EnsureLoaded(
-							location,
-							func() *ast.Program {
-								return imported
-							},
-						)
-						if err != nil {
-							return nil, err
-						}
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 
-						return sema.CheckerImport{
-							Checker: importChecker,
+						imported, err := ParseAndCheck(t, `
+                           pub resource R {}
+
+                           pub fun createR(): @R {
+                               return <-create R()
+                           }
+
+                           priv var x <- createR()
+                           pub var y <- createR()
+                        `)
+						require.NoError(t, err)
+
+						return sema.ElaborationImport{
+							Elaboration: imported.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -248,9 +248,9 @@ func TestCheckEmitEvent(t *testing.T) {
 			ParseAndCheckOptions{
 				Options: []sema.Option{
 					sema.WithImportHandler(
-						func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
-							return sema.CheckerImport{
-								Checker: importedChecker,
+						func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+							return sema.ElaborationImport{
+								Elaboration: importedChecker.Elaboration,
 							}, nil
 						},
 					),

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -526,130 +527,162 @@ func TestCheckImportTypes(t *testing.T) {
 	}
 }
 
-// TODO:
-//
-//func TestCheckInvalidImportCycleSelf(t *testing.T) {
-//
-//	t.Parallel()
-//
-//	// NOTE: only parse, don't check imported program.
-//	// will be checked by checker checking importing program
-//
-//	const code = `import "test"`
-//	importedProgram, err := parser2.ParseProgram(code)
-//
-//	require.NoError(t, err)
-//
-//	_, err = ParseAndCheckWithOptions(t,
-//		code,
-//		ParseAndCheckOptions{
-//			Location: utils.TestLocation,
-//			Options: []sema.Option{
-//				sema.WithImportHandler(
-//					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
-//						importedChecker, err := checker.EnsureLoaded(
-//							location,
-//							func() *ast.Program {
-//								return importedProgram
-//							},
-//						)
-//						if err != nil {
-//							return nil, err
-//						}
-//
-//						return sema.ElaborationImport{
-//							Elaboration: importedChecker.Elaboration,
-//						}, nil
-//					},
-//				),
-//			},
-//		},
-//	)
-//
-//	errs := ExpectCheckerErrors(t, err, 1)
-//
-//	assert.IsType(t, &sema.CyclicImportsError{}, errs[0])
-//}
-//
-//func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
-//
-//	t.Parallel()
-//
-//	// NOTE: only parse, don't check imported program.
-//	// will be checked by checker checking importing program
-//
-//	const codeEven = `
-//      import odd from "odd"
-//
-//      pub fun even(_ n: Int): Bool {
-//          if n == 0 {
-//              return true
-//          }
-//          return odd(n - 1)
-//      }
-//    `
-//	programEven, err := parser2.ParseProgram(codeEven)
-//	require.NoError(t, err)
-//
-//	const codeOdd = `
-//      import even from "even"
-//
-//      pub fun odd(_ n: Int): Bool {
-//          if n == 0 {
-//              return false
-//          }
-//          return even(n - 1)
-//      }
-//    `
-//	programOdd, err := parser2.ParseProgram(codeOdd)
-//	require.NoError(t, err)
-//
-//	_, err = ParseAndCheckWithOptions(t,
-//		codeEven,
-//		ParseAndCheckOptions{
-//			Location: common.StringLocation("even"),
-//			Options: []sema.Option{
-//				sema.WithImportHandler(
-//					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
-//						importedChecker, err := checker.EnsureLoaded(
-//							location,
-//							func() *ast.Program {
-//								switch location {
-//								case common.StringLocation("even"):
-//									return programEven
-//								case common.StringLocation("odd"):
-//									return programOdd
-//								}
-//
-//								t.Fatalf("invalid import: %#+v", location)
-//								return nil
-//							},
-//						)
-//						if err != nil {
-//							return nil, err
-//						}
-//
-//						return sema.ElaborationImport{
-//							Elaboration: importedChecker.Elaboration,
-//						}, nil
-//					},
-//				),
-//			},
-//		},
-//	)
-//
-//	errs := ExpectCheckerErrors(t, err, 2)
-//
-//	require.IsType(t, &sema.ImportedProgramError{}, errs[0])
-//	assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
-//
-//	importedProgramError := errs[0].(*sema.ImportedProgramError).CheckerError
-//
-//	errs = ExpectCheckerErrors(t, importedProgramError, 2)
-//
-//	require.IsType(t, &sema.CyclicImportsError{}, errs[0])
-//	assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
-//}
+func TestCheckInvalidImportCycleSelf(t *testing.T) {
+
+	t.Parallel()
+
+	// NOTE: only parse, don't check imported program.
+	// will be checked by checker checking importing program
+
+	const code = `import "test"`
+	importedProgram, err := parser2.ParseProgram(code)
+
+	require.NoError(t, err)
+
+	elaborations := map[common.LocationID]*sema.Elaboration{}
+
+	check := func(code string, location common.Location) error {
+		_, err := ParseAndCheckWithOptions(t,
+			code,
+			ParseAndCheckOptions{
+				Location: location,
+				Options: []sema.Option{
+					sema.WithImportHandler(
+						func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+
+							elaboration, ok := elaborations[location.ID()]
+							if !ok {
+								subChecker, err := checker.SubChecker(importedProgram, location)
+								if err != nil {
+									return nil, err
+								}
+								elaborations[location.ID()] = subChecker.Elaboration
+								err = subChecker.Check()
+								if err != nil {
+									return nil, err
+								}
+								elaboration = subChecker.Elaboration
+							}
+
+							return sema.ElaborationImport{
+								Elaboration: elaboration,
+							}, nil
+						},
+					),
+				},
+			},
+		)
+		return err
+	}
+
+	err = check(code, utils.TestLocation)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	require.IsType(t, &sema.ImportedProgramError{}, errs[0])
+	childErrs := errs[0].(*sema.ImportedProgramError).ChildErrors()
+
+	require.Len(t, childErrs, 1)
+	assert.IsType(t, &sema.CyclicImportsError{}, childErrs[0])
+}
+
+func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
+
+	t.Parallel()
+
+	// NOTE: only parse, don't check imported program.
+	// will be checked by checker checking importing program
+
+	const codeEven = `
+      import odd from "odd"
+
+      pub fun even(_ n: Int): Bool {
+          if n == 0 {
+              return true
+          }
+          return odd(n - 1)
+      }
+    `
+	programEven, err := parser2.ParseProgram(codeEven)
+	require.NoError(t, err)
+
+	const codeOdd = `
+      import even from "even"
+
+      pub fun odd(_ n: Int): Bool {
+          if n == 0 {
+              return false
+          }
+          return even(n - 1)
+      }
+    `
+	programOdd, err := parser2.ParseProgram(codeOdd)
+	require.NoError(t, err)
+
+	getProgram := func(location common.Location) *ast.Program {
+		switch location {
+		case common.StringLocation("even"):
+			return programEven
+		case common.StringLocation("odd"):
+			return programOdd
+		}
+
+		t.Fatalf("invalid import: %#+v", location)
+		return nil
+	}
+
+	elaborations := map[common.LocationID]*sema.Elaboration{}
+
+	_, err = ParseAndCheckWithOptions(t,
+		codeEven,
+		ParseAndCheckOptions{
+			Location: common.StringLocation("even"),
+			Options: []sema.Option{
+				sema.WithImportHandler(
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+						importedProgram := getProgram(location)
+
+						elaboration, ok := elaborations[location.ID()]
+						if !ok {
+							subChecker, err := checker.SubChecker(importedProgram, location)
+							if err != nil {
+								return nil, err
+							}
+							elaborations[location.ID()] = subChecker.Elaboration
+							err = subChecker.Check()
+							if err != nil {
+								return nil, err
+							}
+							elaboration = subChecker.Elaboration
+						}
+
+						return sema.ElaborationImport{
+							Elaboration: elaboration,
+						}, nil
+					},
+				),
+			},
+		},
+	)
+
+	errs := ExpectCheckerErrors(t, err, 2)
+
+	require.IsType(t, &sema.ImportedProgramError{}, errs[0])
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
+
+	importedProgramError := errs[0].(*sema.ImportedProgramError).Err
+
+	errs = ExpectCheckerErrors(t, importedProgramError, 2)
+
+	require.IsType(t, &sema.ImportedProgramError{}, errs[0])
+	require.IsType(t, &sema.NotDeclaredError{}, errs[1])
+
+	importedProgramError = errs[0].(*sema.ImportedProgramError).Err
+
+	errs = ExpectCheckerErrors(t, importedProgramError, 2)
+	require.IsType(t, &sema.CyclicImportsError{}, errs[0])
+	require.IsType(t, &sema.NotDeclaredError{}, errs[1])
+}
 
 func TestCheckImportVirtual(t *testing.T) {
 

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -1468,9 +1468,9 @@ func TestCheckInvalidCreateImportedResource(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
-						return sema.CheckerImport{
-							Checker: importedChecker,
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -756,7 +756,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					rType := inter.Checker.Elaboration.GlobalTypes["R"].Type
+					rType := inter.Program.Elaboration.GlobalTypes["R"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -798,7 +798,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					r2Type := inter.Checker.Elaboration.GlobalTypes["R2"].Type
+					r2Type := inter.Program.Elaboration.GlobalTypes["R2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -891,7 +891,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					sType := inter.Checker.Elaboration.GlobalTypes["S"].Type
+					sType := inter.Program.Elaboration.GlobalTypes["S"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -933,7 +933,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					s2Type := inter.Checker.Elaboration.GlobalTypes["S2"].Type
+					s2Type := inter.Program.Elaboration.GlobalTypes["S2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -94,7 +94,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 			},
 			CheckerOptions: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						return sema.VirtualImport{
 							ValueElements: map[string]sema.ImportElement{
 								"Foo": {
@@ -208,7 +208,7 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 					},
 				),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
 
@@ -221,10 +221,15 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 							importedChecker = importedCheckerA
 						case "b":
 							importedChecker = importedCheckerB
+						default:
+							t.Errorf(
+								"invalid address location location name: %s",
+								addressLocation.Name,
+							)
 						}
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -239,7 +239,8 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 	require.NoError(t, err)
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				require.IsType(t, common.AddressLocation{}, location)
@@ -258,8 +259,14 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 					return nil
 				}
 
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -3882,14 +3882,14 @@ func TestInterpretImport(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -3961,14 +3961,14 @@ func TestInterpretImportError(t *testing.T) {
 			Options: []sema.Option{
 				sema.WithPredeclaredValues(valueDeclarations),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -5283,14 +5283,14 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -6782,14 +6782,14 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -71,14 +71,14 @@ func TestInterpretStatementHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -191,14 +191,14 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -318,14 +318,14 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -97,7 +97,8 @@ func TestInterpretStatementHandler(t *testing.T) {
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithOnStatementHandler(
 			func(statement *interpreter.Statement) {
 				inter := statement.Interpreter
@@ -121,8 +122,15 @@ func TestInterpretStatementHandler(t *testing.T) {
 					utils.ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),
@@ -217,29 +225,39 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
-		interpreter.WithOnLoopIterationHandler(func(inter *interpreter.Interpreter, line int) {
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
+		interpreter.WithOnLoopIterationHandler(
+			func(inter *interpreter.Interpreter, line int) {
 
-			id, ok := interpreterIDs[inter]
-			if !ok {
-				id = nextInterpreterID
-				nextInterpreterID++
-				interpreterIDs[inter] = id
-			}
+				id, ok := interpreterIDs[inter]
+				if !ok {
+					id = nextInterpreterID
+					nextInterpreterID++
+					interpreterIDs[inter] = id
+				}
 
-			occurrences = append(occurrences, occurrence{
-				interpreterID: id,
-				line:          line,
-			})
-		}),
+				occurrences = append(occurrences, occurrence{
+					interpreterID: id,
+					line:          line,
+				})
+			},
+		),
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				assert.Equal(t,
 					utils.ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),
@@ -344,7 +362,8 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithOnFunctionInvocationHandler(
 			func(inter *interpreter.Interpreter, line int) {
 
@@ -367,8 +386,15 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 					utils.ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -65,14 +65,14 @@ func TestInterpretResourceUUID(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -84,7 +84,8 @@ func TestInterpretResourceUUID(t *testing.T) {
 	var uuid uint64
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithUUIDHandler(
 			func() (uint64, error) {
 				defer func() { uuid++ }()
@@ -97,8 +98,15 @@ func TestInterpretResourceUUID(t *testing.T) {
 					ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 )
 
 func TestRuntimeTypeStorage(t *testing.T) {
@@ -51,6 +52,7 @@ func TestRuntimeTypeStorage(t *testing.T) {
     `)
 
 	var loggedMessage string
+	programs := map[common.LocationID]*interpreter.Program{}
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestStorage(nil, nil),
@@ -61,6 +63,13 @@ func TestRuntimeTypeStorage(t *testing.T) {
 		},
 		log: func(message string) {
 			loggedMessage = message
+		},
+		setProgram: func(location Location, program *interpreter.Program) error {
+			programs[location.ID()] = program
+			return nil
+		},
+		getProgram: func(location Location) (*interpreter.Program, error) {
+			return programs[location.ID()], nil
 		},
 	}
 


### PR DESCRIPTION
Work towards dapperlabs/flow-go#5229

## Description

- Remove all sub-checkers from checker. Always query the import handler, leave potential caching up to the handler
- Remove checker input from the interpreter, it now only depends on the AST + elaboration
- Change interpreter imports: Remove all sub-checkers from the interpreter, 
  Instead of importing just a program, import other interpreters (`ProgramImport` -> `InterpreterImport`)
- Add elaboration caching to runtime interface
- Refactor runtime to new checker and interpreter import handlers
- Replace the notion of optional caching programs and elaborations with the *requirement* to store prepared programs and returning them when needed (like they were stored)

All tests are passing again, so it seems to work. 
However, I still want to clean this up a bit before opening it up as a proper PR.

NOTE: The diff is at times pretty weird, maybe view in split mode / only look at the new code.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
