### PR TITLE
Add an optional callback for encoding prepare function calls and debug log them to the runtime interface

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -69,8 +69,8 @@ type Interface interface {
 	RemoveAccountContractCode(address Address, name string) (err error)
 	// GetSigningAccounts returns the signing accounts.
 	GetSigningAccounts() ([]Address, error)
-	// Log logs a string.
-	Log(string) error
+	// ProgramLog logs program logs.
+	ProgramLog(string) error
 	// EmitEvent is called when an event is emitted by the runtime.
 	EmitEvent(cadence.Event) error
 	// ValueExists returns true if the given key exists in the storage, owned by the given account.
@@ -106,6 +106,8 @@ type Interface interface {
 	GetStorageUsed(address Address) (value uint64, err error)
 	// GetStorageCapacity gets storage capacity in bytes on the address.
 	GetStorageCapacity(address Address) (value uint64, err error)
+	// ImplementationDebugLog logs implementation log statements on a debug-level
+	ImplementationDebugLog(message string) error
 }
 
 type HighLevelStorage interface {
@@ -197,7 +199,7 @@ func (i *EmptyRuntimeInterface) GetSigningAccounts() ([]Address, error) {
 	return nil, nil
 }
 
-func (i *EmptyRuntimeInterface) Log(_ string) error {
+func (i *EmptyRuntimeInterface) ProgramLog(_ string) error {
 	return nil
 }
 
@@ -231,6 +233,10 @@ func (i *EmptyRuntimeInterface) GetBlockAtHeight(_ uint64) (block Block, exists 
 
 func (i *EmptyRuntimeInterface) UnsafeRandom() (uint64, error) {
 	return 0, nil
+}
+
+func (i *EmptyRuntimeInterface) ImplementationDebugLog(_ string) error {
+	return nil
 }
 
 func (i *EmptyRuntimeInterface) VerifySignature(

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -188,11 +188,14 @@ type EncodingDeferrals struct {
 	Moves  []EncodingDeferralMove
 }
 
+type EncodingPrepareCallback func(value Value, path []string)
+
 // Encoder converts Values into CBOR-encoded bytes.
 //
 type Encoder struct {
-	enc      *cbor.Encoder
-	deferred bool
+	enc             *cbor.Encoder
+	deferred        bool
+	prepareCallback EncodingPrepareCallback
 }
 
 // EncodeValue returns the CBOR-encoded representation of the given value.
@@ -208,13 +211,13 @@ type Encoder struct {
 // which have not been encoded, and which values need to be moved
 // from a previous storage key to another storage key.
 //
-func EncodeValue(value Value, path []string, deferred bool) (
+func EncodeValue(value Value, path []string, deferred bool, prepareCallback EncodingPrepareCallback) (
 	encoded []byte,
 	deferrals *EncodingDeferrals,
 	err error,
 ) {
 	var w bytes.Buffer
-	enc, err := NewEncoder(&w, deferred)
+	enc, err := NewEncoder(&w, deferred, prepareCallback)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -245,7 +248,7 @@ func EncodeValue(value Value, path []string, deferred bool) (
 // NewEncoder initializes an Encoder that will write CBOR-encoded bytes
 // to the given io.Writer.
 //
-func NewEncoder(w io.Writer, deferred bool) (*Encoder, error) {
+func NewEncoder(w io.Writer, deferred bool, prepareCallback EncodingPrepareCallback) (*Encoder, error) {
 	options := cbor.CanonicalEncOptions()
 	options.BigIntConvert = cbor.BigIntConvertNone
 	encMode, err := options.EncMode()
@@ -254,8 +257,9 @@ func NewEncoder(w io.Writer, deferred bool) (*Encoder, error) {
 	}
 	enc := encMode.NewEncoder(w)
 	return &Encoder{
-		enc:      enc,
-		deferred: deferred,
+		enc:             enc,
+		deferred:        deferred,
+		prepareCallback: prepareCallback,
 	}, nil
 }
 
@@ -289,6 +293,10 @@ func (e *Encoder) prepare(
 	interface{},
 	error,
 ) {
+	if e.prepareCallback != nil {
+		e.prepareCallback(v, path)
+	}
+
 	switch v := v.(type) {
 
 	case NilValue:

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1376,7 +1376,7 @@ func (r *interpreterRuntime) newLogFunction(runtimeInterface Interface) interpre
 		message := fmt.Sprint(invocation.Arguments[0])
 		var err error
 		wrapPanic(func() {
-			err = runtimeInterface.Log(message)
+			err = runtimeInterface.ProgramLog(message)
 		})
 		if err != nil {
 			panic(err)

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -19,6 +19,7 @@
 package runtime
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/onflow/cadence"
@@ -331,7 +332,12 @@ func (s *runtimeStorage) encodeValue(
 ) {
 	reportMetric(
 		func() {
-			data, deferrals, err = interpreter.EncodeValue(value, []string{path}, true)
+			data, deferrals, err = interpreter.EncodeValue(
+				value,
+				[]string{path},
+				true,
+				s.prepareCallback,
+			)
 		},
 		s.runtimeInterface,
 		func(metrics Metrics, duration time.Duration) {
@@ -360,4 +366,20 @@ func (s *runtimeStorage) move(
 	if err != nil {
 		panic(err)
 	}
+}
+
+func (s *runtimeStorage) prepareCallback(value interpreter.Value, path []string) {
+	logMessage := fmt.Sprintf(
+		"encoding value for key %s: %[1]T, %[1]v",
+		path,
+		value,
+	)
+	var err error
+	wrapPanic(func() {
+		err = s.runtimeInterface.ImplementationDebugLog(logMessage)
+	})
+	if err != nil {
+		panic(err)
+	}
+
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -117,10 +117,11 @@ type testRuntimeInterface struct {
 		signatureAlgorithm string,
 		hashAlgorithm string,
 	) (bool, error)
-	hash               func(data []byte, hashAlgorithm string) ([]byte, error)
-	setCadenceValue    func(owner Address, key string, value cadence.Value) (err error)
-	getStorageUsed     func(_ Address) (uint64, error)
-	getStorageCapacity func(_ Address) (uint64, error)
+	hash                   func(data []byte, hashAlgorithm string) ([]byte, error)
+	setCadenceValue        func(owner Address, key string, value cadence.Value) (err error)
+	getStorageUsed         func(address Address) (uint64, error)
+	getStorageCapacity     func(address Address) (uint64, error)
+	implementationDebugLog func(message string) error
 }
 
 var _ Interface = &testRuntimeInterface{}
@@ -201,7 +202,7 @@ func (i *testRuntimeInterface) GetSigningAccounts() ([]Address, error) {
 	return i.getSigningAccounts()
 }
 
-func (i *testRuntimeInterface) Log(message string) error {
+func (i *testRuntimeInterface) ProgramLog(message string) error {
 	i.log(message)
 	return nil
 }
@@ -338,6 +339,13 @@ func (i *testRuntimeInterface) GetStorageUsed(address Address) (uint64, error) {
 
 func (i *testRuntimeInterface) GetStorageCapacity(address Address) (uint64, error) {
 	return i.getStorageCapacity(address)
+}
+
+func (i *testRuntimeInterface) ImplementationDebugLog(message string) error {
+	if i.implementationDebugLog == nil {
+		return nil
+	}
+	return i.implementationDebugLog(message)
 }
 
 func TestRuntimeImport(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7774,7 +7774,7 @@ func TestInterpretCompositeValueFieldEncodingOrder(t *testing.T) {
 			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 		})
 
-		encoded, _, err := interpreter.EncodeValue(test, nil, false)
+		encoded, _, err := interpreter.EncodeValue(test, nil, false, nil)
 		require.NoError(t, err)
 
 		encodings[i] = encoded
@@ -7830,7 +7830,7 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 		test.SetOwner(owner)
 
 		var path []string = nil
-		encoded, _, err := interpreter.EncodeValue(test, path, false)
+		encoded, _, err := interpreter.EncodeValue(test, path, false, nil)
 		require.NoError(t, err)
 
 		decoder, err := interpreter.NewDecoder(


### PR DESCRIPTION

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
