### PR TITLE
Delay contract code and value updates to the end of execution

### DIFF
--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -77,7 +77,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 		require.Equal(t, expectedCodeHash[:], actualCodeHash)
 	}
 
-	expectFailure := func(expectedProgramCount int, expectedErrorMessage string) expectation {
+	expectFailure := func(expectedErrorMessage string) expectation {
 		return func(t *testing.T, err error, accountCode []byte, events []cadence.Event, _ cadence.Type) {
 			var runtimeErr Error
 			utils.RequireErrorAs(t, err, &runtimeErr)
@@ -87,7 +87,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			assert.EqualError(t, runtimeErr, expectedErrorMessage)
 
 			assert.Len(t, runtimeErr.Codes, 2)
-			assert.Len(t, runtimeErr.Programs, expectedProgramCount)
+			assert.Len(t, runtimeErr.Programs, 1)
 
 			assert.Nil(t, accountCode)
 			assert.Len(t, events, 0)
@@ -213,12 +213,11 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 				interpreter.BoolValue(true),
 			},
 			check: expectFailure(
-				2,
-				"Execution failed:\n"+
-					"error: invalid argument 0: expected type `Int`, got `Bool`\n"+
-					" --> 00:5:22\n"+
-					"  |\n"+
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b0a202020202020202020202020202020202020696e6974285f20783a20496e7429207b7d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex(), true)\n"+
+				"Execution failed:\n" +
+					"error: invalid argument 0: expected type `Int`, got `Bool`\n" +
+					" --> 00:5:22\n" +
+					"  |\n" +
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b0a202020202020202020202020202020202020696e6974285f20783a20496e7429207b7d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex(), true)\n" +
 					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
 			),
 		})
@@ -233,12 +232,11 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 				interpreter.NewIntValueFromInt64(1),
 			},
 			check: expectFailure(
-				2,
-				"Execution failed:\n"+
-					"error: invalid argument count, too many arguments: expected 0, got 1\n"+
-					" --> 00:5:22\n"+
-					"  |\n"+
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b7d0a202020202020202020202020\".decodeHex(), 1)\n"+
+				"Execution failed:\n" +
+					"error: invalid argument count, too many arguments: expected 0, got 1\n" +
+					" --> 00:5:22\n" +
+					"  |\n" +
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b7d0a202020202020202020202020\".decodeHex(), 1)\n" +
 					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
 			),
 		})
@@ -253,24 +251,23 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
             `,
 			arguments: []argument{},
 			check: expectFailure(
-				2,
-				"Execution failed:\n"+
-					"error: cannot deploy invalid contract\n"+
-					" --> 00:5:22\n"+
-					"  |\n"+
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b7d0a0a202020202020202020202020202066756e2074657374436173652829207b7d0a202020202020202020202020\".decodeHex())\n"+
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
-					"\n"+
-					"error: function declarations are not valid at the top-level\n"+
-					" --> 2a00000000000000.Test:4:18\n"+
-					"  |\n"+
-					"4 |               fun testCase() {}\n"+
-					"  |                   ^^^^^^^^\n"+
-					"\n"+
-					"error: missing access modifier for function\n"+
-					" --> 2a00000000000000.Test:4:14\n"+
-					"  |\n"+
-					"4 |               fun testCase() {}\n"+
+				"Execution failed:\n" +
+					"error: cannot deploy invalid contract\n" +
+					" --> 00:5:22\n" +
+					"  |\n" +
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b7d0a0a202020202020202020202020202066756e2074657374436173652829207b7d0a202020202020202020202020\".decodeHex())\n" +
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+					"\n" +
+					"error: function declarations are not valid at the top-level\n" +
+					" --> 2a00000000000000.Test:4:18\n" +
+					"  |\n" +
+					"4 |               fun testCase() {}\n" +
+					"  |                   ^^^^^^^^\n" +
+					"\n" +
+					"error: missing access modifier for function\n" +
+					" --> 2a00000000000000.Test:4:14\n" +
+					"  |\n" +
+					"4 |               fun testCase() {}\n" +
 					"  |               ^\n",
 			),
 		})
@@ -283,18 +280,17 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
             `,
 			arguments: []argument{},
 			check: expectFailure(
-				1,
-				"Execution failed:\n"+
-					"error: cannot deploy invalid contract\n"+
-					" --> 00:5:22\n"+
-					"  |\n"+
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a2020202020202020202020202020580a202020202020202020202020\".decodeHex())\n"+
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
-					"\n"+
-					"error: unexpected token: identifier\n"+
-					" --> 2a00000000000000.Test:2:14\n"+
-					"  |\n"+
-					"2 |               X\n"+
+				"Execution failed:\n" +
+					"error: cannot deploy invalid contract\n" +
+					" --> 00:5:22\n" +
+					"  |\n" +
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a2020202020202020202020202020580a202020202020202020202020\".decodeHex())\n" +
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+					"\n" +
+					"error: unexpected token: identifier\n" +
+					" --> 2a00000000000000.Test:2:14\n" +
+					"  |\n" +
+					"2 |               X\n" +
 					"  |               ^\n",
 			),
 		})
@@ -309,18 +305,17 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
             `,
 			arguments: []argument{},
 			check: expectFailure(
-				2,
-				"Execution failed:\n"+
-					"error: cannot deploy invalid contract\n"+
-					" --> 00:5:22\n"+
-					"  |\n"+
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b0a2020202020202020202020202020202020207075622066756e20746573742829207b2058207d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex())\n"+
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
-					"\n"+
-					"error: cannot find variable in this scope: `X`\n"+
-					" --> 2a00000000000000.Test:3:35\n"+
-					"  |\n"+
-					"3 |                   pub fun test() { X }\n"+
+				"Execution failed:\n" +
+					"error: cannot deploy invalid contract\n" +
+					" --> 00:5:22\n" +
+					"  |\n" +
+					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202070756220636f6e74726163742054657374207b0a2020202020202020202020202020202020207075622066756e20746573742829207b2058207d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex())\n" +
+					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+					"\n" +
+					"error: cannot find variable in this scope: `X`\n" +
+					" --> 2a00000000000000.Test:3:35\n" +
+					"  |\n" +
+					"3 |                   pub fun test() { X }\n" +
 					"  |                                    ^ not found in this scope\n",
 			),
 		})

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -202,10 +202,6 @@ func (i *emptyRuntimeInterface) RemoveAccountKey(_ Address, _ int) (publicKey []
 	return nil, nil
 }
 
-func (i *emptyRuntimeInterface) UpdateAccountCode(_ Address, _ []byte) error {
-	return nil
-}
-
 func (i *emptyRuntimeInterface) UpdateAccountContractCode(_ Address, _ string, _ []byte) (err error) {
 	return nil
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -5520,6 +5520,8 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	var programHits []string
 
+	var codeChanged bool
+
 	runtimeInterface := &testRuntimeInterface{
 		createAccount: func(payer Address) (address Address, err error) {
 			accountCounter++
@@ -5543,6 +5545,8 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			return accountCodes[key], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			codeChanged = true
+
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
@@ -5555,6 +5559,18 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			events = append(events, event)
 			return nil
 		},
+	}
+
+	// When code is changed, the parsed+checked programs have to be invalidated
+
+	clearProgramsIfNeeded := func() {
+		if !codeChanged {
+			return
+		}
+
+		for locationID := range runtimeInterface.programs {
+			delete(runtimeInterface.programs, locationID)
+		}
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -5580,6 +5596,8 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	signerAddresses = []Address{{accountCounter}}
 
+	codeChanged = false
+
 	err = runtime.ExecuteTransaction(
 		Script{
 			Source: deployTx,
@@ -5591,6 +5609,15 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Empty(t, programHits)
+
+	locationID := common.AddressLocation{
+		Address: signerAddresses[0],
+		Name:    "HelloWorld",
+	}.ID()
+
+	require.NotContains(t, runtimeInterface.programs, locationID)
+
+	clearProgramsIfNeeded()
 
 	// call the initial hello function
 
@@ -5608,9 +5635,17 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cadence.NewString("1"), result1)
 
+	// The deployed hello world contract was imported,
+	// assert that it was stored in the program storage
+	// after it was parsed and checked
+
+	initialProgram := runtimeInterface.programs[locationID]
+	require.NotNil(t, initialProgram)
+
 	// update the contract
 
 	programHits = nil
+	codeChanged = false
 
 	err = runtime.ExecuteTransaction(
 		Script{
@@ -5623,6 +5658,17 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Empty(t, programHits)
+
+	// Assert that the contract update did NOT change
+	// the program in program storage
+
+	require.Same(t,
+		initialProgram,
+		runtimeInterface.programs[locationID],
+	)
+	require.NotNil(t, runtimeInterface.programs[locationID])
+
+	clearProgramsIfNeeded()
 
 	// call the new hello function
 
@@ -5857,29 +5903,17 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
       }
     `
 
-	newDeployTransaction := func(function, name, code string) []byte {
-		return []byte(fmt.Sprintf(
-			`
-              transaction {
-
-                  prepare(signer: AuthAccount) {
-                      signer.contracts.%s(name: "%s", code: "%s".decodeHex())
-                  }
-              }
-            `,
-			function,
-			name,
-			hex.EncodeToString([]byte(code)),
-		))
-	}
-
 	var accountCode []byte
 	var events []cadence.Event
+
+	var codeChanged bool
+
+	signerAddress := common.BytesToAddress([]byte{0x42})
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
-			return []Address{common.BytesToAddress([]byte{0x42})}, nil
+			return []Address{signerAddress}, nil
 		},
 		getCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
@@ -5906,6 +5940,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 			return accountCode, nil
 		},
 		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+			codeChanged = true
 			accountCode = code
 			return nil
 		},
@@ -5915,9 +5950,24 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		},
 	}
 
+	// When code is changed, the parsed+checked programs have to be invalidated
+
+	clearProgramsIfNeeded := func() {
+		if !codeChanged {
+			return
+		}
+
+		for locationID := range runtimeInterface.programs {
+			delete(runtimeInterface.programs, locationID)
+		}
+	}
+
 	nextTransactionLocation := newTransactionLocationGenerator()
 
-	deployTx1 := newDeployTransaction("add", "Test", contract1)
+	// Deploy the Test contract
+
+	codeChanged = false
+	deployTx1 := utils.DeploymentTransaction("Test", []byte(contract1))
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -5929,6 +5979,17 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+
+	locationID := common.AddressLocation{
+		Address: signerAddress,
+		Name:    "Test",
+	}.ID()
+
+	require.NotContains(t, runtimeInterface.programs, locationID)
+
+	clearProgramsIfNeeded()
+
+	// Use the Test contract
 
 	script1 := []byte(`
       import 0x42
@@ -5957,7 +6018,18 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	deployTx2 := newDeployTransaction("update__experimental", "Test", contract2)
+	// The deployed hello world contract was imported,
+	// assert that it was stored in the program storage
+	// after it was parsed and checked
+
+	initialProgram := runtimeInterface.programs[locationID]
+	require.NotNil(t, initialProgram)
+
+	// Update the Test contract
+
+	codeChanged = false
+
+	deployTx2 := utils.UpdateTransaction("Test", []byte(contract2))
 
 	err = runtime.ExecuteTransaction(
 		Script{
@@ -5969,6 +6041,19 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+
+	// Assert that the contract update did NOT change
+	// the program in program storage
+
+	require.Same(t,
+		initialProgram,
+		runtimeInterface.programs[locationID],
+	)
+	require.NotNil(t, runtimeInterface.programs[locationID])
+
+	clearProgramsIfNeeded()
+
+	// Use the new Test contract
 
 	script2 := []byte(`
       import 0x42


### PR DESCRIPTION
## Description

Until now, the behaviour of contract updates was not fully defined, there was a potential for weird side-effects.

Clearly define that a contract update, i.e. the update of contract code and contract value, is delayed until the end of execution. Contract updates shouldn't be effective immediately, as this would effectively result in hot-code patching, which is not supported.

When parsing and checking a contract code update (a new contract or a changed contract), then don't store this new program in the program storage (i.e. don't call `SetProgram`). Doing so would overwrite a potentially currently used program, or would result in this new program being used immediately when being explicitly imported, or implicitly imported through loading a value from storage.


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
