### PR TITLE
Fix the syntax of the signature algorithm enum in docs

### DIFF
--- a/docs/language/crypto.md
+++ b/docs/language/crypto.md
@@ -30,16 +30,16 @@ The built-in enum `SignatureAlgorithm` provides the set of signing algorithms th
 are supported by the language natively.
 
 ```cadence
-pub enum SignatureAlgorithm: UInt8 (
+pub enum SignatureAlgorithm: UInt8 {
     /// ECDSA_P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the NIST P-256 curve.
-    ECDSA_P256 = 1
+    pub case ECDSA_P256 = 1
 
     /// ECDSA_Secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve.
-    ECDSA_Secp256k1 = 2
+    pub case ECDSA_Secp256k1 = 2
 
     /// BLSBLS12381 is BLS Signature algorithm on BLS 12-381 curve.
-    BLSBLS12381 = 3
-)
+    pub case BLSBLS12381 = 3
+}
 ```
 
 ## Crypto Contract


### PR DESCRIPTION
## Description

Fix the syntax of the signature algorithm enum in the crypto doc.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
