### PR TITLE
Improve documentation for block timestamp

### DIFF
--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -51,7 +51,10 @@ pub struct Block {
 
     /// The timestamp of the block.
     ///
-    /// It is the local clock time of the block proposer when it generates the block
+    /// Unix timestamp of when the proposer claims it constructed the block.
+    ///
+    /// NOTE: It is included by the proposer, there are no guarantees on how much the time stamp can deviate from the true time the block was published.
+    /// Consider observing blocks’ status changes off-chain yourself to get a more reliable value.
     ///
     pub let timestamp: UFix64
 }

--- a/runtime/sema/block.go
+++ b/runtime/sema/block.go
@@ -112,5 +112,8 @@ It is essentially the hash of the block
 const blockTypeIdFieldDocString = `
 The timestamp of the block.
 
-It is the local clock time of the block proposer when it generates the block
+Unix timestamp of when the proposer claims it constructed the block.
+
+NOTE: It is included by the proposer, there are no guarantees on how much the time stamp can deviate from the true time the block was published.
+Consider observing blocks’ status changes off-chain yourself to get a more reliable value
 `


### PR DESCRIPTION
## Description

Port [the improvement](https://github.com/onflow/flow/pull/86) made to the [block timestamp documentation](https://docs.onflow.org/access-api#block)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
