### PR TITLE
Optimize encoding of dictionaries

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -304,7 +304,7 @@ func (d *DecoderV4) decodeArray(v []interface{}, path []string) (*ArrayValue, er
 }
 
 func (d *DecoderV4) decodeDictionary(v interface{}, path []string) (*DictionaryValue, error) {
-	encoded, ok := v.([]interface{})
+	encoded, ok := v.(cborArray)
 	if !ok {
 		return nil, fmt.Errorf(
 			"invalid dictionary encoding (@ %s): %T",
@@ -313,8 +313,17 @@ func (d *DecoderV4) decodeDictionary(v interface{}, path []string) (*DictionaryV
 		)
 	}
 
+	if len(encoded) != encodedDictionaryValueLength {
+		return nil, fmt.Errorf(
+			"invalid dictionary encoding (@ %s): invalid size: expected %d, got %d",
+			strings.Join(path, "."),
+			encodedDictionaryValueLength,
+			len(encoded),
+		)
+	}
+
 	keysField := encoded[encodedDictionaryValueKeysFieldKey]
-	encodedKeys, ok := keysField.([]interface{})
+	encodedKeys, ok := keysField.(cborArray)
 	if !ok {
 		return nil, fmt.Errorf(
 			"invalid dictionary keys encoding (@ %s): %T",
@@ -334,7 +343,7 @@ func (d *DecoderV4) decodeDictionary(v interface{}, path []string) (*DictionaryV
 	}
 
 	entriesField := encoded[encodedDictionaryValueEntriesFieldKey]
-	encodedEntries, ok := entriesField.([]interface{})
+	encodedEntries, ok := entriesField.(cborArray)
 	if !ok {
 		return nil, fmt.Errorf(
 			"invalid dictionary entries encoding (@ %s): %T",


### PR DESCRIPTION
Closes #743

## Description
Optimize encoding of dictionaries to:
-  speed up encoding dictionaries
-  speed up decoding dictionaries
-  reduce memory use
-  reduce size of stored data

### Changes
- Switch from CBOR map to CBOR array to improve speed and preserve ordering.
- Remove key strings from encoding.
- Remove old backwards-compatibility decoding code.
- Add tests, including round-trip for decoding old format and encoding new format.
- Continue to support deferred keys (no change).

### Encoding comparisons:
```
name                  old time/op    new time/op    delta
EncodingSmallValue-4     200µs ± 0%     138µs ± 0%  -31.32%  (p=0.000 n=8+10)
EncodingLargeValue-4    19.4ms ± 1%    13.2ms ± 1%  -32.39%  (p=0.000 n=10+10)

name                  old alloc/op   new alloc/op   delta
EncodingSmallValue-4    57.6kB ± 0%    36.2kB ± 0%  -37.12%  (p=0.000 n=10+9)
EncodingLargeValue-4    4.67MB ± 1%    3.55MB ± 0%  -23.95%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
EncodingSmallValue-4     1.10k ± 0%     0.80k ± 0%  -27.46%  (p=0.000 n=10+10)
EncodingLargeValue-4     92.1k ± 0%     70.8k ± 0%  -23.12%  (p=0.000 n=10+10)
```

### Decoding comparisons:
```
name                  old time/op    new time/op    delta
DecodingSmallValue-4     192µs ± 0%     145µs ± 0%  -24.21%  (p=0.000 n=10+8)
DecodingLargeValue-4    19.9ms ± 0%    14.7ms ± 0%  -26.29%  (p=0.000 n=10+10)

name                  old alloc/op   new alloc/op   delta
DecodingSmallValue-4    73.9kB ± 0%    60.7kB ± 0%  -17.84%  (p=0.000 n=10+10)
DecodingLargeValue-4    7.49MB ± 0%    5.75MB ± 0%  -23.23%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
DecodingSmallValue-4     1.57k ± 0%     1.36k ± 0%  -13.36%  (p=0.000 n=10+10)
DecodingLargeValue-4      143k ± 0%      122k ± 0%  -14.63%  (p=0.000 n=10+10)
```

Benchmark comparisons were done on linux_amd64 with Go 1.15.10.

Special thanks to @turbolent and @SupunS for their helpful feedback, explanations, and suggestions during our call!
______

For contributor use:

- [x] Targeted PR against `feature/storage-optimizations` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
