### PR TITLE
Only record member accesses when origins and occurrences are enabled

### DIFF
--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -37,11 +37,13 @@ func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) 
 			}
 		}
 
-		checker.MemberAccesses.Put(
-			expression.AccessPos,
-			expression.EndPosition(),
-			memberAccessType,
-		)
+		if checker.originsAndOccurrencesEnabled {
+			checker.MemberAccesses.Put(
+				expression.AccessPos,
+				expression.EndPosition(),
+				memberAccessType,
+			)
+		}
 	}
 
 	if member == nil {

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -203,6 +203,13 @@ func WithImportHandler(handler ImportHandlerFunc) Option {
 func WithOriginsAndOccurrencesEnabled(enabled bool) Option {
 	return func(checker *Checker) error {
 		checker.originsAndOccurrencesEnabled = enabled
+		if enabled {
+			checker.memberOrigins = map[Type]map[string]*Origin{}
+			checker.variableOrigins = map[*Variable]*Origin{}
+			checker.Occurrences = NewOccurrences()
+			checker.MemberAccesses = NewMemberAccesses()
+		}
+
 		return nil
 	}
 }
@@ -240,10 +247,6 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 		resources:           NewResources(),
 		typeActivations:     typeActivations,
 		functionActivations: functionActivations,
-		Occurrences:         NewOccurrences(),
-		variableOrigins:     map[*Variable]*Origin{},
-		memberOrigins:       map[Type]map[string]*Origin{},
-		MemberAccesses:      NewMemberAccesses(),
 		containerTypes:      map[Type]bool{},
 		Elaboration:         NewElaboration(),
 	}


### PR DESCRIPTION
## Description

In a past PR, recording origins and occurrences was made optional.
Also make recording member accesses optional.

In addition, only allocate the data structures necessary for recording origins and occurrences when it is enabled.

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
