### PR TITLE
Revert the addition of the unsupported signing and hash algorithms

### DIFF
--- a/docs/language/crypto.md
+++ b/docs/language/crypto.md
@@ -19,9 +19,6 @@ pub enum HashAlgorithm: UInt8 {
 
     /// SHA3_384 is Secure Hashing Algorithm 3 (SHA-3) with a 384-bit digest.
     pub case SHA3_384 = 4
-
-    /// KMAC128 is KECCAK Message Authentication Code with a 128-bit digest.
-    pub case KMAC128 = 5
 }
 ```
 
@@ -36,9 +33,6 @@ pub enum SignatureAlgorithm: UInt8 {
 
     /// ECDSA_Secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve.
     pub case ECDSA_Secp256k1 = 2
-
-    /// BLSBLS12381 is BLS Signature algorithm on BLS 12-381 curve.
-    pub case BLSBLS12381 = 3
 }
 ```
 

--- a/runtime/account_keys_test.go
+++ b/runtime/account_keys_test.go
@@ -584,9 +584,9 @@ func TestHashAlgorithm(t *testing.T) {
 
 	script := []byte(`
 		pub fun main(): [HashAlgorithm?] {
-			var key1: HashAlgorithm? = HashAlgorithm.KMAC_128
+			var key1: HashAlgorithm? = HashAlgorithm.SHA3_256
 
-			var key2: HashAlgorithm? = HashAlgorithm(rawValue: 5)
+			var key2: HashAlgorithm? = HashAlgorithm(rawValue: 3)
 
 			var key3: HashAlgorithm? = HashAlgorithm(rawValue: 100)
 			return [key1, key2, key3]
@@ -620,7 +620,7 @@ func TestHashAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(HashAlgorithmKMAC_128.RawValue()),
+		cadence.NewInt(HashAlgorithmSHA3_256.RawValue()),
 		builtinStruct.Fields[0],
 	)
 
@@ -633,7 +633,7 @@ func TestHashAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(HashAlgorithmKMAC_128.RawValue()),
+		cadence.NewInt(HashAlgorithmSHA3_256.RawValue()),
 		builtinStruct.Fields[0],
 	)
 
@@ -652,9 +652,9 @@ func TestSignatureAlgorithm(t *testing.T) {
 
 	script := []byte(`
 		pub fun main(): [SignatureAlgorithm?] {
-			var key1: SignatureAlgorithm? = SignatureAlgorithm.BLS_BLS12381
+			var key1: SignatureAlgorithm? = SignatureAlgorithm.ECDSA_Secp256k1
 
-			var key2: SignatureAlgorithm? = SignatureAlgorithm(rawValue: 3)
+			var key2: SignatureAlgorithm? = SignatureAlgorithm(rawValue: 2)
 
 			var key3: SignatureAlgorithm? = SignatureAlgorithm(rawValue: 100)
 			return [key1, key2, key3]
@@ -688,7 +688,7 @@ func TestSignatureAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(SignatureAlgorithmBLS_BLS12381.RawValue()),
+		cadence.NewInt(SignatureAlgorithmECDSA_Secp256k1.RawValue()),
 		builtinStruct.Fields[0],
 	)
 
@@ -701,7 +701,7 @@ func TestSignatureAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(SignatureAlgorithmBLS_BLS12381.RawValue()),
+		cadence.NewInt(SignatureAlgorithmECDSA_Secp256k1.RawValue()),
 		builtinStruct.Fields[0],
 	)
 

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -29,7 +29,6 @@ import (
 var SignatureAlgorithms = []NativeEnumCase{
 	SignatureAlgorithmECDSA_P256,
 	SignatureAlgorithmECDSA_Secp256k1,
-	SignatureAlgorithmBLS_BLS12381,
 }
 
 var HashAlgorithms = []NativeEnumCase{
@@ -37,7 +36,6 @@ var HashAlgorithms = []NativeEnumCase{
 	HashAlgorithmSHA2_384,
 	HashAlgorithmSHA3_256,
 	HashAlgorithmSHA3_384,
-	HashAlgorithmKMAC_128,
 }
 
 var SignatureAlgorithmType = newNativeEnumType(SignatureAlgorithmTypeName, &UInt8Type{})
@@ -49,7 +47,6 @@ const (
 	SignatureAlgorithmUnknown SignatureAlgorithm = iota
 	SignatureAlgorithmECDSA_P256
 	SignatureAlgorithmECDSA_Secp256k1
-	SignatureAlgorithmBLS_BLS12381
 )
 
 // Name returns the string representation of this signing algorithm.
@@ -61,8 +58,6 @@ func (algo SignatureAlgorithm) Name() string {
 		return "ECDSA_P256"
 	case SignatureAlgorithmECDSA_Secp256k1:
 		return "ECDSA_Secp256k1"
-	case SignatureAlgorithmBLS_BLS12381:
-		return "BLS_BLS12381"
 	}
 
 	panic(errors.NewUnreachableError())
@@ -81,8 +76,6 @@ func (algo SignatureAlgorithm) RawValue() int {
 		return 1
 	case SignatureAlgorithmECDSA_Secp256k1:
 		return 2
-	case SignatureAlgorithmBLS_BLS12381:
-		return 3
 	}
 
 	panic(errors.NewUnreachableError())
@@ -96,8 +89,6 @@ func (algo SignatureAlgorithm) DocString() string {
 		return SignatureAlgorithmDocStringECDSA_P256
 	case SignatureAlgorithmECDSA_Secp256k1:
 		return SignatureAlgorithmDocStringECDSA_Secp256k1
-	case SignatureAlgorithmBLS_BLS12381:
-		return SignatureAlgorithmDocStringBLS_BLS12381
 	}
 
 	panic(errors.NewUnreachableError())
@@ -114,7 +105,6 @@ const (
 	HashAlgorithmSHA2_384
 	HashAlgorithmSHA3_256
 	HashAlgorithmSHA3_384
-	HashAlgorithmKMAC_128
 )
 
 func (algo HashAlgorithm) Name() string {
@@ -129,8 +119,6 @@ func (algo HashAlgorithm) Name() string {
 		return "SHA3_256"
 	case HashAlgorithmSHA3_384:
 		return "SHA3_384"
-	case HashAlgorithmKMAC_128:
-		return "KMAC_128"
 	}
 
 	panic(errors.NewUnreachableError())
@@ -153,8 +141,6 @@ func (algo HashAlgorithm) RawValue() int {
 		return 3
 	case HashAlgorithmSHA3_384:
 		return 4
-	case HashAlgorithmKMAC_128:
-		return 5
 	}
 
 	panic(errors.NewUnreachableError())
@@ -172,8 +158,6 @@ func (algo HashAlgorithm) DocString() string {
 		return HashAlgorithmDocStringSHA3_256
 	case HashAlgorithmSHA3_384:
 		return HashAlgorithmDocStringSHA3_384
-	case HashAlgorithmKMAC_128:
-		return HashAlgorithmDocStringKMAC_128
 	}
 
 	panic(errors.NewUnreachableError())
@@ -205,32 +189,27 @@ func newNativeEnumType(identifier string, rawType Type) *CompositeType {
 const SignatureAlgorithmTypeName = "SignatureAlgorithm"
 
 const SignatureAlgorithmDocStringECDSA_P256 = `
-SignatureAlgorithmECDSA_P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the NIST P-256 curve
+ECDSA_P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the NIST P-256 curve
 `
+
 const SignatureAlgorithmDocStringECDSA_Secp256k1 = `
-SignatureAlgorithmECDSA_Secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve
-`
-const SignatureAlgorithmDocStringBLS_BLS12381 = `
-SignatureAlgorithmDocStringBLS_BLS12381 is BLS Signature algorithm on BLS 12-381 curve
+ECDSA_Secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve
 `
 
 const HashAlgorithmTypeName = "HashAlgorithm"
 
 const HashAlgorithmDocStringSHA2_256 = `
-HashAlgorithmSHA2_256 is Secure Hashing Algorithm 2 (SHA-2) with a 256-bit digest
+SHA2_256 is Secure Hashing Algorithm 2 (SHA-2) with a 256-bit digest
 `
+
 const HashAlgorithmDocStringSHA2_384 = `
-HashAlgorithmSHA2_384 is Secure Hashing Algorithm 2 (SHA-2) with a 384-bit digest
+SHA2_384 is Secure Hashing Algorithm 2 (SHA-2) with a 384-bit digest
 `
 
 const HashAlgorithmDocStringSHA3_256 = `
-HashAlgorithmSHA3_256 is Secure Hashing Algorithm 3 (SHA-3) with a 256-bit digest
+SHA3_256 is Secure Hashing Algorithm 3 (SHA-3) with a 256-bit digest
 `
 
 const HashAlgorithmDocStringSHA3_384 = `
-HashAlgorithmSHA3_384 is Secure Hashing Algorithm 3 (SHA-3) with a 384-bit digest
-`
-
-const HashAlgorithmDocStringKMAC_128 = `
-HashAlgorithmKMAC_128 is KECCAK Message Authentication Code with a 128-bit digest
+SHA3_384 is Secure Hashing Algorithm 3 (SHA-3) with a 384-bit digest
 `

--- a/runtime/sema/hashalgorithm_string.go
+++ b/runtime/sema/hashalgorithm_string.go
@@ -13,12 +13,11 @@ func _() {
 	_ = x[HashAlgorithmSHA2_384-2]
 	_ = x[HashAlgorithmSHA3_256-3]
 	_ = x[HashAlgorithmSHA3_384-4]
-	_ = x[HashAlgorithmKMAC_128-5]
 }
 
-const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384HashAlgorithmKMAC_128"
+const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384"
 
-var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104, 125}
+var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104}
 
 func (i HashAlgorithm) String() string {
 	if i < 0 || i >= HashAlgorithm(len(_HashAlgorithm_index)-1) {

--- a/runtime/sema/signaturealgorithm_string.go
+++ b/runtime/sema/signaturealgorithm_string.go
@@ -11,12 +11,11 @@ func _() {
 	_ = x[SignatureAlgorithmUnknown-0]
 	_ = x[SignatureAlgorithmECDSA_P256-1]
 	_ = x[SignatureAlgorithmECDSA_Secp256k1-2]
-	_ = x[SignatureAlgorithmBLS_BLS12381-3]
 }
 
-const _SignatureAlgorithm_name = "SignatureAlgorithmUnknownSignatureAlgorithmECDSA_P256SignatureAlgorithmECDSA_Secp256k1SignatureAlgorithmBLS_BLS12381"
+const _SignatureAlgorithm_name = "SignatureAlgorithmUnknownSignatureAlgorithmECDSA_P256SignatureAlgorithmECDSA_Secp256k1"
 
-var _SignatureAlgorithm_index = [...]uint8{0, 25, 53, 86, 116}
+var _SignatureAlgorithm_index = [...]uint8{0, 25, 53, 86}
 
 func (i SignatureAlgorithm) String() string {
 	if i < 0 || i >= SignatureAlgorithm(len(_SignatureAlgorithm_index)-1) {

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -49,7 +49,6 @@ const (
 	SignatureAlgorithmUnknown         = sema.SignatureAlgorithmUnknown
 	SignatureAlgorithmECDSA_P256      = sema.SignatureAlgorithmECDSA_P256
 	SignatureAlgorithmECDSA_Secp256k1 = sema.SignatureAlgorithmECDSA_Secp256k1
-	SignatureAlgorithmBLS_BLS12381    = sema.SignatureAlgorithmBLS_BLS12381
 )
 
 type HashAlgorithm = sema.HashAlgorithm
@@ -64,7 +63,6 @@ const (
 	HashAlgorithmSHA2_384 = sema.HashAlgorithmSHA2_384
 	HashAlgorithmSHA3_256 = sema.HashAlgorithmSHA3_256
 	HashAlgorithmSHA3_384 = sema.HashAlgorithmSHA3_384
-	HashAlgorithmKMAC_128 = sema.HashAlgorithmKMAC_128
 )
 
 type AccountKey struct {


### PR DESCRIPTION
## Description

As discussed and decided in onflow/flow-go#529, revert the addition of the KMAC_128 hash and BLS_BLS12381 signature algorithm, as they are currently now supported in FVM and their usage leads to a revert. This behaviour is likely confusing for users, so remove them for now until there is proper support for them.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
