### PR TITLE
Ensure imported checkers/elaborations are reused in tests' import handlers

### DIFF
--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -59,6 +59,14 @@ func TestInterpretVirtualImport(t *testing.T) {
        }
     `
 
+	valueElements := sema.NewStringImportElementOrderedMap()
+
+	valueElements.Set("Foo", sema.ImportElement{
+		DeclarationKind: common.DeclarationKindStructure,
+		Access:          ast.AccessPublic,
+		Type:            fooType,
+	})
+
 	inter := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
@@ -100,14 +108,6 @@ func TestInterpretVirtualImport(t *testing.T) {
 			CheckerOptions: []sema.Option{
 				sema.WithImportHandler(
 					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
-
-						valueElements := sema.NewStringImportElementOrderedMap()
-
-						valueElements.Set("Foo", sema.ImportElement{
-							DeclarationKind: common.DeclarationKindStructure,
-							Access:          ast.AccessPublic,
-							Type:            fooType,
-						})
 
 						return sema.VirtualImport{
 							ValueElements: valueElements,


### PR DESCRIPTION
Import handlers must always return the same elaboration for a location.

Ensure this is the case in the checker tests.

---

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
