### PR TITLE
Fix AuthAccount nested types

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5584,11 +5584,13 @@ func (t *AuthAccountType) GetMembers() map[string]MemberResolver {
 	})
 }
 
-var authAccountTypeNestedTypes = map[string]Type{
-	"Contracts": &AuthAccountContractsType{},
-}
+var authAccountTypeNestedTypes = func() *StringTypeOrderedMap {
+	nestedTypes := NewStringTypeOrderedMap()
+	nestedTypes.Set("Contracts", &AuthAccountContractsType{})
+	return nestedTypes
+}()
 
-func (*AuthAccountType) NestedTypes() map[string]Type {
+func (*AuthAccountType) NestedTypes() *StringTypeOrderedMap {
 	return authAccountTypeNestedTypes
 }
 

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1301,3 +1301,14 @@ func TestCheckAccount_StorageFields(t *testing.T) {
 		}
 	}
 }
+
+func TestAuthAccountContractsType(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckAccount(t, `
+      let contracts: AuthAccount.Contracts = authAccount.contracts
+	`)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Description

Properly implement `ContainerType` for `AuthAccountType`.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
