### PR TITLE
Use location ID as key for maps holding account codes

### DIFF
--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -492,12 +492,7 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		)
 	}
 
-	type contractKey struct {
-		address [common.AddressLength]byte
-		name    string
-	}
-
-	deployedContracts := map[contractKey][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 
 	var events []cadence.Event
 	var loggedMessages []string
@@ -508,27 +503,27 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 			return []Address{common.BytesToAddress([]byte{0x1})}, nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			key := contractKey{
-				address: address,
-				name:    name,
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
 			}
-			deployedContracts[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			key := contractKey{
-				address: address,
-				name:    name,
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
 			}
-			code = deployedContracts[key]
+			code = accountCodes[location.ID()]
 			return code, nil
 		},
 		removeAccountContractCode: func(address Address, name string) error {
-			key := contractKey{
-				address: address,
-				name:    name,
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
 			}
-			delete(deployedContracts, key)
+			delete(accountCodes, location.ID())
 			return nil
 		},
 		resolveLocation: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -53,7 +53,7 @@ func TestContractUpdateValidation(t *testing.T) {
 		))
 	}
 
-	accountCode := map[string][]byte{}
+	accountCode := map[common.LocationID][]byte{}
 	var events []cadence.Event
 	runtimeInterface := getMockedRuntimeInterfaceForTxUpdate(t, accountCode, events)
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -1431,14 +1431,13 @@ func getContractUpdateError(t *testing.T, err error) *ContractUpdateError {
 
 func getMockedRuntimeInterfaceForTxUpdate(
 	t *testing.T,
-	accountStorage map[string][]byte,
+	accountCodes map[common.LocationID][]byte,
 	events []cadence.Event,
 ) *testRuntimeInterface {
 
 	return &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountStorage[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -1450,16 +1449,14 @@ func getMockedRuntimeInterfaceForTxUpdate(
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountStorage[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountStorage[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -1490,7 +1487,7 @@ func TestContractUpdateValidationDisabled(t *testing.T) {
 		))
 	}
 
-	accountCode := map[string][]byte{}
+	accountCode := map[common.LocationID][]byte{}
 	var events []cadence.Event
 	runtimeInterface := getMockedRuntimeInterfaceForTxUpdate(t, accountCode, events)
 	nextTransactionLocation := newTransactionLocationGenerator()

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3487,15 +3487,14 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
       }
     `)
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 
 	signerAccount := address1Value
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -3507,16 +3506,14 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -3632,15 +3629,14 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
       }
     `)
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 
 	signerAccount := address1Value
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		createAccount: func(payer Address) (address Address, err error) {
@@ -3655,16 +3651,14 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -3796,15 +3790,14 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 		)
 	}
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 
 	var nextAccount byte = 0x2
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		createAccount: func(payer Address) (address Address, err error) {
@@ -3821,16 +3814,14 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -4235,14 +4226,13 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
       }
     `)
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -4254,16 +4244,14 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -4414,14 +4402,13 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
       }
     `)
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -4432,8 +4419,7 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
@@ -4441,8 +4427,7 @@ func TestInterpretResourceOwnerFieldUseArray(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -4598,14 +4583,13 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
       }
     `)
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -4617,16 +4601,14 @@ func TestInterpretResourceOwnerFieldUseDictionary(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -5357,7 +5339,7 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 
 	runtime := NewInterpreterRuntime()
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 
 	var accountCounter uint8 = 0
@@ -5370,8 +5352,7 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 			return Address{accountCounter}, nil
 		},
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -5383,16 +5364,14 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -5492,7 +5471,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	runtime := NewInterpreterRuntime()
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 
 	var accountCounter uint8 = 0
@@ -5509,8 +5488,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			return Address{accountCounter}, nil
 		},
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		storage: newTestStorage(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -5522,8 +5500,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			codeChanged = true
@@ -5532,8 +5509,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {
@@ -5710,7 +5686,7 @@ func TestRuntimeNoProgramsHitForToplevelPrograms(t *testing.T) {
 
 	runtime := NewInterpreterRuntime()
 
-	accountCodes := map[string][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
 
 	programs := map[common.LocationID]*interpreter.Program{}
@@ -5727,8 +5703,7 @@ func TestRuntimeNoProgramsHitForToplevelPrograms(t *testing.T) {
 			return Address{accountCounter}, nil
 		},
 		getCode: func(location Location) (bytes []byte, err error) {
-			key := string(location.(common.AddressLocation).ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		setProgram: func(location Location, program *interpreter.Program) error {
 			programs[location.ID()] = program
@@ -5748,16 +5723,14 @@ func TestRuntimeNoProgramsHitForToplevelPrograms(t *testing.T) {
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			return accountCodes[key], nil
+			return accountCodes[location.ID()], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
-			key := string(location.ID())
-			accountCodes[key] = code
+			accountCodes[location.ID()] = code
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {


### PR DESCRIPTION
## Description

Clean up and make tests holding account codes in maps consistent by using location IDs as the key.

______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
