### PR TITLE
Make checker occurrences and origins optional

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1120,6 +1120,7 @@ func (s *Server) getDiagnostics(
 		runtime.FileLocation(uri),
 		sema.WithPredeclaredValues(valueDeclarations),
 		sema.WithPredeclaredTypes(typeDeclarations),
+		sema.WithOriginsAndOccurrencesEnabled(true),
 		sema.WithImportHandler(func(checker *sema.Checker, location ast.Location) (sema.Import, *sema.CheckerError) {
 			switch location {
 			case stdlib.CryptoChecker.Location:

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -71,7 +71,9 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr 
 		allowOuterScopeShadowing: false,
 	})
 	checker.report(err)
-	checker.recordVariableDeclarationOccurrence(identifier, variable)
+	if checker.originsAndOccurrencesEnabled {
+		checker.recordVariableDeclarationOccurrence(identifier, variable)
+	}
 
 	// The body of the loop will maybe be evaluated.
 	// That means that resource invalidations and

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -105,7 +105,9 @@ func (checker *Checker) declareFunctionDeclaration(
 	})
 	checker.report(err)
 
-	checker.recordFunctionDeclarationOrigin(declaration, functionType)
+	if checker.originsAndOccurrencesEnabled {
+		checker.recordFunctionDeclarationOrigin(declaration, functionType)
+	}
 }
 
 func (checker *Checker) checkFunction(
@@ -279,7 +281,9 @@ func (checker *Checker) declareParameters(
 			Pos:             &identifier.Pos,
 		}
 		checker.valueActivations.Set(identifier.Identifier, variable)
-		checker.recordVariableDeclarationOccurrence(identifier.Identifier, variable)
+		if checker.originsAndOccurrencesEnabled {
+			checker.recordVariableDeclarationOccurrence(identifier.Identifier, variable)
+		}
 	}
 }
 

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -250,6 +250,7 @@ func (checker *Checker) EnsureLoaded(location ast.Location, loadProgram func() *
 			WithCheckHandler(checker.checkHandler),
 			WithImportHandler(checker.importHandler),
 			WithLocationHandler(checker.locationHandler),
+			WithOriginsAndOccurrencesEnabled(checker.originsAndOccurrencesEnabled),
 		)
 		if err == nil {
 			checker.allCheckers[locationID] = subChecker

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -308,7 +308,9 @@ func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclar
 
 	interfaceType.Members = members
 	interfaceType.Fields = fields
-	checker.memberOrigins[interfaceType] = origins
+	if checker.originsAndOccurrencesEnabled {
+		checker.memberOrigins[interfaceType] = origins
+	}
 
 	// NOTE: determine initializer parameter types while nested types are in scope,
 	// and after declaring nested types as the initializer may use nested type in parameters

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -144,8 +144,6 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 		checker.resources.AddUse(accessedSelfMember, expression.Identifier.Pos)
 	}
 
-	origins := checker.memberOrigins[accessedType]
-
 	identifier := expression.Identifier.Identifier
 	identifierStartPosition := expression.Identifier.StartPosition()
 	identifierEndPosition := expression.Identifier.EndPosition()
@@ -217,12 +215,16 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 			)
 		}
 	} else {
-		origin := origins[identifier]
-		checker.Occurrences.Put(
-			identifierStartPosition,
-			identifierEndPosition,
-			origin,
-		)
+
+		if checker.originsAndOccurrencesEnabled {
+			origins := checker.memberOrigins[accessedType]
+			origin := origins[identifier]
+			checker.Occurrences.Put(
+				identifierStartPosition,
+				identifierEndPosition,
+				origin,
+			)
+		}
 
 		// Check access and report if inaccessible
 

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -263,7 +263,9 @@ func (checker *Checker) declareTransactionDeclaration(declaration *ast.Transacti
 
 	transactionType.Members = members
 	transactionType.Fields = fields
-	checker.memberOrigins[transactionType] = origins
+	if checker.originsAndOccurrencesEnabled {
+		checker.memberOrigins[transactionType] = origins
+	}
 
 	if declaration.Prepare != nil {
 		parameterList := declaration.Prepare.FunctionDeclaration.ParameterList

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -222,7 +222,9 @@ func (checker *Checker) visitVariableDeclaration(declaration *ast.VariableDeclar
 		allowOuterScopeShadowing: true,
 	})
 	checker.report(err)
-	checker.recordVariableDeclarationOccurrence(identifier, variable)
+	if checker.originsAndOccurrencesEnabled {
+		checker.recordVariableDeclarationOccurrence(identifier, variable)
+	}
 }
 
 func (checker *Checker) checkVariableDeclarationUsability(declaration *ast.VariableDeclaration) {

--- a/runtime/tests/checker/occurrences_test.go
+++ b/runtime/tests/checker/occurrences_test.go
@@ -36,10 +36,16 @@ func TestCheckOccurrencesVariableDeclarations(t *testing.T) {
 
 	t.Parallel()
 
-	checker, err := ParseAndCheck(t, `
+	checker, err := ParseAndCheckWithOptions(t, `
         let x = 1
         var y = x
-    `)
+        `,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithOriginsAndOccurrencesEnabled(true),
+			},
+		},
+	)
 
 	require.NoError(t, err)
 
@@ -90,7 +96,8 @@ func TestCheckOccurrencesFunction(t *testing.T) {
 
 	t.Parallel()
 
-	checker, err := ParseAndCheck(t, `
+	checker, err := ParseAndCheckWithOptions(t,
+		`
 		fun f1(paramX: Int, paramY: Bool) {
 		   let x = 1
 		   var y: Int? = x
@@ -104,7 +111,13 @@ func TestCheckOccurrencesFunction(t *testing.T) {
         fun f3() {
             f1(paramX: 2, paramY: false)
         }
-	`)
+		`,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithOriginsAndOccurrencesEnabled(true),
+			},
+		},
+	)
 
 	require.NoError(t, err)
 
@@ -223,7 +236,8 @@ func TestCheckOccurrencesStructAndInterface(t *testing.T) {
 
 	t.Parallel()
 
-	checker, err := ParseAndCheck(t, `
+	checker, err := ParseAndCheckWithOptions(t,
+		`
 		struct interface I1 {}
 
 	    struct S1: I1 {
@@ -238,7 +252,13 @@ func TestCheckOccurrencesStructAndInterface(t *testing.T) {
 	    fun f(): S1 {
 	       return S1()
 	    }
-	`)
+		`,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithOriginsAndOccurrencesEnabled(true),
+			},
+		},
+	)
 
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Occurrences and origins are only needed by the language server. Disable them by default.

______

For contributor use:

- [ ] Targeted PR against `master` branch – I'll open another PR against master once this is merged
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
