### PR TITLE
Remove prepare and decode callbacks

### DIFF
--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -373,7 +373,7 @@ func (s *runtimeStorage) encodeValue(
 				value,
 				[]string{path},
 				true,
-				s.prepareCallback,
+				nil,
 			)
 		},
 		s.runtimeInterface,
@@ -419,19 +419,4 @@ func (s *runtimeStorage) decodeCallback(value interface{}, path []string) {
 		panic(err)
 	}
 
-}
-
-func (s *runtimeStorage) prepareCallback(value interpreter.Value, path []string) {
-	logMessage := fmt.Sprintf(
-		"encoding value for key %s: %T",
-		path,
-		value,
-	)
-	var err error
-	wrapPanic(func() {
-		err = s.runtimeInterface.ImplementationDebugLog(logMessage)
-	})
-	if err != nil {
-		panic(err)
-	}
 }

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -20,7 +20,6 @@ package runtime
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 	"time"
 
@@ -172,7 +171,7 @@ func (s *runtimeStorage) readValue(
 				&address,
 				[]string{key},
 				version,
-				s.decodeCallback,
+				nil,
 			)
 		},
 		s.runtimeInterface,
@@ -403,20 +402,4 @@ func (s *runtimeStorage) move(
 	if err != nil {
 		panic(err)
 	}
-}
-
-func (s *runtimeStorage) decodeCallback(value interface{}, path []string) {
-	logMessage := fmt.Sprintf(
-		"decoding value for key %s: %T",
-		path,
-		value,
-	)
-	var err error
-	wrapPanic(func() {
-		err = s.runtimeInterface.ImplementationDebugLog(logMessage)
-	})
-	if err != nil {
-		panic(err)
-	}
-
 }


### PR DESCRIPTION
## Description

Remove the prepare and decode callbacks, which were added for debugging purposes 
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
