### PR TITLE
Reuse enc mode and dec mode

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -93,27 +93,26 @@ func NewDecoder(
 	*Decoder,
 	error,
 ) {
-	dm, err := decMode()
-	if err != nil {
-		return nil, err
-	}
-
 	return &Decoder{
-		decoder:        dm.NewDecoder(reader),
+		decoder:        decMode.NewDecoder(reader),
 		owner:          owner,
 		version:        version,
 		decodeCallback: decodeCallback,
 	}, nil
 }
 
-func decMode() (cbor.DecMode, error) {
-	return cbor.DecOptions{
+var decMode = func() cbor.DecMode {
+	decMode, err := cbor.DecOptions{
 		IntDec:           cbor.IntDecConvertNone,
 		MaxArrayElements: 512 * 1024,
 		MaxMapPairs:      512 * 1024,
 		MaxNestedLevels:  256,
 	}.DecMode()
-}
+	if err != nil {
+		panic(err)
+	}
+	return decMode
+}()
 
 // Decode reads CBOR-encoded bytes from the io.Reader and decodes them to a value.
 //

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -19,6 +19,7 @@
 package interpreter
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -4342,4 +4343,42 @@ func TestDecodeCallback(t *testing.T) {
 		},
 		decodeCallbacks,
 	)
+}
+
+func BenchmarkEncoding(b *testing.B) {
+
+	value := prepareLargeTestValue()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = EncodeValue(value, nil, false, nil)
+	}
+}
+
+func BenchmarkDecoding(b *testing.B) {
+
+	value := prepareLargeTestValue()
+	encoded, _, err := EncodeValue(value, nil, false, nil)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = DecodeValue(encoded, nil, nil, CurrentEncodingVersion, nil)
+	}
+}
+
+func prepareLargeTestValue() Value {
+	values := NewArrayValueUnownedNonCopying()
+	for i := 0; i < 100; i++ {
+		dict := NewDictionaryValueUnownedNonCopying()
+		for i := 0; i < 100; i++ {
+			key := NewStringValue(fmt.Sprintf("hello world %d", i))
+			value := NewInt256ValueFromInt64(int64(i))
+			dict.Set(nil, LocationRange{}, key, NewSomeValueOwningNonCopying(value))
+		}
+		values.Append(dict)
+	}
+	return values
 }


### PR DESCRIPTION
## Description

Found by @ramtinms: From https://github.com/fxamacker/cbor:

> 💡 Avoid using init(). For best performance, reuse EncMode and DecMode after creating them.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
