### PR TITLE
Fix runtime representation of native HashAlgorithm/SignAlgorithm enums

### DIFF
--- a/runtime/account_keys_test.go
+++ b/runtime/account_keys_test.go
@@ -641,7 +641,7 @@ func TestRuntimeHashAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(HashAlgorithmSHA3_256.RawValue()),
+		cadence.NewUInt8(HashAlgorithmSHA3_256.RawValue()),
 		builtinStruct.Fields[0],
 	)
 
@@ -654,7 +654,7 @@ func TestRuntimeHashAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(HashAlgorithmSHA3_256.RawValue()),
+		cadence.NewUInt8(HashAlgorithmSHA3_256.RawValue()),
 		builtinStruct.Fields[0],
 	)
 
@@ -711,7 +711,7 @@ func TestRuntimeSignatureAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(SignatureAlgorithmECDSA_Secp256k1.RawValue()),
+		cadence.NewUInt8(SignatureAlgorithmECDSA_Secp256k1.RawValue()),
 		builtinStruct.Fields[0],
 	)
 
@@ -724,7 +724,7 @@ func TestRuntimeSignatureAlgorithm(t *testing.T) {
 
 	require.Len(t, builtinStruct.Fields, 1)
 	assert.Equal(t,
-		cadence.NewInt(SignatureAlgorithmECDSA_Secp256k1.RawValue()),
+		cadence.NewUInt8(SignatureAlgorithmECDSA_Secp256k1.RawValue()),
 		builtinStruct.Fields[0],
 	)
 
@@ -756,13 +756,13 @@ func newBytesValue(bytes []byte) cadence.Array {
 
 func newSignAlgoValue(signAlgo sema.SignatureAlgorithm) cadence.Enum {
 	return cadence.NewEnum([]cadence.Value{
-		cadence.NewInt(signAlgo.RawValue()),
+		cadence.NewUInt8(signAlgo.RawValue()),
 	}).WithType(SignAlgoType)
 }
 
 func newHashAlgoValue(hashAlgo sema.HashAlgorithm) cadence.Enum {
 	return cadence.NewEnum([]cadence.Value{
-		cadence.NewInt(hashAlgo.RawValue()),
+		cadence.NewUInt8(hashAlgo.RawValue()),
 	}).WithType(HashAlgoType)
 }
 
@@ -800,7 +800,7 @@ func accountKeyExportedValue(
 
 			// Hash algo
 			cadence.NewEnum([]cadence.Value{
-				cadence.NewInt(hashAlgo.RawValue()),
+				cadence.NewUInt8(hashAlgo.RawValue()),
 			}).WithType(HashAlgoType),
 
 			// Weight

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7194,9 +7194,9 @@ func NewPublicAccountKeysValue(getFunction FunctionValue) *CompositeValue {
 	}
 }
 
-func NewNativeEnumCaseValue(enumType *sema.CompositeType, rawValue int) *CompositeValue {
+func NewCryptoAlgorithmEnumCaseValue(enumType *sema.CompositeType, rawValue uint8) *CompositeValue {
 	fields := NewStringValueOrderedMap()
-	fields.Set(sema.EnumRawValueFieldName, NewIntValueFromInt64(int64(rawValue)))
+	fields.Set(sema.EnumRawValueFieldName, UInt8Value(rawValue))
 
 	return &CompositeValue{
 		QualifiedIdentifier: enumType.QualifiedIdentifier(),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2314,7 +2314,7 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 		panic("cannot find sign algorithm raw value")
 	}
 
-	signAlgoRawValue := rawValue.(interpreter.IntValue)
+	signAlgoRawValue := rawValue.(interpreter.UInt8Value)
 
 	return &PublicKey{
 		PublicKey: byteArray,
@@ -2325,7 +2325,7 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 func NewPublicKeyValue(publicKey *PublicKey) *interpreter.CompositeValue {
 	return interpreter.NewPublicKeyValue(
 		interpreter.ByteSliceToByteArrayValue(publicKey.PublicKey),
-		interpreter.NewNativeEnumCaseValue(sema.SignatureAlgorithmType, int(publicKey.SignAlgo)),
+		interpreter.NewCryptoAlgorithmEnumCaseValue(sema.SignatureAlgorithmType, publicKey.SignAlgo.RawValue()),
 	)
 }
 
@@ -2333,7 +2333,7 @@ func NewAccountKeyValue(accountKey *AccountKey) *interpreter.CompositeValue {
 	return interpreter.NewAccountKeyValue(
 		interpreter.NewIntValueFromInt64(int64(accountKey.KeyIndex)),
 		NewPublicKeyValue(accountKey.PublicKey),
-		interpreter.NewNativeEnumCaseValue(sema.HashAlgorithmType, int(accountKey.HashAlgo)),
+		interpreter.NewCryptoAlgorithmEnumCaseValue(sema.HashAlgorithmType, accountKey.HashAlgo.RawValue()),
 		interpreter.NewUFix64ValueWithInteger(uint64(accountKey.Weight)),
 		interpreter.BoolValue(accountKey.IsRevoked),
 	)
@@ -2347,7 +2347,7 @@ func NewHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 		panic("cannot find hash algorithm raw value")
 	}
 
-	hashAlgoRawValue := rawValue.(interpreter.IntValue)
+	hashAlgoRawValue := rawValue.(interpreter.UInt8Value)
 
 	return HashAlgorithm(hashAlgoRawValue.ToInt())
 }

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -26,12 +26,12 @@ import (
 //go:generate go run golang.org/x/tools/cmd/stringer -type=SignatureAlgorithm
 //go:generate go run golang.org/x/tools/cmd/stringer -type=HashAlgorithm
 
-var SignatureAlgorithms = []NativeEnumCase{
+var SignatureAlgorithms = []CryptoAlgorithm{
 	SignatureAlgorithmECDSA_P256,
 	SignatureAlgorithmECDSA_Secp256k1,
 }
 
-var HashAlgorithms = []NativeEnumCase{
+var HashAlgorithms = []CryptoAlgorithm{
 	HashAlgorithmSHA2_256,
 	HashAlgorithmSHA2_384,
 	HashAlgorithmSHA3_256,
@@ -40,7 +40,7 @@ var HashAlgorithms = []NativeEnumCase{
 
 var SignatureAlgorithmType = newNativeEnumType(SignatureAlgorithmTypeName, &UInt8Type{})
 
-type SignatureAlgorithm int
+type SignatureAlgorithm uint8
 
 const (
 	// Supported signing algorithms
@@ -63,7 +63,7 @@ func (algo SignatureAlgorithm) Name() string {
 	panic(errors.NewUnreachableError())
 }
 
-func (algo SignatureAlgorithm) RawValue() int {
+func (algo SignatureAlgorithm) RawValue() uint8 {
 	// NOTE: only add new algorithms, do *NOT* change existing items,
 	// reuse raw values for other items, swap the order, etc.
 	//
@@ -96,7 +96,7 @@ func (algo SignatureAlgorithm) DocString() string {
 
 var HashAlgorithmType = newNativeEnumType(HashAlgorithmTypeName, &UInt8Type{})
 
-type HashAlgorithm int
+type HashAlgorithm uint8
 
 const (
 	// Supported hashing algorithms
@@ -124,7 +124,7 @@ func (algo HashAlgorithm) Name() string {
 	panic(errors.NewUnreachableError())
 }
 
-func (algo HashAlgorithm) RawValue() int {
+func (algo HashAlgorithm) RawValue() uint8 {
 	// NOTE: only add new algorithms, do *NOT* change existing items,
 	// reuse raw values for other items, swap the order, etc.
 	//

--- a/runtime/sema/hashalgorithm_string.go
+++ b/runtime/sema/hashalgorithm_string.go
@@ -20,7 +20,7 @@ const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgori
 var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104}
 
 func (i HashAlgorithm) String() string {
-	if i < 0 || i >= HashAlgorithm(len(_HashAlgorithm_index)-1) {
+	if i >= HashAlgorithm(len(_HashAlgorithm_index)-1) {
 		return "HashAlgorithm(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _HashAlgorithm_name[_HashAlgorithm_index[i]:_HashAlgorithm_index[i+1]]

--- a/runtime/sema/signaturealgorithm_string.go
+++ b/runtime/sema/signaturealgorithm_string.go
@@ -18,7 +18,7 @@ const _SignatureAlgorithm_name = "SignatureAlgorithmUnknownSignatureAlgorithmECD
 var _SignatureAlgorithm_index = [...]uint8{0, 25, 53, 86}
 
 func (i SignatureAlgorithm) String() string {
-	if i < 0 || i >= SignatureAlgorithm(len(_SignatureAlgorithm_index)-1) {
+	if i >= SignatureAlgorithm(len(_SignatureAlgorithm_index)-1) {
 		return "SignatureAlgorithm(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _SignatureAlgorithm_name[_SignatureAlgorithm_index[i]:_SignatureAlgorithm_index[i+1]]

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6666,8 +6666,8 @@ var PublicKeyType = func() *CompositeType {
 	return accountKeyType
 }()
 
-type NativeEnumCase interface {
-	RawValue() int
+type CryptoAlgorithm interface {
+	RawValue() uint8
 	Name() string
 	DocString() string
 }

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -174,19 +174,19 @@ var BuiltinValues = StandardLibraryValues{
 
 var SignatureAlgorithmValue = StandardLibraryValue{
 	Name:  sema.SignatureAlgorithmTypeName,
-	Type:  nativeEnumType(sema.SignatureAlgorithmType, sema.SignatureAlgorithms),
-	Value: nativeEnumValue(sema.SignatureAlgorithmType, sema.SignatureAlgorithms),
+	Type:  cryptoAlgorithmEnumType(sema.SignatureAlgorithmType, sema.SignatureAlgorithms),
+	Value: cryptoAlgorithmEnumValue(sema.SignatureAlgorithmType, sema.SignatureAlgorithms),
 	Kind:  common.DeclarationKindEnum,
 }
 
 var HashAlgorithmValue = StandardLibraryValue{
 	Name:  sema.HashAlgorithmTypeName,
-	Type:  nativeEnumType(sema.HashAlgorithmType, sema.HashAlgorithms),
-	Value: nativeEnumValue(sema.HashAlgorithmType, sema.HashAlgorithms),
+	Type:  cryptoAlgorithmEnumType(sema.HashAlgorithmType, sema.HashAlgorithms),
+	Value: cryptoAlgorithmEnumValue(sema.HashAlgorithmType, sema.HashAlgorithms),
 	Kind:  common.DeclarationKindEnum,
 }
 
-func nativeEnumType(enumType *sema.CompositeType, enumCases []sema.NativeEnumCase) *sema.SpecialFunctionType {
+func cryptoAlgorithmEnumType(enumType *sema.CompositeType, enumCases []sema.CryptoAlgorithm) *sema.SpecialFunctionType {
 	members := make([]*sema.Member, len(enumCases))
 	for i, algo := range enumCases {
 		members[i] = sema.NewPublicEnumCaseMember(
@@ -216,13 +216,13 @@ func nativeEnumType(enumType *sema.CompositeType, enumCases []sema.NativeEnumCas
 	return constructorType
 }
 
-func nativeEnumValue(enumType *sema.CompositeType, enumCases []sema.NativeEnumCase) (value interpreter.Value) {
+func cryptoAlgorithmEnumValue(enumType *sema.CompositeType, enumCases []sema.CryptoAlgorithm) (value interpreter.Value) {
 	caseCount := len(enumCases)
 	caseValues := make([]*interpreter.CompositeValue, caseCount)
 	constructorNestedVariables := interpreter.NewStringVariableOrderedMap()
 
 	for i, enumCase := range enumCases {
-		caseValue := interpreter.NewNativeEnumCaseValue(enumType, enumCase.RawValue())
+		caseValue := interpreter.NewCryptoAlgorithmEnumCaseValue(enumType, enumCase.RawValue())
 		caseValues[i] = caseValue
 		constructorNestedVariables.Set(
 			enumCase.Name(),

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -247,7 +247,7 @@ func getHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 		panic("cannot find hash algorithm raw value")
 	}
 
-	hashAlgoRawValue, ok := rawValue.(interpreter.IntValue)
+	hashAlgoRawValue, ok := rawValue.(interpreter.UInt8Value)
 	if !ok {
 		panic("hash algorithm raw value needs to be subtype of integer")
 	}
@@ -266,7 +266,7 @@ func getSignatureAlgorithmFromValue(value interpreter.Value) SignatureAlgorithm 
 		panic("cannot find signature algorithm raw value")
 	}
 
-	hashAlgoRawValue, ok := rawValue.(interpreter.IntValue)
+	hashAlgoRawValue, ok := rawValue.(interpreter.UInt8Value)
 	if !ok {
 		panic("signature algorithm raw value needs to be subtype of integer")
 	}


### PR DESCRIPTION
Separated out the enum changes from #724

## Description

Fixes the runtime representation of HashAlgorith/SignAlgorithm. Checker enforces the use of `uint8` but the runtime was using `int`. 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
