### PR TITLE
Make numeric types singleton

### DIFF
--- a/runtime/compiler/compiler.go
+++ b/runtime/compiler/compiler.go
@@ -389,14 +389,12 @@ func compileBinaryOperation(operation ast.Operation) ir.BinOp {
 
 func compileValueType(ty sema.Type) ir.ValType {
 	// TODO: add remaining types
-	switch ty.(type) {
-	case *sema.IntType:
-		return ir.ValTypeInt
-	}
 
 	switch ty {
 	case sema.StringType:
 		return ir.ValTypeString
+	case sema.IntType:
+		return ir.ValTypeInt
 	}
 
 	panic(errors.NewUnreachableError())

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -39,58 +39,6 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 		switch t := t.(type) {
 		case *sema.OptionalType:
 			return exportOptionalType(t, results)
-		case *sema.NumberType:
-			return cadence.NumberType{}
-		case *sema.SignedNumberType:
-			return cadence.SignedNumberType{}
-		case *sema.IntegerType:
-			return cadence.IntegerType{}
-		case *sema.SignedIntegerType:
-			return cadence.SignedIntegerType{}
-		case *sema.FixedPointType:
-			return cadence.FixedPointType{}
-		case *sema.SignedFixedPointType:
-			return cadence.SignedFixedPointType{}
-		case *sema.IntType:
-			return cadence.IntType{}
-		case *sema.Int8Type:
-			return cadence.Int8Type{}
-		case *sema.Int16Type:
-			return cadence.Int16Type{}
-		case *sema.Int32Type:
-			return cadence.Int32Type{}
-		case *sema.Int64Type:
-			return cadence.Int64Type{}
-		case *sema.Int128Type:
-			return cadence.Int128Type{}
-		case *sema.Int256Type:
-			return cadence.Int256Type{}
-		case *sema.UIntType:
-			return cadence.UIntType{}
-		case *sema.UInt8Type:
-			return cadence.UInt8Type{}
-		case *sema.UInt16Type:
-			return cadence.UInt16Type{}
-		case *sema.UInt32Type:
-			return cadence.UInt32Type{}
-		case *sema.UInt64Type:
-			return cadence.UInt64Type{}
-		case *sema.UInt128Type:
-			return cadence.UInt128Type{}
-		case *sema.UInt256Type:
-			return cadence.UInt256Type{}
-		case *sema.Word8Type:
-			return cadence.Word8Type{}
-		case *sema.Word16Type:
-			return cadence.Word16Type{}
-		case *sema.Word32Type:
-			return cadence.Word32Type{}
-		case *sema.Word64Type:
-			return cadence.Word64Type{}
-		case *sema.Fix64Type:
-			return cadence.Fix64Type{}
-		case *sema.UFix64Type:
-			return cadence.UFix64Type{}
 		case *sema.VariableSizedType:
 			return exportVariableSizedType(t, results)
 		case *sema.ConstantSizedType:
@@ -116,6 +64,58 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 		}
 
 		switch t {
+		case sema.NumberType:
+			return cadence.NumberType{}
+		case sema.SignedNumberType:
+			return cadence.SignedNumberType{}
+		case sema.IntegerType:
+			return cadence.IntegerType{}
+		case sema.SignedIntegerType:
+			return cadence.SignedIntegerType{}
+		case sema.FixedPointType:
+			return cadence.FixedPointType{}
+		case sema.SignedFixedPointType:
+			return cadence.SignedFixedPointType{}
+		case sema.IntType:
+			return cadence.IntType{}
+		case sema.Int8Type:
+			return cadence.Int8Type{}
+		case sema.Int16Type:
+			return cadence.Int16Type{}
+		case sema.Int32Type:
+			return cadence.Int32Type{}
+		case sema.Int64Type:
+			return cadence.Int64Type{}
+		case sema.Int128Type:
+			return cadence.Int128Type{}
+		case sema.Int256Type:
+			return cadence.Int256Type{}
+		case sema.UIntType:
+			return cadence.UIntType{}
+		case sema.UInt8Type:
+			return cadence.UInt8Type{}
+		case sema.UInt16Type:
+			return cadence.UInt16Type{}
+		case sema.UInt32Type:
+			return cadence.UInt32Type{}
+		case sema.UInt64Type:
+			return cadence.UInt64Type{}
+		case sema.UInt128Type:
+			return cadence.UInt128Type{}
+		case sema.UInt256Type:
+			return cadence.UInt256Type{}
+		case sema.Word8Type:
+			return cadence.Word8Type{}
+		case sema.Word16Type:
+			return cadence.Word16Type{}
+		case sema.Word32Type:
+			return cadence.Word32Type{}
+		case sema.Word64Type:
+			return cadence.Word64Type{}
+		case sema.Fix64Type:
+			return cadence.Fix64Type{}
+		case sema.UFix64Type:
+			return cadence.UFix64Type{}
 		case sema.PathType:
 			return cadence.PathType{}
 		case sema.StoragePathType:

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -4274,7 +4274,7 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				value: TypeValue{
-					Type: ConvertSemaToPrimitiveStaticType(&sema.IntType{}),
+					Type: ConvertSemaToPrimitiveStaticType(sema.IntType),
 				},
 				encoded: []byte{
 					// tag

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1315,7 +1315,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 	location := interpreter.Location
 
-	intType := &sema.IntType{}
+	intType := sema.IntType
 
 	enumCases := declaration.Members.EnumCases()
 	caseValues := make([]*CompositeValue, len(enumCases))
@@ -1598,115 +1598,117 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 
 	unwrappedTargetType := sema.UnwrapOptionalType(targetType)
 
-	switch unwrappedTargetType.(type) {
-	case *sema.IntType:
+	switch unwrappedTargetType {
+	case sema.IntType:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertInt(value)
 		}
 
-	case *sema.UIntType:
+	case sema.UIntType:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUInt(value)
 		}
 
-	case *sema.AddressType:
-		if !valueType.Equal(unwrappedTargetType) {
-			return ConvertAddress(value)
-		}
-
 	// Int*
-	case *sema.Int8Type:
+	case sema.Int8Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertInt8(value)
 		}
 
-	case *sema.Int16Type:
+	case sema.Int16Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertInt16(value)
 		}
 
-	case *sema.Int32Type:
+	case sema.Int32Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertInt32(value)
 		}
 
-	case *sema.Int64Type:
+	case sema.Int64Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertInt64(value)
 		}
 
-	case *sema.Int128Type:
+	case sema.Int128Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertInt128(value)
 		}
 
-	case *sema.Int256Type:
+	case sema.Int256Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertInt256(value)
 		}
 
 	// UInt*
-	case *sema.UInt8Type:
+	case sema.UInt8Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUInt8(value)
 		}
 
-	case *sema.UInt16Type:
+	case sema.UInt16Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUInt16(value)
 		}
 
-	case *sema.UInt32Type:
+	case sema.UInt32Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUInt32(value)
 		}
 
-	case *sema.UInt64Type:
+	case sema.UInt64Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUInt64(value)
 		}
 
-	case *sema.UInt128Type:
+	case sema.UInt128Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUInt128(value)
 		}
 
-	case *sema.UInt256Type:
+	case sema.UInt256Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUInt256(value)
 		}
 
 	// Word*
-	case *sema.Word8Type:
+	case sema.Word8Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertWord8(value)
 		}
 
-	case *sema.Word16Type:
+	case sema.Word16Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertWord16(value)
 		}
 
-	case *sema.Word32Type:
+	case sema.Word32Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertWord32(value)
 		}
 
-	case *sema.Word64Type:
+	case sema.Word64Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertWord64(value)
 		}
 
 	// Fix*
 
-	case *sema.Fix64Type:
+	case sema.Fix64Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertFix64(value)
 		}
 
-	case *sema.UFix64Type:
+	case sema.UFix64Type:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertUFix64(value)
+		}
+	}
+
+	switch unwrappedTargetType.(type) {
+	case *sema.AddressType:
+		if !valueType.Equal(unwrappedTargetType) {
+			return ConvertAddress(value)
 		}
 	}
 
@@ -2186,10 +2188,10 @@ func init() {
 		// Only leaf number types require a converter,
 		// "hierarchy" number types don't need one
 
-		switch numberType.(type) {
-		case *sema.NumberType, *sema.SignedNumberType,
-			*sema.IntegerType, *sema.SignedIntegerType,
-			*sema.FixedPointType, *sema.SignedFixedPointType:
+		switch numberType {
+		case sema.NumberType, sema.SignedNumberType,
+			sema.IntegerType, sema.SignedIntegerType,
+			sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -300,22 +300,23 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 	switch t {
 
 	// Number
+
 	case sema.NumberType:
 		return PrimitiveStaticTypeNumber
 	case sema.SignedNumberType:
 		return PrimitiveStaticTypeSignedNumber
-
-	// FixedPoint
-	case sema.FixedPointType:
-		return PrimitiveStaticTypeFixedPoint
-	case sema.SignedFixedPointType:
-		return PrimitiveStaticTypeSignedFixedPoint
 
 	// Integer
 	case sema.IntegerType:
 		return PrimitiveStaticTypeInteger
 	case sema.SignedIntegerType:
 		return PrimitiveStaticTypeSignedInteger
+
+	// FixedPoint
+	case sema.FixedPointType:
+		return PrimitiveStaticTypeFixedPoint
+	case sema.SignedFixedPointType:
+		return PrimitiveStaticTypeSignedFixedPoint
 
 	// Int*
 	case sema.IntType:

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -198,72 +198,72 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 	// Number
 
 	case PrimitiveStaticTypeNumber:
-		return &sema.NumberType{}
+		return sema.NumberType
 	case PrimitiveStaticTypeSignedNumber:
-		return &sema.SignedNumberType{}
+		return sema.SignedNumberType
 
 	// Integer
 	case PrimitiveStaticTypeInteger:
-		return &sema.IntegerType{}
+		return sema.IntegerType
 	case PrimitiveStaticTypeSignedInteger:
-		return &sema.SignedIntegerType{}
+		return sema.SignedIntegerType
 
 	// FixedPoint
 	case PrimitiveStaticTypeFixedPoint:
-		return &sema.FixedPointType{}
+		return sema.FixedPointType
 	case PrimitiveStaticTypeSignedFixedPoint:
-		return &sema.SignedFixedPointType{}
+		return sema.SignedFixedPointType
 
 	// Int*
 	case PrimitiveStaticTypeInt:
-		return &sema.IntType{}
+		return sema.IntType
 	case PrimitiveStaticTypeInt8:
-		return &sema.Int8Type{}
+		return sema.Int8Type
 	case PrimitiveStaticTypeInt16:
-		return &sema.Int16Type{}
+		return sema.Int16Type
 	case PrimitiveStaticTypeInt32:
-		return &sema.Int32Type{}
+		return sema.Int32Type
 	case PrimitiveStaticTypeInt64:
-		return &sema.Int64Type{}
+		return sema.Int64Type
 	case PrimitiveStaticTypeInt128:
-		return &sema.Int128Type{}
+		return sema.Int128Type
 	case PrimitiveStaticTypeInt256:
-		return &sema.Int256Type{}
+		return sema.Int256Type
 
 	// UInt*
 	case PrimitiveStaticTypeUInt:
-		return &sema.UIntType{}
+		return sema.UIntType
 	case PrimitiveStaticTypeUInt8:
-		return &sema.UInt8Type{}
+		return sema.UInt8Type
 	case PrimitiveStaticTypeUInt16:
-		return &sema.UInt16Type{}
+		return sema.UInt16Type
 	case PrimitiveStaticTypeUInt32:
-		return &sema.UInt32Type{}
+		return sema.UInt32Type
 	case PrimitiveStaticTypeUInt64:
-		return &sema.UInt64Type{}
+		return sema.UInt64Type
 	case PrimitiveStaticTypeUInt128:
-		return &sema.UInt128Type{}
+		return sema.UInt128Type
 	case PrimitiveStaticTypeUInt256:
-		return &sema.UInt256Type{}
+		return sema.UInt256Type
 
 	// Word *
 
 	case PrimitiveStaticTypeWord8:
-		return &sema.Word8Type{}
+		return sema.Word8Type
 	case PrimitiveStaticTypeWord16:
-		return &sema.Word16Type{}
+		return sema.Word16Type
 	case PrimitiveStaticTypeWord32:
-		return &sema.Word32Type{}
+		return sema.Word32Type
 	case PrimitiveStaticTypeWord64:
-		return &sema.Word64Type{}
+		return sema.Word64Type
 
 	// Fix*
 	case PrimitiveStaticTypeFix64:
-		return &sema.Fix64Type{}
+		return sema.Fix64Type
 
 	// UFix*
 	case PrimitiveStaticTypeUFix64:
-		return &sema.UFix64Type{}
+		return sema.UFix64Type
 
 	// Storage
 
@@ -297,87 +297,76 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 // Returns `PrimitiveStaticTypeUnknown` if the given type is not a primitive type.
 //
 func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
-	switch t.(type) {
-	case *sema.AddressType:
-		return PrimitiveStaticTypeAddress
+	switch t {
 
 	// Number
-
-	case *sema.NumberType:
+	case sema.NumberType:
 		return PrimitiveStaticTypeNumber
-	case *sema.SignedNumberType:
+	case sema.SignedNumberType:
 		return PrimitiveStaticTypeSignedNumber
 
-	// Integer
-	case *sema.IntegerType:
-		return PrimitiveStaticTypeInteger
-	case *sema.SignedIntegerType:
-		return PrimitiveStaticTypeSignedInteger
-
 	// FixedPoint
-	case *sema.FixedPointType:
+	case sema.FixedPointType:
 		return PrimitiveStaticTypeFixedPoint
-	case *sema.SignedFixedPointType:
+	case sema.SignedFixedPointType:
 		return PrimitiveStaticTypeSignedFixedPoint
 
+	// Integer
+	case sema.IntegerType:
+		return PrimitiveStaticTypeInteger
+	case sema.SignedIntegerType:
+		return PrimitiveStaticTypeSignedInteger
+
 	// Int*
-	case *sema.IntType:
+	case sema.IntType:
 		return PrimitiveStaticTypeInt
-	case *sema.Int8Type:
+	case sema.Int8Type:
 		return PrimitiveStaticTypeInt8
-	case *sema.Int16Type:
+	case sema.Int16Type:
 		return PrimitiveStaticTypeInt16
-	case *sema.Int32Type:
+	case sema.Int32Type:
 		return PrimitiveStaticTypeInt32
-	case *sema.Int64Type:
+	case sema.Int64Type:
 		return PrimitiveStaticTypeInt64
-	case *sema.Int128Type:
+	case sema.Int128Type:
 		return PrimitiveStaticTypeInt128
-	case *sema.Int256Type:
+	case sema.Int256Type:
 		return PrimitiveStaticTypeInt256
 
 	// UInt*
-	case *sema.UIntType:
+	case sema.UIntType:
 		return PrimitiveStaticTypeUInt
-	case *sema.UInt8Type:
+	case sema.UInt8Type:
 		return PrimitiveStaticTypeUInt8
-	case *sema.UInt16Type:
+	case sema.UInt16Type:
 		return PrimitiveStaticTypeUInt16
-	case *sema.UInt32Type:
+	case sema.UInt32Type:
 		return PrimitiveStaticTypeUInt32
-	case *sema.UInt64Type:
+	case sema.UInt64Type:
 		return PrimitiveStaticTypeUInt64
-	case *sema.UInt128Type:
+	case sema.UInt128Type:
 		return PrimitiveStaticTypeUInt128
-	case *sema.UInt256Type:
+	case sema.UInt256Type:
 		return PrimitiveStaticTypeUInt256
 
 	// Word*
-
-	case *sema.Word8Type:
+	case sema.Word8Type:
 		return PrimitiveStaticTypeWord8
-	case *sema.Word16Type:
+	case sema.Word16Type:
 		return PrimitiveStaticTypeWord16
-	case *sema.Word32Type:
+	case sema.Word32Type:
 		return PrimitiveStaticTypeWord32
-	case *sema.Word64Type:
+	case sema.Word64Type:
 		return PrimitiveStaticTypeWord64
 
 	// Fix*
-	case *sema.Fix64Type:
+	case sema.Fix64Type:
 		return PrimitiveStaticTypeFix64
 
 	// UFix*
-	case *sema.UFix64Type:
+	case sema.UFix64Type:
 		return PrimitiveStaticTypeUFix64
 
-	// Storage
-
-	case *sema.CapabilityType:
-		return PrimitiveStaticTypeCapability
-	}
-
-	switch t {
 	case sema.PathType:
 		return PrimitiveStaticTypePath
 	case sema.StoragePathType:
@@ -416,6 +405,15 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 		return PrimitiveStaticTypeAuthAccountContracts
 	case sema.StringType:
 		return PrimitiveStaticTypeString
+	}
+
+	switch t.(type) {
+	case *sema.AddressType:
+		return PrimitiveStaticTypeAddress
+
+	// Storage
+	case *sema.CapabilityType:
+		return PrimitiveStaticTypeCapability
 	}
 
 	return PrimitiveStaticTypeUnknown

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -855,7 +855,7 @@ func (v IntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (IntValue) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.IntType{}}
+	return NumberDynamicType{sema.IntType}
 }
 
 func (IntValue) StaticType() StaticType {
@@ -1063,7 +1063,7 @@ func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Int8Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Int8Type{}}
+	return NumberDynamicType{sema.Int8Type}
 }
 
 func (Int8Value) StaticType() StaticType {
@@ -1299,7 +1299,7 @@ func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Int16Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Int16Type{}}
+	return NumberDynamicType{sema.Int16Type}
 }
 
 func (Int16Value) StaticType() StaticType {
@@ -1537,7 +1537,7 @@ func (v Int32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Int32Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Int32Type{}}
+	return NumberDynamicType{sema.Int32Type}
 }
 
 func (Int32Value) StaticType() StaticType {
@@ -1775,7 +1775,7 @@ func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Int64Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Int64Type{}}
+	return NumberDynamicType{sema.Int64Type}
 }
 
 func (Int64Value) StaticType() StaticType {
@@ -2021,7 +2021,7 @@ func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Int128Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Int128Type{}}
+	return NumberDynamicType{sema.Int128Type}
 }
 
 func (Int128Value) StaticType() StaticType {
@@ -2317,7 +2317,7 @@ func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Int256Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Int256Type{}}
+	return NumberDynamicType{sema.Int256Type}
 }
 
 func (Int256Value) StaticType() StaticType {
@@ -2634,7 +2634,7 @@ func (v UIntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UIntValue) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UIntType{}}
+	return NumberDynamicType{sema.UIntType}
 }
 
 func (UIntValue) StaticType() StaticType {
@@ -2845,7 +2845,7 @@ func (v UInt8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UInt8Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UInt8Type{}}
+	return NumberDynamicType{sema.UInt8Type}
 }
 
 func (UInt8Value) StaticType() StaticType {
@@ -3049,7 +3049,7 @@ func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UInt16Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UInt16Type{}}
+	return NumberDynamicType{sema.UInt16Type}
 }
 
 func (UInt16Value) StaticType() StaticType {
@@ -3253,7 +3253,7 @@ func (v UInt32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UInt32Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UInt32Type{}}
+	return NumberDynamicType{sema.UInt32Type}
 }
 
 func (UInt32Value) StaticType() StaticType {
@@ -3459,7 +3459,7 @@ func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UInt64Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UInt64Type{}}
+	return NumberDynamicType{sema.UInt64Type}
 }
 
 func (UInt64Value) StaticType() StaticType {
@@ -3678,7 +3678,7 @@ func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UInt128Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UInt128Type{}}
+	return NumberDynamicType{sema.UInt128Type}
 }
 
 func (UInt128Value) StaticType() StaticType {
@@ -3943,7 +3943,7 @@ func (v UInt256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UInt256Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UInt256Type{}}
+	return NumberDynamicType{sema.UInt256Type}
 }
 
 func (UInt256Value) StaticType() StaticType {
@@ -4199,7 +4199,7 @@ func (v Word8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Word8Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Word8Type{}}
+	return NumberDynamicType{sema.Word8Type}
 }
 
 func (Word8Value) StaticType() StaticType {
@@ -4364,7 +4364,7 @@ func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Word16Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Word16Type{}}
+	return NumberDynamicType{sema.Word16Type}
 }
 
 func (Word16Value) StaticType() StaticType {
@@ -4529,7 +4529,7 @@ func (v Word32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Word32Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Word32Type{}}
+	return NumberDynamicType{sema.Word32Type}
 }
 
 func (Word32Value) StaticType() StaticType {
@@ -4696,7 +4696,7 @@ func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Word64Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Word64Type{}}
+	return NumberDynamicType{sema.Word64Type}
 }
 
 func (Word64Value) StaticType() StaticType {
@@ -4878,7 +4878,7 @@ func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (Fix64Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.Fix64Type{}}
+	return NumberDynamicType{sema.Fix64Type}
 }
 
 func (Fix64Value) StaticType() StaticType {
@@ -5093,7 +5093,7 @@ func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 }
 
 func (UFix64Value) DynamicType(_ *Interpreter) DynamicType {
-	return NumberDynamicType{&sema.UFix64Type{}}
+	return NumberDynamicType{sema.UFix64Type}
 }
 
 func (UFix64Value) StaticType() StaticType {

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -148,6 +148,7 @@ func integerLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value
 }
 
 func convertIntValue(intValue interpreter.IntValue, ty sema.Type) (interpreter.Value, error) {
+
 	switch ty {
 	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
 		return intValue, nil

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -148,45 +148,44 @@ func integerLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value
 }
 
 func convertIntValue(intValue interpreter.IntValue, ty sema.Type) (interpreter.Value, error) {
-
-	switch ty.(type) {
-	case *sema.IntType, *sema.IntegerType, *sema.SignedIntegerType:
+	switch ty {
+	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
 		return intValue, nil
-	case *sema.Int8Type:
+	case sema.Int8Type:
 		return interpreter.ConvertInt8(intValue), nil
-	case *sema.Int16Type:
+	case sema.Int16Type:
 		return interpreter.ConvertInt16(intValue), nil
-	case *sema.Int32Type:
+	case sema.Int32Type:
 		return interpreter.ConvertInt32(intValue), nil
-	case *sema.Int64Type:
+	case sema.Int64Type:
 		return interpreter.ConvertInt64(intValue), nil
-	case *sema.Int128Type:
+	case sema.Int128Type:
 		return interpreter.ConvertInt128(intValue), nil
-	case *sema.Int256Type:
+	case sema.Int256Type:
 		return interpreter.ConvertInt256(intValue), nil
 
-	case *sema.UIntType:
+	case sema.UIntType:
 		return interpreter.ConvertUInt(intValue), nil
-	case *sema.UInt8Type:
+	case sema.UInt8Type:
 		return interpreter.ConvertUInt8(intValue), nil
-	case *sema.UInt16Type:
+	case sema.UInt16Type:
 		return interpreter.ConvertUInt16(intValue), nil
-	case *sema.UInt32Type:
+	case sema.UInt32Type:
 		return interpreter.ConvertUInt32(intValue), nil
-	case *sema.UInt64Type:
+	case sema.UInt64Type:
 		return interpreter.ConvertUInt64(intValue), nil
-	case *sema.UInt128Type:
+	case sema.UInt128Type:
 		return interpreter.ConvertUInt128(intValue), nil
-	case *sema.UInt256Type:
+	case sema.UInt256Type:
 		return interpreter.ConvertUInt256(intValue), nil
 
-	case *sema.Word8Type:
+	case sema.Word8Type:
 		return interpreter.ConvertWord8(intValue), nil
-	case *sema.Word16Type:
+	case sema.Word16Type:
 		return interpreter.ConvertWord16(intValue), nil
-	case *sema.Word32Type:
+	case sema.Word32Type:
 		return interpreter.ConvertWord32(intValue), nil
-	case *sema.Word64Type:
+	case sema.Word64Type:
 		return interpreter.ConvertWord64(intValue), nil
 
 	default:
@@ -214,10 +213,10 @@ func fixedPointLiteralValue(expression ast.Expression, ty sema.Type) (cadence.Va
 		sema.Fix64Scale,
 	)
 
-	switch ty.(type) {
-	case *sema.Fix64Type, *sema.FixedPointType, *sema.SignedFixedPointType:
+	switch ty {
+	case sema.Fix64Type, sema.FixedPointType, sema.SignedFixedPointType:
 		return cadence.Fix64(value.Int64()), nil
-	case *sema.UFix64Type:
+	case sema.UFix64Type:
 		return cadence.UFix64(value.Uint64()), nil
 	}
 
@@ -311,10 +310,10 @@ func LiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error
 	}
 
 	switch {
-	case sema.IsSubType(ty, &sema.IntegerType{}):
+	case sema.IsSubType(ty, sema.IntegerType):
 		return integerLiteralValue(expression, ty)
 
-	case sema.IsSubType(ty, &sema.FixedPointType{}):
+	case sema.IsSubType(ty, sema.FixedPointType):
 		return fixedPointLiteralValue(expression, ty)
 
 	case sema.IsSubType(ty, sema.PathType):

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -362,7 +362,7 @@ func TestLiteralValue(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(false, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, &sema.Fix64Type{})
+		value, err := ParseLiteral(`1.0`, sema.Fix64Type)
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
@@ -371,13 +371,13 @@ func TestLiteralValue(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(true, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`-1.0`, &sema.Fix64Type{})
+		value, err := ParseLiteral(`-1.0`, sema.Fix64Type)
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("Fix64, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, &sema.Fix64Type{})
+		value, err := ParseLiteral(`1`, sema.Fix64Type)
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
@@ -386,19 +386,19 @@ func TestLiteralValue(t *testing.T) {
 		expected, err := cadence.NewUFix64FromParts(1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, &sema.UFix64Type{})
+		value, err := ParseLiteral(`1.0`, sema.UFix64Type)
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("UFix64, invalid literal, negative", func(t *testing.T) {
-		value, err := ParseLiteral(`-1.0`, &sema.UFix64Type{})
+		value, err := ParseLiteral(`-1.0`, sema.UFix64Type)
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
 
 	t.Run("UFix64, invalid literal, invalid expression", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, &sema.UFix64Type{})
+		value, err := ParseLiteral(`1`, sema.UFix64Type)
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
@@ -407,7 +407,7 @@ func TestLiteralValue(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(false, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, &sema.FixedPointType{})
+		value, err := ParseLiteral(`1.0`, sema.FixedPointType)
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
@@ -416,13 +416,13 @@ func TestLiteralValue(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(true, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`-1.0`, &sema.FixedPointType{})
+		value, err := ParseLiteral(`-1.0`, sema.FixedPointType)
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("FixedPoint, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, &sema.FixedPointType{})
+		value, err := ParseLiteral(`1`, sema.FixedPointType)
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
@@ -431,7 +431,7 @@ func TestLiteralValue(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(false, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, &sema.SignedFixedPointType{})
+		value, err := ParseLiteral(`1.0`, sema.SignedFixedPointType)
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
@@ -440,13 +440,13 @@ func TestLiteralValue(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(true, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`-1.0`, &sema.SignedFixedPointType{})
+		value, err := ParseLiteral(`-1.0`, sema.SignedFixedPointType)
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("SignedFixedPoint, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, &sema.SignedFixedPointType{})
+		value, err := ParseLiteral(`1`, sema.SignedFixedPointType)
 		require.Error(t, err)
 		require.Nil(t, value)
 	})
@@ -492,8 +492,8 @@ func TestLiteralValue(t *testing.T) {
 
 	for _, signedIntegerType := range append(
 		sema.AllSignedIntegerTypes[:],
-		&sema.IntegerType{},
-		&sema.SignedIntegerType{},
+		sema.IntegerType,
+		sema.SignedIntegerType,
 	) {
 
 		t.Run(
@@ -551,7 +551,7 @@ func TestParseLiteralArgumentList(t *testing.T) {
 		arguments, err := ParseLiteralArgumentList(
 			`(a: 1)`,
 			[]sema.Type{
-				&sema.IntType{},
+				sema.IntType,
 			},
 		)
 		require.NoError(t, err)
@@ -567,8 +567,8 @@ func TestParseLiteralArgumentList(t *testing.T) {
 		arguments, err := ParseLiteralArgumentList(
 			`(a: 1, 2)`,
 			[]sema.Type{
-				&sema.IntType{},
-				&sema.IntType{},
+				sema.IntType,
+				sema.IntType,
 			},
 		)
 		require.NoError(t, err)
@@ -585,7 +585,7 @@ func TestParseLiteralArgumentList(t *testing.T) {
 		_, err := ParseLiteralArgumentList(
 			`(a: 1, 2)`,
 			[]sema.Type{
-				&sema.IntType{},
+				sema.IntType,
 				sema.BoolType,
 			},
 		)
@@ -596,7 +596,7 @@ func TestParseLiteralArgumentList(t *testing.T) {
 		_, err := ParseLiteralArgumentList(
 			`(a: 1, 2)`,
 			[]sema.Type{
-				&sema.IntType{},
+				sema.IntType,
 			},
 		)
 		require.Error(t, err)
@@ -606,8 +606,8 @@ func TestParseLiteralArgumentList(t *testing.T) {
 		_, err := ParseLiteralArgumentList(
 			`(a: 1)`,
 			[]sema.Type{
-				&sema.IntType{},
-				&sema.IntType{},
+				sema.IntType,
+				sema.IntType,
 			},
 		)
 		require.Error(t, err)
@@ -617,7 +617,7 @@ func TestParseLiteralArgumentList(t *testing.T) {
 		_, err := ParseLiteralArgumentList(
 			`(a: b)`,
 			[]sema.Type{
-				&sema.IntType{},
+				sema.IntType,
 			},
 		)
 		require.Error(t, err)

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -67,7 +67,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "n",
-					TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 				},
 			},
 			ReturnTypeAnnotation: &sema.TypeAnnotation{

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -103,7 +103,7 @@ var authAccountContractsTypeAddFunctionType = &FunctionType{
 			Identifier: "code",
 			TypeAnnotation: NewTypeAnnotation(
 				&VariableSizedType{
-					Type: &UInt8Type{},
+					Type: UInt8Type,
 				},
 			),
 		},
@@ -146,7 +146,7 @@ var authAccountContractsTypeUpdateExperimentalFunctionType = &FunctionType{
 			Identifier: "code",
 			TypeAnnotation: NewTypeAnnotation(
 				&VariableSizedType{
-					Type: &UInt8Type{},
+					Type: UInt8Type,
 				},
 			),
 		},

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -68,13 +68,13 @@ var AuthAccountType = func() *CompositeType {
 		NewPublicConstantFieldMember(
 			authAccountType,
 			AuthAccountStorageUsedField,
-			&UInt64Type{},
+			UInt64Type,
 			accountTypeStorageUsedFieldDocString,
 		),
 		NewPublicConstantFieldMember(
 			authAccountType,
 			AuthAccountStorageCapacityField,
-			&UInt64Type{},
+			UInt64Type,
 			accountTypeStorageCapacityFieldDocString,
 		),
 		NewPublicFunctionMember(
@@ -163,7 +163,7 @@ var authAccountTypeAddPublicKeyFunctionType = &FunctionType{
 			Identifier: "key",
 			TypeAnnotation: NewTypeAnnotation(
 				&VariableSizedType{
-					Type: &UInt8Type{},
+					Type: UInt8Type,
 				},
 			),
 		},
@@ -183,7 +183,7 @@ var authAccountTypeRemovePublicKeyFunctionType = &FunctionType{
 			Label:      ArgumentLabelNotRequired,
 			Identifier: "index",
 			TypeAnnotation: NewTypeAnnotation(
-				&IntType{},
+				IntType,
 			),
 		},
 	},
@@ -555,7 +555,7 @@ var authAccountKeysTypeAddFunctionType = &FunctionType{
 		},
 		{
 			Identifier:     AccountKeyWeightField,
-			TypeAnnotation: NewTypeAnnotation(&UFix64Type{}),
+			TypeAnnotation: NewTypeAnnotation(UFix64Type),
 		},
 	},
 	ReturnTypeAnnotation:  NewTypeAnnotation(AccountKeyType),
@@ -566,7 +566,7 @@ var accountKeysTypeGetFunctionType = &FunctionType{
 	Parameters: []*Parameter{
 		{
 			Identifier:     AccountKeyKeyIndexField,
-			TypeAnnotation: NewTypeAnnotation(&IntType{}),
+			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},
 	ReturnTypeAnnotation:  NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
@@ -577,7 +577,7 @@ var authAccountKeysTypeRevokeFunctionType = &FunctionType{
 	Parameters: []*Parameter{
 		{
 			Identifier:     AccountKeyKeyIndexField,
-			TypeAnnotation: NewTypeAnnotation(&IntType{}),
+			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},
 	ReturnTypeAnnotation:  NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),

--- a/runtime/sema/block.go
+++ b/runtime/sema/block.go
@@ -42,7 +42,7 @@ var BlockType = &SimpleType{
 					return NewPublicConstantFieldMember(
 						t,
 						identifier,
-						&UInt64Type{},
+						UInt64Type,
 						blockTypeHeightFieldDocString,
 					)
 				},
@@ -53,7 +53,7 @@ var BlockType = &SimpleType{
 					return NewPublicConstantFieldMember(
 						t,
 						identifier,
-						&UInt64Type{},
+						UInt64Type,
 						blockTypeViewFieldDocString,
 					)
 				},
@@ -64,7 +64,7 @@ var BlockType = &SimpleType{
 					return NewPublicConstantFieldMember(
 						t,
 						identifier,
-						&UFix64Type{},
+						UFix64Type,
 						blockTypeTimestampFieldDocString,
 					)
 				},
@@ -87,7 +87,7 @@ var BlockType = &SimpleType{
 const BlockIDSize = 32
 
 var blockIDFieldType = &ConstantSizedType{
-	Type: &UInt8Type{},
+	Type: UInt8Type,
 	Size: BlockIDSize,
 }
 

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -137,10 +137,10 @@ func (checker *Checker) checkBinaryExpressionArithmeticOrNonEqualityComparisonOr
 	case BinaryOperationKindArithmetic,
 		BinaryOperationKindNonEqualityComparison:
 
-		expectedSuperType = &NumberType{}
+		expectedSuperType = NumberType
 
 	case BinaryOperationKindBitwise:
-		expectedSuperType = &IntegerType{}
+		expectedSuperType = IntegerType
 
 	default:
 		panic(errors.NewUnreachableError())

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -933,7 +933,7 @@ func (checker *Checker) enumRawType(declaration *ast.CompositeDeclaration) Type 
 	rawType := checker.ConvertType(conformance)
 
 	if !rawType.IsInvalidType() &&
-		!IsSubType(rawType, &IntegerType{}) {
+		!IsSubType(rawType, IntegerType) {
 
 		checker.report(
 			&InvalidEnumRawTypeError{

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -122,7 +122,7 @@ func IsValidDictionaryKeyType(keyType Type) bool {
 		case NeverType, BoolType, CharacterType, StringType:
 			return true
 		default:
-			return IsSubType(keyType, &NumberType{}) ||
+			return IsSubType(keyType, NumberType) ||
 				IsSubType(keyType, PathType)
 		}
 	}

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -96,7 +96,7 @@ func IsValidEventParameterType(t Type, results map[*Member]bool) bool {
 			return true
 		}
 
-		return IsSubType(t, &NumberType{}) ||
+		return IsSubType(t, NumberType) ||
 			IsSubType(t, PathType)
 	}
 }

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -180,16 +180,16 @@ func (checker *Checker) VisitNilExpression(_ *ast.NilExpression) ast.Repr {
 }
 
 func (checker *Checker) VisitIntegerExpression(_ *ast.IntegerExpression) ast.Repr {
-	return &IntType{}
+	return IntType
 }
 
 func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpression) ast.Repr {
 	// TODO: adjust once/if we support more fixed point types
 
 	if expression.Negative {
-		return &Fix64Type{}
+		return Fix64Type
 	} else {
-		return &UFix64Type{}
+		return UFix64Type
 	}
 }
 

--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -47,7 +47,7 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) as
 		return valueType
 
 	case ast.OperationMinus:
-		expectedType := &SignedNumberType{}
+		expectedType := SignedNumberType
 		if !IsSubType(valueType, expectedType) {
 			reportInvalidUnaryOperator(expectedType)
 		}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -558,7 +558,7 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 			break
 		}
 
-		if IsSubType(unwrappedTargetType, &IntegerType{}) {
+		if IsSubType(unwrappedTargetType, IntegerType) {
 			CheckIntegerLiteral(typedExpression, unwrappedTargetType, checker.report)
 
 			return true
@@ -581,7 +581,7 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 
 		valueTypeOK := CheckFixedPointLiteral(typedExpression, valueType, checker.report)
 
-		if IsSubType(unwrappedTargetType, &FixedPointType{}) {
+		if IsSubType(unwrappedTargetType, FixedPointType) {
 			if valueTypeOK {
 				CheckFixedPointLiteral(typedExpression, unwrappedTargetType, checker.report)
 			}
@@ -2034,7 +2034,7 @@ func (checker *Checker) predeclaredMembers(containerType Type) []*Member {
 
 			addPredeclaredMember(
 				ResourceUUIDFieldName,
-				&UInt64Type{},
+				UInt64Type,
 				common.DeclarationKindField,
 				ast.AccessPublic,
 				false,

--- a/runtime/sema/checker_test.go
+++ b/runtime/sema/checker_test.go
@@ -33,8 +33,8 @@ func TestOptionalSubtyping(t *testing.T) {
 	t.Run("Int? <: Int?", func(t *testing.T) {
 		assert.True(t,
 			IsSubType(
-				&OptionalType{Type: &IntType{}},
-				&OptionalType{Type: &IntType{}},
+				&OptionalType{Type: IntType},
+				&OptionalType{Type: IntType},
 			),
 		)
 	})
@@ -42,7 +42,7 @@ func TestOptionalSubtyping(t *testing.T) {
 	t.Run("Int? <: Bool?", func(t *testing.T) {
 		assert.False(t,
 			IsSubType(
-				&OptionalType{Type: &IntType{}},
+				&OptionalType{Type: IntType},
 				&OptionalType{Type: BoolType},
 			),
 		)
@@ -51,8 +51,8 @@ func TestOptionalSubtyping(t *testing.T) {
 	t.Run("Int8? <: Integer?", func(t *testing.T) {
 		assert.True(t,
 			IsSubType(
-				&OptionalType{Type: &Int8Type{}},
-				&OptionalType{Type: &IntegerType{}},
+				&OptionalType{Type: Int8Type},
+				&OptionalType{Type: IntegerType},
 			),
 		)
 	})
@@ -170,7 +170,7 @@ func TestFunctionSubtyping(t *testing.T) {
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(&IntType{}),
+							TypeAnnotation: NewTypeAnnotation(IntType),
 						},
 					},
 				},
@@ -198,7 +198,7 @@ func TestFunctionSubtyping(t *testing.T) {
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(&IntType{}),
+							TypeAnnotation: NewTypeAnnotation(IntType),
 						},
 					},
 				},
@@ -210,7 +210,7 @@ func TestFunctionSubtyping(t *testing.T) {
 		assert.True(t,
 			IsSubType(
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(&IntType{}),
+					ReturnTypeAnnotation: NewTypeAnnotation(IntType),
 				},
 				&FunctionType{
 					ReturnTypeAnnotation: NewTypeAnnotation(AnyStructType),
@@ -226,7 +226,7 @@ func TestFunctionSubtyping(t *testing.T) {
 					ReturnTypeAnnotation: NewTypeAnnotation(AnyStructType),
 				},
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(&IntType{}),
+					ReturnTypeAnnotation: NewTypeAnnotation(IntType),
 				},
 			),
 		)

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -38,7 +38,7 @@ var HashAlgorithms = []CryptoAlgorithm{
 	HashAlgorithmSHA3_384,
 }
 
-var SignatureAlgorithmType = newNativeEnumType(SignatureAlgorithmTypeName, &UInt8Type{})
+var SignatureAlgorithmType = newNativeEnumType(SignatureAlgorithmTypeName, UInt8Type)
 
 type SignatureAlgorithm uint8
 
@@ -94,7 +94,7 @@ func (algo SignatureAlgorithm) DocString() string {
 	panic(errors.NewUnreachableError())
 }
 
-var HashAlgorithmType = newNativeEnumType(HashAlgorithmTypeName, &UInt8Type{})
+var HashAlgorithmType = newNativeEnumType(HashAlgorithmTypeName, UInt8Type)
 
 type HashAlgorithm uint8
 

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -65,7 +65,7 @@ var DeployedContractType = &SimpleType{
 						t,
 						identifier,
 						&VariableSizedType{
-							Type: &UInt8Type{},
+							Type: UInt8Type,
 						},
 						deployedContractTypeCodeFieldDocString,
 					)

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -56,13 +56,13 @@ var PublicAccountType = func() *CompositeType {
 		NewPublicConstantFieldMember(
 			publicAccountType,
 			PublicAccountStorageUsedField,
-			&UInt64Type{},
+			UInt64Type,
 			accountTypeStorageUsedFieldDocString,
 		),
 		NewPublicConstantFieldMember(
 			publicAccountType,
 			PublicAccountStorageCapacityField,
-			&UInt64Type{},
+			UInt64Type,
 			accountTypeStorageCapacityFieldDocString,
 		),
 		NewPublicFunctionMember(

--- a/runtime/sema/resources_test.go
+++ b/runtime/sema/resources_test.go
@@ -34,17 +34,17 @@ func TestResources_Add(t *testing.T) {
 
 	varX := &Variable{
 		Identifier: "x",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	varY := &Variable{
 		Identifier: "y",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	varZ := &Variable{
 		Identifier: "z",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	assert.Empty(t, resources.Get(varX).Invalidations.All())
@@ -142,12 +142,12 @@ func TestResourceResources_ForEach(t *testing.T) {
 
 	varX := &Variable{
 		Identifier: "x",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	varY := &Variable{
 		Identifier: "y",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	// add resources for X and Y
@@ -216,17 +216,17 @@ func TestResources_MergeBranches(t *testing.T) {
 
 	varX := &Variable{
 		Identifier: "x",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	varY := &Variable{
 		Identifier: "y",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	varZ := &Variable{
 		Identifier: "z",
-		Type:       &IntType{},
+		Type:       IntType,
 	}
 
 	// invalidate X and Y in then branch

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -28,7 +28,7 @@ type ValueIndexingInfo struct {
 	IsValueIndexableType          bool
 	AllowsValueIndexingAssignment bool
 	ElementType                   func(_ bool) Type
-	IndexingType                  *IntegerType
+	IndexingType                  *NumericType
 }
 
 // SimpleType represents a simple nominal type.

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -40,7 +40,7 @@ var StringType = &SimpleType{
 		ElementType: func(_ bool) Type {
 			return CharacterType
 		},
-		IndexingType: &IntegerType{},
+		IndexingType: IntegerType,
 	},
 }
 
@@ -86,7 +86,7 @@ func init() {
 					return NewPublicConstantFieldMember(
 						t,
 						identifier,
-						&IntType{},
+						IntType,
 						stringTypeLengthFieldDocString,
 					)
 				},
@@ -116,11 +116,11 @@ var stringTypeSliceFunctionType = &FunctionType{
 	Parameters: []*Parameter{
 		{
 			Identifier:     "from",
-			TypeAnnotation: NewTypeAnnotation(&IntType{}),
+			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 		{
 			Identifier:     "upTo",
-			TypeAnnotation: NewTypeAnnotation(&IntType{}),
+			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
@@ -139,7 +139,7 @@ If either of the parameters are out of the bounds of the string, the function wi
 var stringTypeDecodeHexFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
 		&VariableSizedType{
-			Type: &UInt8Type{},
+			Type: UInt8Type,
 		},
 	),
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -813,7 +813,7 @@ func (t *NumericType) GetMembers() map[string]MemberResolver {
 //
 type FixedPointNumericType struct {
 	NumericType
-	uint
+	scale         uint
 	minFractional *big.Int
 	maxFractional *big.Int
 }
@@ -826,7 +826,7 @@ func (t *FixedPointNumericType) MaxFractional() *big.Int {
 	return t.maxFractional
 }
 func (t *FixedPointNumericType) Scale() uint {
-	return t.Scale()
+	return t.scale
 }
 
 func NewFixedPointNumericType(typeName string) *FixedPointNumericType {
@@ -852,12 +852,17 @@ func (t *FixedPointNumericType) WithFractionalRange(
 	return t
 }
 
+func (t *FixedPointNumericType) WithScale(scale uint) *FixedPointNumericType {
+	t.scale = scale
+	return t
+}
+
 // Numeric types
 
 var (
 
 	// NumberType represents the super-type of all number types
-	NumberType = NewNumericType(SignedNumberTypeName)
+	NumberType = NewNumericType(NumberTypeName)
 
 	// SignedNumberType represents the super-type of all signed number types
 	SignedNumberType = NewNumericType(SignedNumberTypeName)
@@ -942,13 +947,15 @@ var (
 	// which has a scale of Fix64Scale, and checks for overflow and underflow
 	Fix64Type = NewFixedPointNumericType(Fix64TypeName).
 			WithIntRange(Fix64TypeMinIntBig, Fix64TypeMaxIntBig).
-			WithFractionalRange(Fix64TypeMinFractionalBig, Fix64TypeMaxFractionalBig)
+			WithFractionalRange(Fix64TypeMinFractionalBig, Fix64TypeMaxFractionalBig).
+			WithScale(Fix64Scale)
 
 	// UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
 	// which has a scale of 1E9, and checks for overflow and underflow
 	UFix64Type = NewFixedPointNumericType(UFix64TypeName).
 			WithIntRange(UFix64TypeMinIntBig, UFix64TypeMaxIntBig).
-			WithFractionalRange(UFix64TypeMinFractionalBig, UFix64TypeMaxFractionalBig)
+			WithFractionalRange(UFix64TypeMinFractionalBig, UFix64TypeMaxFractionalBig).
+			WithScale(Fix64Scale)
 )
 
 // Numeric type ranges

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -718,7 +718,8 @@ type FractionalRangedType interface {
 	MaxFractional() *big.Int
 }
 
-// NumericType represent all the types in the interger range.
+// NumericType represent all the types in the integer range
+// and non-fractional ranged types.
 //
 type NumericType struct {
 	name   string
@@ -811,7 +812,7 @@ func (t *NumericType) GetMembers() map[string]MemberResolver {
 	return withBuiltinMembers(t, nil)
 }
 
-// FixedPointNumericType represent all the types in the fixedpoint range.
+// FixedPointNumericType represents all the types in the fixed-point range.
 //
 type FixedPointNumericType struct {
 	name          string
@@ -3903,6 +3904,23 @@ func IsSubType(subType Type, superType Type) bool {
 	case AnyResourceType:
 		return subType.IsResourceType()
 
+	case NumberType:
+		switch subType {
+		case NumberType, SignedNumberType:
+			return true
+		}
+
+		return IsSubType(subType, IntegerType) ||
+			IsSubType(subType, FixedPointType)
+
+	case SignedNumberType:
+		if subType == SignedNumberType {
+			return true
+		}
+
+		return IsSubType(subType, SignedIntegerType) ||
+			IsSubType(subType, SignedFixedPointType)
+
 	case IntegerType:
 		switch subType {
 		case IntegerType, SignedIntegerType,
@@ -3928,23 +3946,6 @@ func IsSubType(subType Type, superType Type) bool {
 		default:
 			return false
 		}
-
-	case NumberType:
-		switch subType {
-		case NumberType, SignedNumberType:
-			return true
-		}
-
-		return IsSubType(subType, IntegerType) ||
-			IsSubType(subType, FixedPointType)
-
-	case SignedNumberType:
-		if subType == SignedNumberType {
-			return true
-		}
-
-		return IsSubType(subType, SignedIntegerType) ||
-			IsSubType(subType, SignedFixedPointType)
 
 	case FixedPointType:
 		switch subType {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -340,7 +340,7 @@ const ToBigEndianBytesFunctionName = "toBigEndianBytes"
 var toBigEndianBytesFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
 		&VariableSizedType{
-			Type: &UInt8Type{},
+			Type: UInt8Type,
 		},
 	),
 }
@@ -384,7 +384,7 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 
 	// All number types and addresses have a `toString` function
 
-	if IsSubType(ty, &NumberType{}) || IsSubType(ty, &AddressType{}) {
+	if IsSubType(ty, NumberType) || IsSubType(ty, &AddressType{}) {
 
 		members[ToStringFunctionName] = MemberResolver{
 			Kind: common.DeclarationKindFunction,
@@ -401,7 +401,7 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 
 	// All number types have a `toBigEndianBytes` function
 
-	if IsSubType(ty, &NumberType{}) {
+	if IsSubType(ty, NumberType) {
 
 		members[ToBigEndianBytesFunctionName] = MemberResolver{
 			Kind: common.DeclarationKindFunction,
@@ -703,146 +703,6 @@ func (t *GenericType) GetMembers() map[string]MemberResolver {
 	return withBuiltinMembers(t, nil)
 }
 
-// NumberType represents the super-type of all signed number types
-type NumberType struct{}
-
-func (*NumberType) IsType() {}
-
-func (*NumberType) String() string {
-	return "Number"
-}
-
-func (*NumberType) QualifiedString() string {
-	return "Number"
-}
-
-func (*NumberType) ID() TypeID {
-	return "Number"
-}
-
-func (*NumberType) Equal(other Type) bool {
-	_, ok := other.(*NumberType)
-	return ok
-}
-
-func (*NumberType) IsResourceType() bool {
-	return false
-}
-
-func (*NumberType) IsInvalidType() bool {
-	return false
-}
-
-func (*NumberType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*NumberType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*NumberType) IsEquatable() bool {
-	return true
-}
-
-func (*NumberType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *NumberType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*NumberType) MinInt() *big.Int {
-	return nil
-}
-
-func (*NumberType) MaxInt() *big.Int {
-	return nil
-}
-
-func (*NumberType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *NumberType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *NumberType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// SignedNumberType represents the super-type of all signed number types
-type SignedNumberType struct{}
-
-func (*SignedNumberType) IsType() {}
-
-func (*SignedNumberType) String() string {
-	return "SignedNumber"
-}
-
-func (*SignedNumberType) QualifiedString() string {
-	return "SignedNumber"
-}
-
-func (*SignedNumberType) ID() TypeID {
-	return "SignedNumber"
-}
-
-func (*SignedNumberType) Equal(other Type) bool {
-	_, ok := other.(*SignedNumberType)
-	return ok
-}
-
-func (*SignedNumberType) IsResourceType() bool {
-	return false
-}
-
-func (*SignedNumberType) IsInvalidType() bool {
-	return false
-}
-
-func (*SignedNumberType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*SignedNumberType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*SignedNumberType) IsEquatable() bool {
-	return true
-}
-
-func (*SignedNumberType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *SignedNumberType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*SignedNumberType) MinInt() *big.Int {
-	return nil
-}
-
-func (*SignedNumberType) MaxInt() *big.Int {
-	return nil
-}
-
-func (*SignedNumberType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *SignedNumberType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *SignedNumberType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
 // IntegerRangedType
 
 type IntegerRangedType interface {
@@ -858,1837 +718,353 @@ type FractionalRangedType interface {
 	MaxFractional() *big.Int
 }
 
-// IntegerType represents the super-type of all integer types
-type IntegerType struct{}
-
-func (*IntegerType) IsType() {}
-
-func (*IntegerType) String() string {
-	return "Integer"
+// NumericType represent all the types in the interger range.
+//
+type NumericType struct {
+	name   string
+	minInt *big.Int
+	maxInt *big.Int
 }
 
-func (*IntegerType) QualifiedString() string {
-	return "Integer"
+func NewNumericType(typeName string) *NumericType {
+	return &NumericType{name: typeName}
 }
 
-func (*IntegerType) ID() TypeID {
-	return "Integer"
-}
-
-func (*IntegerType) Equal(other Type) bool {
-	_, ok := other.(*IntegerType)
-	return ok
-}
-
-func (*IntegerType) IsResourceType() bool {
-	return false
-}
-
-func (*IntegerType) IsInvalidType() bool {
-	return false
-}
-
-func (*IntegerType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*IntegerType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*IntegerType) IsEquatable() bool {
-	return true
-}
-
-func (*IntegerType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *IntegerType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*IntegerType) MinInt() *big.Int {
-	return nil
-}
-
-func (*IntegerType) MaxInt() *big.Int {
-	return nil
-}
-
-func (*IntegerType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *IntegerType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
+func (t *NumericType) WithIntRange(min *big.Int, max *big.Int) *NumericType {
+	t.minInt = min
+	t.maxInt = max
 	return t
 }
 
-func (t *IntegerType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
+func (*NumericType) IsType() {}
+
+func (t *NumericType) String() string {
+	return t.name
 }
 
-// SignedIntegerType represents the super-type of all signed integer types
-type SignedIntegerType struct{}
-
-func (*SignedIntegerType) IsType() {}
-
-func (*SignedIntegerType) String() string {
-	return "SignedInteger"
+func (t *NumericType) QualifiedString() string {
+	return t.name
 }
 
-func (*SignedIntegerType) QualifiedString() string {
-	return "SignedInteger"
+func (t *NumericType) ID() TypeID {
+	return TypeID(t.name)
 }
 
-func (*SignedIntegerType) ID() TypeID {
-	return "SignedInteger"
+func (t *NumericType) Equal(other Type) bool {
+	// Numeric types are singletons. Hence their pointers should be equal.
+	if t == other {
+		return true
+	}
+
+	// Check for the value equality as well, as a backup strategy.
+	otherNumericType, ok := other.(*NumericType)
+	return ok && t.ID() == otherNumericType.ID()
 }
 
-func (*SignedIntegerType) Equal(other Type) bool {
-	_, ok := other.(*SignedIntegerType)
-	return ok
-}
-
-func (*SignedIntegerType) IsResourceType() bool {
+func (*NumericType) IsResourceType() bool {
 	return false
 }
 
-func (*SignedIntegerType) IsInvalidType() bool {
+func (*NumericType) IsInvalidType() bool {
 	return false
 }
 
-func (*SignedIntegerType) IsStorable(_ map[*Member]bool) bool {
+func (*NumericType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
-func (*SignedIntegerType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (*NumericType) IsExternallyReturnable(_ map[*Member]bool) bool {
 	return true
 }
 
-func (*SignedIntegerType) IsEquatable() bool {
+func (*NumericType) IsEquatable() bool {
 	return true
 }
 
-func (*SignedIntegerType) TypeAnnotationState() TypeAnnotationState {
+func (*NumericType) TypeAnnotationState() TypeAnnotationState {
 	return TypeAnnotationStateValid
 }
 
-func (t *SignedIntegerType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
+func (t *NumericType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
 	return t, false
 }
 
-func (*SignedIntegerType) MinInt() *big.Int {
-	return nil
+func (t *NumericType) MinInt() *big.Int {
+	return t.minInt
 }
 
-func (*SignedIntegerType) MaxInt() *big.Int {
-	return nil
+func (t *NumericType) MaxInt() *big.Int {
+	return t.maxInt
 }
 
-func (*SignedIntegerType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
+func (*NumericType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
 	return false
 }
 
-func (t *SignedIntegerType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
+func (t *NumericType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
 	return t
 }
 
-func (t *SignedIntegerType) GetMembers() map[string]MemberResolver {
+func (t *NumericType) GetMembers() map[string]MemberResolver {
 	return withBuiltinMembers(t, nil)
 }
 
-// IntType represents the arbitrary-precision integer type `Int`
-type IntType struct{}
-
-func (*IntType) IsType() {}
-
-func (*IntType) String() string {
-	return "Int"
+// FixedPointNumericType represent all the types in the fixedpoint range.
+//
+type FixedPointNumericType struct {
+	NumericType
+	uint
+	minFractional *big.Int
+	maxFractional *big.Int
 }
 
-func (*IntType) QualifiedString() string {
-	return "Int"
+func (t *FixedPointNumericType) MinFractional() *big.Int {
+	return t.minFractional
 }
 
-func (*IntType) ID() TypeID {
-	return "Int"
+func (t *FixedPointNumericType) MaxFractional() *big.Int {
+	return t.maxFractional
+}
+func (t *FixedPointNumericType) Scale() uint {
+	return t.Scale()
 }
 
-func (*IntType) Equal(other Type) bool {
-	_, ok := other.(*IntType)
-	return ok
+func NewFixedPointNumericType(typeName string) *FixedPointNumericType {
+	return &FixedPointNumericType{
+		NumericType: NumericType{
+			name: typeName,
+		},
+	}
 }
 
-func (*IntType) IsResourceType() bool {
-	return false
-}
-
-func (*IntType) IsInvalidType() bool {
-	return false
-}
-
-func (*IntType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*IntType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*IntType) IsEquatable() bool {
-	return true
-}
-
-func (*IntType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *IntType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*IntType) MinInt() *big.Int {
-	return nil
-}
-
-func (*IntType) MaxInt() *big.Int {
-	return nil
-}
-
-func (*IntType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *IntType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
+func (t *FixedPointNumericType) WithIntRange(minInt *big.Int, maxInt *big.Int) *FixedPointNumericType {
+	t.NumericType.WithIntRange(minInt, maxInt)
 	return t
 }
 
-func (t *IntType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
+func (t *FixedPointNumericType) WithFractionalRange(
+	minFractional *big.Int,
+	maxFractional *big.Int,
+) *FixedPointNumericType {
 
-// Int8Type represents the 8-bit signed integer type `Int8`
-
-type Int8Type struct{}
-
-func (*Int8Type) IsType() {}
-
-func (*Int8Type) String() string {
-	return "Int8"
-}
-
-func (*Int8Type) QualifiedString() string {
-	return "Int8"
-}
-
-func (*Int8Type) ID() TypeID {
-	return "Int8"
-}
-
-func (*Int8Type) Equal(other Type) bool {
-	_, ok := other.(*Int8Type)
-	return ok
-}
-
-func (*Int8Type) IsResourceType() bool {
-	return false
-}
-
-func (*Int8Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Int8Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Int8Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Int8Type) IsEquatable() bool {
-	return true
-}
-
-func (*Int8Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Int8Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var Int8TypeMinInt = new(big.Int).SetInt64(math.MinInt8)
-var Int8TypeMaxInt = new(big.Int).SetInt64(math.MaxInt8)
-
-func (*Int8Type) MinInt() *big.Int {
-	return Int8TypeMinInt
-}
-
-func (*Int8Type) MaxInt() *big.Int {
-	return Int8TypeMaxInt
-}
-
-func (*Int8Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Int8Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
+	t.minFractional = minFractional
+	t.maxFractional = maxFractional
 	return t
 }
 
-func (t *Int8Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
+// Numeric types
 
-// Int16Type represents the 16-bit signed integer type `Int16`
-type Int16Type struct{}
+var (
 
-func (*Int16Type) IsType() {}
+	// NumberType represents the super-type of all number types
+	NumberType = NewNumericType(SignedNumberTypeName)
 
-func (*Int16Type) String() string {
-	return "Int16"
-}
+	// SignedNumberType represents the super-type of all signed number types
+	SignedNumberType = NewNumericType(SignedNumberTypeName)
 
-func (*Int16Type) QualifiedString() string {
-	return "Int16"
-}
+	// IntegerType represents the super-type of all integer types
+	IntegerType = NewNumericType(IntegerTypeName)
 
-func (*Int16Type) ID() TypeID {
-	return "Int16"
-}
+	// SignedIntegerType represents the super-type of all signed integer types
+	SignedIntegerType = NewNumericType(SignedIntegerTypeName)
 
-func (*Int16Type) Equal(other Type) bool {
-	_, ok := other.(*Int16Type)
-	return ok
-}
+	// IntType represents the arbitrary-precision integer type `Int`
+	IntType = NewNumericType(IntTypeName)
 
-func (*Int16Type) IsResourceType() bool {
-	return false
-}
+	// Int8Type represents the 8-bit signed integer type `Int8`
+	Int8Type = NewNumericType(Int8TypeName).WithIntRange(Int8TypeMinInt, Int8TypeMaxInt)
 
-func (*Int16Type) IsInvalidType() bool {
-	return false
-}
+	// Int16Type represents the 16-bit signed integer type `Int16`
+	Int16Type = NewNumericType(Int16TypeName).WithIntRange(Int16TypeMinInt, Int16TypeMaxInt)
 
-func (*Int16Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
+	// Int32Type represents the 32-bit signed integer type `Int32`
+	Int32Type = NewNumericType(Int32TypeName).WithIntRange(Int32TypeMinInt, Int32TypeMaxInt)
 
-func (*Int16Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
+	// Int64Type represents the 64-bit signed integer type `Int64`
+	Int64Type = NewNumericType(Int64TypeName).WithIntRange(Int64TypeMinInt, Int64TypeMaxInt)
 
-func (*Int16Type) IsEquatable() bool {
-	return true
-}
+	// Int128Type represents the 128-bit signed integer type `Int128`
+	Int128Type = NewNumericType(Int128TypeName).WithIntRange(Int128TypeMinIntBig, Int128TypeMaxIntBig)
 
-func (*Int16Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
+	// Int256Type represents the 256-bit signed integer type `Int256`
+	Int256Type = NewNumericType(Int256TypeName).WithIntRange(Int256TypeMinIntBig, Int256TypeMaxIntBig)
 
-func (t *Int16Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
+	// UIntType represents the arbitrary-precision unsigned integer type `UInt`
+	UIntType = NewNumericType(UIntTypeName).WithIntRange(UIntTypeMin, nil)
 
-var Int16TypeMinInt = new(big.Int).SetInt64(math.MinInt16)
-var Int16TypeMaxInt = new(big.Int).SetInt64(math.MaxInt16)
+	// UInt8Type represents the 8-bit unsigned integer type `UInt8`
+	// which checks for overflow and underflow
+	UInt8Type = NewNumericType(UInt8TypeName).WithIntRange(UInt8TypeMinInt, UInt8TypeMaxInt)
 
-func (*Int16Type) MinInt() *big.Int {
-	return Int16TypeMinInt
-}
+	// UInt16Type represents the 16-bit unsigned integer type `UInt16`
+	// which checks for overflow and underflow
+	UInt16Type = NewNumericType(UInt16TypeName).WithIntRange(UInt16TypeMinInt, UInt16TypeMaxInt)
 
-func (*Int16Type) MaxInt() *big.Int {
-	return Int16TypeMaxInt
-}
+	// UInt32Type represents the 32-bit unsigned integer type `UInt32`
+	// which checks for overflow and underflow
+	UInt32Type = NewNumericType(UInt32TypeName).WithIntRange(UInt32TypeMinInt, UInt32TypeMaxInt)
 
-func (*Int16Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
+	// UInt64Type represents the 64-bit unsigned integer type `UInt64`
+	// which checks for overflow and underflow
+	UInt64Type = NewNumericType(UInt64TypeName).WithIntRange(UInt64TypeMinInt, UInt64TypeMaxInt)
 
-func (t *Int16Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
+	// UInt128Type represents the 128-bit unsigned integer type `UInt128`
+	// which checks for overflow and underflow
+	UInt128Type = NewNumericType(UInt128TypeName).WithIntRange(UInt128TypeMinIntBig, UInt128TypeMaxIntBig)
 
-func (t *Int16Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
+	// UInt256Type represents the 256-bit unsigned integer type `UInt256`
+	// which checks for overflow and underflow
+	UInt256Type = NewNumericType(UInt256TypeName).WithIntRange(UInt256TypeMinIntBig, UInt256TypeMaxIntBig)
 
-// Int32Type represents the 32-bit signed integer type `Int32`
-type Int32Type struct{}
+	// Word8Type represents the 8-bit unsigned integer type `Word8`
+	// which does NOT check for overflow and underflow
+	Word8Type = NewNumericType(Word8TypeName).WithIntRange(Word8TypeMinInt, Word8TypeMaxInt)
 
-func (*Int32Type) IsType() {}
+	// Word16Type represents the 16-bit unsigned integer type `Word16`
+	// which does NOT check for overflow and underflow
+	Word16Type = NewNumericType(Word16TypeName).WithIntRange(Word16TypeMinInt, Word16TypeMaxInt)
 
-func (*Int32Type) String() string {
-	return "Int32"
-}
+	// Word32Type represents the 32-bit unsigned integer type `Word32`
+	// which does NOT check for overflow and underflow
+	Word32Type = NewNumericType(Word32TypeName).WithIntRange(Word32TypeMinInt, Word32TypeMaxInt)
 
-func (*Int32Type) QualifiedString() string {
-	return "Int32"
-}
+	// Word64Type represents the 64-bit unsigned integer type `Word64`
+	// which does NOT check for overflow and underflow
+	Word64Type = NewNumericType(Word64TypeName).WithIntRange(Word64TypeMinInt, Word64TypeMaxInt)
 
-func (*Int32Type) ID() TypeID {
-	return "Int32"
-}
+	// FixedPointType represents the super-type of all fixed-point types
+	FixedPointType = NewFixedPointNumericType(FixedPointTypeName)
 
-func (*Int32Type) Equal(other Type) bool {
-	_, ok := other.(*Int32Type)
-	return ok
-}
+	// SignedFixedPointType represents the super-type of all signed fixed-point types
+	SignedFixedPointType = NewFixedPointNumericType(SignedFixedPointTypeName)
 
-func (*Int32Type) IsResourceType() bool {
-	return false
-}
+	// Fix64Type represents the 64-bit signed decimal fixed-point type `Fix64`
+	// which has a scale of Fix64Scale, and checks for overflow and underflow
+	Fix64Type = NewFixedPointNumericType(Fix64TypeName).
+			WithIntRange(Fix64TypeMinIntBig, Fix64TypeMaxIntBig).
+			WithFractionalRange(Fix64TypeMinFractionalBig, Fix64TypeMaxFractionalBig)
 
-func (*Int32Type) IsInvalidType() bool {
-	return false
-}
+	// UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
+	// which has a scale of 1E9, and checks for overflow and underflow
+	UFix64Type = NewFixedPointNumericType(UFix64TypeName).
+			WithIntRange(UFix64TypeMinIntBig, UFix64TypeMaxIntBig).
+			WithFractionalRange(UFix64TypeMinFractionalBig, UFix64TypeMaxFractionalBig)
+)
 
-func (*Int32Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
+// Numeric type ranges
+var (
+	Int8TypeMinInt = new(big.Int).SetInt64(math.MinInt8)
+	Int8TypeMaxInt = new(big.Int).SetInt64(math.MaxInt8)
 
-func (*Int32Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
+	Int16TypeMinInt = new(big.Int).SetInt64(math.MinInt16)
+	Int16TypeMaxInt = new(big.Int).SetInt64(math.MaxInt16)
 
-func (*Int32Type) IsEquatable() bool {
-	return true
-}
+	Int32TypeMinInt = new(big.Int).SetInt64(math.MinInt32)
+	Int32TypeMaxInt = new(big.Int).SetInt64(math.MaxInt32)
 
-func (*Int32Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
+	Int64TypeMinInt = new(big.Int).SetInt64(math.MinInt64)
+	Int64TypeMaxInt = new(big.Int).SetInt64(math.MaxInt64)
 
-func (t *Int32Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
+	Int128TypeMinIntBig = func() *big.Int {
+		int128TypeMin := big.NewInt(-1)
+		int128TypeMin.Lsh(int128TypeMin, 127)
+		return int128TypeMin
+	}()
 
-var Int32TypeMinInt = new(big.Int).SetInt64(math.MinInt32)
-var Int32TypeMaxInt = new(big.Int).SetInt64(math.MaxInt32)
+	Int128TypeMaxIntBig = func() *big.Int {
+		int128TypeMax := big.NewInt(1)
+		int128TypeMax.Lsh(int128TypeMax, 127)
+		int128TypeMax.Sub(int128TypeMax, big.NewInt(1))
+		return int128TypeMax
+	}()
 
-func (*Int32Type) MinInt() *big.Int {
-	return Int32TypeMinInt
-}
+	Int256TypeMinIntBig = func() *big.Int {
+		int256TypeMin := big.NewInt(-1)
+		int256TypeMin.Lsh(int256TypeMin, 255)
+		return int256TypeMin
+	}()
 
-func (*Int32Type) MaxInt() *big.Int {
-	return Int32TypeMaxInt
-}
+	Int256TypeMaxIntBig = func() *big.Int {
+		int256TypeMax := big.NewInt(1)
+		int256TypeMax.Lsh(int256TypeMax, 255)
+		int256TypeMax.Sub(int256TypeMax, big.NewInt(1))
+		return int256TypeMax
+	}()
 
-func (*Int32Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
+	UIntTypeMin = new(big.Int)
 
-func (t *Int32Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
+	UInt8TypeMinInt = new(big.Int)
+	UInt8TypeMaxInt = new(big.Int).SetUint64(math.MaxUint8)
 
-func (t *Int32Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
+	UInt16TypeMinInt = new(big.Int)
+	UInt16TypeMaxInt = new(big.Int).SetUint64(math.MaxUint16)
 
-// Int64Type represents the 64-bit signed integer type `Int64`
-type Int64Type struct{}
+	UInt32TypeMinInt = new(big.Int)
+	UInt32TypeMaxInt = new(big.Int).SetUint64(math.MaxUint32)
 
-func (*Int64Type) IsType() {}
+	UInt64TypeMinInt = new(big.Int)
+	UInt64TypeMaxInt = new(big.Int).SetUint64(math.MaxUint64)
 
-func (*Int64Type) String() string {
-	return "Int64"
-}
+	UInt128TypeMinIntBig = new(big.Int)
 
-func (*Int64Type) QualifiedString() string {
-	return "Int64"
-}
+	UInt128TypeMaxIntBig = func() *big.Int {
+		uInt128TypeMax := big.NewInt(1)
+		uInt128TypeMax.Lsh(uInt128TypeMax, 128)
+		uInt128TypeMax.Sub(uInt128TypeMax, big.NewInt(1))
+		return uInt128TypeMax
 
-func (*Int64Type) ID() TypeID {
-	return "Int64"
-}
+	}()
 
-func (*Int64Type) Equal(other Type) bool {
-	_, ok := other.(*Int64Type)
-	return ok
-}
+	UInt256TypeMinIntBig = new(big.Int)
 
-func (*Int64Type) IsResourceType() bool {
-	return false
-}
+	UInt256TypeMaxIntBig = func() *big.Int {
+		uInt256TypeMax := big.NewInt(1)
+		uInt256TypeMax.Lsh(uInt256TypeMax, 256)
+		uInt256TypeMax.Sub(uInt256TypeMax, big.NewInt(1))
+		return uInt256TypeMax
+	}()
 
-func (*Int64Type) IsInvalidType() bool {
-	return false
-}
+	Word8TypeMinInt = new(big.Int)
+	Word8TypeMaxInt = new(big.Int).SetUint64(math.MaxUint8)
 
-func (*Int64Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
+	Word16TypeMinInt = new(big.Int)
+	Word16TypeMaxInt = new(big.Int).SetUint64(math.MaxUint16)
 
-func (*Int64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
+	Word32TypeMinInt = new(big.Int)
+	Word32TypeMaxInt = new(big.Int).SetUint64(math.MaxUint32)
 
-func (*Int64Type) IsEquatable() bool {
-	return true
-}
+	Word64TypeMinInt = new(big.Int)
+	Word64TypeMaxInt = new(big.Int).SetUint64(math.MaxUint64)
 
-func (*Int64Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
+	Fix64FactorBig = new(big.Int).SetUint64(uint64(Fix64Factor))
 
-func (t *Int64Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
+	Fix64TypeMinIntBig = fixedpoint.Fix64TypeMinIntBig
+	Fix64TypeMaxIntBig = fixedpoint.Fix64TypeMaxIntBig
 
-var Int64TypeMinInt = new(big.Int).SetInt64(math.MinInt64)
-var Int64TypeMaxInt = new(big.Int).SetInt64(math.MaxInt64)
+	Fix64TypeMinFractionalBig = fixedpoint.Fix64TypeMinFractionalBig
+	Fix64TypeMaxFractionalBig = fixedpoint.Fix64TypeMaxFractionalBig
 
-func (*Int64Type) MinInt() *big.Int {
-	return Int64TypeMinInt
-}
+	UFix64TypeMinIntBig = fixedpoint.UFix64TypeMinIntBig
+	UFix64TypeMaxIntBig = fixedpoint.UFix64TypeMaxIntBig
 
-func (*Int64Type) MaxInt() *big.Int {
-	return Int64TypeMaxInt
-}
-
-func (*Int64Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Int64Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Int64Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// Int128Type represents the 128-bit signed integer type `Int128`
-type Int128Type struct{}
-
-func (*Int128Type) IsType() {}
-
-func (*Int128Type) String() string {
-	return "Int128"
-}
-
-func (*Int128Type) QualifiedString() string {
-	return "Int128"
-}
-
-func (*Int128Type) ID() TypeID {
-	return "Int128"
-}
-
-func (*Int128Type) Equal(other Type) bool {
-	_, ok := other.(*Int128Type)
-	return ok
-}
-
-func (*Int128Type) IsResourceType() bool {
-	return false
-}
-
-func (*Int128Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Int128Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Int128Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Int128Type) IsEquatable() bool {
-	return true
-}
-
-func (*Int128Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Int128Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var Int128TypeMinIntBig *big.Int
-
-func init() {
-	Int128TypeMinIntBig = big.NewInt(-1)
-	Int128TypeMinIntBig.Lsh(Int128TypeMinIntBig, 127)
-}
-
-var Int128TypeMaxIntBig *big.Int
-
-func init() {
-	Int128TypeMaxIntBig = big.NewInt(1)
-	Int128TypeMaxIntBig.Lsh(Int128TypeMaxIntBig, 127)
-	Int128TypeMaxIntBig.Sub(Int128TypeMaxIntBig, big.NewInt(1))
-}
-
-func (*Int128Type) MinInt() *big.Int {
-	return Int128TypeMinIntBig
-}
-
-func (*Int128Type) MaxInt() *big.Int {
-	return Int128TypeMaxIntBig
-}
-
-func (*Int128Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Int128Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Int128Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// Int256Type represents the 256-bit signed integer type `Int256`
-type Int256Type struct{}
-
-func (*Int256Type) IsType() {}
-
-func (*Int256Type) String() string {
-	return "Int256"
-}
-
-func (*Int256Type) QualifiedString() string {
-	return "Int256"
-}
-
-func (*Int256Type) ID() TypeID {
-	return "Int256"
-}
-
-func (*Int256Type) Equal(other Type) bool {
-	_, ok := other.(*Int256Type)
-	return ok
-}
-
-func (*Int256Type) IsResourceType() bool {
-	return false
-}
-
-func (*Int256Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Int256Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Int256Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Int256Type) IsEquatable() bool {
-	return true
-}
-
-func (*Int256Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Int256Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var Int256TypeMinIntBig *big.Int
-
-func init() {
-	Int256TypeMinIntBig = big.NewInt(-1)
-	Int256TypeMinIntBig.Lsh(Int256TypeMinIntBig, 255)
-}
-
-var Int256TypeMaxIntBig *big.Int
-
-func init() {
-	Int256TypeMaxIntBig = big.NewInt(1)
-	Int256TypeMaxIntBig.Lsh(Int256TypeMaxIntBig, 255)
-	Int256TypeMaxIntBig.Sub(Int256TypeMaxIntBig, big.NewInt(1))
-}
-
-func (*Int256Type) MinInt() *big.Int {
-	return Int256TypeMinIntBig
-}
-
-func (*Int256Type) MaxInt() *big.Int {
-	return Int256TypeMaxIntBig
-}
-
-func (*Int256Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Int256Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Int256Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UIntType represents the arbitrary-precision unsigned integer type `UInt`
-type UIntType struct{}
-
-func (*UIntType) IsType() {}
-
-func (*UIntType) String() string {
-	return "UInt"
-}
-
-func (*UIntType) QualifiedString() string {
-	return "UInt"
-}
-
-func (*UIntType) ID() TypeID {
-	return "UInt"
-}
-
-func (*UIntType) Equal(other Type) bool {
-	_, ok := other.(*UIntType)
-	return ok
-}
-
-func (*UIntType) IsResourceType() bool {
-	return false
-}
-
-func (*UIntType) IsInvalidType() bool {
-	return false
-}
-
-func (*UIntType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UIntType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UIntType) IsEquatable() bool {
-	return true
-}
-
-func (*UIntType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UIntType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var UIntTypeMin = new(big.Int)
-
-func (*UIntType) MinInt() *big.Int {
-	return UIntTypeMin
-}
-
-func (*UIntType) MaxInt() *big.Int {
-	return nil
-}
-
-func (*UIntType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UIntType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UIntType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UInt8Type represents the 8-bit unsigned integer type `UInt8`
-// which checks for overflow and underflow
-type UInt8Type struct{}
-
-func (*UInt8Type) IsType() {}
-
-func (*UInt8Type) String() string {
-	return "UInt8"
-}
-
-func (*UInt8Type) QualifiedString() string {
-	return "UInt8"
-}
-
-func (*UInt8Type) ID() TypeID {
-	return "UInt8"
-}
-
-func (*UInt8Type) Equal(other Type) bool {
-	_, ok := other.(*UInt8Type)
-	return ok
-}
-
-func (*UInt8Type) IsResourceType() bool {
-	return false
-}
-
-func (*UInt8Type) IsInvalidType() bool {
-	return false
-}
-
-func (*UInt8Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt8Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt8Type) IsEquatable() bool {
-	return true
-}
-
-func (*UInt8Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UInt8Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var UInt8TypeMinInt = new(big.Int)
-var UInt8TypeMaxInt = new(big.Int).SetUint64(math.MaxUint8)
-
-func (*UInt8Type) MinInt() *big.Int {
-	return UInt8TypeMinInt
-}
-
-func (*UInt8Type) MaxInt() *big.Int {
-	return UInt8TypeMaxInt
-}
-
-func (*UInt8Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UInt8Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UInt8Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UInt16Type represents the 16-bit unsigned integer type `UInt16`
-// which checks for overflow and underflow
-type UInt16Type struct{}
-
-func (*UInt16Type) IsType() {}
-
-func (*UInt16Type) String() string {
-	return "UInt16"
-}
-
-func (*UInt16Type) QualifiedString() string {
-	return "UInt16"
-}
-
-func (*UInt16Type) ID() TypeID {
-	return "UInt16"
-}
-
-func (*UInt16Type) Equal(other Type) bool {
-	_, ok := other.(*UInt16Type)
-	return ok
-}
-
-func (*UInt16Type) IsResourceType() bool {
-	return false
-}
-
-func (*UInt16Type) IsInvalidType() bool {
-	return false
-}
-
-func (*UInt16Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt16Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt16Type) IsEquatable() bool {
-	return true
-}
-
-func (*UInt16Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UInt16Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var UInt16TypeMinInt = new(big.Int)
-var UInt16TypeMaxInt = new(big.Int).SetUint64(math.MaxUint16)
-
-func (*UInt16Type) MinInt() *big.Int {
-	return UInt16TypeMinInt
-}
-
-func (*UInt16Type) MaxInt() *big.Int {
-	return UInt16TypeMaxInt
-}
-
-func (*UInt16Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UInt16Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UInt16Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UInt32Type represents the 32-bit unsigned integer type `UInt32`
-// which checks for overflow and underflow
-type UInt32Type struct{}
-
-func (*UInt32Type) IsType() {}
-
-func (*UInt32Type) String() string {
-	return "UInt32"
-}
-
-func (*UInt32Type) QualifiedString() string {
-	return "UInt32"
-}
-
-func (*UInt32Type) ID() TypeID {
-	return "UInt32"
-}
-
-func (*UInt32Type) Equal(other Type) bool {
-	_, ok := other.(*UInt32Type)
-	return ok
-}
-
-func (*UInt32Type) IsResourceType() bool {
-	return false
-}
-
-func (*UInt32Type) IsInvalidType() bool {
-	return false
-}
-
-func (*UInt32Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt32Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt32Type) IsEquatable() bool {
-	return true
-}
-
-func (*UInt32Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UInt32Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var UInt32TypeMinInt = new(big.Int)
-var UInt32TypeMaxInt = new(big.Int).SetUint64(math.MaxUint32)
-
-func (*UInt32Type) MinInt() *big.Int {
-	return UInt32TypeMinInt
-}
-
-func (*UInt32Type) MaxInt() *big.Int {
-	return UInt32TypeMaxInt
-}
-
-func (*UInt32Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UInt32Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UInt32Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UInt64Type represents the 64-bit unsigned integer type `UInt64`
-// which checks for overflow and underflow
-type UInt64Type struct{}
-
-func (*UInt64Type) IsType() {}
-
-func (*UInt64Type) String() string {
-	return "UInt64"
-}
-
-func (*UInt64Type) QualifiedString() string {
-	return "UInt64"
-}
-
-func (*UInt64Type) ID() TypeID {
-	return "UInt64"
-}
-
-func (*UInt64Type) Equal(other Type) bool {
-	_, ok := other.(*UInt64Type)
-	return ok
-}
-
-func (*UInt64Type) IsResourceType() bool {
-	return false
-}
-
-func (*UInt64Type) IsInvalidType() bool {
-	return false
-}
-
-func (*UInt64Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt64Type) IsEquatable() bool {
-	return true
-}
-
-func (*UInt64Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UInt64Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var UInt64TypeMinInt = new(big.Int)
-var UInt64TypeMaxInt = new(big.Int).SetUint64(math.MaxUint64)
-
-func (*UInt64Type) MinInt() *big.Int {
-	return UInt64TypeMinInt
-}
-
-func (*UInt64Type) MaxInt() *big.Int {
-	return UInt64TypeMaxInt
-}
-
-func (*UInt64Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UInt64Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UInt64Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UInt128Type represents the 128-bit unsigned integer type `UInt128`
-// which checks for overflow and underflow
-type UInt128Type struct{}
-
-func (*UInt128Type) IsType() {}
-
-func (*UInt128Type) String() string {
-	return "UInt128"
-}
-
-func (*UInt128Type) QualifiedString() string {
-	return "UInt128"
-}
-
-func (*UInt128Type) ID() TypeID {
-	return "UInt128"
-}
-
-func (*UInt128Type) Equal(other Type) bool {
-	_, ok := other.(*UInt128Type)
-	return ok
-}
-
-func (*UInt128Type) IsResourceType() bool {
-	return false
-}
-
-func (*UInt128Type) IsInvalidType() bool {
-	return false
-}
-
-func (*UInt128Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt128Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt128Type) IsEquatable() bool {
-	return true
-}
-
-func (*UInt128Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UInt128Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var UInt128TypeMinIntBig = new(big.Int)
-var UInt128TypeMaxIntBig *big.Int
-
-func init() {
-	UInt128TypeMaxIntBig = big.NewInt(1)
-	UInt128TypeMaxIntBig.Lsh(UInt128TypeMaxIntBig, 128)
-	UInt128TypeMaxIntBig.Sub(UInt128TypeMaxIntBig, big.NewInt(1))
-}
-
-func (*UInt128Type) MinInt() *big.Int {
-	return UInt128TypeMinIntBig
-}
-
-func (*UInt128Type) MaxInt() *big.Int {
-	return UInt128TypeMaxIntBig
-}
-
-func (*UInt128Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UInt128Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UInt128Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UInt256Type represents the 256-bit unsigned integer type `UInt256`
-// which checks for overflow and underflow
-type UInt256Type struct{}
-
-func (*UInt256Type) IsType() {}
-
-func (*UInt256Type) String() string {
-	return "UInt256"
-}
-
-func (*UInt256Type) QualifiedString() string {
-	return "UInt256"
-}
-
-func (*UInt256Type) ID() TypeID {
-	return "UInt256"
-}
-
-func (*UInt256Type) Equal(other Type) bool {
-	_, ok := other.(*UInt256Type)
-	return ok
-}
-
-func (*UInt256Type) IsResourceType() bool {
-	return false
-}
-
-func (*UInt256Type) IsInvalidType() bool {
-	return false
-}
-
-func (*UInt256Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt256Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UInt256Type) IsEquatable() bool {
-	return true
-}
-
-func (*UInt256Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UInt256Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var UInt256TypeMinIntBig = new(big.Int)
-var UInt256TypeMaxIntBig *big.Int
-
-func init() {
-	UInt256TypeMaxIntBig = big.NewInt(1)
-	UInt256TypeMaxIntBig.Lsh(UInt256TypeMaxIntBig, 256)
-	UInt256TypeMaxIntBig.Sub(UInt256TypeMaxIntBig, big.NewInt(1))
-}
-
-func (*UInt256Type) MinInt() *big.Int {
-	return UInt256TypeMinIntBig
-}
-
-func (*UInt256Type) MaxInt() *big.Int {
-	return UInt256TypeMaxIntBig
-}
-
-func (*UInt256Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UInt256Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UInt256Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// Word8Type represents the 8-bit unsigned integer type `Word8`
-// which does NOT check for overflow and underflow
-type Word8Type struct{}
-
-func (*Word8Type) IsType() {}
-
-func (*Word8Type) String() string {
-	return "Word8"
-}
-
-func (*Word8Type) QualifiedString() string {
-	return "Word8"
-}
-
-func (*Word8Type) ID() TypeID {
-	return "Word8"
-}
-
-func (*Word8Type) Equal(other Type) bool {
-	_, ok := other.(*Word8Type)
-	return ok
-}
-
-func (*Word8Type) IsResourceType() bool {
-	return false
-}
-
-func (*Word8Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Word8Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word8Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word8Type) IsEquatable() bool {
-	return true
-}
-
-func (*Word8Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Word8Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var Word8TypeMinInt = new(big.Int)
-var Word8TypeMaxInt = new(big.Int).SetUint64(math.MaxUint8)
-
-func (*Word8Type) MinInt() *big.Int {
-	return Word8TypeMinInt
-}
-
-func (*Word8Type) MaxInt() *big.Int {
-	return Word8TypeMaxInt
-}
-
-func (*Word8Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Word8Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Word8Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// Word16Type represents the 16-bit unsigned integer type `Word16`
-// which does NOT check for overflow and underflow
-type Word16Type struct{}
-
-func (*Word16Type) IsType() {}
-
-func (*Word16Type) String() string {
-	return "Word16"
-}
-
-func (*Word16Type) QualifiedString() string {
-	return "Word16"
-}
-
-func (*Word16Type) ID() TypeID {
-	return "Word16"
-}
-
-func (*Word16Type) Equal(other Type) bool {
-	_, ok := other.(*Word16Type)
-	return ok
-}
-
-func (*Word16Type) IsResourceType() bool {
-	return false
-}
-
-func (*Word16Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Word16Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word16Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word16Type) IsEquatable() bool {
-	return true
-}
-
-func (*Word16Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Word16Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var Word16TypeMinInt = new(big.Int)
-var Word16TypeMaxInt = new(big.Int).SetUint64(math.MaxUint16)
-
-func (*Word16Type) MinInt() *big.Int {
-	return Word16TypeMinInt
-}
-
-func (*Word16Type) MaxInt() *big.Int {
-	return Word16TypeMaxInt
-}
-
-func (*Word16Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Word16Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Word16Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// Word32Type represents the 32-bit unsigned integer type `Word32`
-// which does NOT check for overflow and underflow
-type Word32Type struct{}
-
-func (*Word32Type) IsType() {}
-
-func (*Word32Type) String() string {
-	return "Word32"
-}
-
-func (*Word32Type) QualifiedString() string {
-	return "Word32"
-}
-
-func (*Word32Type) ID() TypeID {
-	return "Word32"
-}
-
-func (*Word32Type) Equal(other Type) bool {
-	_, ok := other.(*Word32Type)
-	return ok
-}
-
-func (*Word32Type) IsResourceType() bool {
-	return false
-}
-
-func (*Word32Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Word32Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word32Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word32Type) IsEquatable() bool {
-	return true
-}
-
-func (*Word32Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Word32Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var Word32TypeMinInt = new(big.Int)
-var Word32TypeMaxInt = new(big.Int).SetUint64(math.MaxUint32)
-
-func (*Word32Type) MinInt() *big.Int {
-	return Word32TypeMinInt
-}
-
-func (*Word32Type) MaxInt() *big.Int {
-	return Word32TypeMaxInt
-}
-
-func (*Word32Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Word32Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Word32Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// Word64Type represents the 64-bit unsigned integer type `Word64`
-// which does NOT check for overflow and underflow
-type Word64Type struct{}
-
-func (*Word64Type) IsType() {}
-
-func (*Word64Type) String() string {
-	return "Word64"
-}
-
-func (*Word64Type) QualifiedString() string {
-	return "Word64"
-}
-
-func (*Word64Type) ID() TypeID {
-	return "Word64"
-}
-
-func (*Word64Type) Equal(other Type) bool {
-	_, ok := other.(*Word64Type)
-	return ok
-}
-
-func (*Word64Type) IsResourceType() bool {
-	return false
-}
-
-func (*Word64Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Word64Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Word64Type) IsEquatable() bool {
-	return true
-}
-
-func (*Word64Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Word64Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-var Word64TypeMinInt = new(big.Int)
-var Word64TypeMaxInt = new(big.Int).SetUint64(math.MaxUint64)
-
-func (*Word64Type) MinInt() *big.Int {
-	return Word64TypeMinInt
-}
-
-func (*Word64Type) MaxInt() *big.Int {
-	return Word64TypeMaxInt
-}
-
-func (*Word64Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Word64Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Word64Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// FixedPointType represents the super-type of all fixed-point types
-type FixedPointType struct{}
-
-func (*FixedPointType) IsType() {}
-
-func (*FixedPointType) String() string {
-	return "FixedPoint"
-}
-
-func (*FixedPointType) QualifiedString() string {
-	return "FixedPoint"
-}
-
-func (*FixedPointType) ID() TypeID {
-	return "FixedPoint"
-}
-
-func (*FixedPointType) Equal(other Type) bool {
-	_, ok := other.(*FixedPointType)
-	return ok
-}
-
-func (*FixedPointType) IsResourceType() bool {
-	return false
-}
-
-func (*FixedPointType) IsInvalidType() bool {
-	return false
-}
-
-func (*FixedPointType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*FixedPointType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*FixedPointType) IsEquatable() bool {
-	return true
-}
-
-func (*FixedPointType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *FixedPointType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*FixedPointType) MinInt() *big.Int {
-	return nil
-}
-
-func (*FixedPointType) MaxInt() *big.Int {
-	return nil
-}
-
-func (*FixedPointType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *FixedPointType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *FixedPointType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// SignedFixedPointType represents the super-type of all signed fixed-point types
-type SignedFixedPointType struct{}
-
-func (*SignedFixedPointType) IsType() {}
-
-func (*SignedFixedPointType) String() string {
-	return "SignedFixedPoint"
-}
-
-func (*SignedFixedPointType) QualifiedString() string {
-	return "SignedFixedPoint"
-}
-
-func (*SignedFixedPointType) ID() TypeID {
-	return "SignedFixedPoint"
-}
-
-func (*SignedFixedPointType) Equal(other Type) bool {
-	_, ok := other.(*SignedFixedPointType)
-	return ok
-}
-
-func (*SignedFixedPointType) IsResourceType() bool {
-	return false
-}
-
-func (*SignedFixedPointType) IsInvalidType() bool {
-	return false
-}
-
-func (*SignedFixedPointType) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*SignedFixedPointType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*SignedFixedPointType) IsEquatable() bool {
-	return true
-}
-
-func (*SignedFixedPointType) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *SignedFixedPointType) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
-func (*SignedFixedPointType) MinInt() *big.Int {
-	return nil
-}
-
-func (*SignedFixedPointType) MaxInt() *big.Int {
-	return nil
-}
-
-func (*SignedFixedPointType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *SignedFixedPointType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *SignedFixedPointType) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
+	UFix64TypeMinFractionalBig = fixedpoint.UFix64TypeMinFractionalBig
+	UFix64TypeMaxFractionalBig = fixedpoint.UFix64TypeMaxFractionalBig
+)
 
 const Fix64Scale = fixedpoint.Fix64Scale
 const Fix64Factor = fixedpoint.Fix64Factor
 
-var Fix64FactorBig = new(big.Int).SetUint64(uint64(Fix64Factor))
-
-// Fix64Type represents the 64-bit signed decimal fixed-point type `Fix64`
-// which has a scale of Fix64Scale, and checks for overflow and underflow
-type Fix64Type struct{}
-
-func (*Fix64Type) IsType() {}
-
-func (*Fix64Type) String() string {
-	return "Fix64"
-}
-
-func (*Fix64Type) QualifiedString() string {
-	return "Fix64"
-}
-
-func (*Fix64Type) ID() TypeID {
-	return "Fix64"
-}
-
-func (*Fix64Type) Equal(other Type) bool {
-	_, ok := other.(*Fix64Type)
-	return ok
-}
-
-func (*Fix64Type) IsResourceType() bool {
-	return false
-}
-
-func (*Fix64Type) IsInvalidType() bool {
-	return false
-}
-
-func (*Fix64Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Fix64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*Fix64Type) IsEquatable() bool {
-	return true
-}
-
-func (*Fix64Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *Fix64Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
 const Fix64TypeMinInt = fixedpoint.Fix64TypeMinInt
 const Fix64TypeMaxInt = fixedpoint.Fix64TypeMaxInt
-
-var Fix64TypeMinIntBig = fixedpoint.Fix64TypeMinIntBig
-var Fix64TypeMaxIntBig = fixedpoint.Fix64TypeMaxIntBig
 
 const Fix64TypeMinFractional = fixedpoint.Fix64TypeMinFractional
 const Fix64TypeMaxFractional = fixedpoint.Fix64TypeMaxFractional
 
-var Fix64TypeMinFractionalBig = fixedpoint.Fix64TypeMinFractionalBig
-var Fix64TypeMaxFractionalBig = fixedpoint.Fix64TypeMaxFractionalBig
-
-func (*Fix64Type) MinInt() *big.Int {
-	return Fix64TypeMinIntBig
-}
-
-func (*Fix64Type) MaxInt() *big.Int {
-	return Fix64TypeMaxIntBig
-}
-
-func (*Fix64Type) Scale() uint {
-	return Fix64Scale
-}
-
-func (*Fix64Type) MinFractional() *big.Int {
-	return Fix64TypeMinFractionalBig
-}
-
-func (*Fix64Type) MaxFractional() *big.Int {
-	return Fix64TypeMaxFractionalBig
-}
-
-func (*Fix64Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *Fix64Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *Fix64Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
-
-// UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
-// which has a scale of 1E9, and checks for overflow and underflow
-type UFix64Type struct{}
-
-func (*UFix64Type) IsType() {}
-
-func (*UFix64Type) String() string {
-	return "UFix64"
-}
-
-func (*UFix64Type) QualifiedString() string {
-	return "UFix64"
-}
-
-func (*UFix64Type) ID() TypeID {
-	return "UFix64"
-}
-
-func (*UFix64Type) Equal(other Type) bool {
-	_, ok := other.(*UFix64Type)
-	return ok
-}
-
-func (*UFix64Type) IsResourceType() bool {
-	return false
-}
-
-func (*UFix64Type) IsInvalidType() bool {
-	return false
-}
-
-func (*UFix64Type) IsStorable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UFix64Type) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return true
-}
-
-func (*UFix64Type) IsEquatable() bool {
-	return true
-}
-
-func (*UFix64Type) TypeAnnotationState() TypeAnnotationState {
-	return TypeAnnotationStateValid
-}
-
-func (t *UFix64Type) RewriteWithRestrictedTypes() (result Type, rewritten bool) {
-	return t, false
-}
-
 const UFix64TypeMinInt = fixedpoint.UFix64TypeMinInt
 const UFix64TypeMaxInt = fixedpoint.UFix64TypeMaxInt
 
-var UFix64TypeMinIntBig = fixedpoint.UFix64TypeMinIntBig
-var UFix64TypeMaxIntBig = fixedpoint.UFix64TypeMaxIntBig
-
 const UFix64TypeMinFractional = fixedpoint.UFix64TypeMinFractional
 const UFix64TypeMaxFractional = fixedpoint.UFix64TypeMaxFractional
-
-var UFix64TypeMinFractionalBig = fixedpoint.UFix64TypeMinFractionalBig
-var UFix64TypeMaxFractionalBig = fixedpoint.UFix64TypeMaxFractionalBig
-
-func (*UFix64Type) MinInt() *big.Int {
-	return UFix64TypeMinIntBig
-}
-
-func (*UFix64Type) MaxInt() *big.Int {
-	return UFix64TypeMaxIntBig
-}
-
-func (*UFix64Type) Scale() uint {
-	return Fix64Scale
-}
-
-func (*UFix64Type) MinFractional() *big.Int {
-	return UFix64TypeMinFractionalBig
-}
-
-func (*UFix64Type) MaxFractional() *big.Int {
-	return UFix64TypeMaxFractionalBig
-}
-
-func (*UFix64Type) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
-	return false
-}
-
-func (t *UFix64Type) Resolve(_ *TypeParameterTypeOrderedMap) Type {
-	return t
-}
-
-func (t *UFix64Type) GetMembers() map[string]MemberResolver {
-	return withBuiltinMembers(t, nil)
-}
 
 // ArrayType
 
@@ -2805,7 +1181,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				return NewPublicConstantFieldMember(
 					arrayType,
 					identifier,
-					&IntType{},
+					IntType,
 					arrayTypeLengthFieldDocString,
 				)
 			},
@@ -2925,7 +1301,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 						Parameters: []*Parameter{
 							{
 								Identifier:     "at",
-								TypeAnnotation: NewTypeAnnotation(&IntegerType{}),
+								TypeAnnotation: NewTypeAnnotation(IntegerType),
 							},
 							{
 								Label:          ArgumentLabelNotRequired,
@@ -2955,7 +1331,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 						Parameters: []*Parameter{
 							{
 								Identifier:     "at",
-								TypeAnnotation: NewTypeAnnotation(&IntegerType{}),
+								TypeAnnotation: NewTypeAnnotation(IntegerType),
 							},
 						},
 						ReturnTypeAnnotation: NewTypeAnnotation(
@@ -3102,7 +1478,7 @@ func (t *VariableSizedType) ElementType(_ bool) Type {
 }
 
 func (t *VariableSizedType) IndexingType() Type {
-	return &IntegerType{}
+	return IntegerType
 }
 
 func (t *VariableSizedType) Unify(
@@ -3226,7 +1602,7 @@ func (t *ConstantSizedType) ElementType(_ bool) Type {
 }
 
 func (t *ConstantSizedType) IndexingType() Type {
-	return &IntegerType{}
+	return IntegerType
 }
 
 func (t *ConstantSizedType) Unify(
@@ -3969,11 +2345,11 @@ func baseTypeVariable(name string, ty Type) *Variable {
 var BaseValueActivation = NewVariableActivation(nil)
 
 var AllSignedFixedPointTypes = []Type{
-	&Fix64Type{},
+	Fix64Type,
 }
 
 var AllUnsignedFixedPointTypes = []Type{
-	&UFix64Type{},
+	UFix64Type,
 }
 
 var AllFixedPointTypes = append(
@@ -3981,34 +2357,34 @@ var AllFixedPointTypes = append(
 		AllUnsignedFixedPointTypes[:],
 		AllSignedFixedPointTypes...,
 	),
-	&FixedPointType{},
-	&SignedFixedPointType{},
+	FixedPointType,
+	SignedFixedPointType,
 )
 
 var AllSignedIntegerTypes = []Type{
-	&IntType{},
-	&Int8Type{},
-	&Int16Type{},
-	&Int32Type{},
-	&Int64Type{},
-	&Int128Type{},
-	&Int256Type{},
+	IntType,
+	Int8Type,
+	Int16Type,
+	Int32Type,
+	Int64Type,
+	Int128Type,
+	Int256Type,
 }
 
 var AllUnsignedIntegerTypes = []Type{
 	// UInt*
-	&UIntType{},
-	&UInt8Type{},
-	&UInt16Type{},
-	&UInt32Type{},
-	&UInt64Type{},
-	&UInt128Type{},
-	&UInt256Type{},
+	UIntType,
+	UInt8Type,
+	UInt16Type,
+	UInt32Type,
+	UInt64Type,
+	UInt128Type,
+	UInt256Type,
 	// Word*
-	&Word8Type{},
-	&Word16Type{},
-	&Word32Type{},
-	&Word64Type{},
+	Word8Type,
+	Word16Type,
+	Word32Type,
+	Word64Type,
 }
 
 var AllIntegerTypes = append(
@@ -4016,8 +2392,8 @@ var AllIntegerTypes = append(
 		AllUnsignedIntegerTypes[:],
 		AllSignedIntegerTypes...,
 	),
-	&IntegerType{},
-	&SignedIntegerType{},
+	IntegerType,
+	SignedIntegerType,
 )
 
 var AllNumberTypes = append(
@@ -4025,8 +2401,8 @@ var AllNumberTypes = append(
 		AllIntegerTypes[:],
 		AllFixedPointTypes...,
 	),
-	&NumberType{},
-	&SignedNumberType{},
+	NumberType,
+	SignedNumberType,
 )
 
 func init() {
@@ -4035,10 +2411,10 @@ func init() {
 
 	for _, numberType := range AllNumberTypes {
 
-		switch numberType.(type) {
-		case *NumberType, *SignedNumberType,
-			*IntegerType, *SignedIntegerType,
-			*FixedPointType, *SignedFixedPointType:
+		switch numberType {
+		case NumberType, SignedNumberType,
+			IntegerType, SignedIntegerType,
+			FixedPointType, SignedFixedPointType:
 			continue
 
 		default:
@@ -4060,7 +2436,7 @@ func init() {
 								{
 									Label:          ArgumentLabelNotRequired,
 									Identifier:     "value",
-									TypeAnnotation: NewTypeAnnotation(&NumberType{}),
+									TypeAnnotation: NewTypeAnnotation(NumberType),
 								},
 							},
 							ReturnTypeAnnotation: NewTypeAnnotation(numberType),
@@ -4107,7 +2483,7 @@ func init() {
 						{
 							Label:          ArgumentLabelNotRequired,
 							Identifier:     "value",
-							TypeAnnotation: NewTypeAnnotation(&IntegerType{}),
+							TypeAnnotation: NewTypeAnnotation(IntegerType),
 						},
 					},
 					ReturnTypeAnnotation: NewTypeAnnotation(addressType),
@@ -4161,12 +2537,12 @@ func suggestIntegerLiteralConversionReplacement(
 ) {
 	negative := argument.Value.Sign() < 0
 
-	if IsSubType(targetType, &FixedPointType{}) {
+	if IsSubType(targetType, FixedPointType) {
 
 		// If the integer literal is converted to a fixed-point type,
 		// suggest replacing it with a fixed-point literal
 
-		signed := IsSubType(targetType, &SignedFixedPointType{})
+		signed := IsSubType(targetType, SignedFixedPointType)
 
 		var hintExpression ast.Expression = &ast.FixedPointExpression{
 			Negative:        negative,
@@ -4201,7 +2577,7 @@ func suggestIntegerLiteralConversionReplacement(
 			},
 		)
 
-	} else if IsSubType(targetType, &IntegerType{}) {
+	} else if IsSubType(targetType, IntegerType) {
 
 		// If the integer literal is converted to an integer type,
 		// suggest replacing it with a fixed-point literal
@@ -4213,7 +2589,7 @@ func suggestIntegerLiteralConversionReplacement(
 		// as all integer literals (positive and negative)
 		// are inferred to be of type `Int`
 
-		if !IsSubType(targetType, &IntType{}) {
+		if !IsSubType(targetType, IntType) {
 			hintExpression = &ast.CastingExpression{
 				Expression: hintExpression,
 				Operation:  ast.OperationCast,
@@ -4246,12 +2622,12 @@ func suggestFixedPointLiteralConversionReplacement(
 	// If the fixed-point literal is converted to a fixed-point type,
 	// suggest replacing it with a fixed-point literal
 
-	if !IsSubType(targetType, &FixedPointType{}) {
+	if !IsSubType(targetType, FixedPointType) {
 		return
 	}
 
 	negative := argument.Negative
-	signed := IsSubType(targetType, &SignedFixedPointType{})
+	signed := IsSubType(targetType, SignedFixedPointType)
 
 	if (!negative && !signed) || (negative && signed) {
 		checker.hint(
@@ -5020,7 +3396,7 @@ func (t *DictionaryType) initializeMemberResolvers() {
 					return NewPublicConstantFieldMember(
 						t,
 						identifier,
-						&IntType{},
+						IntType,
 						dictionaryTypeLengthFieldDocString,
 					)
 				},
@@ -5389,7 +3765,7 @@ const AddressTypeToBytesFunctionName = `toBytes`
 var arrayTypeToBytesFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
 		&VariableSizedType{
-			Type: &UInt8Type{},
+			Type: UInt8Type,
 		},
 	),
 }
@@ -5440,73 +3816,73 @@ func IsSubType(subType Type, superType Type) bool {
 
 	case AnyResourceType:
 		return subType.IsResourceType()
+
+	case IntegerType:
+		switch subType {
+		case IntegerType, SignedIntegerType,
+			IntType, UIntType,
+			Int8Type, Int16Type, Int32Type, Int64Type, Int128Type, Int256Type,
+			UInt8Type, UInt16Type, UInt32Type, UInt64Type, UInt128Type, UInt256Type,
+			Word8Type, Word16Type, Word32Type, Word64Type:
+
+			return true
+
+		default:
+			return false
+		}
+
+	case SignedIntegerType:
+		switch subType {
+		case SignedIntegerType,
+			IntType,
+			Int8Type, Int16Type, Int32Type, Int64Type, Int128Type, Int256Type:
+
+			return true
+
+		default:
+			return false
+		}
+
+	case NumberType:
+		switch subType {
+		case NumberType, SignedNumberType:
+			return true
+		}
+
+		return IsSubType(subType, IntegerType) ||
+			IsSubType(subType, FixedPointType)
+
+	case SignedNumberType:
+		if subType == SignedNumberType {
+			return true
+		}
+
+		return IsSubType(subType, SignedIntegerType) ||
+			IsSubType(subType, SignedFixedPointType)
+
+	case FixedPointType:
+		switch subType {
+		case FixedPointType, SignedFixedPointType,
+			Fix64Type, UFix64Type:
+
+			return true
+
+		default:
+			return false
+		}
+
+	case SignedFixedPointType:
+		switch subType {
+		case SignedNumberType, Fix64Type:
+
+			return true
+
+		default:
+			return false
+		}
 	}
 
 	switch typedSuperType := superType.(type) {
-	case *NumberType:
-		switch subType.(type) {
-		case *NumberType, *SignedNumberType:
-			return true
-		}
-
-		return IsSubType(subType, &IntegerType{}) ||
-			IsSubType(subType, &FixedPointType{})
-
-	case *SignedNumberType:
-		if _, ok := subType.(*SignedNumberType); ok {
-			return true
-		}
-
-		return IsSubType(subType, &SignedIntegerType{}) ||
-			IsSubType(subType, &SignedFixedPointType{})
-
-	case *IntegerType:
-		switch subType.(type) {
-		case *IntegerType, *SignedIntegerType,
-			*IntType, *UIntType,
-			*Int8Type, *Int16Type, *Int32Type, *Int64Type, *Int128Type, *Int256Type,
-			*UInt8Type, *UInt16Type, *UInt32Type, *UInt64Type, *UInt128Type, *UInt256Type,
-			*Word8Type, *Word16Type, *Word32Type, *Word64Type:
-
-			return true
-
-		default:
-			return false
-		}
-
-	case *SignedIntegerType:
-		switch subType.(type) {
-		case *SignedIntegerType,
-			*IntType,
-			*Int8Type, *Int16Type, *Int32Type, *Int64Type, *Int128Type, *Int256Type:
-
-			return true
-
-		default:
-			return false
-		}
-
-	case *FixedPointType:
-		switch subType.(type) {
-		case *FixedPointType, *SignedFixedPointType,
-			*Fix64Type, *UFix64Type:
-
-			return true
-
-		default:
-			return false
-		}
-
-	case *SignedFixedPointType:
-		switch subType.(type) {
-		case *SignedNumberType, *Fix64Type:
-
-			return true
-
-		default:
-			return false
-		}
-
 	case *OptionalType:
 		optionalSubType, ok := subType.(*OptionalType)
 		if !ok {
@@ -6641,7 +5017,7 @@ var AccountKeyType = func() *CompositeType {
 		NewPublicConstantFieldMember(
 			accountKeyType,
 			AccountKeyKeyIndexField,
-			&IntType{},
+			IntType,
 			accountKeyIndexFieldDocString,
 		),
 		NewPublicConstantFieldMember(
@@ -6659,7 +5035,7 @@ var AccountKeyType = func() *CompositeType {
 		NewPublicConstantFieldMember(
 			accountKeyType,
 			AccountKeyWeightField,
-			&UFix64Type{},
+			UFix64Type,
 			accountKeyWeightFieldDocString,
 		),
 		NewPublicConstantFieldMember(
@@ -6694,7 +5070,7 @@ var PublicKeyType = func() *CompositeType {
 		NewPublicConstantFieldMember(
 			accountKeyType,
 			PublicKeyPublicKeyField,
-			&VariableSizedType{Type: &UInt8Type{}},
+			&VariableSizedType{Type: UInt8Type},
 			publicKeyKeyFieldDocString,
 		),
 		NewPublicConstantFieldMember(

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3960,7 +3960,7 @@ func IsSubType(subType Type, superType Type) bool {
 
 	case SignedFixedPointType:
 		switch subType {
-		case SignedNumberType, Fix64Type:
+		case SignedFixedPointType, Fix64Type:
 
 			return true
 

--- a/runtime/sema/type_names.go
+++ b/runtime/sema/type_names.go
@@ -1,0 +1,52 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+const (
+	NumberTypeName           = "Number"
+	SignedNumberTypeName     = "SignedNumber"
+	IntegerTypeName          = "Integer"
+	SignedIntegerTypeName    = "SignedInteger"
+	FixedPointTypeName       = "FixedPoint"
+	SignedFixedPointTypeName = "SignedFixedPoint"
+
+	IntTypeName    = "Int"
+	Int8TypeName   = "Int8"
+	Int16TypeName  = "Int16"
+	Int32TypeName  = "Int32"
+	Int64TypeName  = "Int64"
+	Int128TypeName = "Int128"
+	Int256TypeName = "Int256"
+
+	UIntTypeName    = "UInt"
+	UInt8TypeName   = "UInt8"
+	UInt16TypeName  = "UInt16"
+	UInt32TypeName  = "UInt32"
+	UInt64TypeName  = "UInt64"
+	UInt128TypeName = "UInt128"
+	UInt256TypeName = "UInt256"
+
+	Word8TypeName  = "Word8"
+	Word16TypeName = "Word16"
+	Word32TypeName = "Word32"
+	Word64TypeName = "Word64"
+
+	Fix64TypeName  = "Fix64"
+	UFix64TypeName = "UFix64"
+)

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -33,7 +33,7 @@ func TestConstantSizedType_String(t *testing.T) {
 	t.Parallel()
 
 	ty := &ConstantSizedType{
-		Type: &VariableSizedType{Type: &IntType{}},
+		Type: &VariableSizedType{Type: IntType},
 		Size: 2,
 	}
 
@@ -51,11 +51,11 @@ func TestConstantSizedType_String_OfFunctionType(t *testing.T) {
 		Type: &FunctionType{
 			Parameters: []*Parameter{
 				{
-					TypeAnnotation: NewTypeAnnotation(&Int8Type{}),
+					TypeAnnotation: NewTypeAnnotation(Int8Type),
 				},
 			},
 			ReturnTypeAnnotation: NewTypeAnnotation(
-				&Int16Type{},
+				Int16Type,
 			),
 		},
 		Size: 2,
@@ -73,7 +73,7 @@ func TestVariableSizedType_String(t *testing.T) {
 
 	ty := &VariableSizedType{
 		Type: &ConstantSizedType{
-			Type: &IntType{},
+			Type: IntType,
 			Size: 2,
 		},
 	}
@@ -92,11 +92,11 @@ func TestVariableSizedType_String_OfFunctionType(t *testing.T) {
 		Type: &FunctionType{
 			Parameters: []*Parameter{
 				{
-					TypeAnnotation: NewTypeAnnotation(&Int8Type{}),
+					TypeAnnotation: NewTypeAnnotation(Int8Type),
 				},
 			},
 			ReturnTypeAnnotation: NewTypeAnnotation(
-				&Int16Type{},
+				Int16Type,
 			),
 		},
 	}
@@ -445,7 +445,7 @@ func TestRestrictedType_GetMember(t *testing.T) {
 		resourceType.Members.Set(fieldName, NewPublicConstantFieldMember(
 			ty.Type,
 			fieldName,
-			&IntType{},
+			IntType,
 			"",
 		))
 
@@ -491,14 +491,14 @@ func TestRestrictedType_GetMember(t *testing.T) {
 		resourceType.Members.Set(fieldName, NewPublicConstantFieldMember(
 			restrictedType.Type,
 			fieldName,
-			&IntType{},
+			IntType,
 			"",
 		))
 
 		interfaceMember := NewPublicConstantFieldMember(
 			restrictedType.Type,
 			fieldName,
-			&IntType{},
+			IntType,
 			"",
 		)
 		interfaceType.Members.Set(fieldName, interfaceMember)

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -146,7 +146,7 @@ var CreatePublicKeyFunction = NewStandardLibraryFunction(
 			{
 				Label:          sema.PublicKeyPublicKeyField,
 				Identifier:     sema.PublicKeyPublicKeyField,
-				TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{Type: &sema.UInt8Type{}}),
+				TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{Type: sema.UInt8Type}),
 			},
 			{
 				Label:          sema.PublicKeySignAlgoField,

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -89,7 +89,7 @@ var getBlockFunctionType = &sema.FunctionType{
 			Label:      "at",
 			Identifier: "height",
 			TypeAnnotation: sema.NewTypeAnnotation(
-				&sema.UInt64Type{},
+				sema.UInt64Type,
 			),
 		},
 	},
@@ -102,7 +102,7 @@ var getBlockFunctionType = &sema.FunctionType{
 
 var unsafeRandomFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
-		&sema.UInt64Type{},
+		sema.UInt64Type,
 	),
 }
 
@@ -299,7 +299,7 @@ const HashSize = 32
 
 var HashType = &sema.ConstantSizedType{
 	Size: HashSize,
-	Type: &sema.UInt8Type{},
+	Type: sema.UInt8Type,
 }
 
 var TypeIDsType = &sema.VariableSizedType{
@@ -320,7 +320,7 @@ var AccountEventPublicKeyParameter = &sema.Parameter{
 	Identifier: "publicKey",
 	TypeAnnotation: sema.NewTypeAnnotation(
 		&sema.VariableSizedType{
-			Type: &sema.UInt8Type{},
+			Type: sema.UInt8Type,
 		},
 	),
 }

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1225,7 +1225,7 @@ func TestCheckAccount_getCapability(t *testing.T) {
 			var expectedBorrowType sema.Type
 			if typed {
 				expectedBorrowType = &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				}
 			}
 
@@ -1296,7 +1296,7 @@ func TestCheckAccount_StorageFields(t *testing.T) {
 
 				amountType := RequireGlobalValue(t, checker.Elaboration, "amount")
 
-				assert.Equal(t, &sema.UInt64Type{}, amountType)
+				assert.Equal(t, sema.UInt64Type, amountType)
 			})
 		}
 	}

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -134,7 +134,7 @@ func TestCheckDictionaryIndexingString(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.OptionalType{
-			Type: &sema.IntType{},
+			Type: sema.IntType,
 		},
 		yType,
 	)
@@ -287,7 +287,7 @@ func TestCheckDictionaryValues(t *testing.T) {
 	valuesType := RequireGlobalValue(t, checker.Elaboration, "values")
 
 	assert.Equal(t,
-		&sema.VariableSizedType{Type: &sema.IntType{}},
+		&sema.VariableSizedType{Type: sema.IntType},
 		valuesType,
 	)
 }

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -80,7 +80,7 @@ func TestCheckToBytes(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.VariableSizedType{
-				Type: &sema.UInt8Type{},
+				Type: sema.UInt8Type,
 			},
 			resType,
 		)
@@ -106,7 +106,7 @@ func TestCheckToBigEndianBytes(t *testing.T) {
 
 			assert.Equal(t,
 				&sema.VariableSizedType{
-					Type: &sema.UInt8Type{},
+					Type: sema.UInt8Type,
 				},
 				resType,
 			)

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -64,7 +64,7 @@ func TestCheckCapability(t *testing.T) {
 
 		assert.IsType(t,
 			&sema.CapabilityType{
-				BorrowType: &sema.IntType{},
+				BorrowType: sema.IntType,
 			},
 			capType,
 		)

--- a/runtime/tests/checker/declaration_test.go
+++ b/runtime/tests/checker/declaration_test.go
@@ -41,12 +41,12 @@ func TestCheckConstantAndVariableDeclarations(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.IsType(t,
-		&sema.IntType{},
+		sema.IntType,
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 
 	assert.IsType(t,
-		&sema.IntType{},
+		sema.IntType,
 		RequireGlobalValue(t, checker.Elaboration, "y"),
 	)
 }

--- a/runtime/tests/checker/dictionary_test.go
+++ b/runtime/tests/checker/dictionary_test.go
@@ -44,7 +44,7 @@ func TestCheckIncompleteDictionaryType(t *testing.T) {
 
 	assert.IsType(t,
 		&sema.DictionaryType{
-			KeyType:   &sema.IntType{},
+			KeyType:   sema.IntType,
 			ValueType: sema.InvalidType,
 		},
 		RequireGlobalValue(t, checker.Elaboration, "dict"),

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -304,7 +304,7 @@ func TestCheckDynamicCastingVoid(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.BoolType,
 					sema.StringType,
-					&sema.IntType{},
+					sema.IntType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -368,7 +368,7 @@ func TestCheckDynamicCastingString(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.BoolType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -431,7 +431,7 @@ func TestCheckDynamicCastingBool(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.StringType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -495,7 +495,7 @@ func TestCheckDynamicCastingAddress(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.StringType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 					sema.BoolType,
 				} {
 
@@ -581,7 +581,7 @@ func TestCheckDynamicCastingStruct(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.StringType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 					sema.BoolType,
 				} {
 
@@ -1014,7 +1014,7 @@ func TestCheckDynamicCastingSome(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.OptionalType{Type: &sema.IntType{}},
+		&sema.OptionalType{Type: sema.IntType},
 		&sema.OptionalType{Type: sema.AnyStructType},
 		sema.AnyStructType,
 	}
@@ -1076,7 +1076,7 @@ func TestCheckDynamicCastingArray(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.VariableSizedType{Type: &sema.IntType{}},
+		&sema.VariableSizedType{Type: sema.IntType},
 		&sema.VariableSizedType{Type: sema.AnyStructType},
 		sema.AnyStructType,
 	}
@@ -1140,7 +1140,7 @@ func TestCheckDynamicCastingDictionary(t *testing.T) {
 	types := []sema.Type{
 		&sema.DictionaryType{
 			KeyType:   sema.StringType,
-			ValueType: &sema.IntType{},
+			ValueType: sema.IntType,
 		},
 		&sema.DictionaryType{
 			KeyType:   sema.StringType,

--- a/runtime/tests/checker/entrypoint_test.go
+++ b/runtime/tests/checker/entrypoint_test.go
@@ -62,7 +62,7 @@ func TestEntryPointParameters(t *testing.T) {
 				{
 					Label:          "",
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 				},
 			},
 			parameters,
@@ -101,7 +101,7 @@ func TestEntryPointParameters(t *testing.T) {
 				{
 					Label:          "",
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 				},
 			},
 			parameters,

--- a/runtime/tests/checker/fixedpoint_test.go
+++ b/runtime/tests/checker/fixedpoint_test.go
@@ -123,8 +123,8 @@ func TestCheckFixedPointLiteralRanges(t *testing.T) {
 	}
 
 	for _, ty := range sema.AllFixedPointTypes {
-		switch ty.(type) {
-		case *sema.FixedPointType, *sema.SignedFixedPointType:
+		switch ty {
+		case sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 
@@ -625,8 +625,8 @@ func TestCheckFixedPointLiteralScales(t *testing.T) {
 
 	for _, ty := range sema.AllFixedPointTypes {
 
-		switch ty.(type) {
-		case *sema.FixedPointType, *sema.SignedFixedPointType:
+		switch ty {
+		case sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 

--- a/runtime/tests/checker/force_test.go
+++ b/runtime/tests/checker/force_test.go
@@ -41,12 +41,12 @@ func TestCheckForce(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t,
-			&sema.OptionalType{Type: &sema.IntType{}},
+			&sema.OptionalType{Type: sema.IntType},
 			RequireGlobalValue(t, checker.Elaboration, "x"),
 		)
 
 		assert.Equal(t,
-			&sema.IntType{},
+			sema.IntType,
 			RequireGlobalValue(t, checker.Elaboration, "y"),
 		)
 
@@ -62,12 +62,12 @@ func TestCheckForce(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t,
-			&sema.IntType{},
+			sema.IntType,
 			RequireGlobalValue(t, checker.Elaboration, "x"),
 		)
 
 		assert.Equal(t,
-			&sema.IntType{},
+			sema.IntType,
 			RequireGlobalValue(t, checker.Elaboration, "y"),
 		)
 

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -166,7 +166,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for parameter %#+v", typeParameter)
-		assert.IsType(t, &sema.IntType{}, ty)
+		assert.IsType(t, sema.IntType, ty)
 	})
 
 	t.Run("valid: one type parameter, no type argument, one parameter, one arguments", func(t *testing.T) {
@@ -216,7 +216,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
-		assert.IsType(t, &sema.IntType{}, ty)
+		assert.IsType(t, sema.IntType, ty)
 	})
 
 	t.Run("invalid: one type parameter, no type argument, one parameter, no argument", func(t *testing.T) {
@@ -389,7 +389,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		ty, present := typeParameterTypes.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
-		assert.IsType(t, &sema.IntType{}, ty)
+		assert.IsType(t, sema.IntType, ty)
 	})
 
 	t.Run("invalid: one type parameter, no type argument, two parameters, two argument: not matching argument types", func(t *testing.T) {
@@ -513,10 +513,10 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
-		assert.IsType(t, &sema.IntType{}, ty)
+		assert.IsType(t, sema.IntType, ty)
 
 		assert.IsType(t,
-			&sema.IntType{},
+			sema.IntType,
 			RequireGlobalValue(t, checker.Elaboration, "res"),
 		)
 	})
@@ -572,10 +572,10 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
-		assert.IsType(t, &sema.IntType{}, ty)
+		assert.IsType(t, sema.IntType, ty)
 
 		assert.IsType(t,
-			&sema.IntType{},
+			sema.IntType,
 			RequireGlobalValue(t, checker.Elaboration, "res"),
 		)
 	})
@@ -586,7 +586,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		typeParameter := &sema.TypeParameter{
 			Name:      "T",
-			TypeBound: &sema.NumberType{},
+			TypeBound: sema.NumberType,
 		}
 
 		checker, err := parseAndCheckWithTestValue(t,
@@ -617,7 +617,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
-		assert.IsType(t, &sema.IntType{}, ty)
+		assert.IsType(t, sema.IntType, ty)
 	})
 
 	t.Run("invalid: one type parameter with type bound, one type argument, no parameters, no arguments: bound not satisfied", func(t *testing.T) {
@@ -626,7 +626,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		typeParameter := &sema.TypeParameter{
 			Name:      "T",
-			TypeBound: &sema.NumberType{},
+			TypeBound: sema.NumberType,
 		}
 
 		_, err := parseAndCheckWithTestValue(t,
@@ -654,7 +654,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 		typeParameter := &sema.TypeParameter{
 			Name:      "T",
-			TypeBound: &sema.NumberType{},
+			TypeBound: sema.NumberType,
 		}
 
 		_, err := parseAndCheckWithTestValue(t,
@@ -736,7 +736,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 				typeParameter := &sema.TypeParameter{
 					Name:      "T",
-					TypeBound: &sema.NumberType{},
+					TypeBound: sema.NumberType,
 				}
 
 				checker, err := parseAndCheckWithTestValue(t,
@@ -762,7 +762,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.Equal(t,
-					test.generateType(&sema.IntType{}),
+					test.generateType(sema.IntType),
 					RequireGlobalValue(t, checker.Elaboration, "res"),
 				)
 			})
@@ -827,7 +827,7 @@ func TestCheckGenericFunction(t *testing.T) {
 
 				typeParameter := &sema.TypeParameter{
 					Name:      "T",
-					TypeBound: &sema.NumberType{},
+					TypeBound: sema.NumberType,
 				}
 
 				checker, err := parseAndCheckWithTestValue(t,
@@ -870,7 +870,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.Equal(t,
-					test.generateType(&sema.IntType{}),
+					test.generateType(sema.IntType),
 					RequireGlobalValue(t, checker.Elaboration, "res"),
 				)
 			})

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -704,7 +704,7 @@ func TestCheckImportVirtual(t *testing.T) {
 			fooType,
 			"bar",
 			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.UInt64Type{}),
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
 			},
 			"",
 		))

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -440,8 +440,8 @@ func TestCheckInvalidIntegerConversionFunctionWithoutArgs(t *testing.T) {
 
 	for _, ty := range allIntegerTypesAndAddressType {
 
-		switch ty.(type) {
-		case *sema.IntegerType, *sema.SignedIntegerType:
+		switch ty {
+		case sema.IntegerType, sema.SignedIntegerType:
 			continue
 		}
 
@@ -470,8 +470,8 @@ func TestCheckFixedPointToIntegerConversion(t *testing.T) {
 
 	for _, ty := range sema.AllIntegerTypes {
 
-		switch ty.(type) {
-		case *sema.IntegerType, *sema.SignedIntegerType:
+		switch ty {
+		case sema.IntegerType, sema.SignedIntegerType:
 			continue
 		}
 

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -1978,7 +1978,7 @@ func TestCheckInvalidInterfaceUseAsTypeSuggestion(t *testing.T) {
 			},
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(
 				&sema.DictionaryType{
-					KeyType: &sema.IntType{},
+					KeyType: sema.IntType,
 					ValueType: &sema.RestrictedType{
 						Type: sema.AnyStructType,
 						Restrictions: []*sema.InterfaceType{

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -47,7 +47,7 @@ func TestCheckOptionalChainingNonOptionalFieldRead(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&sema.OptionalType{Type: &sema.IntType{}},
+		&sema.OptionalType{Type: sema.IntType},
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }
@@ -72,7 +72,7 @@ func TestCheckOptionalChainingOptionalFieldRead(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&sema.OptionalType{Type: &sema.IntType{}},
+		&sema.OptionalType{Type: sema.IntType},
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }
@@ -99,7 +99,7 @@ func TestCheckOptionalChainingFunctionRead(t *testing.T) {
 			&sema.OptionalType{
 				Type: &sema.FunctionType{
 					ReturnTypeAnnotation: &sema.TypeAnnotation{
-						Type: &sema.IntType{},
+						Type: sema.IntType,
 					},
 				},
 			},
@@ -126,7 +126,7 @@ func TestCheckOptionalChainingFunctionCall(t *testing.T) {
 
 	assert.True(t,
 		RequireGlobalValue(t, checker.Elaboration, "x").Equal(
-			&sema.OptionalType{Type: &sema.IntType{}},
+			&sema.OptionalType{Type: sema.IntType},
 		),
 	)
 }

--- a/runtime/tests/checker/nil_coalescing_test.go
+++ b/runtime/tests/checker/nil_coalescing_test.go
@@ -193,7 +193,7 @@ func TestCheckNilCoalescingOptionalRightHandSide(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.IsType(t, &sema.OptionalType{Type: &sema.IntType{}}, RequireGlobalValue(t, checker.Elaboration, "z"))
+	assert.IsType(t, &sema.OptionalType{Type: sema.IntType}, RequireGlobalValue(t, checker.Elaboration, "z"))
 }
 
 func TestCheckNilCoalescingBothOptional(t *testing.T) {
@@ -208,7 +208,7 @@ func TestCheckNilCoalescingBothOptional(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.IsType(t, &sema.OptionalType{Type: &sema.IntType{}}, RequireGlobalValue(t, checker.Elaboration, "z"))
+	assert.IsType(t, &sema.OptionalType{Type: sema.IntType}, RequireGlobalValue(t, checker.Elaboration, "z"))
 }
 
 func TestCheckNilCoalescingWithNever(t *testing.T) {

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -103,34 +103,34 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 				ast.OperationDiv,
 			},
 			tests: []operationTest{
-				{&sema.IntType{}, "1", "2", nil},
-				{&sema.UFix64Type{}, "1.2", "3.4", nil},
-				{&sema.Fix64Type{}, "-1.2", "-3.4", nil},
-				{&sema.UFix64Type{}, "1.2", "3", []error{
+				{sema.IntType, "1", "2", nil},
+				{sema.UFix64Type, "1.2", "3.4", nil},
+				{sema.Fix64Type, "-1.2", "-3.4", nil},
+				{sema.UFix64Type, "1.2", "3", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.IntType{}, "1", "2.3", []error{
+				{sema.IntType, "1", "2.3", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.IntType{}, "true", "2", []error{
+				{sema.IntType, "true", "2", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 					&sema.TypeMismatchError{},
 				}},
-				{&sema.Fix64Type{}, "true", "1.2", []error{
+				{sema.Fix64Type, "true", "1.2", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 					&sema.TypeMismatchError{},
 				}},
-				{&sema.IntType{}, "1", "true", []error{
+				{sema.IntType, "1", "true", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.UFix64Type{}, "1.2", "true", []error{
+				{sema.UFix64Type, "1.2", "true", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.IntType{}, "true", "false", []error{
+				{sema.IntType, "true", "false", []error{
 					&sema.InvalidBinaryOperandsError{},
 					&sema.TypeMismatchError{},
 				}},
@@ -224,35 +224,35 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 				ast.OperationBitwiseRightShift,
 			},
 			tests: []operationTest{
-				{&sema.IntType{}, "1", "2", nil},
-				{&sema.UFix64Type{}, "1.2", "3.4", []error{
+				{sema.IntType, "1", "2", nil},
+				{sema.UFix64Type, "1.2", "3.4", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.UFix64Type{}, "1.2", "3", []error{
+				{sema.UFix64Type, "1.2", "3", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.IntType{}, "1", "2.3", []error{
+				{sema.IntType, "1", "2.3", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.IntType{}, "true", "2", []error{
+				{sema.IntType, "true", "2", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 					&sema.TypeMismatchError{},
 				}},
-				{&sema.UFix64Type{}, "true", "1.2", []error{
+				{sema.UFix64Type, "true", "1.2", []error{
 					&sema.InvalidBinaryOperandsError{},
 					&sema.TypeMismatchError{},
 				}},
-				{&sema.IntType{}, "1", "true", []error{
+				{sema.IntType, "1", "true", []error{
 					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.UFix64Type{}, "1.2", "true", []error{
+				{sema.UFix64Type, "1.2", "true", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{&sema.IntType{}, "true", "false", []error{
+				{sema.IntType, "true", "false", []error{
 					&sema.InvalidBinaryOperandsError{},
 					&sema.TypeMismatchError{},
 				}},

--- a/runtime/tests/checker/predeclaredvalues_test.go
+++ b/runtime/tests/checker/predeclaredvalues_test.go
@@ -107,7 +107,7 @@ func TestCheckPredeclaredValues(t *testing.T) {
 					{
 						Label:          sema.ArgumentLabelNotRequired,
 						Identifier:     "n",
-						TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+						TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 					},
 				},
 				ReturnTypeAnnotation: &sema.TypeAnnotation{

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -186,7 +186,7 @@ func TestCheckReferenceExpressionWithNonCompositeResultType(t *testing.T) {
 
 	assert.Equal(t,
 		&sema.ReferenceType{
-			Type: &sema.IntType{},
+			Type: sema.IntType,
 		},
 		refValueType,
 	)

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -114,7 +114,7 @@ func TestCheckStorable(t *testing.T) {
 
 	nonStorableTypes := []sema.Type{
 		&sema.FunctionType{
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+			ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 		},
 		sema.NeverType,
 		sema.VoidType,

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -76,7 +76,7 @@ func TestCheckTypeArguments(t *testing.T) {
             `,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 		)
@@ -85,7 +85,7 @@ func TestCheckTypeArguments(t *testing.T) {
 		assert.Equal(t,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 			RequireGlobalValue(t, checker.Elaboration, "cap"),
@@ -101,7 +101,7 @@ func TestCheckTypeArguments(t *testing.T) {
               let cap: Capability<Int> = test
             `,
 			&sema.CapabilityType{
-				BorrowType: &sema.IntType{},
+				BorrowType: sema.IntType,
 			},
 		)
 
@@ -142,7 +142,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
             `,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 		)
@@ -151,7 +151,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 		assert.Equal(t,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 			RequireGlobalValue(t, checker.Elaboration, "cap"),
@@ -174,7 +174,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
             `,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 		)
@@ -184,7 +184,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 		assert.Equal(t,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 			RequireGlobalValue(t, checker.Elaboration, "cap"),
@@ -193,7 +193,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 		assert.Equal(t,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 			RequireGlobalValue(t, checker.Elaboration, "cap2"),
@@ -220,7 +220,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 		assert.Equal(t,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 			RequireGlobalValue(t, checker.Elaboration, "cap2"),
@@ -261,7 +261,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 		assert.Equal(t,
 			&sema.CapabilityType{
 				BorrowType: &sema.ReferenceType{
-					Type: &sema.IntType{},
+					Type: sema.IntType,
 				},
 			},
 			RequireGlobalValue(t, checker.Elaboration, "cap2"),

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -1346,7 +1346,7 @@ func TestInterpretAccount_getCapability(t *testing.T) {
 						expectedBorrowType := interpreter.ConvertSemaToStaticType(
 							&sema.ReferenceType{
 								Authorized: false,
-								Type:       &sema.IntType{},
+								Type:       sema.IntType,
 							},
 						)
 						require.Equal(t,

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -55,8 +55,8 @@ var integerTestValues = map[string]interpreter.NumberValue{
 func init() {
 
 	for _, integerType := range sema.AllIntegerTypes {
-		switch integerType.(type) {
-		case *sema.IntegerType, *sema.SignedIntegerType:
+		switch integerType {
+		case sema.IntegerType, sema.SignedIntegerType:
 			continue
 		}
 

--- a/runtime/tests/interpreter/bitwise_test.go
+++ b/runtime/tests/interpreter/bitwise_test.go
@@ -91,8 +91,8 @@ var bitwiseTestValueFunctions = map[string]func(int) interpreter.NumberValue{
 func init() {
 
 	for _, integerType := range sema.AllIntegerTypes {
-		switch integerType.(type) {
-		case *sema.IntegerType, *sema.SignedIntegerType:
+		switch integerType {
+		case sema.IntegerType, sema.SignedIntegerType:
 			continue
 		}
 

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -274,10 +274,10 @@ func TestInterpretToBigEndianBytes(t *testing.T) {
 	// Ensure the test cases are complete
 
 	for _, integerType := range sema.AllNumberTypes {
-		switch integerType.(type) {
-		case *sema.NumberType, *sema.SignedNumberType,
-			*sema.IntegerType, *sema.SignedIntegerType,
-			*sema.FixedPointType, *sema.SignedFixedPointType:
+		switch integerType {
+		case sema.NumberType, sema.SignedNumberType,
+			sema.IntegerType, sema.SignedIntegerType,
+			sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -51,26 +51,26 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 	}
 
 	tests := []test{
-		{&sema.IntType{}, "42", interpreter.NewIntValueFromInt64(42)},
-		{&sema.UIntType{}, "42", interpreter.NewUIntValueFromUint64(42)},
-		{&sema.Int8Type{}, "42", interpreter.Int8Value(42)},
-		{&sema.Int16Type{}, "42", interpreter.Int16Value(42)},
-		{&sema.Int32Type{}, "42", interpreter.Int32Value(42)},
-		{&sema.Int64Type{}, "42", interpreter.Int64Value(42)},
-		{&sema.Int128Type{}, "42", interpreter.NewInt128ValueFromInt64(42)},
-		{&sema.Int256Type{}, "42", interpreter.NewInt256ValueFromInt64(42)},
-		{&sema.UInt8Type{}, "42", interpreter.UInt8Value(42)},
-		{&sema.UInt16Type{}, "42", interpreter.UInt16Value(42)},
-		{&sema.UInt32Type{}, "42", interpreter.UInt32Value(42)},
-		{&sema.UInt64Type{}, "42", interpreter.UInt64Value(42)},
-		{&sema.UInt128Type{}, "42", interpreter.NewUInt128ValueFromUint64(42)},
-		{&sema.UInt256Type{}, "42", interpreter.NewUInt256ValueFromUint64(42)},
-		{&sema.Word8Type{}, "42", interpreter.Word8Value(42)},
-		{&sema.Word16Type{}, "42", interpreter.Word16Value(42)},
-		{&sema.Word32Type{}, "42", interpreter.Word32Value(42)},
-		{&sema.Word64Type{}, "42", interpreter.Word64Value(42)},
-		{&sema.Fix64Type{}, "1.23", interpreter.Fix64Value(123000000)},
-		{&sema.UFix64Type{}, "1.23", interpreter.UFix64Value(123000000)},
+		{sema.IntType, "42", interpreter.NewIntValueFromInt64(42)},
+		{sema.UIntType, "42", interpreter.NewUIntValueFromUint64(42)},
+		{sema.Int8Type, "42", interpreter.Int8Value(42)},
+		{sema.Int16Type, "42", interpreter.Int16Value(42)},
+		{sema.Int32Type, "42", interpreter.Int32Value(42)},
+		{sema.Int64Type, "42", interpreter.Int64Value(42)},
+		{sema.Int128Type, "42", interpreter.NewInt128ValueFromInt64(42)},
+		{sema.Int256Type, "42", interpreter.NewInt256ValueFromInt64(42)},
+		{sema.UInt8Type, "42", interpreter.UInt8Value(42)},
+		{sema.UInt16Type, "42", interpreter.UInt16Value(42)},
+		{sema.UInt32Type, "42", interpreter.UInt32Value(42)},
+		{sema.UInt64Type, "42", interpreter.UInt64Value(42)},
+		{sema.UInt128Type, "42", interpreter.NewUInt128ValueFromUint64(42)},
+		{sema.UInt256Type, "42", interpreter.NewUInt256ValueFromUint64(42)},
+		{sema.Word8Type, "42", interpreter.Word8Value(42)},
+		{sema.Word16Type, "42", interpreter.Word16Value(42)},
+		{sema.Word32Type, "42", interpreter.Word32Value(42)},
+		{sema.Word64Type, "42", interpreter.Word64Value(42)},
+		{sema.Fix64Type, "1.23", interpreter.Fix64Value(123000000)},
+		{sema.UFix64Type, "1.23", interpreter.UFix64Value(123000000)},
 	}
 
 	for operation, returnsOptional := range dynamicCastingOperations {
@@ -218,7 +218,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.BoolType,
 					sema.StringType,
-					&sema.IntType{},
+					sema.IntType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -304,7 +304,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.BoolType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -389,7 +389,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.StringType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 				} {
 
 					t.Run(fmt.Sprintf("invalid: from %s to %s", fromType, otherType), func(t *testing.T) {
@@ -478,7 +478,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.StringType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 					sema.BoolType,
 				} {
 
@@ -602,7 +602,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 				for _, otherType := range []sema.Type{
 					sema.StringType,
 					sema.VoidType,
-					&sema.IntType{},
+					sema.IntType,
 					sema.BoolType,
 				} {
 
@@ -1004,7 +1004,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.OptionalType{Type: &sema.IntType{}},
+		&sema.OptionalType{Type: sema.IntType},
 		&sema.OptionalType{Type: sema.AnyStructType},
 		sema.AnyStructType,
 	}
@@ -1104,7 +1104,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 	t.Parallel()
 
 	types := []sema.Type{
-		&sema.VariableSizedType{Type: &sema.IntType{}},
+		&sema.VariableSizedType{Type: sema.IntType},
 		&sema.VariableSizedType{Type: sema.AnyStructType},
 		sema.AnyStructType,
 	}
@@ -1195,7 +1195,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 	types := []sema.Type{
 		&sema.DictionaryType{
 			KeyType:   sema.StringType,
-			ValueType: &sema.IntType{},
+			ValueType: sema.IntType,
 		},
 		&sema.DictionaryType{
 			KeyType:   sema.StringType,

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -56,8 +56,8 @@ func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
 	}
 
 	for _, fixedPointType := range sema.AllFixedPointTypes {
-		switch fixedPointType.(type) {
-		case *sema.FixedPointType, *sema.SignedFixedPointType:
+		switch fixedPointType {
+		case sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 
@@ -107,8 +107,8 @@ var testFixedPointValues = map[string]interpreter.Value{
 
 func init() {
 	for _, fixedPointType := range sema.AllFixedPointTypes {
-		switch fixedPointType.(type) {
-		case *sema.FixedPointType, *sema.SignedFixedPointType:
+		switch fixedPointType {
+		case sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 
@@ -352,12 +352,12 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 	t.Run("invalid big integer (>uint64) to UFix64", func(t *testing.T) {
 
 		bigIntegerTypes := []sema.Type{
-			&sema.Word64Type{},
-			&sema.UInt64Type{},
-			&sema.UInt128Type{},
-			&sema.UInt256Type{},
-			&sema.Int256Type{},
-			&sema.Int128Type{},
+			sema.Word64Type,
+			sema.UInt64Type,
+			sema.UInt128Type,
+			sema.UInt256Type,
+			sema.Int256Type,
+			sema.Int128Type,
 		}
 
 		for _, integerType := range bigIntegerTypes {

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -46,7 +46,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 			fooType,
 			"bar",
 			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(&sema.UInt64Type{}),
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
 			},
 			"",
 		))

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -56,8 +56,8 @@ var testIntegerTypesAndValues = map[string]interpreter.Value{
 func init() {
 	for _, integerType := range sema.AllIntegerTypes {
 
-		switch integerType.(type) {
-		case *sema.IntegerType, *sema.SignedIntegerType:
+		switch integerType {
+		case sema.IntegerType, sema.SignedIntegerType:
 			continue
 		}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -8197,7 +8197,7 @@ func TestInterpretCountDigits256(t *testing.T) {
 			36,
 		},
 		{
-			sema.UInt64Type,
+			sema.UInt128Type,
 			"676983016644359394637212096269997871",
 			36,
 		},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -1412,16 +1412,16 @@ func TestInterpretHostFunction(t *testing.T) {
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 				},
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "b",
-					TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 				},
 			},
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				&sema.IntType{},
+				sema.IntType,
 			),
 		},
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1485,11 +1485,11 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "value",
-					TypeAnnotation: sema.NewTypeAnnotation(&sema.IntType{}),
+					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 				},
 			},
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				&sema.IntType{},
+				sema.IntType,
 			),
 			RequiredArgumentCount: sema.RequiredArgumentCount(1),
 		},
@@ -1497,7 +1497,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 			called = true
 
 			require.Len(t, invocation.ArgumentTypes, 3)
-			assert.IsType(t, &sema.IntType{}, invocation.ArgumentTypes[0])
+			assert.IsType(t, sema.IntType, invocation.ArgumentTypes[0])
 			assert.IsType(t, sema.BoolType, invocation.ArgumentTypes[1])
 			assert.IsType(t, sema.StringType, invocation.ArgumentTypes[2])
 
@@ -3459,10 +3459,10 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 								interpreter.NewIntValueFromInt64(1),
 							},
 							[]sema.Type{
-								&sema.IntType{},
+								sema.IntType,
 							},
 							[]sema.Type{
-								&sema.IntType{},
+								sema.IntType,
 							},
 						),
 					},
@@ -3741,10 +3741,10 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 									interpreter.NewIntValueFromInt64(value),
 								},
 								[]sema.Type{
-									&sema.IntType{},
+									sema.IntType,
 								},
 								[]sema.Type{
-									&sema.IntType{},
+									sema.IntType,
 								},
 							),
 							uuidHandler,
@@ -5998,8 +5998,8 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 	for _, integerType := range sema.AllIntegerTypes {
 
-		switch integerType.(type) {
-		case *sema.IntegerType, *sema.SignedIntegerType:
+		switch integerType {
+		case sema.IntegerType, sema.SignedIntegerType:
 			continue
 		}
 
@@ -6010,8 +6010,8 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 	for _, fixedPointType := range sema.AllFixedPointTypes {
 
-		switch fixedPointType.(type) {
-		case *sema.FixedPointType, *sema.SignedFixedPointType:
+		switch fixedPointType {
+		case sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 
@@ -8182,22 +8182,22 @@ func TestInterpretCountDigits256(t *testing.T) {
 
 	for _, test := range []test{
 		{
-			&sema.Int256Type{},
+			sema.Int256Type,
 			"676983016644359394637212096269997871684197836659065544033845082275068334",
 			72,
 		},
 		{
-			&sema.UInt256Type{},
+			sema.UInt256Type,
 			"676983016644359394637212096269997871684197836659065544033845082275068334",
 			72,
 		},
 		{
-			&sema.Int128Type{},
+			sema.Int128Type,
 			"676983016644359394637212096269997871",
 			36,
 		},
 		{
-			&sema.UInt128Type{},
+			sema.UInt64Type,
 			"676983016644359394637212096269997871",
 			36,
 		},

--- a/values_test.go
+++ b/values_test.go
@@ -439,10 +439,10 @@ func TestToBigEndianBytes(t *testing.T) {
 	// Ensure the test cases are complete
 
 	for _, integerType := range sema.AllNumberTypes {
-		switch integerType.(type) {
-		case *sema.NumberType, *sema.SignedNumberType,
-			*sema.IntegerType, *sema.SignedIntegerType,
-			*sema.FixedPointType, *sema.SignedFixedPointType:
+		switch integerType {
+		case sema.NumberType, sema.SignedNumberType,
+			sema.IntegerType, sema.SignedIntegerType,
+			sema.FixedPointType, sema.SignedFixedPointType:
 			continue
 		}
 


### PR DESCRIPTION
Closes #691

## Description
This PR makes the numeric types singleton, so that there will only be one instance of a given numeric type throughout the checker and the runtime.

Related PRs: #698

---
This PR introduces the following changes:

**1.** Add a new go-struct `NumericType`

```go
// NumericType represent all the types in the integer range
// and non-fractional ranged types.
//
type NumericType struct {
	name   string
	minInt *big.Int
	maxInt *big.Int
}

var _ IntegerRangedType = &NumericType{}
```


**2.** Add a new go-struct `FixedPointNumericType`

```go
// FixedPointNumericType represents all the types in the fixed-point range.
//
type FixedPointNumericType struct {
	name          string
	scale         uint
	minInt        *big.Int
	maxInt        *big.Int
	minFractional *big.Int
	maxFractional *big.Int
}

var _ FractionalRangedType = &FixedPointNumericType{}
```

**3.** Replace all the go-structs for integer ranged and non-fractional ranged types (everything that implements `IntegerRangedType` interface), using instances of the newly added `NumericType`.
```go
// NumberType represents the super-type of all number types
NumberType = NewNumericType(NumberTypeName)

// SignedNumberType represents the super-type of all signed number types
SignedNumberType = NewNumericType(SignedNumberTypeName)

// IntegerType represents the super-type of all integer types
IntegerType = NewNumericType(IntegerTypeName)

// SignedIntegerType represents the super-type of all signed integer types
SignedIntegerType = NewNumericType(SignedIntegerTypeName)

// IntType represents the arbitrary-precision integer type `Int`
IntType = NewNumericType(IntTypeName)

// Int8Type represents the 8-bit signed integer type `Int8`
Int8Type = NewNumericType(Int8TypeName).WithIntRange(Int8TypeMinInt, Int8TypeMaxInt)

// Int16Type represents the 16-bit signed integer type `Int16`
Int16Type = NewNumericType(Int16TypeName).WithIntRange(Int16TypeMinInt, Int16TypeMaxInt)

...
```

**4.** Replace all the go-structs for fractional-ranged types (everything that implements `FractionalRangedType` interface), using instances of the newly added `FixedPointNumericType`.
```go

// Fix64Type represents the 64-bit signed decimal fixed-point type `Fix64`
// which has a scale of Fix64Scale, and checks for overflow and underflow
Fix64Type = NewFixedPointNumericType(Fix64TypeName).
		WithIntRange(Fix64TypeMinIntBig, Fix64TypeMaxIntBig).
		WithFractionalRange(Fix64TypeMinFractionalBig, Fix64TypeMaxFractionalBig).
		WithScale(Fix64Scale)

// UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
// which has a scale of 1E9, and checks for overflow and underflow
UFix64Type = NewFixedPointNumericType(UFix64TypeName).
		WithIntRange(UFix64TypeMinIntBig, UFix64TypeMaxIntBig).
		WithFractionalRange(UFix64TypeMinFractionalBig, UFix64TypeMaxFractionalBig).
		WithScale(Fix64Scale)
```

___

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
