### PR TITLE
Handle field initialization using force-move assignment

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -996,7 +996,12 @@ func (interpreter *Interpreter) visitAssignment(
 
 	if transferOperation == ast.TransferOperationMoveForced {
 		target := getterSetter.get()
-		if _, ok := target.(NilValue); !ok {
+
+		// The value may be a NilValue or nil.
+		// The latter case exists when the force-move assignment is the initialization of a field
+		// in an initializer, in which case there is no prior value for the field.
+
+		if _, ok := target.(NilValue); !ok && target != nil {
 			getLocationRange := locationRangeGetter(interpreter.Location, position)
 			panic(ForceAssignmentToNonNilResourceError{
 				LocationRange: getLocationRange(),
@@ -2947,9 +2952,6 @@ func (interpreter *Interpreter) getMember(self Value, getLocationRange func() Lo
 		case sema.GetTypeFunctionName:
 			return interpreter.getTypeFunction(self)
 		}
-	}
-	if result == nil {
-		panic(errors.NewUnreachableError())
 	}
 	return result
 }

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -387,6 +387,9 @@ func (interpreter *Interpreter) VisitMemberExpression(expression *ast.MemberExpr
 
 	getLocationRange := locationRangeGetter(interpreter.Location, expression)
 	resultValue := interpreter.getMember(result, getLocationRange, expression.Identifier.Identifier)
+	if resultValue == nil {
+		panic(errors.NewUnreachableError())
+	}
 
 	// If the member access is optional chaining, only wrap the result value
 	// in an optional, if it is not already an optional value
@@ -656,6 +659,9 @@ func (interpreter *Interpreter) visitPotentialStorageRemoval(expression ast.Expr
 
 	getterSetter := interpreter.indexExpressionGetterSetter(movingStorageIndexExpression)
 	value := getterSetter.get()
+	if value == nil {
+		panic(errors.NewUnreachableError())
+	}
 	getterSetter.set(NilValue{})
 	return value
 }

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -334,6 +334,9 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) ast.
 	// Evaluate the left expression
 	leftGetterSetter := interpreter.assignmentGetterSetter(swap.Left)
 	leftValue := leftGetterSetter.get()
+	if leftValue == nil {
+		panic(errors.NewUnreachableError())
+	}
 	if interpreter.movingStorageIndexExpression(swap.Left) != nil {
 		leftGetterSetter.set(NilValue{})
 	}
@@ -341,6 +344,9 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) ast.
 	// Evaluate the right expression
 	rightGetterSetter := interpreter.assignmentGetterSetter(swap.Right)
 	rightValue := rightGetterSetter.get()
+	if rightValue == nil {
+		panic(errors.NewUnreachableError())
+	}
 	if interpreter.movingStorageIndexExpression(swap.Right) != nil {
 		rightGetterSetter.set(NilValue{})
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6340,7 +6340,11 @@ func (v *StorageReferenceValue) GetMember(interpreter *Interpreter, getLocationR
 		})
 	}
 
-	return interpreter.getMember(*referencedValue, getLocationRange, name)
+	value := interpreter.getMember(*referencedValue, getLocationRange, name)
+	if value == nil {
+		panic(errors.NewUnreachableError())
+	}
+	return value
 }
 
 func (v *StorageReferenceValue) SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string, value Value) {
@@ -6468,7 +6472,11 @@ func (v *EphemeralReferenceValue) GetMember(interpreter *Interpreter, getLocatio
 		})
 	}
 
-	return interpreter.getMember(*referencedValue, getLocationRange, name)
+	value := interpreter.getMember(*referencedValue, getLocationRange, name)
+	if value == nil {
+		panic(errors.NewUnreachableError())
+	}
+	return value
 }
 
 func (v *EphemeralReferenceValue) SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string, value Value) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7756,6 +7756,35 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 
 		require.ErrorAs(t, err, &interpreter.ForceAssignmentToNonNilResourceError{})
 	})
+
+	t.Run("new to non-nil", func(t *testing.T) {
+
+		inter := parseCheckAndInterpret(t, `
+	     resource X {}
+
+	     resource Y {
+
+             var x: @X?
+
+             init() {
+                 self.x <-! create X()
+             }
+
+             destroy() {
+                 destroy self.x
+             }
+         }
+
+	     fun test() {
+	         let y <- create Y()
+	         destroy y
+	     }
+	   `)
+
+		_, err := inter.Invoke("test")
+		require.NoError(t, err)
+	})
+
 }
 
 func TestInterpretForce(t *testing.T) {


### PR DESCRIPTION
Closes #739 

## Description

Assignment using the force-move operator gets the current value, and if it is non-nil, aborts the program.

However, when the force-move operator is used in an initializer to initialize a field, getting the value will naturally result in no value, which is not an implementation error like in all other cases (e.g. in a non-initializer like a function).

______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
