### PR TITLE
Add unknown constants for signature algorithm and hash algorithm

### DIFF
--- a/docs/language/crypto.md
+++ b/docs/language/crypto.md
@@ -8,20 +8,20 @@ are supported by the language natively.
 
 ```cadence
 pub enum HashAlgorithm: UInt8 {
-    // SHA2_256 is Secure Hashing Algorithm 2 (SHA-2) with a 256-bit digest.
-    pub case SHA2_256
+    /// SHA2_256 is Secure Hashing Algorithm 2 (SHA-2) with a 256-bit digest.
+    pub case SHA2_256 = 1
 
-    // SHA2_384 is Secure Hashing Algorithm 2 (SHA-2) with a 384-bit digest.
-    pub case SHA2_384
+    /// SHA2_384 is Secure Hashing Algorithm 2 (SHA-2) with a 384-bit digest.
+    pub case SHA2_384 = 2
 
-    // SHA3_256 is Secure Hashing Algorithm 3 (SHA-3) with a 256-bit digest.
-    pub case SHA3_256
+    /// SHA3_256 is Secure Hashing Algorithm 3 (SHA-3) with a 256-bit digest.
+    pub case SHA3_256 = 3
 
-    // SHA3_384 is Secure Hashing Algorithm 3 (SHA-3) with a 384-bit digest.
-    pub case SHA3_384
+    /// SHA3_384 is Secure Hashing Algorithm 3 (SHA-3) with a 384-bit digest.
+    pub case SHA3_384 = 4
 
-    // KMAC128 is KECCAK Message Authentication Code with a 128-bit digest.
-    pub case KMAC128
+    /// KMAC128 is KECCAK Message Authentication Code with a 128-bit digest.
+    pub case KMAC128 = 5
 }
 ```
 
@@ -31,14 +31,14 @@ are supported by the language natively.
 
 ```cadence
 pub enum SignatureAlgorithm: UInt8 (
-    // ECDSA_P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the NIST P-256 curve.
-    ECDSA_P256
+    /// ECDSA_P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the NIST P-256 curve.
+    ECDSA_P256 = 1
 
-    // ECDSA_Secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve.
-    ECDSA_Secp256k1
+    /// ECDSA_Secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve.
+    ECDSA_Secp256k1 = 2
 
-    // BLSBLS12381 is BLS Signature algorithm on BLS 12-381 curve.
-    BLSBLS12381
+    /// BLSBLS12381 is BLS Signature algorithm on BLS 12-381 curve.
+    BLSBLS12381 = 3
 )
 ```
 

--- a/runtime/account_keys_test.go
+++ b/runtime/account_keys_test.go
@@ -586,9 +586,9 @@ func TestHashAlgorithm(t *testing.T) {
 		pub fun main(): [HashAlgorithm?] {
 			var key1: HashAlgorithm? = HashAlgorithm.KMAC_128
 
-			var key2: HashAlgorithm? = HashAlgorithm(rawValue:4)
+			var key2: HashAlgorithm? = HashAlgorithm(rawValue: 5)
 
-			var key3: HashAlgorithm? = HashAlgorithm(rawValue:10)
+			var key3: HashAlgorithm? = HashAlgorithm(rawValue: 100)
 			return [key1, key2, key3]
       	}
 	`)
@@ -609,7 +609,7 @@ func TestHashAlgorithm(t *testing.T) {
 	require.IsType(t, cadence.Array{}, result)
 	array := result.(cadence.Array)
 
-	require.Equal(t, 3, len(array.Values))
+	require.Len(t, array.Values, 3)
 
 	// Check key1
 	require.IsType(t, cadence.Optional{}, array.Values[0])
@@ -618,8 +618,11 @@ func TestHashAlgorithm(t *testing.T) {
 	require.IsType(t, cadence.Enum{}, optionalValue.Value)
 	builtinStruct := optionalValue.Value.(cadence.Enum)
 
-	require.Equal(t, 1, len(builtinStruct.Fields))
-	assert.Equal(t, cadence.NewInt(HashAlgorithmKMAC_128.RawValue()), builtinStruct.Fields[0])
+	require.Len(t, builtinStruct.Fields, 1)
+	assert.Equal(t,
+		cadence.NewInt(HashAlgorithmKMAC_128.RawValue()),
+		builtinStruct.Fields[0],
+	)
 
 	// Check key2
 	require.IsType(t, cadence.Optional{}, array.Values[1])
@@ -628,8 +631,11 @@ func TestHashAlgorithm(t *testing.T) {
 	require.IsType(t, cadence.Enum{}, optionalValue.Value)
 	builtinStruct = optionalValue.Value.(cadence.Enum)
 
-	require.Equal(t, 1, len(builtinStruct.Fields))
-	assert.Equal(t, cadence.NewInt(HashAlgorithmKMAC_128.RawValue()), builtinStruct.Fields[0])
+	require.Len(t, builtinStruct.Fields, 1)
+	assert.Equal(t,
+		cadence.NewInt(HashAlgorithmKMAC_128.RawValue()),
+		builtinStruct.Fields[0],
+	)
 
 	// Check key3
 	require.IsType(t, cadence.Optional{}, array.Values[2])
@@ -648,9 +654,9 @@ func TestSignatureAlgorithm(t *testing.T) {
 		pub fun main(): [SignatureAlgorithm?] {
 			var key1: SignatureAlgorithm? = SignatureAlgorithm.BLS_BLS12381
 
-			var key2: SignatureAlgorithm? = SignatureAlgorithm(rawValue:2)
+			var key2: SignatureAlgorithm? = SignatureAlgorithm(rawValue: 3)
 
-			var key3: SignatureAlgorithm? = SignatureAlgorithm(rawValue:5)
+			var key3: SignatureAlgorithm? = SignatureAlgorithm(rawValue: 100)
 			return [key1, key2, key3]
 		}
 	`)
@@ -671,7 +677,7 @@ func TestSignatureAlgorithm(t *testing.T) {
 	require.IsType(t, cadence.Array{}, result)
 	array := result.(cadence.Array)
 
-	require.Equal(t, 3, len(array.Values))
+	require.Len(t, array.Values, 3)
 
 	// Check key1
 	require.IsType(t, cadence.Optional{}, array.Values[0])
@@ -680,8 +686,11 @@ func TestSignatureAlgorithm(t *testing.T) {
 	require.IsType(t, cadence.Enum{}, optionalValue.Value)
 	builtinStruct := optionalValue.Value.(cadence.Enum)
 
-	require.Equal(t, 1, len(builtinStruct.Fields))
-	assert.Equal(t, cadence.NewInt(SignatureAlgorithmBLS_BLS12381.RawValue()), builtinStruct.Fields[0])
+	require.Len(t, builtinStruct.Fields, 1)
+	assert.Equal(t,
+		cadence.NewInt(SignatureAlgorithmBLS_BLS12381.RawValue()),
+		builtinStruct.Fields[0],
+	)
 
 	// Check key2
 	require.IsType(t, cadence.Optional{}, array.Values[1])
@@ -690,8 +699,11 @@ func TestSignatureAlgorithm(t *testing.T) {
 	require.IsType(t, cadence.Enum{}, optionalValue.Value)
 	builtinStruct = optionalValue.Value.(cadence.Enum)
 
-	require.Equal(t, 1, len(builtinStruct.Fields))
-	assert.Equal(t, cadence.NewInt(SignatureAlgorithmBLS_BLS12381.RawValue()), builtinStruct.Fields[0])
+	require.Len(t, builtinStruct.Fields, 1)
+	assert.Equal(t,
+		cadence.NewInt(SignatureAlgorithmBLS_BLS12381.RawValue()),
+		builtinStruct.Fields[0],
+	)
 
 	// Check key3
 	require.IsType(t, cadence.Optional{}, array.Values[2])

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -46,7 +46,8 @@ type SignatureAlgorithm int
 
 const (
 	// Supported signing algorithms
-	SignatureAlgorithmECDSA_P256 SignatureAlgorithm = iota
+	SignatureAlgorithmUnknown SignatureAlgorithm = iota
+	SignatureAlgorithmECDSA_P256
 	SignatureAlgorithmECDSA_Secp256k1
 	SignatureAlgorithmBLS_BLS12381
 )
@@ -54,6 +55,8 @@ const (
 // Name returns the string representation of this signing algorithm.
 func (algo SignatureAlgorithm) Name() string {
 	switch algo {
+	case SignatureAlgorithmUnknown:
+		return "unknown"
 	case SignatureAlgorithmECDSA_P256:
 		return "ECDSA_P256"
 	case SignatureAlgorithmECDSA_Secp256k1:
@@ -66,11 +69,29 @@ func (algo SignatureAlgorithm) Name() string {
 }
 
 func (algo SignatureAlgorithm) RawValue() int {
-	return int(algo)
+	// NOTE: only add new algorithms, do *NOT* change existing items,
+	// reuse raw values for other items, swap the order, etc.
+	//
+	// Existing stored values use these raw values and should not change
+
+	switch algo {
+	case SignatureAlgorithmUnknown:
+		return 0
+	case SignatureAlgorithmECDSA_P256:
+		return 1
+	case SignatureAlgorithmECDSA_Secp256k1:
+		return 2
+	case SignatureAlgorithmBLS_BLS12381:
+		return 3
+	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func (algo SignatureAlgorithm) DocString() string {
 	switch algo {
+	case SignatureAlgorithmUnknown:
+		return ""
 	case SignatureAlgorithmECDSA_P256:
 		return SignatureAlgorithmDocStringECDSA_P256
 	case SignatureAlgorithmECDSA_Secp256k1:
@@ -88,7 +109,8 @@ type HashAlgorithm int
 
 const (
 	// Supported hashing algorithms
-	HashAlgorithmSHA2_256 HashAlgorithm = iota
+	HashAlgorithmUnknown HashAlgorithm = iota
+	HashAlgorithmSHA2_256
 	HashAlgorithmSHA2_384
 	HashAlgorithmSHA3_256
 	HashAlgorithmSHA3_384
@@ -97,6 +119,8 @@ const (
 
 func (algo HashAlgorithm) Name() string {
 	switch algo {
+	case HashAlgorithmUnknown:
+		return "unknown"
 	case HashAlgorithmSHA2_256:
 		return "SHA2_256"
 	case HashAlgorithmSHA2_384:
@@ -113,11 +137,33 @@ func (algo HashAlgorithm) Name() string {
 }
 
 func (algo HashAlgorithm) RawValue() int {
-	return int(algo)
+	// NOTE: only add new algorithms, do *NOT* change existing items,
+	// reuse raw values for other items, swap the order, etc.
+	//
+	// Existing stored values use these raw values and should not change
+
+	switch algo {
+	case HashAlgorithmUnknown:
+		return 0
+	case HashAlgorithmSHA2_256:
+		return 1
+	case HashAlgorithmSHA2_384:
+		return 2
+	case HashAlgorithmSHA3_256:
+		return 3
+	case HashAlgorithmSHA3_384:
+		return 4
+	case HashAlgorithmKMAC_128:
+		return 5
+	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func (algo HashAlgorithm) DocString() string {
 	switch algo {
+	case HashAlgorithmUnknown:
+		return ""
 	case HashAlgorithmSHA2_256:
 		return HashAlgorithmDocStringSHA2_256
 	case HashAlgorithmSHA2_384:

--- a/runtime/sema/hashalgorithm_string.go
+++ b/runtime/sema/hashalgorithm_string.go
@@ -8,16 +8,17 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[HashAlgorithmSHA2_256-0]
-	_ = x[HashAlgorithmSHA2_384-1]
-	_ = x[HashAlgorithmSHA3_256-2]
-	_ = x[HashAlgorithmSHA3_384-3]
-	_ = x[HashAlgorithmKMAC_128-4]
+	_ = x[HashAlgorithmUnknown-0]
+	_ = x[HashAlgorithmSHA2_256-1]
+	_ = x[HashAlgorithmSHA2_384-2]
+	_ = x[HashAlgorithmSHA3_256-3]
+	_ = x[HashAlgorithmSHA3_384-4]
+	_ = x[HashAlgorithmKMAC_128-5]
 }
 
-const _HashAlgorithm_name = "HashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384HashAlgorithmKMAC_128"
+const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384HashAlgorithmKMAC_128"
 
-var _HashAlgorithm_index = [...]uint8{0, 21, 42, 63, 84, 105}
+var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104, 125}
 
 func (i HashAlgorithm) String() string {
 	if i < 0 || i >= HashAlgorithm(len(_HashAlgorithm_index)-1) {

--- a/runtime/sema/signaturealgorithm_string.go
+++ b/runtime/sema/signaturealgorithm_string.go
@@ -8,14 +8,15 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[SignatureAlgorithmECDSA_P256-0]
-	_ = x[SignatureAlgorithmECDSA_Secp256k1-1]
-	_ = x[SignatureAlgorithmBLS_BLS12381-2]
+	_ = x[SignatureAlgorithmUnknown-0]
+	_ = x[SignatureAlgorithmECDSA_P256-1]
+	_ = x[SignatureAlgorithmECDSA_Secp256k1-2]
+	_ = x[SignatureAlgorithmBLS_BLS12381-3]
 }
 
-const _SignatureAlgorithm_name = "SignatureAlgorithmECDSA_P256SignatureAlgorithmECDSA_Secp256k1SignatureAlgorithmBLS_BLS12381"
+const _SignatureAlgorithm_name = "SignatureAlgorithmUnknownSignatureAlgorithmECDSA_P256SignatureAlgorithmECDSA_Secp256k1SignatureAlgorithmBLS_BLS12381"
 
-var _SignatureAlgorithm_index = [...]uint8{0, 28, 61, 91}
+var _SignatureAlgorithm_index = [...]uint8{0, 25, 53, 86, 116}
 
 func (i SignatureAlgorithm) String() string {
 	if i < 0 || i >= SignatureAlgorithm(len(_SignatureAlgorithm_index)-1) {

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -20,6 +20,7 @@ package stdlib
 
 import (
 	"fmt"
+
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -153,7 +154,7 @@ var CreatePublicKeyFunction = NewStandardLibraryFunction(
 				TypeAnnotation: sema.NewTypeAnnotation(sema.SignatureAlgorithmType),
 			},
 		},
-		ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.PublicKeyType),
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.PublicKeyType),
 	},
 
 	func(invocation interpreter.Invocation) interpreter.Value {
@@ -187,8 +188,8 @@ var HashAlgorithmValue = StandardLibraryValue{
 
 func nativeEnumType(enumType *sema.CompositeType, enumCases []sema.NativeEnumCase) *sema.SpecialFunctionType {
 	members := make([]*sema.Member, len(enumCases))
-	for _, algo := range enumCases {
-		members[algo.RawValue()] = sema.NewPublicEnumCaseMember(
+	for i, algo := range enumCases {
+		members[i] = sema.NewPublicEnumCaseMember(
 			enumType,
 			algo.Name(),
 			algo.DocString(),
@@ -220,10 +221,9 @@ func nativeEnumValue(enumType *sema.CompositeType, enumCases []sema.NativeEnumCa
 	caseValues := make([]*interpreter.CompositeValue, caseCount)
 	constructorMembers := interpreter.NewStringValueOrderedMap()
 
-	for _, enumCase := range enumCases {
-		rawValue := enumCase.RawValue()
-		caseValue := interpreter.NewNativeEnumCaseValue(enumType, rawValue)
-		caseValues[rawValue] = caseValue
+	for i, enumCase := range enumCases {
+		caseValue := interpreter.NewNativeEnumCaseValue(enumType, enumCase.RawValue())
+		caseValues[i] = caseValue
 		constructorMembers.Set(enumCase.Name(), caseValue)
 	}
 

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -41,22 +41,30 @@ type Location = common.Location
 
 type SignatureAlgorithm = sema.SignatureAlgorithm
 
+// NOTE: do *NOT* replace with iota or assign literal values,
+// the values should be exactly the same as the ones declared in sema!
+
 const (
 	// Supported signing algorithms
-	SignatureAlgorithmECDSA_P256 SignatureAlgorithm = iota
-	SignatureAlgorithmECDSA_Secp256k1
-	SignatureAlgorithmBLS_BLS12381
+	SignatureAlgorithmUnknown         = sema.SignatureAlgorithmUnknown
+	SignatureAlgorithmECDSA_P256      = sema.SignatureAlgorithmECDSA_P256
+	SignatureAlgorithmECDSA_Secp256k1 = sema.SignatureAlgorithmECDSA_Secp256k1
+	SignatureAlgorithmBLS_BLS12381    = sema.SignatureAlgorithmBLS_BLS12381
 )
 
 type HashAlgorithm = sema.HashAlgorithm
 
+// NOTE: do *NOT* replace with iota or assign literal values,
+// the values should be exactly the same as the ones declared in sema!
+
 const (
 	// Supported hashing algorithms
-	HashAlgorithmSHA2_256 HashAlgorithm = iota
-	HashAlgorithmSHA2_384
-	HashAlgorithmSHA3_256
-	HashAlgorithmSHA3_384
-	HashAlgorithmKMAC_128
+	HashAlgorithmUnknown  = sema.HashAlgorithmUnknown
+	HashAlgorithmSHA2_256 = sema.HashAlgorithmSHA2_256
+	HashAlgorithmSHA2_384 = sema.HashAlgorithmSHA2_384
+	HashAlgorithmSHA3_256 = sema.HashAlgorithmSHA3_256
+	HashAlgorithmSHA3_384 = sema.HashAlgorithmSHA3_384
+	HashAlgorithmKMAC_128 = sema.HashAlgorithmKMAC_128
 )
 
 type AccountKey struct {


### PR DESCRIPTION
## Description

Add unknown constants for signature algorithm and hash algorithm: Just like in flow-go's crypto library, add constants for the unknown case.

Also prevent raw value from accidentally changing, because this could have serious consequences for existing stored values/keys.

This requires supporting enum cases which have a raw value that is not the enum case index (at least internally – we can add user-facing support later, i.e. extend the parsing rule for enum case declarations)

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
