### PR TITLE
Properly handle recursive types when checking validity of event parameter types

### DIFF
--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -83,18 +83,7 @@ func IsValidEventParameterType(t Type, results map[*Member]bool) bool {
 		for pair := t.Members.Oldest(); pair != nil; pair = pair.Next() {
 			member := pair.Value
 
-			test := func(t Type) bool {
-				if member.DeclarationKind == common.DeclarationKindField &&
-					!member.IgnoreInSerialization &&
-					!IsValidEventParameterType(member.TypeAnnotation.Type, results) {
-
-					return false
-				}
-
-				return true
-			}
-
-			if !member.testType(test, results) {
+			if !member.IsValidParameterType(results) {
 				return false
 			}
 		}

--- a/runtime/sema/check_event_declaration_test.go
+++ b/runtime/sema/check_event_declaration_test.go
@@ -1,0 +1,52 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence/runtime/common"
+)
+
+func TestIsValidEventParameterType(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("no infinite recursion", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &CompositeType{
+			Kind:       common.CompositeKindStructure,
+			Identifier: "Nested",
+		}
+		ty.Members = func() *StringMemberOrderedMap {
+			members := NewStringMemberOrderedMap()
+			// field `nested` refers to the container type,
+			// leading to a recursive type declaration
+			const fieldName = "nested"
+			members.Set(fieldName, NewPublicConstantFieldMember(ty, fieldName, ty, ""))
+			return members
+		}()
+
+		assert.True(t, IsValidEventParameterType(ty, map[*Member]bool{}))
+	})
+}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4560,14 +4560,7 @@ func (m *Member) IsExternallyReturnable(results map[*Member]bool) (result bool) 
 // IsValidParameterType returns whether has a valid event parameter type
 func (m *Member) IsValidParameterType(results map[*Member]bool) bool {
 	test := func(t Type) bool {
-		if m.DeclarationKind == common.DeclarationKindField &&
-			!m.IgnoreInSerialization &&
-			!IsValidEventParameterType(m.TypeAnnotation.Type, results) {
-
-			return false
-		}
-
-		return true
+		return IsValidEventParameterType(t, results)
 	}
 	return m.testType(test, results)
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4557,6 +4557,21 @@ func (m *Member) IsExternallyReturnable(results map[*Member]bool) (result bool) 
 	return m.testType(test, results)
 }
 
+// IsValidParameterType returns whether has a valid event parameter type
+func (m *Member) IsValidParameterType(results map[*Member]bool) bool {
+	test := func(t Type) bool {
+		if m.DeclarationKind == common.DeclarationKindField &&
+			!m.IgnoreInSerialization &&
+			!IsValidEventParameterType(m.TypeAnnotation.Type, results) {
+
+			return false
+		}
+
+		return true
+	}
+	return m.testType(test, results)
+}
+
 func (m *Member) testType(test func(Type) bool, results map[*Member]bool) (result bool) {
 
 	// Prevent a potential stack overflow due to cyclic declarations

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -151,6 +151,24 @@ func TestCheckEventDeclaration(t *testing.T) {
 		}
 	})
 
+	t.Run("recursive", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          event E(recursive: Recursive)
+
+          struct Recursive {
+              let children: [Recursive]
+              init() {
+                  self.children = []
+              }
+          }
+		`)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("RedeclaredEvent", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -227,7 +227,7 @@ func TestCheckStorable(t *testing.T) {
 
 			if compositeKind == common.CompositeKindEvent &&
 				testCase.Type != nil &&
-				!sema.IsValidEventParameterType(testCase.Type) {
+				!sema.IsValidEventParameterType(testCase.Type, map[*sema.Member]bool{}) {
 
 				continue
 			}


### PR DESCRIPTION
Closes dapperlabs/flow-internal#1495

## Description

Event parameter types may be recursive. 

Properly handle the recursion by keeping track of results.

This follows the same pattern as checking is a type is storable or externally returnable, which use `Member.testType` to handle potentially recursive types: 
https://github.com/onflow/cadence/blob/29bfb95af70b974f027b50b6246ef6ee965deda5/runtime/sema/type.go#L85-L101
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
