### PR TITLE
Improve Virtual Machine

### DIFF
--- a/runtime/compiler/codegen.go
+++ b/runtime/compiler/codegen.go
@@ -207,6 +207,7 @@ var addFunctionType = &wasm.FunctionType{
 }
 
 func (codeGen *wasmCodeGen) addRuntimeImports() {
+	// NOTE: ensure to update the imports in the vm
 	codeGen.runtimeFunctionIndexInt = codeGen.addRuntimeImport("Int", constantFunctionType)
 	codeGen.runtimeFunctionIndexString = codeGen.addRuntimeImport("String", constantFunctionType)
 	codeGen.runtimeFunctionIndexAdd = codeGen.addRuntimeImport("add", addFunctionType)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -125,6 +125,10 @@ func NewVM(wasm []byte) (VM, error) {
 		return leftNumber.Plus(rightNumber), nil
 	})
 
+	// NOTE: wasmtime currently does not support specifying imports by name,
+	// unlike other WebAssembly APIs like wasmer, JavaScript, etc.,
+	// i.e. imports are imported in the order they are given.
+
 	instance, err := wasmtime.NewInstance(
 		store,
 		module,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -71,28 +71,31 @@ func NewVM(wasm []byte) (VM, error) {
 		return nil, err
 	}
 
-	var mem *wasmtime.Memory
+	intFunc := wasmtime.WrapFunc(
+		store,
+		func(caller *wasmtime.Caller, offset int32, length int32) (interface{}, *wasmtime.Trap) {
+			if offset < 0 {
+				return nil, wasmtime.NewTrap(store, fmt.Sprintf("Int: invalid offset: %d", offset))
+			}
 
-	intFunc := wasmtime.WrapFunc(store, func(offset int32, length int32) (interface{}, *wasmtime.Trap) {
-		if offset < 0 {
-			return nil, wasmtime.NewTrap(store, fmt.Sprintf("Int: invalid offset: %d", offset))
-		}
+			if length < 2 {
+				return nil, wasmtime.NewTrap(store, fmt.Sprintf("Int: invalid length: %d", length))
+			}
 
-		if length < 2 {
-			return nil, wasmtime.NewTrap(store, fmt.Sprintf("Int: invalid length: %d", length))
-		}
+			mem := caller.GetExport("mem").Memory()
 
-		bytes := C.GoBytes(mem.Data(), C.int(length))
+			bytes := C.GoBytes(mem.Data(), C.int(length))
 
-		value := new(big.Int).SetBytes(bytes[1:])
-		if bytes[0] == 0 {
-			value = value.Neg(value)
-		}
+			value := new(big.Int).SetBytes(bytes[1:])
+			if bytes[0] == 0 {
+				value = value.Neg(value)
+			}
 
-		return interpreter.NewIntValueFromBigInt(value), nil
-	})
+			return interpreter.NewIntValueFromBigInt(value), nil
+		},
+	)
 
-	stringFunc := wasmtime.WrapFunc(store, func(offset int32, length int32) (interface{}, *wasmtime.Trap) {
+	stringFunc := wasmtime.WrapFunc(store, func(caller *wasmtime.Caller, offset int32, length int32) (interface{}, *wasmtime.Trap) {
 		if offset < 0 {
 			return nil, wasmtime.NewTrap(store, fmt.Sprintf("String: invalid offset: %d", offset))
 		}
@@ -100,6 +103,8 @@ func NewVM(wasm []byte) (VM, error) {
 		if length < 0 {
 			return nil, wasmtime.NewTrap(store, fmt.Sprintf("String: invalid length: %d", length))
 		}
+
+		mem := caller.GetExport("mem").Memory()
 
 		bytes := C.GoBytes(mem.Data(), C.int(length))
 
@@ -132,8 +137,6 @@ func NewVM(wasm []byte) (VM, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	mem = instance.GetExport("mem").Memory()
 
 	return &vm{
 		instance: instance,


### PR DESCRIPTION
## Description

Instead of closing over the wasmtime store/memory in the imports of the module, get the exported memory from the caller argument.

See bytecodealliance/wasmtime-go#57

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
