### PR TITLE
Reject indirect incompatible updates to composite declarations

### DIFF
--- a/runtime/contract_update_validation.go
+++ b/runtime/contract_update_validation.go
@@ -213,7 +213,7 @@ func (validator *ContractUpdateValidator) checkNestedDeclarations(
 	// Hence report an error.
 	for name := range oldCompositeAndInterfaceDecls { //nolint:maprangecheck
 		validator.report(&MissingCompositeDeclarationError{
-			DeclName: name,
+			Name: name,
 			Range:    ast.NewRangeFromPositioned(newDeclaration.DeclarationIdentifier()),
 		})
 	}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -408,13 +408,13 @@ func (e *MissingEnumCasesError) Error() string {
 // MissingCompositeDeclarationError is reported during an contract update, if an existing
 // composite declaration (struct or struct interface) is removed.
 type MissingCompositeDeclarationError struct {
-	DeclName string
+	Name string
 	ast.Range
 }
 
 func (e *MissingCompositeDeclarationError) Error() string {
 	return fmt.Sprintf(
 		"missing composite declaration `%s`",
-		e.DeclName,
+		e.Name,
 	)
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -404,3 +404,17 @@ func (e *MissingEnumCasesError) Error() string {
 		e.Found,
 	)
 }
+
+// MissingCompositeDeclarationError is reported during an contract update, if an existing
+// composite declaration (struct or struct interface) is removed.
+type MissingCompositeDeclarationError struct {
+	DeclName string
+	ast.Range
+}
+
+func (e *MissingCompositeDeclarationError) Error() string {
+	return fmt.Sprintf(
+		"missing composite declaration `%s`",
+		e.DeclName,
+	)
+}


### PR DESCRIPTION
Closes #771

## Description

Currently, doing incompatible changes to a composite type (like changing field types, adding new fields, etc) is not allowed. However, it is possible to remove an existing composite type, and add another composite type with the same name, but with a different structure, which has the same effect as doing an incompatible change.

This PR rejects such indirect changes to a struct. With this,
  - Removing any existing composite type declaration is not allowed
  - Adding new composite type declarations is allowed

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
