### PR TITLE
Optimize checker activations

### DIFF
--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -48,7 +48,8 @@ func NewKeyTypeValueTypeOrderedMap() *KeyTypeValueTypeOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *KeyTypeValueTypeOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -45,6 +45,14 @@ func NewKeyTypeValueTypeOrderedMap() *KeyTypeValueTypeOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *KeyTypeValueTypeOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/common/orderedmap/orderedmap_string_interface.go
+++ b/runtime/common/orderedmap/orderedmap_string_interface.go
@@ -42,6 +42,14 @@ func NewStringInterfaceOrderedMap() *StringInterfaceOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringInterfaceOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/common/orderedmap/orderedmap_string_interface.go
+++ b/runtime/common/orderedmap/orderedmap_string_interface.go
@@ -45,7 +45,8 @@ func NewStringInterfaceOrderedMap() *StringInterfaceOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringInterfaceOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/common/orderedmap/orderedmap_string_string.go
+++ b/runtime/common/orderedmap/orderedmap_string_string.go
@@ -42,6 +42,14 @@ func NewStringStringOrderedMap() *StringStringOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringStringOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/common/orderedmap/orderedmap_string_string.go
+++ b/runtime/common/orderedmap/orderedmap_string_string.go
@@ -45,7 +45,8 @@ func NewStringStringOrderedMap() *StringStringOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringStringOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/common/orderedmap/orderedmap_string_struct.go
+++ b/runtime/common/orderedmap/orderedmap_string_struct.go
@@ -45,7 +45,8 @@ func NewStringStructOrderedMap() *StringStructOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringStructOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/common/orderedmap/orderedmap_string_struct.go
+++ b/runtime/common/orderedmap/orderedmap_string_struct.go
@@ -42,6 +42,14 @@ func NewStringStructOrderedMap() *StringStructOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringStructOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/common/orderedmap/string_fruit_orderedmap_test.go
+++ b/runtime/common/orderedmap/string_fruit_orderedmap_test.go
@@ -42,6 +42,14 @@ func NewStringFruitOrderedMap() *StringFruitOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringFruitOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/common/orderedmap/string_fruit_orderedmap_test.go
+++ b/runtime/common/orderedmap/string_fruit_orderedmap_test.go
@@ -45,7 +45,8 @@ func NewStringFruitOrderedMap() *StringFruitOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringFruitOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/interpreter/ordered_map_string_computedfield.go
+++ b/runtime/interpreter/ordered_map_string_computedfield.go
@@ -42,6 +42,14 @@ func NewStringComputedFieldOrderedMap() *StringComputedFieldOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringComputedFieldOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/interpreter/ordered_map_string_computedfield.go
+++ b/runtime/interpreter/ordered_map_string_computedfield.go
@@ -45,7 +45,8 @@ func NewStringComputedFieldOrderedMap() *StringComputedFieldOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringComputedFieldOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/interpreter/ordered_map_string_value.go
+++ b/runtime/interpreter/ordered_map_string_value.go
@@ -45,7 +45,8 @@ func NewStringValueOrderedMap() *StringValueOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringValueOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/interpreter/ordered_map_string_value.go
+++ b/runtime/interpreter/ordered_map_string_value.go
@@ -42,6 +42,14 @@ func NewStringValueOrderedMap() *StringValueOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringValueOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -220,8 +220,8 @@ func NewChecker(program *ast.Program, location common.Location, options ...Optio
 		return nil, &MissingLocationError{}
 	}
 
-	valueActivations := NewValueActivations(BaseValueActivation)
-	typeActivations := NewValueActivations(BaseTypeActivation)
+	valueActivations := NewVariableActivations(BaseValueActivation)
+	typeActivations := NewVariableActivations(BaseTypeActivation)
 	functionActivations := &FunctionActivations{}
 	functionActivations.EnterFunction(&FunctionType{
 		ReturnTypeAnnotation: NewTypeAnnotation(VoidType)},

--- a/runtime/sema/ordered_map_interface_resourceinfo.go
+++ b/runtime/sema/ordered_map_interface_resourceinfo.go
@@ -45,7 +45,8 @@ func NewInterfaceResourceInfoOrderedMap() *InterfaceResourceInfoOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *InterfaceResourceInfoOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_interface_resourceinfo.go
+++ b/runtime/sema/ordered_map_interface_resourceinfo.go
@@ -42,6 +42,14 @@ func NewInterfaceResourceInfoOrderedMap() *InterfaceResourceInfoOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *InterfaceResourceInfoOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_interfacetype_struct.go
+++ b/runtime/sema/ordered_map_interfacetype_struct.go
@@ -45,7 +45,8 @@ func NewInterfaceTypeStructOrderedMap() *InterfaceTypeStructOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *InterfaceTypeStructOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_interfacetype_struct.go
+++ b/runtime/sema/ordered_map_interfacetype_struct.go
@@ -42,6 +42,14 @@ func NewInterfaceTypeStructOrderedMap() *InterfaceTypeStructOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *InterfaceTypeStructOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_member_fielddeclaration.go
+++ b/runtime/sema/ordered_map_member_fielddeclaration.go
@@ -49,7 +49,8 @@ func NewMemberAstFieldDeclarationOrderedMap() *MemberAstFieldDeclarationOrderedM
 // Clear removes all entries from this ordered map.
 func (om *MemberAstFieldDeclarationOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_member_fielddeclaration.go
+++ b/runtime/sema/ordered_map_member_fielddeclaration.go
@@ -46,6 +46,14 @@ func NewMemberAstFieldDeclarationOrderedMap() *MemberAstFieldDeclarationOrderedM
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *MemberAstFieldDeclarationOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_member_struct.go
+++ b/runtime/sema/ordered_map_member_struct.go
@@ -42,6 +42,14 @@ func NewMemberStructOrderedMap() *MemberStructOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *MemberStructOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_member_struct.go
+++ b/runtime/sema/ordered_map_member_struct.go
@@ -45,7 +45,8 @@ func NewMemberStructOrderedMap() *MemberStructOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *MemberStructOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_position_resourceuse.go
+++ b/runtime/sema/ordered_map_position_resourceuse.go
@@ -46,6 +46,14 @@ func NewAstPositionResourceUseOrderedMap() *AstPositionResourceUseOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *AstPositionResourceUseOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_position_resourceuse.go
+++ b/runtime/sema/ordered_map_position_resourceuse.go
@@ -49,7 +49,8 @@ func NewAstPositionResourceUseOrderedMap() *AstPositionResourceUseOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *AstPositionResourceUseOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_resourceinvalidation_struct.go
+++ b/runtime/sema/ordered_map_resourceinvalidation_struct.go
@@ -45,7 +45,8 @@ func NewResourceInvalidationStructOrderedMap() *ResourceInvalidationStructOrdere
 // Clear removes all entries from this ordered map.
 func (om *ResourceInvalidationStructOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_resourceinvalidation_struct.go
+++ b/runtime/sema/ordered_map_resourceinvalidation_struct.go
@@ -42,6 +42,14 @@ func NewResourceInvalidationStructOrderedMap() *ResourceInvalidationStructOrdere
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *ResourceInvalidationStructOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_string_importelement.go
+++ b/runtime/sema/ordered_map_string_importelement.go
@@ -42,6 +42,14 @@ func NewStringImportElementOrderedMap() *StringImportElementOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringImportElementOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_string_importelement.go
+++ b/runtime/sema/ordered_map_string_importelement.go
@@ -45,7 +45,8 @@ func NewStringImportElementOrderedMap() *StringImportElementOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringImportElementOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_string_member.go
+++ b/runtime/sema/ordered_map_string_member.go
@@ -45,7 +45,8 @@ func NewStringMemberOrderedMap() *StringMemberOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringMemberOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_string_member.go
+++ b/runtime/sema/ordered_map_string_member.go
@@ -42,6 +42,14 @@ func NewStringMemberOrderedMap() *StringMemberOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringMemberOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_string_type.go
+++ b/runtime/sema/ordered_map_string_type.go
@@ -45,7 +45,8 @@ func NewStringTypeOrderedMap() *StringTypeOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringTypeOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_string_type.go
+++ b/runtime/sema/ordered_map_string_type.go
@@ -42,6 +42,14 @@ func NewStringTypeOrderedMap() *StringTypeOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringTypeOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_string_valuedeclaration.go
+++ b/runtime/sema/ordered_map_string_valuedeclaration.go
@@ -45,7 +45,8 @@ func NewStringValueDeclarationOrderedMap() *StringValueDeclarationOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringValueDeclarationOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_string_valuedeclaration.go
+++ b/runtime/sema/ordered_map_string_valuedeclaration.go
@@ -42,6 +42,14 @@ func NewStringValueDeclarationOrderedMap() *StringValueDeclarationOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringValueDeclarationOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_string_variable.go
+++ b/runtime/sema/ordered_map_string_variable.go
@@ -45,7 +45,8 @@ func NewStringVariableOrderedMap() *StringVariableOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *StringVariableOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_string_variable.go
+++ b/runtime/sema/ordered_map_string_variable.go
@@ -42,6 +42,14 @@ func NewStringVariableOrderedMap() *StringVariableOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *StringVariableOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/ordered_map_typeparameter_type.go
+++ b/runtime/sema/ordered_map_typeparameter_type.go
@@ -45,7 +45,8 @@ func NewTypeParameterTypeOrderedMap() *TypeParameterTypeOrderedMap {
 // Clear removes all entries from this ordered map.
 func (om *TypeParameterTypeOrderedMap) Clear() {
 	om.list.Init()
-	for key := range om.pairs {
+	// NOTE: Range over map is safe, as it is only used to delete entries
+	for key := range om.pairs { //nolint:maprangecheck
 		delete(om.pairs, key)
 	}
 }

--- a/runtime/sema/ordered_map_typeparameter_type.go
+++ b/runtime/sema/ordered_map_typeparameter_type.go
@@ -42,6 +42,14 @@ func NewTypeParameterTypeOrderedMap() *TypeParameterTypeOrderedMap {
 	}
 }
 
+// Clear removes all entries from this ordered map.
+func (om *TypeParameterTypeOrderedMap) Clear() {
+	om.list.Init()
+	for key := range om.pairs {
+		delete(om.pairs, key)
+	}
+}
+
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.

--- a/runtime/sema/variable_activations_test.go
+++ b/runtime/sema/variable_activations_test.go
@@ -28,7 +28,7 @@ func TestActivations(t *testing.T) {
 
 	t.Parallel()
 
-	activations := NewValueActivations(nil)
+	activations := NewVariableActivations(nil)
 
 	one := &Variable{}
 	two := &Variable{}

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -1860,6 +1860,7 @@ func BenchmarkContractInterfaceFungibleToken(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -1893,6 +1894,7 @@ func BenchmarkCheckContractInterfaceFungibleTokenConformance(b *testing.B) {
 		}.ToSemaValueDeclarations(),
 	)
 
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
## Description

Reduce allocation in the checker by reusing activations through an object pool.

```
before: BenchmarkCheckContractInterfaceFungibleTokenConformance-12    	    8824	    115880 ns/op	   80832 B/op	    1381 allocs/op
after:  BenchmarkCheckContractInterfaceFungibleTokenConformance-12    	   10022	    110549 ns/op	   68713 B/op	    1193 allocs/op
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
