### PR TITLE
Fix updating contracts with reference typed fields

### DIFF
--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -936,6 +936,85 @@ func TestContractUpdateValidation(t *testing.T) {
 
 		require.Contains(t, err.Error(), expectedError)
 	})
+
+	t.Run("Test reference types", func(t *testing.T) {
+		const oldCode = `
+			pub contract Test22 {
+
+				pub var vault: Capability<&TestStruct>?
+
+				init() {
+					self.vault = nil
+				}
+
+				pub struct TestStruct {
+					pub let a: Int
+
+					init() {
+						self.a = 123
+					}
+				}
+			}`
+
+		const newCode = `
+			pub contract Test22 {
+
+				pub var vault: Capability<&TestStruct>?
+
+				init() {
+					self.vault = nil
+				}
+
+				pub struct TestStruct {
+					pub let a: Int
+
+					init() {
+						self.a = 123
+					}
+				}
+			}`
+
+		err := deployAndUpdate("Test22", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("Test function type", func(t *testing.T) {
+		const oldCode = `
+			pub contract Test23 {
+
+				pub struct TestStruct {
+					pub let a: Int
+
+					init() {
+						self.a = 123
+					}
+				}
+			}`
+
+		const newCode = `
+			pub contract Test23 {
+
+				pub var add: ((Int, Int): Int)
+
+				init() {
+					self.add = fun (a: Int, b: Int): Int {
+						return a + b
+					}
+				}
+
+				pub struct TestStruct {
+					pub let a: Int
+
+					init() {
+						self.a = 123
+					}
+				}
+			}`
+
+		err := deployAndUpdate("Test23", oldCode, newCode)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error: field add has non-storable type: ((Int, Int): Int)")
+	})
 }
 
 func assertDeclTypeChangeError(

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -344,17 +344,6 @@ func (e *InvalidDeclarationKindChangeError) Error() string {
 	return fmt.Sprintf("trying to convert %s `%s` to a %s", e.oldKind.Name(), e.name, e.newKind.Name())
 }
 
-// InvalidNonStorableTypeUsageError is reported during a contract update, when an attempt is made
-// to use a non-storable type as a field of a composite declaration.
-type InvalidNonStorableTypeUsageError struct {
-	nonStorableType ast.Type
-	ast.Range
-}
-
-func (e *InvalidNonStorableTypeUsageError) Error() string {
-	return fmt.Sprintf("cannot use non-storable type `%s` in a composite type field", e.nonStorableType)
-}
-
 // ConformanceMismatchError is reported during a contract update, when the enum conformance of the new program
 // does not match the existing one.
 type ConformanceMismatchError struct {


### PR DESCRIPTION
Closes #648

## Description

Removes all the 'unreachable' assumptions in the contract-validator, and relies on the checker to do the validations.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
