### PR TITLE
Fix `String()` function of `DicitonaryValue` when values are deferred

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5907,12 +5907,23 @@ func (v *DictionaryValue) String() string {
 	for i, keyValue := range v.Keys.Values {
 		key := dictionaryKey(keyValue)
 		value := v.Entries[key]
+
+		// Value is potentially deferred,
+		// so might be nil
+
+		var valueString string
+		if value == nil {
+			valueString = "..."
+		} else {
+			valueString = value.String()
+		}
+
 		pairs[i] = struct {
 			Key   string
 			Value string
 		}{
 			Key:   keyValue.String(),
-			Value: value.String(),
+			Value: valueString,
 		}
 	}
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -573,6 +573,25 @@ func TestStringer(t *testing.T) {
 			},
 			expected: "Capability<Int>(address: 0x102030405, path: /storage/foo)",
 		},
+		"Dictionary with non-deferred values": {
+			value: NewDictionaryValueUnownedNonCopying(
+				NewStringValue("a"), UInt8Value(42),
+				NewStringValue("b"), UInt8Value(99),
+			),
+			expected: `{"a": 42, "b": 99}`,
+		},
+		"Dictionary with deferred value": {
+			value: &DictionaryValue{
+				Keys: NewArrayValueUnownedNonCopying(
+					NewStringValue("a"),
+					NewStringValue("b"),
+				),
+				Entries: map[string]Value{
+					NewStringValue("a").KeyString(): UInt8Value(42),
+				},
+			},
+			expected: `{"a": 42, "b": ...}`,
+		},
 	}
 
 	test := func(name string, testCase testCase) {
@@ -594,6 +613,8 @@ func TestStringer(t *testing.T) {
 }
 
 func TestVisitor(t *testing.T) {
+
+	t.Parallel()
 
 	var intVisits, stringVisits int
 
@@ -628,9 +649,17 @@ func TestVisitor(t *testing.T) {
 }
 
 func TestBlockValue(t *testing.T) {
-	var block BlockValue = BlockValue{ 4, 5, &ArrayValue{}, 5.0}
+
+	t.Parallel()
+
+	block := BlockValue{
+		Height:    4,
+		View:      5,
+		ID:        NewArrayValueUnownedNonCopying(),
+		Timestamp: 5.0,
+	}
 	// static type test
-	var actualTs UFix64Value = block.Timestamp
+	var actualTs = block.Timestamp
 	const expectedTs UFix64Value = 5.0
 	assert.Equal(t, expectedTs, actualTs)
 }

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -370,7 +370,7 @@ func (s *runtimeStorage) move(
 
 func (s *runtimeStorage) prepareCallback(value interpreter.Value, path []string) {
 	logMessage := fmt.Sprintf(
-		"encoding value for key %[1]s: %[2]T, %[2]v",
+		"encoding value for key %s: %T",
 		path,
 		value,
 	)
@@ -381,5 +381,4 @@ func (s *runtimeStorage) prepareCallback(value interpreter.Value, path []string)
 	if err != nil {
 		panic(err)
 	}
-
 }


### PR DESCRIPTION
## Description

Properly handle the case in the `String()` function of `DictionaryValue` where values are deferred, i.e. are stored in separate storage keys and are loaded lazily.

In this case just print and ellipsis for now. To fully print the deferred values the `Get` function must be used, but it requires an `Interpreter` to access storage and load the deferred value. However, it is not available in `String()`. We might consider not implementing the `Stringer` interface / `String()` function, but a variant of it that has an `Interpreter` parameter.

Also adjust the debug logging of encoded values and don't fully log the whole encoded value, as it might be very large.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
