### PR TITLE
Report a hint when a dynamic cast is statically known to always succeed

### DIFF
--- a/runtime/sema/hints.go
+++ b/runtime/sema/hints.go
@@ -62,3 +62,41 @@ func (h *RemovalHint) Hint() string {
 }
 
 func (*RemovalHint) isHint() {}
+
+// AlwaysSucceedingFailableCastHint
+
+type AlwaysSucceedingFailableCastHint struct {
+	ValueType  Type
+	TargetType Type
+	ast.Range
+}
+
+func (h *AlwaysSucceedingFailableCastHint) Hint() string {
+	return fmt.Sprintf(
+		"failable cast ('%s') from `%s` to `%s` always succeeds",
+		ast.OperationFailableCast.Symbol(),
+		h.ValueType,
+		h.TargetType,
+	)
+}
+
+func (*AlwaysSucceedingFailableCastHint) isHint() {}
+
+// AlwaysSucceedingForceCastHint
+
+type AlwaysSucceedingForceCastHint struct {
+	ValueType  Type
+	TargetType Type
+	ast.Range
+}
+
+func (h *AlwaysSucceedingForceCastHint) Hint() string {
+	return fmt.Sprintf(
+		"force cast ('%s') from `%s` to `%s` always succeeds",
+		ast.OperationForceCast.Symbol(),
+		h.ValueType,
+		h.TargetType,
+	)
+}
+
+func (*AlwaysSucceedingForceCastHint) isHint() {}

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -1292,3 +1292,54 @@ func TestCheckDynamicCastingCapability(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckAlwaysSucceedingDynamicCast(t *testing.T) {
+
+	const types = `
+          struct interface I {}
+
+          struct S1: I {}
+
+          struct S2 {}
+        `
+
+	test := func(t *testing.T, operation ast.Operation, hintType sema.Hint) {
+
+		usage := fmt.Sprintf(
+			`
+              let s1 = S1()
+              let s2 = S2()
+              let s3 = s1 %[1]s {I}
+              let s4 = s2 %[1]s {I}
+            `,
+			operation.Symbol(),
+		)
+		checker, err := ParseAndCheck(t, types+usage)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+
+		hints := checker.Hints()
+
+		require.Len(t, hints, 1)
+
+		require.IsType(t, hintType, hints[0])
+	}
+
+	t.Run("failable", func(t *testing.T) {
+		test(
+			t,
+			ast.OperationFailableCast,
+			&sema.AlwaysSucceedingFailableCastHint{},
+		)
+	})
+
+	t.Run("forced", func(t *testing.T) {
+		test(
+			t,
+			ast.OperationForceCast,
+			&sema.AlwaysSucceedingForceCastHint{},
+		)
+	})
+}

--- a/runtime/tests/checker/occurrences_test.go
+++ b/runtime/tests/checker/occurrences_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 // TODO: implement occurrences for type references
-//  (e.g. conformances, conditional casting expression)
+//  (e.g. conformances, failable casting expression)
 
 func TestCheckOccurrencesVariableDeclarations(t *testing.T) {
 


### PR DESCRIPTION
Closes #500

Context: https://axiomzen.slack.com/archives/CG0B7CJAJ/p1615428232000300

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
