### PR TITLE
Fix nested error pretty printing

### DIFF
--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -296,7 +296,10 @@ func TestRuntimeError(t *testing.T) {
               // import program that has errors
               import A from 0x1
             `,
-			common.AddressLocation{Address: HexToAddress("01"), Name: "A"}.ID(): `
+			common.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x1}),
+				Name:    "A",
+			}.ID(): `
               // import program that has errors
               import B from 0x2
 
@@ -308,8 +311,10 @@ func TestRuntimeError(t *testing.T) {
                   Y
               }
             `,
-			common.AddressLocation{Address: HexToAddress("02"), Name: "B"}.ID(): `
-
+			common.AddressLocation{
+				Address: common.BytesToAddress([]byte{0x2}),
+				Name:    "B",
+			}.ID(): `
               // invalid top-level declaration
               pub fun bar() {
                   // invalid reference to undeclared variable
@@ -338,11 +343,7 @@ func TestRuntimeError(t *testing.T) {
 					Name:    name,
 					Address: address,
 				}
-				locationID := location.ID()
-				code, ok := codes[locationID]
-				if !ok {
-					code = secondaryCodes[locationID]
-				}
+				code := codes[location.ID()]
 				return []byte(code), nil
 			},
 		}
@@ -360,28 +361,28 @@ func TestRuntimeError(t *testing.T) {
 		require.EqualError(t, err,
 			"Execution failed:\n"+
 				"error: function declarations are not valid at the top-level\n"+
-				" --> 0000000000000002.B:2:20\n"+
+				" --> 0000000000000002.B:3:22\n"+
 				"  |\n"+
-				"2 |             pub fun bar() {\n"+
-				"  |                     ^^^\n"+
+				"3 |               pub fun bar() {\n"+
+				"  |                       ^^^\n"+
 				"\n"+
 				"error: cannot find variable in this scope: `X`\n"+
-				" --> 0000000000000002.B:3:16\n"+
+				" --> 0000000000000002.B:5:18\n"+
 				"  |\n"+
-				"3 |                 X\n"+
-				"  |                 ^ not found in this scope\n"+
+				"5 |                   X\n"+
+				"  |                   ^ not found in this scope\n"+
 				"\n"+
 				"error: function declarations are not valid at the top-level\n"+
-				" --> 0000000000000001.A:4:20\n"+
+				" --> 0000000000000001.A:8:22\n"+
 				"  |\n"+
-				"4 |             pub fun foo() {\n"+
-				"  |                     ^^^\n"+
+				"8 |               pub fun foo() {\n"+
+				"  |                       ^^^\n"+
 				"\n"+
 				"error: cannot find variable in this scope: `Y`\n"+
-				" --> 0000000000000001.A:5:16\n"+
-				"  |\n"+
-				"5 |                 Y\n"+
-				"  |                 ^ not found in this scope\n",
+				"  --> 0000000000000001.A:10:18\n"+
+				"   |\n"+
+				"10 |                   Y\n"+
+				"   |                   ^ not found in this scope\n",
 		)
 
 	})

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -161,16 +161,19 @@ func (p ErrorPrettyPrinter) PrettyPrintError(err error, location common.Location
 		}
 
 		if err, ok := err.(errors.ParentError); ok {
+
 			for _, childErr := range err.ChildErrors() {
+
+				childLocation := location
 
 				if childErr, ok := childErr.(common.HasImportLocation); ok {
 					importLocation := childErr.ImportLocation()
 					if importLocation != nil {
-						location = importLocation
+						childLocation = importLocation
 					}
 				}
 
-				printErr := printError(childErr, location)
+				printErr := printError(childErr, childLocation)
 				if printErr != nil {
 					return printErr
 				}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1052,26 +1052,29 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 
 	var compositeType *CompositeType
 
-	if typeResult, ok := restrictedType.(*CompositeType); ok {
-		switch typeResult.Kind {
+	if !restrictedType.IsInvalidType() {
 
-		case common.CompositeKindResource,
-			common.CompositeKindStructure:
+		if typeResult, ok := restrictedType.(*CompositeType); ok {
+			switch typeResult.Kind {
 
-			compositeType = typeResult
+			case common.CompositeKindResource,
+				common.CompositeKindStructure:
 
-		default:
-			reportInvalidRestrictedType()
-		}
-	} else {
+				compositeType = typeResult
 
-		switch restrictedType {
-		case AnyResourceType, AnyStructType, AnyType:
-			break
-
-		default:
-			if t.Type != nil {
+			default:
 				reportInvalidRestrictedType()
+			}
+		} else {
+
+			switch restrictedType {
+			case AnyResourceType, AnyStructType, AnyType:
+				break
+
+			default:
+				if t.Type != nil {
+					reportInvalidRestrictedType()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Don't let nested error's location override outer errors' locations: 
When pretty printing errors of a program that has errors, but also imports another program that has errors, the location of the nested errors was accidentally used for the outer errors.

While debugging I also noticed that the "invalid restricted type" error (`InvalidRestrictedTypeError`) was generated for invalid types, but should not. (Invalid types are produced when a previous error occurred, and indicates that the error was caused due to the preceding error).

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
