### PR TITLE
Add support for importing enum values

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -193,6 +193,8 @@ func decodeJSON(v interface{}) cadence.Value {
 		return decodeTypeValue(valueJSON)
 	case capabilityTypeStr:
 		return decodeCapability(valueJSON)
+	case enumTypeStr:
+		return decodeEnum(valueJSON)
 	}
 
 	panic(ErrInvalidJSONCadence)
@@ -566,6 +568,16 @@ func decodeContract(valueJSON interface{}) cadence.Contract {
 	comp := decodeComposite(valueJSON)
 
 	return cadence.NewContract(comp.fieldValues).WithType(&cadence.ContractType{
+		Location:            comp.location,
+		QualifiedIdentifier: comp.qualifiedIdentifier,
+		Fields:              comp.fieldTypes,
+	})
+}
+
+func decodeEnum(valueJSON interface{}) cadence.Enum {
+	comp := decodeComposite(valueJSON)
+
+	return cadence.NewEnum(comp.fieldValues).WithType(&cadence.EnumType{
 		Location:            comp.location,
 		QualifiedIdentifier: comp.qualifiedIdentifier,
 		Fields:              comp.fieldTypes,

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -181,6 +181,7 @@ const (
 	pathTypeStr       = "Path"
 	typeTypeStr       = "Type"
 	capabilityTypeStr = "Capability"
+	enumTypeStr       = "Enum"
 )
 
 // prepare traverses the object graph of the provided value and constructs
@@ -257,6 +258,8 @@ func Prepare(v cadence.Value) jsonValue {
 		return prepareTypeValue(x)
 	case cadence.Capability:
 		return prepareCapability(x)
+	case cadence.Enum:
+		return prepareEnum(x)
 	default:
 		panic(fmt.Errorf("unsupported value: %T, %v", v, v))
 	}
@@ -483,6 +486,10 @@ func prepareEvent(v cadence.Event) jsonValue {
 
 func prepareContract(v cadence.Contract) jsonValue {
 	return prepareComposite(contractTypeStr, v.ContractType.ID(), v.ContractType.Fields, v.Fields)
+}
+
+func prepareEnum(v cadence.Enum) jsonValue {
+	return prepareComposite(enumTypeStr, v.EnumType.ID(), v.EnumType.Fields, v.Fields)
 }
 
 func prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -376,6 +376,14 @@ func importValue(value cadence.Value) interpreter.Value {
 			Domain:     common.PathDomainFromIdentifier(v.Domain),
 			Identifier: v.Identifier,
 		}
+	case cadence.Enum:
+		return importCompositeValue(
+			common.CompositeKindStructure,
+			v.EnumType.Location,
+			v.EnumType.QualifiedIdentifier,
+			v.EnumType.Fields,
+			v.Fields,
+		)
 	}
 
 	panic(fmt.Sprintf("cannot import value of type %T", value))

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -992,9 +992,7 @@ func TestEnumValue(t *testing.T) {
 
 func importAndExportValuesFromScript(t *testing.T, script string, arg cadence.Value) cadence.Value {
 	encodedArg, err := json.Encode(arg)
-	if err != nil {
-		panic(fmt.Errorf("invalid argument: %w", err))
-	}
+	require.NoError(t, err)
 
 	rt := NewInterpreterRuntime()
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/parser2"
@@ -927,25 +928,11 @@ var fooEventType = &cadence.EventType{
 	Fields:              fooFields,
 }
 
-func TestExportEnumValue(t *testing.T) {
+func TestEnumValue(t *testing.T) {
 
 	t.Parallel()
 
-	script := `
-			pub fun main(): Direction {
-				return Direction.RIGHT
-			}
-
-			pub enum Direction: Int {
-				pub case UP
-				pub case DOWN
-				pub case LEFT
-				pub case RIGHT
-			}
-        `
-
-	actual := exportValueFromScript(t, script)
-	expected := cadence.Enum{
+	enumValue := cadence.Enum{
 		EnumType: &cadence.EnumType{
 			Location:            utils.TestLocation,
 			QualifiedIdentifier: "Direction",
@@ -962,5 +949,73 @@ func TestExportEnumValue(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, actual)
+	t.Run("test export", func(t *testing.T) {
+		script := `
+			pub fun main(): Direction {
+				return Direction.RIGHT
+			}
+
+			pub enum Direction: Int {
+				pub case UP
+				pub case DOWN
+				pub case LEFT
+				pub case RIGHT
+			}
+		`
+
+		actual := exportValueFromScript(t, script)
+		assert.Equal(t, enumValue, actual)
+	})
+
+	t.Run("test import", func(t *testing.T) {
+		script := `
+			pub fun main(dir: Direction): Direction {
+				if !dir.isInstance(Type<Direction>()) {
+					panic("Not a Direction value")
+				}
+
+				return dir
+			}
+
+			pub enum Direction: Int {
+				pub case UP
+				pub case DOWN
+				pub case LEFT
+				pub case RIGHT
+			}
+		`
+
+		actual := importAndExportValuesFromScript(t, script, enumValue)
+		assert.Equal(t, enumValue, actual)
+	})
+}
+
+func importAndExportValuesFromScript(t *testing.T, script string, arg cadence.Value) cadence.Value {
+	encodedArg, err := json.Encode(arg)
+	if err != nil {
+		panic(fmt.Errorf("invalid argument: %w", err))
+	}
+
+	rt := NewInterpreterRuntime()
+
+	runtimeInterface := &testRuntimeInterface{
+		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(b)
+		},
+	}
+
+	value, err := rt.ExecuteScript(
+		Script{
+			Source:    []byte(script),
+			Arguments: [][]byte{encodedArg},
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  utils.TestLocation,
+		},
+	)
+
+	require.NoError(t, err)
+
+	return value
 }


### PR DESCRIPTION
Closes #671

## Description

Adds support for importing enum values as arguments to a cadence script/transaction.


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
