### PR TITLE
Refactor Any type, AnyResource type, and AnyStruct type to singleton

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -37,12 +37,6 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 
 	result := func() cadence.Type {
 		switch t := t.(type) {
-		case *sema.AnyType:
-			return cadence.AnyType{}
-		case *sema.AnyStructType:
-			return cadence.AnyStructType{}
-		case *sema.AnyResourceType:
-			return cadence.AnyResourceType{}
 		case *sema.OptionalType:
 			return exportOptionalType(t, results)
 		case *sema.StringType:
@@ -152,6 +146,12 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.BoolType{}
 		case sema.CharacterType:
 			return cadence.CharacterType{}
+		case sema.AnyType:
+			return cadence.AnyType{}
+		case sema.AnyStructType:
+			return cadence.AnyStructType{}
+		case sema.AnyResourceType:
+			return cadence.AnyResourceType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -119,8 +119,8 @@ func TestInterpreterBoxing(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, anyType := range []sema.Type{
-		&sema.AnyStructType{},
-		&sema.AnyResourceType{},
+		sema.AnyStructType,
+		sema.AnyResourceType,
 	} {
 
 		t.Run(anyType.String(), func(t *testing.T) {

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -166,16 +166,16 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return sema.VoidType
 
 	case PrimitiveStaticTypeAny:
-		return &sema.AnyType{}
+		return sema.AnyType
 
 	case PrimitiveStaticTypeNever:
 		return sema.NeverType
 
 	case PrimitiveStaticTypeAnyStruct:
-		return &sema.AnyStructType{}
+		return sema.AnyStructType
 
 	case PrimitiveStaticTypeAnyResource:
-		return &sema.AnyResourceType{}
+		return sema.AnyResourceType
 
 	case PrimitiveStaticTypeBool:
 		return sema.BoolType
@@ -299,15 +299,6 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 //
 func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	switch t.(type) {
-	case *sema.AnyType:
-		return PrimitiveStaticTypeAny
-
-	case *sema.AnyStructType:
-		return PrimitiveStaticTypeAnyStruct
-
-	case *sema.AnyResourceType:
-		return PrimitiveStaticTypeAnyResource
-
 	case *sema.AddressType:
 		return PrimitiveStaticTypeAddress
 
@@ -422,6 +413,12 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 		return PrimitiveStaticTypeBool
 	case sema.CharacterType:
 		return PrimitiveStaticTypeCharacter
+	case sema.AnyType:
+		return PrimitiveStaticTypeAny
+	case sema.AnyStructType:
+		return PrimitiveStaticTypeAnyStruct
+	case sema.AnyResourceType:
+		return PrimitiveStaticTypeAnyResource
 	}
 
 	return PrimitiveStaticTypeUnknown

--- a/runtime/sema/any_type.go
+++ b/runtime/sema/any_type.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,18 @@
 
 package sema
 
-// VoidType represents the void type
+// AnyType represents the top type of all types.
+// NOTE: This type is only used internally and is not available in programs.
 //
-var VoidType = &NominalType{
-	Name:                 "Void",
-	QualifiedName:        "Void",
-	TypeID:               "Void",
-	IsInvalid:            false,
-	IsResource:           false,
-	Storable:             false,
-	Equatable:            false,
-	ExternallyReturnable: true,
+var AnyType = &NominalType{
+	Name:          "Any",
+	QualifiedName: "Any",
+	TypeID:        "Any",
+	IsInvalid:     false,
+	IsResource:    false,
+	// `Any` is never a valid type in user programs
+	Storable:  true,
+	Equatable: false,
+	// `Any` is never a valid type in user programs
+	ExternallyReturnable: false,
 }

--- a/runtime/sema/anyresource_type.go
+++ b/runtime/sema/anyresource_type.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,17 @@
 
 package sema
 
-// VoidType represents the void type
+// AnyResourceType represents the top type of all resource types
 //
-var VoidType = &NominalType{
-	Name:                 "Void",
-	QualifiedName:        "Void",
-	TypeID:               "Void",
-	IsInvalid:            false,
-	IsResource:           false,
-	Storable:             false,
-	Equatable:            false,
+var AnyResourceType = &NominalType{
+	Name:          "AnyResource",
+	QualifiedName: "AnyResource",
+	TypeID:        "AnyResource",
+	IsInvalid:     false,
+	IsResource:    true,
+	// The actual storability of a value is checked at run-time
+	Storable:  true,
+	Equatable: false,
+	// The actual returnability of a value is checked at run-time
 	ExternallyReturnable: true,
 }

--- a/runtime/sema/anystruct_type.go
+++ b/runtime/sema/anystruct_type.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,16 @@
 
 package sema
 
-// VoidType represents the void type
+// AnyStructType represents the top type of all non-resource types
 //
-var VoidType = &NominalType{
-	Name:                 "Void",
-	QualifiedName:        "Void",
-	TypeID:               "Void",
-	IsInvalid:            false,
-	IsResource:           false,
-	Storable:             false,
+var AnyStructType = &NominalType{
+	Name:          "AnyStruct",
+	QualifiedName: "AnyStruct",
+	TypeID:        "AnyStruct",
+	IsInvalid:     false,
+	IsResource:    false,
+	// The actual storability of a value is checked at run-time
+	Storable:             true,
 	Equatable:            false,
 	ExternallyReturnable: true,
 }

--- a/runtime/sema/bool_type.go
+++ b/runtime/sema/bool_type.go
@@ -29,5 +29,4 @@ var BoolType = &NominalType{
 	Storable:             true,
 	Equatable:            true,
 	ExternallyReturnable: true,
-	IsSuperTypeOf:        nil,
 }

--- a/runtime/sema/character_type.go
+++ b/runtime/sema/character_type.go
@@ -29,5 +29,4 @@ var CharacterType = &NominalType{
 	Storable:             true,
 	Equatable:            true,
 	ExternallyReturnable: true,
-	IsSuperTypeOf:        nil,
 }

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -182,9 +182,10 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 		switch typedSubType := subType.(type) {
 		case *RestrictedType:
 
-			switch restrictedSuperType := typedSuperType.Type.(type) {
+			restrictedSuperType := typedSuperType.Type
+			switch restrictedSuperType {
 
-			case *AnyResourceType:
+			case AnyResourceType:
 				// A restricted type `T{Us}`
 				// is a subtype of a restricted type `AnyResource{Vs}`:
 				//
@@ -195,8 +196,8 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 				// if `T` conforms to `Vs`.
 				// `Us` and `Vs` do *not* have to be subsets.
 
-				switch typedSubType.Type.(type) {
-				case *AnyResourceType, *AnyType:
+				switch typedSubType.Type {
+				case AnyResourceType, AnyType:
 					return true
 				default:
 					if typedInnerSubType, ok := typedSubType.Type.(*CompositeType); ok {
@@ -207,7 +208,7 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 					}
 				}
 
-			case *AnyStructType:
+			case AnyStructType:
 				// A restricted type `T{Us}`
 				// is a subtype of a restricted type `AnyStruct{Vs}`:
 				//
@@ -216,8 +217,8 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 				// When `T != AnyStruct && T != Any`: if `T` conforms to `Vs`.
 				// `Us` and `Vs` do *not* have to be subsets.
 
-				switch typedSubType.Type.(type) {
-				case *AnyStructType, *AnyType:
+				switch typedSubType.Type {
+				case AnyStructType, AnyType:
 					return true
 				default:
 					if typedInnerSubType, ok := typedSubType.Type.(*CompositeType); ok {
@@ -228,7 +229,7 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 					}
 				}
 
-			case *AnyType:
+			case AnyType:
 				// A restricted type `T{Us}`
 				// is a subtype of a restricted type `Any{Vs}`:
 				//
@@ -239,8 +240,8 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 				// if `T` conforms to `Vs`.
 				// `Us` and `Vs` do *not* have to be subsets.
 
-				switch typedSubType.Type.(type) {
-				case *AnyResourceType, *AnyStructType, *AnyType:
+				switch typedSubType.Type {
+				case AnyResourceType, AnyStructType, AnyType:
 					return true
 				default:
 					if typedInnerSubType, ok := typedSubType.Type.(*CompositeType); ok {
@@ -264,8 +265,8 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 				// `Us` and `Ws` do *not* have to be subsets:
 				// The owner may freely restrict and unrestrict.
 
-				switch typedSubType.Type.(type) {
-				case *AnyResourceType, *AnyStructType, *AnyType:
+				switch typedSubType.Type {
+				case AnyResourceType, AnyStructType, AnyType:
 					return true
 				default:
 					return typedSubType.Type.Equal(typedSuperType.Type)
@@ -274,8 +275,8 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 
 		case *CompositeType:
 
-			switch typedSuperType.Type.(type) {
-			case *AnyResourceType, *AnyStructType, *AnyType:
+			switch typedSuperType.Type {
+			case AnyResourceType, AnyStructType, AnyType:
 
 				// An unrestricted type `T`
 				// is a subtype of a restricted type `AnyResource{Us}` / `AnyStruct{Us}` / `Any{Us}`:
@@ -299,10 +300,13 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 				return typedSubType.Equal(typedSuperType.Type)
 			}
 
-		case *AnyResourceType, *AnyStructType, *AnyType:
+		}
 
-			switch typedSuperType.Type.(type) {
-			case *AnyResourceType, *AnyStructType, *AnyType:
+		switch subType {
+		case AnyResourceType, AnyStructType, AnyType:
+
+			switch typedSuperType.Type {
+			case AnyResourceType, AnyStructType, AnyType:
 
 				// An unrestricted type `T`
 				// is a subtype of a restricted type `AnyResource{Us}` / `AnyStruct{Us}` / `Any{Us}`:
@@ -322,7 +326,7 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 
 				// NOTE: inverse!
 
-				return IsSubType(typedSuperType.Type, typedSubType)
+				return IsSubType(typedSuperType.Type, subType)
 			}
 		}
 
@@ -341,8 +345,8 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 			// if `T == V`.
 			// The owner may freely unrestrict.
 
-			switch typedSubType.Type.(type) {
-			case *AnyResourceType, *AnyStructType, *AnyType:
+			switch typedSubType.Type {
+			case AnyResourceType, AnyStructType, AnyType:
 				return true
 
 			default:
@@ -350,7 +354,10 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 			}
 		}
 
-	case *AnyResourceType, *AnyStructType:
+	}
+
+	switch superType {
+	case AnyResourceType, AnyStructType:
 
 		// A restricted type `T{Us}`
 		// or unrestricted type `T`
@@ -362,14 +369,12 @@ func FailableCastCanSucceed(subType, superType Type) bool {
 			innerSubtype = restrictedSubType.Type
 		}
 
-		if _, ok := innerSubtype.(*AnyType); ok {
-			return true
-		}
+		return innerSubtype == AnyType ||
+			IsSubType(innerSubtype, superType)
 
-		return IsSubType(innerSubtype, superType)
-
-	case *AnyType:
+	case AnyType:
 		return true
+
 	}
 
 	return true

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -39,7 +39,7 @@ var beforeType = func() *FunctionType {
 
 	typeParameter := &TypeParameter{
 		Name:      "T",
-		TypeBound: &AnyStructType{},
+		TypeBound: AnyStructType,
 	}
 
 	typeAnnotation := NewTypeAnnotation(
@@ -1050,10 +1050,10 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 			)
 
 		case common.CompositeKindResource:
-			restrictedType = &AnyResourceType{}
+			restrictedType = AnyResourceType
 
 		case common.CompositeKindStructure:
-			restrictedType = &AnyStructType{}
+			restrictedType = AnyStructType
 
 		default:
 			panic(errors.NewUnreachableError())
@@ -1074,9 +1074,7 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 
 	var compositeType *CompositeType
 
-	switch typeResult := restrictedType.(type) {
-	case *CompositeType:
-
+	if typeResult, ok := restrictedType.(*CompositeType); ok {
 		switch typeResult.Kind {
 
 		case common.CompositeKindResource,
@@ -1087,13 +1085,16 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 		default:
 			reportInvalidRestrictedType()
 		}
+	} else {
 
-	case *AnyResourceType, *AnyStructType, *AnyType:
-		break
+		switch restrictedType {
+		case AnyResourceType, AnyStructType, AnyType:
+			break
 
-	default:
-		if t.Type != nil {
-			reportInvalidRestrictedType()
+		default:
+			if t.Type != nil {
+				reportInvalidRestrictedType()
+			}
 		}
 	}
 

--- a/runtime/sema/checker_test.go
+++ b/runtime/sema/checker_test.go
@@ -177,7 +177,7 @@ func TestFunctionSubtyping(t *testing.T) {
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(&AnyStructType{}),
+							TypeAnnotation: NewTypeAnnotation(AnyStructType),
 						},
 					},
 				},
@@ -191,7 +191,7 @@ func TestFunctionSubtyping(t *testing.T) {
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(&AnyStructType{}),
+							TypeAnnotation: NewTypeAnnotation(AnyStructType),
 						},
 					},
 				},
@@ -213,7 +213,7 @@ func TestFunctionSubtyping(t *testing.T) {
 					ReturnTypeAnnotation: NewTypeAnnotation(&IntType{}),
 				},
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(&AnyStructType{}),
+					ReturnTypeAnnotation: NewTypeAnnotation(AnyStructType),
 				},
 			),
 		)
@@ -223,7 +223,7 @@ func TestFunctionSubtyping(t *testing.T) {
 		assert.False(t,
 			IsSubType(
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(&AnyStructType{}),
+					ReturnTypeAnnotation: NewTypeAnnotation(AnyStructType),
 				},
 				&FunctionType{
 					ReturnTypeAnnotation: NewTypeAnnotation(&IntType{}),

--- a/runtime/sema/invalid_type.go
+++ b/runtime/sema/invalid_type.go
@@ -31,5 +31,4 @@ var InvalidType = &NominalType{
 	Storable:             false,
 	Equatable:            false,
 	ExternallyReturnable: false,
-	IsSuperTypeOf:        nil,
 }

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -38,7 +38,6 @@ var MetaType = &NominalType{
 	Storable:             true,
 	Equatable:            true,
 	ExternallyReturnable: true,
-	IsSuperTypeOf:        nil,
 	Members: func(t *NominalType) map[string]MemberResolver {
 		return map[string]MemberResolver{
 			"identifier": {

--- a/runtime/sema/never_type.go
+++ b/runtime/sema/never_type.go
@@ -28,5 +28,4 @@ var NeverType = &NominalType{
 	Storable:             false,
 	Equatable:            false,
 	ExternallyReturnable: false,
-	IsSuperTypeOf:        nil,
 }

--- a/runtime/sema/path_type.go
+++ b/runtime/sema/path_type.go
@@ -45,8 +45,7 @@ var StoragePathType = &NominalType{
 	IsResource:    false,
 	Storable:      true,
 	// TODO: implement support for equating paths in the future
-	Equatable:     false,
-	IsSuperTypeOf: nil,
+	Equatable: false,
 }
 
 // CapabilityPathType
@@ -74,8 +73,7 @@ var PublicPathType = &NominalType{
 	IsResource:    false,
 	Storable:      true,
 	// TODO: implement support for equating paths in the future
-	Equatable:     false,
-	IsSuperTypeOf: nil,
+	Equatable: false,
 }
 
 // PrivatePathType
@@ -87,6 +85,5 @@ var PrivatePathType = &NominalType{
 	IsResource:    false,
 	Storable:      true,
 	// TODO: implement support for equating paths in the future
-	Equatable:     false,
-	IsSuperTypeOf: nil,
+	Equatable: false,
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -409,198 +409,6 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 	return members
 }
 
-// AnyType represents the top type of all types.
-// NOTE: This type is only used internally and not available in programs.
-type AnyType struct{}
-
-func (*AnyType) IsType() {}
-
-func (*AnyType) String() string {
-	return "Any"
-}
-
-func (*AnyType) QualifiedString() string {
-	return "Any"
-}
-
-func (*AnyType) ID() TypeID {
-	return "Any"
-}
-
-func (*AnyType) Equal(other Type) bool {
-	_, ok := other.(*AnyType)
-	return ok
-}
-
-func (*AnyType) IsResourceType() bool {
-	return false
-}
-
-func (*AnyType) IsInvalidType() bool {
-	return false
-}
-
-func (*AnyType) IsStorable(_ map[*Member]bool) bool {
-	// `Any` is never a valid type in user programs
-	return false
-}
-
-func (*AnyType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	// `Any` is never a valid type in user programs
-	return false
-}
-
-func (*AnyType) IsEquatable() bool {
-	return false
-}
-
-func (*AnyType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *AnyType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*AnyType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *AnyType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *AnyType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// AnyStructType represents the top type of all non-resource types
-type AnyStructType struct{}
-
-func (*AnyStructType) IsType() {}
-
-func (*AnyStructType) String() string {
-	return "AnyStruct"
-}
-
-func (*AnyStructType) QualifiedString() string {
-	return "AnyStruct"
-}
-
-func (*AnyStructType) ID() TypeID {
-	return "AnyStruct"
-}
-
-func (*AnyStructType) Equal(other Type) bool {
-	_, ok := other.(*AnyStructType)
-	return ok
-}
-
-func (*AnyStructType) IsResourceType() bool {
-	return false
-}
-
-func (*AnyStructType) IsInvalidType() bool {
-	return false
-}
-
-func (*AnyStructType) IsStorable(_ map[*Member]bool) bool {
-	// The actual storability of a value is checked at run-time
-	return true
-}
-
-func (*AnyStructType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*AnyStructType) IsEquatable() bool {
-	return false
-}
-
-func (*AnyStructType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *AnyStructType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*AnyStructType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *AnyStructType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *AnyStructType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// AnyResourceType represents the top type of all resource types
-type AnyResourceType struct{}
-
-func (*AnyResourceType) IsType() {}
-
-func (*AnyResourceType) String() string {
-	return "AnyResource"
-}
-
-func (*AnyResourceType) QualifiedString() string {
-	return "AnyResource"
-}
-
-func (*AnyResourceType) ID() TypeID {
-	return "AnyResource"
-}
-
-func (*AnyResourceType) Equal(other Type) bool {
-	_, ok := other.(*AnyResourceType)
-	return ok
-}
-
-func (*AnyResourceType) IsResourceType() bool {
-	return true
-}
-
-func (*AnyResourceType) IsInvalidType() bool {
-	return false
-}
-
-func (*AnyResourceType) IsStorable(_ map[*Member]bool) bool {
-	// The actual storability of a value is checked at run-time
-	return true
-}
-
-func (*AnyResourceType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	// The actual returnability of a value is checked at run-time
-	return true
-}
-
-func (*AnyResourceType) IsEquatable() bool {
-	return false
-}
-
-func (*AnyResourceType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *AnyResourceType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*AnyResourceType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *AnyResourceType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *AnyResourceType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
 // OptionalType represents the optional variant of another type
 type OptionalType struct {
 	Type Type
@@ -4212,8 +4020,8 @@ func init() {
 	otherTypes := []Type{
 		MetaType,
 		VoidType,
-		&AnyStructType{},
-		&AnyResourceType{},
+		AnyStructType,
+		AnyResourceType,
 		NeverType,
 		BoolType,
 		CharacterType,
@@ -4974,7 +4782,7 @@ var authAccountTypeCopyFunctionType = func() *FunctionType {
 
 	typeParameter := &TypeParameter{
 		Name:      "T",
-		TypeBound: &AnyStructType{},
+		TypeBound: AnyStructType,
 	}
 
 	return &FunctionType{
@@ -5015,7 +4823,7 @@ var authAccountTypeBorrowFunctionType = func() *FunctionType {
 
 	typeParameter := &TypeParameter{
 		TypeBound: &ReferenceType{
-			Type: &AnyType{},
+			Type: AnyType,
 		},
 		Name: "T",
 	}
@@ -5060,7 +4868,7 @@ var authAccountTypeLinkFunctionType = func() *FunctionType {
 
 	typeParameter := &TypeParameter{
 		TypeBound: &ReferenceType{
-			Type: &AnyType{},
+			Type: AnyType,
 		},
 		Name: "T",
 	}
@@ -5124,7 +4932,7 @@ var authAccountTypeGetCapabilityFunctionType = func() *FunctionType {
 
 	typeParameter := &TypeParameter{
 		TypeBound: &ReferenceType{
-			Type: &AnyType{},
+			Type: AnyType,
 		},
 		Name:     "T",
 		Optional: true,
@@ -5155,7 +4963,7 @@ var publicAccountTypeGetCapabilityFunctionType = func() *FunctionType {
 
 	typeParameter := &TypeParameter{
 		TypeBound: &ReferenceType{
-			Type: &AnyType{},
+			Type: AnyType,
 		},
 		Name:     "T",
 		Optional: true,
@@ -5764,13 +5572,13 @@ func (t *InterfaceType) RewriteWithRestrictedTypes() (Type, bool) {
 	switch t.CompositeKind {
 	case common.CompositeKindResource:
 		return &RestrictedType{
-			Type:         &AnyResourceType{},
+			Type:         AnyResourceType,
 			Restrictions: []*InterfaceType{t},
 		}, true
 
 	case common.CompositeKindStructure:
 		return &RestrictedType{
-			Type:         &AnyStructType{},
+			Type:         AnyStructType,
 			Restrictions: []*InterfaceType{t},
 		}, true
 
@@ -6330,22 +6138,21 @@ func IsSubType(subType Type, superType Type) bool {
 		return true
 	}
 
-	switch typedSuperType := superType.(type) {
-	case *AnyType:
+	switch superType {
+	case AnyType:
 		return true
 
-	case *AnyStructType:
+	case AnyStructType:
 		if subType.IsResourceType() {
 			return false
 		}
-		if _, ok := subType.(*AnyType); ok {
-			return false
-		}
-		return true
+		return subType != AnyType
 
-	case *AnyResourceType:
+	case AnyResourceType:
 		return subType.IsResourceType()
+	}
 
+	switch typedSuperType := superType.(type) {
 	case *NumberType:
 		switch subType.(type) {
 		case *NumberType, *SignedNumberType:
@@ -6482,8 +6289,9 @@ func IsSubType(subType Type, superType Type) bool {
 		switch typedInnerSuperType := typedSuperType.Type.(type) {
 		case *RestrictedType:
 
-			switch restrictedSuperType := typedInnerSuperType.Type.(type) {
-			case *AnyResourceType, *AnyStructType, *AnyType:
+			restrictedSuperType := typedInnerSuperType.Type
+			switch restrictedSuperType {
+			case AnyResourceType, AnyStructType, AnyType:
 
 				switch typedInnerSubType := typedSubType.Type.(type) {
 				case *RestrictedType:
@@ -6514,8 +6322,10 @@ func IsSubType(subType Type, superType Type) bool {
 					return IsSubType(typedInnerSubType, restrictedSuperType) &&
 						typedInnerSuperType.RestrictionSet().
 							IsSubsetOf(typedInnerSubType.ExplicitInterfaceConformanceSet())
+				}
 
-				case *AnyResourceType, *AnyStructType, *AnyType:
+				switch typedSubType.Type {
+				case AnyResourceType, AnyStructType, AnyType:
 					// An unauthorized reference to an unrestricted type `&T`
 					// is a subtype of a reference to a restricted type
 					// `&AnyResource{Us}` / `&AnyStruct{Us}` / `&Any{Us}`:
@@ -6534,8 +6344,7 @@ func IsSubType(subType Type, superType Type) bool {
 					// An unauthorized reference to a restricted type `&T{Us}`
 					// is a subtype of a reference to a restricted type `&V{Ws}:`
 
-					switch typedInnerSubType.Type.(type) {
-					case *CompositeType:
+					if _, ok := typedInnerSubType.Type.(*CompositeType); ok {
 						// When `T != AnyResource && T != AnyStruct && T != Any`:
 						// if `T == V` and `Ws` is a subset of `Us`.
 						//
@@ -6545,8 +6354,10 @@ func IsSubType(subType Type, superType Type) bool {
 						return typedInnerSubType.Type == typedInnerSuperType.Type &&
 							typedInnerSuperType.RestrictionSet().
 								IsSubsetOf(typedInnerSubType.RestrictionSet())
+					}
 
-					case *AnyResourceType, *AnyStructType, *AnyType:
+					switch typedInnerSubType.Type {
+					case AnyResourceType, AnyStructType, AnyType:
 						// When `T == AnyResource || T == AnyStruct || T == Any`: never.
 
 						return false
@@ -6561,7 +6372,10 @@ func IsSubType(subType Type, superType Type) bool {
 
 					return typedInnerSubType == typedInnerSuperType.Type
 
-				case *AnyResourceType, *AnyStructType, *AnyType:
+				}
+
+				switch typedSubType.Type {
+				case AnyResourceType, AnyStructType, AnyType:
 					// An unauthorized reference to an unrestricted type `&T`
 					// is a subtype of a reference to a restricted type `&U{Vs}`:
 					// When `T == AnyResource || T == AnyStruct || T == Any`: never.
@@ -6579,8 +6393,11 @@ func IsSubType(subType Type, superType Type) bool {
 			// The holder of the reference may not gain more permissions or knowledge.
 
 			return false
+		}
 
-		case *AnyType:
+		switch typedSuperType.Type {
+
+		case AnyType:
 
 			// An unauthorized reference to a restricted type `&T{Us}`
 			// or to a unrestricted type `&T`
@@ -6588,7 +6405,7 @@ func IsSubType(subType Type, superType Type) bool {
 
 			return true
 
-		case *AnyResourceType:
+		case AnyResourceType:
 
 			// An unauthorized reference to a restricted type `&T{Us}`
 			// or to a unrestricted type `&T`
@@ -6597,22 +6414,17 @@ func IsSubType(subType Type, superType Type) bool {
 
 			switch typedInnerSubType := typedSubType.Type.(type) {
 			case *RestrictedType:
-				switch typedInnerInnerSubType := typedInnerSubType.Type.(type) {
-				case *AnyResourceType:
-					return true
-
-				case *CompositeType:
+				if typedInnerInnerSubType, ok := typedInnerSubType.Type.(*CompositeType); ok {
 					return typedInnerInnerSubType.Kind == common.CompositeKindResource
-
-				default:
-					return false
 				}
+
+				return typedInnerSubType.Type == AnyResourceType
 
 			case *CompositeType:
 				return typedInnerSubType.Kind == common.CompositeKindResource
 			}
 
-		case *AnyStructType:
+		case AnyStructType:
 			// `&T <: &AnyStruct` iff `T <: AnyStruct`
 			return IsSubType(typedSubType.Type, typedSuperType.Type)
 		}
@@ -6658,8 +6470,35 @@ func IsSubType(subType Type, superType Type) bool {
 
 	case *RestrictedType:
 
-		switch restrictedSuperType := typedSuperType.Type.(type) {
-		case *AnyResourceType, *AnyStructType, *AnyType:
+		restrictedSuperType := typedSuperType.Type
+		switch restrictedSuperType {
+		case AnyResourceType, AnyStructType, AnyType:
+
+			switch subType {
+			case AnyResourceType:
+				// `AnyResource` is a subtype of a restricted type
+				// - `AnyResource{Us}`: not statically;
+				// - `AnyStruct{Us}`: never.
+				// - `Any{Us}`: not statically;
+
+				return false
+
+			case AnyStructType:
+				// `AnyStruct` is a subtype of a restricted type
+				// - `AnyStruct{Us}`: not statically.
+				// - `AnyResource{Us}`: never;
+				// - `Any{Us}`: not statically.
+
+				return false
+
+			case AnyType:
+				// `Any` is a subtype of a restricted type
+				// - `Any{Us}: not statically.`
+				// - `AnyStruct{Us}`: never;
+				// - `AnyResource{Us}`: never;
+
+				return false
+			}
 
 			switch typedSubType := subType.(type) {
 			case *RestrictedType:
@@ -6667,8 +6506,9 @@ func IsSubType(subType Type, superType Type) bool {
 				// A restricted type `T{Us}`
 				// is a subtype of a restricted type `AnyResource{Vs}` / `AnyStruct{Vs}` / `Any{Vs}`:
 
-				switch restrictedSubtype := typedSubType.Type.(type) {
-				case *AnyResourceType, *AnyStructType, *AnyType:
+				restrictedSubtype := typedSubType.Type
+				switch restrictedSubtype {
+				case AnyResourceType, AnyStructType, AnyType:
 					// When `T == AnyResource || T == AnyStruct || T == Any`:
 					// if the restricted type of the subtype
 					// is a subtype of the restricted supertype,
@@ -6677,8 +6517,9 @@ func IsSubType(subType Type, superType Type) bool {
 					return IsSubType(restrictedSubtype, restrictedSuperType) &&
 						typedSuperType.RestrictionSet().
 							IsSubsetOf(typedSubType.RestrictionSet())
+				}
 
-				case *CompositeType:
+				if restrictedSubtype, ok := restrictedSubtype.(*CompositeType); ok {
 					// When `T != AnyResource && T != AnyStruct && T != Any`:
 					// if the restricted type of the subtype
 					// is a subtype of the restricted supertype,
@@ -6690,30 +6531,6 @@ func IsSubType(subType Type, superType Type) bool {
 						typedSuperType.RestrictionSet().
 							IsSubsetOf(restrictedSubtype.ExplicitInterfaceConformanceSet())
 				}
-
-			case *AnyResourceType:
-				// `AnyResource` is a subtype of a restricted type
-				// - `AnyResource{Us}`: not statically;
-				// - `AnyStruct{Us}`: never.
-				// - `Any{Us}`: not statically;
-
-				return false
-
-			case *AnyStructType:
-				// `AnyStruct` is a subtype of a restricted type
-				// - `AnyStruct{Us}`: not statically.
-				// - `AnyResource{Us}`: never;
-				// - `Any{Us}`: not statically.
-
-				return false
-
-			case *AnyType:
-				// `Any` is a subtype of a restricted type
-				// - `Any{Us}: not statically.`
-				// - `AnyStruct{Us}`: never;
-				// - `AnyResource{Us}`: never;
-
-				return false
 
 			case *CompositeType:
 				// An unrestricted type `T`
@@ -6734,13 +6551,14 @@ func IsSubType(subType Type, superType Type) bool {
 				// A restricted type `T{Us}`
 				// is a subtype of a restricted type `V{Ws}`:
 
-				switch restrictedSubType := typedSubType.Type.(type) {
-				case *AnyResourceType, *AnyStructType, *AnyType:
+				switch typedSubType.Type {
+				case AnyResourceType, AnyStructType, AnyType:
 					// When `T == AnyResource || T == AnyStruct || T == Any`:
 					// not statically.
 					return false
+				}
 
-				case *CompositeType:
+				if restrictedSubType, ok := typedSubType.Type.(*CompositeType); ok {
 					// When `T != AnyResource && T != AnyStructType && T != Any`: if `T == V`.
 					//
 					// `Us` and `Ws` do *not* have to be subsets:
@@ -6757,7 +6575,10 @@ func IsSubType(subType Type, superType Type) bool {
 
 				return typedSubType == typedSuperType.Type
 
-			case *AnyResourceType, *AnyStructType, *AnyType:
+			}
+
+			switch subType {
+			case AnyResourceType, AnyStructType, AnyType:
 				// An unrestricted type `T`
 				// is a subtype of a restricted type `AnyResource{Vs}` / `AnyStruct{Vs}` / `Any{Vs}`:
 				// not statically.
@@ -6777,12 +6598,13 @@ func IsSubType(subType Type, superType Type) bool {
 			// A restricted type `T{Us}`
 			// is a subtype of an unrestricted type `V`:
 
-			switch restrictedSubType := typedSubType.Type.(type) {
-			case *AnyResourceType, *AnyStructType, *AnyType:
+			switch typedSubType.Type {
+			case AnyResourceType, AnyStructType, AnyType:
 				// When `T == AnyResource || T == AnyStruct || T == Any`: not statically.
 				return false
+			}
 
-			case *CompositeType:
+			if restrictedSubType, ok := typedSubType.Type.(*CompositeType); ok {
 				// When `T != AnyResource && T != AnyStruct`: if `T == V`.
 				//
 				// The owner may freely unrestrict.
@@ -7374,7 +7196,7 @@ func (t *CapabilityType) Resolve(typeArguments *TypeParameterTypeOrderedMap) Typ
 var capabilityTypeParameter = &TypeParameter{
 	Name: "T",
 	TypeBound: &ReferenceType{
-		Type: &AnyType{},
+		Type: AnyType,
 	},
 }
 
@@ -7402,7 +7224,7 @@ func (t *CapabilityType) TypeArguments() []Type {
 	borrowType := t.BorrowType
 	if borrowType == nil {
 		borrowType = &ReferenceType{
-			Type: &AnyType{},
+			Type: AnyType,
 		}
 	}
 	return []Type{

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -112,7 +112,7 @@ func TestIsResourceType_AnyStructNestedInArray(t *testing.T) {
 	t.Parallel()
 
 	ty := &VariableSizedType{
-		Type: &AnyStructType{},
+		Type: AnyStructType,
 	}
 
 	assert.False(t, ty.IsResourceType())
@@ -123,7 +123,7 @@ func TestIsResourceType_AnyResourceNestedInArray(t *testing.T) {
 	t.Parallel()
 
 	ty := &VariableSizedType{
-		Type: &AnyResourceType{},
+		Type: AnyResourceType,
 	}
 
 	assert.True(t, ty.IsResourceType())

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -115,9 +115,11 @@ var LogFunction = NewStandardLibraryFunction(
 	&sema.FunctionType{
 		Parameters: []*sema.Parameter{
 			{
-				Label:          sema.ArgumentLabelNotRequired,
-				Identifier:     "value",
-				TypeAnnotation: sema.NewTypeAnnotation(&sema.AnyStructType{}),
+				Label:      sema.ArgumentLabelNotRequired,
+				Identifier: "value",
+				TypeAnnotation: sema.NewTypeAnnotation(
+					sema.AnyStructType,
+				),
 			},
 		},
 		ReturnTypeAnnotation: sema.NewTypeAnnotation(

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -69,7 +69,7 @@ var logFunctionType = &sema.FunctionType{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "value",
 			TypeAnnotation: sema.NewTypeAnnotation(
-				&sema.AnyStructType{},
+				sema.AnyStructType,
 			),
 		},
 	},

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -91,7 +91,7 @@ func TestCheckCastingIntLiteralToAnyStruct(t *testing.T) {
 	xType := RequireGlobalValue(t, checker.Elaboration, "x")
 
 	assert.Equal(t,
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		xType,
 	)
 
@@ -855,7 +855,7 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.IsType(t,
 				&sema.RestrictedType{
-					Type: &sema.AnyResourceType{},
+					Type: sema.AnyResourceType,
 					Restrictions: []*sema.InterfaceType{
 						iType.(*sema.InterfaceType),
 					},
@@ -913,7 +913,7 @@ func TestCheckCastResourceType(t *testing.T) {
 
 			require.IsType(t,
 				&sema.RestrictedType{
-					Type: &sema.AnyResourceType{},
+					Type: sema.AnyResourceType,
 					Restrictions: []*sema.InterfaceType{
 						i2Type.(*sema.InterfaceType),
 					},
@@ -1907,7 +1907,7 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.IsType(t,
 				&sema.RestrictedType{
-					Type: &sema.AnyStructType{},
+					Type: sema.AnyStructType,
 					Restrictions: []*sema.InterfaceType{
 						iType.(*sema.InterfaceType),
 					},
@@ -1958,7 +1958,7 @@ func TestCheckCastStructType(t *testing.T) {
 
 			require.IsType(t,
 				&sema.RestrictedType{
-					Type: &sema.AnyStructType{},
+					Type: sema.AnyStructType,
 					Restrictions: []*sema.InterfaceType{
 						i2Type.(*sema.InterfaceType),
 					},
@@ -2638,8 +2638,8 @@ func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
 	})
 
 	for _, ty := range []sema.Type{
-		&sema.AnyResourceType{},
-		&sema.AnyType{},
+		sema.AnyResourceType,
+		sema.AnyType,
 	} {
 
 		t.Run(fmt.Sprintf("restricted %s -> conforming restricted type", ty), func(t *testing.T) {
@@ -2841,8 +2841,8 @@ func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
 	})
 
 	for _, ty := range []sema.Type{
-		&sema.AnyResourceType{},
-		&sema.AnyType{},
+		sema.AnyResourceType,
+		sema.AnyType,
 	} {
 
 		t.Run(fmt.Sprintf("restricted %s -> conforming resource", ty), func(t *testing.T) {
@@ -3183,8 +3183,8 @@ func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
 		})
 
 		for _, otherType := range []sema.Type{
-			&sema.AnyResourceType{},
-			&sema.AnyType{},
+			sema.AnyResourceType,
+			sema.AnyType,
 		} {
 
 			t.Run(fmt.Sprintf("restricted %s -> restricted %s: fewer restrictions", ty, otherType), func(t *testing.T) {
@@ -3214,15 +3214,13 @@ func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
 						),
 					)
 
-					if _, ok := ty.(*sema.AnyType); ok {
-						if _, ok = otherType.(*sema.AnyResourceType); ok {
+					if ty == sema.AnyType && otherType == sema.AnyResourceType {
 
-							errs := ExpectCheckerErrors(t, err, 1)
+						errs := ExpectCheckerErrors(t, err, 1)
 
-							assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+						assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 
-							return
-						}
+						return
 					}
 
 					require.NoError(t, err)
@@ -3428,8 +3426,8 @@ func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
 		})
 
 		for _, otherType := range []sema.Type{
-			&sema.AnyResourceType{},
-			&sema.AnyType{},
+			sema.AnyResourceType,
+			sema.AnyType,
 		} {
 			t.Run(fmt.Sprintf("restricted %s -> %s", ty, otherType), func(t *testing.T) {
 
@@ -3458,15 +3456,13 @@ func TestCheckCastAuthorizedResourceReferenceType(t *testing.T) {
 						),
 					)
 
-					if _, ok := ty.(*sema.AnyType); ok {
-						if _, ok = otherType.(*sema.AnyResourceType); ok {
+					if ty == sema.AnyType && otherType == sema.AnyResourceType {
 
-							errs := ExpectCheckerErrors(t, err, 1)
+						errs := ExpectCheckerErrors(t, err, 1)
 
-							assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+						assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 
-							return
-						}
+						return
 					}
 
 					require.NoError(t, err)
@@ -3727,8 +3723,8 @@ func TestCheckCastAuthorizedStructReferenceType(t *testing.T) {
 	})
 
 	for _, ty := range []sema.Type{
-		&sema.AnyStructType{},
-		&sema.AnyType{},
+		sema.AnyStructType,
+		sema.AnyType,
 	} {
 		t.Run(fmt.Sprintf("restricted %s -> conforming restricted type", ty), func(t *testing.T) {
 
@@ -3932,8 +3928,8 @@ func TestCheckCastAuthorizedStructReferenceType(t *testing.T) {
 	})
 
 	for _, ty := range []sema.Type{
-		&sema.AnyStructType{},
-		&sema.AnyType{},
+		sema.AnyStructType,
+		sema.AnyType,
 	} {
 
 		t.Run(fmt.Sprintf("restricted %s -> conforming struct", ty), func(t *testing.T) {
@@ -4274,8 +4270,8 @@ func TestCheckCastAuthorizedStructReferenceType(t *testing.T) {
 		})
 
 		for _, otherType := range []sema.Type{
-			&sema.AnyStructType{},
-			&sema.AnyType{},
+			sema.AnyStructType,
+			sema.AnyType,
 		} {
 
 			t.Run(fmt.Sprintf("restricted %s -> restricted %s: fewer restrictions", ty, otherType), func(t *testing.T) {
@@ -4305,15 +4301,13 @@ func TestCheckCastAuthorizedStructReferenceType(t *testing.T) {
 						),
 					)
 
-					if _, ok := ty.(*sema.AnyType); ok {
-						if _, ok := otherType.(*sema.AnyStructType); ok {
+					if ty == sema.AnyType && otherType == sema.AnyStructType {
 
-							errs := ExpectCheckerErrors(t, err, 1)
+						errs := ExpectCheckerErrors(t, err, 1)
 
-							assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+						assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 
-							return
-						}
+						return
 					}
 
 					require.NoError(t, err)
@@ -4735,8 +4729,8 @@ func TestCheckCastUnauthorizedResourceReferenceType(t *testing.T) {
 			})
 
 			for _, ty := range []sema.Type{
-				&sema.AnyResourceType{},
-				&sema.AnyType{},
+				sema.AnyResourceType,
+				sema.AnyType,
 			} {
 
 				t.Run(fmt.Sprintf("restricted %s -> conforming restricted type", ty), func(t *testing.T) {
@@ -4860,8 +4854,8 @@ func TestCheckCastUnauthorizedResourceReferenceType(t *testing.T) {
 			})
 
 			for _, ty := range []sema.Type{
-				&sema.AnyResourceType{},
-				&sema.AnyType{},
+				sema.AnyResourceType,
+				sema.AnyType,
 			} {
 
 				t.Run(fmt.Sprintf("restricted %s -> conforming resource", ty), func(t *testing.T) {
@@ -5054,8 +5048,8 @@ func TestCheckCastUnauthorizedResourceReferenceType(t *testing.T) {
 				})
 
 				for _, otherType := range []sema.Type{
-					&sema.AnyResourceType{},
-					&sema.AnyType{},
+					sema.AnyResourceType,
+					sema.AnyType,
 				} {
 
 					t.Run(fmt.Sprintf("restricted %s -> restricted %s: fewer restrictions", ty, otherType), func(t *testing.T) {
@@ -5079,15 +5073,13 @@ func TestCheckCastUnauthorizedResourceReferenceType(t *testing.T) {
 							),
 						)
 
-						if _, ok := ty.(*sema.AnyType); ok {
-							if _, ok := otherType.(*sema.AnyResourceType); ok {
+						if ty == sema.AnyType && otherType == sema.AnyResourceType {
 
-								errs := ExpectCheckerErrors(t, err, 1)
+							errs := ExpectCheckerErrors(t, err, 1)
 
-								assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+							assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 
-								return
-							}
+							return
 						}
 
 						require.NoError(t, err)
@@ -5192,15 +5184,13 @@ func TestCheckCastUnauthorizedResourceReferenceType(t *testing.T) {
 							),
 						)
 
-						if _, ok := ty.(*sema.AnyType); ok {
-							if _, ok := otherType.(*sema.AnyResourceType); ok {
+						if ty == sema.AnyType && otherType == sema.AnyResourceType {
 
-								errs := ExpectCheckerErrors(t, err, 1)
+							errs := ExpectCheckerErrors(t, err, 1)
 
-								assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+							assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 
-								return
-							}
+							return
 						}
 
 						require.NoError(t, err)
@@ -5386,8 +5376,8 @@ func TestCheckCastUnauthorizedStructReferenceType(t *testing.T) {
 			})
 
 			for _, ty := range []sema.Type{
-				&sema.AnyStructType{},
-				&sema.AnyType{},
+				sema.AnyStructType,
+				sema.AnyType,
 			} {
 
 				t.Run(fmt.Sprintf("restricted %s -> conforming restricted type", ty), func(t *testing.T) {
@@ -5511,8 +5501,8 @@ func TestCheckCastUnauthorizedStructReferenceType(t *testing.T) {
 			})
 
 			for _, ty := range []sema.Type{
-				&sema.AnyStructType{},
-				&sema.AnyType{},
+				sema.AnyStructType,
+				sema.AnyType,
 			} {
 
 				t.Run(fmt.Sprintf("restricted %s -> conforming resource", ty), func(t *testing.T) {
@@ -5704,8 +5694,8 @@ func TestCheckCastUnauthorizedStructReferenceType(t *testing.T) {
 				})
 
 				for _, otherType := range []sema.Type{
-					&sema.AnyStructType{},
-					&sema.AnyType{},
+					sema.AnyStructType,
+					sema.AnyType,
 				} {
 
 					t.Run(fmt.Sprintf("restricted %s -> restricted %s: fewer restrictions", ty, otherType), func(t *testing.T) {
@@ -5729,15 +5719,13 @@ func TestCheckCastUnauthorizedStructReferenceType(t *testing.T) {
 							),
 						)
 
-						if _, ok := ty.(*sema.AnyType); ok {
-							if _, ok := otherType.(*sema.AnyStructType); ok {
+						if ty == sema.AnyType && otherType == sema.AnyStructType {
 
-								errs := ExpectCheckerErrors(t, err, 1)
+							errs := ExpectCheckerErrors(t, err, 1)
 
-								assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+							assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 
-								return
-							}
+							return
 						}
 
 						require.NoError(t, err)

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -205,7 +205,7 @@ func TestCheckDynamicCastingNumber(t *testing.T) {
 				t.Run(test.ty.String(), func(t *testing.T) {
 
 					types := []sema.Type{
-						&sema.AnyStructType{},
+						sema.AnyStructType,
 						test.ty,
 					}
 					for _, fromType := range types {
@@ -270,7 +270,7 @@ func TestCheckDynamicCastingVoid(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		sema.VoidType,
 	}
 
@@ -336,7 +336,7 @@ func TestCheckDynamicCastingString(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		&sema.StringType{},
 	}
 
@@ -399,7 +399,7 @@ func TestCheckDynamicCastingBool(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		sema.BoolType,
 	}
 
@@ -462,7 +462,7 @@ func TestCheckDynamicCastingAddress(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		&sema.AddressType{},
 	}
 
@@ -1015,8 +1015,8 @@ func TestCheckDynamicCastingSome(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.OptionalType{Type: &sema.IntType{}},
-		&sema.OptionalType{Type: &sema.AnyStructType{}},
-		&sema.AnyStructType{},
+		&sema.OptionalType{Type: sema.AnyStructType},
+		sema.AnyStructType,
 	}
 
 	for _, operation := range dynamicCastingOperations {
@@ -1077,8 +1077,8 @@ func TestCheckDynamicCastingArray(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.VariableSizedType{Type: &sema.IntType{}},
-		&sema.VariableSizedType{Type: &sema.AnyStructType{}},
-		&sema.AnyStructType{},
+		&sema.VariableSizedType{Type: sema.AnyStructType},
+		sema.AnyStructType,
 	}
 
 	for _, operation := range dynamicCastingOperations {
@@ -1144,7 +1144,7 @@ func TestCheckDynamicCastingDictionary(t *testing.T) {
 		},
 		&sema.DictionaryType{
 			KeyType:   &sema.StringType{},
-			ValueType: &sema.AnyStructType{},
+			ValueType: sema.AnyStructType,
 		},
 	}
 
@@ -1220,11 +1220,11 @@ func TestCheckDynamicCastingCapability(t *testing.T) {
 		},
 		&sema.CapabilityType{
 			BorrowType: &sema.ReferenceType{
-				Type: &sema.AnyStructType{},
+				Type: sema.AnyStructType,
 			},
 		},
 		&sema.CapabilityType{},
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 	}
 
 	capabilityType := &sema.CapabilityType{

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -1966,7 +1966,7 @@ func TestCheckInvalidInterfaceUseAsTypeSuggestion(t *testing.T) {
 				{
 					TypeAnnotation: sema.NewTypeAnnotation(
 						&sema.RestrictedType{
-							Type: &sema.AnyStructType{},
+							Type: sema.AnyStructType,
 							Restrictions: []*sema.InterfaceType{
 								iType,
 							},
@@ -1978,7 +1978,7 @@ func TestCheckInvalidInterfaceUseAsTypeSuggestion(t *testing.T) {
 				&sema.DictionaryType{
 					KeyType: &sema.IntType{},
 					ValueType: &sema.RestrictedType{
-						Type: &sema.AnyStructType{},
+						Type: sema.AnyStructType,
 						Restrictions: []*sema.InterfaceType{
 							iType,
 						},

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -845,7 +845,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyResourceType{}, ty.Type)
+		assert.IsType(t, sema.AnyResourceType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
@@ -869,7 +869,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyStructType{}, ty.Type)
+		assert.IsType(t, sema.AnyStructType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
@@ -893,7 +893,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyResourceType{}, ty.Type)
+		assert.IsType(t, sema.AnyResourceType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,
@@ -921,7 +921,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyStructType{}, ty.Type)
+		assert.IsType(t, sema.AnyStructType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,
@@ -965,7 +965,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyResourceType{}, ty.Type)
+		assert.IsType(t, sema.AnyResourceType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
@@ -992,7 +992,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyStructType{}, ty.Type)
+		assert.IsType(t, sema.AnyStructType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 1)
 		assert.Same(t,
@@ -1019,7 +1019,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyResourceType{}, ty.Type)
+		assert.IsType(t, sema.AnyResourceType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,
@@ -1050,7 +1050,7 @@ func TestCheckRestrictedTypeNoType(t *testing.T) {
 
 		ty := rType.(*sema.RestrictedType)
 
-		assert.IsType(t, &sema.AnyStructType{}, ty.Type)
+		assert.IsType(t, sema.AnyStructType, ty.Type)
 
 		require.Len(t, ty.Restrictions, 2)
 		assert.Same(t,

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -101,8 +101,8 @@ func TestCheckStorable(t *testing.T) {
 		sema.BoolType,
 		sema.MetaType,
 		sema.CharacterType,
-		&sema.AnyStructType{},
-		&sema.AnyResourceType{},
+		sema.AnyStructType,
+		sema.AnyResourceType,
 	)
 
 	for _, storableType := range storableTypes {

--- a/runtime/tests/checker/utils_test.go
+++ b/runtime/tests/checker/utils_test.go
@@ -48,7 +48,7 @@ func ParseAndCheckWithAny(t *testing.T, code string) (*sema.Checker, error) {
 				sema.WithPredeclaredTypes([]sema.TypeDeclaration{
 					stdlib.StandardLibraryType{
 						Name: "Any",
-						Type: &sema.AnyType{},
+						Type: sema.AnyType,
 						Kind: common.DeclarationKindType,
 					},
 				}),

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -82,7 +82,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 				t.Run(test.ty.String(), func(t *testing.T) {
 
 					types := []sema.Type{
-						&sema.AnyStructType{},
+						sema.AnyStructType,
 						test.ty,
 					}
 					for _, fromType := range types {
@@ -174,7 +174,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		sema.VoidType,
 	}
 
@@ -262,7 +262,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		&sema.StringType{},
 	}
 
@@ -347,7 +347,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		sema.BoolType,
 	}
 
@@ -432,7 +432,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 		&sema.AddressType{},
 	}
 
@@ -1005,8 +1005,8 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.OptionalType{Type: &sema.IntType{}},
-		&sema.OptionalType{Type: &sema.AnyStructType{}},
-		&sema.AnyStructType{},
+		&sema.OptionalType{Type: sema.AnyStructType},
+		sema.AnyStructType,
 	}
 
 	for operation, returnsOptional := range dynamicCastingOperations {
@@ -1040,7 +1040,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							inter.Globals["y"].Value,
 						)
 
-						if _, ok := targetType.(*sema.AnyStructType); ok && !returnsOptional {
+						if targetType == sema.AnyStructType && !returnsOptional {
 
 							assert.Equal(t,
 								expectedValue,
@@ -1105,8 +1105,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 
 	types := []sema.Type{
 		&sema.VariableSizedType{Type: &sema.IntType{}},
-		&sema.VariableSizedType{Type: &sema.AnyStructType{}},
-		&sema.AnyStructType{},
+		&sema.VariableSizedType{Type: sema.AnyStructType},
+		sema.AnyStructType,
 	}
 
 	for operation, returnsOptional := range dynamicCastingOperations {
@@ -1199,7 +1199,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 		},
 		&sema.DictionaryType{
 			KeyType:   &sema.StringType{},
-			ValueType: &sema.AnyStructType{},
+			ValueType: sema.AnyStructType,
 		},
 	}
 
@@ -3317,11 +3317,11 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 		},
 		&sema.CapabilityType{
 			BorrowType: &sema.ReferenceType{
-				Type: &sema.AnyStructType{},
+				Type: sema.AnyStructType,
 			},
 		},
 		&sema.CapabilityType{},
-		&sema.AnyStructType{},
+		sema.AnyStructType,
 	}
 
 	capabilityValue := interpreter.CapabilityValue{

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -8131,7 +8131,7 @@ func TestInterpretNestedDestroy(t *testing.T) {
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "value",
-					TypeAnnotation: sema.NewTypeAnnotation(&sema.AnyStructType{}),
+					TypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 				},
 			},
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(


### PR DESCRIPTION
⚠️ Depends on #617

## Description

Reduce allocations by allocating only one instance for the `Any`, `AnyStruct`, and `AnyResource` types.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
