### PR TITLE
Properly handle recursive types when checking validity of event parameter types

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4590,6 +4590,14 @@ func (m *Member) IsExternallyReturnable(results map[*Member]bool) (result bool) 
 	return m.testType(test, results)
 }
 
+// IsValidEventParameterType returns whether has a valid event parameter type
+func (m *Member) IsValidEventParameterType(results map[*Member]bool) bool {
+	test := func(t Type) bool {
+		return IsValidEventParameterType(t, results)
+	}
+	return m.testType(test, results)
+}
+
 func (m *Member) testType(test func(Type) bool, results map[*Member]bool) (result bool) {
 
 	// Prevent a potential stack overflow due to cyclic declarations

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -151,6 +151,24 @@ func TestCheckEventDeclaration(t *testing.T) {
 		}
 	})
 
+	t.Run("recursive", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          event E(recursive: Recursive)
+
+          struct Recursive {
+              let children: [Recursive]
+              init() {
+                  self.children = []
+              }
+          }
+		`)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("RedeclaredEvent", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -227,7 +227,7 @@ func TestCheckStorable(t *testing.T) {
 
 			if compositeKind == common.CompositeKindEvent &&
 				testCase.Type != nil &&
-				!sema.IsValidEventParameterType(testCase.Type) {
+				!sema.IsValidEventParameterType(testCase.Type, map[*sema.Member]bool{}) {
 
 				continue
 			}


### PR DESCRIPTION
Closes dapperlabs/flow-internal#1495

## Description

Event parameter types may be recursive. 

Properly handle the recursion by keeping track of results.

This follows the same pattern as checking is a type is storable or externally returnable, which use `Member.testType` to handle potentially recursive types: 
https://github.com/onflow/cadence/blob/29bfb95af70b974f027b50b6246ef6ee965deda5/runtime/sema/type.go#L85-L101
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
