### PR TITLE
Optimize encoding of composites

### DIFF
--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -508,41 +508,79 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 		expected.modified = false
 
+		encoded := []byte{
+			// tag
+			0xd8, cborTagCompositeValue,
+			// array, 5 items follow
+			0x85,
+
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+
+			// nil
+			0xf6,
+
+			// positive integer 1
+			0x1,
+
+			// array, 0 items follow
+			0x80,
+
+			// UTF-8 string, length 10
+			0x6a,
+			0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagCompositeValue,
+			// map, 4 pairs of items follow
+			0xa4,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 2
+			0x2,
+			// positive integer 1
+			0x1,
+			// key 3
+			0x3,
+			// map, 0 pairs of items follow
+			0xa0,
+			// key 4
+			0x4,
+			// UTF-8 string, length 10
+			0x6a,
+			0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: expected,
-				encoded: []byte{
-					// tag
-					0xd8, cborTagCompositeValue,
-					// map, 4 pairs of items follow
-					0xa4,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagStringLocation,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 2
-					0x2,
-					// positive integer 1
-					0x1,
-					// key 3
-					0x3,
-					// map, 0 pairs of items follow
-					0xa0,
-					// key 4
-					0x4,
-					// UTF-8 string, length 10
-					0x6a,
-					0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
-				},
+				value:   expected,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   expected,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
-	t.Run("empty structure, string location, type ID", func(t *testing.T) {
+	t.Run("empty structure, string location, type ID, version <= 3", func(t *testing.T) {
 		expected := NewCompositeValue(
 			utils.TestLocation,
 			"TestStruct",
@@ -554,8 +592,10 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly:   true,
-				decodedValue: expected,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
+				decodedValue:          expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -591,7 +631,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("empty structure, address location without name", func(t *testing.T) {
+	t.Run("empty structure, address location without name, version <= 3", func(t *testing.T) {
 		expected := NewCompositeValue(
 			common.AddressLocation{
 				Address: common.BytesToAddress([]byte{0x1}),
@@ -606,8 +646,10 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly:   true,
-				decodedValue: expected,
+				decodeOnly:            true,
+				decodedValue:          expected,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -662,55 +704,107 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 		expected.modified = false
 
+		encoded := []byte{
+			// tag
+			0xd8, cborTagCompositeValue,
+			// array, 5 items follow
+			0x85,
+
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+
+			// nil
+			0xf6,
+
+			// positive integer 2
+			0x2,
+
+			// array, 4 items follow
+			0x84,
+			// UTF-8 string, length 6
+			0x66,
+			// s, t, r, i, n, g
+			0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// UTF-8 string, length 4
+			0x64,
+			// t, r, u, e
+			0x74, 0x72, 0x75, 0x65,
+			// true
+			0xf5,
+
+			// UTF-8 string, length 12
+			0x6c,
+			0x54, 0x65, 0x73, 0x74, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagCompositeValue,
+			// map, 4 pairs of items follow
+			0xa4,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 2
+			0x2,
+			// positive integer 2
+			0x2,
+			// key 3
+			0x3,
+			// map, 2 pairs of items follow
+			0xa2,
+			// UTF-8 string, length 4
+			0x64,
+			// t, r, u, e
+			0x74, 0x72, 0x75, 0x65,
+			// true
+			0xf5,
+			// UTF-8 string, length 6
+			0x66,
+			// s, t, r, i, n, g
+			0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 4
+			0x4,
+			// UTF-8 string, length 12
+			0x6c,
+			0x54, 0x65, 0x73, 0x74, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: expected,
-				encoded: []byte{
-					// tag
-					0xd8, cborTagCompositeValue,
-					// map, 4 pairs of items follow
-					0xa4,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagStringLocation,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 2
-					0x2,
-					// positive integer 2
-					0x2,
-					// key 3
-					0x3,
-					// map, 2 pairs of items follow
-					0xa2,
-					// UTF-8 string, length 4
-					0x64,
-					// t, r, u, e
-					0x74, 0x72, 0x75, 0x65,
-					// true
-					0xf5,
-					// UTF-8 string, length 6
-					0x66,
-					// s, t, r, i, n, g
-					0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 4
-					0x4,
-					// UTF-8 string, length 12
-					0x6c,
-					0x54, 0x65, 0x73, 0x74, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65,
-				},
+				value:   expected,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   expected,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
-	t.Run("non-empty resource, type ID", func(t *testing.T) {
+	t.Run("non-empty resource, type ID, version <= 3", func(t *testing.T) {
 		stringValue := NewStringValue("test")
 		stringValue.modified = false
 
@@ -729,8 +823,10 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly:   true,
-				decodedValue: expected,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
+				decodedValue:          expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -778,7 +874,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("empty, address location, nested", func(t *testing.T) {
+	t.Run("empty, address location, nested, version <= 3", func(t *testing.T) {
 
 		expected := NewCompositeValue(
 			common.AddressLocation{
@@ -795,7 +891,9 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodedValue: expected,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodedValue:          expected,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -835,9 +933,11 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 	})
 
-	t.Run("empty, address location, address too long", func(t *testing.T) {
+	t.Run("empty, address location, address too long, version <= 3", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
+				decodeVersionOverride: true,
+				decodeVersion:         3,
 				encoded: []byte{
 					// tag
 					0xd8, cborTagCompositeValue,
@@ -886,52 +986,101 @@ func TestEncodeDecodeComposite(t *testing.T) {
 		)
 		expected.modified = false
 
+		encoded := []byte{
+			// tag
+			0xd8, cborTagCompositeValue,
+			// array, 5 items follow
+			0x85,
+
+			// tag
+			0xd8, cborTagAddressLocation,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// byte sequence, length 1
+			0x41,
+			// positive integer 1
+			0x1,
+			// key 1
+			0x1,
+			// UTF-8 string, length 10
+			0x6a,
+			0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
+			0x63, 0x74,
+
+			// nil
+			0xf6,
+
+			// positive integer 1
+			0x1,
+
+			// array, 0 items follow
+			0x80,
+
+			// UTF-8 string, length 10
+			0x6a,
+			0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
+			0x63, 0x74,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagCompositeValue,
+			// map, 4 pairs of items follow
+			0xa4,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagAddressLocation,
+			// map, 4 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// byte sequence, length 1
+			0x41,
+			// positive integer 1
+			0x1,
+			// key 1
+			0x1,
+			// UTF-8 string, length 10
+			0x6a,
+			0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
+			0x63, 0x74,
+			// key 2
+			0x2,
+			// positive integer 1
+			0x1,
+			// key 3
+			0x3,
+			// map, 0 pairs of items follow
+			0xa0,
+			// key 4
+			0x4,
+			// UTF-8 string, length 10
+			0x6a,
+			0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
+			0x63, 0x74,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: expected,
-				encoded: []byte{
-					// tag
-					0xd8, cborTagCompositeValue,
-					// map, 4 pairs of items follow
-					0xa4,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagAddressLocation,
-					// map, 4 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// byte sequence, length 1
-					0x41,
-					// positive integer 1
-					0x1,
-					// key 1
-					0x1,
-					// UTF-8 string, length 10
-					0x6a,
-					0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
-					0x63, 0x74,
-					// key 2
-					0x2,
-					// positive integer 1
-					0x1,
-					// key 3
-					0x3,
-					// map, 0 pairs of items follow
-					0xa0,
-					// key 4
-					0x4,
-					// UTF-8 string, length 10
-					0x6a,
-					0x54, 0x65, 0x73, 0x74, 0x53, 0x74, 0x72, 0x75,
-					0x63, 0x74,
-				},
+				value:   expected,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   expected,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
-	t.Run("empty, address location, address too long", func(t *testing.T) {
+	t.Run("empty, address location, address too long, version <= 3", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
@@ -943,7 +1092,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					0x0,
 					// tag
 					0xd8, cborTagAddressLocation,
-					// map, 4 pairs of items follow
+					// map, 2 pairs of items follow
 					0xa2,
 					// key 0
 					0x0,
@@ -974,7 +1123,9 @@ func TestEncodeDecodeComposite(t *testing.T) {
 					// map, 0 pairs of items follow
 					0xa0,
 				},
-				invalid: true,
+				invalid:               true,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
 			},
 		)
 	})


### PR DESCRIPTION
Closes #744
Updates #738

## Description

### Changes
 - Switch from CBOR map to CBOR array to improve speed and preserve ordering.
 - Remove unnecessary field sorting when decoding.
 - Remove old backwards-compatibility decoding code (decoding type ID).
 - Add tests, including round-trip for decoding old format and encoding new format.

### Benchmark comparisons

Encoding speed improved by 44.35% and decoding speed improved by 34.56% for a 776,155 byte value from production data that contains both composites and dictionaries.  Memory use also improved.  Encoded/decoded data includes Cadence `Value` types that have not yet been optimized.

Speed gains were only 15-27% for encoding and 16-24% for decoding for smaller production data that did not include dictionaries.  However, these will gain more from optimizing remaining `Value` types (outside the scope of this PR).

__Click to expand:__

<details>
  <summary> Big Value with Composites and Dictionaries 🚀🚀 </summary><p>
  
#### Encoding Comparisons
```
name                                           old time/op    new time/op    delta
EncodeComposite/870comp_837dict_776155bytes-4    35.2ms ± 1%    19.6ms ± 1%  -44.35%  (p=0.000 n=10+10)

name                                           old alloc/op   new alloc/op   delta
EncodeComposite/870comp_837dict_776155bytes-4    7.50MB ± 5%    4.35MB ± 0%  -41.99%  (p=0.000 n=10+10)

name                                           old allocs/op  new allocs/op  delta
EncodeComposite/870comp_837dict_776155bytes-4      141k ± 0%       76k ± 0%  -46.02%  (p=0.000 n=10+10)
```

#### Decoding Comparisons ####
```
name                                           old time/op    new time/op    delta
DecodeComposite/870comp_837dict_776155bytes-4    40.3ms ± 1%    26.3ms ± 1%  -34.65%  (p=0.000 n=10+10)

name                                           old alloc/op   new alloc/op   delta
DecodeComposite/870comp_837dict_776155bytes-4    15.0MB ± 0%    10.5MB ± 0%  -29.67%  (p=0.000 n=10+10)

name                                           old allocs/op  new allocs/op  delta
DecodeComposite/870comp_837dict_776155bytes-4      265k ± 0%      216k ± 0%  -18.56%  (p=0.000 n=10+10)
```

</details>

<details>
  <summary> Values with Composites and No Dictionaries  🚀 </summary><p>

#### Encoding Comparisons
```
name                                           old time/op    new time/op    delta
EncodeComposite/1comp_0dict_139bytes-4           16.0µs ± 1%    13.6µs ± 1%  -15.27%  (p=0.000 n=10+10)
EncodeComposite/2comp_0dict_160bytes-4           20.9µs ± 1%    15.7µs ± 1%  -25.16%  (p=0.000 n=10+10)
EncodeComposite/104comp_0dict_14850bytes-4        910µs ± 1%     657µs ± 1%  -27.78%  (p=0.000 n=9+10)

name                                           old alloc/op   new alloc/op   delta
EncodeComposite/1comp_0dict_139bytes-4           3.79kB ± 1%    2.98kB ± 2%  -21.32%  (p=0.000 n=10+10)
EncodeComposite/2comp_0dict_160bytes-4           4.85kB ± 2%    3.36kB ± 0%  -30.74%  (p=0.000 n=9+10)
EncodeComposite/104comp_0dict_14850bytes-4        247kB ± 1%     188kB ± 0%  -24.16%  (p=0.000 n=8+10)

name                                           old allocs/op  new allocs/op  delta
EncodeComposite/1comp_0dict_139bytes-4             76.0 ± 0%      62.0 ± 0%  -18.42%  (p=0.000 n=10+9)
EncodeComposite/2comp_0dict_160bytes-4              103 ± 0%        73 ± 0%  -29.13%  (p=0.000 n=7+10)
EncodeComposite/104comp_0dict_14850bytes-4        5.03k ± 0%     3.45k ± 0%  -31.28%  (p=0.000 n=8+10)
```

#### Decoding Comparisons ####
```
name                                           old time/op    new time/op    delta
DecodeComposite/1comp_0dict_139bytes-4           11.6µs ± 1%     9.7µs ± 1%  -16.38%  (p=0.000 n=9+10)
DecodeComposite/2comp_0dict_160bytes-4           16.9µs ± 1%    12.7µs ± 1%  -24.47%  (p=0.000 n=10+9)
DecodeComposite/104comp_0dict_14850bytes-4        757µs ± 1%     569µs ± 1%  -24.90%  (p=0.000 n=9+10)

name                                           old alloc/op   new alloc/op   delta
DecodeComposite/1comp_0dict_139bytes-4           3.90kB ± 0%    3.35kB ± 0%  -13.96%  (p=0.000 n=10+10)
DecodeComposite/2comp_0dict_160bytes-4           5.54kB ± 0%    4.38kB ± 0%  -20.92%  (p=0.000 n=10+10)
DecodeComposite/104comp_0dict_14850bytes-4        296kB ± 0%     238kB ± 0%  -19.61%  (p=0.000 n=10+10)

name                                           old allocs/op  new allocs/op  delta
DecodeComposite/1comp_0dict_139bytes-4             56.0 ± 0%      53.0 ± 0%   -5.36%  (p=0.000 n=10+10)
DecodeComposite/2comp_0dict_160bytes-4             97.0 ± 0%      89.0 ± 0%   -8.25%  (p=0.000 n=10+10)
DecodeComposite/104comp_0dict_14850bytes-4        5.05k ± 0%     4.65k ± 0%   -7.98%  (p=0.000 n=10+10)
```

</details>

Benchmarks used Go 1.15.10 on linux_amd64 using production data.

Special thanks to @turbolent for the state decoding tool in #759 and @ramtinms for production data in jsonl!
______

For contributor use:

- [x] Targeted PR against `feature/storage-optimizations` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
