### PR TITLE
Add parser for pragma signers

### DIFF
--- a/runtime/parser2/docstring.go
+++ b/runtime/parser2/docstring.go
@@ -45,3 +45,26 @@ func ParseDocstringPragmaArguments(docString string) []string {
 
 	return pragmaArguments
 }
+
+var pragmaSignersRegexp = regexp.MustCompile(`^\s+pragma\s+signers\s+(.*)(?:\n|$)`)
+
+// ParseDocstringPragmaSigners parses the docstring and returns the values of all pragma signers declarations.
+//
+// A pragma signers declaration has the form `pragma signers <signers-list>`,
+// where <signers-list> is a list of strings.
+//
+// The validity of the argument list is NOT checked by this function.
+//
+func ParseDocstringPragmaSigners(docString string) []string {
+	var pragmaSigners []string
+
+	for _, line := range strings.Split(docString, "\n") {
+		match := pragmaSignersRegexp.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		pragmaSigners = append(pragmaSigners, match[1])
+	}
+
+	return pragmaSigners
+}

--- a/runtime/parser2/docstring_test.go
+++ b/runtime/parser2/docstring_test.go
@@ -43,3 +43,23 @@ func TestParseDocstringPragmaArguments(t *testing.T) {
 		actual,
 	)
 }
+
+func TestParseDocstringPragmaSigners(t *testing.T) {
+
+	actual := ParseDocstringPragmaSigners(`
+	  pragma signers (alice)
+      other stuff
+
+      pragma signers   (alice, bob)  
+
+      pragma signers  ( alice ,  bob   )`)
+
+	require.Equal(t,
+		[]string{
+			"(alice)",
+			"(alice, bob)  ",
+			"( alice ,  bob   )",
+		},
+		actual,
+	)
+}


### PR DESCRIPTION
Closes #655 

## Description
Create method to parse `///pragma signers` docstring

- Implement ParseDocstringPragmaSigners method 
- Create tests for it
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
