### PR TITLE
Improve type equality check in the contract update validation

### DIFF
--- a/runtime/contract_update_validation.go
+++ b/runtime/contract_update_validation.go
@@ -482,21 +482,19 @@ func identifiersEqual(expected []ast.Identifier, found []ast.Identifier) bool {
 	return true
 }
 
-func isAnyStructOrAnyResourceType(restrictedType ast.Type) bool {
+func isAnyStructOrAnyResourceType(astType ast.Type) bool {
 	// If the restricted type is not stated, then it is either AnyStruct or AnyResource
-	if restrictedType == nil {
+	if astType == nil {
 		return true
 	}
 
-	nominalType, ok := restrictedType.(*ast.NominalType)
+	nominalType, ok := astType.(*ast.NominalType)
 	if !ok {
 		return false
 	}
 
 	switch nominalType.Identifier.Identifier {
-	case sema.AnyStructType.Name:
-		return true
-	case sema.AnyResourceType.Name:
+	case sema.AnyStructType.Name, sema.AnyResourceType.Name:
 		return true
 	default:
 		return false

--- a/runtime/contract_update_validation.go
+++ b/runtime/contract_update_validation.go
@@ -396,18 +396,18 @@ func (validator *ContractUpdateValidator) checkIdentifierEquality(
 }
 
 func (validator *ContractUpdateValidator) checkConformances(
-	oldEnum *ast.CompositeDeclaration,
-	newEnum *ast.CompositeDeclaration,
+	oldDecl *ast.CompositeDeclaration,
+	newDecl *ast.CompositeDeclaration,
 ) {
 
-	oldConformances := oldEnum.Conformances
-	newConformances := newEnum.Conformances
+	oldConformances := oldDecl.Conformances
+	newConformances := newDecl.Conformances
 
 	if len(oldConformances) != len(newConformances) {
 		validator.report(&ConformanceCountMismatchError{
 			expected: len(oldConformances),
 			found:    len(newConformances),
-			Range:    ast.NewRangeFromPositioned(newEnum.Identifier),
+			Range:    ast.NewRangeFromPositioned(newDecl.Identifier),
 		})
 
 		// If the lengths are not the same, trying to match the conformance
@@ -420,7 +420,7 @@ func (validator *ContractUpdateValidator) checkConformances(
 		err := oldConformance.CheckEqual(newConformance, validator)
 		if err != nil {
 			validator.report(&ConformanceMismatchError{
-				declName: newEnum.Identifier.Identifier,
+				declName: newDecl.Identifier.Identifier,
 				err:      err,
 				Range:    ast.NewRangeFromPositioned(newConformance),
 			})
@@ -457,7 +457,7 @@ func identifiersEqual(expected []ast.Identifier, found []ast.Identifier) bool {
 	}
 
 	for index, element := range found {
-		if expected[index] != element {
+		if expected[index].Identifier != element.Identifier {
 			return false
 		}
 	}

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -1086,6 +1086,246 @@ func TestContractUpdateValidation(t *testing.T) {
 		err = deployAndUpdate("Test24", oldCode, newCode)
 		require.NoError(t, err)
 	})
+
+	t.Run("Test all types", func(t *testing.T) {
+
+		const oldCode = `
+			pub contract Test25 {
+				// simple nominal type
+				pub var a: TestStruct
+
+				// qualified nominal type
+				pub var b: Test25.TestStruct
+
+				// optional type
+				pub var c: Int?
+
+				// variable sized type
+				pub var d: [Int]
+
+				// constant sized type
+				pub var e: [Int; 2]
+
+				// dictionary type
+				pub var f: {Int: String}
+
+				// restricted type
+				pub var g: {TestInterface}
+
+				// instantiation and reference types
+				pub var h:  Capability<&TestStruct>?
+
+				// function type
+				pub var i: Capability<&((Int, Int): Int)>?
+
+				init() {
+					var count: Int = 567
+					self.a = TestStruct()
+					self.b = Test25.TestStruct()
+					self.c = 123
+					self.d = [123]
+					self.e = [123, 456]
+					self.f = {1: "Hello"}
+					self.g = TestStruct()
+					self.h = nil
+					self.i = nil
+				}
+
+				pub struct TestStruct:TestInterface {
+					pub let a: Int
+					init() {
+						self.a = 123
+					}
+				}
+
+				pub struct interface TestInterface {
+					pub let a: Int
+				}
+			}`
+
+		const newCode = `
+			pub contract Test25 {
+
+
+				// function type
+				pub var i: Capability<&((Int, Int): Int)>?
+
+				// instantiation and reference types
+				pub var h:  Capability<&TestStruct>?
+
+				// restricted type
+				pub var g: {TestInterface}
+
+				// dictionary type
+				pub var f: {Int: String}
+
+				// constant sized type
+				pub var e: [Int; 2]
+
+				// variable sized type
+				pub var d: [Int]
+
+				// optional type
+				pub var c: Int?
+
+				// qualified nominal type
+				pub var b: Test25.TestStruct
+
+				// simple nominal type
+				pub var a: TestStruct
+
+				init() {
+					var count: Int = 567
+					self.a = TestStruct()
+					self.b = Test25.TestStruct()
+					self.c = 123
+					self.d = [123]
+					self.e = [123, 456]
+					self.f = {1: "Hello"}
+					self.g = TestStruct()
+					self.h = nil
+					self.i = nil
+				}
+
+				pub struct TestStruct:TestInterface {
+					pub let a: Int
+					init() {
+						self.a = 123
+					}
+				}
+
+				pub struct interface TestInterface {
+					pub let a: Int
+				}
+			}`
+
+		err := deployAndUpdate("Test25", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("Test restricted types", func(t *testing.T) {
+
+		const oldCode = `
+			pub contract Test26 {
+
+				// restricted type
+				pub var a: {TestInterface}
+				pub var b: {TestInterface}
+				pub var c: AnyStruct{TestInterface}
+				pub var d: AnyStruct{TestInterface}
+
+				init() {
+					var count: Int = 567
+					self.a = TestStruct()
+					self.b = TestStruct()
+					self.c = TestStruct()
+					self.d = TestStruct()
+				}
+
+				pub struct TestStruct:TestInterface {
+					pub let a: Int
+					init() {
+						self.a = 123
+					}
+				}
+
+				pub struct interface TestInterface {
+					pub let a: Int
+				}
+			}`
+
+		const newCode = `
+			pub contract Test26 {
+				pub var a: {TestInterface}
+				pub var b: AnyStruct{TestInterface}
+				pub var c: {TestInterface}
+				pub var d: AnyStruct{TestInterface}
+
+				init() {
+					var count: Int = 567
+					self.a = TestStruct()
+					self.b = TestStruct()
+					self.c = TestStruct()
+					self.d = TestStruct()
+				}
+
+				pub struct TestStruct:TestInterface {
+					pub let a: Int
+					init() {
+						self.a = 123
+					}
+				}
+
+				pub struct interface TestInterface {
+					pub let a: Int
+				}
+			}`
+
+		err := deployAndUpdate("Test26", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("Test invalid restricted types change", func(t *testing.T) {
+
+		const oldCode = `
+			pub contract Test27 {
+
+				// restricted type
+				pub var a: TestStruct{TestInterface}
+				pub var b: {TestInterface}
+
+				init() {
+					var count: Int = 567
+					self.a = TestStruct()
+					self.b = TestStruct()
+				}
+
+				pub struct TestStruct:TestInterface {
+					pub let a: Int
+					init() {
+						self.a = 123
+					}
+				}
+
+				pub struct interface TestInterface {
+					pub let a: Int
+				}
+			}`
+
+		const newCode = `
+			pub contract Test27 {
+				pub var a: {TestInterface}
+				pub var b: TestStruct{TestInterface}
+
+				init() {
+					var count: Int = 567
+					self.a = TestStruct()
+					self.b = TestStruct()
+				}
+
+				pub struct TestStruct:TestInterface {
+					pub let a: Int
+					init() {
+						self.a = 123
+					}
+				}
+
+				pub struct interface TestInterface {
+					pub let a: Int
+				}
+			}`
+
+		err := deployAndUpdate("Test27", oldCode, newCode)
+		require.Error(t, err)
+
+		assert.Contains(t, err.Error(), "pub var a: {TestInterface}"+
+			"\n  |                ^^^^^^^^^^^^^^^ "+
+			"incompatible type annotations. expected `TestStruct{TestInterface}`, found `{TestInterface}`")
+
+		assert.Contains(t, err.Error(), "pub var b: TestStruct{TestInterface}"+
+			"\n  |                ^^^^^^^^^^^^^^^^^^^^^^^^^ "+
+			"incompatible type annotations. expected `{TestInterface}`, found `TestStruct{TestInterface}`")
+	})
 }
 
 func assertDeclTypeChangeError(


### PR DESCRIPTION
Closes #648

## Description
Solve some issues:
- The identifier equality check also considers the position info as well, in the contract validator. This breaks the validation, when the constructs are moved around. Thanks @turbolent for pointing to this one!

- In restricted types, handle the scenarios where `AnyStruct` and `AnyResource` are omitted. 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
