### PR TITLE
Add validation for enum cases during contract updates

### DIFF
--- a/runtime/contract_update_validation.go
+++ b/runtime/contract_update_validation.go
@@ -107,9 +107,9 @@ func (validator *ContractUpdateValidator) checkDeclarationUpdatability(
 	//      - 'structs' and 'enums'
 	if oldDeclaration.DeclarationKind() != newDeclaration.DeclarationKind() {
 		validator.report(&InvalidDeclarationKindChangeError{
-			name:    oldDeclaration.DeclarationIdentifier().Identifier,
-			oldKind: oldDeclaration.DeclarationKind(),
-			newKind: newDeclaration.DeclarationKind(),
+			Name:    oldDeclaration.DeclarationIdentifier().Identifier,
+			OldKind: oldDeclaration.DeclarationKind(),
+			NewKind: newDeclaration.DeclarationKind(),
 			Range:   ast.NewRangeFromPositioned(newDeclaration.DeclarationIdentifier()),
 		})
 
@@ -147,8 +147,8 @@ func (validator *ContractUpdateValidator) checkFields(oldDeclaration ast.Declara
 		oldField := oldFields[newField.Identifier.Identifier]
 		if oldField == nil {
 			validator.report(&ExtraneousFieldError{
-				declName:  newDeclaration.DeclarationIdentifier().Identifier,
-				fieldName: newField.Identifier.Identifier,
+				DeclName:  newDeclaration.DeclarationIdentifier().Identifier,
+				FieldName: newField.Identifier.Identifier,
 				Range:     ast.NewRangeFromPositioned(newField.Identifier),
 			})
 
@@ -163,9 +163,9 @@ func (validator *ContractUpdateValidator) checkField(oldField *ast.FieldDeclarat
 	err := oldField.TypeAnnotation.Type.CheckEqual(newField.TypeAnnotation.Type, validator)
 	if err != nil {
 		validator.report(&FieldMismatchError{
-			declName:  validator.currentDecl.DeclarationIdentifier().Identifier,
-			fieldName: newField.Identifier.Identifier,
-			err:       err,
+			DeclName:  validator.currentDecl.DeclarationIdentifier().Identifier,
+			FieldName: newField.Identifier.Identifier,
+			Err:       err,
 			Range:     ast.NewRangeFromPositioned(newField.TypeAnnotation),
 		})
 	}
@@ -233,9 +233,9 @@ func (validator *ContractUpdateValidator) checkEnumCases(oldDeclaration ast.Decl
 
 	if newEnumCaseCount < oldEnumCaseCount {
 		validator.report(&MissingEnumCasesError{
-			declName: newDeclaration.DeclarationIdentifier().Identifier,
-			expected: oldEnumCaseCount,
-			found:    newEnumCaseCount,
+			DeclName: newDeclaration.DeclarationIdentifier().Identifier,
+			Expected: oldEnumCaseCount,
+			Found:    newEnumCaseCount,
 			Range:    ast.NewRangeFromPositioned(newDeclaration.DeclarationIdentifier()),
 		})
 
@@ -244,7 +244,7 @@ func (validator *ContractUpdateValidator) checkEnumCases(oldDeclaration ast.Decl
 		return
 	}
 
-	// Validate the the new enum cases.
+	// Check whether the enum cases matches the old enum cases.
 	for index, newEnumCase := range newEnumCases {
 		// If there are no more old enum-cases, then these are newly added enum-cases,
 		// which should be fine.
@@ -255,8 +255,8 @@ func (validator *ContractUpdateValidator) checkEnumCases(oldDeclaration ast.Decl
 		oldEnumCase := oldEnumCases[index]
 		if oldEnumCase.Identifier.Identifier != newEnumCase.Identifier.Identifier {
 			validator.report(&EnumCaseMismatchError{
-				expectedName: oldEnumCase.Identifier.Identifier,
-				foundName:    newEnumCase.Identifier.Identifier,
+				ExpectedName: oldEnumCase.Identifier.Identifier,
+				FoundName:    newEnumCase.Identifier.Identifier,
 				Range:        ast.NewRangeFromPositioned(newEnumCase),
 			})
 		}
@@ -470,8 +470,8 @@ func (validator *ContractUpdateValidator) checkConformances(
 
 	if len(oldConformances) != len(newConformances) {
 		validator.report(&ConformanceCountMismatchError{
-			expected: len(oldConformances),
-			found:    len(newConformances),
+			Expected: len(oldConformances),
+			Found:    len(newConformances),
 			Range:    ast.NewRangeFromPositioned(newDecl.Identifier),
 		})
 
@@ -485,8 +485,8 @@ func (validator *ContractUpdateValidator) checkConformances(
 		err := oldConformance.CheckEqual(newConformance, validator)
 		if err != nil {
 			validator.report(&ConformanceMismatchError{
-				declName: newDecl.Identifier.Identifier,
-				err:      err,
+				DeclName: newDecl.Identifier.Identifier,
+				Err:      err,
 				Range:    ast.NewRangeFromPositioned(newConformance),
 			})
 		}
@@ -502,16 +502,16 @@ func (validator *ContractUpdateValidator) report(err error) {
 
 func (validator *ContractUpdateValidator) getContractUpdateError() error {
 	return &ContractUpdateError{
-		contractName: validator.contractName,
-		errors:       validator.errors,
-		location:     validator.location,
+		ContractName: validator.contractName,
+		Errors:       validator.errors,
+		Location:     validator.location,
 	}
 }
 
 func getTypeMismatchError(expectedType ast.Type, foundType ast.Type) *TypeMismatchError {
 	return &TypeMismatchError{
-		expectedType: expectedType,
-		foundType:    foundType,
+		ExpectedType: expectedType,
+		FoundType:    foundType,
 		Range:        ast.NewRangeFromPositioned(foundType),
 	}
 }

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -1365,7 +1365,10 @@ func TestContractUpdateValidation(t *testing.T) {
 			}`
 
 		err := deployAndUpdate("Test29", oldCode, newCode)
-		require.NoError(t, err)
+		require.Error(t, err)
+
+		cause := getErrorCause(t, err, "Test29")
+		assertMissingEnumCasesError(t, cause, "Foo", 2, 1)
 	})
 
 	t.Run("enum add case", func(t *testing.T) {
@@ -1387,10 +1390,7 @@ func TestContractUpdateValidation(t *testing.T) {
 			}`
 
 		err := deployAndUpdate("Test30", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test30")
-		assertExtraneousFieldError(t, cause, "Foo", "left")
+		require.NoError(t, err)
 	})
 
 	t.Run("enum swap cases", func(t *testing.T) {
@@ -1517,6 +1517,22 @@ func assertEnumCaseMismatchError(t *testing.T, err error, expectedEnumCase strin
 			foundEnumCase,
 		),
 		enumMismatchError.Error(),
+	)
+}
+
+func assertMissingEnumCasesError(t *testing.T, err error, declName string, expectedCaes int, foundCases int) {
+	require.Error(t, err)
+	require.IsType(t, &MissingEnumCasesError{}, err)
+	extraFieldError := err.(*MissingEnumCasesError)
+	assert.Equal(
+		t,
+		fmt.Sprintf(
+			"missing enum cases in `%s`: expected %d or more, found %d",
+			declName,
+			expectedCaes,
+			foundCases,
+		),
+		extraFieldError.Error(),
 	)
 }
 

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -1326,6 +1326,106 @@ func TestContractUpdateValidation(t *testing.T) {
 			"\n  |                ^^^^^^^^^^^^^^^^^^^^^^^^^ "+
 			"incompatible type annotations. expected `{TestInterface}`, found `TestStruct{TestInterface}`")
 	})
+
+	t.Run("enum valid", func(t *testing.T) {
+		const oldCode = `
+			pub contract Test28 {
+				pub enum Foo: UInt8 {
+					pub case up
+					pub case down
+				}
+			}`
+
+		const newCode = `
+			pub contract Test28 {
+				pub enum Foo: UInt8 {
+					pub case up
+					pub case down
+				}
+			}`
+
+		err := deployAndUpdate("Test28", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("enum remove case", func(t *testing.T) {
+		const oldCode = `
+			pub contract Test29 {
+				pub enum Foo: UInt8 {
+					pub case up
+					pub case down
+				}
+			}`
+
+		const newCode = `
+			pub contract Test29 {
+				pub enum Foo: UInt8 {
+					pub case up
+				}
+			}`
+
+		err := deployAndUpdate("Test29", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("enum add case", func(t *testing.T) {
+		const oldCode = `
+			pub contract Test30 {
+				pub enum Foo: UInt8 {
+					pub case up
+					pub case down
+				}
+			}`
+
+		const newCode = `
+			pub contract Test30 {
+				pub enum Foo: UInt8 {
+					pub case up
+					pub case down
+					pub case left
+				}
+			}`
+
+		err := deployAndUpdate("Test30", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getErrorCause(t, err, "Test30")
+		assertExtraneousFieldError(t, cause, "Foo", "left")
+	})
+
+	t.Run("enum swap cases", func(t *testing.T) {
+		const oldCode = `
+			pub contract Test31 {
+				pub enum Foo: UInt8 {
+					pub case up
+					pub case down
+					pub case left
+				}
+			}`
+
+		const newCode = `
+			pub contract Test31 {
+				pub enum Foo: UInt8 {
+					pub case down
+					pub case left
+					pub case up
+				}
+			}`
+
+		err := deployAndUpdate("Test31", oldCode, newCode)
+		require.Error(t, err)
+
+		updateErr := getContractUpdateError(t, err)
+		require.NotNil(t, updateErr)
+		assert.Equal(t, fmt.Sprintf("cannot update contract `%s`", "Test31"), updateErr.Error())
+
+		childErrors := updateErr.ChildErrors()
+		require.Equal(t, 3, len(childErrors))
+
+		assertEnumCaseMismatchError(t, childErrors[0], "up", "down")
+		assertEnumCaseMismatchError(t, childErrors[1], "down", "left")
+		assertEnumCaseMismatchError(t, childErrors[2], "left", "up")
+	})
 }
 
 func assertDeclTypeChangeError(
@@ -1401,6 +1501,22 @@ func assertConformanceMismatchError(
 		t,
 		fmt.Sprintf("incompatible type annotations. expected `%s`, found `%s`", expectedType, foundType),
 		conformanceMismatchError.err.Error(),
+	)
+}
+
+func assertEnumCaseMismatchError(t *testing.T, err error, expectedEnumCase string, foundEnumCase string) {
+	require.Error(t, err)
+	require.IsType(t, &EnumCaseMismatchError{}, err)
+	enumMismatchError := err.(*EnumCaseMismatchError)
+
+	assert.Equal(
+		t,
+		fmt.Sprintf(
+			"mismatching enum case: expected `%s`, found `%s`",
+			expectedEnumCase,
+			foundEnumCase,
+		),
+		enumMismatchError.Error(),
 	)
 }
 

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -1471,11 +1471,11 @@ func assertFieldTypeMismatchError(
 		fieldMismatchError.Error(),
 	)
 
-	assert.IsType(t, &TypeMismatchError{}, fieldMismatchError.err)
+	assert.IsType(t, &TypeMismatchError{}, fieldMismatchError.Err)
 	assert.Equal(
 		t,
 		fmt.Sprintf("incompatible type annotations. expected `%s`, found `%s`", expectedType, foundType),
-		fieldMismatchError.err.Error(),
+		fieldMismatchError.Err.Error(),
 	)
 }
 
@@ -1496,11 +1496,11 @@ func assertConformanceMismatchError(
 		conformanceMismatchError.Error(),
 	)
 
-	assert.IsType(t, &TypeMismatchError{}, conformanceMismatchError.err)
+	assert.IsType(t, &TypeMismatchError{}, conformanceMismatchError.Err)
 	assert.Equal(
 		t,
 		fmt.Sprintf("incompatible type annotations. expected `%s`, found `%s`", expectedType, foundType),
-		conformanceMismatchError.err.Error(),
+		conformanceMismatchError.Err.Error(),
 	)
 }
 
@@ -1520,7 +1520,7 @@ func assertEnumCaseMismatchError(t *testing.T, err error, expectedEnumCase strin
 	)
 }
 
-func assertMissingEnumCasesError(t *testing.T, err error, declName string, expectedCaes int, foundCases int) {
+func assertMissingEnumCasesError(t *testing.T, err error, declName string, expectedCases int, foundCases int) {
 	require.Error(t, err)
 	require.IsType(t, &MissingEnumCasesError{}, err)
 	extraFieldError := err.(*MissingEnumCasesError)
@@ -1529,7 +1529,7 @@ func assertMissingEnumCasesError(t *testing.T, err error, declName string, expec
 		fmt.Sprintf(
 			"missing cases in enum `%s`: expected %d or more, found %d",
 			declName,
-			expectedCaes,
+			expectedCases,
 			foundCases,
 		),
 		extraFieldError.Error(),

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -1527,7 +1527,7 @@ func assertMissingEnumCasesError(t *testing.T, err error, declName string, expec
 	assert.Equal(
 		t,
 		fmt.Sprintf(
-			"missing enum cases in `%s`: expected %d or more, found %d",
+			"missing cases in enum `%s`: expected %d or more, found %d",
 			declName,
 			expectedCaes,
 			foundCases,

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -254,70 +254,70 @@ func (*InvalidContractDeploymentOriginError) Error() string {
 // ContractUpdateError is reported upon any invalid update to a contract or contract interface.
 // It contains all the errors reported during the update validation.
 type ContractUpdateError struct {
-	contractName string
-	errors       []error
-	location     common.Location
+	ContractName string
+	Errors       []error
+	Location     common.Location
 }
 
 func (e *ContractUpdateError) Error() string {
-	return fmt.Sprintf("cannot update contract `%s`", e.contractName)
+	return fmt.Sprintf("cannot update contract `%s`", e.ContractName)
 }
 
 func (e *ContractUpdateError) ChildErrors() []error {
-	return e.errors
+	return e.Errors
 }
 
 func (e *ContractUpdateError) ImportLocation() common.Location {
-	return e.location
+	return e.Location
 }
 
 // FieldMismatchError is reported during a contract update, when a type of a field
 // does not match the existing type of the same field.
 type FieldMismatchError struct {
-	declName  string
-	fieldName string
-	err       error
+	DeclName  string
+	FieldName string
+	Err       error
 	ast.Range
 }
 
 func (e *FieldMismatchError) Error() string {
 	return fmt.Sprintf("mismatching field `%s` in `%s`",
-		e.fieldName,
-		e.declName,
+		e.FieldName,
+		e.DeclName,
 	)
 }
 
 func (e *FieldMismatchError) SecondaryError() string {
-	return e.err.Error()
+	return e.Err.Error()
 }
 
 // TypeMismatchError is reported during a contract update, when a type of the new program
 // does not match the existing type.
 type TypeMismatchError struct {
-	expectedType ast.Type
-	foundType    ast.Type
+	ExpectedType ast.Type
+	FoundType    ast.Type
 	ast.Range
 }
 
 func (e *TypeMismatchError) Error() string {
 	return fmt.Sprintf("incompatible type annotations. expected `%s`, found `%s`",
-		e.expectedType,
-		e.foundType,
+		e.ExpectedType,
+		e.FoundType,
 	)
 }
 
 // ExtraneousFieldError is reported during a contract update, when an updated composite
 // declaration has more fields than the existing declaration.
 type ExtraneousFieldError struct {
-	declName  string
-	fieldName string
+	DeclName  string
+	FieldName string
 	ast.Range
 }
 
 func (e *ExtraneousFieldError) Error() string {
 	return fmt.Sprintf("found new field `%s` in `%s`",
-		e.fieldName,
-		e.declName,
+		e.FieldName,
+		e.DeclName,
 	)
 }
 
@@ -334,73 +334,73 @@ func (e *ContractNotFoundError) Error() string {
 // InvalidDeclarationKindChangeError is reported during a contract update, when an attempt is made
 // to convert an existing contract to a contract interface, or vise versa.
 type InvalidDeclarationKindChangeError struct {
-	name    string
-	oldKind common.DeclarationKind
-	newKind common.DeclarationKind
+	Name    string
+	OldKind common.DeclarationKind
+	NewKind common.DeclarationKind
 	ast.Range
 }
 
 func (e *InvalidDeclarationKindChangeError) Error() string {
-	return fmt.Sprintf("trying to convert %s `%s` to a %s", e.oldKind.Name(), e.name, e.newKind.Name())
+	return fmt.Sprintf("trying to convert %s `%s` to a %s", e.OldKind.Name(), e.Name, e.NewKind.Name())
 }
 
 // ConformanceMismatchError is reported during a contract update, when the enum conformance of the new program
 // does not match the existing one.
 type ConformanceMismatchError struct {
-	declName string
-	err      error
+	DeclName string
+	Err      error
 	ast.Range
 }
 
 func (e *ConformanceMismatchError) Error() string {
-	return fmt.Sprintf("conformances does not match in `%s`", e.declName)
+	return fmt.Sprintf("conformances does not match in `%s`", e.DeclName)
 }
 
 func (e *ConformanceMismatchError) SecondaryError() string {
-	return e.err.Error()
+	return e.Err.Error()
 }
 
 // ConformanceCountMismatchError is reported during a contract update, when the conformance count
 // does not match the existing conformance count.
 type ConformanceCountMismatchError struct {
-	expected int
-	found    int
+	Expected int
+	Found    int
 	ast.Range
 }
 
 func (e *ConformanceCountMismatchError) Error() string {
-	return fmt.Sprintf("conformances count does not match: expected %d, found %d", e.expected, e.found)
+	return fmt.Sprintf("conformances count does not match: expected %d, found %d", e.Expected, e.Found)
 }
 
 // EnumCaseMismatchError is reported during an enum update, when an updated enum case
 // does not match the existing enum case.
 type EnumCaseMismatchError struct {
-	expectedName string
-	foundName    string
+	ExpectedName string
+	FoundName    string
 	ast.Range
 }
 
 func (e *EnumCaseMismatchError) Error() string {
 	return fmt.Sprintf("mismatching enum case: expected `%s`, found `%s`",
-		e.expectedName,
-		e.foundName,
+		e.ExpectedName,
+		e.FoundName,
 	)
 }
 
 // MissingEnumCasesError is reported during an enum update, if any enum cases are removed
 // from an existing enum.
 type MissingEnumCasesError struct {
-	declName string
-	expected int
-	found    int
+	DeclName string
+	Expected int
+	Found    int
 	ast.Range
 }
 
 func (e *MissingEnumCasesError) Error() string {
 	return fmt.Sprintf(
 		"missing cases in enum `%s`: expected %d or more, found %d",
-		e.declName,
-		e.expected,
-		e.found,
+		e.DeclName,
+		e.Expected,
+		e.Found,
 	)
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -306,8 +306,8 @@ func (e *TypeMismatchError) Error() string {
 	)
 }
 
-// ExtraneousFieldError is reported during a contract update, when the new contract
-// has more fields than the existing contract.
+// ExtraneousFieldError is reported during a contract update, when an updated composite
+// declaration has more fields than the existing declaration.
 type ExtraneousFieldError struct {
 	declName  string
 	fieldName string
@@ -370,4 +370,19 @@ type ConformanceCountMismatchError struct {
 
 func (e *ConformanceCountMismatchError) Error() string {
 	return fmt.Sprintf("conformances count does not match: expected %d, found %d", e.expected, e.found)
+}
+
+// EnumCaseMismatchError is reported during an enum update, when an updated enum case
+// does not match the existing enum case.
+type EnumCaseMismatchError struct {
+	expectedName string
+	foundName    string
+	ast.Range
+}
+
+func (e *EnumCaseMismatchError) Error() string {
+	return fmt.Sprintf("mismatching enum case: expected `%s`, found `%s`",
+		e.expectedName,
+		e.foundName,
+	)
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -386,3 +386,21 @@ func (e *EnumCaseMismatchError) Error() string {
 		e.foundName,
 	)
 }
+
+// MissingEnumCasesError is reported during an enum update, if any enum cases are removed
+// from an existing enum.
+type MissingEnumCasesError struct {
+	declName string
+	expected int
+	found    int
+	ast.Range
+}
+
+func (e *MissingEnumCasesError) Error() string {
+	return fmt.Sprintf(
+		"missing enum cases in `%s`: expected %d or more, found %d",
+		e.declName,
+		e.expected,
+		e.found,
+	)
+}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -398,7 +398,7 @@ type MissingEnumCasesError struct {
 
 func (e *MissingEnumCasesError) Error() string {
 	return fmt.Sprintf(
-		"missing enum cases in `%s`: expected %d or more, found %d",
+		"missing cases in enum `%s`: expected %d or more, found %d",
 		e.declName,
 		e.expected,
 		e.found,


### PR DESCRIPTION
Closes #757

## Description

As in #757, the enum-case values are represented using a composite value, having a field called `rawValue`  which stores the enum-case raw value. Hence serializing/deserializing, only the raw value gets serialized/deserialized, but not the actual enum-case name. So changing enum-cases can lead to type/value confusions.

This PR adds a validation to avoid such scenarios. With these changes, update to an enum need to make sure that:

1. Order of the updated enum-cases must be the same as the existing enum.
2. Updated enum must have at-least the same number of enum-cases as the existing one.
 
 
The above restrictions would mean:
  - Adding enum-cases at the end is allowed
  - Adding enum cases to middle/top is not allowed (violates 1)
  - Swapping enum-cases is not allowed (violates 1)
  - Removing new enum cases is not allowed (violates 2)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
