### PR TITLE
Use correct CommandSubmitTransaction command in entrypoint code lens

### DIFF
--- a/languageserver/integration/codelenses.go
+++ b/languageserver/integration/codelenses.go
@@ -182,7 +182,7 @@ func (i *FlowIntegration) entryPointActions(
 			i.activeAddress.Hex(),
 		)
 		argumentListConjunction = "and"
-		command = CommandExecuteScript
+		command = CommandSubmitTransaction
 	}
 
 	argumentLists := entryPointInfo.pragmaArguments[:]


### PR DESCRIPTION
## Description

Transactions are currently submitted as scripts to the language server -- looks like the command name is just wrong.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
