### PR TITLE
Use elaborations instead of checkers – Part 2: Interpreter

### DIFF
--- a/runtime/interpreter/import.go
+++ b/runtime/interpreter/import.go
@@ -18,10 +18,6 @@
 
 package interpreter
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-)
-
 // Import
 
 type Import interface {
@@ -37,10 +33,10 @@ type VirtualImport struct {
 
 func (VirtualImport) isImport() {}
 
-// ProgramImport
+// InterpreterImport
 
-type ProgramImport struct {
-	Program *ast.Program
+type InterpreterImport struct {
+	Interpreter *Interpreter
 }
 
-func (ProgramImport) isImport() {}
+func (InterpreterImport) isImport() {}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4459,20 +4459,35 @@ func (interpreter *Interpreter) getElaboration(location common.Location) *sema.E
 }
 
 func (interpreter *Interpreter) getCompositeType(location common.Location, qualifiedIdentifier string) *sema.CompositeType {
-	elaboration := interpreter.getElaboration(location)
 	typeID := location.TypeID(qualifiedIdentifier)
+
+	elaboration := interpreter.getElaboration(location)
+	if elaboration == nil {
+		panic(TypeLoadingError{
+			TypeID: typeID,
+		})
+	}
+
 	ty := elaboration.CompositeTypes[typeID]
 	if ty == nil {
 		panic(TypeLoadingError{
 			TypeID: typeID,
 		})
 	}
+
 	return ty
 }
 
 func (interpreter *Interpreter) getInterfaceType(location common.Location, qualifiedIdentifier string) *sema.InterfaceType {
-	elaboration := interpreter.getElaboration(location)
 	typeID := location.TypeID(qualifiedIdentifier)
+
+	elaboration := interpreter.getElaboration(location)
+	if elaboration == nil {
+		panic(TypeLoadingError{
+			TypeID: typeID,
+		})
+	}
+
 	ty := elaboration.InterfaceTypes[typeID]
 	if ty == nil {
 		panic(TypeLoadingError{

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -212,13 +212,13 @@ func (c TypeCodes) Merge(codes TypeCodes) {
 }
 
 type Interpreter struct {
-	Checker                        *sema.Checker
+	Program                        *Program
+	Location                       common.Location
 	PredeclaredValues              []ValueDeclaration
 	effectivePredeclaredValues     map[string]ValueDeclaration
 	activations                    *activations.Activations
 	Globals                        map[string]*Variable
 	allInterpreters                map[common.LocationID]*Interpreter
-	allCheckers                    map[common.LocationID]*sema.Checker
 	typeCodes                      TypeCodes
 	Transactions                   []*HostFunctionValue
 	onEventEmitted                 OnEventEmittedFunc
@@ -233,6 +233,7 @@ type Interpreter struct {
 	contractValueHandler           ContractValueHandlerFunc
 	importLocationHandler          ImportLocationHandlerFunc
 	uuidHandler                    UUIDHandlerFunc
+	interpreted                    bool
 }
 
 type Option func(*Interpreter) error
@@ -388,16 +389,6 @@ func WithAllInterpreters(allInterpreters map[common.LocationID]*Interpreter) Opt
 	}
 }
 
-// WithAllCheckers returns an interpreter option which sets
-// the given map of checkers as the map of all checkers.
-//
-func WithAllCheckers(allCheckers map[common.LocationID]*sema.Checker) Option {
-	return func(interpreter *Interpreter) error {
-		interpreter.SetAllCheckers(allCheckers)
-		return nil
-	}
-}
-
 // withTypeCodes returns an interpreter option which sets the type codes.
 //
 func withTypeCodes(typeCodes TypeCodes) Option {
@@ -407,9 +398,11 @@ func withTypeCodes(typeCodes TypeCodes) Option {
 	}
 }
 
-func NewInterpreter(checker *sema.Checker, options ...Option) (*Interpreter, error) {
+func NewInterpreter(program *Program, location common.Location, options ...Option) (*Interpreter, error) {
+
 	interpreter := &Interpreter{
-		Checker:                    checker,
+		Program:                    program,
+		Location:                   location,
 		activations:                &activations.Activations{},
 		Globals:                    map[string]*Variable{},
 		effectivePredeclaredValues: map[string]ValueDeclaration{},
@@ -417,7 +410,6 @@ func NewInterpreter(checker *sema.Checker, options ...Option) (*Interpreter, err
 
 	defaultOptions := []Option{
 		WithAllInterpreters(map[common.LocationID]*Interpreter{}),
-		WithAllCheckers(map[common.LocationID]*sema.Checker{}),
 		withTypeCodes(TypeCodes{
 			CompositeCodes:       map[sema.TypeID]CompositeTypeCode{},
 			InterfaceCodes:       map[sema.TypeID]WrapperCode{},
@@ -516,17 +508,7 @@ func (interpreter *Interpreter) SetAllInterpreters(allInterpreters map[common.Lo
 	interpreter.allInterpreters = allInterpreters
 
 	// Register self
-	interpreter.allInterpreters[interpreter.Checker.Location.ID()] = interpreter
-}
-
-// SetAllCheckers sets the given map of checkers as the map of all checkers.
-//
-func (interpreter *Interpreter) SetAllCheckers(allCheckers map[common.LocationID]*sema.Checker) {
-	interpreter.allCheckers = allCheckers
-
-	// Register self
-	checker := interpreter.Checker
-	interpreter.allCheckers[checker.Location.ID()] = checker
+	interpreter.allInterpreters[interpreter.Location.ID()] = interpreter
 }
 
 // setTypeCodes sets the type codes.
@@ -539,7 +521,7 @@ func (interpreter *Interpreter) setTypeCodes(typeCodes TypeCodes) {
 //
 func (interpreter *Interpreter) locationRange(hasPosition ast.HasPosition) LocationRange {
 	return LocationRange{
-		Location: interpreter.Checker.Location,
+		Location: interpreter.Location,
 		Range:    ast.NewRangeFromPositioned(hasPosition),
 	}
 }
@@ -565,13 +547,18 @@ func (interpreter *Interpreter) setVariable(name string, variable *Variable) {
 }
 
 func (interpreter *Interpreter) Interpret() (err error) {
+	if interpreter.interpreted {
+		return
+	}
+
 	// recover internal panics and return them as an error
 	defer recoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
-	// declare all declarations and then run all statements
 	interpreter.runAllStatements(interpreter.interpret())
+
+	interpreter.interpreted = true
 
 	return nil
 }
@@ -642,7 +629,7 @@ func (interpreter *Interpreter) runAllStatements(t Trampoline) interface{} {
 
 		panic(Error{
 			Err:      internalErr,
-			Location: statement.Interpreter.Checker.Location,
+			Location: statement.Interpreter.Location,
 		})
 	})
 
@@ -683,11 +670,11 @@ func getStatement(t Trampoline) *StatementTrampoline {
 // interpret returns a Trampoline that is done when all top-level declarations
 // have been declared and evaluated.
 func (interpreter *Interpreter) interpret() Trampoline {
-	return interpreter.Checker.Program.Accept(interpreter).(Trampoline)
+	return interpreter.Program.Program.Accept(interpreter).(Trampoline)
 }
 
 func (interpreter *Interpreter) prepareInterpretation() {
-	program := interpreter.Checker.Program
+	program := interpreter.Program.Program
 
 	// Pre-declare empty variables for all interfaces, composites, and function declarations
 	for _, declaration := range program.InterfaceDeclarations() {
@@ -769,7 +756,7 @@ func (interpreter *Interpreter) prepareInvokeVariable(
 		}
 	}
 
-	ty := interpreter.Checker.Elaboration.GlobalValues[functionName].Type
+	ty := interpreter.Program.Elaboration.GlobalValues[functionName].Type
 
 	// function must be invokable
 	invokableType, ok := ty.(sema.InvokableType)
@@ -795,7 +782,7 @@ func (interpreter *Interpreter) prepareInvokeTransaction(
 
 	functionValue := interpreter.Transactions[index]
 
-	transactionType := interpreter.Checker.Elaboration.TransactionTypes[index]
+	transactionType := interpreter.Program.Elaboration.TransactionTypes[index]
 	functionType := transactionType.EntryPointFunctionType()
 
 	return interpreter.prepareInvoke(functionValue, functionType, arguments)
@@ -913,7 +900,7 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 
 	identifier := declaration.Identifier.Identifier
 
-	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]
+	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[declaration]
 
 	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
 	variable := interpreter.findOrDeclareVariable(identifier)
@@ -950,7 +937,7 @@ func (interpreter *Interpreter) functionDeclarationValue(
 
 	if declaration.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
 
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
 		beforeStatements = postConditionsRewrite.BeforeStatements
@@ -1129,8 +1116,8 @@ func (interpreter *Interpreter) VisitReturnStatement(statement *ast.ReturnStatem
 		Map(func(result interface{}) interface{} {
 			value := result.(Value)
 
-			valueType := interpreter.Checker.Elaboration.ReturnStatementValueTypes[statement]
-			returnType := interpreter.Checker.Elaboration.ReturnStatementReturnTypes[statement]
+			valueType := interpreter.Program.Elaboration.ReturnStatementValueTypes[statement]
+			returnType := interpreter.Program.Elaboration.ReturnStatementReturnTypes[statement]
 
 			// NOTE: copy on return
 			value = interpreter.copyAndConvert(value, valueType, returnType)
@@ -1187,8 +1174,8 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 
 			if someValue, ok := result.(*SomeValue); ok {
 
-				targetType := interpreter.Checker.Elaboration.VariableDeclarationTargetTypes[declaration]
-				valueType := interpreter.Checker.Elaboration.VariableDeclarationValueTypes[declaration]
+				targetType := interpreter.Program.Elaboration.VariableDeclarationTargetTypes[declaration]
+				valueType := interpreter.Program.Elaboration.VariableDeclarationValueTypes[declaration]
 				unwrappedValueCopy := interpreter.copyAndConvert(someValue.Value, valueType, targetType)
 
 				interpreter.activations.PushCurrent()
@@ -1381,9 +1368,9 @@ func (interpreter *Interpreter) visitPotentialStorageRemoval(expression ast.Expr
 // then declares the variable with the name bound to the value
 func (interpreter *Interpreter) VisitVariableDeclaration(declaration *ast.VariableDeclaration) ast.Repr {
 
-	targetType := interpreter.Checker.Elaboration.VariableDeclarationTargetTypes[declaration]
-	valueType := interpreter.Checker.Elaboration.VariableDeclarationValueTypes[declaration]
-	secondValueType := interpreter.Checker.Elaboration.VariableDeclarationSecondValueTypes[declaration]
+	targetType := interpreter.Program.Elaboration.VariableDeclarationTargetTypes[declaration]
+	valueType := interpreter.Program.Elaboration.VariableDeclarationValueTypes[declaration]
+	secondValueType := interpreter.Program.Elaboration.VariableDeclarationSecondValueTypes[declaration]
 
 	return interpreter.visitPotentialStorageRemoval(declaration.Value).
 		FlatMap(func(result interface{}) Trampoline {
@@ -1413,7 +1400,7 @@ func (interpreter *Interpreter) VisitVariableDeclaration(declaration *ast.Variab
 
 func (interpreter *Interpreter) movingStorageIndexExpression(expression ast.Expression) *ast.IndexExpression {
 	indexExpression, ok := expression.(*ast.IndexExpression)
-	if !ok || !interpreter.Checker.Elaboration.IsResourceMovingStorageIndexExpression[indexExpression] {
+	if !ok || !interpreter.Program.Elaboration.IsResourceMovingStorageIndexExpression[indexExpression] {
 		return nil
 	}
 
@@ -1422,7 +1409,7 @@ func (interpreter *Interpreter) movingStorageIndexExpression(expression ast.Expr
 
 func (interpreter *Interpreter) declareValue(declaration ValueDeclaration) *Variable {
 
-	if !declaration.ValueDeclarationAvailable(interpreter.Checker.Location) {
+	if !declaration.ValueDeclarationAvailable(interpreter.Location) {
 		return nil
 	}
 
@@ -1442,8 +1429,8 @@ func (interpreter *Interpreter) declareVariable(identifier string, value Value) 
 }
 
 func (interpreter *Interpreter) VisitAssignmentStatement(assignment *ast.AssignmentStatement) ast.Repr {
-	targetType := interpreter.Checker.Elaboration.AssignmentStatementTargetTypes[assignment]
-	valueType := interpreter.Checker.Elaboration.AssignmentStatementValueTypes[assignment]
+	targetType := interpreter.Program.Elaboration.AssignmentStatementTargetTypes[assignment]
+	valueType := interpreter.Program.Elaboration.AssignmentStatementValueTypes[assignment]
 
 	target := assignment.Target
 	value := assignment.Value
@@ -1498,8 +1485,8 @@ func (interpreter *Interpreter) visitAssignment(
 
 func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) ast.Repr {
 
-	leftType := interpreter.Checker.Elaboration.SwapStatementLeftTypes[swap]
-	rightType := interpreter.Checker.Elaboration.SwapStatementRightTypes[swap]
+	leftType := interpreter.Program.Elaboration.SwapStatementLeftTypes[swap]
+	rightType := interpreter.Program.Elaboration.SwapStatementRightTypes[swap]
 
 	// Evaluate the left expression
 	return interpreter.assignmentGetterSetter(swap.Left).
@@ -1841,8 +1828,8 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 						Map(func(result interface{}) interface{} {
 							value := result.(Value)
 
-							rightType := interpreter.Checker.Elaboration.BinaryExpressionRightTypes[expression]
-							resultType := interpreter.Checker.Elaboration.BinaryExpressionResultTypes[expression]
+							rightType := interpreter.Program.Elaboration.BinaryExpressionRightTypes[expression]
+							resultType := interpreter.Program.Elaboration.BinaryExpressionResultTypes[expression]
 
 							// NOTE: important to convert both any and optional
 							return interpreter.convertAndBox(value, rightType, resultType)
@@ -1979,8 +1966,8 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 		FlatMap(func(result interface{}) Trampoline {
 			values := result.(*ArrayValue)
 
-			argumentTypes := interpreter.Checker.Elaboration.ArrayExpressionArgumentTypes[expression]
-			elementType := interpreter.Checker.Elaboration.ArrayExpressionElementType[expression]
+			argumentTypes := interpreter.Program.Elaboration.ArrayExpressionArgumentTypes[expression]
+			elementType := interpreter.Program.Elaboration.ArrayExpressionElementType[expression]
 
 			copies := make([]Value, len(values.Values))
 			for i, argument := range values.Values {
@@ -1996,8 +1983,8 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 	return interpreter.visitEntries(expression.Entries).
 		FlatMap(func(result interface{}) Trampoline {
 
-			entryTypes := interpreter.Checker.Elaboration.DictionaryExpressionEntryTypes[expression]
-			dictionaryType := interpreter.Checker.Elaboration.DictionaryExpressionType[expression]
+			entryTypes := interpreter.Program.Elaboration.DictionaryExpressionEntryTypes[expression]
+			dictionaryType := interpreter.Program.Elaboration.DictionaryExpressionType[expression]
 
 			newDictionary := NewDictionaryValueUnownedNonCopying()
 			for i, dictionaryEntryValues := range result.([]DictionaryEntryValues) {
@@ -2128,11 +2115,11 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 					arguments := result.(*ArrayValue).Values
 
 					typeParameterTypes :=
-						interpreter.Checker.Elaboration.InvocationExpressionTypeArguments[invocationExpression]
+						interpreter.Program.Elaboration.InvocationExpressionTypeArguments[invocationExpression]
 					argumentTypes :=
-						interpreter.Checker.Elaboration.InvocationExpressionArgumentTypes[invocationExpression]
+						interpreter.Program.Elaboration.InvocationExpressionArgumentTypes[invocationExpression]
 					parameterTypes :=
-						interpreter.Checker.Elaboration.InvocationExpressionParameterTypes[invocationExpression]
+						interpreter.Program.Elaboration.InvocationExpressionParameterTypes[invocationExpression]
 
 					invocation := interpreter.functionValueInvocationTrampoline(
 						function,
@@ -2212,7 +2199,7 @@ func (interpreter *Interpreter) functionValueInvocationTrampoline(
 	// TODO: optimize: only potentially used by host-functions
 
 	locationRange := LocationRange{
-		Location: interpreter.Checker.Location,
+		Location: interpreter.Location,
 		Range:    invocationRange,
 	}
 
@@ -2349,7 +2336,7 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 	// lexical scope: variables in functions are bound to what is visible at declaration time
 	lexicalScope := interpreter.activations.CurrentOrNew()
 
-	functionType := interpreter.Checker.Elaboration.FunctionExpressionFunctionType[expression]
+	functionType := interpreter.Program.Elaboration.FunctionExpressionFunctionType[expression]
 
 	var preConditions ast.Conditions
 	if expression.FunctionBlock.PreConditions != nil {
@@ -2361,7 +2348,7 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 
 	if expression.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[expression.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[expression.FunctionBlock.PostConditions]
 
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
 		beforeStatements = postConditionsRewrite.BeforeStatements
@@ -2485,7 +2472,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 		}
 	})()
 
-	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
 
 	var initializerFunction FunctionValue
 	if declaration.CompositeKind == common.CompositeKindEvent {
@@ -2566,7 +2553,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 		CompositeFunctions: functions,
 	}
 
-	location := interpreter.Checker.Location
+	location := interpreter.Location
 
 	qualifiedIdentifier := compositeType.QualifiedIdentifier()
 
@@ -2682,10 +2669,10 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 	lexicalScope = lexicalScope.Insert(identifier, variable)
 
-	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
 	qualifiedIdentifier := compositeType.QualifiedIdentifier()
 
-	location := interpreter.Checker.Location
+	location := interpreter.Location
 
 	intType := &sema.IntType{}
 
@@ -2758,7 +2745,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 	}
 
 	initializer = initializers[0]
-	functionType := interpreter.Checker.Elaboration.SpecialFunctionTypes[initializer].FunctionType
+	functionType := interpreter.Program.Elaboration.SpecialFunctionTypes[initializer].FunctionType
 
 	parameterList := initializer.FunctionDeclaration.ParameterList
 
@@ -2775,7 +2762,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 	postConditions := initializer.FunctionDeclaration.FunctionBlock.PostConditions
 	if postConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[postConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[postConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -2818,7 +2805,7 @@ func (interpreter *Interpreter) compositeDestructorFunction(
 	postConditions := destructor.FunctionDeclaration.FunctionBlock.PostConditions
 	if postConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[postConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[postConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -2863,7 +2850,7 @@ func (interpreter *Interpreter) functionWrappers(
 
 	for _, functionDeclaration := range members.Functions() {
 
-		functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+		functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
 
 		name := functionDeclaration.Identifier.Identifier
 		functionWrapper := interpreter.functionConditionsWrapper(
@@ -2885,7 +2872,7 @@ func (interpreter *Interpreter) compositeFunction(
 	lexicalScope activations.Activation,
 ) InterpretedFunctionValue {
 
-	functionType := interpreter.Checker.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
 
 	var preConditions ast.Conditions
 
@@ -2899,7 +2886,7 @@ func (interpreter *Interpreter) compositeFunction(
 	if functionDeclaration.FunctionBlock.PostConditions != nil {
 
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[functionDeclaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[functionDeclaration.FunctionBlock.PostConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		postConditions = postConditionsRewrite.RewrittenPostConditions
@@ -3101,7 +3088,7 @@ func (interpreter *Interpreter) declareInterface(
 		}
 	})()
 
-	interfaceType := interpreter.Checker.Elaboration.InterfaceDeclarationTypes[declaration]
+	interfaceType := interpreter.Program.Elaboration.InterfaceDeclarationTypes[declaration]
 	typeID := interfaceType.ID()
 
 	initializerFunctionWrapper := interpreter.initializerFunctionWrapper(declaration.Members, lexicalScope)
@@ -3135,7 +3122,7 @@ func (interpreter *Interpreter) declareTypeRequirement(
 		}
 	})()
 
-	compositeType := interpreter.Checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
 	typeID := compositeType.ID()
 
 	initializerFunctionWrapper := interpreter.initializerFunctionWrapper(declaration.Members, lexicalScope)
@@ -3211,7 +3198,7 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 	if declaration.FunctionBlock.PostConditions != nil {
 
 		postConditionsRewrite :=
-			interpreter.Checker.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -3274,49 +3261,72 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 func (interpreter *Interpreter) ensureLoaded(
 	location common.Location,
 	loadLocation func() Import,
-) (subInterpreter *Interpreter) {
+) *Interpreter {
 
 	locationID := location.ID()
 
 	// If a sub-interpreter already exists, return it
 
-	subInterpreter = interpreter.allInterpreters[locationID]
+	subInterpreter := interpreter.allInterpreters[locationID]
 	if subInterpreter != nil {
 		return subInterpreter
 	}
 
-	// Create a sub-checker and sub-interpreter
-
-	var importedChecker *sema.Checker
+	// Load the import
 
 	var virtualImport *VirtualImport
 
-	var checkerErr *sema.CheckerError
-	importedChecker, checkerErr = interpreter.Checker.EnsureLoaded(location, func() *ast.Program {
-		imported := loadLocation()
+	imported := loadLocation()
 
-		switch imported := imported.(type) {
-		case VirtualImport:
-			virtualImport = &imported
-			return nil
-
-		case ProgramImport:
-			return imported.Program
-
-		default:
-			panic(errors.NewUnreachableError())
+	switch imported := imported.(type) {
+	case InterpreterImport:
+		subInterpreter = imported.Interpreter
+		err := subInterpreter.Interpret()
+		if err != nil {
+			panic(err)
 		}
-	})
-	if importedChecker == nil {
-		panic("missing checker")
-	}
-	if checkerErr != nil {
-		panic(checkerErr)
-	}
 
-	var err error
-	subInterpreter, err = NewInterpreter(
-		importedChecker,
+		return subInterpreter
+
+	case VirtualImport:
+		virtualImport = &imported
+
+		var err error
+		// NOTE: virtual import, no program
+		subInterpreter, err = interpreter.NewSubInterpreter(nil, location)
+		if err != nil {
+			panic(err)
+		}
+
+		// If the imported location is a virtual import,
+		// prepare the interpreter
+
+		for name, value := range virtualImport.Globals {
+			variable := NewVariable(value, 0)
+			subInterpreter.setVariable(name, variable)
+			subInterpreter.Globals[name] = variable
+		}
+
+		subInterpreter.typeCodes.
+			Merge(virtualImport.TypeCodes)
+
+		return subInterpreter
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (interpreter *Interpreter) NewSubInterpreter(
+	program *Program,
+	location common.Location,
+	options ...Option,
+) (
+	*Interpreter,
+	error,
+) {
+
+	defaultOptions := []Option{
 		WithPredeclaredValues(interpreter.PredeclaredValues),
 		WithOnEventEmittedHandler(interpreter.onEventEmitted),
 		WithOnStatementHandler(interpreter.onStatement),
@@ -3331,34 +3341,17 @@ func (interpreter *Interpreter) ensureLoaded(
 		WithImportLocationHandler(interpreter.importLocationHandler),
 		WithUUIDHandler(interpreter.uuidHandler),
 		WithAllInterpreters(interpreter.allInterpreters),
-		WithAllCheckers(interpreter.allCheckers),
 		withTypeCodes(interpreter.typeCodes),
+	}
+
+	return NewInterpreter(
+		program,
+		location,
+		append(
+			defaultOptions,
+			options...,
+		)...,
 	)
-	if err != nil {
-		panic(err)
-	}
-
-	if virtualImport != nil {
-		// If the imported location is a virtual import,
-		// prepare the interpreter
-
-		for name, value := range virtualImport.Globals {
-			variable := NewVariable(value, 0)
-			subInterpreter.setVariable(name, variable)
-			subInterpreter.Globals[name] = variable
-		}
-
-		subInterpreter.typeCodes.
-			Merge(virtualImport.TypeCodes)
-
-	} else {
-		// If the imported location is an interpreted program,
-		// evaluate its top-level declarations
-
-		subInterpreter.runAllStatements(subInterpreter.interpret())
-	}
-
-	return subInterpreter
 }
 
 func (interpreter *Interpreter) VisitPragmaDeclaration(_ *ast.PragmaDeclaration) ast.Repr {
@@ -3367,7 +3360,7 @@ func (interpreter *Interpreter) VisitPragmaDeclaration(_ *ast.PragmaDeclaration)
 
 func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDeclaration) ast.Repr {
 
-	resolvedLocations := interpreter.Checker.Elaboration.ImportDeclarationsResolvedLocations[declaration]
+	resolvedLocations := interpreter.Program.Elaboration.ImportDeclarationsResolvedLocations[declaration]
 
 	for _, resolvedLocation := range resolvedLocations {
 		interpreter.importResolvedLocation(resolvedLocation)
@@ -3404,8 +3397,8 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 	for name, variable := range variables {
 
 		// don't import predeclared values
-		if subInterpreter.Checker != nil {
-			if _, ok := subInterpreter.Checker.Elaboration.EffectivePredeclaredValues[name]; ok {
+		if subInterpreter.Program != nil {
+			if _, ok := subInterpreter.Program.Elaboration.EffectivePredeclaredValues[name]; ok {
 				continue
 			}
 		}
@@ -3428,7 +3421,7 @@ func (interpreter *Interpreter) VisitTransactionDeclaration(declaration *ast.Tra
 }
 
 func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.TransactionDeclaration) {
-	transactionType := interpreter.Checker.Elaboration.TransactionDeclarationTypes[declaration]
+	transactionType := interpreter.Program.Elaboration.TransactionDeclarationTypes[declaration]
 
 	lexicalScope := interpreter.activations.CurrentOrNew()
 
@@ -3447,10 +3440,10 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 	}
 
 	postConditionsRewrite :=
-		interpreter.Checker.Elaboration.PostConditionsRewrite[declaration.PostConditions]
+		interpreter.Program.Elaboration.PostConditionsRewrite[declaration.PostConditions]
 
 	self := &CompositeValue{
-		Location: interpreter.Checker.Location,
+		Location: interpreter.Location,
 		Fields:   map[string]Value{},
 		modified: true,
 	}
@@ -3534,7 +3527,7 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 		FlatMap(func(result interface{}) Trampoline {
 			event := result.(*CompositeValue)
 
-			eventType := interpreter.Checker.Elaboration.EmitStatementEventTypes[statement]
+			eventType := interpreter.Program.Elaboration.EmitStatementEventTypes[statement]
 
 			if interpreter.onEventEmitted == nil {
 				panic(EventEmissionUnavailableError{
@@ -3557,7 +3550,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		Map(func(result interface{}) interface{} {
 			value := result.(Value)
 
-			expectedType := interpreter.Checker.Elaboration.CastingTargetTypes[expression]
+			expectedType := interpreter.Program.Elaboration.CastingTargetTypes[expression]
 
 			switch expression.Operation {
 			case ast.OperationFailableCast, ast.OperationForceCast:
@@ -3589,7 +3582,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 				}
 
 			case ast.OperationCast:
-				staticValueType := interpreter.Checker.Elaboration.CastingStaticValueTypes[expression]
+				staticValueType := interpreter.Program.Elaboration.CastingStaticValueTypes[expression]
 				return interpreter.convertAndBox(value, staticValueType, expectedType)
 
 			default:
@@ -4457,11 +4450,12 @@ func (interpreter *Interpreter) getElaboration(location common.Location) *sema.E
 
 	locationID := location.ID()
 
-	checker := inter.allCheckers[locationID]
-	if checker == nil {
+	subInterpreter := inter.allInterpreters[locationID]
+	if subInterpreter == nil || subInterpreter.Program == nil {
 		return nil
 	}
-	return checker.Elaboration
+
+	return subInterpreter.Program.Elaboration
 }
 
 func (interpreter *Interpreter) getCompositeType(location common.Location, qualifiedIdentifier string) *sema.CompositeType {

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -36,7 +36,9 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	checker, err := sema.NewChecker(nil, utils.TestLocation)
 	require.NoError(t, err)
 
-	inter, err := NewInterpreter(checker)
+	program := ProgramFromChecker(checker)
+
+	inter, err := NewInterpreter(program, checker.Location)
 	require.NoError(t, err)
 
 	t.Run("Bool to Bool?", func(t *testing.T) {
@@ -111,7 +113,9 @@ func TestInterpreterBoxing(t *testing.T) {
 	checker, err := sema.NewChecker(nil, utils.TestLocation)
 	require.NoError(t, err)
 
-	inter, err := NewInterpreter(checker)
+	program := ProgramFromChecker(checker)
+
+	inter, err := NewInterpreter(program, checker.Location)
 	require.NoError(t, err)
 
 	for _, anyType := range []sema.Type{

--- a/runtime/interpreter/program.go
+++ b/runtime/interpreter/program.go
@@ -1,0 +1,36 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+type Program struct {
+	Program     *ast.Program
+	Elaboration *sema.Elaboration
+}
+
+func ProgramFromChecker(checker *sema.Checker) *Program {
+	return &Program{
+		Program:     checker.Program,
+		Elaboration: checker.Elaboration,
+	}
+}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5565,7 +5565,7 @@ func (v *CompositeValue) getInterpreter(interpreter *Interpreter) *Interpreter {
 	// Get the correct interpreter. The program code might need to be loaded.
 	// NOTE: standard library values have no location
 
-	if v.Location == nil || common.LocationsMatch(interpreter.Checker.Location, v.Location) {
+	if v.Location == nil || common.LocationsMatch(interpreter.Location, v.Location) {
 		return interpreter
 	}
 

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -756,7 +756,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					rType := inter.Checker.Elaboration.GlobalTypes["R"].Type
+					rType := inter.Program.Elaboration.GlobalTypes["R"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -798,7 +798,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					r2Type := inter.Checker.Elaboration.GlobalTypes["R2"].Type
+					r2Type := inter.Program.Elaboration.GlobalTypes["R2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -891,7 +891,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					sType := inter.Checker.Elaboration.GlobalTypes["S"].Type
+					sType := inter.Program.Elaboration.GlobalTypes["S"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{
@@ -933,7 +933,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					actualBorrowType := capability.(interpreter.CapabilityValue).BorrowType
 
-					s2Type := inter.Checker.Elaboration.GlobalTypes["S2"].Type
+					s2Type := inter.Program.Elaboration.GlobalTypes["S2"].Type
 
 					expectedBorrowType := interpreter.ConvertSemaToStaticType(
 						&sema.ReferenceType{

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -94,7 +94,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 			},
 			CheckerOptions: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						return sema.VirtualImport{
 							ValueElements: map[string]sema.ImportElement{
 								"Foo": {
@@ -208,7 +208,7 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 					},
 				),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
 
@@ -221,10 +221,15 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 							importedChecker = importedCheckerA
 						case "b":
 							importedChecker = importedCheckerB
+						default:
+							t.Errorf(
+								"invalid address location location name: %s",
+								addressLocation.Name,
+							)
 						}
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -239,7 +239,8 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 	require.NoError(t, err)
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				require.IsType(t, common.AddressLocation{}, location)
@@ -258,8 +259,14 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 					return nil
 				}
 
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -3882,14 +3882,14 @@ func TestInterpretImport(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -3961,14 +3961,14 @@ func TestInterpretImportError(t *testing.T) {
 			Options: []sema.Option{
 				sema.WithPredeclaredValues(valueDeclarations),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -5283,14 +5283,14 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -6782,14 +6782,14 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -71,14 +71,14 @@ func TestInterpretStatementHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -191,14 +191,14 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),
@@ -318,14 +318,14 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -97,7 +97,8 @@ func TestInterpretStatementHandler(t *testing.T) {
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithOnStatementHandler(
 			func(statement *interpreter.Statement) {
 				inter := statement.Interpreter
@@ -121,8 +122,15 @@ func TestInterpretStatementHandler(t *testing.T) {
 					utils.ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),
@@ -217,29 +225,39 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
-		interpreter.WithOnLoopIterationHandler(func(inter *interpreter.Interpreter, line int) {
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
+		interpreter.WithOnLoopIterationHandler(
+			func(inter *interpreter.Interpreter, line int) {
 
-			id, ok := interpreterIDs[inter]
-			if !ok {
-				id = nextInterpreterID
-				nextInterpreterID++
-				interpreterIDs[inter] = id
-			}
+				id, ok := interpreterIDs[inter]
+				if !ok {
+					id = nextInterpreterID
+					nextInterpreterID++
+					interpreterIDs[inter] = id
+				}
 
-			occurrences = append(occurrences, occurrence{
-				interpreterID: id,
-				line:          line,
-			})
-		}),
+				occurrences = append(occurrences, occurrence{
+					interpreterID: id,
+					line:          line,
+				})
+			},
+		),
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				assert.Equal(t,
 					utils.ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),
@@ -344,7 +362,8 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithOnFunctionInvocationHandler(
 			func(inter *interpreter.Interpreter, line int) {
 
@@ -367,8 +386,15 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 					utils.ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -65,14 +65,14 @@ func TestInterpretResourceUUID(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, *sema.CheckerError) {
+					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
 							location,
 						)
 
-						return sema.CheckerImport{
-							Checker: importedChecker,
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
 				),

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -84,7 +84,8 @@ func TestInterpretResourceUUID(t *testing.T) {
 	var uuid uint64
 
 	inter, err := interpreter.NewInterpreter(
-		importingChecker,
+		interpreter.ProgramFromChecker(importingChecker),
+		importingChecker.Location,
 		interpreter.WithUUIDHandler(
 			func() (uint64, error) {
 				defer func() { uuid++ }()
@@ -97,8 +98,15 @@ func TestInterpretResourceUUID(t *testing.T) {
 					ImportedLocation,
 					location,
 				)
-				return interpreter.ProgramImport{
-					Program: importedChecker.Program,
+
+				program := interpreter.ProgramFromChecker(importedChecker)
+				subInterpreter, err := inter.NewSubInterpreter(program, location)
+				if err != nil {
+					panic(err)
+				}
+
+				return interpreter.InterpreterImport{
+					Interpreter: subInterpreter,
 				}
 			},
 		),


### PR DESCRIPTION
⚠️ Depends on #572

## Description

This PR is the second part of #562, which only contains the changes to the interpreter.

It's targeting a feature branch that can be merged at the end, as the PR itself doesn't pass CI.
