### PR TITLE
Cache members of composite types and interface types

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -584,7 +584,7 @@ func (checker *Checker) declareCompositeMembersAndValue(
 					continue
 				}
 
-				nestedCompositeType.AddImplicitTypeRequirementConformance(typeRequirement)
+				nestedCompositeType.addImplicitTypeRequirementConformance(typeRequirement)
 			}
 		})
 


### PR DESCRIPTION
## Description

Only compute composite types' and interface types' members once.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
