### PR TITLE
Allow the Language Server to be debugged

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,16 @@
 
 This will automatically recompile the language server every time it is started.
 
+## Debugging the Language Server
+
+- Follow the instructions above (see "Running the latest version of the Language Server in the Visual Studio Code Extension")
+
+- Attach to the process of the language server started by Visual Studio Code.
+
+  For example, in Goland, choose Run -> Attach to Process.
+
+  This requires gops to be installed, which can be done using `go get github.com/google/gops`.
+
 ## Tools
 
 The [`runtime/cmd` directory](https://github.com/onflow/cadence/tree/master/runtime/cmd)

--- a/languageserver/run.sh
+++ b/languageserver/run.sh
@@ -3,8 +3,8 @@
 SCRIPTPATH=$(dirname "$0")
 
 
-if [ $1 == "cadence" -a $2 == "language-server" ] ; then
-	(cd "$SCRIPTPATH" && /usr/local/bin/go run ./cmd/languageserver/main.go "$@");
+if [ "$1" = "cadence" ] && [ "$2" = "language-server" ] ; then
+	(cd "$SCRIPTPATH" && /usr/local/bin/go build -gcflags='-N -l' ./cmd/languageserver && ./languageserver "$@");
 else
 	flow "$@"
 fi


### PR DESCRIPTION
## Description

Development on the Language Server is difficult, because standard input/output is used as a communication channel between server and client.

Compile the server with debug information, which enables it to be attached to by a debugger.

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
