### PR TITLE
Fix handling of capability values without borrow type

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -274,7 +274,11 @@ func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) ca
 }
 
 func exportCapabilityValue(v interpreter.CapabilityValue, inter *interpreter.Interpreter) cadence.Capability {
-	borrowType := string(inter.ConvertStaticToSemaType(v.BorrowType).ID())
+	var borrowType string
+	if v.BorrowType != nil {
+		borrowType = string(inter.ConvertStaticToSemaType(v.BorrowType).ID())
+	}
+
 	return cadence.Capability{
 		Path:       exportPathValue(v.Path),
 		Address:    cadence.NewAddress(v.Address),

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -804,6 +804,27 @@ func TestExportCapabilityValue(t *testing.T) {
 
 		assert.Equal(t, expected, actual)
 	})
+
+	t.Run("no borrow type", func(t *testing.T) {
+
+		capability := interpreter.CapabilityValue{
+			Address: interpreter.AddressValue{0x1},
+			Path: interpreter.PathValue{
+				Domain:     common.PathDomainStorage,
+				Identifier: "foo",
+			},
+		}
+		actual := exportValueWithInterpreter(capability, nil, exportResults{})
+		expected := cadence.Capability{
+			Path: cadence.Path{
+				Domain:     "storage",
+				Identifier: "foo",
+			},
+			Address: cadence.Address{0x1},
+		}
+
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestExportLinkValue(t *testing.T) {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7075,8 +7075,12 @@ func (v CapabilityValue) Destroy(_ *Interpreter, _ LocationRange) trampoline.Tra
 }
 
 func (v CapabilityValue) String() string {
+	var borrowType string
+	if v.BorrowType != nil {
+		borrowType = v.BorrowType.String()
+	}
 	return format.Capability(
-		v.BorrowType.String(),
+		borrowType,
 		v.Address.String(),
 		v.Path.String(),
 	)

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -565,7 +565,7 @@ func TestStringer(t *testing.T) {
 			value:    TypeValue{Type: PrimitiveStaticTypeInt},
 			expected: "Type<Int>()",
 		},
-		"Capability": {
+		"Capability with borrow type": {
 			value: CapabilityValue{
 				Path: PathValue{
 					Domain:     common.PathDomainStorage,
@@ -575,6 +575,16 @@ func TestStringer(t *testing.T) {
 				BorrowType: PrimitiveStaticTypeInt,
 			},
 			expected: "Capability<Int>(address: 0x102030405, path: /storage/foo)",
+		},
+		"Capability without borrow type": {
+			value: CapabilityValue{
+				Path: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "foo",
+				},
+				Address: NewAddressValueFromBytes([]byte{1, 2, 3, 4, 5}),
+			},
+			expected: "Capability(address: 0x102030405, path: /storage/foo)",
 		},
 		"Dictionary with non-deferred values": {
 			value: NewDictionaryValueUnownedNonCopying(


### PR DESCRIPTION
## Description


- Fix export of capability value without borrow type
- Fix `String()` function of capability value, handle missing borrow type 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
