### PR TITLE
Panic with a dedicated error when a member access results in no value

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -380,3 +380,14 @@ func (e EncodingUnsupportedValueError) Error() string {
 		e.Value,
 	)
 }
+
+// MissingMemberValueError
+
+type MissingMemberValueError struct {
+	Name string
+	LocationRange
+}
+
+func (e MissingMemberValueError) Error() string {
+	return fmt.Sprintf("missing value for member `%s`", e.Name)
+}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2935,6 +2935,7 @@ func (interpreter *Interpreter) reportFunctionInvocation(pos ast.HasPosition) {
 }
 
 // getMember gets the member value by the given identifier from the given Value depending on its type.
+// May return nil if the member does not exist.
 func (interpreter *Interpreter) getMember(self Value, getLocationRange func() LocationRange, identifier string) Value {
 	var result Value
 	// When the accessed value has a type that supports the declaration of members
@@ -2953,6 +2954,10 @@ func (interpreter *Interpreter) getMember(self Value, getLocationRange func() Lo
 			return interpreter.getTypeFunction(self)
 		}
 	}
+
+	// NOTE: do not panic if the member is nil. This is a valid state.
+	// For example, when a composite field is initialized with a force-assignment, the field's value is read.
+
 	return result
 }
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -386,9 +386,13 @@ func (interpreter *Interpreter) VisitMemberExpression(expression *ast.MemberExpr
 	}
 
 	getLocationRange := locationRangeGetter(interpreter.Location, expression)
-	resultValue := interpreter.getMember(result, getLocationRange, expression.Identifier.Identifier)
+	identifier := expression.Identifier.Identifier
+	resultValue := interpreter.getMember(result, getLocationRange, identifier)
 	if resultValue == nil {
-		panic(errors.NewUnreachableError())
+		panic(MissingMemberValueError{
+			Name:          identifier,
+			LocationRange: getLocationRange(),
+		})
 	}
 
 	// If the member access is optional chaining, only wrap the result value
@@ -659,9 +663,6 @@ func (interpreter *Interpreter) visitPotentialStorageRemoval(expression ast.Expr
 
 	getterSetter := interpreter.indexExpressionGetterSetter(movingStorageIndexExpression)
 	value := getterSetter.get()
-	if value == nil {
-		panic(errors.NewUnreachableError())
-	}
 	getterSetter.set(NilValue{})
 	return value
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6365,11 +6365,7 @@ func (v *StorageReferenceValue) GetMember(interpreter *Interpreter, getLocationR
 		})
 	}
 
-	value := interpreter.getMember(*referencedValue, getLocationRange, name)
-	if value == nil {
-		panic(errors.NewUnreachableError())
-	}
-	return value
+	return interpreter.getMember(*referencedValue, getLocationRange, name)
 }
 
 func (v *StorageReferenceValue) SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string, value Value) {
@@ -6497,11 +6493,7 @@ func (v *EphemeralReferenceValue) GetMember(interpreter *Interpreter, getLocatio
 		})
 	}
 
-	value := interpreter.getMember(*referencedValue, getLocationRange, name)
-	if value == nil {
-		panic(errors.NewUnreachableError())
-	}
-	return value
+	return interpreter.getMember(*referencedValue, getLocationRange, name)
 }
 
 func (v *EphemeralReferenceValue) SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string, value Value) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -8492,3 +8492,75 @@ func BenchmarkInterpretRecursionFib(b *testing.B) {
 		require.Equal(b, expected, result)
 	}
 }
+
+func TestInterpretMissingMember(t *testing.T) {
+
+	// prepare type `struct X { let y: Int }`
+
+	const typeName = "X"
+	ty := &sema.CompositeType{
+		Location:   TestLocation,
+		Identifier: typeName,
+	}
+
+	members := sema.NewStringMemberOrderedMap()
+	ty.Members = members
+
+	const fieldName = "y"
+	fieldMember := sema.NewPublicConstantFieldMember(
+		ty,
+		fieldName,
+		&sema.IntType{},
+		"",
+	)
+	members.Set(fieldName, fieldMember)
+
+	// prepare value of type X,
+	// which is missing field `y`!
+
+	value := interpreter.NewCompositeValue(
+		TestLocation,
+		typeName,
+		common.CompositeKindStructure,
+		interpreter.NewStringValueOrderedMap(),
+		nil,
+	)
+
+	predeclaredValues :=
+		stdlib.StandardLibraryValues{
+			{
+				Name:  "x",
+				Type:  ty,
+				Value: value,
+				Kind:  common.DeclarationKindStructure,
+			},
+		}
+
+	valueDeclarations := predeclaredValues.ToSemaValueDeclarations()
+	values := predeclaredValues.ToInterpreterValueDeclarations()
+
+	inter := parseCheckAndInterpretWithOptions(t,
+		`
+          fun test() {
+              // access missing field y
+              x.y
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			CheckerOptions: []sema.Option{
+				sema.WithPredeclaredValues(valueDeclarations),
+			},
+			Options: []interpreter.Option{
+				interpreter.WithPredeclaredValues(values),
+			},
+		},
+	)
+
+	_, err := inter.Invoke("test")
+	require.Error(t, err)
+
+	var missingMemberError interpreter.MissingMemberValueError
+	require.ErrorAs(t, err, &missingMemberError)
+
+	require.Equal(t, "y", missingMemberError.Name)
+}


### PR DESCRIPTION
Closes #758 

## Description

When member access fails, panic with a dedicated error (which includes the location and range).

This is an improvement of #741.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
