### PR TITLE
Refactor Type, Bool, and Character type to singletons

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -47,8 +47,6 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return exportOptionalType(t, results)
 		case *sema.StringType:
 			return cadence.StringType{}
-		case *sema.CharacterType:
-			return cadence.CharacterType{}
 		case *sema.NumberType:
 			return cadence.NumberType{}
 		case *sema.SignedNumberType:
@@ -152,6 +150,8 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.MetaType{}
 		case sema.BoolType:
 			return cadence.BoolType{}
+		case sema.CharacterType:
+			return cadence.CharacterType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -43,8 +43,6 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.AnyStructType{}
 		case *sema.AnyResourceType:
 			return cadence.AnyResourceType{}
-		case *sema.MetaType:
-			return cadence.MetaType{}
 		case *sema.OptionalType:
 			return exportOptionalType(t, results)
 		case *sema.BoolType:
@@ -152,6 +150,8 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.VoidType{}
 		case sema.InvalidType:
 			return nil
+		case sema.MetaType:
+			return cadence.MetaType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -45,8 +45,6 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.AnyResourceType{}
 		case *sema.OptionalType:
 			return exportOptionalType(t, results)
-		case *sema.BoolType:
-			return cadence.BoolType{}
 		case *sema.StringType:
 			return cadence.StringType{}
 		case *sema.CharacterType:
@@ -152,6 +150,8 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return nil
 		case sema.MetaType:
 			return cadence.MetaType{}
+		case sema.BoolType:
+			return cadence.BoolType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3504,7 +3504,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 			encodeDecodeTest{
 				value: LinkValue{
 					TargetPath: publicPathValue,
-					Type:       ConvertSemaToPrimitiveStaticType(&sema.BoolType{}),
+					Type:       ConvertSemaToPrimitiveStaticType(sema.BoolType),
 				},
 				encoded: append(
 					expectedLinkEncodingPrefix[:],
@@ -4199,7 +4199,7 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				value: TypeValue{
-					Type: ConvertSemaToPrimitiveStaticType(&sema.BoolType{}),
+					Type: ConvertSemaToPrimitiveStaticType(sema.BoolType),
 				},
 				encoded: []byte{
 					// tag

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3829,13 +3829,11 @@ func IsSubType(subType DynamicType, superType sema.Type) bool {
 		}
 
 	case BoolDynamicType:
-		switch superType.(type) {
-		case *sema.BoolType, *sema.AnyStructType:
+		if _, ok := superType.(*sema.AnyStructType); ok {
 			return true
-
-		default:
-			return false
 		}
+
+		return superType == sema.BoolType
 
 	case AddressDynamicType:
 		switch superType.(type) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3806,13 +3806,11 @@ func (interpreter *Interpreter) newConverterFunction(converter ValueConverter) F
 func IsSubType(subType DynamicType, superType sema.Type) bool {
 	switch typedSubType := subType.(type) {
 	case MetaTypeDynamicType:
-		switch superType.(type) {
-		case *sema.MetaType, *sema.AnyStructType:
+		if _, ok := superType.(*sema.AnyStructType); ok {
 			return true
-
-		default:
-			return false
 		}
+
+		return superType == sema.MetaType
 
 	case VoidDynamicType:
 		if _, ok := superType.(*sema.AnyStructType); ok {

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -44,8 +44,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	t.Run("Bool to Bool?", func(t *testing.T) {
 		value := inter.boxOptional(
 			BoolValue(true),
-			&sema.BoolType{},
-			&sema.OptionalType{Type: &sema.BoolType{}},
+			sema.BoolType,
+			&sema.OptionalType{Type: sema.BoolType},
 		)
 		assert.Equal(t,
 			NewSomeValueOwningNonCopying(BoolValue(true)),
@@ -56,8 +56,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	t.Run("Bool? to Bool?", func(t *testing.T) {
 		value := inter.boxOptional(
 			NewSomeValueOwningNonCopying(BoolValue(true)),
-			&sema.OptionalType{Type: &sema.BoolType{}},
-			&sema.OptionalType{Type: &sema.BoolType{}},
+			&sema.OptionalType{Type: sema.BoolType},
+			&sema.OptionalType{Type: sema.BoolType},
 		)
 		assert.Equal(t,
 			NewSomeValueOwningNonCopying(BoolValue(true)),
@@ -68,8 +68,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	t.Run("Bool? to Bool??", func(t *testing.T) {
 		value := inter.boxOptional(
 			NewSomeValueOwningNonCopying(BoolValue(true)),
-			&sema.OptionalType{Type: &sema.BoolType{}},
-			&sema.OptionalType{Type: &sema.OptionalType{Type: &sema.BoolType{}}},
+			&sema.OptionalType{Type: sema.BoolType},
+			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
 			NewSomeValueOwningNonCopying(
@@ -84,7 +84,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		value := inter.boxOptional(
 			NilValue{},
 			&sema.OptionalType{Type: sema.NeverType},
-			&sema.OptionalType{Type: &sema.OptionalType{Type: &sema.BoolType{}}},
+			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
 			NilValue{},
@@ -97,7 +97,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		value := inter.boxOptional(
 			NewSomeValueOwningNonCopying(NilValue{}),
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.NeverType}},
-			&sema.OptionalType{Type: &sema.OptionalType{Type: &sema.BoolType{}}},
+			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
 			NilValue{},
@@ -133,7 +133,7 @@ func TestInterpreterBoxing(t *testing.T) {
 					),
 					inter.convertAndBox(
 						BoolValue(true),
-						&sema.BoolType{},
+						sema.BoolType,
 						&sema.OptionalType{Type: anyType},
 					),
 				)
@@ -148,7 +148,7 @@ func TestInterpreterBoxing(t *testing.T) {
 					),
 					inter.convertAndBox(
 						NewSomeValueOwningNonCopying(BoolValue(true)),
-						&sema.OptionalType{Type: &sema.BoolType{}},
+						&sema.OptionalType{Type: sema.BoolType},
 						&sema.OptionalType{Type: anyType},
 					),
 				)

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -190,7 +190,7 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return &sema.CharacterType{}
 
 	case PrimitiveStaticTypeMetaType:
-		return &sema.MetaType{}
+		return sema.MetaType
 
 	case PrimitiveStaticTypeBlock:
 		return &sema.BlockType{}
@@ -320,9 +320,6 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	case *sema.CharacterType:
 		return PrimitiveStaticTypeCharacter
 
-	case *sema.MetaType:
-		return PrimitiveStaticTypeMetaType
-
 	case *sema.BlockType:
 		return PrimitiveStaticTypeBlock
 
@@ -425,6 +422,8 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 		return PrimitiveStaticTypeNever
 	case sema.VoidType:
 		return PrimitiveStaticTypeVoid
+	case sema.MetaType:
+		return PrimitiveStaticTypeMetaType
 	}
 
 	return PrimitiveStaticTypeUnknown

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -187,7 +187,7 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return &sema.StringType{}
 
 	case PrimitiveStaticTypeCharacter:
-		return &sema.CharacterType{}
+		return sema.CharacterType
 
 	case PrimitiveStaticTypeMetaType:
 		return sema.MetaType
@@ -314,9 +314,6 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	case *sema.StringType:
 		return PrimitiveStaticTypeString
 
-	case *sema.CharacterType:
-		return PrimitiveStaticTypeCharacter
-
 	case *sema.BlockType:
 		return PrimitiveStaticTypeBlock
 
@@ -423,6 +420,8 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 		return PrimitiveStaticTypeMetaType
 	case sema.BoolType:
 		return PrimitiveStaticTypeBool
+	case sema.CharacterType:
+		return PrimitiveStaticTypeCharacter
 	}
 
 	return PrimitiveStaticTypeUnknown

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -178,7 +178,7 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return &sema.AnyResourceType{}
 
 	case PrimitiveStaticTypeBool:
-		return &sema.BoolType{}
+		return sema.BoolType
 
 	case PrimitiveStaticTypeAddress:
 		return &sema.AddressType{}
@@ -308,9 +308,6 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	case *sema.AnyResourceType:
 		return PrimitiveStaticTypeAnyResource
 
-	case *sema.BoolType:
-		return PrimitiveStaticTypeBool
-
 	case *sema.AddressType:
 		return PrimitiveStaticTypeAddress
 
@@ -424,6 +421,8 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 		return PrimitiveStaticTypeVoid
 	case sema.MetaType:
 		return PrimitiveStaticTypeMetaType
+	case sema.BoolType:
+		return PrimitiveStaticTypeBool
 	}
 
 	return PrimitiveStaticTypeUnknown

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -282,14 +282,6 @@ func LiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error
 
 		return cadence.NewString(expression.Value), nil
 
-	case *sema.BoolType:
-		expression, ok := expression.(*ast.BoolExpression)
-		if !ok {
-			return nil, LiteralExpressionTypeError
-		}
-
-		return cadence.NewBool(expression.Value), nil
-
 	case *sema.AddressType:
 		expression, ok := expression.(*ast.IntegerExpression)
 		if !ok {
@@ -301,6 +293,16 @@ func LiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error
 		}
 
 		return cadence.BytesToAddress(expression.Value.Bytes()), nil
+	}
+
+	switch ty {
+	case sema.BoolType:
+		expression, ok := expression.(*ast.BoolExpression)
+		if !ok {
+			return nil, LiteralExpressionTypeError
+		}
+
+		return cadence.NewBool(expression.Value), nil
 	}
 
 	switch {

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -47,7 +47,7 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("Bool, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`true`, &sema.BoolType{})
+		value, err := ParseLiteral(`true`, sema.BoolType)
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewBool(true),
@@ -56,13 +56,13 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("Bool, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`"hello"`, &sema.BoolType{})
+		value, err := ParseLiteral(`"hello"`, sema.BoolType)
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
 
 	t.Run("Optional, nil", func(t *testing.T) {
-		value, err := ParseLiteral(`nil`, &sema.OptionalType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`nil`, &sema.OptionalType{Type: sema.BoolType})
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewOptional(nil),
@@ -71,7 +71,7 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("Optional, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`true`, &sema.OptionalType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`true`, &sema.OptionalType{Type: sema.BoolType})
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewOptional(cadence.NewBool(true)),
@@ -80,13 +80,13 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("Optional, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`"hello"`, &sema.OptionalType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`"hello"`, &sema.OptionalType{Type: sema.BoolType})
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
 
 	t.Run("VariableSizedArray, empty", func(t *testing.T) {
-		value, err := ParseLiteral(`[]`, &sema.VariableSizedType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`[]`, &sema.VariableSizedType{Type: sema.BoolType})
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewArray([]cadence.Value{}),
@@ -95,7 +95,7 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("VariableSizedArray, one element", func(t *testing.T) {
-		value, err := ParseLiteral(`[true]`, &sema.VariableSizedType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`[true]`, &sema.VariableSizedType{Type: sema.BoolType})
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewArray([]cadence.Value{
@@ -106,13 +106,13 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("VariableSizedArray, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`"hello"`, &sema.VariableSizedType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`"hello"`, &sema.VariableSizedType{Type: sema.BoolType})
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
 
 	t.Run("ConstantSizedArray, empty", func(t *testing.T) {
-		value, err := ParseLiteral(`[]`, &sema.ConstantSizedType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`[]`, &sema.ConstantSizedType{Type: sema.BoolType})
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewArray([]cadence.Value{}),
@@ -121,7 +121,7 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("ConstantSizedArray, one element", func(t *testing.T) {
-		value, err := ParseLiteral(`[true]`, &sema.ConstantSizedType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`[true]`, &sema.ConstantSizedType{Type: sema.BoolType})
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewArray([]cadence.Value{
@@ -132,7 +132,7 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("ConstantSizedArray, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`"hello"`, &sema.ConstantSizedType{Type: &sema.BoolType{}})
+		value, err := ParseLiteral(`"hello"`, &sema.ConstantSizedType{Type: sema.BoolType})
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
@@ -140,7 +140,7 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("Dictionary, empty", func(t *testing.T) {
 		value, err := ParseLiteral(`{}`, &sema.DictionaryType{
 			KeyType:   &sema.StringType{},
-			ValueType: &sema.BoolType{},
+			ValueType: sema.BoolType,
 		})
 		require.NoError(t, err)
 		require.Equal(t,
@@ -152,7 +152,7 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("Dictionary, one entry", func(t *testing.T) {
 		value, err := ParseLiteral(`{"hello": true}`, &sema.DictionaryType{
 			KeyType:   &sema.StringType{},
-			ValueType: &sema.BoolType{},
+			ValueType: sema.BoolType,
 		})
 		require.NoError(t, err)
 		require.Equal(t,
@@ -169,7 +169,7 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("Dictionary, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`"hello"`, &sema.DictionaryType{
 			KeyType:   &sema.StringType{},
-			ValueType: &sema.BoolType{},
+			ValueType: sema.BoolType,
 		})
 		require.Error(t, err)
 		require.Nil(t, value)
@@ -586,7 +586,7 @@ func TestParseLiteralArgumentList(t *testing.T) {
 			`(a: 1, 2)`,
 			[]sema.Type{
 				&sema.IntType{},
-				&sema.BoolType{},
+				sema.BoolType,
 			},
 		)
 		require.Error(t, err)

--- a/runtime/sema/bool_type.go
+++ b/runtime/sema/bool_type.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/sema/bool_type.go
+++ b/runtime/sema/bool_type.go
@@ -16,31 +16,18 @@
  * limitations under the License.
  */
 
-package checker
+package sema
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/onflow/cadence/runtime/sema"
-)
-
-func TestCheckBoolean(t *testing.T) {
-
-	t.Parallel()
-
-	checker, err := ParseAndCheck(t, `
-        let x = true
-    `)
-
-	require.NoError(t, err)
-
-	xType := RequireGlobalValue(t, checker.Elaboration, "x")
-
-	assert.Equal(t,
-		sema.BoolType,
-		xType,
-	)
+// BoolType represents the boolean type
+//
+var BoolType = &NominalType{
+	Name:                 "Bool",
+	QualifiedName:        "Bool",
+	TypeID:               "Bool",
+	IsInvalid:            false,
+	IsResource:           false,
+	Storable:             true,
+	Equatable:            true,
+	ExternallyReturnable: true,
+	IsSuperTypeOf:        nil,
 }

--- a/runtime/sema/character_type.go
+++ b/runtime/sema/character_type.go
@@ -18,40 +18,16 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
-)
-
-const typeIdentifierDocString = `
-The fully-qualified identifier of the type
-`
-
-// MetaType represents the type of a type.
+// CharacterType represents the character type
 //
-var MetaType = &NominalType{
-	Name:                 "Type",
-	QualifiedName:        "Type",
-	TypeID:               "Type",
+var CharacterType = &NominalType{
+	Name:                 "Character",
+	QualifiedName:        "Character",
+	TypeID:               "Character",
 	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             true,
 	Equatable:            true,
 	ExternallyReturnable: true,
 	IsSuperTypeOf:        nil,
-	Members: func(t *NominalType) map[string]MemberResolver {
-		return map[string]MemberResolver{
-			"identifier": {
-				Kind: common.DeclarationKindField,
-				Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
-					return NewPublicConstantFieldMember(
-						t,
-						identifier,
-						&StringType{},
-						typeIdentifierDocString,
-					)
-				},
-			},
-		}
-	},
 }

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -212,7 +212,7 @@ func (checker *Checker) checkBinaryExpressionArithmeticOrNonEqualityComparisonOr
 		return leftType
 
 	case BinaryOperationKindNonEqualityComparison:
-		return &BoolType{}
+		return BoolType
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -227,7 +227,7 @@ func (checker *Checker) checkBinaryExpressionEquality(
 	leftIsInvalid, rightIsInvalid, anyInvalid bool,
 ) (resultType Type) {
 
-	resultType = &BoolType{}
+	resultType = BoolType
 
 	if anyInvalid {
 		return
@@ -259,8 +259,8 @@ func (checker *Checker) checkBinaryExpressionBooleanLogic(
 ) Type {
 	// check both types are boolean subtypes
 
-	leftIsBool := IsSubType(leftType, &BoolType{})
-	rightIsBool := IsSubType(rightType, &BoolType{})
+	leftIsBool := IsSubType(leftType, BoolType)
+	rightIsBool := IsSubType(rightType, BoolType)
 
 	if !leftIsBool && !rightIsBool {
 		if !anyInvalid {
@@ -279,7 +279,7 @@ func (checker *Checker) checkBinaryExpressionBooleanLogic(
 				&InvalidBinaryOperandError{
 					Operation:    operation,
 					Side:         common.OperandSideLeft,
-					ExpectedType: &BoolType{},
+					ExpectedType: BoolType,
 					ActualType:   leftType,
 					Range:        ast.NewRangeFromPositioned(expression.Left),
 				},
@@ -291,7 +291,7 @@ func (checker *Checker) checkBinaryExpressionBooleanLogic(
 				&InvalidBinaryOperandError{
 					Operation:    operation,
 					Side:         common.OperandSideRight,
-					ExpectedType: &BoolType{},
+					ExpectedType: BoolType,
 					ActualType:   rightType,
 					Range:        ast.NewRangeFromPositioned(expression.Right),
 				},
@@ -299,7 +299,7 @@ func (checker *Checker) checkBinaryExpressionBooleanLogic(
 		}
 	}
 
-	return &BoolType{}
+	return BoolType
 }
 
 func (checker *Checker) checkBinaryExpressionNilCoalescing(

--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -98,11 +98,11 @@ func (checker *Checker) visitConditional(
 	testType := test.Accept(checker).(Type)
 
 	if !testType.IsInvalidType() &&
-		!IsSubType(testType, &BoolType{}) {
+		!IsSubType(testType, BoolType) {
 
 		checker.report(
 			&TypeMismatchError{
-				ExpectedType: &BoolType{},
+				ExpectedType: BoolType,
 				ActualType:   testType,
 				Range:        ast.NewRangeFromPositioned(test),
 			},

--- a/runtime/sema/check_conditions.go
+++ b/runtime/sema/check_conditions.go
@@ -47,11 +47,11 @@ func (checker *Checker) VisitCondition(condition *ast.Condition) ast.Repr {
 	testType := condition.Test.Accept(checker).(Type)
 
 	if !testType.IsInvalidType() &&
-		!IsSubType(testType, &BoolType{}) {
+		!IsSubType(testType, BoolType) {
 
 		checker.report(
 			&TypeMismatchError{
-				ExpectedType: &BoolType{},
+				ExpectedType: BoolType,
 				ActualType:   testType,
 				Range:        ast.NewRangeFromPositioned(condition.Test),
 			},

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -113,13 +113,13 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 func IsValidDictionaryKeyType(keyType Type) bool {
 	// TODO: implement support for more built-in types here and in interpreter
 	switch keyType := keyType.(type) {
-	case *StringType, *CharacterType, *AddressType:
+	case *StringType, *AddressType:
 		return true
 	case *CompositeType:
 		return keyType.Kind == common.CompositeKindEnum
 	default:
 		switch keyType {
-		case NeverType, BoolType:
+		case NeverType, BoolType, CharacterType:
 			return true
 		default:
 			return IsSubType(keyType, &NumberType{}) ||

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -113,13 +113,17 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 func IsValidDictionaryKeyType(keyType Type) bool {
 	// TODO: implement support for more built-in types here and in interpreter
 	switch keyType := keyType.(type) {
-	case *StringType, *BoolType, *CharacterType, *AddressType:
+	case *StringType, *CharacterType, *AddressType:
 		return true
 	case *CompositeType:
 		return keyType.Kind == common.CompositeKindEnum
 	default:
-		return keyType == NeverType ||
-			IsSubType(keyType, &NumberType{}) ||
-			IsSubType(keyType, PathType)
+		switch keyType {
+		case NeverType, BoolType:
+			return true
+		default:
+			return IsSubType(keyType, &NumberType{}) ||
+				IsSubType(keyType, PathType)
+		}
 	}
 }

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -56,7 +56,7 @@ func (checker *Checker) checkEventParameters(
 //
 func IsValidEventParameterType(t Type) bool {
 	switch t := t.(type) {
-	case *BoolType, *StringType, *CharacterType, *AddressType, *MetaType:
+	case *BoolType, *StringType, *CharacterType, *AddressType:
 		return true
 
 	case *OptionalType:
@@ -88,6 +88,11 @@ func IsValidEventParameterType(t Type) bool {
 		return true
 
 	default:
+		switch t {
+		case MetaType:
+			return true
+		}
+
 		return IsSubType(t, &NumberType{}) ||
 			IsSubType(t, PathType)
 	}

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -56,7 +56,7 @@ func (checker *Checker) checkEventParameters(
 //
 func IsValidEventParameterType(t Type) bool {
 	switch t := t.(type) {
-	case *StringType, *CharacterType, *AddressType:
+	case *StringType, *AddressType:
 		return true
 
 	case *OptionalType:
@@ -89,7 +89,7 @@ func IsValidEventParameterType(t Type) bool {
 
 	default:
 		switch t {
-		case MetaType, BoolType:
+		case MetaType, BoolType, CharacterType:
 			return true
 		}
 

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -56,7 +56,7 @@ func (checker *Checker) checkEventParameters(
 //
 func IsValidEventParameterType(t Type) bool {
 	switch t := t.(type) {
-	case *BoolType, *StringType, *CharacterType, *AddressType:
+	case *StringType, *CharacterType, *AddressType:
 		return true
 
 	case *OptionalType:
@@ -89,7 +89,7 @@ func IsValidEventParameterType(t Type) bool {
 
 	default:
 		switch t {
-		case MetaType:
+		case MetaType, BoolType:
 			return true
 		}
 

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -168,14 +168,15 @@ func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatem
 }
 
 func (checker *Checker) VisitBoolExpression(_ *ast.BoolExpression) ast.Repr {
-	return &BoolType{}
+	return BoolType
+}
+
+var TypeOfNil = &OptionalType{
+	Type: NeverType,
 }
 
 func (checker *Checker) VisitNilExpression(_ *ast.NilExpression) ast.Repr {
-	// TODO: verify
-	return &OptionalType{
-		Type: NeverType,
-	}
+	return TypeOfNil
 }
 
 func (checker *Checker) VisitIntegerExpression(_ *ast.IntegerExpression) ast.Repr {

--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -40,7 +40,7 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) as
 
 	switch expression.Operation {
 	case ast.OperationNegate:
-		expectedType := &BoolType{}
+		expectedType := BoolType
 		if !IsSubType(valueType, expectedType) {
 			reportInvalidUnaryOperator(expectedType)
 		}

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -29,11 +29,11 @@ func (checker *Checker) VisitWhileStatement(statement *ast.WhileStatement) ast.R
 	testType := testExpression.Accept(checker).(Type)
 
 	if !testType.IsInvalidType() &&
-		!IsSubType(testType, &BoolType{}) {
+		!IsSubType(testType, BoolType) {
 
 		checker.report(
 			&TypeMismatchError{
-				ExpectedType: &BoolType{},
+				ExpectedType: BoolType,
 				ActualType:   testType,
 				Range:        ast.NewRangeFromPositioned(testExpression),
 			},

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -648,7 +648,7 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 	case *ast.StringExpression:
 		unwrappedTargetType := UnwrapOptionalType(targetType)
 
-		if IsSubType(unwrappedTargetType, &CharacterType{}) {
+		if IsSubType(unwrappedTargetType, CharacterType) {
 			checker.checkCharacterLiteral(typedExpression)
 
 			return true

--- a/runtime/sema/checker_test.go
+++ b/runtime/sema/checker_test.go
@@ -43,7 +43,7 @@ func TestOptionalSubtyping(t *testing.T) {
 		assert.False(t,
 			IsSubType(
 				&OptionalType{Type: &IntType{}},
-				&OptionalType{Type: &BoolType{}},
+				&OptionalType{Type: BoolType},
 			),
 		)
 	})

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -1,0 +1,57 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+const typeIdentifierDocString = `
+The fully-qualified identifier of the type
+`
+
+// MetaType represents the type of a type.
+//
+var MetaType = &NominalType{
+	Name:                 "Type",
+	QualifiedName:        "Type",
+	TypeID:               "Type",
+	IsInvalid:            false,
+	IsResource:           false,
+	Storable:             true,
+	Equatable:            true,
+	ExternallyReturnable: true,
+	IsSuperTypeOf:        nil,
+	Members: func(t *NominalType) map[string]MemberResolver {
+		return map[string]MemberResolver{
+			"identifier": {
+				Kind: common.DeclarationKindField,
+				Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
+					return NewPublicConstantFieldMember(
+						t,
+						identifier,
+						&StringType{},
+						typeIdentifierDocString,
+					)
+				},
+			},
+		}
+	},
+}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -885,69 +885,6 @@ func (t *GenericType) GetMembers() map[string]MemberResolver {
 	return withBuiltinMembers(t, nil)
 }
 
-// CharacterType represents the character type
-
-type CharacterType struct{}
-
-func (*CharacterType) IsType() {}
-
-func (*CharacterType) String() string {
-	return "Character"
-}
-
-func (*CharacterType) QualifiedString() string {
-	return "Character"
-}
-
-func (*CharacterType) ID() TypeID {
-	return "Character"
-}
-
-func (*CharacterType) Equal(other Type) bool {
-	_, ok := other.(*CharacterType)
-	return ok
-}
-
-func (*CharacterType) IsResourceType() bool {
-	return false
-}
-
-func (*CharacterType) IsInvalidType() bool {
-	return false
-}
-
-func (*CharacterType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*CharacterType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*CharacterType) IsEquatable() bool {
-	return true
-}
-
-func (*CharacterType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *CharacterType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*CharacterType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *CharacterType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *CharacterType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
 // StringType represents the string type
 type StringType struct{}
 
@@ -1116,7 +1053,7 @@ func (*StringType) AllowsValueIndexingAssignment() bool {
 }
 
 func (t *StringType) ElementType(_ bool) Type {
-	return &CharacterType{}
+	return CharacterType
 }
 
 func (t *StringType) IndexingType() Type {
@@ -4279,7 +4216,7 @@ func init() {
 		&AnyResourceType{},
 		NeverType,
 		BoolType,
-		&CharacterType{},
+		CharacterType,
 		&StringType{},
 		&AddressType{},
 		&AuthAccountType{},

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -287,7 +287,7 @@ var isInstanceFunctionType = &FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&BoolType{},
+		BoolType,
 	),
 }
 
@@ -882,68 +882,6 @@ func (t *GenericType) Resolve(typeArguments *TypeParameterTypeOrderedMap) Type {
 }
 
 func (t *GenericType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// BoolType represents the boolean type
-type BoolType struct{}
-
-func (*BoolType) IsType() {}
-
-func (*BoolType) String() string {
-	return "Bool"
-}
-
-func (*BoolType) QualifiedString() string {
-	return "Bool"
-}
-
-func (*BoolType) ID() TypeID {
-	return "Bool"
-}
-
-func (*BoolType) Equal(other Type) bool {
-	_, ok := other.(*BoolType)
-	return ok
-}
-
-func (*BoolType) IsResourceType() bool {
-	return false
-}
-
-func (*BoolType) IsInvalidType() bool {
-	return false
-}
-
-func (*BoolType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*BoolType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*BoolType) IsEquatable() bool {
-	return true
-}
-
-func (*BoolType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *BoolType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*BoolType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *BoolType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *BoolType) GetMembers() map[string]MemberResolver {
 	return withBuiltinMembers(t, nil)
 }
 
@@ -3278,7 +3216,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 							},
 						},
 						ReturnTypeAnnotation: NewTypeAnnotation(
-							&BoolType{},
+							BoolType,
 						),
 					},
 					arrayTypeContainsFunctionDocString,
@@ -4340,7 +4278,7 @@ func init() {
 		&AnyStructType{},
 		&AnyResourceType{},
 		NeverType,
-		&BoolType{},
+		BoolType,
 		&CharacterType{},
 		&StringType{},
 		&AddressType{},
@@ -7571,7 +7509,7 @@ func capabilityTypeCheckFunctionType(borrowType Type) *FunctionType {
 
 	return &FunctionType{
 		TypeParameters:       typeParameters,
-		ReturnTypeAnnotation: NewTypeAnnotation(&BoolType{}),
+		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
 	}
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -282,7 +282,7 @@ var isInstanceFunctionType = &FunctionType{
 			Label:      ArgumentLabelNotRequired,
 			Identifier: "type",
 			TypeAnnotation: NewTypeAnnotation(
-				&MetaType{},
+				MetaType,
 			),
 		},
 	},
@@ -301,7 +301,7 @@ const GetTypeFunctionName = "getType"
 
 var getTypeFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&MetaType{},
+		MetaType,
 	),
 }
 
@@ -407,84 +407,6 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 	}
 
 	return members
-}
-
-// MetaType represents the type of a type.
-type MetaType struct{}
-
-func (*MetaType) IsType() {}
-
-func (*MetaType) String() string {
-	return "Type"
-}
-
-func (*MetaType) QualifiedString() string {
-	return "Type"
-}
-
-func (*MetaType) ID() TypeID {
-	return "Type"
-}
-
-func (*MetaType) Equal(other Type) bool {
-	_, ok := other.(*MetaType)
-	return ok
-}
-
-func (*MetaType) IsResourceType() bool {
-	return false
-}
-
-func (*MetaType) IsInvalidType() bool {
-	return false
-}
-
-func (*MetaType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*MetaType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*MetaType) IsEquatable() bool {
-	return true
-}
-
-func (*MetaType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *MetaType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*MetaType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *MetaType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-const typeIdentifierDocString = `
-The fully-qualified identifier of the type
-`
-
-func (t *MetaType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, map[string]MemberResolver{
-		"identifier": {
-			Kind: common.DeclarationKindField,
-			Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
-				return NewPublicConstantFieldMember(
-					t,
-					identifier,
-					&StringType{},
-					typeIdentifierDocString,
-				)
-			},
-		},
-	})
 }
 
 // AnyType represents the top type of all types.
@@ -4413,7 +4335,7 @@ func init() {
 	baseTypes.Set("", VoidType)
 
 	otherTypes := []Type{
-		&MetaType{},
+		MetaType,
 		VoidType,
 		&AnyStructType{},
 		&AnyResourceType{},
@@ -4734,8 +4656,7 @@ func suggestFixedPointLiteralConversionReplacement(
 
 func init() {
 
-	metaType := &MetaType{}
-	typeName := metaType.String()
+	typeName := MetaType.String()
 
 	// check type is not accidentally redeclared
 	if _, ok := BaseValues.Get(typeName); ok {
@@ -4746,7 +4667,7 @@ func init() {
 		name: typeName,
 		invokableType: &FunctionType{
 			TypeParameters:       []*TypeParameter{{Name: "T"}},
-			ReturnTypeAnnotation: NewTypeAnnotation(metaType),
+			ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	})
 }

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -37,7 +37,7 @@ var AssertFunction = NewStandardLibraryFunction(
 			{
 				Label:          sema.ArgumentLabelNotRequired,
 				Identifier:     "condition",
-				TypeAnnotation: sema.NewTypeAnnotation(&sema.BoolType{}),
+				TypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
 			},
 			{
 				Identifier:     "message",

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -317,7 +317,7 @@ func TestCheckCapability_check(t *testing.T) {
 				okType := RequireGlobalValue(t, checker.Elaboration, "ok")
 
 				require.Equal(t,
-					&sema.BoolType{},
+					sema.BoolType,
 					okType,
 				)
 			})
@@ -342,7 +342,7 @@ func TestCheckCapability_check(t *testing.T) {
 				okType := RequireGlobalValue(t, checker.Elaboration, "ok")
 
 				require.Equal(t,
-					&sema.BoolType{},
+					sema.BoolType,
 					okType,
 				)
 			})
@@ -367,7 +367,7 @@ func TestCheckCapability_check(t *testing.T) {
 				okType := RequireGlobalValue(t, checker.Elaboration, "ok")
 
 				require.Equal(t,
-					&sema.BoolType{},
+					sema.BoolType,
 					okType,
 				)
 			})
@@ -392,7 +392,7 @@ func TestCheckCapability_check(t *testing.T) {
 				okType := RequireGlobalValue(t, checker.Elaboration, "ok")
 
 				require.Equal(t,
-					&sema.BoolType{},
+					sema.BoolType,
 					okType,
 				)
 			})

--- a/runtime/tests/checker/character_test.go
+++ b/runtime/tests/checker/character_test.go
@@ -40,7 +40,7 @@ func TestCheckCharacterLiteral(t *testing.T) {
 	aType := RequireGlobalValue(t, checker.Elaboration, "a")
 
 	assert.Equal(t,
-		&sema.CharacterType{},
+		sema.CharacterType,
 		aType,
 	)
 }

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -233,7 +233,7 @@ func TestCheckDynamicCastingNumber(t *testing.T) {
 						}
 
 						for _, otherType := range []sema.Type{
-							&sema.BoolType{},
+							sema.BoolType,
 							&sema.StringType{},
 							sema.VoidType,
 						} {
@@ -302,7 +302,7 @@ func TestCheckDynamicCastingVoid(t *testing.T) {
 				}
 
 				for _, otherType := range []sema.Type{
-					&sema.BoolType{},
+					sema.BoolType,
 					&sema.StringType{},
 					&sema.IntType{},
 				} {
@@ -366,7 +366,7 @@ func TestCheckDynamicCastingString(t *testing.T) {
 				}
 
 				for _, otherType := range []sema.Type{
-					&sema.BoolType{},
+					sema.BoolType,
 					sema.VoidType,
 					&sema.IntType{},
 				} {
@@ -400,7 +400,7 @@ func TestCheckDynamicCastingBool(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.AnyStructType{},
-		&sema.BoolType{},
+		sema.BoolType,
 	}
 
 	for _, operation := range dynamicCastingOperations {
@@ -496,7 +496,7 @@ func TestCheckDynamicCastingAddress(t *testing.T) {
 					&sema.StringType{},
 					sema.VoidType,
 					&sema.IntType{},
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -582,7 +582,7 @@ func TestCheckDynamicCastingStruct(t *testing.T) {
 					&sema.StringType{},
 					sema.VoidType,
 					&sema.IntType{},
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -1047,7 +1047,7 @@ func TestCheckDynamicCastingSome(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.OptionalType{Type: &sema.StringType{}},
 					&sema.OptionalType{Type: sema.VoidType},
-					&sema.OptionalType{Type: &sema.BoolType{}},
+					&sema.OptionalType{Type: sema.BoolType},
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -1109,7 +1109,7 @@ func TestCheckDynamicCastingArray(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
 					sema.VoidType,
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -1176,7 +1176,7 @@ func TestCheckDynamicCastingDictionary(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
 					sema.VoidType,
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -1264,7 +1264,7 @@ func TestCheckDynamicCastingCapability(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
 					sema.VoidType,
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to Capability<&%s>", fromType, otherType), func(t *testing.T) {

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -97,7 +97,7 @@ func TestCheckEventDeclaration(t *testing.T) {
 		validTypes := append(
 			[]sema.Type{
 				&sema.StringType{},
-				&sema.CharacterType{},
+				sema.CharacterType,
 				sema.BoolType,
 				&sema.AddressType{},
 				sema.MetaType,

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -98,7 +98,7 @@ func TestCheckEventDeclaration(t *testing.T) {
 			[]sema.Type{
 				&sema.StringType{},
 				&sema.CharacterType{},
-				&sema.BoolType{},
+				sema.BoolType,
 				&sema.AddressType{},
 				sema.MetaType,
 				sema.PathType,

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -100,7 +100,7 @@ func TestCheckEventDeclaration(t *testing.T) {
 				&sema.CharacterType{},
 				&sema.BoolType{},
 				&sema.AddressType{},
-				&sema.MetaType{},
+				sema.MetaType,
 				sema.PathType,
 				sema.StoragePathType,
 				sema.PublicPathType,

--- a/runtime/tests/checker/metatype_test.go
+++ b/runtime/tests/checker/metatype_test.go
@@ -130,7 +130,7 @@ func TestCheckIsInstance(t *testing.T) {
 			if testCase.valid {
 				require.NoError(t, err)
 				assert.Equal(t,
-					&sema.BoolType{},
+					sema.BoolType,
 					RequireGlobalValue(t, checker.Elaboration, "result"),
 				)
 			} else {

--- a/runtime/tests/checker/metatype_test.go
+++ b/runtime/tests/checker/metatype_test.go
@@ -42,7 +42,7 @@ func TestCheckMetaType(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t,
-			&sema.MetaType{},
+			sema.MetaType,
 			RequireGlobalValue(t, checker.Elaboration, "type"),
 		)
 	})
@@ -59,7 +59,7 @@ func TestCheckMetaType(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t,
-			&sema.MetaType{},
+			sema.MetaType,
 			RequireGlobalValue(t, checker.Elaboration, "type"),
 		)
 	})
@@ -192,7 +192,7 @@ func TestCheckGetType(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t,
-				&sema.MetaType{},
+				sema.MetaType,
 				RequireGlobalValue(t, checker.Elaboration, "result"),
 			)
 		})

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -144,31 +144,31 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 				ast.OperationGreaterEqual,
 			},
 			tests: []operationTest{
-				{&sema.BoolType{}, "1", "2", nil},
-				{&sema.BoolType{}, "1.2", "3.4", nil},
-				{&sema.BoolType{}, "true", "2", []error{
+				{sema.BoolType, "1", "2", nil},
+				{sema.BoolType, "1.2", "3.4", nil},
+				{sema.BoolType, "true", "2", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "1.2", "3", []error{
+				{sema.BoolType, "1.2", "3", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "1", "2.3", []error{
+				{sema.BoolType, "1", "2.3", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "true", "1.2", []error{
+				{sema.BoolType, "true", "1.2", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "1", "true", []error{
+				{sema.BoolType, "1", "true", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "1.2", "true", []error{
+				{sema.BoolType, "1.2", "true", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "true", "false", []error{
+				{sema.BoolType, "true", "false", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
 			},
@@ -179,14 +179,14 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 				ast.OperationAnd,
 			},
 			tests: []operationTest{
-				{&sema.BoolType{}, "true", "false", nil},
-				{&sema.BoolType{}, "true", "2", []error{
+				{sema.BoolType, "true", "false", nil},
+				{sema.BoolType, "true", "2", []error{
 					&sema.InvalidBinaryOperandError{},
 				}},
-				{&sema.BoolType{}, "1", "true", []error{
+				{sema.BoolType, "1", "true", []error{
 					&sema.InvalidBinaryOperandError{},
 				}},
-				{&sema.BoolType{}, "1", "2", []error{
+				{sema.BoolType, "1", "2", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
 			},
@@ -197,22 +197,22 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 				ast.OperationNotEqual,
 			},
 			tests: []operationTest{
-				{&sema.BoolType{}, "true", "false", nil},
-				{&sema.BoolType{}, "1", "2", nil},
-				{&sema.BoolType{}, "1.2", "3.4", nil},
-				{&sema.BoolType{}, "true", "2", []error{
+				{sema.BoolType, "true", "false", nil},
+				{sema.BoolType, "1", "2", nil},
+				{sema.BoolType, "1.2", "3.4", nil},
+				{sema.BoolType, "true", "2", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "1.2", "3", []error{
+				{sema.BoolType, "1.2", "3", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "1", "2.3", []error{
+				{sema.BoolType, "1", "2.3", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, "1", "true", []error{
+				{sema.BoolType, "1", "true", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.BoolType{}, `"test"`, `"test"`, nil},
+				{sema.BoolType, `"test"`, `"test"`, nil},
 			},
 		},
 		{

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -100,7 +100,7 @@ func TestCheckStorable(t *testing.T) {
 		&sema.StringType{},
 		sema.BoolType,
 		sema.MetaType,
-		&sema.CharacterType{},
+		sema.CharacterType,
 		&sema.AnyStructType{},
 		&sema.AnyResourceType{},
 	)

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -57,7 +57,7 @@ func TestCheckStorable(t *testing.T) {
 			&sema.VariableSizedType{Type: ty},
 			&sema.ConstantSizedType{Type: ty, Size: 1},
 			&sema.DictionaryType{
-				KeyType:   &sema.BoolType{},
+				KeyType:   sema.BoolType,
 				ValueType: ty,
 			},
 		}
@@ -76,7 +76,7 @@ func TestCheckStorable(t *testing.T) {
 			nestedTypes = append(nestedTypes,
 				&sema.DictionaryType{
 					KeyType:   ty,
-					ValueType: &sema.BoolType{},
+					ValueType: sema.BoolType,
 				},
 			)
 		}
@@ -98,7 +98,7 @@ func TestCheckStorable(t *testing.T) {
 		sema.PathType,
 		&sema.CapabilityType{},
 		&sema.StringType{},
-		&sema.BoolType{},
+		sema.BoolType,
 		sema.MetaType,
 		&sema.CharacterType{},
 		&sema.AnyStructType{},
@@ -137,7 +137,7 @@ func TestCheckStorable(t *testing.T) {
 
 	nonStorableTypes = append(nonStorableTypes,
 		&sema.ReferenceType{
-			Type: &sema.BoolType{},
+			Type: sema.BoolType,
 		},
 	)
 

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -99,7 +99,7 @@ func TestCheckStorable(t *testing.T) {
 		&sema.CapabilityType{},
 		&sema.StringType{},
 		&sema.BoolType{},
-		&sema.MetaType{},
+		sema.MetaType,
 		&sema.CharacterType{},
 		&sema.AnyStructType{},
 		&sema.AnyResourceType{},

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -38,7 +38,7 @@ func TestCheckCharacter(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&sema.CharacterType{},
+		sema.CharacterType,
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }
@@ -54,7 +54,7 @@ func TestCheckCharacterUnicodeScalar(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&sema.CharacterType{},
+		sema.CharacterType,
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -125,7 +125,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 						}
 
 						for _, otherType := range []sema.Type{
-							&sema.BoolType{},
+							sema.BoolType,
 							&sema.StringType{},
 							sema.VoidType,
 						} {
@@ -216,7 +216,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 				}
 
 				for _, otherType := range []sema.Type{
-					&sema.BoolType{},
+					sema.BoolType,
 					&sema.StringType{},
 					&sema.IntType{},
 				} {
@@ -302,7 +302,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 				}
 
 				for _, otherType := range []sema.Type{
-					&sema.BoolType{},
+					sema.BoolType,
 					sema.VoidType,
 					&sema.IntType{},
 				} {
@@ -348,7 +348,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.AnyStructType{},
-		&sema.BoolType{},
+		sema.BoolType,
 	}
 
 	for operation, returnsOptional := range dynamicCastingOperations {
@@ -479,7 +479,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 					&sema.StringType{},
 					sema.VoidType,
 					&sema.IntType{},
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -603,7 +603,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 					&sema.StringType{},
 					sema.VoidType,
 					&sema.IntType{},
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -1062,7 +1062,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.OptionalType{Type: &sema.StringType{}},
 					&sema.OptionalType{Type: sema.VoidType},
-					&sema.OptionalType{Type: &sema.BoolType{}},
+					&sema.OptionalType{Type: sema.BoolType},
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -1151,7 +1151,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
 					sema.VoidType,
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -1246,7 +1246,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
 					sema.VoidType,
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -3397,7 +3397,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					&sema.StringType{},
 					sema.VoidType,
-					&sema.BoolType{},
+					sema.BoolType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to Capability<&%s>", fromType, otherType), func(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -1500,7 +1500,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 
 			require.Len(t, invocation.ArgumentTypes, 3)
 			assert.IsType(t, &sema.IntType{}, invocation.ArgumentTypes[0])
-			assert.IsType(t, &sema.BoolType{}, invocation.ArgumentTypes[1])
+			assert.IsType(t, sema.BoolType, invocation.ArgumentTypes[1])
 			assert.IsType(t, &sema.StringType{}, invocation.ArgumentTypes[2])
 
 			require.Len(t, invocation.Arguments, 3)

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -111,7 +111,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 		valueDeclarations := stdlib.StandardLibraryValues{
 			{
 				Name: "unknownType",
-				Type: &sema.MetaType{},
+				Type: sema.MetaType,
 				Value: interpreter.TypeValue{
 					Type: nil,
 				},
@@ -149,7 +149,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 		valueDeclarations := stdlib.StandardLibraryValues{
 			{
 				Name: "unknownType1",
-				Type: &sema.MetaType{},
+				Type: sema.MetaType,
 				Value: interpreter.TypeValue{
 					Type: nil,
 				},
@@ -157,7 +157,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			},
 			{
 				Name: "unknownType2",
-				Type: &sema.MetaType{},
+				Type: sema.MetaType,
 				Value: interpreter.TypeValue{
 					Type: nil,
 				},
@@ -232,7 +232,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 		valueDeclarations := stdlib.StandardLibraryValues{
 			{
 				Name: "unknownType",
-				Type: &sema.MetaType{},
+				Type: sema.MetaType,
 				Value: interpreter.TypeValue{
 					Type: nil,
 				},
@@ -356,7 +356,7 @@ func TestInterpretIsInstance(t *testing.T) {
 	valueDeclarations := stdlib.StandardLibraryValues{
 		{
 			Name: "unknownType",
-			Type: &sema.MetaType{},
+			Type: sema.MetaType,
 			Value: interpreter.TypeValue{
 				Type: nil,
 			},


### PR DESCRIPTION
## Description

Reduce allocations by allocating only one instance for the `Type`, `Bool`, and `Character` types.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
