### PR TITLE
Adds contentType tags. 

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-type: EXP
+type: FAQ
 ---
 
 # FAQ

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,3 +1,8 @@
+---
+title: FAQ
+type: EXP
+---
+
 # FAQ
 
 ## Is there a formal grammar (e.g. in BNF) for Cadence?

--- a/docs/anti-patterns.mdx
+++ b/docs/anti-patterns.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cadence Anti-Patterns
+type: EXP
 ---
 
 This is an opinionated list of issues that can be improved if they are found in Cadence code intended for production.

--- a/docs/anti-patterns.mdx
+++ b/docs/anti-patterns.mdx
@@ -1,0 +1,117 @@
+---
+title: Cadence Anti-Patterns
+---
+
+This is an opinionated list of issues that can be improved if they are found in Cadence code intended for production.
+
+## Security and Robustness
+
+### Events From Resources Might Not Be Unique
+
+A public function on a contract that creates a resource can be called by any account.
+
+If that resource has functions that emit events, any account can create an instance of that resource and emit those events.
+
+If those events are meant to indicate actions taken using a single instance of that resource (for example an admin object, switchboard, or registry), or instances created through a particular workflow, then this will make event log search and management harder because events from other instances may be mixed in with the ones that you wish to examine.
+
+To fix this, if there should be only a single instance of the resource it should be created and `link()`ed to a public path in an admin account's storage during the contracts's initializer.
+
+### Named Value Fields Are Preferable
+
+Where contracts, resources, and scripts all have to repeatedly refer to the same constant values, entering these manually is a potential source of error. These are known as [magic values](<https://en.wikipedia.org/wiki/Magic_number_(programming)>).
+
+Rather than typing the values manually in functions, transactions and scripts, store the values once in fields of the contract responsible and then access them via those fields. This is the [Named Value Field pattern](../design-patterns/#named-value-field)
+
+### Public Functions and Fields Should Be Avoided
+
+Be sure to keep track of access modifiers when structuring your code, and make public only what should be public.
+
+### Array or Dictionary Fields Should Be Private
+
+#### Problem
+
+This is a specific case of "Public Functions And Fields Should Be Avoided", above.
+
+Public array or dictionary fields are not directly over-writable, but their members can be accessed and overwritten if the field is public. This could potentially result in security vulnerabilities for the contract if these fields are mistakenly made public.
+
+Ex:
+
+```cadence
+pub contract Array {
+    // array is inteded to be initialized to something constant
+    pub let shouldBeConstantArray: [Int]
+}
+```
+
+Anyone could use a transaction like this to modify it:
+
+```cadence
+import Array from 0x01
+
+transaction {
+    execute {
+		    Array.shouldbeConstantArray[0] = 1000
+    }
+}
+```
+
+#### Solution
+
+Make sure that any array or dictionary fields in contracts, structs, or resources are `access(contract)` or `access(self)` unless they need to be intentionally made public.
+
+```cadence
+pub contract Array {
+    // array is inteded to be initialized to something constant
+    access(self) let shouldBeConstantArray: [Int]
+}
+```
+
+### Public Admin Resource Creation Functions Are Unsafe
+
+This is a specific case of "Public Functions And Fields Should Be Avoided", above.
+
+A public function on a contract that creates a resource can be called by any account.
+
+If that resource provides access to admin functions then the function should not be public.
+
+To fix this, a single instance of that resource created using it then `link()`ed to a private path in an admin account's storage during the contract's initializer. If the code to create the resource is complex enough that it needs its own function, the function that creates the resource should use `access(contract)` as its access modifier.
+
+### Public Capability Fields Are A Security Hole
+
+This is a specific case of "Public Functions And Fields Should Be Avoided", above.
+
+The values of public fields can be copied. Capabilities are value types. Anyone who receives a Capability can use it. So if they can copy it from a public field they can call the functions that it exposes.
+
+This almost certainly is not what you want if a capability has been stored in this way. For public access to a capability, place it in an accounts public area.
+
+### Users Might Rebind Restricted Public Capability Paths
+
+A public capability on a user account that is a variant of a standard resource (such as a Vault) that has additional logic implemented to restrict or alter its behaviour can be replaced by that user at the same path with another resource that does not have those alterations.
+
+To fix this, make sure to carefully specify the type of the capability that you are expecting in any code that accesses it.
+
+## Readability
+
+### Descriptive Names Are Preferable
+
+`account` / `accounts` is better than `array` / `element`.
+
+`providerAccount` / `tokenRecipientAccount` is better than `acct1` / `acct2`.
+
+Unless of course you are dealing with entities that really are best named that way, for example in utility code.
+
+### Omitting "Any" Types In Constraints Is Preferable
+
+Prefer `&{Receiver}` to `&AnyResource{Receiver}`.
+
+It's clearer and the `Any...` is implicit.
+
+Note that this doesn't mean that the restricted type should _always_ be emitted, only if it's specifically `AnyStruct` or `AnyResource` .
+
+A good example of when the code should specify the type being restricted is checking the FLOW balance: the code must borrow `&FlowToken.Vault{FungibleToken.Balance}`, in order to ensure that it gets a FLOW token balance, and not just `&{FungibleToken.Balance}`, any balance – the user could store another object that conforms to the balance interface and return whatever value as the amount.
+
+### Plural Names For Arrays And Maps Are Preferable
+
+e.g. `accounts` rather than `account` for an array of accounts.
+
+This signals that the field or variable is not scalar. It also makes it easier to the singular form for a variable name during iteration.

--- a/docs/anti-patterns.mdx
+++ b/docs/anti-patterns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cadence Anti-Patterns
-type: EXP
+contentType: EXP
 ---
 
 This is an opinionated list of issues that can be improved if they are found in Cadence code intended for production.

--- a/docs/design-patterns.mdx
+++ b/docs/design-patterns.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cadence Design Patterns
+type: EXP
 ---
 
 This is a selection of software design patterns developed by core Flow developers while writing Cadence code for deployment to Flow Mainnet.

--- a/docs/design-patterns.mdx
+++ b/docs/design-patterns.mdx
@@ -1,0 +1,144 @@
+---
+title: Cadence Design Patterns
+---
+
+This is a selection of software design patterns developed by core Flow developers while writing Cadence code for deployment to Flow Mainnet.
+
+[Design patterns](https://en.wikipedia.org/wiki/Software_design_pattern) are building blocks for software development. They may provide a solution to a problem that you encounter when writing smart contracts in Cadence. Remember that if they do fit they may not be the right solution for a given situation, and they are not meant to be a set of prescriptions to be followed exclusively even where a better solution represents itself.
+
+## Capability Receiver
+
+### Problem
+
+An account must be given a [capability](/cadence/language/capability-based-access-control/) to a resource or contract in another account but a single transaction with both accounts authorizing it cannot be easily produced. This prevents a single transaction from fetching the capability from one account and delivering it to the other.
+
+### Solution
+
+Account B creates a resource that can receive the capability and stores this in their `/storage/` area. They then expose a Capability to this in their `/public/` area with a function that can receive the desired Capability and store it in the resource for later use.
+
+Account A fetches the receiver Capability from B's `/public/` area, creates the desired Capability, and passes it to the receiver function. The receiver function stores the Capability in the resource that it is on in account B's `/storage/` area for later use.
+
+There are two nuances to this workflow that are required to ensure that it is secure.
+
+The first is that only Account A should be able to create instances of the desired Capability. This ensures that nobody else can create instances of it and call the receiver function on B's receiver capability instead of A. This means that A is probably an admin account.
+
+The second is that the field on the receiver resource that stores the desired Capability should be access(contract) and only accessed by code within the contract that needs to. This ensures that B cannot copy and share the Capability with anyone else.
+
+### Example Code
+
+See:
+
+[LockedTokens.cdc](https://github.com/onflow/flow-core-contracts/blob/bfb115869bd9f815cde1fe64ab6d91ca95c0938e/contracts/LockedTokens.cdc#L527)
+
+[custody_setup_account_creator.cdc](https://github.com/onflow/flow-core-contracts/blob/79941fe65b634800065a440ae5243744b2ca8a2f/transactions/lockedTokens/admin/custody_setup_account_creator.cdc)
+
+[admin_deposit_account_creator.cdc](https://github.com/onflow/flow-core-contracts/blob/79941fe65b634800065a440ae5243744b2ca8a2f/transactions/lockedTokens/admin/admin_deposit_account_creator.cdc)
+
+## Capability Revocation
+
+### Problem
+
+A capability provided by one account to a second account must able to be revoked by the first account without the co-operation of the second.
+
+### Solution
+
+The first account should create the capability as a link to a capability in /private/, which then links to a resource in /storage/ . That first link is then handed to the second account as the capability for them to use. This can be stored in their private storage or a Capability Receiver.
+
+**Account 1:** `/private/capability` → `/storage/resource`
+
+**Account 2:** `Capability Receiver(Capability(→Account 1: /private/capability))`
+
+If the first account wants to revoke access to the resource in storage, they should delete the `/private/` link that the second account's capability refers to. Capabilities use paths rather than resource identifiers, so this will break the capability.
+
+The first account should be careful not to create another link at the same location in its private storage once the capability has been revoked, otherwise this will restore the second account's capability.
+
+## Init Singleton
+
+### Problem
+
+An admin resource must be created and delivered to a specified account. There should not be a function to do this, as that would allow anyone to create an admin resource.
+
+### Solution
+
+Create any one-off resources in the contract's `init()` function and deliver them to an address or AuthAccount specified as an argument.
+
+See how this is done in the LockedTokens contract init function:
+
+[LockedTokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/LockedTokens.cdc#L583)
+
+and in the transaction that is used to deploy it:
+
+[admin_deploy_contract.cdc](https://github.com/onflow/flow-core-contracts/blob/master/transactions/lockedTokens/admin/admin_deploy_contract.cdc)
+
+## Named Value Field
+
+### Problem
+
+Your contracts, resources, and scripts all have to refer to the same value. A number, a string, a storage path. Entering these values manually in transactions and scripts is a potential source of error. See: [https://en.wikipedia.org/wiki/Magic*number*(programming)](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
+
+### Solution
+
+Add an `access(all)` field, e.g. a `Path` , to the contract responsible for the value, and set it in the contract's initializer. Then refer to that value via this public field rather than specifying it manually.
+
+[Example Code](https://github.com/onflow/flow-core-contracts/blob/master/contracts/LockedTokens.cdc#L583)
+
+## Script-Accessible Public Field
+
+### Problem
+
+Your contract, resource or struct has a field that will need to be read and used off-chain, often in bulk.
+
+### Solution
+
+Make sure that the field can be accessed from a script (using an `Account`) rather than requiring a transaction (using an `AuthAccount`). This saves the time and soon the expense required by having to read a property using a transaction. Making the field `access(all)` and exposing it via a `/public/` capability will allow this. Be careful not to expose any data or functionality that should be kept private when doing so.
+
+## Script-Accessible Report
+
+### Problem
+
+Your contract, resource or struct has a resource that you wish to access fields of off-chain via a script. But scripts cannot return resources.
+
+### Solution
+
+Declare a struct to hold the data that you wish to return from the script. Write a function that fills out the fields of this struct with the data from the resource that you wish to access. Then call this on the resource that you wish to access the fields of in a script, and return the struct from the script.
+
+See [Script-Accessible Public Field](#script-accessible-public-field), above, for how best to expose this capability.
+
+### Example Code
+
+```cadence
+pub contract AContract {
+    pub struct BReportStruct {
+        pub var c: UInt64
+        pub var d: string
+
+        init(c: UInt64, d: string) {
+            self.c = c
+            self.d = d
+        }
+
+    }
+
+    pub resource BResource {
+        pub var c: UInt64
+        pub var d: string
+
+        pub fun generateReport() BReportStruct {
+            return BReportStruct(c: c, d: d)
+        }
+
+        init(c: UInt64, d: string) {
+            self.c = c
+            self.d = d
+        }
+    }
+}
+...
+import A from 0xA
+
+pub fun main(): A.BReport {
+    let b: AContract.BResource // Borrow the resource
+    let report = b.generateReport()
+    return b
+}
+```

--- a/docs/design-patterns.mdx
+++ b/docs/design-patterns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cadence Design Patterns
-type: EXP
+contentType: EXP
 ---
 
 This is a selection of software design patterns developed by core Flow developers while writing Cadence code for deployment to Flow Mainnet.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,3 @@
----
-
----
-
 # Development
 
 ## Running the latest version of the Language Server in the Visual Studio Code Extension

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,7 @@
+---
+
+---
+
 # Development
 
 ## Running the latest version of the Language Server in the Visual Studio Code Extension

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Cadence
-type: INTRO
+contentType: INTRO
 ---
 
 We commonly refer to programs that are stored in user accounts as smart contracts.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,171 @@
+---
+title: Introduction to Cadence
+---
+
+We commonly refer to programs that are stored in user accounts as smart contracts. 
+A smart contract is a program that verifies and executes the performance of a contract without the need for a trusted third party.
+Programs that run on blockchains are commonly referred to as smart contracts because they mediate important functionality (such as currency)
+without having to rely on a central authority (like a bank).
+
+## A New Programming Language
+
+---
+
+Cadence is a resource-oriented programming language that introduces new features to smart contract programming
+that help developers ensure that their code is safe, secure, clear, and approachable. Some of these features are:
+
+- Type safety and a strong static type system
+- Resource-oriented programming, a new paradigm that pairs linear types with object capabilities
+to create a secure and declarative model for digital ownership by ensuring that resources (and their associated assets)
+can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted
+- Built-in pre-conditions and post-conditions for functions and [transactions](/intro/glossary/#transaction)
+- The utilization of capability-based security, which enforces access control by requiring that access to objects
+is restricted to only the owner and those who have a valid reference to the object
+
+Swift and Rust inspire Cadence’s syntax. Its use of resource types maps well to that of Move, the programming language being developed by the Libra team.
+
+## Cadence's Programming Language Pillars
+
+---
+
+Cadence, a new high-level programming language, observes the following requirements:
+
+- **Safety and Security:** Safety is the underlying reliability of any smart contract (i.e., it’s bug-free and performs its function). 
+Security is the prevention of attacks on the network or smart contracts (i.e., unauthorized actions by malicious actors).
+Safety and security are critical in smart contracts because of the immutable nature of blockchains,
+and because they often deal with high-value assets. While auditing and reviewing code will be a crucial part of smart contract development, 
+Cadence maximizes efficiency while maintaining the highest levels of safety and security at its foundation. 
+It accomplishes this via a strong static type system, design by contract, and ownership primitives inspired by linear types (which are useful when dealing with assets).
+- **Clarity:** Code needs to be easy to read, and its meaning should be as unambiguous as possible. 
+It should also be suited for verification so that tooling can help with ensuring safety and security guarantees. 
+These guarantees can be achieved by making the code declarative and allowing the developer to express their intentions directly. 
+We make those intentions explicit by design, which, along with readability, make auditing and reviewing more efficient, at a small cost to verbosity.
+- **Approachability:** Writing code and creating programs should be as approachable as possible.
+Incorporating features from languages like Swift and Rust, developers should find Cadence’s syntax and semantics familiar.
+Practical tooling, documentation, and examples enable developers to start creating programs quickly and effectively.
+- **Developer Experience:** The developer should be supported throughout the entire development lifecycle, from initial application logic to on-chain bugfixes.
+- **Intuiting Ownership with Resources:** Resources are a composite data type, similar to a struct, that expresses direct ownership of assets.
+Cadence’s strong static type system ensures that resources can only exist in one location at a time and cannot be copied or lost because of a coding mistake.
+Most smart contract languages currently use a ledger-style approach to record ownership,
+where an asset like a fungible token is stored in the smart contract as an entry in a central ledger.
+Cadence’s resources directly tie an asset’s ownership to the [account](glossary#section-account) that owns it by saving the resource in the account’s storage.
+As a result, ownership isn’t centralized in a smart contract’s storage. Each account owns its assets,
+and the assets can be transferred freely between accounts without the need for arbitration by a central smart contract.
+
+## Addressing Challenges with Existing Languages
+
+---
+
+Other languages pioneered smart contract development, but they lack in areas that affect the long-term viability of next-generation applications.
+
+### Safety
+
+Safety is the reliability of a smart contract to perform its function as intended. It is heavily influenced by the unchangeable-once-deployed nature of smart contracts:
+developers have to avoid introducing any potentially catastrophic weaknesses before releasing a smart contract.
+For example, in 2016, an overlooked vulnerability in the DAO code saw millions of dollars siphoned from a smart contract,
+eventually leading to a fork in Ethereum and two separate active blockchains (Ethereum and Ethereum Classic).
+
+Bug fixes are only possible if a smart contract is designed to support changes, a feature that introduces complexity and security issues.
+Lengthy auditing and review processes can ensure a bug-free smart contract. Still, they add substantial time to the already time-consuming task of getting the smart contract’s core logic working correctly.
+
+Overlooked mistakes cause the most damaging scenarios. 
+It is easy to lose or duplicate monetary value or assets because existing languages don’t check relevant invariants or make it harder to express them.
+For example, a plain number represents a transferred amount that can be accidentally (or maliciously) multiplied or ignored.
+
+Some languages also express behaviors that developers tend to forget about.
+For example, a fixed-range type might express monetary value, without considerations for a potential overflow or underflow.
+In Solidity, an overflow causes the value to wrap around, as shown [here](https://ethfiddle.com/CAp-kQrDUP).
+Solidity also allows contracts to declare variables without initializing them. If the developer forgets to add an initialization somewhere,
+and then tries to read the variable somewhere else in the code expecting it to be a specific value, issues will occur.
+
+Cadence is type safe and has a strong static type system, which prevents important classes of erroneous or undesirable program behavior at compile-time (i.e., before the program is run on-chain).
+Types are checked statically and are not implicitly converted. Cadence also improves the safety of programs by preventing arithmetic underflow and overflow,
+introduces optionals to make nil-cases explicit, and always requires variables to be initialized.
+This helps ensure the behavior of these smart contracts is apparent and not dependent on context.
+
+### Security
+
+Security, in combination with safety, ensures the successful execution of a smart contract over time by preventing unsanctioned access
+and guaranteeing that only authorized actions can be performed in the protocol.
+In some languages, functions are public by default, creating vulnerabilities that allow malicious users to find attack vectors.
+Cadence utilizes capability-based security, which allows the type system to enforce access control based on rules that users and developers have control over.
+
+Security is a consideration when interacting with other smart contracts. Any external call potentially allows malicious code to be executed.
+For example, in Solidity, when the called function signature does not match any of the available ones, it triggers Solidity’s fallback functions.
+These functions can be used in malicious ways. Language features such as multiple inheritances and overloading or dispatch can also make it difficult
+to determine which code is invoked.
+
+In Cadence, the safety and security of programs are enhanced by **Design By Contract** and **Ownership Primitives.**
+Design by contract allows developers to state pre-conditions and post-conditions for functions and interfaces in a declarative manner
+so that callers can be certain about the behavior of called code. Ownership primitives are inspired by linear types and increase safety when working with assets.
+They ensure that valuable assets are, for example, not accidentally or maliciously lost or duplicated.
+
+### Clarity and Approachability
+
+Implicitness, context-dependability, and expressiveness are language-based challenges that developers often encounter.
+They affect the clarity (i.e. the readability of code and the ability to determine its intended function)
+and the approachability (i.e. the ability to interpret or write code) of the language and the programs built using it.
+For example, in Solidity, storage must be implemented in a low-level key-value manner, which obfuscates the developer’s intentions.
+Syntax confusion is another example, with “=+” being legal syntax leading to an assignment instead of a probably-intended increment.
+Solidity also has features with uncommon behaviors that can lead to unintended results.
+[Multiple inheritance may lead to unexpected behaviours in the program](https://medium.com/consensys-diligence/a-case-against-inheritance-in-smart-contracts-d7f2c738f78e),
+and testing and auditing the code is unlikely to identify this issue.
+
+The Ethereum blockchain’s code immutability showcases the need for considerations around extensibility and mechanisms that allow ad-hoc fixes.
+Trail of Bits details the Ethereum’s current upgrade strategies and their issues:
+Developers using the ‘data separation’ approach to upgradability may run into problems with the complexity of data structures,
+while developers using ‘delegatecall-based proxies` may run into problems with the consistency of memory layouts.
+Either way, these challenges compromise approachability and overall extensibility.
+
+Cadence improves the clarity and extensibility of programs by utilizing interfaces to allow extensibility, code reuse, and interoperability between contracts.
+Cadence modules also have configurable and transparent upgradeability built-in to enable projects to test and iterate before making their code immutable.
+
+Cadence allows the use of argument labels to describe the meaning of function arguments.
+It also provides a rich standard library with useful data structures (e.g., dictionaries, sets) and data types for common use cases,
+like fixed-point arithmetic, which helps when working with currencies.
+
+## Intuiting Ownership with Resources
+
+Most smart contract languages currently use a ledger-style approach to record ownership, 
+where an asset is stored in the smart contract as an entry in a central ledger, and this ledger is the source of truth around asset ownership.
+There are many disadvantages to this design, especially when it comes to tracking the ownership of multiple assets belonging to a single account.
+To find out all of the assets that an account owns, you would have to enumerate all the possible smart contracts that could potentially include this account
+and search to see if the account owns these assets.
+
+In a resource-oriented language like Cadence, resources directly tie an asset to the [account](/intro/glossary/#account) that owns it
+by saving the resource in the account’s storage. As a result, ownership isn’t centralized in a single, central smart contract’s storage.
+Instead, each account owns and stores its own assets, and the assets can be transferred freely between accounts without the need for arbitration by a central smart contract.
+
+Resources are inspired by linear types and increase safety when working with assets, which often have real, intrinsic value.
+Resources, as enforced by Cadence’s type system, ensure that assets are correctly manipulated and not abused.
+
+- Every resource has exactly one owner. If a resource is used as a function parameter, an initial value for a variable, or something similar, the object is not copied.
+Instead, it is moved to the new location, and the old location is immediately invalidated.
+- The language will report an error if ownership of a resource was not properly transferred, i.e.,
+when the program attempts to introduce multiple owners for the resource or the resource ends up in a state where it does not have an owner.
+For example, a resource can only be assigned to exactly one variable and cannot be passed to functions multiple times.
+- Resources cannot go out of scope. If a function or transaction removes a resource from an account’s storage,
+it either needs to end the transaction in an account's storage, or it needs to be explicitly and safely deleted. There is no “garbage collection” for resources.
+
+The special status of Resource objects must be enforced by the runtime; if they were just a compiler abstraction it would be easy for malicious code to break the value guarantees.
+
+Resources change how assets are used in a programming environment to better resemble assets in the real world.
+Users store their currencies and assets in their own account, in their own wallet storage, and they can do with them as they wish.
+Users can define custom logic and structures for resources that give them flexibility with how they are stored.
+Additionally, because everyone stores their own assets, the calculation and charging of state rent is fair and balanced across all users in the network.
+
+## An Interpreted Language
+
+---
+
+Currently, Cadence is an interpreted language, as opposed to a compiled language. This means that there is no Cadence Assembly, bytecode, compiler, or Cadence VM.
+
+The structure of the language lends itself well to compilation (for example, static typing),
+but using an interpreter for the first version allows us to refine the language features more quickly as we define them.
+
+## Getting Started with Cadence
+
+---
+
+Now that you've learned about the goals and design of Cadence and Flow, you're ready to get started with the Flow emulator and tools!
+Go to the [Getting Started](/cadence/tutorial/01-first-steps/) page to work through language fundamentals and tutorials.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,8 +1,9 @@
 ---
 title: Introduction to Cadence
+type: INTRO
 ---
 
-We commonly refer to programs that are stored in user accounts as smart contracts. 
+We commonly refer to programs that are stored in user accounts as smart contracts.
 A smart contract is a program that verifies and executes the performance of a contract without the need for a trusted third party.
 Programs that run on blockchains are commonly referred to as smart contracts because they mediate important functionality (such as currency)
 without having to rely on a central authority (like a bank).
@@ -16,11 +17,11 @@ that help developers ensure that their code is safe, secure, clear, and approach
 
 - Type safety and a strong static type system
 - Resource-oriented programming, a new paradigm that pairs linear types with object capabilities
-to create a secure and declarative model for digital ownership by ensuring that resources (and their associated assets)
-can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted
+  to create a secure and declarative model for digital ownership by ensuring that resources (and their associated assets)
+  can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted
 - Built-in pre-conditions and post-conditions for functions and [transactions](/intro/glossary/#transaction)
 - The utilization of capability-based security, which enforces access control by requiring that access to objects
-is restricted to only the owner and those who have a valid reference to the object
+  is restricted to only the owner and those who have a valid reference to the object
 
 Swift and Rust inspire Cadence’s syntax. Its use of resource types maps well to that of Move, the programming language being developed by the Libra team.
 
@@ -30,27 +31,27 @@ Swift and Rust inspire Cadence’s syntax. Its use of resource types maps well t
 
 Cadence, a new high-level programming language, observes the following requirements:
 
-- **Safety and Security:** Safety is the underlying reliability of any smart contract (i.e., it’s bug-free and performs its function). 
-Security is the prevention of attacks on the network or smart contracts (i.e., unauthorized actions by malicious actors).
-Safety and security are critical in smart contracts because of the immutable nature of blockchains,
-and because they often deal with high-value assets. While auditing and reviewing code will be a crucial part of smart contract development, 
-Cadence maximizes efficiency while maintaining the highest levels of safety and security at its foundation. 
-It accomplishes this via a strong static type system, design by contract, and ownership primitives inspired by linear types (which are useful when dealing with assets).
-- **Clarity:** Code needs to be easy to read, and its meaning should be as unambiguous as possible. 
-It should also be suited for verification so that tooling can help with ensuring safety and security guarantees. 
-These guarantees can be achieved by making the code declarative and allowing the developer to express their intentions directly. 
-We make those intentions explicit by design, which, along with readability, make auditing and reviewing more efficient, at a small cost to verbosity.
+- **Safety and Security:** Safety is the underlying reliability of any smart contract (i.e., it’s bug-free and performs its function).
+  Security is the prevention of attacks on the network or smart contracts (i.e., unauthorized actions by malicious actors).
+  Safety and security are critical in smart contracts because of the immutable nature of blockchains,
+  and because they often deal with high-value assets. While auditing and reviewing code will be a crucial part of smart contract development,
+  Cadence maximizes efficiency while maintaining the highest levels of safety and security at its foundation.
+  It accomplishes this via a strong static type system, design by contract, and ownership primitives inspired by linear types (which are useful when dealing with assets).
+- **Clarity:** Code needs to be easy to read, and its meaning should be as unambiguous as possible.
+  It should also be suited for verification so that tooling can help with ensuring safety and security guarantees.
+  These guarantees can be achieved by making the code declarative and allowing the developer to express their intentions directly.
+  We make those intentions explicit by design, which, along with readability, make auditing and reviewing more efficient, at a small cost to verbosity.
 - **Approachability:** Writing code and creating programs should be as approachable as possible.
-Incorporating features from languages like Swift and Rust, developers should find Cadence’s syntax and semantics familiar.
-Practical tooling, documentation, and examples enable developers to start creating programs quickly and effectively.
+  Incorporating features from languages like Swift and Rust, developers should find Cadence’s syntax and semantics familiar.
+  Practical tooling, documentation, and examples enable developers to start creating programs quickly and effectively.
 - **Developer Experience:** The developer should be supported throughout the entire development lifecycle, from initial application logic to on-chain bugfixes.
 - **Intuiting Ownership with Resources:** Resources are a composite data type, similar to a struct, that expresses direct ownership of assets.
-Cadence’s strong static type system ensures that resources can only exist in one location at a time and cannot be copied or lost because of a coding mistake.
-Most smart contract languages currently use a ledger-style approach to record ownership,
-where an asset like a fungible token is stored in the smart contract as an entry in a central ledger.
-Cadence’s resources directly tie an asset’s ownership to the [account](glossary#section-account) that owns it by saving the resource in the account’s storage.
-As a result, ownership isn’t centralized in a smart contract’s storage. Each account owns its assets,
-and the assets can be transferred freely between accounts without the need for arbitration by a central smart contract.
+  Cadence’s strong static type system ensures that resources can only exist in one location at a time and cannot be copied or lost because of a coding mistake.
+  Most smart contract languages currently use a ledger-style approach to record ownership,
+  where an asset like a fungible token is stored in the smart contract as an entry in a central ledger.
+  Cadence’s resources directly tie an asset’s ownership to the [account](glossary#section-account) that owns it by saving the resource in the account’s storage.
+  As a result, ownership isn’t centralized in a smart contract’s storage. Each account owns its assets,
+  and the assets can be transferred freely between accounts without the need for arbitration by a central smart contract.
 
 ## Addressing Challenges with Existing Languages
 
@@ -68,7 +69,7 @@ eventually leading to a fork in Ethereum and two separate active blockchains (Et
 Bug fixes are only possible if a smart contract is designed to support changes, a feature that introduces complexity and security issues.
 Lengthy auditing and review processes can ensure a bug-free smart contract. Still, they add substantial time to the already time-consuming task of getting the smart contract’s core logic working correctly.
 
-Overlooked mistakes cause the most damaging scenarios. 
+Overlooked mistakes cause the most damaging scenarios.
 It is easy to lose or duplicate monetary value or assets because existing languages don’t check relevant invariants or make it harder to express them.
 For example, a plain number represents a transferred amount that can be accidentally (or maliciously) multiplied or ignored.
 
@@ -126,7 +127,7 @@ like fixed-point arithmetic, which helps when working with currencies.
 
 ## Intuiting Ownership with Resources
 
-Most smart contract languages currently use a ledger-style approach to record ownership, 
+Most smart contract languages currently use a ledger-style approach to record ownership,
 where an asset is stored in the smart contract as an entry in a central ledger, and this ledger is the source of truth around asset ownership.
 There are many disadvantages to this design, especially when it comes to tracking the ownership of multiple assets belonging to a single account.
 To find out all of the assets that an account owns, you would have to enumerate all the possible smart contracts that could potentially include this account
@@ -140,12 +141,12 @@ Resources are inspired by linear types and increase safety when working with ass
 Resources, as enforced by Cadence’s type system, ensure that assets are correctly manipulated and not abused.
 
 - Every resource has exactly one owner. If a resource is used as a function parameter, an initial value for a variable, or something similar, the object is not copied.
-Instead, it is moved to the new location, and the old location is immediately invalidated.
+  Instead, it is moved to the new location, and the old location is immediately invalidated.
 - The language will report an error if ownership of a resource was not properly transferred, i.e.,
-when the program attempts to introduce multiple owners for the resource or the resource ends up in a state where it does not have an owner.
-For example, a resource can only be assigned to exactly one variable and cannot be passed to functions multiple times.
+  when the program attempts to introduce multiple owners for the resource or the resource ends up in a state where it does not have an owner.
+  For example, a resource can only be assigned to exactly one variable and cannot be passed to functions multiple times.
 - Resources cannot go out of scope. If a function or transaction removes a resource from an account’s storage,
-it either needs to end the transaction in an account's storage, or it needs to be explicitly and safely deleted. There is no “garbage collection” for resources.
+  it either needs to end the transaction in an account's storage, or it needs to be explicitly and safely deleted. There is no “garbage collection” for resources.
 
 The special status of Resource objects must be enforced by the runtime; if they were just a compiler abstraction it would be easy for malicious code to break the value guarantees.
 

--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -1,0 +1,368 @@
+---
+title: JSON-Cadence Data Interchange Format
+---
+
+> Version 0.2.0
+
+JSON-Cadence is a data interchange format used to represent Cadence values as language-independent JSON objects.
+
+This format includes less type information than a complete [ABI](https://en.wikipedia.org/wiki/Application_binary_interface), and instead promotes the following tenets:
+
+- **Human-readability** - JSON-Cadence is easy to read and comprehend, which speeds up development and debugging.
+- **Compatibility** - JSON is a common format with built-in support in most high-level programming languages, making it easy to parse on a variety of platforms.
+- **Portability** - JSON-Cadence is self-describing and thus can be transported and decoded without accompanying type definitions (i.e. an ABI).
+
+---
+
+## Void
+
+```json
+{
+  "type": "Void"
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Void"
+}
+```
+
+---
+
+## Optional
+
+```json
+{
+  "type": "Optional",
+  "value": null | <value>
+}
+```
+
+### Example
+
+```json
+// Non-nil
+
+{
+  "type": "Optional",
+  "value": {
+    "type": "UInt8",
+    "value": "123"
+  }
+}
+
+// Nil
+
+{
+  "type": "Optional",
+  "value": null
+}
+```
+
+---
+
+## Bool
+
+```json
+{
+  "type": "Bool",
+  "value": true | false
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Bool",
+  "value": true
+}
+```
+
+---
+
+## String
+
+```json
+{
+  "type": "String",
+  "value": "..."
+}
+
+```
+
+### Example
+
+```json
+{
+  "type": "String",
+  "value": "Hello, world!"
+}
+```
+
+---
+
+## Address
+
+```json
+{
+  "type": "Address",
+  "value": "0x0" // as hex-encoded string with 0x prefix
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Address",
+  "value": "0x1234"
+}
+```
+
+---
+
+## Integers
+
+`[U]Int`, `[U]Int8`, `[U]Int16`, `[U]Int32`,`[U]Int64`,`[U]Int128`, `[U]Int256`,  `Word8`, `Word16`, `Word32`, or `Word64`
+
+Although JSON supports integer literals up to 64 bits, all integer types are encoded as strings for consistency.
+
+While the static type is not strictly required for decoding, it is provided to inform client of potential range.
+
+```json
+{
+  "type": "<type>",
+  "value": "<decimal string representation of integer>"
+}
+```
+
+### Example
+
+```json
+{
+  "type": "UInt8",
+  "value": "123"
+}
+```
+
+---
+
+## Fixed Point Numbers
+
+`[U]Fix64`
+
+Although fixed point numbers are implemented as integers, JSON-Cadence uses a decimal string representation for readability.
+
+```json
+{
+    "type": "[U]Fix64",
+    "value": "<integer>.<fractional>"
+}
+```
+
+### Example
+
+```json
+{
+    "type": "Fix64",
+    "value": "12.3"
+}
+```
+
+---
+
+## Array
+
+```json
+{
+  "type": "Array",
+  "value": [
+    <value at index 0>,
+    <value at index 1>
+    // ...
+  ]
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Array",
+  "value": [
+    {
+      "type": "Int16",
+      "value": "123"
+    },
+    {
+      "type": "String",
+      "value": "test"
+    },
+    {
+      "type": "Bool",
+      "value": true
+    }
+  ]
+}
+```
+
+---
+
+## Dictionary
+
+Dictionaries are encoded as a list of key-value pairs to preserve the deterministic ordering implemented by Cadence.
+
+```json
+{
+  "type": "Dictionary",
+  "value": [
+    {
+      "key": "<key>",
+      "value": <value>
+    },
+    ...
+  ]
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Dictionary",
+  "value": [
+    {
+      "key": {
+        "type": "UInt8",
+        "value": "123"
+      },
+      "value": {
+        "type": "String",
+        "value": "test"
+      },
+    }
+  ],
+  // ...
+}
+```
+
+---
+
+## Composites (Struct, Resource, Event, Contract, Enum)
+
+Composite fields are encoded as a list of name-value pairs in the order in which they appear in the composite type declaration.
+
+```json
+{
+  "type": "Struct" | "Resource" | "Event" | "Contract" | "Enum",
+  "value": {
+    "id": "<fully qualified type identifier>",
+    "fields": [
+      {
+        "name": "<field name>",
+        "value": <field value>
+      },
+      // ...
+    ]
+  }
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Resource",
+  "value": {
+    "id": "0x3.GreatContract.GreatNFT",
+    "fields": [
+      {
+        "name": "power",
+        "value": {"type": "Int", "value": "1"}
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Path
+
+```json
+{
+  "type": "Path",
+  "value": {
+    "domain": "storage" | "private" | "public",
+    "identifier": "..."
+  }
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Path",
+  "value": {
+    "domain": "storage",
+    "identifier": "flowTokenVault"
+  }
+}
+```
+
+---
+
+## Type
+
+```json
+{
+  "type": "Type",
+  "value": {
+    "staticType": "..."
+  }
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Type",
+  "value": {
+    "staticType": "Int"
+  }
+}
+```
+
+---
+
+## Capability
+
+```json
+{
+  "type": "Capability",
+  "value": {
+    "path": <path>,
+    "address": "0x0",  // as hex-encoded string with 0x prefix
+    "borrowType": "<type ID>",
+  }
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Capability",
+  "value": {
+    "path": "/public/someInteger",
+    "address": "0x1",
+    "borrowType": "Int",
+  }
+}
+```

--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -1,6 +1,6 @@
 ---
 title: JSON-Cadence Data Interchange Format
-type: REF
+contentType: REF
 ---
 
 > Version 0.2.0

--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -1,5 +1,6 @@
 ---
 title: JSON-Cadence Data Interchange Format
+type: REF
 ---
 
 > Version 0.2.0

--- a/docs/language/access-control.md
+++ b/docs/language/access-control.md
@@ -1,5 +1,6 @@
 ---
 title: Access control
+type: REF
 ---
 
 Access control allows making certain parts of the program accessible/visible

--- a/docs/language/access-control.md
+++ b/docs/language/access-control.md
@@ -1,6 +1,6 @@
 ---
 title: Access control
-type: REF
+contentType: REF
 ---
 
 Access control allows making certain parts of the program accessible/visible

--- a/docs/language/accounts.md
+++ b/docs/language/accounts.md
@@ -1,6 +1,6 @@
 ---
 title: Accounts
-type: REF
+contentType: REF
 ---
 
 Every account can be accessed through two types:

--- a/docs/language/accounts.md
+++ b/docs/language/accounts.md
@@ -1,5 +1,6 @@
 ---
 title: Accounts
+type: REF
 ---
 
 Every account can be accessed through two types:

--- a/docs/language/built-in-functions.md
+++ b/docs/language/built-in-functions.md
@@ -1,5 +1,6 @@
 ---
 title: Built-in Functions
+type: REF
 ---
 
 - `cadence•fun panic(_ message: String): Never`

--- a/docs/language/built-in-functions.md
+++ b/docs/language/built-in-functions.md
@@ -1,6 +1,6 @@
 ---
 title: Built-in Functions
-type: REF
+contentType: REF
 ---
 
 - `cadence•fun panic(_ message: String): Never`

--- a/docs/language/capability-based-access-control.md
+++ b/docs/language/capability-based-access-control.md
@@ -1,5 +1,6 @@
 ---
 title: Capability-based Access Control
+type: REF
 ---
 
 Users will often want to make it so that specific other users or even anyone else

--- a/docs/language/capability-based-access-control.md
+++ b/docs/language/capability-based-access-control.md
@@ -1,6 +1,6 @@
 ---
 title: Capability-based Access Control
-type: REF
+contentType: REF
 ---
 
 Users will often want to make it so that specific other users or even anyone else

--- a/docs/language/composite-types.mdx
+++ b/docs/language/composite-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: Composite Types
+type: REF
 ---
 
 Composite types allow composing simpler types into more complex types,
@@ -19,31 +20,31 @@ and when the value is returned from a function:
 
 - [**Structures**](#structures) are **copied**, they are value types.
 
-    Structures are useful when copies with independent state are desired.
+  Structures are useful when copies with independent state are desired.
 
 - [**Resources**](#resources) are **moved**, they are linear types and **must** be used **exactly once**.
 
-    Resources are useful when it is desired to model ownership
-    (a value exists exactly in one location and it should not be lost).
+  Resources are useful when it is desired to model ownership
+  (a value exists exactly in one location and it should not be lost).
 
-    Certain constructs in a blockchain represent assets of real, tangible value,
-    as much as a house or car or bank account.
-    We have to worry about literal loss and theft,
-    perhaps even on the scale of millions of dollars.
+  Certain constructs in a blockchain represent assets of real, tangible value,
+  as much as a house or car or bank account.
+  We have to worry about literal loss and theft,
+  perhaps even on the scale of millions of dollars.
 
-    Structures are not an ideal way to represent this ownership because they are copied.
-    This would mean that there could be a risk of having multiple copies
-    of certain assets floating around,
-    which breaks the scarcity requirements needed for these assets to have real value.
+  Structures are not an ideal way to represent this ownership because they are copied.
+  This would mean that there could be a risk of having multiple copies
+  of certain assets floating around,
+  which breaks the scarcity requirements needed for these assets to have real value.
 
-    A structure is much more useful for representing information
-    that can be grouped together in a logical way,
-    but doesn't have value or a need to be able to be owned or transferred.
+  A structure is much more useful for representing information
+  that can be grouped together in a logical way,
+  but doesn't have value or a need to be able to be owned or transferred.
 
-    A structure could for example be used to contain the information associated
-    with a division of a company,
-    but a resource would be used to represent the assets that have been allocated
-    to that organization for spending.
+  A structure could for example be used to contain the information associated
+  with a division of a company,
+  but a resource would be used to represent the assets that have been allocated
+  to that organization for spending.
 
 Nesting of resources is only allowed within other resource types,
 or in data structures like arrays and dictionaries,
@@ -118,33 +119,33 @@ The initializer always follows any fields.
 There are three kinds of fields:
 
 - **Constant fields** are also stored in the composite value,
-    but after they have been initialized with a value
-    they **cannot** have new values assigned to them afterwards.
-    A constant field must be initialized exactly once.
+  but after they have been initialized with a value
+  they **cannot** have new values assigned to them afterwards.
+  A constant field must be initialized exactly once.
 
-    Constant fields are declared using the `let` keyword.
+  Constant fields are declared using the `let` keyword.
 
 - **Variable fields** are stored in the composite value
-    and can have new values assigned to them.
+  and can have new values assigned to them.
 
-    Variable fields are declared using the `var` keyword.
+  Variable fields are declared using the `var` keyword.
 
 - **Synthetic fields** are **not stored** in the composite value,
-    i.e. they are derived/computed from other values.
-    They can have new values assigned to them.
+  i.e. they are derived/computed from other values.
+  They can have new values assigned to them.
 
-    Synthetic fields are declared using the `synthetic` keyword.
+  Synthetic fields are declared using the `synthetic` keyword.
 
-    Synthetic fields must have a getter and a setter.
-    Getters and setters are explained in the
-    [next section](#composite-type-field-getters-and-setters).
-    Synthetic fields are explained in a [separate section](#synthetic-composite-type-fields).
+  Synthetic fields must have a getter and a setter.
+  Getters and setters are explained in the
+  [next section](#composite-type-field-getters-and-setters).
+  Synthetic fields are explained in a [separate section](#synthetic-composite-type-fields).
 
-| Field Kind           | Stored in memory | Assignable         | Keyword     |
-|----------------------|------------------|--------------------|-------------|
-| **Variable field**   | Yes              | Yes                | `var`       |
-| **Constant field**   | Yes              | **No**             | `let`       |
-| **Synthetic field**  | **No**           | Yes                | `synthetic` |
+| Field Kind          | Stored in memory | Assignable | Keyword     |
+| ------------------- | ---------------- | ---------- | ----------- |
+| **Variable field**  | Yes              | Yes        | `var`       |
+| **Constant field**  | Yes              | **No**     | `let`       |
+| **Synthetic field** | **No**           | Yes        | `synthetic` |
 
 In initializers, the special constant `self` refers to the composite value
 that is to be initialized.
@@ -194,7 +195,7 @@ pub struct StructureWithConstantField {
 }
 ```
 
-The field access syntax must be used to access fields –  fields are not available as variables.
+The field access syntax must be used to access fields – fields are not available as variables.
 
 ```cadence
 pub struct Token {
@@ -376,7 +377,7 @@ example.balance = -50
 
 </Callout>
 
-Fields which are not stored in the composite value are *synthetic*,
+Fields which are not stored in the composite value are _synthetic_,
 i.e., the field value is computed.
 Synthetic can be either read-only, or readable and writable.
 
@@ -1337,6 +1338,7 @@ id3 != id1  // true
 The details of how the identifiers are generated is an implementation detail.
 
 Do not rely on or assume any particular behaviour in Cadence programs.
+
 </Callout>
 
 ## Unbound References / Nulls

--- a/docs/language/composite-types.mdx
+++ b/docs/language/composite-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Composite Types
-type: REF
+contentType: REF
 ---
 
 Composite types allow composing simpler types into more complex types,

--- a/docs/language/constants-and-variables.md
+++ b/docs/language/constants-and-variables.md
@@ -1,6 +1,6 @@
 ---
 title: Constants and Variable Declarations
-type: REF
+contentType: REF
 ---
 
 Constants and variables are declarations that bind

--- a/docs/language/constants-and-variables.md
+++ b/docs/language/constants-and-variables.md
@@ -1,5 +1,6 @@
 ---
 title: Constants and Variable Declarations
+type: REF
 ---
 
 Constants and variables are declarations that bind

--- a/docs/language/contracts.md
+++ b/docs/language/contracts.md
@@ -1,6 +1,6 @@
 ---
 title: Contracts
-type: REF
+contentType: REF
 ---
 
 A contract in Cadence is a collection of type definitions

--- a/docs/language/contracts.md
+++ b/docs/language/contracts.md
@@ -1,5 +1,6 @@
 ---
 title: Contracts
+type: REF
 ---
 
 A contract in Cadence is a collection of type definitions

--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -1,6 +1,6 @@
 ---
 title: Control Flow
-type: REF
+contentType: REF
 ---
 
 Control flow statements control the flow of execution in a function.

--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -1,5 +1,6 @@
 ---
 title: Control Flow
+type: REF
 ---
 
 Control flow statements control the flow of execution in a function.

--- a/docs/language/crypto.md
+++ b/docs/language/crypto.md
@@ -1,6 +1,6 @@
 ---
 title: Crypto
-type: REF
+contentType: REF
 ---
 
 The built-in contract `Crypto` can be used to perform cryptographic operations.

--- a/docs/language/crypto.md
+++ b/docs/language/crypto.md
@@ -1,5 +1,6 @@
 ---
 title: Crypto
+type: REF
 ---
 
 The built-in contract `Crypto` can be used to perform cryptographic operations.

--- a/docs/language/enumerations.md
+++ b/docs/language/enumerations.md
@@ -1,5 +1,6 @@
 ---
 title: Enumerations
+type: REF
 ---
 
 Enumerations are sets of symbolic names bound to unique, constant values,

--- a/docs/language/enumerations.md
+++ b/docs/language/enumerations.md
@@ -1,6 +1,6 @@
 ---
 title: Enumerations
-type: REF
+contentType: REF
 ---
 
 Enumerations are sets of symbolic names bound to unique, constant values,

--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -1,5 +1,6 @@
 ---
 title: Environment Information
+type: REF
 ---
 
 ## Transaction Information

--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -1,6 +1,6 @@
 ---
 title: Environment Information
-type: REF
+contentType: REF
 ---
 
 ## Transaction Information

--- a/docs/language/events.md
+++ b/docs/language/events.md
@@ -1,5 +1,6 @@
 ---
 title: Events
+type: REF
 ---
 
 Events are special values that can be emitted during the execution of a program.

--- a/docs/language/events.md
+++ b/docs/language/events.md
@@ -1,6 +1,6 @@
 ---
 title: Events
-type: REF
+contentType: REF
 ---
 
 Events are special values that can be emitted during the execution of a program.

--- a/docs/language/functions.mdx
+++ b/docs/language/functions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Functions
+type: REF
 ---
 
 Functions are sequences of statements that perform a specific task.
@@ -13,8 +14,8 @@ This behavior is often called "first-class functions".
 ## Function Declarations
 
 Functions can be declared by using the `fun` keyword, followed by the name of the declaration,
- the parameters, the optional return type,
- and the code that should be executed when the function is called.
+the parameters, the optional return type,
+and the code that should be executed when the function is called.
 
 The parameters need to be enclosed in parentheses.
 The return type, if any, is separated from the parameters by a colon (`:`).
@@ -515,4 +516,3 @@ fun incrementN() {
     n = n + 1
 }
 ```
-

--- a/docs/language/functions.mdx
+++ b/docs/language/functions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Functions
-type: REF
+contentType: REF
 ---
 
 Functions are sequences of statements that perform a specific task.

--- a/docs/language/imports.mdx
+++ b/docs/language/imports.mdx
@@ -1,6 +1,6 @@
 ---
 title: Imports
-type: REF
+contentType: REF
 ---
 
 Programs can import declarations (types, functions, variables, etc.) from other programs.

--- a/docs/language/imports.mdx
+++ b/docs/language/imports.mdx
@@ -1,5 +1,6 @@
 ---
 title: Imports
+type: REF
 ---
 
 Programs can import declarations (types, functions, variables, etc.) from other programs.

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -1,5 +1,6 @@
 ---
 title: The Cadence Programming Language
+type: REF
 ---
 
 ## Introduction

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -1,6 +1,6 @@
 ---
 title: The Cadence Programming Language
-type: REF
+contentType: REF
 ---
 
 ## Introduction

--- a/docs/language/interfaces.mdx
+++ b/docs/language/interfaces.mdx
@@ -1,6 +1,6 @@
 ---
 title: Interfaces
-type: REF
+contentType: REF
 ---
 
 An interface is an abstract type that specifies the behavior of types

--- a/docs/language/interfaces.mdx
+++ b/docs/language/interfaces.mdx
@@ -1,9 +1,10 @@
 ---
 title: Interfaces
+type: REF
 ---
 
 An interface is an abstract type that specifies the behavior of types
-that *implement* the interface.
+that _implement_ the interface.
 Interfaces declare the required functions and fields,
 the access control for those declarations,
 and preconditions and postconditions that implementing types need to provide.
@@ -555,7 +556,7 @@ resource ExampleToken: FungibleToken {
 </Callout>
 
 An equatable type is a type that can be compared for equality.
-Types are equatable when they  implement the `Equatable` interface.
+Types are equatable when they implement the `Equatable` interface.
 
 Equatable types can be compared for equality using the equals operator (`==`)
 or inequality using the unequals operator (`!=`).

--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -1,6 +1,6 @@
 ---
 title: Operators
-type: REF
+contentType: REF
 ---
 
 Operators are special symbols that perform a computation

--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -1,5 +1,6 @@
 ---
 title: Operators
+type: REF
 ---
 
 Operators are special symbols that perform a computation

--- a/docs/language/references.md
+++ b/docs/language/references.md
@@ -1,5 +1,6 @@
 ---
 title: References
+type: REF
 ---
 
 It is possible to create references to objects, i.e. resources or structures.

--- a/docs/language/references.md
+++ b/docs/language/references.md
@@ -1,6 +1,6 @@
 ---
 title: References
-type: REF
+contentType: REF
 ---
 
 It is possible to create references to objects, i.e. resources or structures.

--- a/docs/language/restricted-types.md
+++ b/docs/language/restricted-types.md
@@ -1,6 +1,6 @@
 ---
 title: Restricted Types
-type: REF
+contentType: REF
 ---
 
 Structure and resource types can be **restricted**. Restrictions are interfaces.

--- a/docs/language/restricted-types.md
+++ b/docs/language/restricted-types.md
@@ -1,5 +1,6 @@
 ---
 title: Restricted Types
+type: REF
 ---
 
 Structure and resource types can be **restricted**. Restrictions are interfaces.

--- a/docs/language/run-time-types.md
+++ b/docs/language/run-time-types.md
@@ -1,6 +1,6 @@
 ---
 title: Run-time Types
-type: REF
+contentType: REF
 ---
 
 Types can be represented at run-time.

--- a/docs/language/run-time-types.md
+++ b/docs/language/run-time-types.md
@@ -1,5 +1,6 @@
 ---
 title: Run-time Types
+type: REF
 ---
 
 Types can be represented at run-time.

--- a/docs/language/scope.md
+++ b/docs/language/scope.md
@@ -1,6 +1,6 @@
 ---
 title: Scope
-type: REF
+contentType: REF
 ---
 
 Every function and block (`{` ... `}`) introduces a new scope for declarations.

--- a/docs/language/scope.md
+++ b/docs/language/scope.md
@@ -1,5 +1,6 @@
 ---
 title: Scope
+type: REF
 ---
 
 Every function and block (`{` ... `}`) introduces a new scope for declarations.

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -1,5 +1,6 @@
 ---
 title: Syntax
+type: REF
 ---
 
 ## Comments

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -1,6 +1,6 @@
 ---
 title: Syntax
-type: REF
+contentType: REF
 ---
 
 ## Comments

--- a/docs/language/transactions.md
+++ b/docs/language/transactions.md
@@ -1,5 +1,6 @@
 ---
 title: Transactions
+type: REF
 ---
 
 Transactions are objects that are signed by one or more [accounts](../accounts)

--- a/docs/language/transactions.md
+++ b/docs/language/transactions.md
@@ -1,6 +1,6 @@
 ---
 title: Transactions
-type: REF
+contentType: REF
 ---
 
 Transactions are objects that are signed by one or more [accounts](../accounts)

--- a/docs/language/type-annotations.md
+++ b/docs/language/type-annotations.md
@@ -1,6 +1,6 @@
 ---
 title: Type Annotations
-type: REF
+contentType: REF
 ---
 
 When declaring a constant or variable,

--- a/docs/language/type-annotations.md
+++ b/docs/language/type-annotations.md
@@ -1,5 +1,6 @@
 ---
 title: Type Annotations
+type: REF
 ---
 
 When declaring a constant or variable,

--- a/docs/language/type-hierarchy.md
+++ b/docs/language/type-hierarchy.md
@@ -1,5 +1,6 @@
 ---
 title: Type Hierarchy
+type: REF
 ---
 
 ![Cadence type hierarchy](type-hierarchy.png)

--- a/docs/language/type-hierarchy.md
+++ b/docs/language/type-hierarchy.md
@@ -1,6 +1,6 @@
 ---
 title: Type Hierarchy
-type: REF
+contentType: REF
 ---
 
 ![Cadence type hierarchy](type-hierarchy.png)

--- a/docs/language/type-inference.mdx
+++ b/docs/language/type-inference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Type Inference
+type: REF
 ---
 
 <Callout type="info">

--- a/docs/language/type-inference.mdx
+++ b/docs/language/type-inference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Type Inference
-type: REF
+contentType: REF
 ---
 
 <Callout type="info">

--- a/docs/language/type-safety.md
+++ b/docs/language/type-safety.md
@@ -1,5 +1,6 @@
 ---
 title: Type Safety
+type: REF
 ---
 
 The Cadence programming language is a *type-safe* language.

--- a/docs/language/type-safety.md
+++ b/docs/language/type-safety.md
@@ -1,6 +1,6 @@
 ---
 title: Type Safety
-type: REF
+contentType: REF
 ---
 
 The Cadence programming language is a *type-safe* language.

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Values and Types
-type: REF
+contentType: REF
 ---
 
 Values are objects, like for example booleans, integers, or arrays.

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: Values and Types
+type: REF
 ---
 
 Values are objects, like for example booleans, integers, or arrays.
@@ -15,8 +16,8 @@ Numbers can be written in various bases. Numbers are assumed to be decimal by de
 Non-decimal literals have a specific prefix.
 
 | Numeral system  | Prefix | Characters                                                            |
-|:----------------|:-------|:----------------------------------------------------------------------|
-| **Decimal**     | *None* | one or more numbers (`0` to `9`)                                      |
+| :-------------- | :----- | :-------------------------------------------------------------------- |
+| **Decimal**     | _None_ | one or more numbers (`0` to `9`)                                      |
 | **Binary**      | `0b`   | one or more zeros or ones (`0` or `1`)                                |
 | **Octal**       | `0o`   | one or more numbers in the range `0` to `7`                           |
 | **Hexadecimal** | `0x`   | one or more numbers, or characters `a` to `f`, lowercase or uppercase |
@@ -67,8 +68,8 @@ let binaryNumber = 0b10_11_01
 ## Integers
 
 Integers are numbers without a fractional part.
-They are either *signed* (positive, zero, or negative)
-or *unsigned* (positive or zero).
+They are either _signed_ (positive, zero, or negative)
+or _unsigned_ (positive or zero).
 
 Signed integer types which check for overflow and underflow have an `Int` prefix
 and can represent values in the following ranges:
@@ -838,7 +839,7 @@ Array literals start with an opening square bracket `[` and end with a closing s
 Arrays either have a fixed size or are variably sized, i.e., elements can be added and removed.
 
 Fixed-size arrays have the form `[T; N]`, where `T` is the element type,
-and `N` is the size of the array.  `N` has to be statically known, meaning
+and `N` is the size of the array. `N` has to be statically known, meaning
 that it needs to be an integer literal.
 For example, a fixed-size array of 3 `Int8` elements has the type `[Int8; 3]`.
 
@@ -1321,7 +1322,7 @@ booleans[0] = true
 
 - `cadence•let keys: [K]`
 
-  Returns an array of the keys of type `K` in the dictionary.  This does not
+  Returns an array of the keys of type `K` in the dictionary. This does not
   modify the dictionary, just returns a copy of the keys as an array.
   If the dictionary is empty, this returns an empty array.
 
@@ -1337,7 +1338,7 @@ booleans[0] = true
 
 - `cadence•let values: [V]`
 
-  Returns an array of the values of type `V` in the dictionary.  This does not
+  Returns an array of the values of type `V` in the dictionary. This does not
   modify the dictionary, just returns a copy of the values as an array.
   If the dictionary is empty, this returns an empty array.
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Migration Guide
+type: HOWTO
 ---
 
 ## v0.11

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Migration Guide
-type: HOWTO
+contentType: HOWTO
 ---
 
 ## v0.11

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,59 @@
+---
+title: Migration Guide
+---
+
+## v0.11
+
+Version 0.11 [introduced breaking changes](https://github.com/onflow/cadence/releases/tag/v0.11.0):
+Paths are now typed, i.e. there are specific subtypes for storage, public, and private paths,
+and the Storage API has been made type-safer by changing parameter types to more specific path types.
+
+Please read the release notes linked above to learn more.
+
+The following hints should help with updating your Cadence code:
+
+- The return types of `PublicAccount.getCapability` and `AuthAccount.getCapability` are not optional anymore.
+
+  For example, in the following code the force unwrapping should be removed:
+
+  ```diff
+       let balanceRef = account
+  -        .getCapability(/public/flowTokenBalance)!
+  +        .getCapability(/public/flowTokenBalance)
+           .borrow<&FlowToken.Vault{FungibleToken.Balance}>()!
+  ```
+
+  In the next example, optional binding was used and is not allowed anymore:
+
+  ```diff
+  -    if let balanceCap = account.getCapability(/public/flowTokenBalance) {
+  -        return balanceCap.borrow<&FlowToken.Vault{FungibleToken.Balance}>()!
+  -    }
+
+  +    let balanceCap = account.getCapability(/public/flowTokenBalance)
+  +    return balanceCap.borrow<&FlowToken.Vault{FungibleToken.Balance}>()!
+  ```
+
+- Parameters of the Storage API functions that had the type `Path` now have more specific types.
+  For example, the `getCapability` functions now require a `CapabilityPath` instead of just a `Path`.
+
+  Ensure path values with the correct path type are passed to these functions.
+
+  For example, a contract may have declared a field with the type `Path`, then used it in a function to call `getCapability`.
+  The type of the field must be changed to the more specific type:
+
+    ```diff
+     pub contract SomeContract {
+
+    -    pub let somethingPath: Path
+    +    pub let somethingPath: StoragePath
+
+         init() {
+             self.somethingPath = /storage/something
+         }
+
+         pub fun borrow(): &Something {
+             return self.account.borrow<&Something>(self.somethingPath)
+         }
+     }
+    ```

--- a/docs/subtyping.md
+++ b/docs/subtyping.md
@@ -1,4 +1,7 @@
-
+---
+title: Sub-typing
+type: REF
+---
 ## Resources
 
 - Supertype: **Restricted Resource**:

--- a/docs/subtyping.md
+++ b/docs/subtyping.md
@@ -1,6 +1,6 @@
 ---
 title: Sub-typing
-type: REF
+contentType: REF
 ---
 ## Resources
 

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -1,6 +1,6 @@
 ---
 title: Syntax Highlighting Cadence
-type: HOWTO
+contentType: HOWTO
 ---
 
 # Syntax Highlighting Cadence

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -1,3 +1,8 @@
+---
+title: Syntax Highlighting Cadence
+type: HOWTO
+---
+
 # Syntax Highlighting Cadence
 
 There are currently several options to highlight Cadence code.

--- a/docs/tutorial/01-first-steps.mdx
+++ b/docs/tutorial/01-first-steps.mdx
@@ -1,6 +1,6 @@
 ---
 title: 1. First Steps
-type: TUT
+contentType: TUT
 ---
 
 In this tutorial, we will learn how to use smart contracts, switch accounts, and view account state.

--- a/docs/tutorial/01-first-steps.mdx
+++ b/docs/tutorial/01-first-steps.mdx
@@ -1,5 +1,6 @@
 ---
 title: 1. First Steps
+type: TUT
 ---
 
 In this tutorial, we will learn how to use smart contracts, switch accounts, and view account state.

--- a/docs/tutorial/01-first-steps.mdx
+++ b/docs/tutorial/01-first-steps.mdx
@@ -1,0 +1,73 @@
+---
+title: 1. First Steps
+---
+
+In this tutorial, we will learn how to use smart contracts, switch accounts, and view account state.
+
+## What is Cadence?
+
+---
+
+Cadence is a new smart contract programming language for use on the Flow Blockchain.
+Cadence introduces new features to smart contract programming that help developers ensure that their code is safe, secure, clear, and approachable. Some of these features are:
+
+- Type safety and a strong static type system
+- Resource-oriented programming, a new paradigm that pairs linear types with object capabilities to create a secure and declarative model for digital ownership
+  by ensuring that resources (and their associated assets) can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted
+- Built-in pre-conditions and post-conditions for functions and [transactions](/cadence/language/transactions/)
+- The utilization of capability-based security, which enforces access control by requiring that access to objects
+  is restricted to only the owner and those who have a valid reference to the object
+
+Please see the [Cadence introduction](/cadence/index) for more information about the high level design of the language.
+
+## What is the Flow Developer Playground?
+
+---
+
+The [Flow Playground](https://play.onflow.org) includes an in-browser editor and emulator to experiment with Flow.
+Using the Flow Playground, you can write Cadence smart contracts, deploy them to a local Flow emulated blockchain, and submit transactions.
+
+The Flow Playground should be compatible with any standard web browser, but we recommend that you use Google Chrome with it,
+because it has been tested and optimized for only the Chrome browser so far.
+
+<!-- If you encounter issues using the Flow Developer Playground, see the [Playground Manual](doc:playground-manual) or [Debugging](doc:debugging) for help. -->
+
+## Getting to know the Playground
+
+The Playground contains everything you need to get familiar with deploying Cadence smart contracts and interacting with transaction and scripts.
+
+The Playground comes pre-loaded with contract and transaction templates that correspond to each of the tutorials in the docs site.
+To load the contracts from a specific tutorial, click the "Examples" link at the top of the Playground. This opens up a menu with each tutorial.
+
+When you click on one of these links, the tutorial will open in a new tab and the contracts, transactions, and scripts will be loaded into the templates in the Playground for you to use.
+
+## Accounts and Contracts
+
+The Accounts section on the left side of the screen is where the active accounts are listed and selected.
+You can click on an account tab to view the contract that is associated with that account in the main editor.
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-accounts.png" />
+
+When you have Cadence code open in the account editor that contains a contract,
+you can click the deploy button in the top-right of the screen to deploy that contract to the currently selected account.
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-deploy.png" />
+
+After a few seconds, you should see a message in the console confirming that the contract was deployed.
+You should also see the name of the contract show up in the tab for that account, indicating the account now has that contract deployed to it.
+
+You can also select transactions and scripts from the left selection menu and submit them to interact with your deployed smart contracts,
+which will be covered in the Hello World tutorial.
+
+This is just a small set of the things you can do with the Playground.
+If you would like a more detailed explanation of the different Playground features, look at the Playground Manual.
+
+## Resources
+
+Each tutorial in this package uses several files containing transactions, contracts, and scripts.
+All the code you need will be provided in the text of the tutorials for you to copy and paste,
+or you can use the pre-generated tutorial setups in the Playground.
+
+## Say Hello, World!
+
+Now that you have the Flow Developer Playground running, you can create a smart contract for Flow!

--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -1,5 +1,6 @@
 ---
 title: 2. Hello World
+type: TUT
 ---
 
 ### Let's write and deploy our first smart contract!

--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -1,0 +1,763 @@
+---
+title: 2. Hello World
+---
+
+### Let's write and deploy our first smart contract!
+
+<Callout type="success">
+  Open the starter code for this tutorial in the Flow Playground: <br />
+  <a
+    href="https://play.onflow.org/83315e10-8a9d-40d1-9f4a-877ca93eb93c"
+    target="_blank"
+  >
+    https://play.onflow.org/83315e10-8a9d-40d1-9f4a-877ca93eb93c
+  </a>
+  <br />
+  The tutorial will be asking you to take various actions to interact with this code.
+</Callout>
+<Callout type="info">
+  Instructions that require you to take action are always included in a callout
+  box like this one. These highlighted actions are all that you need to do to
+  get your code running, but reading the rest is necessary to understand the
+  language's design.
+</Callout>
+
+A smart contract is a program that verifies and executes the performance of a contract without the need for a trusted third party.
+Programs that run on blockchains are commonly referred to as smart contracts because they mediate important functionality (such as currency)
+without having to rely on a central authority (like a bank).
+
+Before you get started with Flow, you need to understand how accounts and transactions are modeled.
+
+## Accounts and Transactions
+
+---
+
+Like most other blockchains, the programming model in Flow is centered around accounts and transactions.
+All persistent state is stored in [accounts](/cadence/language/accounts).
+The interfaces to this state (the ways to interact with it) are also stored in accounts.
+All code execution takes place within transactions, which are blocks of code that are submitted by external users to interact with the persistent state,
+which includes directly modifying account storage.
+
+Each user has an account controlled by one or more private keys.
+This means that support for accounts/wallets with [multiple controllers](https://www.coindesk.com/what-is-a-multisignature-crypto-wallet) is built into the protocol by default.
+
+An account is divided into two main areas:
+
+1. The first area is the [contract area](/cadence/language/accounts).
+   This is the area that stores any number smart contracts that contain type definitions, fields,
+   and functions that relate to a common functionality.
+   This area also holds contract interfaces, which are basically program guidelines that other contracts can import and implement.
+   This area cannot be directly read from in a transaction, unless the transaction is just reading the code deployed to an account.
+   The owner of an account can directly add, remove, or update/overwrite contracts that are stored in it.
+
+2. The second area is the account filesystem. This area is where an account stores the objects
+   that they own and the capabilities for controlling how these objects are accessed.
+
+Objects are stored under [paths in the account filesystem](/cadence/language/accounts/#paths). Paths consist of a domain and an identifier.
+
+Paths start with the character `/`, followed by the domain, the path separator `/`, and finally the identifier. For example, the path `/storage/test` has the domain `storage` and the identifier `test`.
+
+There are only three valid domains which represent the three areas in the account filesystem: `storage`, `private`, and `public`.
+
+Identifiers are custom and can be any name you want them to be to indicate what is stored in that path.
+
+- The `storage` domain is where all objects (such as structs and resource objects representing tokens or NFTs) are stored. It is only directly accessible by the owner of the account.
+- The `private` domain is like a private API. You can optionally store [capabilities](/cadence/language/capability-based-access-control/) to any of your stored assets here.
+  Only the owner and anyone they give access to can use these interfaces to call functions that are defined in your private assets.
+  Users will commonly store private capabilities here that refer to other accounts private objects.
+- The `public` domain is kind of like your account's public API. The owner can link capabilities here that that anyone else in the network can access
+  to interact with the private assets that are stored in the account.
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/accounts-diagram.png" />
+
+A [Transaction](/cadence/language/transactions) in Flow is defined as an arbitrary-sized block of Cadence code that is signed by one or more accounts.
+Transactions have access to the `/storage/` and `/private/` domains of the accounts that signed the transaction and can read and write to those domains,
+as well as read and call functions in public contracts and the public domains in other users` accounts.
+
+## Creating a Smart Contract
+
+---
+
+We will start by writing a smart contract that contains a public function that returns `"Hello World!"`.
+
+<Callout type="info">
+
+First, you'll need to follow this link to open a playground session with the
+Hello World contracts, transactions, and scripts pre-loaded: {" "}
+
+  <a
+    href="https://play.onflow.org/83315e10-8a9d-40d1-9f4a-877ca93eb93c"
+    target="_blank"
+  >
+    https://play.onflow.org/83315e10-8a9d-40d1-9f4a-877ca93eb93c
+  </a>
+  
+</Callout>
+<Callout type="info">
+
+Open the Account `0x01` tab with the file called
+`HelloWorld.cdc`. <br />
+`HelloWorld.cdc` should contain this code:
+
+</Callout>
+
+```cadence:title=HelloWorld.cdc
+pub contract HelloWorld {
+
+    // Declare a public field of type String.
+    //
+    // All fields must be initialized in the init() function.
+    pub let greeting: String
+
+    // The init() function is required if the contract contains any fields.
+    init() {
+        self.greeting = "Hello, World!"
+    }
+
+    // Public function that returns our friendly greeting!
+    pub fun hello(): String {
+        return self.greeting
+    }
+}
+```
+
+A contract is a collection of code (its functions) and data (its state) that lives in the contract area of an account in Flow.
+Accounts can have one or more contracts and/or contract interfaces, and these can be freely added, removed, or updated (with some restrictions) by the owner of the account.
+
+The line `pub let greeting: String` declares a public (`pub`) state constant (`let`) called `greeting` of type `String`.
+We would have used `var` if we wanted to declare a variable.
+
+The `pub` keyword is an example of an access control specification meaning that it can be accessed in all scopes, but not written to in all scopes.
+You can also use `access(all)` interchangeably with `pub` if you prefer something more descriptive.
+Please refer to the [Access Control section of the language reference](/cadence/language/access-control/) to learn more about the different levels of access control permitted in Cadence.
+
+The `init()` section is called the initializer. It is a function that is only run when the contract is created and never again.
+In this example, the initializer sets the `greeting` field to `"Hello, World!"`.
+
+Next is a public function declaration that returns a value of type `String`.
+Anyone who imports this contract can read the public fields, use the public types, and call the public contract functions; i.e. the ones that have `pub` or `access(all)` specified.
+
+Now we can deploy this contract to your account and run a transaction that calls its function.
+
+## Deploying Code
+
+---
+
+Now that you have some Cadence code to work with, you can deploy it to your account.
+
+<Callout type="info">
+
+Make sure that the account `0x01` tab is selected and that the
+`HelloWorld.cdc` file is in the editor. <br />
+Click the deploy button to deploy the contents of the editor to account `0x01`.
+
+</Callout>
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-deploy.png" />
+
+You should see a log in the output area indicating that the deployment succeeded. (Don't worry if the transaction number or block is different.)
+
+    Deployed Contract To: 0x01
+
+You'll also see the name of the contract show up in the selected account tab underneath the number for the account.
+This indicates that the `HelloWorld` contract has been deployed to the account.
+You can always look at this tab to verify which contracts are in which accounts, but there can only be one contract per account.
+
+## Creating a Transaction
+
+---
+
+<Callout type="info">
+
+Open the transaction named `Say Hello` <br />
+`Say Hello` should contain this code:
+
+</Callout>
+
+```cadence:title=Say Hello.cdc
+import HelloWorld from 0x01
+
+transaction {
+
+    // No need to do anything in prepare because we are not working with
+    // account storage.
+    prepare(acct: AuthAccount) {}
+
+    // In execute, we simply call the hello function
+    // of the HelloWorld contract and log the returned String.
+    execute {
+        log(HelloWorld.hello())
+    }
+}
+```
+
+This is a Cadence **transaction**. A transaction can contain arbitrary code that imports from other accounts,
+interact with account storage, interact with other accounts, and more.
+
+To interact with a smart contract, the transaction first needs to import that smart contract
+by retrieving its definition from the address where it is stored. This imports the interface definitions, resource definitions,
+and public functions from that contract so that the transaction can use them to interact with the contract itself or with other accounts that utilize that contract.
+
+To import a smart contract from another account, you type the line:
+
+```cadence
+import {Contract Name} from {Address}
+```
+
+Transactions are divided into two main phases, `prepare` and `execute`.
+
+1. The `prepare` phase is the only place that has access to the signing accounts' private `AuthAccount` object.
+   `AuthAccount` has special methods that allow saving to and loading from `/storage/`, and creating `/private/` and `/public/` links to the objects in `/storage/`.
+   (called [capabilities](/cadence/language/capability-based-access-control), will be covered later)
+2. The `execute` phase does not have access to `AuthAccount` and thus can only modify the objects that were removed in the `prepare` phase and call functions on external contracts and objects.
+
+By not allowing the execute phase to access account storage, we can statically verify which assets and areas of the signers storage a given transaction can modify.
+Browser wallets and applications that submit transactions for users can use this to show what a transaction could alter,
+and users can have more confidence that they aren't getting fed a malicious or dangerous transaction via an application-generated transaction.
+
+You can have multiple signers of a transaction by clicking multiple account avatars in the playground,
+but the number of parameters of the prepare block of the transaction NEEDS to be the same as the number of signers. If not, this will cause an error.
+
+In this transaction, we are importing the contract from the address that it was deployed to and calling its `hello` function.
+
+<Callout type="info">
+
+In the box at the top right of the editor, select Account `0x01` as the
+transaction signer. <br />
+Click the `Send` button to submit the transaction
+
+</Callout>
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-signers.png" />
+
+You should see something like this:
+
+```
+"Hello, World!"
+```
+
+Congratulations, you just executed your first Cadence transaction! :100:
+
+## Creating a Resource
+
+---
+
+Next, we are going to get some practice with an example that uses **[resources](/cadence/language/composite-types/#resources)**,
+one of the defining features in Cadence. A resource is a composite type like a struct or a class, but with some special rules.
+
+<Callout type="info">
+
+Open the Account `0x02` tab with file named `HelloWorldResource.cdc`. <br />
+`HelloWorldResource.cdc` should contain the following code:
+
+</Callout>
+
+```cadence:title=HelloWorldResource.cdc
+pub contract HelloWorld {
+
+  // Declare a resource that only includes one function.
+  pub resource HelloAsset {
+    // A transaction can call this function to get the "Hello, World!"
+    // message from the resource.
+    pub fun hello(): String {
+      return "Hello, World!"
+    }
+  }
+
+  init() {
+    // Use the create built-in function to create a new instance
+    // of the HelloAsset resource
+    let newHello <- create HelloAsset()
+
+    // We can do anything in the init function, including accessing
+    // the storage of the account that this contract is deployed to.
+    //
+    // Here we are storing the newly created HelloAsset resource
+    // in the private account storage
+    // by specifying a custom path to the resource
+    self.account.save(<-newHello, to: /storage/Hello)
+
+    log("HelloAsset created and stored")
+  }
+}
+```
+
+<Callout type="info">
+
+Deploy this code to account `0x02` using the `Deploy` button.
+
+</Callout>
+
+This is another example of what we can do with a contract. Cadence can declare type definitions within deployed contracts.
+Any account can import these definitions and use them to interact with objects of those types.
+This contract declares a definition for the `HelloAsset` resource.
+
+Let's walk through this contract:
+
+```cadence
+pub resource HelloAsset {
+    pub fun hello(): String {
+        return "Hello, World!"
+    }
+}
+```
+
+Resources are a composite type similar to a struct or a class because they can have any number of fields or functions within them.
+The difference is how code is allowed to interact with them. They are useful when you want to model direct ownership.
+Each instance of a resource exists in exactly one location and cannot be copied.
+They must be explicitly moved when accessed, making it difficult to lose accidentally.
+
+Structs from other conventional programming languages are not an ideal way to represent this ownership because they can be copied.
+This means a coding error can easily result in creating multiple copies of the same asset,
+which breaks the scarcity requirements needed for these assets to have real value.
+We have to consider loss and theft at the scale of a house, a car, or a bank account with millions of dollars, or a horse.
+Resources, in turn, solve this problem by making creation, destruction, and movement of assets explicit.
+
+```cadence
+init() {
+// ...
+```
+
+This example also declares an `init()` function. All composite types like contracts, resources, and structs can have an optional `init()` function
+that only runs when the object is initially created. Cadence requires that all fields must be explicitly initialized,
+so if the object has fields, this function has to be used to initialize them.
+
+Contracts also have read and write access to the storage of the account that they are deployed to
+by using the built-in [`self.account`](/cadence/language/contracts) object.
+This is an `AuthAccount` object that gives them access to many different functions to interact with the private storage of the account.
+
+In this contract's `init` function, the contract uses the `create` keyword to create an instance of the `HelloAsset` type and saves it to a local variable.
+To create a new resource object, we use the `create` keyword followed by an invocation of the name of the resource with any `init()` arguments.
+A resource can only be created in the scope that it is defined in.
+This prevents anyone from being able to create arbitrary amounts of resource objects that others have defined.
+
+```cadence
+let newHello <- create HelloAsset()
+```
+
+Here we use the `<-` symbol. This is the move operator. The move operator `<-` replaces the assignment operator `=` in assignments that involve resources.
+To make assignment of resources explicit, the move operator `<-` must be used when:
+
+- the resource is the initial value of a constant or variable,
+- the resource is moved to a different variable in an assignment,
+- the resource is moved to a function as an argument
+- the resource is returned from a function.
+
+When a resource is moved, the old location is invalidated, and the object moves into the context of the new location.
+Regular assignments of resources are not allowed because assignments only copy the value.
+Resources can only exist in one location at a time, so movement must be explicitly shown in the code.
+
+Then it uses the `AuthAccount.save` function to store it in the account storage.
+
+```cadence
+self.account.save(<-newHello, to: /storage/Hello)
+```
+
+A contract can refer to its member functions and fields with the keyword `self`.
+All contracts have access to the storage of the account where they are deployed and can access that `AuthAccount` object with `self.account`.
+
+`AuthAccount` objects have many different methods that are used to interact with account storage.
+You can see the documentation for all of these in the Storage section of the language reference or in the [glossary](/intro/glossary/#account).
+The `save` method saves an object to account storage. The type parameter for the object type is contained in `<>` to indicate what type the stored object is.
+It can also be inferred from the argument's type.
+
+The first parameter is the object that is being stored, and the `to` parameter is the path that the object is being stored at.
+The path must be a storage path, i.e., only the domain storage is allowed as the `to` parameter.
+
+If there is already an object stored under the given path, the program aborts.
+Remember, the Cadence type system ensures that a resource can never be accidentally lost.
+When moving a resource to a field, into an array, into a dictionary, or into storage, there is the possibility that the location already contains a resource.
+Cadence forces the developer to handle the case of an existing resource so that it is not accidentally lost through an overwrite.
+This is also why we can't let the execution reach the end of the block without doing anything with `newHello`,
+and why `save` would fail if there is already a resource at the specified path.
+
+In this case, this is the first transaction we have run with the selected account, so we know that the storage spot at `/storage/Hello is empty.
+In real applications, we would likely perform necessary checks and actions with the location we are storing to
+to make sure we don't abort the transaction because of an accidental overwrite.
+
+Now that you have stored a resource in an account, you should see that resource show up in the `Resources` box below the editor.
+This box indicates which resources are stored in the selected account, and the values of the fields inside those resources.
+Right now, you should see that the `HelloAsset` resource is stored in account `0x02`'s storage and it has no fields.
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-resources.png" />
+
+## Interacting with a Resource
+
+---
+
+<Callout type="info">
+
+Open the transaction named `Load Hello`.
+
+<br />
+
+`Load Hello` should contain the following code:
+
+</Callout>
+
+```cadence:title=Load Hello.cdc
+import HelloWorld from 0x02
+
+// This transaction calls the "hello" method on the HelloAsset object
+// that is stored in the account's storage by removing that object
+// from storage, calling the method, and then putting it back in storage
+
+transaction {
+
+    prepare(acct: AuthAccount) {
+
+        // load the resource from storage, specifying the type to load it as
+        // and the path where it is stored
+        let helloResource <- acct.load<@HelloWorld.HelloAsset>(from: /storage/Hello)
+
+        // We use optional chaining (?) because the value in storage
+        // may or may not exist, and thus is considered optional.
+        log(helloResource?.hello())
+
+        // Put the resource back in storage at the same spot
+        // We use the force-unwrap operator `!` to get the value
+        // out of the optional. It aborts if the optional is nil
+        acct.save(<-helloResource!, to: /storage/Hello)
+    }
+}
+```
+
+This transaction imports the `HelloWorld` definitions from the account we just deployed them to, removes the `HelloAsset` object from storage,
+and calls the `hello()` function of the stored `HelloAsset` resource.
+
+To remove an object from storage, we use the `load` method.
+
+```cadence
+let helloResource <- acct.load<@HelloWorld.HelloAsset>(from: /storage/Hello)
+```
+
+If no object is stored under the given path, the function returns nil. When the function returns, the storage no longer contains an object under the given path.
+
+The type parameter for the object type to load is contained in `<>`.
+A type argument for the parameter must be provided explicitly, which is `@HelloWorld.HelloAsset` here. (Note the `@` symbol to specify that it is a resource)
+
+The path `from` must be a storage path, i.e., only the domain `/storage/` is allowed.
+
+Next, we call the `hello` function and log the output.
+
+```cadence
+log(helloResource?.hello())
+```
+
+We use `?` because the values in the storage are returned as [optionals](/cadence/language/values-and-types/#optionals).
+Optionals are values that can represent the absence of a value.
+Optionals have two cases: either there is a value of the specified type, or there is nothing (`nil`).
+An optional type is declared using the `?` suffix.
+
+```cadence
+let newResource: HelloAsset?  // could either have a value of type `HelloAsset`
+                              // or it could have a value of `nil`
+```
+
+Optionals allow developers to account for `nil` cases more gracefully.
+Here, we explicitly have to account for the possibility that the `helloResource` object we got with `load` is `nil`.
+Using `?` "unwraps" the optional before calling `hello`, but only if the value isn't `nil`. If the value is nil, `?` returns `nil`.
+
+Because `?` is used when calling the `hello` function, the function call only happens if the stored value is not `nil`.
+In this case, the result of the `hello` function will be returned as an optional.
+However, if the stored value was `nil`, the function call would not occur and the result is `nil`.
+
+Next, we use `save` again to put the object back in storage in the same spot:
+
+```cadence
+acct.save(<-helloResource!, to: /storage/Hello)
+```
+
+Remember, `helloResource` is still an optional, so we have to handle the possibility that it is `nil`.
+Here, we use the force-unwrap operator (`!`). This operator gets the value in the optional if it contains a value,
+and aborts the entire transaction if the object is `nil`.
+It is a more risky way of dealing with optionals, but if your program is ever in a state where a value being `nil`
+would defeat the purpose of the whole transaction, then the force-unwrap operator is a good choice to deal with that.
+
+Refer to [Optionals In Cadence](/cadence/language/values-and-types/#optionals) to learn more about optionals and how they are used.
+
+<Callout type="info">
+
+Select account `0x02` as the only signer. Click the `Send` button to submit
+the transaction.
+
+</Callout>
+
+You should see something like this:
+
+```
+"Hello, World!"
+```
+
+## Creating Capabilities and References to Stored Resources
+
+---
+
+In this example, we create a link and reference to your `HelloAsset` resource object, then use that reference to call the `hello` function.
+A detailed explanation of what is happening in this transaction is below the transaction code so, if you feel lost, keep reading!
+
+<Callout type="info">
+
+Open the transaction named `Create Link`.
+
+<br />
+
+`Create Link` should contain the following code:
+
+</Callout>
+
+```cadence:title=Create Link
+import HelloWorld from 0x02
+
+// This transaction creates a new capability
+// for the HelloAsset resource in storage
+// and adds it to the account's public area.
+//
+// Other accounts and scripts can use this capability
+// to create a reference to the private object to be able to
+// access its fields and call its methods.
+
+transaction {
+  prepare(account: AuthAccount) {
+
+    // Create a public capability by linking the capability to
+    // a `target` object in account storage.
+    // The capability allows access to the object through an
+    // interface defined by the owner.
+    // This does not check if the link is valid or if the target exists.
+    // It just creates the capability.
+    // The capability is created and stored at /public/Hello, and is
+    // also returned from the function.
+    let capability = account.link<&HelloWorld.HelloAsset>(/public/Hello, target: /storage/Hello)
+
+    // Use the capability's borrow method to create a new reference
+    // to the object that the capability links to
+    // We use optional chaining "??" to get the value because
+    // result of the borrow could fail, so it is an optional.
+    // If the optional is nil,
+    // the panic will happen with a descriptive error message
+    let helloReference = capability!.borrow()
+      ?? panic("Could not borrow a reference to the hello capability")
+
+    // Call the hello function using the reference
+    // to the HelloAsset resource.
+    //
+    log(helloReference.hello())
+  }
+}
+```
+
+<Callout type="info">
+
+Ensure account `0x02` is still selected as a transaction signer. <br />
+Click the `Send` button to send the transaction.
+
+</Callout>
+
+You should see `"Hello, World"` show up in the console again. This is because we created a **capability** for the `HelloAsset` object,
+stored the capability in `/public/Hello`, borrowed a reference from the capability,
+and used our reference to call the `hello` method of the object.
+
+Capabilities are kind of like pointers in other languages. The `/storage/` domain of account storage is private,
+but users will still want to allow other users to access the functionality of their private objects without having the ability to remove them.
+
+In our example, the owner of `HelloAsset` might still want to let other people call the `hello` method.
+This is what capabilities are for. They represent a link to an object in an account's storage that has the type specified when the link is created.
+
+Capabilities do not have any meaningful functionality on their own, but every capability has a `borrow` method,
+which creates a reference to the object that the capability is linked to.
+This reference is used to read fields or call methods on the object they reference as if the owner of the reference had the actual object.
+
+Note that this only allows access to field and methods. It does not allow coping, moving, or modifying the original object directly.
+
+Let's break down what is happening in this transaction.
+
+First, we create a capability that is linked to the private `HelloAsset` object in `/storage/`:
+
+```cadence
+let capability = account.link<&HelloWorld.HelloAsset>(/public/Hello, target: /storage/Hello)
+```
+
+The `HelloAsset` object is stored in `/storage/Hello`, which only the account owner can access.
+They want any user in the network to be able to call the `hello` method. So they make a public capability in `/public/Hello`.
+
+To create a capability, we use the `AuthAccount.link` method to link a new capability to an object in storage.
+The type contained in `<>` is the restricted reference type that the capability represents.
+The capability says that whoever borrows a reference from this capability can only have access to the fields and methods
+that are specified by the type in `<>`.
+
+A reference is referred to by the `&` symbol. Here, the capability references the `HelloAsset` object,
+so we specify `<&HelloWorld.HelloAsset>` as the type, which give access to everything in the `HelloAsset` object.
+
+The first argument to the `link` function is the path where you want to store the capability
+and the `target` argument is the path to the object in storage that is to be linked to.
+
+To borrow a reference to an object from the capability, we use the capability's `borrow` method.
+
+```cadence
+let helloReference = capability!.borrow()
+    ?? panic("Could not borrow a reference to the hello capability")
+```
+
+This method creates the reference as the type we specified in `<>` in the `link` function.
+Here we use the force-unwrap operator (`!`) because the capability is an optional. If the capability is `nil` the transaction will abort.
+While borrowing the reference, we use optional chaining because the borrowing of the reference could fail.
+The reference could be `nil` if the targeted storage slot is empty, is already borrowed, or if the requested type exceeds what is allowed by the capability.
+We panic with a descriptive error message so the caller can know better what went wrong.
+
+The reason we separate this process into capabilities and references is to protect against re-entrancy bugs
+where a malicious actor could call into an object multiple times.
+These bugs have plagued other smart contract languages. Only one reference to an object can exist at a time,
+so this type of vulnerability isn't possible for objects in storage.
+
+Additionally, the owner of an object can effectively revoke capabilities they have created by moving the underlying object or destroying the link with the `unlink` method.
+If the referenced object is moved or the link is destroyed, capabilities have been created from that link are invalidated.
+
+You can find more [detailed documentation about capabilities in the language reference.](/cadence/language/capability-based-access-control)
+
+Now, anyone can call the `hello()` method on your `HelloAsset` object by borrowing a reference with your public capability in `/public/Hello`!
+
+Lastly, we call the `hello()` method with our borrowed reference:
+
+```cadence
+// Call the hello function using the reference to the HelloAsset resource
+log(helloReference.hello())
+```
+
+## Executing Scripts
+
+---
+
+A script is a very simple transaction type in Cadence that cannot perform any writes to the blockchain
+and can only read the state of an account. It runs without permissions from any account.
+
+To execute a script, you write a function called `pub fun main()`. You can click the execute script button to run the script.
+The result of the script will be printed to the console output.
+
+<Callout type="info">
+
+Open the file `Script1.cdc`.
+
+<br />
+
+`Script1.cdc` should look like the following:
+
+</Callout>
+
+```cadence:title=Script1.cdc
+import HelloWorld from 0x02
+
+pub fun main() {
+
+    // Cadence code can get an account's public account object
+    // by using the getAccount() built-in function.
+    let helloAccount = getAccount(0x02)
+
+    // Get the public capability from the public path of the owner's account
+    let helloCapability = helloAccount.getCapability<&HelloWorld.HelloAsset>(/public/Hello)
+
+    // borrow a reference for the capability
+    let helloReference = helloCapability.borrow()
+        ?? panic("Could not borrow a reference to the hello capability")
+
+    // The log built-in function logs its argument to stdout.
+    //
+    // Here we are using optional chaining to call the "hello"
+    // method on the HelloAsset resource that is referenced
+    // in the published area of the account.
+    log(helloReference.hello())
+}
+```
+
+This script fetches the `PublicAccount` object with `getAccount`.
+
+```cadence
+let helloAccount = getAccount(0x02)
+```
+
+The `PublicAccount` object is available to anyone in the network for every account,
+but only has access to a small subset of functions that can only read from the `/public/` domain in an account.
+See more about accounts here: https://docs.onflow.org/cadence/language/accounts/
+
+Then, it gets the capability that was created in `Create Link`.
+
+```cadence
+// Get the public capability from the public path of the owner's account
+let helloCapability = helloAccount.getCapability(/public/Hello)
+```
+
+To get a capability that is stored in an account, we use the `account.getCapability` function.
+This function is available on `AuthAccount`s and on `PublicAccount`s. It returns a capability at the path that is specified,
+also with the type that is specified. It does not check if the target exists,
+but the borrow will fail if the capability is invalid.
+
+After that, the script borrows a reference from the capability.
+
+```cadence
+let helloReference = helloCapability.borrow()
+```
+
+Then, the script uses the reference to call the `hello` function and prints the result.
+
+Lets execute the script to see it run correctly.
+
+<Callout type="info">
+
+Click the `Execute` button in the playground.
+
+</Callout>
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-execute.png" />
+
+You should see something like this print:
+
+```
+> "Hello, World"
+> Result > "void"
+
+```
+
+Good work! You've deployed your first Cadence smart contracts and used transactions and scripts to interact with them!
+
+Here are a few pointers on certain aspects of the Playground if you still need some clarification.
+
+## Accounts
+
+---
+
+The playground is initialized with a configurable number of default accounts when you open it.
+
+In the playground, you can select accounts to edit the contracts that are deployed for them
+by selecting the tab for that account in the left section of the screen.
+The contract corresponding to that account will be displayed in the editor where you can edit and deploy it to the blockchain.
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-accounts.png" />
+
+Upgrading contrats that are already deployed is very risky, so be careful!
+
+## Transactions
+
+Once a contract has been deployed, you can submit transactions to interact with it.
+In the transactions selection section on the left side of the screen, you can select different transactions to edit and send.
+While a transaction is open, you can select one or more accounts to sign a transaction.
+This is because in Flow, multiple accounts can sign the same transaction, giving the access to their private storage.
+If multiple accounts are selected as signers, this needs to be reflected in the signature of the transaction to show multiple signers:
+
+```cadence
+// One signer
+
+transaction {
+    prepare(acct1: AuthAccount) {}
+}
+
+// Two signers
+
+transaction {
+    prepare(acct1: AuthAccount, acct2: AuthAccount) {}
+}
+```
+
+If you want more practice, you can run some of the previous transactions on new accounts to explore some different interactions and potential error messages.
+
+## Fungible Tokens on Flow
+
+---
+
+Now that you have written and launched your first smart contract on Flow, you're ready for something more complex!

--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -1,6 +1,6 @@
 ---
 title: 2. Hello World
-type: TUT
+contentType: TUT
 ---
 
 ### Let's write and deploy our first smart contract!

--- a/docs/tutorial/03-fungible-tokens.mdx
+++ b/docs/tutorial/03-fungible-tokens.mdx
@@ -1,0 +1,976 @@
+---
+title: 3. Fungible Tokens
+---
+
+In this tutorial, we're going to deploy, store, and transfer fungible tokens.
+
+---
+
+<Callout type="success">
+  Open the starter code for this tutorial in the Flow Playground:
+  <br />
+  <a
+    href="https://play.onflow.org/7c60f681-40c7-4a18-82de-b81b3b6c7915"
+    target="_blank"
+  >
+    https://play.onflow.org/7c60f681-40c7-4a18-82de-b81b3b6c7915
+  </a>
+  <br />
+  The tutorial will ask you to take various actions to interact with this code.
+</Callout>
+<Callout type="info">
+  Instructions that require you to take action are always included in a callout
+  box like this one. These highlighted actions are all that you need to do to
+  get your code running, but reading the rest is necessary to understand the
+  language's design.
+</Callout>
+
+Some of the most popular contract classes on blockchains today are fungible tokens.
+These contracts create homogeneous tokens that can be transferred to other users and spent as currency (e.g., ERC-20 on Ethereum).
+
+Usually, a central ledger keeps track of a user's token balances. With Cadence, we use a new resource paradigm to implement fungible tokens and avoid using a central ledger.
+
+### Flow Network Token
+
+In Flow, the native network token will be implemented as a normal fungible token smart contract using a smart contract similar to the one in this tutorial.
+There will be special contracts and hooks that allow it be used for transaction execution payments and staking,
+but besides that, developers and users will be able to treat it and use it just like any other token in the network!
+
+We're going to take you through these steps to get comfortable with the fungible token:
+
+1. Deploy the fungible token contract to account `0x01`
+2. Create a fungible token object and store it in your account storage.
+3. Create a reference to your tokens that others can use to send you tokens.
+4. Set up another account the same way.
+5. Transfer tokens from one account to another.
+6. Use a script to read the accounts' balances.
+
+**Before proceeding with this tutorial**, we recommend following the instructions in [Getting Started](/cadence/tutorial/01-first-steps/)
+and [Hello, World!](/cadence/tutorial/02-hello-world/) to learn the basics of the language and the playground.
+
+<!-- For additional support, see the [Playground Manual](doc:playground-manual) -->
+
+## Fungible Tokens on the Flow Emulator
+
+---
+
+<Callout type="info">
+  First, you'll need to follow this link to open a playground session with the
+  Fungible Token contracts, transactions, and scripts pre-loaded:{" "}
+  <a
+    href="https://play.onflow.org/7c60f681-40c7-4a18-82de-b81b3b6c7915"
+    target="_blank"
+  >
+    https://play.onflow.org/7c60f681-40c7-4a18-82de-b81b3b6c7915
+  </a>
+</Callout>
+<Callout type="info">
+
+Open the account `0x01` tab to see the file named
+`ExampleToken.cdc`. `ExampleToken.cdc` should contain the full code for the
+fungible token, which provides the core functionality to store fungible tokens
+in your account and transfer to and accept tokens from other users.
+
+</Callout>
+
+The concepts involved in implementing a fungible token in Cadence can be hard to grasp at first. For an in-depth explanation of this functionality and code, continue reading the next section.
+
+Or, if you'd like to go immediately into deploying it and using it in the playground, you can skip to the [Interacting with the Fungible Token](#interacting-with-the-fungible-token-in-the-flow-playground) section of this tutorial.
+
+## Fungible Tokens: An In-Depth Exploration
+
+---
+
+How Flow implements fungible tokens is different from other programming languages. As a result:
+
+- Ownership is decentralized and does not rely on a central ledger
+- Bugs and exploits present less risk for users and less opportunity for attackers
+- There is no risk of integer underflow or overflow
+- Assets cannot be duplicated, and it is very hard for them to be lost, stolen, or destroyed
+- Code can be composable
+- Rules can be immutable
+- Code is not unintentionally made public
+
+## Decentralizing Ownership
+
+---
+
+Instead of using a central ledger system, Flow ties ownership to each account via a new paradigm for asset ownership.
+The example below showcases how Solidity implements fungible tokens, with only the code for storage and transferring tokens shown for brevity.
+
+```solidity:title=ERC20.sol
+contract ERC20 {
+    mapping (address => uint256) private _balances;
+
+    function _transfer(address sender, address recipient, uint256 amount) {
+        // ensure the sender has a valid balance
+        require(_balances[sender] >= amount);
+
+        // subtract the amount from the senders ledger balance
+        _balances[sender] = _balances[sender] - amount;
+
+        // add the amount to the recipient’s ledger balance
+        _balances[recipient] = _balances[recipient] + amount
+    }
+}
+```
+
+As you can see, Solidity uses a central ledger system for its fungible tokens. There is one contract that manages the state of the tokens
+and every time that a user wants to do anything with their tokens, they have to interact with the central ERC20 contract,
+calling its functions to update their balance. This contract handles access control for all functionality, implements all of its own correctness checks,
+and enforces rules for all of its users.
+
+Instead of using a central ledger system, Flow utilizes a few different concepts to provide better safety, security, and clarity for smart contract developers and users.
+In this section, we'll show how Flow's resources, interfaces, and other features are employed via a fungible token example.
+
+## Intuiting Ownership with Resources
+
+---
+
+An important concept in Cadence is **Resources**, which are linear types.
+A resource is a composite type that has its own defined fields and functions, similar to a struct.
+The difference is that resource objects have special rules that keep them from being copied or lost.
+Resources are a new paradigm for asset ownership. Instead of representing token ownership in a central ledger smart contract,
+each account owns a resource object in their account storage that records the number of tokens they own.
+This way, when users want to transact with each other, they can do so peer-to-peer without having to interact with a central token contract.
+To transfer tokens to each other, they call a `transfer` function (or something equivalent) on their own resource object and other users' resources, instead of a central `transfer` function.
+
+This approach simplifies access control because instead of a central contract having to check the sender of a function call,
+most function calls happen on resource objects stored in users' account, and each user controls who is able to call the functions on resources in their account.
+This concept, called Capability-based security, will be explained more in a later section.
+
+This approach also helps protect against potential bugs. In a Solidity contract with all the logic contained in a central contract,
+an exploit is likely to affect all users who are involved in the contract.
+In Cadence, if there is a bug in the resource logic, an attacker would have to exploit the bug in each token holder's account individually,
+which is much more complicated and time-consuming than it is in a central ledger system.
+
+Below is an example of a resource for a fungible token vault. Every user who owns these tokens would have this resource stored in their account.
+It is important to remember that each account stores only a copy of the `Vault` resource, and not a copy of the entire `ExampleToken` contract.
+The `ExampleToken` contract only needs to be stored in the initial account that manages the token definitions.
+
+```cadence:title=Token.cdc
+pub resource Vault: Provider, Receiver {
+
+    // Balance of a user's Vault
+    // we use unsigned integers for balances because they do not require the
+    // concept of a negative number
+    pub var balance: UFix64
+
+    init(balance: UFix64) {
+        self.balance = balance
+    }
+
+    pub fun withdraw(amount: UFix64): @Vault {
+        self.balance = self.balance - amount
+        return <-create Vault(balance: amount)
+    }
+
+    pub fun deposit(from: @Vault) {
+        self.balance = self.balance + from.balance
+        destroy from
+    }
+}
+```
+
+This piece of code is for educational purposes and is not comprehensive. However, it still showcases how a resource for a token works.
+Each token resource object has a balance and associated functions (e.g., `deposit`, `withdraw`, etc).
+When a user wants to use these tokens, they instantiate a zero-balance copy of this resource in their account storage.
+The language requires that the initialization function `init`, which is only run once, must initialize all member variables.
+
+```cadence
+// Balance of a user's Vault
+// we use unsigned fixed-point integers for balances because they do not require the
+// concept of a negative number and allow for more clear precision
+pub var balance: UFix64
+
+init(balance: UFix64) {
+    self.balance = balance
+}
+```
+
+Then, the deposit function can be available for any account to transfer tokens to.
+
+```cadence
+pub fun deposit(from: @Vault) {
+    self.balance = self.balance + from.balance
+    destroy from
+}
+```
+
+When an account wants to send tokens to a different account, the sending account calls their own withdraw function first,
+which subtracts tokens from their resource’s balance and temporarily creates a new resource object that holds this balance.
+The sending account then calls the recipient account’s deposit function, which literally moves the resource instance to the other account,
+adds it to their balance, and then destroys the used resource. The resource needs to be destroyed because Cadence enforces strict rules around resource interactions.
+A resource can never be left hanging in a piece of code. It either needs to be explicitly destroyed or stored in an account's storage.
+
+When interacting with resources, you use the `@` symbol and a special “move operator” `<-`.
+
+```cadence
+pub fun withdraw(amount: UInt64): @Vault {
+```
+
+This `@` symbol is required when specifying a resource type for a field, an argument, or a return value.
+The move operator `<-` makes it clear that when a resource is used in an assignment, parameter, or return value,
+it is moved to a new location and the old location is invalidated. This ensures that the resource only ever exists in one location at a time.
+
+If a resource is moved out of an account's storage, it either needs to be moved to an account’s storage or explicitly destroyed.
+
+```cadence
+destroy from
+```
+
+This rule ensures that resources, which often represent real value, do not get lost because of a coding error.
+
+You’ll notice that the arithmetic operations aren't explicitly protected against overflow or underflow.
+
+```cadence
+self.balance = self.balance - amount
+```
+
+In Solidity, this could be a risk for integer overflow or underflow, but Cadence has built-in overflow and underflow protection, so it is not a risk.
+We are also using unsigned integers in this example, so the vault`s balance cannot go below 0.
+
+Additionally, the requirement that an account contains a copy of the token’s resource type in its storage
+ensures that funds cannot be lost by being sent to the wrong address.
+If an address doesn’t have the correct resource type imported, the transaction will revert, ensuring that transactions sent to the wrong address are not lost.
+
+The line in `withdraw` that creates a new `Vault` has the parameter name `balance` specified in the function call.
+
+```cadence
+return <-create Vault(balance: amount)
+```
+
+This is another feature that Cadence has to improve the clarity of code.
+All function calls are required to specify the names of the arguments they are sending
+unless the developer has specifically overridden the requirement in the funtion declaration.
+
+## Ensuring Security in Public: Capability Security
+
+---
+
+Another important feature in Cadence is its utilization of **Capability Security.**
+This feature ensures that, while the withdraw function is public, no one except the intended user and those they approve of can withdraw tokens from their vault.
+
+Cadence's security model ensures that objects stored in an account's storage can only be accessed by the account that owns them.
+If a user wants to give another user access to their stored objects, they can link a public capability,
+which is like an "API" that allows others to call specified functions on their objects.
+
+An account only has access to the fields and methods of an object in a different account if they own a capability to that object
+that explicitly allows them to access those fields and methods. Only the owner of an object can create a reference for it.
+Therefore, when a user creates a Vault in their account, they only publish references to the deposit function and the balance.
+The withdraw function can remain hidden as a function that only the owner can call.
+
+As you can hopefully see, this removes the need to check `msg.sender` for access control purposes,
+because this functionality is handled by the protocol and type checker.
+If you aren't the owner of an object or don't have a valid reference to it that was created by the owner, you cannot access the object at all!
+
+## Using Interfaces to Secure Implementations
+
+---
+
+The next important concept in Cadence is design-by-contract,
+which uses preconditions and postconditions to document and programmatically assert the change in state caused by a piece of a program.
+These conditions are specified in interfaces that enforce rules about how types are defined and behave.
+They can be stored on-chain in an immutable fashion so that certain pieces of code can import and implement them to ensure that they meet certain standards.
+
+Here is an example of how interfaces for the `Vault` resource we defined above would look.
+
+```cadence:title=Interfaces.cdc
+// Interface that enforces the requirements for withdrawing
+// tokens from the implementing type
+//
+pub resource interface Provider {
+    pub fun withdraw(amount: UFix64): @Vault {
+        post {
+            result.balance == amount:
+                "Withdrawal amount must be the same as the balance of the withdrawn Vault"
+        }
+    }
+}
+// Interface that enforces the requirements for depositing
+// tokens into the implementing type
+//
+pub resource interface Receiver {
+
+    // There aren't any meaningful requirements for only a deposit function
+    // but this still shows that the deposit function is required in an implementation.
+    pub fun deposit(from: @Vault)
+}
+```
+
+In our example, the `Vault` resource would implement both of these interfaces.
+The interfaces ensure that specific fields and functions are present in the resource implementation
+and that those functions meet certain conditions before and/or after execution.
+These interfaces can be stored on-chain and imported into other contracts or resources
+so that these requirements are enforced by an immutable source of truth that is not susceptible to human error.
+
+You can also see that functions and fields have the `pub` keyword next to them.
+We have explicitly defined these fields as public because all fields and functions in Cadence are private by default,
+meaning that the local scope can only access them. Users have to make parts of their owned types explicitly public.
+This helps prevent types from having unintentionally public code.
+
+## Interacting with the Fungible Token in the Flow Playground
+
+Now that you have read about how the Fungible Token works, we can deploy it to your account and send some transactions to interact with it.
+
+<Callout type="info">
+
+Make sure that you have opened the Fungible Token templates in the playground
+by following the link at the top of this page. You should have Account `0x01`
+open and should see the code below.
+
+</Callout>
+
+```cadence:title=ExampleToken.cdc
+pub contract ExampleToken {
+
+    // Total supply of all tokens in existence.
+    pub var totalSupply: UFix64
+
+    // Provider
+    //
+    // Interface that enforces the requirements for withdrawing
+    // tokens from the implementing type.
+    //
+    // We don't enforce requirements on self.balance here because
+    // it leaves open the possibility of creating custom providers
+    // that don't necessarily need their own balance.
+    //
+    pub resource interface Provider {
+
+        // withdraw
+        //
+        // Function that subtracts tokens from the owner's Vault
+        // and returns a Vault resource (@Vault) with the removed tokens.
+        //
+        // The function's access level is public, but this isn't a problem
+        // because even the public functions are not fully public at first.
+        // anyone in the network can call them, but only if the owner grants
+        // them access by publishing a resource that exposes the withdraw
+        // function.
+        //
+        pub fun withdraw(amount: UFix64): @Vault {
+            post {
+                // `result` refers to the return value of the function
+                result.balance == UFix64(amount):
+                    "Withdrawal amount must be the same as the balance of the withdrawn Vault"
+            }
+        }
+    }
+
+    // Receiver
+    //
+    // Interface that enforces the requirements for depositing
+    // tokens into the implementing type.
+    //
+    // We don't include a condition that checks the balance because
+    // we want to give users the ability to make custom Receivers that
+    // can do custom things with the tokens, like split them up and
+    // send them to different places.
+    //
+    pub resource interface Receiver {
+        // deposit
+        //
+        // Function that can be called to deposit tokens
+        // into the implementing resource type
+        //
+        pub fun deposit(from: @Vault)
+    }
+
+    // Balance
+    //
+    // Interface that specifies a public `balance` field for the vault
+    //
+    pub resource interface Balance {
+        pub var balance: UFix64
+    }
+
+    // Vault
+    //
+    // Each user stores an instance of only the Vault in their storage
+    // The functions in the Vault and governed by the pre and post conditions
+    // in the interfaces when they are called.
+    // The checks happen at runtime whenever a function is called.
+    //
+    // Resources can only be created in the context of the contract that they
+    // are defined in, so there is no way for a malicious user to create Vaults
+    // out of thin air. A special Minter resource needs to be defined to mint
+    // new tokens.
+    //
+    pub resource Vault: Provider, Receiver, Balance {
+
+        // keeps track of the total balance of the account's tokens
+        pub var balance: UFix64
+
+        // initialize the balance at resource creation time
+        init(balance: UFix64) {
+            self.balance = balance
+        }
+
+        // withdraw
+        //
+        // Function that takes an integer amount as an argument
+        // and withdraws that amount from the Vault.
+        //
+        // It creates a new temporary Vault that is used to hold
+        // the money that is being transferred. It returns the newly
+        // created Vault to the context that called so it can be deposited
+        // elsewhere.
+        //
+        pub fun withdraw(amount: UFix64): @Vault {
+            self.balance = self.balance - amount
+            return <-create Vault(balance: amount)
+        }
+
+        // deposit
+        //
+        // Function that takes a Vault object as an argument and adds
+        // its balance to the balance of the owners Vault.
+        //
+        // It is allowed to destroy the sent Vault because the Vault
+        // was a temporary holder of the tokens. The Vault's balance has
+        // been consumed and therefore can be destroyed.
+        pub fun deposit(from: @Vault) {
+            self.balance = self.balance + from.balance
+            destroy from
+        }
+    }
+
+    // createEmptyVault
+    //
+    // Function that creates a new Vault with a balance of zero
+    // and returns it to the calling context. A user must call this function
+    // and store the returned Vault in their storage in order to allow their
+    // account to be able to receive deposits of this token type.
+    //
+    pub fun createEmptyVault(): @Vault {
+        return <-create Vault(balance: UFix64(0))
+    }
+
+    // VaultMinter
+    //
+    // Resource object that an admin can control to mint new tokens
+    pub resource VaultMinter {
+
+        // Function that mints new tokens and deposits into an account's vault
+        // using their `Receiver` reference.
+        // We say `&AnyResource{Receiver}` to say that the recipient can be any resource
+        // as long as it implements the Receiver interface
+        pub fun mintTokens(amount: UFix64, recipient: &AnyResource{Receiver}) {
+                  ExampleToken.totalSupply = ExampleToken.totalSupply + UFix64(amount)
+            recipient.deposit(from: <-create Vault(balance: amount))
+        }
+    }
+
+    // The init function for the contract. All fields in the contract must
+    // be initialized at deployment. This is just an example of what
+    // an implementation could do in the init function. The numbers are arbitrary.
+    init() {
+        self.totalSupply = UFix64(30)
+
+        // create the Vault with the initial balance and put it in storage
+        // account.save saves an object to the specified `to` path
+        // The path is a literal path that consists of a domain and identifier
+        // The domain must be `storage`, `private`, or `public`
+        // the identifier can be any name
+        self.account.save(<-create Vault(balance: UFix64(30)), to: /storage/MainVault)
+
+        // Create a new VaultMinter resource and store it in account storage
+        self.account.save(<-create VaultMinter(), to: /storage/MainMinter)
+    }
+}
+
+```
+
+<Callout type="info">
+
+Click the `Deploy` button at the bottom right of the editor to deploy the code.
+
+</Callout>>
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-deploy" />
+
+This deployment stores the contract for the fungible token in your active account (account `0x01`) so that it can be imported into transactions.
+
+A contract's `init` function runs at contract creation, and never again afterwards.
+In our example, this function stores an instance of the `Vault` object with an initial balance of 30, and stores the `VaultMinter` object that you can use to mint new tokens.
+
+```cadence
+// create the Vault with the initial balance and put it in storage
+// account.save saves an object to the specified `to` path
+// The path is a literal path that consists of a domain and identifier
+// The domain must be `storage`, `private`, or `public`
+// the identifier can be any name
+self.account.save(<-create Vault(balance: UFix64(30)), to: /storage/MainVault)
+```
+
+This line saves the new `@Vault` object to storage.
+Account storage is indexed with paths, which consist of a domain and identifier. `/domain/identifier`. Only three domains are allowed for paths:
+
+- `storage`: The place where all objects are stored. Only accessible by the owner of the account.
+- `private`: Stores links, otherwise known as capabilities, to objects in storage. Only accessible by the owner of the account
+- `public`: Stores links to objects in storage: Accessible by anyone in the network.
+
+Contracts have access to the private `AuthAccount` object of the account it is deployed to, using `self.account`.
+This object has methods that can modify storage in many ways. See the [account](/cadence/language/accounts) documentation for a list of all the methods it can call.
+
+In this line, we call the `save` method to store an object in storage.
+The first argument is the value to store, and the second argument is the path where the value is being stored.
+For `save` the path has to be in the `/storage` domain.
+
+We also store the `VaultMinter` object to `/storage/` in the next line in the same way:
+
+```cadence
+self.account.save(<-create VaultMinter(), to: /storage/MainMinter)
+```
+
+You should also see that the `ExampleToken.Vault` and `ExampleToken.VaultMinter` resource objects are stored in the account storage.
+This will be shown in the Resources box at the bottom of the screen.
+
+You are now ready to run transactions that use the fungible tokens!
+
+## Create, Store, and Publish Capabilities and References to a Vault
+
+---
+
+Capabilities are like pointers in other languages. They are a link to an object in an account's storage
+and can be used to read fields or call functions on the object they reference. They cannot move or modify the object directly.
+
+There are many different situations in which you would create a capability to your fungible token vault.
+You might want a simple way to call methods on your `Vault` from anywhere in a transaction.
+You could also send a capavility that only exposes withdraw function in your `Vault` so that others can transfer tokens for you.
+You could also have one that only exposes the `Balance` interface, so that others can check how many tokens you own.
+There could also be a function that takes a capability to a `Vault` as an argument, borrows a reference to the capability,
+makes a single function call on the reference, then finishes and destroys the reference.
+
+We already use this pattern in the `Vault` resource in the `mintTokens` function, shown here:
+
+```cadence
+// Function that mints new tokens and deposits into an account's vault
+// using their `Receiver` capability.
+// We say `&AnyResource{Receiver}` to say that the recipient can be any resource
+// as long as it implements the Receiver interface
+pub fun mintTokens(amount: UFix64, recipient: Capability<&AnyResource{Receiver}>) {
+    let recipientRef = recipient.borrow()
+        ?? panic("Could not borrow a receiver reference to the vault")
+
+    ExampleToken.totalSupply = ExampleToken.totalSupply + UFix64(amount)
+    recipientRef.deposit(from: <-create Vault(balance: amount))
+}
+```
+
+The function takes a capability to any resource that implements the `Receiver` interface, borrows a reference from it,
+and uses the reference to call the `deposit` function of that resource.
+
+Let's create capabilities to your `Vault` so that a separate account can send tokens to you.
+
+<Callout type="info">
+
+Open the transaction named `Create Link`. <br/>
+`Create Link` should contain the following code for creating a reference to the stored Vault:
+
+</Callout>
+
+```cadence:title=Create Link.cdc
+import ExampleToken from 0x01
+
+// This transaction creates a capability
+// that is linked to the account's token vault.
+// The capability is restricted to the fields in the `Receiver` interface,
+// so it can only be used to deposit funds into the account.
+transaction {
+  prepare(acct: AuthAccount) {
+
+    // Create a link to the Vault in storage that is restricted to the
+    // fields and functions in `Receiver` and `Balance` interfaces,
+    // this only exposes the balance field
+    // and deposit function of the underlying vault.
+    //
+    acct.link<&ExampleToken.Vault{ExampleToken.Receiver, ExampleToken.Balance}>(/public/MainReceiver, target: /storage/MainVault)
+
+    log("Public Receiver reference created!")
+  }
+
+  post {
+    // Check that the capabilities were created correctly
+    // by getting the public capability and checking
+    // that it points to a valid `Vault` object
+    // that implements the `Receiver` interface
+    getAccount(0x01).getCapability<&ExampleToken.Vault{ExampleToken.Receiver}>(/public/MainReceiver)
+                    .check():
+                    "Vault Receiver Reference was not created correctly"
+    }
+}
+```
+
+In order to use a capability, we have to first create a link to that object in storage.
+A reference can then be created from a capability, and references cannot be stored.
+They need to be lost at the end of a transaction execution.
+This restriction is to prevent reentrancy attacks which are attacks where a malicious user calls into the same function over and over again
+before the original execution has finished. Only allowing one reference at a time for an object prevents these attacks for objects in storage.
+
+To create a capability, we use the `link` function.
+
+```cadence
+// Create a link to the Vault in storage that is restricted to the
+// fields and functions in `Receiver` and `Balance` interfaces,
+// this only exposes the balance field
+// and deposit function of the underlying vault.
+//
+acct.link<&ExampleToken.Vault{ExampleToken.Receiver, ExampleToken.Balance}>.
+(/public/MainReceiver, target: /storage/MainVault)
+```
+
+`link` creates a new capability that is kept at the path in the first argument, targeting the `target` in the second argument.
+The type restriction for the link is specified in the `<>`. We use `&ExampleToken.Vault{ExampleToken.Receiver, ExampleToken.Balance}`
+to say that the link can be any resource as long as it implements and is cast as the Receiver interface.
+This is the common format for describing references.
+You first have a `&` followed by the concrete type, then the interface in curly braces to ensure that
+it is a reference that implements that interface and only includes the fields specified in that interface.
+
+We put the capability in `/public/MainReceiver` because we want it to be publicly accessible.
+The `public` domain of an account is accessible to anyone in the network via an account's `PublicAccount` object, which is fetched by using the `getAccount(address)` function.
+
+Next is the `post` phase of the transaction.
+
+```cadence
+post {
+// Check that the capabilities were created correctly
+// by getting the public capability and checking
+// that it points to a valid `Vault` object
+// that implements the `Receiver` interface
+getAccount(0x01).getCapability(/public/MainReceiver)
+                .check<&ExampleToken.Vault{ExampleToken.Receiver}>():
+                "Vault Receiver Reference was not created correctly"
+}
+```
+
+The `post` phase is for ensuring that certain conditions are met after the transaction has been executed.
+Here, we are getting the capability from its public path and calling its `check` function to ensure
+that the capability contains a valid link to a valid object in storage that is the specified type.
+
+<Callout type="info">
+
+Select account `0x01` as the only signer. <br/>
+Click the `Send` button to submit the transaction. <br/>
+This transaction creates a new public reference to your `Vault` and checks that it was created correctly.
+
+</Callout>
+
+## Transfer Tokens to Another User
+
+---
+
+Now, we are going to run a transaction that sends 10 tokens to account `0x02`. We will do this by calling the `withdraw` function on account `0x01`'s Vault,
+which creates a temporary Vault object for moving the tokens, then deposits those tokens into account `0x02`'s account by calling their `deposit` function.
+
+Here we encounter another safety feature that Cadence introduces. Owning tokens requires you to have a `Vault` object stored in your account,
+so if anyone tries to send tokens to an account who isn't prepared to receive them, the transaction will fail.
+This way, Cadence protects the user if they accidentally enter the account address incorrectly when sending tokens.
+
+Account `0x02` has not been set up to receive tokens, so we will do that now:
+
+<Callout type="info">
+
+Open the transaction `Setup Account`.<br/>
+Select account `0x02` as the only signer. <br/>
+Click the `Send` button to set up account `0x02` so that it can receive tokens.
+
+</Callout>
+
+```cadence:title=Setup Account.cdc
+import ExampleToken from 0x01
+
+// This transaction configures an account to store and receive tokens defined by
+// the ExampleToken contract.
+transaction {
+  prepare(acct: AuthAccount) {
+    // Create a new empty Vault object
+    let vaultA <- ExampleToken.createEmptyVault()
+
+    // Store the vault in the account storage
+    acct.save<@ExampleToken.Vault>(<-vaultA, to: /storage/MainVault)
+
+    log("Empty Vault stored")
+
+    // Create a public Receiver capability to the Vault
+    let ReceiverRef = acct.link<&ExampleToken.Vault{ExampleToken.Receiver, ExampleToken.Balance}>(/public/MainReceiver, target: /storage/MainVault)
+
+    log("References created")
+  }
+
+  post {
+    // Check that the capabilities were created correctly
+    getAccount(0x02).getCapability(/public/MainReceiver)
+                    .check<&ExampleToken.Vault{ExampleToken.Receiver}>():
+                    "Vault Receiver Reference was not created correctly"
+  }
+}
+```
+
+Here we perform the same actions that account `0x01` did to set up its `Vault`, but all in one transaction.
+Account `0x02` is ready to start building its fortune! As you can see, when we created the Vault for account `0x02`,
+we had to create one with a balance of zero by calling the `createEmptyVault()` function.
+Resource creation is restricted to the contract where it is defined, so in this way, the Fungible Token smart contract can ensure that
+nobody is able to create new tokens out of thin air.
+
+As part of the initial deployment process for the ExampleToken contract, account `0x01` created a `VaultMinter` object.
+By using this object, the account that owns it can mint new tokens. Right now, account `0x01` owns it, so it has sole power to mint new tokens.
+We could have had a `mintTokens` function defined in the contract, but then we would have to check the sender of the function call to make sure that they are authorized,
+which is not the recommended way to perform access control.
+
+As we explained before, the resource model plus capability security handles this access control for us as a built in language construct
+instead of having to be defined in the code. If account `0x01` wanted to authorize another account to mint tokens,
+they could either move the `VaultMinter` object to the other account, or give the other account a private capability to the single `VaultMinter`.
+Or, if they didn't want minting to be possible after deployment, they would simply mint all the tokens at contract initialization
+and not even include the `VaultMinter` in the contract.
+
+In the next transaction, account `0x01` will mint 30 new tokens and deposit them into account `0x02`'s newly created Vault.
+
+<Callout type="info">
+
+Select only account `0x01` as a signer and send `Mint Tokens` to mint 30 tokens for account `0x02`.
+
+<br />
+
+`Mint Tokens` should contain the code below.
+
+</Callout>
+
+```cadence:title=Mint Tokens.cdc
+import ExampleToken from 0x01
+
+// This transaction mints tokens and deposits them into account 2's vault
+transaction {
+
+  // Local variable for storing the reference to the minter resource
+  let mintingRef: &ExampleToken.VaultMinter
+
+  // Local variable for storing the reference to the Vault of
+  // the account that will receive the newly minted tokens
+  var receiverRef: &ExampleToken.Vault{ExampleToken.Receiver}
+
+  prepare(acct: AuthAccount) {
+    // Borrow a reference to the stored, private minter resource
+    self.mintingRef = acct.borrow<&ExampleToken.VaultMinter>(from: /storage/MainMinter)
+        ?? panic("Could not borrow a reference to the minter")
+
+    // Get the public account object for account 0x02
+    let recipient = getAccount(0x02)
+
+    // Get the public receiver capability
+    let cap = recipient.getCapability(/public/MainReceiver)
+
+    // Borrow a reference from the capability
+    self.receiverRef = cap.borrow<&ExampleToken.Vault{ExampleToken.Receiver}>()
+        ?? panic("Could not borrow a reference to the receiver")
+}
+
+  execute {
+      // Mint 30 tokens and deposit them into the recipient's Vault
+      self.mintingRef.mintTokens(amount: UFix64(30), recipient: self.receiverRef)
+
+      log("30 tokens minted and deposited to account 0x02")
+  }
+}
+```
+
+This is the first example of a transaction where we utilize local transaction variables that span different stages in the transaction.
+We declare the `mintingRef` and `receiverRef` variables outside of the prepare stage but must initialize them in prepare.
+We can then use them in later stages in the transaction.
+
+In addition to borrowing references from capabilities, you'll see in this transaction that you can also borrow a reference directly from an object in storage.
+
+```cadence
+// Borrow a reference to the stored, private minter resource
+self.mintingRef = acct.borrow<&ExampleToken.VaultMinter>(from: /storage/MainMinter)
+    ?? panic("Could not borrow a reference to the minter")
+```
+
+Here, we specify the borrow as a `VaultMinter` reference and have the reference point to `/storage/MainMinter`.
+The reference is borrowed as an optional so we use the nil-coalescing operator (`??`) to make sure the value isn't nil.
+If the value is nil, the transaction will execute the code after the `??`. The code is a panic, so it will revert and print the error message.
+
+You can use the `getAccount()` built-in function to get any account's public account object.
+The public account object lets you get capabilities from the `public` domain of an account, where public capabilities are stored.
+
+We use the `getCapability` function to get the public capability from a public path,
+then use the `borrow` function on the capability to get the reference from it, typed as a `ExampleToken.Vault{ExampleToken.Receiver}`.
+
+```cadence
+// Get the public receiver capability
+let cap = recipient.getCapability(/public/MainReceiver)!
+
+// Borrow a reference from the capability
+self.receiverRef = cap.borrow<&ExampleToken.Vault{ExampleToken.Receiver}>()
+        ?? panic("Could not borrow a reference to the receiver")
+```
+
+In the execute phase, we simply use the reference to mint 30 tokens and deposit them into the `Vault` of account `0x02`.
+
+## Check Account Balances
+
+Now, both account `0x01` and account `0x02` should have a `Vault` object in their storage that has a balance of 30 tokens.
+They both should also have a `Receiver` capability stored in their `/public/` domains that links to their stored `Vault`.
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/account-balances.png" />
+
+An account cannot receive any token type unless it is specifically configured to accept those tokens.
+As a result, it is difficult to send tokens to the wrong address accidentally.
+But, if you make a mistake setting up the `Vault` in the new account, you won't be able to send tokens to it.
+
+Let's run a script to make sure we have our vaults set up correctly.
+
+You can use scripts to access an account's public state. Scripts aren't signed by any account and cannot modify state.
+
+In this example, we will query the balance of each account's vault. The following will print out the balance of each account in the emulator.
+
+<Callout type="info">
+
+Open the script named `Script1.cdc` in the scripts pane.<br/>
+`Script1.cdc` should contain the following code:
+
+</Callout>
+
+```cadence:title=Script1.cdc
+import ExampleToken from 0x01
+
+// This script reads the Vault balances of two accounts.
+pub fun main() {
+    // Get the accounts' public account objects
+    let acct1 = getAccount(0x01)
+    let acct2 = getAccount(0x02)
+
+    // Get references to the account's receivers
+    // by getting their public capability
+    // and borrowing a reference from the capability
+    let acct1ReceiverRef = acct1.getCapability<&ExampleToken.Vault{ExampleToken.Balance}>(/public/MainReceiver)
+        .borrow()
+        ?? panic("Could not borrow a reference to the acct1 receiver")
+
+    let acct2ReceiverRef = acct2.getCapability<&ExampleToken.Vault{ExampleToken.Balance}>(/public/MainReceiver)
+        .borrow()
+        ?? panic("Could not borrow a reference to the acct2 receiver")
+
+    // Read and log balance fields
+    log("Account 1 Balance")
+    log(acct1ReceiverRef.balance)
+    log("Account 2 Balance")
+    log(acct2ReceiverRef.balance)
+}
+```
+
+<Callout type="info">
+
+Execute `Script1.cdc` by clicking the Execute button.<br/>
+This should ensure the following:
+
+</Callout>
+
+- Account `0x01`'s balance is 30
+- Account `0x02`'s balance is 30
+
+If correct, you should see the following lines:
+
+```
+"Account 1 Balance"
+30
+"Account 2 Balance"
+30
+Result > "void"
+```
+
+If there is an error, this probably means that you missed a step earlier
+and might need to restart from the beginning.
+
+To restart the playground, close your current session and open the link at the top of the tutorial.
+
+Now that we have two accounts, each with a `Vault`, we can see how they transfer tokens to each other!
+
+<Callout type="info">
+
+Open the transaction named `Transfer Tokens`. <br/>
+Select account `0x02` as a signer and send the transaction. <br/>
+`Transfer Tokens` should contain the following code for sending tokens to another user:
+
+</Callout>
+
+```cadence:title=Transfer Tokens.cdc
+import ExampleToken from 0x01
+
+// This transaction is a template for a transaction that
+// could be used by anyone to send tokens to another account
+// that owns a Vault
+transaction {
+
+  // Temporary Vault object that holds the balance that is being transferred
+  var temporaryVault: @ExampleToken.Vault
+
+  prepare(acct: AuthAccount) {
+    // withdraw tokens from your vault by borrowing a reference to it
+    // and calling the withdraw function with that reference
+    let vaultRef = acct.borrow<&ExampleToken.Vault>(from: /storage/MainVault)
+        ?? panic("Could not borrow a reference to the owner's vault")
+
+    self.temporaryVault <- vaultRef.withdraw(amount: UFix64(10))
+  }
+
+  execute {
+    // get the recipient's public account object
+    let recipient = getAccount(0x01)
+
+    // get the recipient's Receiver reference to their Vault
+    // by borrowing the reference from the public capability
+    let receiverRef = recipient.getCapability(/public/MainReceiver)
+                      .borrow<&ExampleToken.Vault{ExampleToken.Receiver}>()
+                      ?? panic("Could not borrow a reference to the receiver")
+
+    // deposit your tokens to their Vault
+    receiverRef.deposit(from: <-self.temporaryVault)
+
+    log("Transfer succeeded!")
+  }
+}
+```
+
+In this example, the signer withdraws tokens from their `Vault`, which creates and returns a temporary `Vault` resource object with `balance=10`
+that is used for transferring the tokens. In the execute phase. the transaction moves that resource to another user's `Vault` using their `deposit` method.
+The temporary `Vault` is destroyed after its balance is added to the recipient's `Vault`.
+
+You might be wondering why we have to use two function calls to complete a token transfer when it is possible to do it in one.
+This is because of the way resources work in Cadence. In a ledger-based model, you would just call transfer, which just updates the ledger,
+but in Cadence, the location of the tokens matters, and therefore most token transfer situations will not just be a direct account-to-account transfer.
+Most of the time, tokens will be used for a different purpose first,
+like purchasing something, and that requires the `Vault` to be separately sent and verified before being deposited to the storage of an account.
+Separating the two also allows us to take advantage of being able to statically verify which parts of accounts can be modified in the `prepare` section of a transaction,
+which will help users have peace of mind when getting fed transactions to sign from an app.
+
+<Callout type="info">
+
+Execute `Script1.cdc` again.
+
+</Callout>
+
+If correct, you should see the following lines indicating that account `0x01`'s balance is 40 and account `0x02`'s balance is 20:
+
+```
+"Account 1 Balance"
+40
+"Account 2 Balance"
+20
+Result > "void"
+```
+
+You now know how a basic fungible token is used in Cadence and Flow!
+
+From here, you could try to extend the functionality of fungible tokens by making:
+
+- A faucet for these tokens
+- An escrow that can be deposited to (but only withdrawn when the balance reaches a certain point)
+- A function to the resource that mints new tokens!
+
+## Non-Fungible Tokens on Flow
+
+---
+
+Now that you have an understanding of how fungible tokens work on Flow, you're ready to play with non-fungible tokens!

--- a/docs/tutorial/03-fungible-tokens.mdx
+++ b/docs/tutorial/03-fungible-tokens.mdx
@@ -1,5 +1,6 @@
 ---
 title: 3. Fungible Tokens
+type: TUT
 ---
 
 In this tutorial, we're going to deploy, store, and transfer fungible tokens.

--- a/docs/tutorial/03-fungible-tokens.mdx
+++ b/docs/tutorial/03-fungible-tokens.mdx
@@ -1,6 +1,6 @@
 ---
 title: 3. Fungible Tokens
-type: TUT
+contentType: TUT
 ---
 
 In this tutorial, we're going to deploy, store, and transfer fungible tokens.

--- a/docs/tutorial/04-non-fungible-tokens.mdx
+++ b/docs/tutorial/04-non-fungible-tokens.mdx
@@ -1,5 +1,6 @@
 ---
 title: 4. Non-Fungible Tokens
+type: TUT
 ---
 
 In this tutorial, we're going to deploy, store, and transfer **Non-Fungible Tokens (NFTs)**.

--- a/docs/tutorial/04-non-fungible-tokens.mdx
+++ b/docs/tutorial/04-non-fungible-tokens.mdx
@@ -1,6 +1,6 @@
 ---
 title: 4. Non-Fungible Tokens
-type: TUT
+contentType: TUT
 ---
 
 In this tutorial, we're going to deploy, store, and transfer **Non-Fungible Tokens (NFTs)**.

--- a/docs/tutorial/04-non-fungible-tokens.mdx
+++ b/docs/tutorial/04-non-fungible-tokens.mdx
@@ -1,0 +1,755 @@
+---
+title: 4. Non-Fungible Tokens
+---
+
+In this tutorial, we're going to deploy, store, and transfer **Non-Fungible Tokens (NFTs)**.
+
+---
+
+<Callout type="success">
+
+Open the starter code for this tutorial in the Flow Playground:
+
+<a
+  href="https://play.onflow.org/b60aa97d-d030-476e-9490-24f3a6f90161"
+  target="_blank"
+>
+  https://play.onflow.org/b60aa97d-d030-476e-9490-24f3a6f90161
+</a> <br />
+The tutorial will ask you to take various actions to interact with this code.
+
+</Callout>
+
+<Callout type="info">
+
+Instructions that require you to take action are always included in a callout box like this one.
+These highlighted actions are all that you need to do to get your code running,
+but reading the rest is necessary to understand the language's design.
+
+</Callout>
+
+The NFT is an integral part of blockchain technology. We need NFTs to represent assets that are unique and indivisible (like CryptoKitties! Or Top Shot Moments!).
+
+Instead of being represented in a central ledger, like in most smart contract languages, Cadence represents each NFT as a resource object that users store in their accounts.
+
+We're going to take you through these steps to get comfortable with the NFT:
+
+1. Deploy the NFT contract and type definitions.
+2. Create an NFT object and store it in your account storage.
+3. Create an NFT collection object to store multiple NFTs in your account.
+4. Create an `NFTMinter` and use it to mint an NFT.
+5. Create references to your collection that others can use to send you tokens.
+6. Set up another account the same way.
+7. Transfer an NFT from one account to another.
+8. Use a script to see what NFTs are stored in each account's collection.
+
+**Before proceeding with this tutorial**, we highly recommend following the instructions in [Getting Started](/cadence/tutorial/01-first-steps/),
+[Hello, World!](/cadence/tutorial/02-hello-world/), and [Fungible Tokens](/cadence/tutorial/03-fungible-tokens/)
+to learn how to use the Playground tools and to learn the fundamentals of Cadence. We will cover some of the concepts again here, but not all.
+
+## Non-Fungible Tokens on the Flow Emulator
+
+---
+
+In Cadence, each NFT is represented by a resource with an integer ID. Resources are a perfect type to represent NFTs
+because resources have important ownership rules that are enforced by the type system.
+They can only have one owner, cannot be copied, and cannot be accidentally or maliciously lost or duplicated.
+These protections ensure that owners know that their NFT is safe and can represent an asset that has real value.
+
+An NFT is also usually represented by some sort of metadata like a name or a picture. Historically, most of this metadata has been stored off-chain,
+and the on-chain token only contains a URL or something similar that points to the off-chain metadata.
+In Flow, this is possible, but the goal is to make it possible for all the metadata associated with a token to be stored on-chain.
+This is out of the scope of this tutorial though.
+This paradigm is still being designed and you can participate by seeing the [relevant issue](https://github.com/onflow/flow-nft/issues/9) in the flow NFT repository.
+
+When users on Flow want to transact with each other, they can do so peer-to-peer and without having to interact with a central NFT contract
+by calling resource-defined methods in each users' account.
+
+## Adding an NFT Your Account
+
+---
+
+<Callout type="info">
+
+First, you'll need to follow this link to open a playground session with the Non-Fungible Token contracts, transactions, and scripts pre-loaded:
+
+<a
+  href="https://play.onflow.org/b60aa97d-d030-476e-9490-24f3a6f90161"
+  target="_blank"
+>
+  https://play.onflow.org/b60aa97d-d030-476e-9490-24f3a6f90161
+</a>
+
+</Callout>
+
+<Callout type="info">
+
+Open Account `0x01` to see `NFTv1.cdc`.
+`NFTv1.cdc` should contain the following code:
+
+</Callout>
+
+```cadence:title=NFTv1.cdc
+pub contract ExampleNFT {
+
+    // Declare the NFT resource type
+    pub resource NFT {
+        // The unique ID that differentiates each NFT
+        pub let id: UInt64
+
+        // String mapping to hold metadata
+        pub var metadata: {String: String}
+
+        // Initialize both fields in the init function
+        init(initID: UInt64) {
+            self.id = initID
+            self.metadata = {}
+        }
+    }
+
+    // Create a single new NFT and save it to account storage
+    init() {
+        self.account.save<@NFT>(<-create NFT(initID: 1), to: /storage/NFT1)
+    }
+}
+```
+
+In this contract, the NFT is a resource with an integer ID and a field for metadata.
+
+This is different from the Fungible Token because a fungible token simply was a vault with a balance
+that could change when tokens were withdrawn or deposited.
+Each NFT resource has a unique ID, so they cannot be combined or duplicated, unless the smart contract allows it.
+
+Another unique feature of this design is that each NFT can contain its own metadata.
+In this example, we use a simple `String`-to-`String` mapping, but you could imagine a much more rich
+version that can allow the storage of complex file formats and other such data.
+
+An NFT could even own other NFTs! This example is shown in a later tutorial.
+
+In the contract's `init` function, we create a new NFT object and move it into the account storage.
+
+```cadence
+// put it in storage
+self.account.save<@NFT>(<-create NFT(initID: 1), to: /storage/NFT1)
+```
+
+Here we access the `AuthAccount` object on the account the contract is deployed to and call its `save` method,
+specifying `@NFT` as the type it is being saved as. We also create the NFT in the same line and pass it as the first argument to `save`.
+We save it to the `/storage` domain, where objects are meant to be stored.
+
+<Callout type="info">
+
+Deploy `NFTv1` by clicking the Deploy button in the bottom right of the editor.
+
+</Callout>
+
+You should now have an NFT in your account. Let's run a transaction to check.
+
+<Callout type="info">
+
+Open the `NFT Exists` transaction, select account `0x01` as the only signer, and send the transaction.<br/>
+`NFT Exists` should look like this:
+
+</Callout>
+
+```cadence:title=NFT Exists.cdc
+import ExampleNFT from 0x01
+
+// This transaction checks if an NFT exists in the storage of the given account
+// by trying to borrow from it
+transaction {
+    prepare(acct: AuthAccount) {
+        if acct.borrow<&ExampleNFT.NFT>(from: /storage/NFT1) != nil {
+            log("The token exists!")
+        } else {
+            log("No token found!")
+        }
+    }
+}
+```
+
+Here, we are trying to directly borrow a reference from the NFT in storage.
+If the object exists, the borrow will succeed and the reference optional will not be `nil`, but if the borrow fails, the optional will be `nil`.
+
+You should see something that says `"The token exists!"`.
+
+Good work! You have your first NFT in your account.
+
+## Storing Multiple NFTs in a Collection
+
+---
+
+We could store our NFTs at the top level of storage, but this could start to get confusing to organize all your NFTs if you have many.
+This approach is not as scalable, but we can overcome this issue by using a data structure that can hold as many NFTs as we want.
+We can accomplish this via an array or dictionary, but those types are relatively opaque.
+Instead, we can use a resource as our NFT collection to enable more-sophisticated ways to interact with our NFTs.
+
+<Callout type="info">
+
+Open Account `0x02` to see `NFTv2.cdc`.<br/>
+Deploy the contract by clicking the Deploy button in the bottom right of the editor.<br/>
+`NFTv2.cdc` should contain the code below.
+It contains what was already in `NFTv1.cdc` plus additional resource declarations in the contract body.
+
+</Callout>
+
+```cadence:title=NFTv2.cdc
+// NFTv2.cdc
+//
+// This is a complete version of the ExampleNFT contract
+// that includes withdraw and deposit functionality, as well as a
+// collection resource that can be used to bundle NFTs together.
+//
+// It also includes a definition for the Minter resource,
+// which can be used by admins to mint new NFTs.
+//
+// Learn more about non-fungible tokens in this tutorial: https://docs.onflow.org/docs/non-fungible-tokens
+
+pub contract ExampleNFT {
+
+    // Declare the NFT resource type
+    pub resource NFT {
+        // The unique ID that differentiates each NFT
+        pub let id: UInt64
+
+        // Initialize both fields in the init function
+        init(initID: UInt64) {
+            self.id = initID
+        }
+    }
+
+    // We define this interface purely as a way to allow users
+    // to create public, restricted references to their NFT Collection.
+    // They would use this to only expose the deposit, getIDs,
+    // and idExists fields in their Collection
+    pub resource interface NFTReceiver {
+
+        pub fun deposit(token: @NFT)
+
+        pub fun getIDs(): [UInt64]
+
+        pub fun idExists(id: UInt64): Bool
+    }
+
+    // The definition of the Collection resource that
+    // holds the NFTs that a user owns
+    pub resource Collection: NFTReceiver {
+        // dictionary of NFT conforming tokens
+        // NFT is a resource type with an `UInt64` ID field
+        pub var ownedNFTs: @{UInt64: NFT}
+
+        // Initialize the NFTs field to an empty collection
+        init () {
+            self.ownedNFTs <- {}
+        }
+
+        // withdraw
+        //
+        // Function that removes an NFT from the collection
+        // and moves it to the calling context
+        pub fun withdraw(withdrawID: UInt64): @NFT {
+            // If the NFT isn't found, the transaction panics and reverts
+            let token <- self.ownedNFTs.remove(key: withdrawID)!
+
+            return <-token
+        }
+
+        // deposit
+        //
+        // Function that takes a NFT as an argument and
+        // adds it to the collections dictionary
+        pub fun deposit(token: @NFT) {
+            // add the new token to the dictionary with a force assignment
+            // if there is already a value at that key, it will fail and revert
+            self.ownedNFTs[token.id] <-! token
+        }
+
+        // idExists checks to see if a NFT
+        // with the given ID exists in the collection
+        pub fun idExists(id: UInt64): Bool {
+            return self.ownedNFTs[id] != nil
+        }
+
+        // getIDs returns an array of the IDs that are in the collection
+        pub fun getIDs(): [UInt64] {
+            return self.ownedNFTs.keys
+        }
+
+        destroy() {
+            destroy self.ownedNFTs
+        }
+    }
+
+    // creates a new empty Collection resource and returns it
+    pub fun createEmptyCollection(): @Collection {
+        return <- create Collection()
+    }
+
+    // NFTMinter
+    //
+    // Resource that would be owned by an admin or by a smart contract
+    // that allows them to mint new NFTs when needed
+    pub resource NFTMinter {
+
+        // the ID that is used to mint NFTs
+        // it is only incremented so that NFT ids remain
+        // unique. It also keeps track of the total number of NFTs
+        // in existence
+        pub var idCount: UInt64
+
+        init() {
+            self.idCount = 1
+        }
+
+        // mintNFT
+        //
+        // Function that mints a new NFT with a new ID
+        // and returns it to the caller
+        pub fun mintNFT(): @NFT {
+
+            // create a new NFT
+            var newNFT <- create NFT(initID: self.idCount)
+
+            // change the id so that each ID is unique
+            self.idCount = self.idCount + 1 as UInt64
+
+            return <-newNFT
+        }
+    }
+
+	init() {
+		// store an empty NFT Collection in account storage
+        self.account.save(<-self.createEmptyCollection(), to: /storage/NFTCollection)
+
+        // publish a reference to the Collection in storage
+        self.account.link<&{NFTReceiver}>(/public/NFTReceiver, target: /storage/NFTCollection)
+
+        // store a minter resource in account storage
+        self.account.save(<-create NFTMinter(), to: /storage/NFTMinter)
+	}
+}
+
+
+
+```
+
+Any user who owns one or more `ExampleNFT` will have an instance of this `ExampleNFT.Collection` resource stored in their account.
+This collection stores all of their NFTs in a dictionary that maps integer IDs to `NFT`s,
+similar to how a `Vault` resource stores all the tokens in the `balance` field.
+Another similarity is how each collection has a `deposit` and `withdraw` function.
+These functions allow users to follow the pattern of first withdrawing the token from their collection and then depositing to another collection.
+
+When a user wants to store NFTs in their account,
+they will instantiate an empty `Collection` by calling the `createEmptyCollection` function in the `ExampleNFT` smart contract.
+This returns an empty `Collection` object that they can store in their account storage.
+
+There are a few new features that we use in this example, so let's walk through them.
+
+## Dictionaries
+
+This resource uses a [**Dictionary**: a mutable, unordered collection of key-value associations](/cadence/language/values-and-types#dictionaries).
+
+```cadence
+pub var ownedNFTs: @{Int: NFT}
+```
+
+In a dictionary, all keys must have the same type, and all values must have the same type.
+In this case, we are mapping integer IDs to `NFT` resource objects.
+Dictionary definitions don't usually have the `@` symbol in the type specification,
+but because the `ownedNFTs` mapping stores resources, the whole field also has to become a resource type,
+which is why the field has the `@` symbol indicating that it is a resource type. This means that all the rules that apply to resources apply to this type.
+
+If the NFT collection resource is destroyed with the `destroy` command, it needs to know what to do with the resources it stores in the dictionary.
+This is why resources that store other resources have to include a `destroy` function that runs when `destroy` is called on it.
+This destroy function has to either explicitly destroy the contained resources or move them somewhere else. In this example, we destroy them.
+
+```cadence
+destroy() {
+    destroy self.ownedNFTs
+}
+```
+
+When the collection is created, the `init` function is run and must explicitly initialize all member variables.
+This helps prevent issues in some smart contracts where uninitialized fields can cause bugs.
+The init function can never run again after this. Here, we initialize the dictionary as a resource type with an empty dictionary.
+
+```cadence
+init () {
+  self.ownedNFTs <- {}
+}
+```
+
+Another feature for dictionaries is the ability to get an array of the keys of the dictionary using the build-in `keys` function.
+
+```cadence
+// getIDs returns an array of the IDs that are in the collection
+pub fun getIDs(): [UInt64] {
+    return self.ownedNFTs.keys
+}
+```
+
+This can be used to iterate through the dictionary or just to see a list of what is stored.
+As you can see, a variable length array type is declared by enclosing the member type within square brackets.
+
+## Resources Owning Resources
+
+This NFT Collection example in `NFTv2.cdc` illustrates an important feature: resources can own other resources.
+
+In the example, a user can transfer one NFT to another user.
+Additionally, since the `Collection` explicitly owns the NFTs in it,
+the owner could transfer all of the NFTs at once by just transferring the single collection.
+
+This is an important feature because it enables numerous additional use cases.
+In addition to allowing easy batch transfers, this means that if a unique NFT wants to own another unique NFT,
+like a CryptoKitty owning a hat accessory, the Kitty literally stores the hat in its own storage and effectively owns it.
+The hat belongs to the CryptoKitty that it is stored in, and the hat can be transferred separately or along with the CryptoKitty that owns it,
+
+Capabilities cannot be created for resources that are stored in other resources, but references can.
+The owning resource has control over it and therefore controls the type of access that external calls have on the stored resource.
+
+<!-- This feature is covered in more detail in [Composable Resources: Kitty Hats](doc:composable-resources-kitty-hats). -->
+
+## Restricting Access to the NFT Collection
+
+In the NFT Collection, all the functions and fields are public,
+but we do not want everyone in the network to be able to call our `withdraw` function.
+This is where Cadence's second layer of access control comes in.
+adence utilizes capability security, which means that for any given object, a user is allowed to access a field or method of that object if they either:
+
+- Are the owner of the object
+- Have a valid reference to that field or method (note that references can only be created from capabilities, and capabilities can only be created by the owner of the object)
+
+When a user stores their NFT `Collection` in their account storage, it is by default not available for other users to access.
+A user's account storage object is inaccessible by anyone except its owner. To give external accounts read access to the `deposit` function, the `getIDs` function, and the `idExists` function, the owner would create a reference using an interface that only includes those fields:
+
+```cadence
+pub resource interface NFTReceiver {
+
+    pub fun deposit(token: @NFT)
+
+    pub fun getIDs(): [UInt64]
+
+    pub fun idExists(id: UInt64): Bool
+}
+```
+
+Then, using that interface, they would create a link to the object in storage, specifying that the link only contains the functions in the `NFTReceiver` interface. This link is called a capability. From there, the owner can then do whatever they want with that capability: they could pass it as a parameter to a function for one-time-use, or they could put in the `/public/` domain of their account so that anyone can access it. If a user tried to use this capability to call the `withdraw` function, it wouldn't work because it doesn't exist in the interface or reference.
+
+The creation of the link and capability is seen in line 132 of `NFTv2.cdc` in the init function:
+
+```cadence
+// publish a reference to the Collection in storage
+self.account.link<&{NFTReceiver}>(/public/NFTReceiver, target: /storage/NFTCollection)
+```
+
+The `link` function specifies that the capability is typed as `&AnyResource{NFTReceiver}` to only expose those fields and functions.
+Then the link is stored in `/public/` which is accessible by anyone. The link targets the `/storage/NFTCollection` that we created earlier.
+
+Now the user has an NFT collection in their account `/storage`, along with a capability for it that others can use to see what NFTs they own and to send an NFT to them.
+
+Let's confirm this is true by running a script!
+
+## Run a Script
+
+---
+
+Scripts in Cadence are simple transactions that run without any account permissions and only read information from the blockchain.
+
+<Callout type="info">
+
+Open the script file named `Print 0x02 NFTs`.
+`Print 0x02 NFTs` should contain the following code:
+
+</Callout>
+
+```cadence
+import ExampleNFT from 0x02
+
+// Print the NFTs owned by account 0x03.
+pub fun main() {
+    // Get the public account object for account 0x03
+    let nftOwner = getAccount(0x02)
+
+    // Find the public Receiver capability for their Collection
+    let capability = nftOwner.getCapability<&{ExampleNFT.NFTReceiver}>(/public/NFTReceiver)
+
+    // borrow a reference from the capability
+    let receiverRef = capability.borrow()
+            ?? panic("Could not borrow receiver reference")
+
+    // Log the NFTs that they own as an array of IDs
+    log("Account 2 NFTs")
+    log(receiverRef.getIDs())
+}
+```
+
+<Callout type="info">
+
+Execute `Print 0x02 NFTs` by clicking the Execute button in the bottom right of the editor box.<br/>
+This script prints a list of the NFTs that account `0x02` owns.
+
+</Callout>
+
+Because account `0x02` currently doesn't own any in its collection, it will just print an empty array:
+
+```
+"Account 2 NFTs"
+[]
+Result > "void"
+```
+
+If the script cannot be executed, it probably means that the NFT collection hasn't been stored correctly in account `0x02`.
+If you run into issues, make sure that you selected account `0x02` as the signer account and that you followed the previous steps correctly.
+
+## Mint and Distribute Tokens as an Admin
+
+---
+
+One way to create NFTs is by having an admin mint new tokens and send them to a user.
+Most would implement this by having an NFT Minter resource. The owner of this resource can mint tokens,
+or if they want to give other users and contracts the ability to mint tokens,
+the owner could give out a capability that only exposes the `mintNFT` function to utilize the capability security model.
+No need to explicitly check the sender of a transaction like in ledger-based models!
+
+Let's use an NFT Minter to mint some tokens.
+
+If you refer back to the `ExampleNFT` contract in `NFTv2.cdc`, you'll see that it defined another resource, `NFTMinter`.
+This is a simple example of what an admin with minting permissions would own to mint new NFTs.
+This simply has a single function to mint the NFTs and an incrementing integer field for assigning unique IDs to the NFTs.
+
+You should see that there is a `ExampleNFT.NFTMinter` resource stored in account `0x02`'s account storage. This is shown in the `Resources` box below the editor.
+
+Now we can use our stored `NFTMinter` to mint a new NFT and deposit it into account `0x02`'s collection.
+
+<Callout type="info">
+
+Open the file named `Mint NFT`.
+Select account `0x02` as the only signer and send the transaction.<br/>
+This transaction deposits the minted NFT into the account owner's NFT collection:
+
+</Callout>
+
+```cadence:title=Mint NFT.cdc
+import ExampleNFT from 0x02
+
+// This transaction allows the Minter account to mint an NFT
+// and deposit it into its collection.
+
+transaction {
+
+    // The reference to the collection that will be receiving the NFT
+    let receiverRef: &{ExampleNFT.NFTReceiver}
+
+    // The reference to the Minter resource stored in account storage
+    let minterRef: &ExampleNFT.NFTMinter
+
+    prepare(acct: AuthAccount) {
+        // Get the owner's collection capability and borrow a reference
+        self.receiverRef = acct.getCapability<&{ExampleNFT.NFTReceiver}>(/public/NFTReceiver)
+            .borrow()
+            ?? panic("Could not borrow receiver reference")
+
+        // Borrow a capability for the NFTMinter in storage
+        self.minterRef = acct.borrow<&ExampleNFT.NFTMinter>(from: /storage/NFTMinter)
+            ?? panic("Could not borrow minter reference")
+    }
+
+    execute {
+        // Use the minter reference to mint an NFT, which deposits
+        // the NFT into the collection that is sent as a parameter.
+        let newNFT <- self.minterRef.mintNFT()
+
+        self.receiverRef.deposit(token: <-newNFT)
+
+        log("NFT Minted and deposited to Account 2's Collection")
+    }
+}
+```
+
+<Callout type="info">
+
+Reopen `Print 0x02 NFTs` and execute the script.
+This prints a list of the NFTs that account `0x02` owns.
+
+</Callout>
+
+```cadence:title=Print 0x02 NFTs.cdc
+import ExampleNFT from 0x02
+
+// Print the NFTs owned by account 0x02.
+pub fun main() {
+    // Get the public account object for account 0x02
+    let nftOwner = getAccount(0x02)
+
+    // Find the public Receiver capability for their Collection
+    let capability = nftOwner.getCapability<&{ExampleNFT.NFTReceiver}>(/public/NFTReceiver)
+
+    // borrow a reference from the capability
+    let receiverRef = capability.borrow()
+            ?? panic("Could not borrow the receiver reference")
+
+    // Log the NFTs that they own as an array of IDs
+    log("Account 2 NFTs")
+    log(receiverRef.getIDs())
+}
+
+```
+
+You should see that account `0x02` owns the NFT with `id=1`
+
+```
+"Account 2 NFTs"
+[1]
+```
+
+## Transferring an NFT
+
+Before we are able to transfer an NFT to another account, we need to set up that account with an NFTCollection of their own so they are able to receive NFTs.
+
+<Callout type="info">
+
+Open the file named `Setup Account` and submit the transaction, using account `0x01` as the only signer.
+
+</Callout>
+
+```cadence:title=Setup Account.cdc
+import ExampleNFT from 0x02
+
+// This transaction configures a user's account
+// to use the NFT contract by creating a new empty collection,
+// storing it in their account storage, and publishing a capability
+transaction {
+  prepare(acct: AuthAccount) {
+
+    // Create a new empty collection
+    let collection <- ExampleNFT.createEmptyCollection()
+
+    // store the empty NFT Collection in account storage
+    acct.save<@ExampleNFT.Collection>(<-collection, to: /storage/NFTCollection)
+
+    log("Collection created for account 1")
+
+    // create a public capability for the Collection
+    acct.link<&{ExampleNFT.NFTReceiver}>(/public/NFTReceiver, target: /storage/NFTCollection)
+
+    log("Capability created")
+  }
+}
+```
+
+Account `0x01` should now have an empty `Collection` resource stored in its account storage.
+It has also created and stored a capability to the collection in its `/public/` domain.
+
+<Callout type="info">
+
+Open the file named `Transfer`, select account `0x02` as the only signer, and send the transaction.<br/>
+This transaction transfers a token from account `0x02` to account `0x01`.
+
+</Callout>
+
+```cadence:title=Transfer.cdc
+import ExampleNFT from 0x02
+
+// This transaction transfers an NFT from one user's collection
+// to another user's collection.
+transaction {
+
+    // The field that will hold the NFT as it is being
+    // transferred to the other account
+    let transferToken: @ExampleNFT.NFT
+
+    prepare(acct: AuthAccount) {
+
+        // Borrow a reference from the stored collection
+        let collectionRef = acct.borrow<&ExampleNFT.Collection>(from: /storage/NFTCollection)
+            ?? panic("Could not borrow a reference to the owner's collection")
+
+        // Call the withdraw function on the sender's Collection
+        // to move the NFT out of the collection
+        self.transferToken <- collectionRef.withdraw(withdrawID: 1)
+    }
+
+    execute {
+        // Get the recipient's public account object
+        let recipient = getAccount(0x01)
+
+        // Get the Collection reference for the receiver
+        // getting the public capability and borrowing a reference from it
+        let receiverRef = recipient.getCapability<&{ExampleNFT.NFTReceiver}>(/public/NFTReceiver)
+            .borrow()
+            ?? panic("Could not borrow receiver reference")
+
+        // Deposit the NFT in the receivers collection
+        receiverRef.deposit(token: <-self.transferToken)
+
+        log("NFT ID 1 transferred from account 2 to account 1")
+    }
+}
+```
+
+Now we can check both accounts' collections to make sure that account `0x01` owns the token and account `0x02` has nothing.
+
+<Callout type="info">
+
+Execute the script `Print all NFTs` to see the tokens in each account:
+
+</Callout>
+
+```cadence:title=Script2.cdc
+import ExampleNFT from 0x02
+
+// Print the NFTs owned by accounts 0x01 and 0x02.
+pub fun main() {
+
+    // Get both public account objects
+    let account1 = getAccount(0x01)
+      let account2 = getAccount(0x02)
+
+    // Find the public Receiver capability for their Collections
+    let acct1Capability = account1.getCapability<&{ExampleNFT.NFTReceiver}>(/public/NFTReceiver)
+    let acct2Capability = account2.getCapability<&{ExampleNFT.NFTReceiver}>(/public/NFTReceiver)
+
+    // borrow references from the capabilities
+    let receiver1Ref = acct1Capability.borrow()
+        ?? panic("Could not borrow account 1 receiver reference")
+    let receiver2Ref = acct2Capability.borrow()
+        ?? panic("Could not borrow account 2 receiver reference")
+
+    // Print both collections as arrays of IDs
+    log("Account 1 NFTs")
+    log(receiver1Ref.getIDs())
+
+    log("Account 2 NFTs")
+    log(receiver2Ref.getIDs())
+}
+```
+
+You should see something like this in the output:
+
+```
+"Account 1 NFTs"
+[1]
+"Account 2 NFTs"
+[]
+```
+
+Account `0x01` has one NFT with ID=1 and account `0x02` has none.
+This shows that the NFT was transferred from account `0x02` to account `0x01`.
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/account-nft-storage.png" />
+
+Congratulations, you now have a working NFT!
+
+## Putting It All Together
+
+---
+
+This was only a basic example how a NFT might work on Flow.
+Please refer to the [Flow NFT Standard repo](https://github.com/onflow/flow-nft)
+for information about the official Flow NFT standard and an example implementation of it.
+
+## Create a Flow Marketplace
+
+---
+
+Now that you have a working NFT, you can attempt to extend its functionality on your own, or you can learn how to create a marketplace that uses both fungible tokens and NFTs.

--- a/docs/tutorial/05-marketplace-setup.mdx
+++ b/docs/tutorial/05-marketplace-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: 5. Marketplace Setup
+type: TUT
 ---
 
 <Callout type="success">

--- a/docs/tutorial/05-marketplace-setup.mdx
+++ b/docs/tutorial/05-marketplace-setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: 5. Marketplace Setup
-type: TUT
+contentType: TUT
 ---
 
 <Callout type="success">

--- a/docs/tutorial/05-marketplace-setup.mdx
+++ b/docs/tutorial/05-marketplace-setup.mdx
@@ -1,0 +1,226 @@
+---
+title: 5. Marketplace Setup
+---
+
+<Callout type="success">
+
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846"
+target="_blank">https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846</a><br/>
+The tutorial will be asking you to take various actions to interact with this code.
+
+</Callout>
+
+If you have already completed the Marketplace tutorial, please move on to [Composable Resources: Kitty Hats](/cadence/tutorial/07-resources-compose/).
+
+This guide will help you quickly get the playground to the state you need to complete the Marketplace tutorial. The marketplace tutorial uses the Fungible Token and Non-Fungible token contracts to allow users to buy and sell NFTs with fungible tokens.
+
+The state of the accounts is the same as if you had completed the Fungible Token and Non-Fungible Token tutorials in the same playground session. Having your playground in this state is necessary to follow the [Composable Smart Contracts: Marketplace](/cadence/tutorial/06-marketplace-compose/) tutorial.
+
+---
+
+1. Open account `0x01`. Make sure the Fungible Token definitions in `FungibleToken.cdc` from the fungible token tutorial are in this account.
+2. Deploy the Fungible Token code to account `0x01`.
+3. Switch to account `0x02` by selecting account `0x02` from the account selection menu.
+4. Make sure you have the NFT definitions in `NFTv2.cdc` from the Non-fungible token tutorial in account `0x02`.
+5. Deploy the NFT code to account `0x02`.
+6. Run the transaction in Transaction 3. This is the `SetupAccount1Transaction.cdc` file. Use account `0x01` as the only signer to set up account `0x01`'s account.
+
+```cadence:title=SetupAccount1Transaction.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+
+// This transaction sets up account 0x01 for the marketplace tutorial
+// by publishing a Vault reference and creating an empty NFT Collection.
+transaction {
+  prepare(acct: AuthAccount) {
+    // Create a public Receiver capability to the Vault
+    acct.link<&FungibleToken.Vault{FungibleToken.Receiver, FungibleToken.Balance}>
+             (/public/MainReceiver, target: /storage/MainVault)
+
+    log("Created Vault references")
+
+    // store an empty NFT Collection in account storage
+    acct.save<@NonFungibleToken.Collection>(<-NonFungibleToken.createEmptyCollection(), to: /storage/NFTCollection)
+
+    // publish a capability to the Collection in storage
+    acct.link<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver, target: /storage/NFTCollection)
+
+    log("Created a new empty collection and published a reference")
+  }
+}
+```
+
+7. Run the transaction in Transaction 4. This is the `SetupAccount2Transaction.cdc` file. Use account `0x02` as the only signer to set up account `0x02`'s account.
+
+```cadence:title=SetupAccount2Transaction.cdc
+
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+
+// This transaction adds an empty Vault to account 0x02
+// and mints an NFT with id=1 that is deposited into
+// the NFT collection on account 0x01.
+transaction {
+
+  // Private reference to this account's minter resource
+  let minterRef: &NonFungibleToken.NFTMinter
+
+  prepare(acct: AuthAccount) {
+    // create a new vault instance with an initial balance of 30
+    let vaultA <- FungibleToken.createEmptyVault()
+
+    // Store the vault in the account storage
+    acct.save<@FungibleToken.Vault>(<-vaultA, to: /storage/MainVault)
+
+    // Create a public Receiver capability to the Vault
+    let ReceiverRef = acct.link<&FungibleToken.Vault{FungibleToken.Receiver, FungibleToken.Balance}>(/public/MainReceiver, target: /storage/MainVault)
+
+    log("Created a Vault and published a reference")
+
+    // Borrow a reference for the NFTMinter in storage
+    self.minterRef = acct.borrow<&NonFungibleToken.NFTMinter>(from: /storage/NFTMinter)
+            ?? panic("Could not borrow an nft minter reference")
+  }
+  execute {
+    // Get the recipient's public account object
+    let recipient = getAccount(0x01)
+
+    // Get the Collection reference for the receiver
+    // getting the public capability and borrowing a reference from it
+    let receiverRef = recipient.getCapability<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver)
+        .borrow()
+        ?? panic("Could not borrow an nft receiver reference")
+
+    // Mint an NFT and deposit it into account 0x01's collection
+    self.minterRef.mintNFT(recipient: receiverRef)
+
+    log("New NFT minted for account 1")
+  }
+}
+```
+
+8. Run the transaction in Transaction 5. This is the `SetupAccount1TransactionMinting.cdc` file. Use account `0x01` as the only signer to mint fungible tokens for account 1 and 2.
+
+```cadence:title=SetupAccount1TransactionMinting.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+
+// This transaction mints tokens for both accounts using
+// the minter stored on account 0x01.
+transaction {
+
+    // Public Vault Receiver References for both accounts
+    let acct1Ref: &AnyResource{FungibleToken.Receiver}
+    let acct2Ref: &AnyResource{FungibleToken.Receiver}
+
+    // Private minter references for this account to mint tokens
+    let minterRef: &FungibleToken.VaultMinter
+
+    prepare(acct: AuthAccount) {
+        // Get the public object for account 0x02
+        let account2 = getAccount(0x02)
+
+        // Retrieve public Vault Receiver references for both accounts
+        self.acct1Ref = acct.getCapability<&FungibleToken.Vault{FungibleToken.Receiver}>(/public/MainReceiver)
+            .borrow()
+            ?? panic("Could not borrow acct1 vault receiver reference")
+        self.acct2Ref = account2.getCapability<&FungibleToken.Vault{FungibleToken.Receiver}>(/public/MainReceiver)
+            .borrow()
+            ?? panic("Could not borrow acct2 vault receiver reference")
+
+        // Get the stored Minter reference for account 0x01
+        self.minterRef = acct.borrow<&FungibleToken.VaultMinter>(from: /storage/MainMinter)
+            ?? panic("Could not borrow vault minter reference")
+    }
+
+    execute {
+        // Mint tokens for both accounts
+        self.minterRef.mintTokens(amount: 20.0, recipient: self.acct2Ref)
+        self.minterRef.mintTokens(amount: 10.0, recipient: self.acct1Ref)
+
+        log("Minted new fungible tokens for account 1 and 2")
+    }
+}
+```
+
+9. Run the script `CheckSetupScript.cdc` file in Script 1 to ensure everything is set up.
+
+```cadence:title=CheckSetupScript.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+
+// This script checks that the accounts are set up correctly for the marketplace tutorial.
+//
+// Account 0x01: Vault Balance = 40, NFT.id = 1
+// Account 0x02: Vault Balance = 20, No NFTs
+pub fun main() {
+    // Get the accounts' public account objects
+    let acct1 = getAccount(0x01)
+    let acct2 = getAccount(0x02)
+
+    // Get references to the account's receivers
+    // by getting their public capability
+    // and borrowing a reference from the capability
+    let acct1ReceiverRef = acct1.getCapability<&FungibleToken.Vault{FungibleToken.Balance}>(/public/MainReceiver)
+        .borrow<&FungibleToken.Vault{FungibleToken.Balance}>()
+        ?? panic("Could not borrow acct1 vault receiver reference")
+    let acct2ReceiverRef = acct2.getCapability<&FungibleToken.Vault{FungibleToken.Balance}>(/public/MainReceiver)
+        .borrow()
+        ?? panic("Could not borrow acct2 vault receiver reference")
+
+    // Log the Vault balance of both accounts and ensure they are
+    // the correct numbers.
+    // Account 0x01 should have 40.
+    // Account 0x02 should have 20.
+    log("Account 1 Balance")
+    log(acct1ReceiverRef.balance)
+    log("Account 2 Balance")
+    log(acct2ReceiverRef.balance)
+
+    // verify that the balances are correct
+    if acct1ReceiverRef.balance != 40.0 || acct2ReceiverRef.balance != 20.0 {
+        panic("Wrong balances!")
+    }
+
+    // Find the public Receiver capability for their Collections
+    let acct1Capability = acct1.getCapability<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver)
+    let acct2Capability = acct2.getCapability<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver)
+
+    // borrow references from the capabilities
+    let nft1Ref = acct1Capability.borrow()
+        ?? panic("Could not borrow acct1 nft receiver reference")
+    let nft2Ref = acct2Capability.borrow()
+        ?? panic("Could not borrow acct2 nft receiver reference")
+
+    // Print both collections as arrays of IDs
+    log("Account 1 NFTs")
+    log(nft1Ref.getIDs())
+
+    log("Account 2 NFTs")
+    log(nft2Ref.getIDs())
+
+    // verify that the collections are correct
+    if nft1Ref.getIDs()[0] != 1 as UInt64 || nft2Ref.getIDs().length != 0 {
+        panic("Wrong Collections!")
+    }
+}
+```
+
+10. The script should not panic and you should see something like this output
+
+```
+"Account 1 Vault Balance"
+40
+"Account 2 Vault Balance"
+20
+"Account 1 NFTs"
+[1]
+"Account 2 NFTs"
+[]
+```
+
+---
+
+With your playground now in the correct state, you're ready to continue with the next tutorial.
+
+You do not need to open a new playground session for the marketplace tutorial. You can just continue using this one.

--- a/docs/tutorial/06-marketplace-compose.mdx
+++ b/docs/tutorial/06-marketplace-compose.mdx
@@ -1,0 +1,650 @@
+---
+title: 6. Marketplace
+---
+
+In this tutorial, we're going to create a marketplace that uses both the fungible and non-fungible token (NFTs) contracts that we have learned about in previous tutorials.
+
+---
+
+<Callout type="success">
+
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846"
+target="_blank">https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846</a><br/>
+The tutorial will be asking you to take various actions to interact with this code.
+
+</Callout>
+
+<Callout type="info">
+
+Instructions that require you to take action are always included in a callout box like this one. These highlighted actions are all that you need to do to get your code running, but reading the rest is necessary to understand the language's design.
+
+</Callout>
+
+Marketplaces are a popular application of blockchain technology and smart contracts. When there are NFTs in existence, users will want to be able to buy and sell them with their fungible tokens.
+
+Now that there is a standard for both fungible and non-fungible tokens, we can build a marketplace that uses both. This is referred to as **composability**: the ability for developers to leverage shared resources, such as code or userbases, and use them as building blocks for new applications. Flow is designed to enable composability because it empowers developers to do more with less, which can lead to rapid innovation.
+
+To create a marketplace, we need to integrate the functionality of both fungible and non-fungible tokens into a single contract that gives users control over their money and assets. To accomplish this, we're going to take you through these steps to create a composable smart contract and get comfortable with the marketplace:
+
+1. Ensure that your fungible token and non-fungible token contracts are deployed and set up correctly.
+2. Deploy the marketplace type declarations to account `0x03`.
+3. Create a marketplace object and store it in your account storage, putting an NFT up for sale and publishing a public capability for your sale.
+4. Use a different account to purchase the NFT from the sale.
+5. Run a script to verify that the NFT was purchased.
+
+**Before proceeding with this tutorial**, you need to complete the [Fungible Tokens](/cadence/tutorial/03-fungible-tokens/) and [Non-Fungible Token](/cadence/tutorial/04-non-fungible-tokens/) tutorials to understand how the building blocks of this smart contract work.
+
+## Marketplace Design
+
+---
+
+One way to implement a marketplace is to have a central smart contract that users deposit their NFTs and their price into, and have anyone come by and be able to buy the token for that price. This approach is reasonable, but it centralizes the process. We want users to be able to maintain ownership of the NFTs that they are trying to sell while they are trying to sell them.
+
+Instead of taking this centralized approach, each user can list a sale in their account. Then, users could either provide a reference to their sale to an application that can list it centrally, or to a central sale aggregator smart contract if they want the entire transaction to stay on-chain. This way, the owner of the token keeps custody of their token while it is on sale.
+
+<Callout type="info">
+
+Before we start, we need to confirm the state of your accounts. <br/>
+If you haven't already, please perform the steps in the previous tutorial to ensure that the Fungible Token and Non-Fungible Token contracts are deployed to account 1 and 2 and own some tokens. Your accounts should look like this:
+
+</Callout>
+
+<Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/account-nft-storage.png" />
+
+<Callout type="info">
+
+You can run the `CheckSetupScript.cdc` script to ensure that your accounts are correctly set up:
+
+</Callout>
+
+```cadence:title=CheckSetupScript.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+
+// This script checks that the accounts are set up correctly for the marketplace tutorial.
+//
+// Account 0x01: Vault Balance = 40, NFT.id = 1
+// Account 0x02: Vault Balance = 20, No NFTs
+pub fun main() {
+  // Get the accounts' public account objects
+  let acct1 = getAccount(0x01)
+  let acct2 = getAccount(0x02)
+
+  // Get references to the account's receivers
+  // by getting their public capability
+  // and borrowing a reference from the capability
+  let acct1ReceiverRef = acct1.getCapability<&FungibleToken.Vault{FungibleToken.Balance}>(/public/MainReceiver)
+    .borrow()
+    ?? panic("Could not borrow a reference to acc1 vault receiver")
+
+  let acct2ReceiverRef = acct2.getCapability<&FungibleToken.Vault{FungibleToken.Balance}>(/public/MainReceiver)
+    .borrow()
+    ?? panic("Could not borrow a reference to acc2 vault receiver")
+
+  // Log the Vault balance of both accounts and ensure they are
+  // the correct numbers.
+  // Account 0x01 should have 40.
+  // Account 0x02 should have 20.
+  log("Account 1 Balance")
+  log(acct1ReceiverRef.balance)
+  log("Account 2 Balance")
+  log(acct2ReceiverRef.balance)
+
+  // verify that the balances are correct
+  if acct1ReceiverRef.balance != 40.0 || acct2ReceiverRef.balance != 40.0 {
+      panic("Wrong balances!")
+  }
+
+  // Find the public Receiver capability for their Collections
+  let acct1Capability = acct1.getCapability<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver)
+  let acct2Capability = acct2.getCapability<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver)
+
+  // borrow references from the capabilities
+  let nft1Ref = acct1Capability.borrow()
+        ?? panic("Could not borrow a reference to acc1 nft collection receiver")
+
+  let nft2Ref = acct2Capability.borrow()
+        ?? panic("Could not borrow a reference to acc2 nft collection receiver")
+
+  // Print both collections as arrays of IDs
+  log("Account 1 NFTs")
+  log(nft1Ref.getIDs())
+
+  log("Account 2 NFTs")
+  log(nft2Ref.getIDs())
+
+  // verify that the collections are correct
+  if nft1Ref.getIDs()[0] != UInt64(1) || nft2Ref.getIDs().length != 0 {
+      panic("Wrong Collections!")
+  }
+}
+```
+
+You should see something similar to this output if your accounts are set up correctly.
+They are in the same state that they would have been in if you followed
+the [Fungible Tokens](/cadence/tutorial/03-fungible-tokens/) and [Non-Fungible Tokens](/cadence/tutorial/04-non-fungible-tokens/) tutorials in succession:
+
+```
+"Account 1 Vault Balance"
+40
+"Account 2 Vault Balance"
+20
+"Account 1 NFTs"
+[1]
+"Account 2 NFTs"
+[]
+```
+
+Now that your accounts are in the correct state, we can build a marketplace that enables the sale of NFT's between accounts.
+
+## Setting up an NFT **Marketplace**
+
+---
+
+Every user who wants to sell an NFT will store an instance of a `SaleCollection` resource in their account storage.
+
+<Callout type="info">
+
+Switch to account `0x03`.
+Open `Marketplace.cdc`<br/>
+With `Marketplace.cdc` open, click the `Deploy` button that appears at the bottom right of the editor.
+`Marketplace.cdc` should contain the following contract definition:
+
+</Callout>
+
+```cadence:title=Marketplace.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+
+// The Marketplace contract is a sample implementation of an NFT Marketplace on Flow.
+//
+// This contract allows users to put their NFTs up for sale. Other users
+// can purchase these NFTs with fungible tokens.
+
+pub contract Marketplace {
+
+  // Event that is emitted when a new NFT is put up for sale
+  pub event ForSale(id: UInt64, price: UFix64)
+
+  // Event that is emitted when the price of an NFT changes
+  pub event PriceChanged(id: UInt64, newPrice: UFix64)
+
+  // Event that is emitted when a token is purchased
+  pub event TokenPurchased(id: UInt64, price: UFix64)
+
+  // Event that is emitted when a seller withdraws their NFT from the sale
+  pub event SaleWithdrawn(id: UInt64)
+
+  // Interface that users will publish for their Sale collection
+  // that only exposes the methods that are supposed to be public
+  //
+  pub resource interface SalePublic {
+    pub fun purchase(tokenID: UInt64, recipient: &AnyResource{NonFungibleToken.NFTReceiver}, buyTokens: @FungibleToken.Vault)
+    pub fun idPrice(tokenID: UInt64): UFix64?
+    pub fun getIDs(): [UInt64]
+  }
+
+  // SaleCollection
+  //
+  // NFT Collection object that allows a user to put their NFT up for sale
+  // where others can send fungible tokens to purchase it
+  //
+  pub resource SaleCollection: SalePublic {
+
+    // Dictionary of the NFTs that the user is putting up for sale
+    pub var forSale: @{UInt64: NonFungibleToken.NFT}
+
+    // Dictionary of the prices for each NFT by ID
+    pub var prices: {UInt64: UFix64}
+
+    // The fungible token vault of the owner of this sale.
+    // When someone buys a token, this resource can deposit
+    // tokens into their account.
+    access(account) let ownerVault: Capability<&AnyResource{FungibleToken.Receiver}>
+
+    init (vault: Capability<&AnyResource{FungibleToken.Receiver}>) {
+        self.forSale <- {}
+        self.ownerVault = vault
+        self.prices = {}
+    }
+
+    // withdraw gives the owner the opportunity to remove a sale from the collection
+    pub fun withdraw(tokenID: UInt64): @NonFungibleToken.NFT {
+        // remove the price
+        self.prices.remove(key: tokenID)
+        // remove and return the token
+        let token <- self.forSale.remove(key: tokenID) ?? panic("missing NFT")
+        return <-token
+    }
+
+    // listForSale lists an NFT for sale in this collection
+    pub fun listForSale(token: @NonFungibleToken.NFT, price: UFix64) {
+        let id = token.id
+
+        // store the price in the price array
+        self.prices[id] = price
+
+        // put the NFT into the the forSale dictionary
+        let oldToken <- self.forSale[id] <- token
+        destroy oldToken
+
+        emit ForSale(id: id, price: price)
+    }
+
+    // changePrice changes the price of a token that is currently for sale
+    pub fun changePrice(tokenID: UInt64, newPrice: UFix64) {
+        self.prices[tokenID] = newPrice
+
+        emit PriceChanged(id: tokenID, newPrice: newPrice)
+    }
+
+    // purchase lets a user send tokens to purchase an NFT that is for sale
+    pub fun purchase(tokenID: UInt64, recipient: &AnyResource{NonFungibleToken.NFTReceiver}, buyTokens: @FungibleToken.Vault) {
+        pre {
+            self.forSale[tokenID] != nil && self.prices[tokenID] != nil:
+                "No token matching this ID for sale!"
+            buyTokens.balance >= (self.prices[tokenID] ?? 0.0):
+                "Not enough tokens to by the NFT!"
+        }
+
+        // get the value out of the optional
+        let price = self.prices[tokenID]!
+
+        self.prices[tokenID] = nil
+
+        let vaultRef = self.ownerVault.borrow()
+            ?? panic("Could not borrow reference to owner token vault")
+
+        // deposit the purchasing tokens into the owners vault
+        vaultRef.deposit(from: <-buyTokens)
+
+        // deposit the NFT into the buyers collection
+        recipient.deposit(token: <-self.withdraw(tokenID: tokenID))
+
+        emit TokenPurchased(id: tokenID, price: price)
+    }
+
+    // idPrice returns the price of a specific token in the sale
+    pub fun idPrice(tokenID: UInt64): UFix64? {
+        return self.prices[tokenID]
+    }
+
+    // getIDs returns an array of token IDs that are for sale
+    pub fun getIDs(): [UInt64] {
+        return self.forSale.keys
+    }
+
+    destroy() {
+        destroy self.forSale
+    }
+  }
+
+  // createCollection returns a new collection resource to the caller
+  pub fun createSaleCollection(ownerVault: Capability<&AnyResource{FungibleToken.Receiver}>): @SaleCollection {
+    return <- create SaleCollection(vault: ownerVault)
+  }
+}
+```
+
+This marketplace contract has resources that function similarly to the NFT `Collection` that was explained in [Non-Fungible Tokens](/cadence/tutorial/04-non-fungible-tokens), with a few differences and additions:
+
+- This marketplace contract has methods to add and remove NFTs, but these functions also involve setting and removing a price. When a user wants to put their NFT up for sale, they do so by depositing it into the collection with the `listForSale` function. Then, another user can call the `purchase` method, sending their `Vault` that contains the currency they are using to make the purchase. The buyer also includes a reference to their NFT `Collection` so that the purchased token can be immediately deposited into their collection when the purchase is made.
+- This marketplace contract stores a capability: `pub let ownerVault: Capability<&AnyResource{FungibleToken.Receiver}>`.
+  The owner of the sale saves a capability to their Fungible Token `Receiver` within the sale.
+  This allows the sale resource to be able to immediately deposit the currency that was used to buy the NFT into the owners `Vault` when a purchase is made.
+- This marketplace contract includes events. Cadence supports defining events within contracts that can be emitted when important actions happen.
+
+```cadence
+pub event ForSale(id: UInt64, price: UFix64)
+pub event PriceChanged(id: UInt64, newPrice: UFix64)
+pub event TokenPurchased(id: UInt64, price: UFix64)
+pub event SaleWithdrawn(id: UInt64)
+```
+
+Events are declared by indicating the access level, `event`, and the name and parameters of the event, like a function declaration.
+Events cannot modify state at all; they indicate when important actions happen in the smart contract.
+Events are emitted with the `emit` keyword followed by the invocation of the event as if it were a function call.
+External applications can monitor the blockchain to take action when certain events are emitted.
+
+At this point, we should have a fungible token `Vault` and an NFT `Collection` in both accounts' storage.
+Account `0x01` should have an NFT in their collection.
+
+You can create a `SaleCollection` and list account `0x01`'s token for sale by following these steps:
+
+<Callout type="info">
+
+Open `Transaction1.cdc` <br/>
+Select account `0x01` as the only signer and click the `Send` button to submit the transaction.
+
+</Callout>
+
+```cadence:title=Transaction1.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+import Marketplace from 0x03
+
+// This transaction creates a new Sale Collection object,
+// lists an NFT for sale, puts it in account storage,
+// and creates a public capability to the sale so that others can buy the token.
+transaction {
+
+  prepare(acct: AuthAccount) {
+
+    // Borrow a reference to the stored Vault
+    let receiver = acct.getCapability<&{FungibleToken.Receiver}>(/public/MainReceiver)
+
+    // Create a new Sale object,
+    // initializing it with the reference to the owner's vault
+    let sale <- Marketplace.createSaleCollection(ownerVault: receiver)
+
+    // borrow a reference to the NFTCollection in storage
+    let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/NFTCollection)
+            ?? panic("Could not borrow a reference to the owner's nft collection")
+
+    // Withdraw the NFT from the collection that you want to sell
+    // and move it into the transaction's context
+    let token <- collectionRef.withdraw(withdrawID: 1)
+
+    // List the token for sale by moving it into the sale object
+    sale.listForSale(token: <-token, price: 10.0)
+
+    // Store the sale object in the account storage
+    acct.save<@Marketplace.SaleCollection>(<-sale, to: /storage/NFTSale)
+
+    // Create a public capability to the sale so that others can call its methods
+    acct.link<&Marketplace.SaleCollection{Marketplace.SalePublic}>(/public/NFTSale, target: /storage/NFTSale)
+
+    log("Sale Created for account 1. Selling NFT 1 for 10 tokens")
+  }
+}
+```
+
+This transaction:
+
+1. Gets a capability for the owners `Vault`
+2. Creates the `SaleCollection`, which stores their `Vault` reference.
+3. Withdraws the owner's token from their normal collection
+4. Lists that token for sale and sets its price
+5. Stores the sale in their account storage and publishes a capability that allows others to purchase any NFTs for sale.
+
+Let's run a script to ensure that the sale was created correctly.
+
+<Callout type="info">
+
+Open `Script2.cdc`<br/>
+Click the `Execute` button to print the ID and price of the NFT that account `0x01` has for sale.s
+
+</Callout>
+
+```cadence:title=Script2.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+import Marketplace from 0x03
+
+// This script prints the NFTs that account 0x01 has for sale.
+pub fun main() {
+  // Get the public account object for account 0x01
+  let account1 = getAccount(0x01)
+
+  // Find the public Sale reference to their Collection
+  let acct1saleRef = account1.getCapability<&AnyResource{Marketplace.SalePublic}>(/public/NFTSale)
+        .borrow()
+        ?? panic("Could not borrow a reference to the sale")
+
+  // Los the NFTs that are for sale
+  log("Account 1 NFTs for sale")
+  log(acct1saleRef.getIDs())
+  log("Price")
+  log(acct1saleRef.idPrice(tokenID: 1))
+}
+```
+
+This script should complete and print something like this:
+
+```
+"Account 1 NFTs for sale"
+[1]
+"Price"
+10
+```
+
+## Purchasing an NFT
+
+---
+
+The buyer can now purchase the seller's NFT by using the transaction in `Transaction2.cdc`.
+
+<Callout type="info">
+
+Open the `Transaction2.cdc` file<br/>
+Select account `0x02` as the only signer and click the `Send` button.
+
+</Callout>
+
+```cadence:title=Transaction2.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+import Marketplace from 0x03
+
+// This transaction uses the signer's Vault tokens to purchase an NFT
+// from the Sale collection of account 0x01.
+transaction {
+
+  // reference to the buyer's NFT collection where they
+  // will store the bought NFT
+  let collectionRef: &AnyResource{NonFungibleToken.NFTReceiver}
+
+  // Vault that will hold the tokens that will be used to
+  // but the NFT
+  let temporaryVault: @FungibleToken.Vault
+
+  prepare(acct: AuthAccount) {
+
+    // get the references to the buyer's fungible token Vault
+    // and NFT Collection Receiver
+    self.collectionRef = acct.borrow<&AnyResource{NonFungibleToken.NFTReceiver}>(from: /storage/NFTCollection)
+        ?? panic("Could not borrow reference to the signer's nft collection")
+
+    let vaultRef = acct.borrow<&FungibleToken.Vault>(from: /storage/MainVault)
+        ?? panic("Could not borrow reference to the signer's vault")
+
+    // withdraw tokens from the buyers Vault
+    self.temporaryVault <- vaultRef.withdraw(amount: 10.0)
+  }
+
+  execute {
+    // get the read-only account storage of the seller
+    let seller = getAccount(0x01)
+
+    // get the reference to the seller's sale
+    let saleRef = seller.getCapability<&AnyResource{Marketplace.SalePublic}>(/public/NFTSale)
+        .borrow()
+        ?? panic("could not borrow reference to the seller's sale")
+
+    // purchase the NFT the the seller is selling, giving them the reference
+    // to your NFT collection and giving them the tokens to buy it
+    saleRef.purchase(tokenID: 1,
+        recipient: self.collectionRef,
+        buyTokens: <-self.temporaryVault)
+
+    log("Token 1 has been bought by account 2!")
+  }
+}
+
+```
+
+This transaction:
+
+1. Gets the public account object for account `0x01`
+2. Gets the references to the buyer's stored resources
+3. Withdraws the tokens that the buyer will use to purchase the NFT
+4. Gets the reference to the seller's public sale
+5. Calls the `purchase` function, passing in the tokens and the `Collection` reference. Then `purchase` deposits the bought NFT directly into the buyer's collection.
+
+## Verifying the NFT Was Purchased Correctly
+
+---
+
+You can run now run a script to verify that the NFT was purchased correctly because:
+
+- account `0x01` has 50 tokens and does not have any NFTs for sale or in their collection and account
+- account `0x02` has 10 tokens and an NFT with id=1
+
+To run a script that verifies the NFT was purchased correctly, follow these steps:
+
+<Callout type="info">
+  Open the `Script3.cdc` file.
+  <br />
+  Click `Execute` button `Script3.cdc` should contain the following code:
+</Callout>
+
+```cadence:title=Script3.cdc
+import FungibleToken from 0x01
+import NonFungibleToken from 0x02
+import Marketplace from 0x03
+
+// This script checks that the Vault balances and NFT collections are correct
+// for both accounts.
+//
+// Account 1: Vault balance = 50, No NFTs
+// Account 2: Vault balance = 10, NFT ID=1
+pub fun main() {
+  // Get the accounts' public account objects
+  let acct1 = getAccount(0x01)
+  let acct2 = getAccount(0x02)
+
+  // Get references to the account's receivers
+  // by getting their public capability
+  // and borrowing a reference from the capability
+  let acct1ReceiverRef = acct1.getCapability<&FungibleToken.Vault{FungibleToken.Balance}>(/public/MainReceiver)
+        .borrow()
+        ?? panic("Could not borrow reference to acct1 vault")
+
+  let acct2ReceiverRef = acct2.getCapability<&FungibleToken.Vault{FungibleToken.Balance}>(/public/MainReceiver)
+        .borrow()
+        ?? panic("Could not borrow reference to acct2 vault")
+
+  // Log the Vault balance of both accounts and ensure they are
+  // the correct numbers.
+  // Account 0x01 should have 50.
+  // Account 0x02 should have 10.
+  log("Account 1 Balance")
+  log(acct1ReceiverRef.balance)
+  log("Account 2 Balance")
+  log(acct2ReceiverRef.balance)
+
+  // verify that the balances are correct
+  if acct1ReceiverRef.balance != 50.0
+     || acct2ReceiverRef.balance != 10.0
+  {
+      panic("Wrong balances!")
+  }
+
+  // Find the public Receiver capability for their Collections
+  let acct1Capability = acct1.getCapability<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver)
+  let acct2Capability = acct2.getCapability<&{NonFungibleToken.NFTReceiver}>(/public/NFTReceiver)
+
+  // borrow references from the capabilities
+  let nft1Ref = acct1Capability.borrow()
+    ?? panic("Could not borrow reference to acct1 nft collection")
+
+  let nft2Ref = acct2Capability.borrow()
+    ?? panic("Could not borrow reference to acct2 nft collection")
+
+  // Print both collections as arrays of IDs
+  log("Account 1 NFTs")
+  log(nft1Ref.getIDs())
+
+  log("Account 2 NFTs")
+  log(nft2Ref.getIDs())
+
+  // verify that the collections are correct
+  if nft2Ref.getIDs()[0] != 1 as UInt64 || nft1Ref.getIDs().length != 0 {
+      panic("Wrong Collections!")
+  }
+
+  // Get the public sale reference for Account 0x01
+  let acct1SaleRef = acct1.getCapability<&AnyResource{Marketplace.SalePublic}>(/public/NFTSale)
+        .borrow()
+        ?? panic("Could not borrow a reference to the sale")
+
+  // Print the NFTs that account 0x01 has for sale
+  log("Account 1 NFTs for sale")
+  log(acct1SaleRef.getIDs())
+  if acct1SaleRef.getIDs().length != 0 { panic("Sale should be empty!") }
+}
+```
+
+If you did everything correctly, the transaction should succeed and it should print something similar to this:
+
+```
+"Account 1 Vault Balance"
+50
+"Account 2 Vault Balance"
+10
+"Account 1 NFTs"
+[]
+"Account 2 NFTs"
+[1]
+"Account 1 NFTs for Sale"
+[]
+```
+
+Congratulations, you have successfully implemented a simple marketplace in Cadence and used it to allow one account to buy an NFT from another!
+
+## Scaling the Marketplace
+
+---
+
+A user can hold a sale in their account with these resources and transactions.
+Support for a central marketplace where users can discover sales is relatively easy to implement and can build on what we already have.
+If we wanted to build a central marketplace on-chain, we could use a contract that looks something like this:
+
+```cadence:title=CentralMarketplace.cdc
+// Marketplace would be the central contract where people can post their sale
+// references so that anyone can access them
+pub contract Marketplace {
+    // Data structure to store active sales
+    pub var tokensForSale: [Capability<&SaleCollection>]
+
+    // listSaleCollection lists a users sale reference in the array
+    // and returns the index of the sale so that users can know
+    // how to remove it from the marketplace
+    pub fun listSaleCollection(collection: Capability<&SaleCollection>): Int {
+        self.tokensForSale.append(collection)
+        return (self.tokensForSale.length - 1)
+    }
+
+    // removeSaleCollection removes a user's sale from the array
+    // of sale references
+    pub fun removeSaleCollection(index: Int) {
+        self.tokensForSale.remove(at: index)
+    }
+
+}
+```
+
+This contract isn't meant to be a working or production-ready contract, but it could be extended to make a complete central marketplace by having:
+
+- Sellers list a capability to their `SaleCollection` in this contract
+- Other functions that buyers could call to get info about all the different sales and to make purchases.
+
+A central marketplace in an off-chain application is easier to implement because:
+
+- The app could host the marketplace and a user would simply log in to the app and give the app its account address.
+- The app could read the user's public storage and find their sale reference.
+- With the sale reference, the app could get all the information they need about how to display the sales on their website.
+- Any buyer could discover the sale in the app and login with their account, which gives the app access to their public references.
+- When the buyer wants to buy a specific NFT, the app would automatically generate the proper transaction to purchase the NFT from the seller.
+
+## Creating a **Marketplace for Any Generic NFT**
+
+---
+
+The previous examples show how a simple marketplace could be created for a specific class of NFTs. However, users will want to have a marketplace where they can buy and sell any NFT they want, regardless of its type. Support for this feature is in development and will be shared soon.
+
+## Composable Resources on Flow
+
+---
+
+Now that you have an understanding of how composable smart contracts and the marketplace work on Flow, you're ready to play with composable resources!

--- a/docs/tutorial/06-marketplace-compose.mdx
+++ b/docs/tutorial/06-marketplace-compose.mdx
@@ -1,6 +1,6 @@
 ---
 title: 6. Marketplace
-type: TUT
+contentType: TUT
 ---
 
 In this tutorial, we're going to create a marketplace that uses both the fungible and non-fungible token (NFTs) contracts that we have learned about in previous tutorials.

--- a/docs/tutorial/06-marketplace-compose.mdx
+++ b/docs/tutorial/06-marketplace-compose.mdx
@@ -1,5 +1,6 @@
 ---
 title: 6. Marketplace
+type: TUT
 ---
 
 In this tutorial, we're going to create a marketplace that uses both the fungible and non-fungible token (NFTs) contracts that we have learned about in previous tutorials.

--- a/docs/tutorial/07-resources-compose.mdx
+++ b/docs/tutorial/07-resources-compose.mdx
@@ -1,5 +1,6 @@
 ---
 title: 7. Composable Resources
+type: TUT
 ---
 
 In this tutorial, we're going to walk through how resources can own other resources by creating, deploying, and moving composable NFTs.

--- a/docs/tutorial/07-resources-compose.mdx
+++ b/docs/tutorial/07-resources-compose.mdx
@@ -1,0 +1,241 @@
+---
+title: 7. Composable Resources
+---
+
+In this tutorial, we're going to walk through how resources can own other resources by creating, deploying, and moving composable NFTs.
+
+---
+
+<Callout type="info">
+
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/fb934880-ba3a-4d0d-8350-7bea017e6138" target="_blank">https://play.onflow.org/fb934880-ba3a-4d0d-8350-7bea017e6138</a><br/>
+The tutorial will be asking you do take various actions to interact with this code.
+
+</Callout>
+
+<Callout type="info">
+
+Instructions that require you to take action are always included in a callout box like this one. These highlighted actions are all that you need to do to get your code running, but reading the rest is necessary to understand the language's design.
+
+</Callout>
+
+Resources owning other resources is a powerful feature in the world of blockchain and smart contracts. To showcase how this feature works on Flow, this tutorial will take you through these steps with a composable NFT:
+
+1. Deploy the `Kitty` and `KittyHat` definitions to account `0x01`
+2. Create a `Kitty` and two `KittyHat`s and store them in your account
+3. Move the Kitties and Hats around to see how composable NFTs function on Flow
+
+**Before proceeding with this tutorial**, we recommend following the instructions in [Getting Started](/cadence/tutorial/01-first-steps/) and [Hello, World!](/cadence/tutorial/02-hello-world/) to learn about the Playground and Cadence.
+
+For additional support, see the [Playground Manual](/intro/playground-manual/)
+
+## Resources Owning Resources
+
+---
+
+The NFT collections talked about in [Non-Fungible Tokens](/cadence/tutorial/04-non-fungible-tokens) are examples of resources that own other resources. We have a resource, the NFT collection, that has ownership of the NFT resources that are stored within it. The owner and anyone with a reference can move these resources around, but they still belong to the collection while they are in it and the code defined in the collection has ultimate control over the resources.
+
+When the collection is moved or destroyed, all of the NFTs inside of it are moved or destroyed with it.
+
+If the owner of the collection transferred the whole collection resource to another user's account, all of the tokens will move to the other user's account with it. The tokens don't stay in the original owner's account. This is like handing someone your wallet instead of just a dollar bill. It isn't a common action, but certainly is possible.
+
+References cannot be created for resources that are stored in other resources. The owning resource has control over it and therefore controls the type of access that external calls have on the stored resource.
+
+## Resources Owning Resources: An Example
+
+---
+
+The NFT collection is a simple example of how resources can own other resources, but innovative and more powerful versions can be made.
+
+An important feature of CryptoKitties (and other applications on the Ethereum blockchain) is that any developer can make new experiences around the existing application. Even though the original contract didn't include specific support for CryptoKitty accessories (like hats), an independent developer was still able to make hats that Kitties from the original contract could use.
+
+Here is a basic example of how we can replicate this feature in Cadence:
+
+<!-- [block:callout]
+{
+"type": "info",
+"body": ""
+}
+[/block] -->
+
+<Callout type="info">
+
+Open the account `0x01` tab which has the contract named `KittyVerse.cdc`. Deploy the code to account `0x01`
+
+</Callout>
+
+```cadence:title=KittyVerse.cdc
+// The KittyVerse contract defines two types of NFTs.
+// One is a KittyHat, which represents a special hat, and
+// the second is the Kitty resource, which can own Kitty Hats.
+//
+// You can put the hats on the cats and then call a hat function
+// that tips the hat and prints a fun message.
+//
+// This is a simple example of how Cadence supports
+// extensibility for smart contracts, but the language will soon
+// support even more powerful versions of this.
+
+pub contract KittyVerse {
+
+    // KittyHat is a special resource type that represents a hat
+    pub resource KittyHat {
+        pub let id: Int
+        pub let name: String
+
+        init(id: Int, name: String) {
+            self.id = id
+            self.name = name
+        }
+
+        // An example of a function someone might put in their hat resource
+        pub fun tipHat(): String {
+            if self.name == "Cowboy Hat" {
+                return "Howdy Y'all"
+            } else if self.name == "Top Hat" {
+                return "Greetings, fellow aristocats!"
+            }
+
+            return "Hello"
+        }
+    }
+
+    // Create a new hat
+    pub fun createHat(id: Int, name: String): @KittyHat {
+        return <-create KittyHat(id: id, name: name)
+    }
+
+    pub resource Kitty {
+
+        pub let id: Int
+
+        // place where the Kitty hats are stored
+        pub let items: @{String: KittyHat}
+
+        init(newID: Int) {
+            self.id = newID
+            self.items <- {}
+        }
+
+        destroy() {
+            destroy self.items
+        }
+    }
+
+    pub fun createKitty(): @Kitty {
+        return <-create Kitty(newID: 1)
+    }
+}
+```
+
+These definitions show how a Kitty resource could own hats.
+
+The hats are stored in a variable in the Kitty resource.
+
+    // place where the Kitty hats are stored
+    pub let items: <-{String: KittyHat}
+
+A Kitty owner can take the hats off the Kitty and transfer them individually. Or the owner can transfer a Kitty that owns a hat, and the hat will go along with the Kitty.
+
+Here is a transaction to create a `Kitty` and a `KittyHat`, store the hat in the Kitty, then store it in your account storage.
+
+<Callout type="info">
+
+Open `Transaction1.cdc`. <br/>
+Select account `0x01` as the only signer<br/>
+Send the transaction by clicking the Send button. <br/>
+`Transaction1.cdc` should contain the following code:
+
+</Callout>
+
+```cadence:title=Transaction1.cdc
+import KittyVerse from 0x01
+
+// This transaction creates a new kitty, creates two new hats and
+// puts the hats on the cat. Then it stores the kitty in account storage.
+transaction {
+  prepare(acct: AuthAccount) {
+
+    // Create the Kitty object
+    let kitty <- KittyVerse.createKitty()
+
+    // Create the KittyHat objects
+    let hat1 <- KittyVerse.createHat(id: 1, name: "Cowboy Hat")
+    let hat2 <- KittyVerse.createHat(id: 2, name: "Top Hat")
+
+    // Put the hat on the cat!
+    let oldCowboyHat <- kitty.items["Cowboy Hat"] <- hat1
+    destroy oldCowboyHat
+    let oldTopHat <- kitty.items["Top Hat"] <- hat2
+    destroy oldTopHat
+
+    log("The cat has the hats")
+
+    // Store the Kitty in storage
+    acct.save<@KittyVerse.Kitty>(<-kitty, to: /storage/Kitty)
+  }
+}
+```
+
+You should see an output that looks something like this:
+
+```
+> "The Cat has the Hats"
+```
+
+Now we can run a transaction to move the Kitty along with its hat, remove the cowboy hat from the Kitty, then make the Kitty tip its hat.
+
+<Callout type="info">
+
+Open `Transaction2.cdc`<br/>
+Select account `0x01` as the only signer.<br/>
+Send the transaction.<br/>
+Transaction2.cdc` should contain the following code:
+
+</Callout>
+
+```cadence:title=Transaction2.cdc
+import KittyVerse from 0x01
+
+// This transaction moves a kitty out of storage,
+// takes the cowboy hat off of the kitty,
+// calls its tip hat function, and then moves it back into storage.
+transaction {
+  prepare(acct: AuthAccount) {
+
+    // Move the Kitty out of storage, which also moves its hat along with it
+    let kitty <- acct.load<@KittyVerse.Kitty>(from: /storage/Kitty)!
+
+    // Take the cowboy hat off the Kitty
+    let cowboyHat <- kitty.items.remove(key: "Cowboy Hat")!
+
+    // Tip the cowboy hat
+    log(cowboyHat.tipHat())
+    destroy cowboyHat
+
+    // Tip the top hat that is on the Kitty
+    log(kitty.items["Top Hat"]?.tipHat())
+
+    // Move the Kitty to storage, which
+    // also moves its hat along with it.
+    acct.save<@KittyVerse.Kitty>(<-kitty, to: /storage/Kitty)
+  }
+}
+```
+
+You should see something like this output:
+
+```
+> "Howdy Y'all"
+> "Greetings, fellow aristocats!"
+```
+
+Whenever the Kitty is moved, its hats are implicitly moved along with it. This is because the hats are owned by the Kitty.
+
+## The Future is Meow! Extensibility is coming!
+
+---
+
+The above is a simple example of composable resources. We had to explicitly say that a Kitty could own a Hat in this example, but in the near future, Cadence will support more powerful ways of achieving resource extensibility where developers can declare types that separate resources can own even if the owning resource never specified the ownership possibility in the first place. This is a very complex problem to solve in a safe way, and the Flow community is working very hard to design a solution for this, but it is coming.
+
+Practice what you're learned in the Flow Playground!

--- a/docs/tutorial/07-resources-compose.mdx
+++ b/docs/tutorial/07-resources-compose.mdx
@@ -1,6 +1,6 @@
 ---
 title: 7. Composable Resources
-type: TUT
+contentType: TUT
 ---
 
 In this tutorial, we're going to walk through how resources can own other resources by creating, deploying, and moving composable NFTs.

--- a/docs/tutorial/08-voting.mdx
+++ b/docs/tutorial/08-voting.mdx
@@ -1,6 +1,6 @@
 ---
 title: 8. Voting Contract
-type: TUT
+contentType: TUT
 ---
 
 In this tutorial, we're going to deploy a contract that allows users to vote on multiple proposals that a voting administrator controls.

--- a/docs/tutorial/08-voting.mdx
+++ b/docs/tutorial/08-voting.mdx
@@ -1,5 +1,6 @@
 ---
 title: 8. Voting Contract
+type: TUT
 ---
 
 In this tutorial, we're going to deploy a contract that allows users to vote on multiple proposals that a voting administrator controls.

--- a/docs/tutorial/08-voting.mdx
+++ b/docs/tutorial/08-voting.mdx
@@ -1,0 +1,406 @@
+---
+title: 8. Voting Contract
+---
+
+In this tutorial, we're going to deploy a contract that allows users to vote on multiple proposals that a voting administrator controls.
+
+---
+
+<Callout type="success">
+
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/f608ebbd-f8a0-4c6a-9a51-d1c62fc0d3bb" target="_blank">https://play.onflow.org/f608ebbd-f8a0-4c6a-9a51-d1c62fc0d3bb</a><br/>
+The tutorial will be asking you to take various actions to interact with this code.
+
+</Callout>
+
+<Callout type="info">
+
+Instructions that require you to take action are always included in a callout box like this one. These highlighted actions are all that you need to do to get your code running, but reading the rest is necessary to understand the language's design.
+
+</Callout>
+
+With the advent of blockchain technology and smart contracts, it has become popular to try to create decentralized voting mechanisms that allow large groups of users to vote completely on chain. This tutorial will provide a trivial example for how this might be achieved by using a resource-oriented programming model.
+
+We'll take you through these steps to get comfortable with the Voting contract.
+
+1. Deploy the contract to account 1
+2. Create proposals for users to vote on
+3. Use a transaction with multiple signers to directly transfer the `Ballot` resource to another account.
+4. Record and cast your vote in the central Voting contract
+5. Read the results of the vote
+
+Before proceeding with this tutorial, we highly recommend following the instructions in [Getting Started](/cadence/tutorial/01-first-steps/) and [Hello World](/cadence/tutorial/02-hello-world/) to learn how to use the Playground tools and to learn the fundamentals of Cadence.
+
+## A Voting Contract in Cadence
+
+In this contract, a Ballot is represented as a resource. An administrator can give Ballots to other accounts, then those account mark which proposals they vote for and submit the Ballot to the central smart contract to have their votes recorded. Using a resource type is logical for this application, because if a user wants to delegate their vote, they can send that Ballot to another account.
+
+## Deploy the Contract
+
+<Callout type="info">
+
+Open Account `0x01` which has the `ApprovalVoting` contract.<br/>
+Click the Deploy button to deploy it to account `0x01`"
+
+</Callout>
+
+```cadence:title=ApprovalVoting.cdc
+/*
+*
+*   In this example, we want to create a simple approval voting contract
+*   where a polling place issues ballots to addresses.
+*
+*   The run a vote, the Admin deploys the smart contract,
+*   then initializes the proposals
+*   using the initialize_proposals.cdc transaction.
+*   The array of proposals cannot be modified after it has been initialized.
+*
+*   Then they will give ballots to users by
+*   using the issue_ballot.cdc transaction.
+*
+*   Every user with a ballot is allowed to approve any number of proposals.
+*   A user can choose their votes and cast them
+*   with the cast_vote.cdc transaction.
+*
+*/
+
+pub contract ApprovalVoting {
+
+    //list of proposals to be approved
+    pub var proposals: [String]
+
+    // number of votes per proposal
+    pub let votes: {Int: Int}
+
+    // This is the resource that is issued to users.
+    // When a user gets a Ballot object, they call the `vote` function
+    // to include their votes, and then cast it in the smart contract
+    // using the `cast` function to have their vote included in the polling
+    pub resource Ballot {
+
+        // array of all the proposals
+        pub let proposals: [String]
+
+        // corresponds to an array index in proposals after a vote
+        pub var choices: {Int: Bool}
+
+        init() {
+            self.proposals = ApprovalVoting.proposals
+            self.choices = {}
+
+            // Set each choice to false
+            var i = 0
+            while i < self.proposals.length {
+                self.choices[i] = false
+                i = i + 1
+            }
+        }
+
+        // modifies the ballot
+        // to indicate which proposals it is voting for
+        pub fun vote(proposal: Int) {
+            pre {
+                self.proposals[proposal] != nil: "Cannot vote for a proposal that doesn't exist"
+            }
+            self.choices[proposal] = true
+        }
+    }
+
+    // Resource that the Administrator of the vote controls to
+    // initialize the proposals and to pass out ballot resources to voters
+    pub resource Administrator {
+
+        // function to initialize all the proposals for the voting
+        pub fun initializeProposals(_ proposals: [String]) {
+            pre {
+                ApprovalVoting.proposals.length == 0: "Proposals can only be initialized once"
+                proposals.length > 0: "Cannot initialize with no proposals"
+            }
+            ApprovalVoting.proposals = proposals
+
+            // Set each tally of votes to zero
+            var i = 0
+            while i < proposals.length {
+                ApprovalVoting.votes[i] = 0
+                i = i + 1
+            }
+        }
+
+        // The admin calls this function to create a new Ballo
+        // that can be transferred to another user
+        pub fun issueBallot(): @Ballot {
+            return <-create Ballot()
+        }
+    }
+
+    // A user moves their ballot to this function in the contract where
+    // its votes are tallied and the ballot is destroyed
+    pub fun cast(ballot: @Ballot) {
+        var index = 0
+        // look through the ballot
+        while index < self.proposals.length {
+            if ballot.choices[index]! {
+                // tally the vote if it is approved
+                self.votes[index] = self.votes[index]! + 1
+            }
+            index = index + 1;
+        }
+        // Destroy the ballot because it has been tallied
+        destroy ballot
+    }
+
+    // initializes the contract by setting the proposals and votes to empty
+    // and creating a new Admin resource to put in storage
+    init() {
+        self.proposals = []
+        self.votes = {}
+
+        self.account.save<@Administrator>(<-create Administrator(), to: /storage/VotingAdmin)
+    }
+}
+
+```
+
+This contract implements a simple voting mechanism where an administrator can initialize it with an array of proposals to vote on by using the `initializeProposals` function.
+
+```cadence
+// function to initialize all the proposals for the voting
+pub fun initializeProposals(_ proposals: [String]) {
+    pre {
+        ApprovalVoting.proposals.length == 0: "Proposals can only be initialized once"
+        proposals.length > 0: "Cannot initialize with no proposals"
+    }
+    ApprovalVoting.proposals = proposals
+
+    // Set each tally of votes to zero
+    var i = 0
+    while i < proposals.length {
+        ApprovalVoting.votes[i] = 0
+        i = i + 1
+    }
+}
+```
+
+Then they can give `Ballot` resources to other accounts. The other accounts can record their votes on their `Ballot` resource by calling the `vote` function.
+
+```cadence
+pub fun vote(proposal: Int) {
+    pre {
+        self.proposals[proposal] != nil: "Cannot vote for a proposal that doesn't exist"
+    }
+    self.choices[proposal] = true
+}
+```
+
+After a user has voted, they submit their vote to the central smart contract by calling the `cast` function, which records the votes in the `Ballot` and destroys the used `Ballot`.
+
+```cadence
+// A user moves their ballot to this function in the contract where
+// its votes are tallied and the ballot is destroyed
+pub fun cast(ballot: @Ballot) {
+    var index = 0
+    // look through the ballot
+    while index < self.proposals.length {
+        if ballot.choices[index]! {
+            // tally the vote if it is approved
+            self.votes[index] = self.votes[index]! + 1
+        }
+        index = index + 1;
+    }
+    // Destroy the ballot because it has been tallied
+    destroy ballot
+}
+```
+
+When the voting time ends, the administrator can read the tallies for each proposal to see if a proposal has received the right number of votes.
+
+## Perform Voting
+
+Performing the common actions in this voting contract only takes three types of transactions.
+
+1. Initialize Proposals
+2. Send `Ballot` to a voter
+3. Cast Vote
+
+We have a transaction for each step that we provide for you.
+
+<Callout type="info">
+
+"You should have the ApprovalVoting already deployed to account `0x01`.<br/>
+Open Transaction 1 which should have `Transaction1.cdc`<br/>
+Submit the transaction with account `0x01` selected as the only signer.
+
+</Callout>
+
+```cadence:title=Transaction1.cdc
+import ApprovalVoting from 0x01
+
+// This transaction allows the administrator of the Voting contract
+// to create new proposals for voting and save them to the smart contract
+
+transaction {
+    prepare(admin: AuthAccount) {
+
+        // borrow a reference to the admin Resource
+        let adminRef = admin.borrow<&ApprovalVoting.Administrator>(from: /storage/VotingAdmin)!
+
+        // Call the initializeProposals function
+        // to create the proposals array as an array of strings
+        adminRef.initializeProposals(
+            ["Longer Shot Clock", "Trampolines instead of hardwood floors"]
+        )
+
+        log("Proposals Initialized!")
+    }
+
+    post {
+        ApprovalVoting.proposals.length == 2
+    }
+
+}
+```
+
+This transaction allows the administrator of the Voting contract to create new proposals for voting and save them to the smart contract. They do this by calling the `initializeProposals` function on their stored `Administrator` resource, giving it two new proposals to vote on.
+We use the `post` block to ensure that there were two proposals created, like we wished for.
+
+Next, the administrator needs to hand out Ballots to the voters. There isn't an easy `deposit` function this time for them to send a `Ballot` to another account, so how would they do it? This is where multiple-transaction signers can come in handy!
+
+## Selecting multiple Accounts as Signers
+
+A transaction has access to the private account objects of every account that signed it, so if both the admin and the voter sign a transaction, the admin can directly move a `Ballot` resource object to the other account's storage.
+
+In the Flow playground, you can select multiple accounts to sign a transaction to be able to access the private account objects of both accounts.
+
+To select multiple signers, you first need to include two arguments in the `prepare` block of your transaction:
+
+`prepare(acct1: AuthAccount, acct2: AuthAccount)`
+
+The playground will give you an error if the number of selected signers is different than the number of arguments to the prepare block. The playground also maps the accounts you select as signers to the arguments in the order that you select them. The first account you select will be the first argument, and the second account you select is the second argument.
+
+<Callout type="info">
+
+Open Transaction 2 which should have `Transaction2.cdc`.<br/>
+Select account `0x01` as a signer first, then also select account `0x02`. <br/>
+Submit the transaction by clicking the `Send` button
+
+</Callout>
+
+```cadence:title=Transaction2.cdc
+
+import ApprovalVoting from 0x01
+
+// This transaction allows the administrator of the Voting contract
+// to create a new ballot and store it in a voter's account
+// The voter and the administrator have to both sign the transaction
+// so it can access their storage
+
+transaction {
+    prepare(admin: AuthAccount, voter: AuthAccount) {
+
+        // borrow a reference to the admin Resource
+        let adminRef = admin.borrow<&ApprovalVoting.Administrator>(from: /storage/VotingAdmin)!
+
+        // create a new Ballot by calling the issueBallot
+        // function of the admin Reference
+        let ballot <- adminRef.issueBallot()
+
+        // store that ballot in the voter's account storage
+        voter.save<@ApprovalVoting.Ballot>(<-ballot, to: /storage/Ballot)
+
+        log("Ballot transferred to voter")
+    }
+}
+
+```
+
+This transaction has two signers as `prepare` parameters, so it is able to access both of their private `AuthAccount` objects, and therefore their private account storage. Because of this, we can perform a direct transfer of the `Ballot` by creating it with the admin's `issueBallot` function and then directly store it in the voter's storage by using the `save` function.
+
+Account `0x02` should now have a `Ballot` resource object in its account storage. You can confirm this by opening the account 2 tab and seeing the `Ballot` resource shown in the Resources box.
+
+## Casting a Vote
+
+Now that account `0x02` has a `Ballot` in their storage, they can cast their vote. To do this, they will call the `vote` method on their stored resource, then cast that `Ballot` by passing it to the `cast` function in the main smart contract.
+
+<Callout type="info">
+
+Open Transaction 3 which should contain `Transaction3.cdc`.<br/>
+Select account `0x02` as the only transaction signer<br/>
+Click the `send` button to submit the transaction.
+
+</Callout>
+
+```cadence:title=Transaction3.cdc
+import ApprovalVoting from 0x01
+
+// This transaction allows a voter to select the votes they would like to make
+// and cast that vote by using the castVote function
+// of the ApprovalVoting smart contract
+
+transaction {
+    prepare(voter: AuthAccount) {
+
+        // take the voter's ballot our of storage
+        let ballot <- voter.load<@ApprovalVoting.Ballot>(from: /storage/Ballot)!
+
+        // Vote on the proposal
+        ballot.vote(proposal: 1)
+
+        // Cast the vote by submitting it to the smart contract
+        ApprovalVoting.cast(ballot: <-ballot)
+
+        log("Vote cast and tallied")
+    }
+}
+```
+
+In this transaction, the user votes for one of the proposals, and then moves their Ballot back to the smart contract where the vote is tallied.
+
+## Reading the result of the vote
+
+At any time, anyone could read the current tally of votes by directly reading the fields of the contract. You can use a script to do that, since it does not need to modify storage.
+
+<Callout type="info">
+
+Open a Script 1 which should contain the code below.<br/>
+Click the `execute` button to run the script.
+
+</Callout>
+
+```cadence:title=Script1.cdc
+import ApprovalVoting from 0x01
+
+// This script allows anyone to read the tallied votes for each proposal
+//
+
+pub fun main() {
+
+    // Access the public fields of the contract to log
+    // the proposal names and vote counts
+
+    log("Number of Votes for Proposal 1:")
+    log(ApprovalVoting.proposals[0])
+    log(ApprovalVoting.votes[0])
+
+    log("Number of Votes for Proposal 2:")
+    log(ApprovalVoting.proposals[1])
+    log(ApprovalVoting.votes[1])
+
+}
+```
+
+You should see something like this print:
+
+```
+"Number of Votes for Proposal 1:"
+"Longer Shot Clock"
+0
+"Number of Votes for Proposal 2:"
+"Trampolines instead of hardwood floors"
+1
+```
+
+This shows that one vote was cast for proposal 1 and no votes were cast for proposal 2.
+
+## Other Voting possibilities
+
+This contract was a very simple example of voting in Cadence. It clearly couldn't be used for a real-world voting situation, but hopefully you can see what kind of features could be added to it to ensure practicality and security.


### PR DESCRIPTION
## Description

### Tagging all markdown with the content type.

Possible content types: 
`HOWTO` (Guide)
`TUT` (Tutorial)
`INTRO` (index /intro page)
`EXP` (Explainer)
`REF` (Reference)
`FAQ` (Answers)

* all `README` are considered `INTRO` and all `CHANGELOG` are considered `REF`

As outlined here: https://www.notion.so/dapperlabs/Types-of-Docs-033e722018f34036811ff38dac03eded

PR also formats whitespace.