### PR TITLE
Add support for access(account) and multiple contracts per account

### DIFF
--- a/runtime/common/location.go
+++ b/runtime/common/location.go
@@ -40,11 +40,12 @@ type Location interface {
 // LocationsMatch returns true if both locations are nil or their IDs are the same.
 //
 func LocationsMatch(first, second Location) bool {
-	if first == nil && second == nil {
-		return true
+
+	if first == nil {
+		return second == nil
 	}
 
-	if (first == nil && second != nil) || (first != nil && second == nil) {
+	if second == nil {
 		return false
 	}
 
@@ -56,11 +57,12 @@ func LocationsMatch(first, second Location) bool {
 // or otherwise if their IDs are the same.
 //
 func LocationsInSameAccount(first, second Location) bool {
-	if first == nil && second == nil {
-		return true
+
+	if first == nil {
+		return second == nil
 	}
 
-	if (first == nil && second != nil) || (first != nil && second == nil) {
+	if second == nil {
 		return false
 	}
 

--- a/runtime/common/location.go
+++ b/runtime/common/location.go
@@ -37,6 +37,8 @@ type Location interface {
 	QualifiedIdentifier(typeID TypeID) string
 }
 
+// LocationsMatch returns true if both locations are nil or their IDs are the same.
+//
 func LocationsMatch(first, second Location) bool {
 	if first == nil && second == nil {
 		return true
@@ -44,6 +46,33 @@ func LocationsMatch(first, second Location) bool {
 
 	if (first == nil && second != nil) || (first != nil && second == nil) {
 		return false
+	}
+
+	return first.ID() == second.ID()
+}
+
+// LocationsInSameAccount returns true if both locations are nil,
+// if both locations are address locations when both locations have the same address,
+// or otherwise if their IDs are the same.
+//
+func LocationsInSameAccount(first, second Location) bool {
+	if first == nil && second == nil {
+		return true
+	}
+
+	if (first == nil && second != nil) || (first != nil && second == nil) {
+		return false
+	}
+
+	if firstAddressLocation, ok := first.(AddressLocation); ok {
+
+		secondAddressLocation, ok := second.(AddressLocation)
+		if !ok {
+			return false
+		}
+
+		// NOTE: only check address, ignore name
+		return firstAddressLocation.Address == secondAddressLocation.Address
 	}
 
 	return first.ID() == second.ID()

--- a/runtime/common/location_test.go
+++ b/runtime/common/location_test.go
@@ -1,0 +1,155 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocationsMatch(t *testing.T) {
+
+	t.Run("AddressLocation", func(t *testing.T) {
+
+		require.True(t,
+			LocationsMatch(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+			),
+		)
+
+		require.False(t,
+			LocationsMatch(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				AddressLocation{
+					Address: Address{0x2},
+					Name:    "A",
+				},
+			),
+		)
+
+		require.False(t,
+			LocationsMatch(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "B",
+				},
+			),
+		)
+
+		require.False(t,
+			LocationsMatch(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				StringLocation("A.0000000000000001"),
+			),
+		)
+
+		require.False(t,
+			LocationsMatch(
+				StringLocation("A.0000000000000001"),
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+			),
+		)
+	})
+}
+
+func TestLocationsInSameAccount(t *testing.T) {
+
+	t.Run("AddressLocation", func(t *testing.T) {
+
+		require.True(t,
+			LocationsInSameAccount(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+			),
+		)
+
+		require.False(t,
+			LocationsInSameAccount(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				AddressLocation{
+					Address: Address{0x2},
+					Name:    "A",
+				},
+			),
+		)
+
+		require.True(t,
+			LocationsInSameAccount(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "B",
+				},
+			),
+		)
+
+		require.False(t,
+			LocationsInSameAccount(
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+				StringLocation("A.0000000000000001"),
+			),
+		)
+
+		require.False(t,
+			LocationsInSameAccount(
+				StringLocation("A.0000000000000001"),
+				AddressLocation{
+					Address: Address{0x1},
+					Name:    "A",
+				},
+			),
+		)
+	})
+}

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -287,7 +287,7 @@ func (checker *Checker) isReadableMember(member *Member) bool {
 		// check if the current location is the same as the member's container location
 
 		location := member.ContainerType.(LocatedType).GetLocation()
-		if common.LocationsMatch(checker.Location, location) {
+		if common.LocationsInSameAccount(checker.Location, location) {
 			return true
 		}
 	}

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -2309,7 +2309,7 @@ func TestCheckAccountAccess(t *testing.T) {
 	}
 
 	const importingCode = `
-	  import A from 0x1
+      import A from 0x1
 
       pub contract B {
           pub fun use() {
@@ -2351,7 +2351,7 @@ func TestCheckAccountAccess(t *testing.T) {
 			importedChecker, err := ParseAndCheckWithOptions(t,
 				fmt.Sprintf(
 					`
-			          pub contract A {
+                      pub contract A {
                           access(account) %s a: Int
 
                           init() {

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -2286,3 +2286,119 @@ func TestCheckInvalidRestrictiveAccessModifier(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckAccountAccess(t *testing.T) {
+
+	t.Parallel()
+
+	location1A := common.AddressLocation{
+		Address: common.BytesToAddress([]byte{0x1}),
+		Name:    "A",
+	}
+
+	location1B := common.AddressLocation{
+		// NOTE: same address as A
+		Address: common.BytesToAddress([]byte{0x1}),
+		Name:    "B",
+	}
+
+	location2B := common.AddressLocation{
+		// NOTE: different address from A
+		Address: common.BytesToAddress([]byte{0x2}),
+		Name:    "B",
+	}
+
+	const importingCode = `
+	  import A from 0x1
+
+      pub contract B {
+          pub fun use() {
+              let b = A.a
+          }
+      }
+	`
+
+	type testCase struct {
+		location         common.Location
+		accessModeChecks map[sema.AccessCheckMode]func(*testing.T, error)
+	}
+
+	tests := []testCase{
+		{
+			location: location1B,
+			accessModeChecks: map[sema.AccessCheckMode]func(*testing.T, error){
+				sema.AccessCheckModeStrict:                   expectSuccess,
+				sema.AccessCheckModeNotSpecifiedRestricted:   expectSuccess,
+				sema.AccessCheckModeNotSpecifiedUnrestricted: expectSuccess,
+				sema.AccessCheckModeNone:                     expectSuccess,
+			},
+		},
+		{
+			location: location2B,
+			accessModeChecks: map[sema.AccessCheckMode]func(*testing.T, error){
+				sema.AccessCheckModeStrict:                   expectInvalidAccessError,
+				sema.AccessCheckModeNotSpecifiedRestricted:   expectInvalidAccessError,
+				sema.AccessCheckModeNotSpecifiedUnrestricted: expectInvalidAccessError,
+				sema.AccessCheckModeNone:                     expectSuccess,
+			},
+		},
+	}
+
+	for _, variableKind := range ast.VariableKinds {
+
+		t.Run(variableKind.Name(), func(t *testing.T) {
+
+			importedChecker, err := ParseAndCheckWithOptions(t,
+				fmt.Sprintf(
+					`
+			          pub contract A {
+                          access(account) %s a: Int
+
+                          init() {
+                              self.a = 1
+                          }
+                      }
+			        `,
+					variableKind.Keyword(),
+				),
+				ParseAndCheckOptions{
+					Location: location1A,
+				},
+			)
+			require.NoError(t, err)
+
+			for _, test := range tests {
+
+				t.Run(test.location.String(), func(t *testing.T) {
+
+					require.Len(t, test.accessModeChecks, len(sema.AccessCheckModes))
+
+					for checkMode, check := range test.accessModeChecks {
+
+						t.Run(checkMode.String(), func(t *testing.T) {
+
+							_, err = ParseAndCheckWithOptions(t,
+								importingCode,
+								ParseAndCheckOptions{
+									Location: test.location,
+									Options: []sema.Option{
+										sema.WithAccessCheckMode(checkMode),
+										sema.WithImportHandler(
+											func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+												return sema.ElaborationImport{
+													Elaboration: importedChecker.Elaboration,
+												}, nil
+											},
+										),
+									},
+								},
+							)
+
+							check(t, err)
+						})
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #702

## Description

When checking `access(account)`, check address locations' addresses are equal, not their full IDs are equal.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
