### PR TITLE
Get resource owner from host environment

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -157,6 +157,7 @@ type ImportLocationHandlerFunc func(
 ) Import
 
 // AccountHandlerFunc is a function that handles retrieving a public account at a given address.
+// The account returned must be of type `PublicAccount`.
 //
 type AccountHandlerFunc func(
 	address AddressValue,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5707,6 +5707,15 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter) OptionalValue {
 	address := AddressValue(*v.Owner)
 	ownerAccount := interpreter.accountHandler(address)
 
+	// Owner must be of `PublicAccount` type.
+	compositeDynamicType, ok := ownerAccount.DynamicType(interpreter).(CompositeDynamicType)
+
+	if !ok || !sema.PublicAccountType.Equal(compositeDynamicType.StaticType) {
+		panic(&TypeMismatchError{
+			ExpectedType: sema.PublicAccountType,
+		})
+	}
+
 	return NewSomeValueOwningNonCopying(ownerAccount)
 }
 
@@ -7233,7 +7242,6 @@ func (v CapabilityValue) GetMember(inter *Interpreter, _ func() LocationRange, n
 			borrowType = inter.ConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
 		}
 		return inter.capabilityCheckFunction(v.Address, v.Path, borrowType)
-
 
 	case "address":
 		return v.Address

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5704,26 +5704,8 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter) OptionalValue {
 		return NilValue{}
 	}
 
-	// There's no direct access to the host environment at this point.
-	// Therefore, load and invoke the `getAccount` host function.
-	getAccountValue, ok := interpreter.effectivePredeclaredValues["getAccount"]
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
-	getAccountHostFunc := getAccountValue.ValueDeclarationValue().(HostFunctionValue)
-
 	address := AddressValue(*v.Owner)
-
-	invocation := Invocation{
-		Arguments: []Value{
-			address,
-		},
-		GetLocationRange: ReturnEmptyLocationRange,
-		Interpreter:      interpreter,
-	}
-
-	ownerAccount := getAccountHostFunc.Function(invocation)
+	ownerAccount := interpreter.accountHandler(address)
 
 	return NewSomeValueOwningNonCopying(ownerAccount)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -811,6 +811,11 @@ func (r *interpreterRuntime) newInterpreter(
 		interpreter.WithOnStatementHandler(
 			r.onStatementHandler(),
 		),
+		interpreter.WithAccountHandlerFunc(
+			func(address interpreter.AddressValue) *interpreter.CompositeValue {
+				return r.getPublicAccount(address, context.Interface, runtimeStorage)
+			},
+		),
 	}
 
 	defaultOptions = append(defaultOptions,
@@ -1511,13 +1516,22 @@ func (r *interpreterRuntime) instantiateContract(
 func (r *interpreterRuntime) newGetAccountFunction(runtimeInterface Interface, runtimeStorage *runtimeStorage) interpreter.HostFunction {
 	return func(invocation interpreter.Invocation) interpreter.Value {
 		accountAddress := invocation.Arguments[0].(interpreter.AddressValue)
-		return interpreter.NewPublicAccountValue(
-			accountAddress,
-			storageUsedGetFunction(accountAddress, runtimeInterface, runtimeStorage),
-			storageCapacityGetFunction(accountAddress, runtimeInterface),
-			r.newPublicAccountKeys(accountAddress, runtimeInterface),
-		)
+		return r.getPublicAccount(accountAddress, runtimeInterface, runtimeStorage)
 	}
+}
+
+func (r *interpreterRuntime) getPublicAccount(
+	accountAddress interpreter.AddressValue,
+	runtimeInterface Interface,
+	runtimeStorage *runtimeStorage,
+) *interpreter.CompositeValue {
+
+	return interpreter.NewPublicAccountValue(
+		accountAddress,
+		storageUsedGetFunction(accountAddress, runtimeInterface, runtimeStorage),
+		storageCapacityGetFunction(accountAddress, runtimeInterface),
+		r.newPublicAccountKeys(accountAddress, runtimeInterface),
+	)
 }
 
 func (r *interpreterRuntime) newLogFunction(runtimeInterface Interface) interpreter.HostFunction {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -4268,13 +4268,8 @@ func TestInterpretResourceOwnerFieldUseComposite(t *testing.T) {
 			loggedMessages = append(loggedMessages, message)
 		},
 		getStorageUsed: func(_ Address) (uint64, error) {
-			var amount uint64 = 0
-
-			for _, data := range storage.storedValues {
-				amount += uint64(len(data))
-			}
-
-			return amount, nil
+			// return a dummy value
+			return 120, nil
 		},
 		getStorageCapacity: func(_ Address) (uint64, error) {
 			// return a dummy value

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5085,7 +5085,9 @@ func init() {
 		PublicKeyType,
 		HashAlgorithmType,
 		SignatureAlgorithmType,
+		AuthAccountType,
 		AuthAccountKeysType,
+		PublicAccountType,
 		PublicAccountKeysType,
 	}
 

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -47,7 +47,7 @@ var accountFunctionType = &sema.FunctionType{
 	),
 }
 
-var getAccountFunctionType = &sema.FunctionType{
+var GetAccountFunctionType = &sema.FunctionType{
 	Parameters: []*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -128,7 +128,7 @@ func FlowBuiltInFunctions(impls FlowBuiltinImpls) StandardLibraryFunctions {
 		),
 		NewStandardLibraryFunction(
 			"getAccount",
-			getAccountFunctionType,
+			GetAccountFunctionType,
 			impls.GetAccount,
 		),
 		NewStandardLibraryFunction(

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -47,7 +47,7 @@ var accountFunctionType = &sema.FunctionType{
 	),
 }
 
-var GetAccountFunctionType = &sema.FunctionType{
+var getAccountFunctionType = &sema.FunctionType{
 	Parameters: []*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -128,7 +128,7 @@ func FlowBuiltInFunctions(impls FlowBuiltinImpls) StandardLibraryFunctions {
 		),
 		NewStandardLibraryFunction(
 			"getAccount",
-			GetAccountFunctionType,
+			getAccountFunctionType,
 			impls.GetAccount,
 		),
 		NewStandardLibraryFunction(

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7724,25 +7724,6 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		Kind: common.DeclarationKindConstant,
 	}
 
-	getAccountHostFunc := stdlib.NewStandardLibraryFunction(
-		"getAccount",
-		stdlib.GetAccountFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			return interpreter.NewPublicAccountValue(
-				addressValue,
-				func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
-					panic(errors.NewUnreachableError())
-				},
-				func() interpreter.UInt64Value {
-					panic(errors.NewUnreachableError())
-				},
-				interpreter.NewPublicAccountKeysValue(
-					panicFunction,
-				),
-			)
-		},
-	)
-
 	inter := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
@@ -7754,7 +7735,6 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 			Options: []interpreter.Option{
 				interpreter.WithPredeclaredValues([]interpreter.ValueDeclaration{
 					valueDeclaration,
-					getAccountHostFunc,
 				}),
 				interpreter.WithStorageExistenceHandler(checker),
 				interpreter.WithStorageReadHandler(getter),
@@ -7762,6 +7742,22 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 				interpreter.WithStorageKeyHandler(
 					func(_ *interpreter.Interpreter, _ common.Address, indexingType sema.Type) string {
 						return string(indexingType.ID())
+					},
+				),
+				interpreter.WithAccountHandlerFunc(
+					func(address interpreter.AddressValue) *interpreter.CompositeValue {
+						return interpreter.NewPublicAccountValue(
+							address,
+							func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
+								panic(errors.NewUnreachableError())
+							},
+							func() interpreter.UInt64Value {
+								panic(errors.NewUnreachableError())
+							},
+							interpreter.NewPublicAccountKeysValue(
+								panicFunction,
+							),
+						)
 					},
 				),
 			},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7724,6 +7724,25 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		Kind: common.DeclarationKindConstant,
 	}
 
+	getAccountHostFunc := stdlib.NewStandardLibraryFunction(
+		"getAccount",
+		stdlib.GetAccountFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			return interpreter.NewPublicAccountValue(
+				addressValue,
+				func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
+					panic(errors.NewUnreachableError())
+				},
+				func() interpreter.UInt64Value {
+					panic(errors.NewUnreachableError())
+				},
+				interpreter.NewPublicAccountKeysValue(
+					panicFunction,
+				),
+			)
+		},
+	)
+
 	inter := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
@@ -7735,6 +7754,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 			Options: []interpreter.Option{
 				interpreter.WithPredeclaredValues([]interpreter.ValueDeclaration{
 					valueDeclaration,
+					getAccountHostFunc,
 				}),
 				interpreter.WithStorageExistenceHandler(checker),
 				interpreter.WithStorageReadHandler(getter),


### PR DESCRIPTION
Closes #754

## Description

Currently, when the owner field of a resource is accessed, the interpreter creates a new `PublicAccount` using the owner address. However, since there's no access to the host environment at that point, some of the fields and member functions are not properly initialized.

### Solution:
Load the owner account from the host environment using the address.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
