### PR TITLE
Return nil when revoking a non-existing key

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2257,6 +2257,13 @@ func (r *interpreterRuntime) newAccountKeysRevokeFunction(
 				panic(err)
 			}
 
+			// Here it is expected the host function to return a nil key, if a key is not found at the given index.
+			// This is done because, if the host function returns an error when a key is not found, then
+			// currently there's no way to distinguish between a 'key not found error' vs other internal errors.
+			if accountKey == nil {
+				return interpreter.NilValue{}
+			}
+
 			r.emitAccountEvent(
 				stdlib.AccountKeyRemovedEventType,
 				runtimeInterface,


### PR DESCRIPTION
Closes #696

## Description

Check and return nil, when revoking a non-existing key, to be consistent with getting non-existing keys.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
