### PR TITLE
Improve value type conformance check

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -196,6 +196,9 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 		fields[i] = exportValueWithInterpreter(fieldValue, inter, results)
 	}
 
+	// NOTE: when modifying the cases below,
+	// also update error message below!
+
 	switch staticType.Kind {
 	case common.CompositeKindStructure:
 		return cadence.NewStruct(fields).WithType(t.(*cadence.StructType))

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -951,17 +951,17 @@ func TestEnumValue(t *testing.T) {
 
 	t.Run("test export", func(t *testing.T) {
 		script := `
-			pub fun main(): Direction {
-				return Direction.RIGHT
-			}
+            pub fun main(): Direction {
+                return Direction.RIGHT
+            }
 
-			pub enum Direction: Int {
-				pub case UP
-				pub case DOWN
-				pub case LEFT
-				pub case RIGHT
-			}
-		`
+            pub enum Direction: Int {
+                pub case UP
+                pub case DOWN
+                pub case LEFT
+                pub case RIGHT
+            }
+        `
 
 		actual := exportValueFromScript(t, script)
 		assert.Equal(t, enumValue, actual)
@@ -969,21 +969,21 @@ func TestEnumValue(t *testing.T) {
 
 	t.Run("test import", func(t *testing.T) {
 		script := `
-			pub fun main(dir: Direction): Direction {
-				if !dir.isInstance(Type<Direction>()) {
-					panic("Not a Direction value")
-				}
+            pub fun main(dir: Direction): Direction {
+                if !dir.isInstance(Type<Direction>()) {
+                    panic("Not a Direction value")
+                }
 
-				return dir
-			}
+                return dir
+            }
 
-			pub enum Direction: Int {
-				pub case UP
-				pub case DOWN
-				pub case LEFT
-				pub case RIGHT
-			}
-		`
+            pub enum Direction: Int {
+                pub case UP
+                pub case DOWN
+                pub case LEFT
+                pub case RIGHT
+            }
+        `
 
 		actual, err := importAndExportValuesFromScript(t, script, enumValue)
 		require.NoError(t, err)
@@ -1015,16 +1015,16 @@ func importAndExportValuesFromScript(t *testing.T, script string, arg cadence.Va
 	)
 }
 
-type argumentPassingTest struct {
-	label         string
-	typeSignature string
-	exportedValue cadence.Value
-	skipExport    bool
-}
-
 func TestArgumentPassing(t *testing.T) {
 
 	t.Parallel()
+
+	type argumentPassingTest struct {
+		label         string
+		typeSignature string
+		exportedValue cadence.Value
+		skipExport    bool
+	}
 
 	var argumentPassingTests = []argumentPassingTest{
 		{
@@ -1211,25 +1211,25 @@ func TestArgumentPassing(t *testing.T) {
 		// TODO: Enable below once https://github.com/onflow/cadence/issues/712 is fixed.
 		// TODO: Add a malformed argument test for capabilities
 		//{
-		//	label:         "Capability",
-		//	typeSignature: "Capability<&Foo>",
-		//	exportedValue: cadence.Capability{
-		//		Path: cadence.Path{
-		//			Domain:     "public",
-		//			Identifier: "bar",
-		//		},
-		//		Address:    cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 1, 0, 2}),
-		//		BorrowType: "Foo",
-		//	},
+		//    label:         "Capability",
+		//    typeSignature: "Capability<&Foo>",
+		//    exportedValue: cadence.Capability{
+		//        Path: cadence.Path{
+		//            Domain:     "public",
+		//            Identifier: "bar",
+		//        },
+		//        Address:    cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 1, 0, 2}),
+		//        BorrowType: "Foo",
+		//    },
 		//},
 
 		// TODO: enable once https://github.com/onflow/cadence/issues/491 is fixed.
 		//{
-		//	label:         "Type",
-		//	typeSignature: "Type",
-		//	exportedValue: cadence.TypeValue{
-		//		StaticType: "Foo",
-		//	},
+		//    label:         "Type",
+		//    typeSignature: "Type",
+		//    exportedValue: cadence.TypeValue{
+		//        StaticType: "Foo",
+		//    },
 		//},
 
 	}
@@ -1251,12 +1251,12 @@ func TestArgumentPassing(t *testing.T) {
 			script := fmt.Sprintf(
 				`pub fun main(arg: %[1]s)%[2]s {
 
-					if !arg.isInstance(Type<%[1]s>()) {
-						panic("Not a %[1]s value")
-					}
+                    if !arg.isInstance(Type<%[1]s>()) {
+                        panic("Not a %[1]s value")
+                    }
 
-					%[3]s
-				}`,
+                    %[3]s
+                }`,
 				test.typeSignature,
 				returnSignature,
 				returnStmt,
@@ -1334,13 +1334,15 @@ func TestComplexStructArgumentPassing(t *testing.T) {
 				},
 				{
 					Identifier: "j",
-					Type: cadence.AnyStructType{},
+					Type:       cadence.AnyStructType{},
 				},
 			},
 		},
 
 		Fields: []cadence.Value{
-			cadence.NewString("John"),
+			cadence.NewOptional(
+				cadence.NewString("John"),
+			),
 			cadence.NewDictionary([]cadence.KeyValuePair{
 				{
 					Key:   cadence.NewString("name"),
@@ -1374,40 +1376,42 @@ func TestComplexStructArgumentPassing(t *testing.T) {
 	}
 
 	script := fmt.Sprintf(
-		`pub fun main(arg: %[1]s): %[1]s {
+		`
+          pub fun main(arg: %[1]s): %[1]s {
 
-			if !arg.isInstance(Type<%[1]s>()) {
-				panic("Not a %[1]s value")
-			}
+              if !arg.isInstance(Type<%[1]s>()) {
+                  panic("Not a %[1]s value")
+              }
 
-			return arg
-		}
+              return arg
+          }
 
-		pub struct Foo {
-			pub var a: String?
-			pub var b: {String: String}
-			pub var c: [String]
-			pub var d: [String; 2]
-			pub var e: Address
-			pub var f: Bool
-			pub var g: StoragePath
-			pub var h: PublicPath
-			pub var i: PrivatePath
-			pub var j: AnyStruct
+          pub struct Foo {
+              pub var a: String?
+              pub var b: {String: String}
+              pub var c: [String]
+              pub var d: [String; 2]
+              pub var e: Address
+              pub var f: Bool
+              pub var g: StoragePath
+              pub var h: PublicPath
+              pub var i: PrivatePath
+              pub var j: AnyStruct
 
-			init() {
-				self.a = "Hello"
-				self.b = {}
-				self.c = []
-				self.d = ["foo", "bar"]
-				self.e = 0x42
-				self.f = true
-				self.g = /storage/foo
-				self.h = /public/foo
-				self.i = /private/foo
-				self.j = nil
-			}
-		}`,
+              init() {
+                  self.a = "Hello"
+                  self.b = {}
+                  self.c = []
+                  self.d = ["foo", "bar"]
+                  self.e = 0x42
+                  self.f = true
+                  self.g = /storage/foo
+                  self.h = /public/foo
+                  self.i = /private/foo
+                  self.j = nil
+              }
+          }
+        `,
 		"Foo",
 	)
 
@@ -1455,13 +1459,13 @@ func TestComplexStructWithAnyStructFields(t *testing.T) {
 				},
 				{
 					Identifier: "e",
-					Type: cadence.AnyStructType{},
+					Type:       cadence.AnyStructType{},
 				},
 			},
 		},
 
 		Fields: []cadence.Value{
-			cadence.NewString("John"),
+			cadence.NewOptional(cadence.NewString("John")),
 			cadence.NewDictionary([]cadence.KeyValuePair{
 				{
 					Key:   cadence.NewString("name"),
@@ -1484,37 +1488,38 @@ func TestComplexStructWithAnyStructFields(t *testing.T) {
 	}
 
 	script := fmt.Sprintf(
-		`pub fun main(arg: %[1]s): %[1]s {
+		`
+          pub fun main(arg: %[1]s): %[1]s {
 
-			if !arg.isInstance(Type<%[1]s>()) {
-				panic("Not a %[1]s value")
-			}
+              if !arg.isInstance(Type<%[1]s>()) {
+                  panic("Not a %[1]s value")
+              }
 
-			return arg
-		}
+              return arg
+          }
 
-		pub struct Foo {
-			pub var a: AnyStruct?
-			pub var b: {String: AnyStruct}
-			pub var c: [AnyStruct]
-			pub var d: [AnyStruct; 2]
-			pub var e: AnyStruct
+          pub struct Foo {
+              pub var a: AnyStruct?
+              pub var b: {String: AnyStruct}
+              pub var c: [AnyStruct]
+              pub var d: [AnyStruct; 2]
+              pub var e: AnyStruct
 
-			init() {
-				self.a = "Hello"
-				self.b = {}
-				self.c = []
-				self.d = ["foo", "bar"]
-				self.e = /storage/foo
-			}
-		}`,
+              init() {
+                  self.a = "Hello"
+                  self.b = {}
+                  self.c = []
+                  self.d = ["foo", "bar"]
+                  self.e = /storage/foo
+              }
+        }
+        `,
 		"Foo",
 	)
 
 	actual, err := importAndExportValuesFromScript(t, script, complexStructValue)
 	require.NoError(t, err)
 	assert.Equal(t, complexStructValue, actual)
-
 }
 
 func TestMalformedArgumentPassing(t *testing.T) {
@@ -1605,31 +1610,43 @@ func TestMalformedArgumentPassing(t *testing.T) {
 		},
 	}
 
+	type argumentPassingTest struct {
+		label           string
+		typeSignature   string
+		exportedValue   cadence.Value
+		expectedErrType error
+	}
+
 	var argumentPassingTests = []argumentPassingTest{
 		{
-			label:         "Malformed Struct field type",
-			typeSignature: "Foo",
-			exportedValue: malformedStruct1,
+			label:           "Malformed Struct field type",
+			typeSignature:   "Foo",
+			exportedValue:   malformedStruct1,
+			expectedErrType: &MalformedValueError{},
 		},
 		{
-			label:         "Malformed Struct field name",
-			typeSignature: "Foo",
-			exportedValue: malformedStruct2,
+			label:           "Malformed Struct field name",
+			typeSignature:   "Foo",
+			exportedValue:   malformedStruct2,
+			expectedErrType: &MalformedValueError{},
 		},
 		{
-			label:         "Malformed AnyStruct",
-			typeSignature: "AnyStruct",
-			exportedValue: malformedStruct1,
+			label:           "Malformed AnyStruct",
+			typeSignature:   "AnyStruct",
+			exportedValue:   malformedStruct1,
+			expectedErrType: &MalformedValueError{},
 		},
 		{
-			label:         "Malformed nested struct array",
-			typeSignature: "Bar",
-			exportedValue: malformedStruct3,
+			label:           "Malformed nested struct array",
+			typeSignature:   "Bar",
+			exportedValue:   malformedStruct3,
+			expectedErrType: &MalformedValueError{},
 		},
 		{
-			label:         "Malformed nested struct dictionary",
-			typeSignature: "Baz",
-			exportedValue: malformedStruct4,
+			label:           "Malformed nested struct dictionary",
+			typeSignature:   "Baz",
+			exportedValue:   malformedStruct4,
+			expectedErrType: &MalformedValueError{},
 		},
 		{
 			label:         "Array with malformed member",
@@ -1637,6 +1654,7 @@ func TestMalformedArgumentPassing(t *testing.T) {
 			exportedValue: cadence.NewArray([]cadence.Value{
 				malformedStruct1,
 			}),
+			expectedErrType: &MalformedValueError{},
 		},
 		{
 			label:         "Array with wrong size",
@@ -1644,21 +1662,24 @@ func TestMalformedArgumentPassing(t *testing.T) {
 			exportedValue: cadence.NewArray([]cadence.Value{
 				malformedStruct1,
 			}),
+			expectedErrType: &InvalidValueTypeError{},
 		},
 		{
-			label:         "Malformed Optional",
-			typeSignature: "Foo?",
-			exportedValue: cadence.NewOptional(malformedStruct1),
+			label:           "Malformed Optional",
+			typeSignature:   "Foo?",
+			exportedValue:   cadence.NewOptional(malformedStruct1),
+			expectedErrType: &MalformedValueError{},
 		},
 		{
 			label:         "Malformed Map",
-			typeSignature: "{String : Foo}",
+			typeSignature: "{String: Foo}",
 			exportedValue: cadence.NewDictionary([]cadence.KeyValuePair{
 				{
 					Key:   cadence.NewString("foo"),
 					Value: malformedStruct1,
 				},
 			}),
+			expectedErrType: &MalformedValueError{},
 		},
 	}
 
@@ -1671,36 +1692,36 @@ func TestMalformedArgumentPassing(t *testing.T) {
 			script := fmt.Sprintf(
 				`pub fun main(arg: %[1]s): %[1]s {
 
-					if !arg.isInstance(Type<%[1]s>()) {
-						panic("Not a %[1]s value")
-					}
+                    if !arg.isInstance(Type<%[1]s>()) {
+                        panic("Not a %[1]s value")
+                    }
 
-					return arg
-				}
+                    return arg
+                }
 
-				pub struct Foo {
-					pub var a: String
+                pub struct Foo {
+                    pub var a: String
 
-					init() {
-						self.a = "Hello"
-					}
-				}
+                    init() {
+                        self.a = "Hello"
+                    }
+                }
 
-				pub struct Bar {
-					pub var a: [Foo]
+                pub struct Bar {
+                    pub var a: [Foo]
 
-					init() {
-						self.a = []
-					}
-				}
+                    init() {
+                        self.a = []
+                    }
+                }
 
-				pub struct Baz {
-					pub var a: {String: Foo}
+                pub struct Baz {
+                    pub var a: {String: Foo}
 
-					init() {
-						self.a = {}
-					}
-				}`,
+                    init() {
+                        self.a = {}
+                    }
+                }`,
 				test.typeSignature,
 			)
 
@@ -1713,12 +1734,7 @@ func TestMalformedArgumentPassing(t *testing.T) {
 			require.IsType(t, &InvalidEntryPointArgumentError{}, runtimeError.Err)
 			argError := runtimeError.Err.(*InvalidEntryPointArgumentError)
 
-			require.IsType(t, &MalformedArgumentError{}, argError.Err)
-			assert.Contains(
-				t,
-				argError.Err.Error(),
-				fmt.Sprintf("malformed argument `%s`", test.exportedValue.String()),
-			)
+			require.IsType(t, test.expectedErrType, argError.Err)
 		})
 	}
 

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -136,36 +136,34 @@ func (e *InvalidEntryPointArgumentError) Error() string {
 	return fmt.Sprintf("invalid argument at index %d", e.Index)
 }
 
-// MalformedArgumentError
+// MalformedValueError
 
-type MalformedArgumentError struct {
-	Value interpreter.Value
+type MalformedValueError struct {
+	ExpectedType sema.Type
 }
 
-func (e *MalformedArgumentError) Error() string {
+func (e *MalformedValueError) Error() string {
 	return fmt.Sprintf(
-		"malformed argument `%s`",
-		e.Value,
+		"value does not conform to expected type `%s`",
+		e.ExpectedType.QualifiedString(),
 	)
 }
 
-// InvalidTypeAssignmentError
-
-type InvalidTypeAssignmentError struct {
-	Value interpreter.Value
-	Type  sema.Type
-	Err   error
+// InvalidValueTypeError
+//
+type InvalidValueTypeError struct {
+	ExpectedType sema.Type
+	Err          error
 }
 
-func (e *InvalidTypeAssignmentError) Unwrap() error {
+func (e *InvalidValueTypeError) Unwrap() error {
 	return e.Err
 }
 
-func (e *InvalidTypeAssignmentError) Error() string {
+func (e *InvalidValueTypeError) Error() string {
 	return fmt.Sprintf(
-		"cannot assign type `%s` to %s",
-		e.Type.QualifiedString(),
-		e.Value,
+		"expected value of type `%s`",
+		e.ExpectedType.QualifiedString(),
 	)
 }
 

--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -110,12 +110,7 @@ func (v BlockValue) String() string {
 	)
 }
 
-func (v BlockValue) ConformsToDynamicType(dynamicType DynamicType) bool {
+func (v BlockValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType) bool {
 	_, ok := dynamicType.(BlockDynamicType)
 	return ok
-}
-
-func (v BlockValue) conformsToSemaType(semaType sema.Type) bool {
-	// No need to check deep equivalency, since these are not importable.
-	return sema.BlockType.Equal(semaType)
 }

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -101,12 +101,7 @@ func (DeployedContractValue) SetMember(_ *Interpreter, _ func() LocationRange, _
 	panic(errors.NewUnreachableError())
 }
 
-func (v DeployedContractValue) ConformsToDynamicType(dynamicType DynamicType) bool {
+func (v DeployedContractValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType) bool {
 	_, ok := dynamicType.(DeployedContractDynamicType)
 	return ok
-}
-
-func (v DeployedContractValue) conformsToSemaType(semaType sema.Type) bool {
-	// No need to check deep equivalency, since these are not importable.
-	return sema.DeployedContractType.Equal(semaType)
 }

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -105,15 +105,10 @@ func (f InterpretedFunctionValue) Invoke(invocation Invocation) Value {
 	return f.Interpreter.invokeInterpretedFunction(f, invocation)
 }
 
-func (f InterpretedFunctionValue) ConformsToDynamicType(dynamicType DynamicType) bool {
-	_, ok := dynamicType.(FunctionDynamicType)
-	return ok
-}
-
-func (f InterpretedFunctionValue) conformsToSemaType(semaType sema.Type) bool {
-	// No need to check deep equivalency, since these are not importable.
-	_, ok := semaType.(*sema.FunctionType)
-	return ok
+func (f InterpretedFunctionValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType) bool {
+	// TODO: once FunctionDynamicType has parameter and return type info,
+	//   check it matches InterpretedFunctionValue's static function type
+	return false
 }
 
 // HostFunctionValue
@@ -193,15 +188,11 @@ func (f HostFunctionValue) SetMember(_ *Interpreter, _ func() LocationRange, _ s
 	panic(errors.NewUnreachableError())
 }
 
-func (f HostFunctionValue) ConformsToDynamicType(dynamicType DynamicType) bool {
-	_, ok := dynamicType.(FunctionDynamicType)
-	return ok
-}
-
-func (f HostFunctionValue) conformsToSemaType(semaType sema.Type) bool {
-	// No need to check deep equivalency, since these are not importable.
-	_, ok := semaType.(*sema.FunctionType)
-	return ok
+func (f HostFunctionValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType) bool {
+	// TODO: once HostFunctionValue has static function type,
+	//   and FunctionDynamicType has parameter and return type info,
+	//   check they match
+	return false
 }
 
 // BoundFunctionValue
@@ -257,13 +248,6 @@ func (f BoundFunctionValue) Invoke(invocation Invocation) Value {
 	return f.Function.Invoke(invocation)
 }
 
-func (f BoundFunctionValue) ConformsToDynamicType(dynamicType DynamicType) bool {
-	_, ok := dynamicType.(FunctionDynamicType)
-	return ok
-}
-
-func (f BoundFunctionValue) conformsToSemaType(semaType sema.Type) bool {
-	// No need to check deep equivalency, since these are not importable.
-	_, ok := semaType.(*sema.FunctionType)
-	return ok
+func (f BoundFunctionValue) ConformsToDynamicType(interpreter *Interpreter, dynamicType DynamicType) bool {
+	return f.Function.ConformsToDynamicType(interpreter, dynamicType)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -529,24 +529,24 @@ func validateArgumentParams(
 
 		arg := importValue(value)
 
-		// Check whether the decoded value conforms to the type associated with the value.
 		dynamicType := arg.DynamicType(inter)
-		if !arg.ConformsToDynamicType(dynamicType) {
-			return nil, &InvalidEntryPointArgumentError{
-				Index: i,
-				Err: &MalformedArgumentError{
-					Value: arg,
-				},
-			}
-		}
 
 		// Check that decoded value is a subtype of static parameter type
 		if !interpreter.IsSubType(dynamicType, parameterType) {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: i,
-				Err: &InvalidTypeAssignmentError{
-					Value: arg,
-					Type:  parameterType,
+				Err: &InvalidValueTypeError{
+					ExpectedType: parameterType,
+				},
+			}
+		}
+
+		// Check whether the decoded value conforms to the type associated with the value
+		if !arg.ConformsToDynamicType(inter, dynamicType) {
+			return nil, &InvalidEntryPointArgumentError{
+				Index: i,
+				Err: &MalformedValueError{
+					ExpectedType: parameterType,
 				},
 			}
 		}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -832,7 +832,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			check: func(t *testing.T, err error) {
 				assert.Error(t, err)
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
-				assert.IsType(t, &InvalidTypeAssignmentError{}, errors.Unwrap(errors.Unwrap(err)))
+				assert.IsType(t, &InvalidValueTypeError{}, errors.Unwrap(errors.Unwrap(err)))
 			},
 		},
 		{
@@ -926,7 +926,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			check: func(t *testing.T, err error) {
 				assert.Error(t, err)
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
-				assert.IsType(t, &InvalidTypeAssignmentError{}, errors.Unwrap(errors.Unwrap(err)))
+				assert.IsType(t, &InvalidValueTypeError{}, errors.Unwrap(errors.Unwrap(err)))
 			},
 		},
 		{
@@ -1128,7 +1128,7 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			check: func(t *testing.T, err error) {
 				assert.Error(t, err)
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
-				assert.IsType(t, &InvalidTypeAssignmentError{}, errors.Unwrap(errors.Unwrap(err)))
+				assert.IsType(t, &InvalidValueTypeError{}, errors.Unwrap(errors.Unwrap(err)))
 			},
 		},
 		{
@@ -1213,7 +1213,7 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			check: func(t *testing.T, err error) {
 				assert.Error(t, err)
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
-				assert.IsType(t, &InvalidTypeAssignmentError{}, errors.Unwrap(errors.Unwrap(err)))
+				assert.IsType(t, &InvalidValueTypeError{}, errors.Unwrap(errors.Unwrap(err)))
 			},
 		},
 		{


### PR DESCRIPTION
⚠️ Targets #724

## Description

Improve the check that an argument value conforms to the dynamic type it claims to be.
Remove `ValueConformsToSemaType` and `conformsToSemaType` and the code duplication it entailed.

Instead, when checking if a composite value conforms to a composite dynamic type (in `CompositeValue.ConformsToDynamicType`), use the same combination of dynamic type check (`interpreter.IsSubType`) and check that the value conforms to the dynamic type it claims to be (`Value.ConformsToDynamicType`) as is already performed by the runtime when validating the arguments (click "Load diff" for `value.go` when following this link):

[`supun/improve-import-export-3...bastian/improve-import-export?expand=1`#diff-424575c293](https://github.com/onflow/cadence/compare/supun/improve-import-export-3...bastian/improve-import-export?expand=1#diff-424575c293dc2bc3a28aab845829d7656fa83a7be4e026de8906935e23bbd52eR5841-R5847)


Also:
- Improve the name of the error types, and fix the error message of `InvalidValueTypeError`.
- Be more conservative in `ConformsToDynamicType` for function values (`interpreter.IsSubType` is also as conservative)
- Fix the test cases (optional values were not boxed correctly, this is now detected)
  - https://github.com/onflow/cadence/pull/776/files?diff=unified&w=1#diff-863660c79fae3d9b381c2dff3025cd88dc46eb62571b754e7695acbfeab4fbfeR1468
  - https://github.com/onflow/cadence/pull/776/files?diff=unified&w=1#diff-863660c79fae3d9b381c2dff3025cd88dc46eb62571b754e7695acbfeab4fbfeR1343

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
