### PR TITLE
Document run-time type identifiers

### DIFF
--- a/docs/language/run-time-types.md
+++ b/docs/language/run-time-types.md
@@ -5,7 +5,7 @@ title: Run-time Types
 Types can be represented at run-time.
 To create a type value, use the constructor function `Type<T>()`, which accepts the static type as a type argument.
 
-This is similar to e.g. `T.self` in Swift, `T::class` in Kotlin, and `T.class` in Java.
+This is similar to e.g. `T.self` in Swift, `T::class`/`KClass<T>` in Kotlin, and `T.class`/`Class<T>` in Java.
 
 For example, to represent the type `Int` at run-time:
 
@@ -31,7 +31,16 @@ Type<Int>() == Type<Int>()
 
 Type<Int>() != Type<String>()
 ```
+
+To get the run-time type's fully qualified type identifier, use the `let identifier: String` field:
+
+```cadence
+let type = Type<Int>()
+type.identifier  // is "Int"
+```
+
 ### Getting the Type from a Value
+
 The method `fun getType(): Type` can be used to get the runtime type of a value.
 
 ```cadence
@@ -56,6 +65,7 @@ let type: Type = something.getType()
 ```
 
 ### Asserting the Type of a Value
+
 The method `fun isInstance(_ type: Type): Bool` can be used to check if a value has a certain type,
 using the concrete run-time type, and considering subtyping rules,
 

--- a/docs/language/run-time-types.md
+++ b/docs/language/run-time-types.md
@@ -39,6 +39,15 @@ let type = Type<Int>()
 type.identifier  // is "Int"
 ```
 
+```cadence
+// in account 0x1
+
+struct Test {}
+
+let type = Type<Test>()
+type.identifier  // is "A.0000000000000001.Test"
+```
+
 ### Getting the Type from a Value
 
 The method `fun getType(): Type` can be used to get the runtime type of a value.


### PR DESCRIPTION

## Description

A prior version of Cadence added support for getting the fully qualified type identifier of a run-time type.

However, the feature was not documented.

Add at least mention it and add a small example to the documentation.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
