### PR TITLE
Fix error range when reporting a type error for an indexing reference expression

### DIFF
--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -60,12 +60,23 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 
 	// Check that the references expression's type is not optional
 
+	getReferencedExpressionRange := func() ast.Range {
+		if isIndexExpression {
+			return ast.Range{
+				StartPos: indexExpression.TargetExpression.StartPosition(),
+				EndPos:   referencedExpression.EndPosition(),
+			}
+		} else {
+			return ast.NewRangeFromPositioned(referencedExpression)
+		}
+	}
+
 	if _, ok := referencedType.(*OptionalType); ok {
 
 		checker.report(
 			&OptionalTypeReferenceError{
 				ActualType: referencedType,
-				Range:      ast.NewRangeFromPositioned(referencedExpression),
+				Range:      getReferencedExpressionRange(),
 			},
 		)
 	}
@@ -100,7 +111,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 			&TypeMismatchError{
 				ExpectedType: referenceType.Type,
 				ActualType:   referencedType,
-				Range:        ast.NewRangeFromPositioned(referencedExpression),
+				Range:        getReferencedExpressionRange(),
 			},
 		)
 	}

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -1045,3 +1045,21 @@ func TestCheckInvalidReferenceExpressionNonReferenceAnyStruct(t *testing.T) {
 	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 	assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[1])
 }
+
+func TestCheckInvalidDictionaryAccessReference(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      let xs: {Int: Int} = {}
+      let ref = &xs[1] as &String
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+
+	typeMismatchError := errs[0].(*sema.TypeMismatchError)
+	assert.Equal(t, 17, typeMismatchError.StartPos.Column)
+	assert.Equal(t, 21, typeMismatchError.EndPos.Column)
+}


### PR DESCRIPTION
## Description

Fix the range in the type mismatch error reported for an indexing reference expression.

Unfortunately, for historic reasons, index expressions' start position is currently the opening square bracket and not the indexed expression's start position.

I opened #718 to fix the node and thus all other potential cases.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
