### PR TITLE
Fix runtime type of Block.timestamp

### DIFF
--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -32,7 +32,7 @@ type BlockValue struct {
 	Height    UInt64Value
 	View      UInt64Value
 	ID        *ArrayValue
-	Timestamp Fix64Value
+	Timestamp UFix64Value
 }
 
 func (BlockValue) IsValue() {}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -626,3 +626,11 @@ func TestVisitor(t *testing.T) {
 	require.Equal(t, 1, intVisits)
 	require.Equal(t, 1, stringVisits)
 }
+
+func TestBlockValue(t *testing.T) {
+	var block BlockValue = BlockValue{ 4, 5, &ArrayValue{}, 5.0}
+	// static type test
+	var actualTs UFix64Value = block.Timestamp
+	const expectedTs UFix64Value = 5.0
+	assert.Equal(t, expectedTs, actualTs)
+}

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -253,7 +253,7 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 		}
 
 		// code, if position
-		if excerpt.startPos != nil && len(code) > 0 {
+		if excerpt.startPos != nil && excerpt.startPos.Line > 0 && len(code) > 0 {
 
 			if i > 0 && lastLineNumber != 0 && excerpt.startPos.Line-1 > lastLineNumber {
 				p.writeCodeExcerptContinuation(lineNumberLength)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1879,7 +1879,7 @@ func NewBlockValue(block Block) interpreter.BlockValue {
 
 	// timestamp
 	// TODO: verify
-	timestampValue := interpreter.NewFix64ValueWithInteger(time.Unix(0, block.Timestamp).Unix())
+	timestampValue := interpreter.NewUFix64ValueWithInteger(uint64(time.Unix(0, block.Timestamp).Unix()))
 
 	return interpreter.BlockValue{
 		Height:    heightValue,

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -369,3 +369,19 @@ func TestCheckInvalidResourceCapturingJustMemberAccess(t *testing.T) {
 	assert.IsType(t, &sema.ResourceCapturingError{}, errs[0])
 	assert.IsType(t, &sema.ResourceLossError{}, errs[1])
 }
+
+func TestCheckInvalidFunctionWithResult(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+     fun test(): Int {
+         let result = 0
+         return result
+     }
+   `)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+}

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -103,7 +103,6 @@ func TestBlockTimestamp(t *testing.T) {
 				log(ts.isInstance(Type<UFix64>()))
 
 				var div: UFix64 = 4.0
-				var x = ts as UFix64
 
 				// Shouldn't panic
 				var result = ts/div
@@ -133,5 +132,5 @@ func TestBlockTimestamp(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	assert.True(t, loggedMessage == "true", "Block.Timestamp is not UFix64")
+	assert.Equal(t, "True", loggedMessage, "Block.Timestamp is not UFix64")
 }

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -90,3 +90,48 @@ func TestRuntimeTypeStorage(t *testing.T) {
 
 	assert.Equal(t, `"Int"`, loggedMessage)
 }
+
+
+func TestBlockTimestamp(t *testing.T) {
+	t.Parallel()
+	runtime := NewInterpreterRuntime()
+	script := []byte(`
+		transaction {
+			prepare() {
+				let block = getCurrentBlock()
+				var ts: UFix64 = block.timestamp
+				log(ts.isInstance(Type<UFix64>()))
+
+				var div: UFix64 = 4.0
+				var x = ts as UFix64
+
+				// Shouldn't panic
+				var result = ts/div
+			}
+		}
+    `)
+
+	var loggedMessage string
+
+	runtimeInterface := &testRuntimeInterface{
+		getSigningAccounts: func() ([]Address, error) {
+			return nil, nil
+		},
+		log: func(message string) {
+			loggedMessage = message
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, loggedMessage == "true", "Block.Timestamp is not UFix64")
+}


### PR DESCRIPTION
Closes #563

## Description

The `timestamp` field of a [Block](https://docs.onflow.org/cadence/language/environment-information/#block-information) supposed to be `UFix64`. 

However, in the runtime/interpreter, this is represented in `Fix64`. This PR changes the runtime type of the `timestamp` field to `UFix64`, and aligns with the type checking of the checker.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
