### PR TITLE
Optimize integer conversion

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1572,82 +1572,119 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 
 	unwrappedTargetType := sema.UnwrapOptionalType(targetType)
 
-	if valueType.Equal(unwrappedTargetType) {
-		return value
-	}
-
 	switch unwrappedTargetType.(type) {
 	case *sema.IntType:
-		return ConvertInt(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertInt(value)
+		}
 
 	case *sema.UIntType:
-		return ConvertUInt(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUInt(value)
+		}
 
 	case *sema.AddressType:
-		return ConvertAddress(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertAddress(value)
+		}
 
 	// Int*
 	case *sema.Int8Type:
-		return ConvertInt8(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertInt8(value)
+		}
 
 	case *sema.Int16Type:
-		return ConvertInt16(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertInt16(value)
+		}
 
 	case *sema.Int32Type:
-		return ConvertInt32(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertInt32(value)
+		}
 
 	case *sema.Int64Type:
-		return ConvertInt64(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertInt64(value)
+		}
 
 	case *sema.Int128Type:
-		return ConvertInt128(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertInt128(value)
+		}
 
 	case *sema.Int256Type:
-		return ConvertInt256(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertInt256(value)
+		}
 
 	// UInt*
 	case *sema.UInt8Type:
-		return ConvertUInt8(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUInt8(value)
+		}
 
 	case *sema.UInt16Type:
-		return ConvertUInt16(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUInt16(value)
+		}
 
 	case *sema.UInt32Type:
-		return ConvertUInt32(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUInt32(value)
+		}
 
 	case *sema.UInt64Type:
-		return ConvertUInt64(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUInt64(value)
+		}
 
 	case *sema.UInt128Type:
-		return ConvertUInt128(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUInt128(value)
+		}
 
 	case *sema.UInt256Type:
-		return ConvertUInt256(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUInt256(value)
+		}
 
 	// Word*
 	case *sema.Word8Type:
-		return ConvertWord8(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertWord8(value)
+		}
 
 	case *sema.Word16Type:
-		return ConvertWord16(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertWord16(value)
+		}
 
 	case *sema.Word32Type:
-		return ConvertWord32(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertWord32(value)
+		}
 
 	case *sema.Word64Type:
-		return ConvertWord64(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertWord64(value)
+		}
 
 	// Fix*
 
 	case *sema.Fix64Type:
-		return ConvertFix64(value, interpreter)
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertFix64(value)
+		}
 
 	case *sema.UFix64Type:
-		return ConvertUFix64(value, interpreter)
-
-	default:
-		return value
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertUFix64(value)
+		}
 	}
+
+	return value
 }
 
 // boxOptional boxes a value in optionals, if necessary
@@ -1995,35 +2032,119 @@ func (interpreter *Interpreter) writeStored(storageAddress common.Address, key s
 	interpreter.storageWriteHandler(interpreter, storageAddress, key, value)
 }
 
-type ValueConverter func(Value, *Interpreter) Value
-
 type valueConverterDeclaration struct {
 	name  string
-	value ValueConverter
+	value FunctionValue
 }
 
+// It would be nice if return types in Go's function types would be covariant
+//
 var converterDeclarations = []valueConverterDeclaration{
-	{"Int", ConvertInt},
-	{"UInt", ConvertUInt},
-	{"Int8", ConvertInt8},
-	{"Int16", ConvertInt16},
-	{"Int32", ConvertInt32},
-	{"Int64", ConvertInt64},
-	{"Int128", ConvertInt128},
-	{"Int256", ConvertInt256},
-	{"UInt8", ConvertUInt8},
-	{"UInt16", ConvertUInt16},
-	{"UInt32", ConvertUInt32},
-	{"UInt64", ConvertUInt64},
-	{"UInt128", ConvertUInt128},
-	{"UInt256", ConvertUInt256},
-	{"Word8", ConvertWord8},
-	{"Word16", ConvertWord16},
-	{"Word32", ConvertWord32},
-	{"Word64", ConvertWord64},
-	{"Fix64", ConvertFix64},
-	{"UFix64", ConvertUFix64},
-	{"Address", ConvertAddress},
+	{"Int", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertInt(invocation.Arguments[0])
+		},
+	)},
+	{"UInt", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUInt(invocation.Arguments[0])
+		},
+	)},
+	{"Int8", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertInt8(invocation.Arguments[0])
+		},
+	)},
+	{"Int16", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertInt16(invocation.Arguments[0])
+		},
+	)},
+	{"Int32", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertInt32(invocation.Arguments[0])
+		},
+	)},
+	{"Int64", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertInt64(invocation.Arguments[0])
+		},
+	)},
+	{"Int128", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertInt128(invocation.Arguments[0])
+		},
+	)},
+	{"Int256", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertInt256(invocation.Arguments[0])
+		},
+	)},
+	{"UInt8", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUInt8(invocation.Arguments[0])
+		},
+	)},
+	{"UInt16", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUInt16(invocation.Arguments[0])
+		},
+	)},
+	{"UInt32", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUInt32(invocation.Arguments[0])
+		},
+	)},
+	{"UInt64", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUInt64(invocation.Arguments[0])
+		},
+	)},
+	{"UInt128", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUInt128(invocation.Arguments[0])
+		},
+	)},
+	{"UInt256", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUInt256(invocation.Arguments[0])
+		},
+	)},
+	{"Word8", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertWord8(invocation.Arguments[0])
+		},
+	)},
+	{"Word16", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertWord16(invocation.Arguments[0])
+		},
+	)},
+	{"Word32", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertWord32(invocation.Arguments[0])
+		},
+	)},
+	{"Word64", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertWord64(invocation.Arguments[0])
+		},
+	)},
+	{"Fix64", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertFix64(invocation.Arguments[0])
+		},
+	)},
+	{"UFix64", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertUFix64(invocation.Arguments[0])
+		},
+	)},
+	{"Address", NewHostFunctionValue(
+		func(invocation Invocation) Value {
+			return ConvertAddress(invocation.Arguments[0])
+		},
+	)},
 }
 
 func init() {
@@ -2061,7 +2182,7 @@ func (interpreter *Interpreter) defineConverterFunctions() {
 	for _, declaration := range converterDeclarations {
 		err := interpreter.ImportValue(
 			declaration.name,
-			interpreter.newConverterFunction(declaration.value),
+			declaration.value,
 		)
 		if err != nil {
 			panic(errors.NewUnreachableError())
@@ -2091,15 +2212,6 @@ func (interpreter *Interpreter) defineTypeFunction() {
 	if err != nil {
 		panic(errors.NewUnreachableError())
 	}
-}
-
-func (interpreter *Interpreter) newConverterFunction(converter ValueConverter) FunctionValue {
-	return NewHostFunctionValue(
-		func(invocation Invocation) Value {
-			value := invocation.Arguments[0]
-			return converter(value, interpreter)
-		},
-	)
 }
 
 // TODO:

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -809,7 +809,7 @@ func NewIntValueFromBigInt(value *big.Int) IntValue {
 	return IntValue{BigInt: value}
 }
 
-func ConvertInt(value Value, _ *Interpreter) Value {
+func ConvertInt(value Value) IntValue {
 	switch value := value.(type) {
 	case BigNumberValue:
 		return NewIntValueFromBigInt(value.ToBigInt())
@@ -1180,7 +1180,7 @@ func (v Int8Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherInt8
 }
 
-func ConvertInt8(value Value, _ *Interpreter) Value {
+func ConvertInt8(value Value) Int8Value {
 	var res int8
 
 	switch value := value.(type) {
@@ -1416,7 +1416,7 @@ func (v Int16Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherInt16
 }
 
-func ConvertInt16(value Value, _ *Interpreter) Value {
+func ConvertInt16(value Value) Int16Value {
 	var res int16
 
 	switch value := value.(type) {
@@ -1654,7 +1654,7 @@ func (v Int32Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherInt32
 }
 
-func ConvertInt32(value Value, _ *Interpreter) Value {
+func ConvertInt32(value Value) Int32Value {
 	var res int32
 
 	switch value := value.(type) {
@@ -1896,7 +1896,7 @@ func (v Int64Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherInt64
 }
 
-func ConvertInt64(value Value, _ *Interpreter) Value {
+func ConvertInt64(value Value) Int64Value {
 	var res int64
 
 	switch value := value.(type) {
@@ -2172,7 +2172,7 @@ func (v Int128Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return cmp == 0
 }
 
-func ConvertInt128(value Value, _ *Interpreter) Value {
+func ConvertInt128(value Value) Int128Value {
 	var v *big.Int
 
 	switch value := value.(type) {
@@ -2468,7 +2468,7 @@ func (v Int256Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return cmp == 0
 }
 
-func ConvertInt256(value Value, _ *Interpreter) Value {
+func ConvertInt256(value Value) Int256Value {
 	var v *big.Int
 
 	switch value := value.(type) {
@@ -2581,7 +2581,7 @@ func NewUIntValueFromBigInt(value *big.Int) UIntValue {
 	return UIntValue{BigInt: value}
 }
 
-func ConvertUInt(value Value, _ *Interpreter) Value {
+func ConvertUInt(value Value) UIntValue {
 	switch value := value.(type) {
 	case BigNumberValue:
 		v := value.ToBigInt()
@@ -2930,7 +2930,7 @@ func (v UInt8Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherUInt8
 }
 
-func ConvertUInt8(value Value, _ *Interpreter) Value {
+func ConvertUInt8(value Value) UInt8Value {
 	var res uint8
 
 	switch value := value.(type) {
@@ -3132,7 +3132,7 @@ func (v UInt16Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherUInt16
 }
 
-func ConvertUInt16(value Value, _ *Interpreter) Value {
+func ConvertUInt16(value Value) UInt16Value {
 	var res uint16
 
 	switch value := value.(type) {
@@ -3338,7 +3338,7 @@ func (v UInt32Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherUInt32
 }
 
-func ConvertUInt32(value Value, _ *Interpreter) Value {
+func ConvertUInt32(value Value) UInt32Value {
 	var res uint32
 
 	switch value := value.(type) {
@@ -3549,7 +3549,7 @@ func (v UInt64Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherUInt64
 }
 
-func ConvertUInt64(value Value, _ *Interpreter) Value {
+func ConvertUInt64(value Value) UInt64Value {
 	var res uint64
 
 	switch value := value.(type) {
@@ -3799,7 +3799,7 @@ func (v UInt128Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return cmp == 0
 }
 
-func ConvertUInt128(value Value, _ *Interpreter) Value {
+func ConvertUInt128(value Value) UInt128Value {
 	var v *big.Int
 
 	switch value := value.(type) {
@@ -4064,7 +4064,7 @@ func (v UInt256Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return cmp == 0
 }
 
-func ConvertUInt256(value Value, _ *Interpreter) Value {
+func ConvertUInt256(value Value) UInt256Value {
 	var v *big.Int
 
 	switch value := value.(type) {
@@ -4270,8 +4270,8 @@ func (v Word8Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherWord8
 }
 
-func ConvertWord8(value Value, interpreter *Interpreter) Value {
-	return Word8Value(ConvertUInt8(value, interpreter).(UInt8Value))
+func ConvertWord8(value Value) Word8Value {
+	return Word8Value(ConvertUInt8(value))
 }
 
 func (v Word8Value) BitwiseOr(other IntegerValue) IntegerValue {
@@ -4433,8 +4433,8 @@ func (v Word16Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherWord16
 }
 
-func ConvertWord16(value Value, interpreter *Interpreter) Value {
-	return Word16Value(ConvertUInt16(value, interpreter).(UInt16Value))
+func ConvertWord16(value Value) Word16Value {
+	return Word16Value(ConvertUInt16(value))
 }
 
 func (v Word16Value) BitwiseOr(other IntegerValue) IntegerValue {
@@ -4600,8 +4600,8 @@ func (v Word32Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherWord32
 }
 
-func ConvertWord32(value Value, interpreter *Interpreter) Value {
-	return Word32Value(ConvertUInt32(value, interpreter).(UInt32Value))
+func ConvertWord32(value Value) Word32Value {
+	return Word32Value(ConvertUInt32(value))
 }
 
 func (v Word32Value) BitwiseOr(other IntegerValue) IntegerValue {
@@ -4767,8 +4767,8 @@ func (v Word64Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherWord64
 }
 
-func ConvertWord64(value Value, interpreter *Interpreter) Value {
-	return Word64Value(ConvertUInt64(value, interpreter).(UInt64Value))
+func ConvertWord64(value Value) Word64Value {
+	return Word64Value(ConvertUInt64(value))
 }
 
 func (v Word64Value) BitwiseOr(other IntegerValue) IntegerValue {
@@ -4981,7 +4981,7 @@ func (v Fix64Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherFix64
 }
 
-func ConvertFix64(value Value, interpreter *Interpreter) Value {
+func ConvertFix64(value Value) Fix64Value {
 	switch value := value.(type) {
 	case Fix64Value:
 		return value
@@ -5012,11 +5012,7 @@ func ConvertFix64(value Value, interpreter *Interpreter) Value {
 		return NewFix64ValueWithInteger(int64(v))
 
 	default:
-		panic(fmt.Sprintf(
-			"can't convert %s to Fix64: %s",
-			value.DynamicType(interpreter),
-			value,
-		))
+		panic(fmt.Sprintf("can't convert Fix64: %s", value))
 	}
 }
 
@@ -5194,7 +5190,7 @@ func (v UFix64Value) Equal(_ *Interpreter, other Value) BoolValue {
 	return v == otherUFix64
 }
 
-func ConvertUFix64(value Value, interpreter *Interpreter) Value {
+func ConvertUFix64(value Value) UFix64Value {
 	switch value := value.(type) {
 	case UFix64Value:
 		return value
@@ -5232,11 +5228,7 @@ func ConvertUFix64(value Value, interpreter *Interpreter) Value {
 		return NewUFix64ValueWithInteger(uint64(v))
 
 	default:
-		panic(fmt.Sprintf(
-			"can't convert %s to UFix64: %s",
-			value.DynamicType(interpreter),
-			value,
-		))
+		panic(fmt.Sprintf("can't convert to UFix64: %s", value))
 	}
 }
 
@@ -6507,7 +6499,7 @@ func NewAddressValueFromBytes(b []byte) AddressValue {
 	return result
 }
 
-func ConvertAddress(value Value, _ *Interpreter) Value {
+func ConvertAddress(value Value) AddressValue {
 	// TODO: https://github.com/dapperlabs/flow-go/issues/2141
 	result := AddressValue{}
 	if intValue, ok := value.(IntValue); ok {

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -137,56 +137,61 @@ func integerLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value
 
 	intValue := interpreter.NewIntValueFromBigInt(integerExpression.Value)
 
-	converter := func(value interpreter.Value, _ *interpreter.Interpreter) interpreter.Value {
-		return value
+	convertedValue, err := convertIntValue(intValue, ty)
+	if err != nil {
+		return nil, err
 	}
+
+	result := ExportValue(convertedValue, nil)
+
+	return result, nil
+}
+
+func convertIntValue(intValue interpreter.IntValue, ty sema.Type) (interpreter.Value, error) {
 
 	switch ty.(type) {
 	case *sema.IntType, *sema.IntegerType, *sema.SignedIntegerType:
-		break
+		return intValue, nil
 	case *sema.Int8Type:
-		converter = interpreter.ConvertInt8
+		return interpreter.ConvertInt8(intValue), nil
 	case *sema.Int16Type:
-		converter = interpreter.ConvertInt16
+		return interpreter.ConvertInt16(intValue), nil
 	case *sema.Int32Type:
-		converter = interpreter.ConvertInt32
+		return interpreter.ConvertInt32(intValue), nil
 	case *sema.Int64Type:
-		converter = interpreter.ConvertInt64
+		return interpreter.ConvertInt64(intValue), nil
 	case *sema.Int128Type:
-		converter = interpreter.ConvertInt128
+		return interpreter.ConvertInt128(intValue), nil
 	case *sema.Int256Type:
-		converter = interpreter.ConvertInt256
+		return interpreter.ConvertInt256(intValue), nil
 
 	case *sema.UIntType:
-		converter = interpreter.ConvertUInt
+		return interpreter.ConvertUInt(intValue), nil
 	case *sema.UInt8Type:
-		converter = interpreter.ConvertUInt8
+		return interpreter.ConvertUInt8(intValue), nil
 	case *sema.UInt16Type:
-		converter = interpreter.ConvertUInt16
+		return interpreter.ConvertUInt16(intValue), nil
 	case *sema.UInt32Type:
-		converter = interpreter.ConvertUInt32
+		return interpreter.ConvertUInt32(intValue), nil
 	case *sema.UInt64Type:
-		converter = interpreter.ConvertUInt64
+		return interpreter.ConvertUInt64(intValue), nil
 	case *sema.UInt128Type:
-		converter = interpreter.ConvertUInt128
+		return interpreter.ConvertUInt128(intValue), nil
 	case *sema.UInt256Type:
-		converter = interpreter.ConvertUInt256
+		return interpreter.ConvertUInt256(intValue), nil
 
 	case *sema.Word8Type:
-		converter = interpreter.ConvertWord8
+		return interpreter.ConvertWord8(intValue), nil
 	case *sema.Word16Type:
-		converter = interpreter.ConvertWord16
+		return interpreter.ConvertWord16(intValue), nil
 	case *sema.Word32Type:
-		converter = interpreter.ConvertWord32
+		return interpreter.ConvertWord32(intValue), nil
 	case *sema.Word64Type:
-		converter = interpreter.ConvertWord64
+		return interpreter.ConvertWord64(intValue), nil
 
 	default:
 		return nil, UnsupportedLiteralError
 	}
-
-	result := ExportValue(converter(intValue, nil), nil)
-	return result, nil
 }
 
 func fixedPointLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error) {


### PR DESCRIPTION
## Description

- Only compare source and target type depending on target type, it is only needed as an optimization to avoid conversions, so don't add overhead in cases where there's no conversion going to happen anyways
- Don't pass unnecessary interpreter argument to conversion functions
- Make conversion functions more type-safe: Return the concrete type instead of just any value 
- Directly inline conversion function calls in host functions of value conversion function

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
