### PR TITLE
Optimize encoding of positive bigints

### DIFF
--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -457,7 +458,7 @@ func (e *Encoder) prepareBool(v BoolValue) bool {
 func (e *Encoder) prepareInt(v IntValue) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagIntValue,
-		Content: v.BigInt,
+		Content: prepareBigInt(v.BigInt),
 	}
 }
 
@@ -492,21 +493,21 @@ func (e *Encoder) prepareInt64(v Int64Value) cbor.Tag {
 func (e *Encoder) prepareInt128(v Int128Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagInt128Value,
-		Content: v.BigInt,
+		Content: prepareBigInt(v.BigInt),
 	}
 }
 
 func (e *Encoder) prepareInt256(v Int256Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagInt256Value,
-		Content: v.BigInt,
+		Content: prepareBigInt(v.BigInt),
 	}
 }
 
 func (e *Encoder) prepareUInt(v UIntValue) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagUIntValue,
-		Content: v.BigInt,
+		Content: prepareBigInt(v.BigInt),
 	}
 }
 
@@ -541,14 +542,33 @@ func (e *Encoder) prepareUInt64(v UInt64Value) cbor.Tag {
 func (e *Encoder) prepareUInt128(v UInt128Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagUInt128Value,
-		Content: v.BigInt,
+		Content: prepareBigInt(v.BigInt),
 	}
 }
 
 func (e *Encoder) prepareUInt256(v UInt256Value) cbor.Tag {
 	return cbor.Tag{
 		Number:  cborTagUInt256Value,
-		Content: v.BigInt,
+		Content: prepareBigInt(v.BigInt),
+	}
+}
+
+func prepareBigInt(v *big.Int) cbor.Tag {
+	sign := v.Sign()
+
+	var tagNum uint64 = 2
+
+	if sign < 0 {
+		tagNum = 3
+
+		// For negative number, convert to CBOR encoded number (-v-1).
+		v = new(big.Int).Abs(v)
+		v.Sub(v, bigOne)
+	}
+
+	return cbor.Tag{
+		Number:  tagNum,
+		Content: v.Bytes(),
 	}
 }
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -4357,23 +4357,28 @@ func BenchmarkEncoding(b *testing.B) {
 
 	value := prepareLargeTestValue()
 
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _, _ = EncodeValue(value, nil, false, nil)
+		_, _, err := EncodeValue(value, nil, false, nil)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkDecoding(b *testing.B) {
 
 	value := prepareLargeTestValue()
+
 	encoded, _, err := EncodeValue(value, nil, false, nil)
 	require.NoError(b, err)
 
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = DecodeValue(encoded, nil, nil, CurrentEncodingVersion, nil)
+		_, err = DecodeValue(encoded, nil, nil, CurrentEncodingVersion, nil)
+		require.NoError(b, err)
 	}
 }
 


### PR DESCRIPTION
## Description

The CBOR library's bigint encoding function always creates a copy of the encoded value: https://github.com/fxamacker/cbor/blob/ee962ff86de23bc964f19d8e4a1a23171b05e58b/encode.go#L1159.
This is not necessary for the case where the value is positive, only when it is negative.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
