### PR TITLE
Optimize encoding of 12 types still using CBOR map

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1074,7 +1074,12 @@ func (d *DecoderV4) decodeCapability(v interface{}) (CapabilityValue, error) {
 	}
 
 	// borrow type (optional, for backwards compatibility)
-
+	// Capabilities used to be untyped, i.e. they didn't have a borrow type.
+	// Later an optional type paramater, the borrow type, was added to it,
+	// which specifies as what type the capability should be borrowed.
+	//
+	// The decoding must be backwards-compatible and support both capability values
+	// with a borrow type and ones without
 	var borrowType StaticType
 
 	if field3 := encoded[encodedCapabilityValueBorrowTypeFieldKey]; field3 != nil {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -303,10 +303,11 @@ func (d *DecoderV4) decodeArray(v []interface{}, path []string) (*ArrayValue, er
 
 func (d *DecoderV4) decodeDictionary(v interface{}, path []string) (*DictionaryValue, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedDictionaryValueLength {
+	const expectedLength = encodedDictionaryValueLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid dictionary encoding (@ %s): expected [%d]interface{}, got %T",
 			strings.Join(path, "."),
-			encodedDictionaryValueLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -485,9 +486,10 @@ func (d *DecoderV4) decodeAddressLocation(v interface{}) (common.Location, error
 	// which includes both address and name
 
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedAddressLocationLength {
+	const expectedLength = encodedAddressLocationLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid address location encoding: expected [%d]interface{}, got %T",
-			encodedAddressLocationLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -521,10 +523,11 @@ func (d *DecoderV4) decodeAddressLocation(v interface{}) (common.Location, error
 
 func (d *DecoderV4) decodeComposite(v interface{}, path []string) (*CompositeValue, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedCompositeValueLength {
+	const expectedLength = encodedCompositeValueLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid composite encoding (@ %s): expected [%d]interface{}, got %T",
 			strings.Join(path, "."),
-			encodedCompositeValueLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -965,9 +968,10 @@ func (d *DecoderV4) decodeSome(v interface{}, path []string) (*SomeValue, error)
 
 func (d *DecoderV4) decodeStorageReference(v interface{}) (*StorageReferenceValue, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedStorageReferenceValueLength {
+	const expectedLength = encodedStorageReferenceValueLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid storage reference encoding: expected [%d]interface{}, got %T",
-			encodedStorageReferenceValueLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1026,9 +1030,10 @@ func (d *DecoderV4) decodeAddress(v interface{}) (AddressValue, error) {
 
 func (d *DecoderV4) decodePath(v interface{}) (PathValue, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedPathValueLength {
+	const expectedLength = encodedPathValueLength
+	if !ok || len(encoded) != expectedLength {
 		return PathValue{}, fmt.Errorf("invalid path encoding: expected [%d]interface{}, got %T",
-			encodedPathValueLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1053,9 +1058,10 @@ func (d *DecoderV4) decodePath(v interface{}) (PathValue, error) {
 
 func (d *DecoderV4) decodeCapability(v interface{}) (CapabilityValue, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedCapabilityValueLength {
+	const expectedLength = encodedCapabilityValueLength
+	if !ok || len(encoded) != expectedLength {
 		return CapabilityValue{}, fmt.Errorf("invalid path encoding: expected [%d]interface{}, got %T",
-			encodedCapabilityValueLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1112,9 +1118,10 @@ func (d *DecoderV4) decodeCapability(v interface{}) (CapabilityValue, error) {
 
 func (d *DecoderV4) decodeLink(v interface{}) (LinkValue, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedLinkValueLength {
+	const expectedLength = encodedLinkValueLength
+	if !ok || len(encoded) != expectedLength {
 		return LinkValue{}, fmt.Errorf("invalid link encoding: expected [%d]interface{}, got %T",
-			encodedLinkValueLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1236,9 +1243,10 @@ func (d *DecoderV4) decodeStaticTypeLocationAndQualifiedIdentifier(
 
 func (d *DecoderV4) decodeCompositeStaticType(v interface{}) (StaticType, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedCompositeStaticTypeLength {
+	const expectedLength = encodedCompositeStaticTypeLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid composite static type encoding: expected [%d]interface{}, got %T",
-			encodedCompositeStaticTypeLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1260,9 +1268,10 @@ func (d *DecoderV4) decodeCompositeStaticType(v interface{}) (StaticType, error)
 
 func (d *DecoderV4) decodeInterfaceStaticType(v interface{}) (StaticType, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedInterfaceStaticTypeLength {
+	const expectedLength = encodedInterfaceStaticTypeLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid interface static type encoding: expected [%d]interface{}, got %T",
-			encodedInterfaceStaticTypeLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1294,9 +1303,10 @@ func (d *DecoderV4) decodeVariableSizedStaticType(v interface{}) (StaticType, er
 
 func (d *DecoderV4) decodeConstantSizedStaticType(v interface{}) (StaticType, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedConstantSizedStaticTypeLength {
+	const expectedLength = encodedConstantSizedStaticTypeLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid constant-sized static type encoding: expected [%d]interface{}, got %T",
-			encodedConstantSizedStaticTypeLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1329,9 +1339,10 @@ func (d *DecoderV4) decodeConstantSizedStaticType(v interface{}) (StaticType, er
 
 func (d *DecoderV4) decodeReferenceStaticType(v interface{}) (StaticType, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedReferenceStaticTypeLength {
+	const expectedLength = encodedReferenceStaticTypeLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid reference static type encoding: expected [%d]interface{}, got %T",
-			encodedReferenceStaticTypeLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1355,9 +1366,10 @@ func (d *DecoderV4) decodeReferenceStaticType(v interface{}) (StaticType, error)
 
 func (d *DecoderV4) decodeDictionaryStaticType(v interface{}) (StaticType, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedDictionaryStaticTypeLength {
+	const expectedLength = encodedDictionaryStaticTypeLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid dictionary static type encoding: expected [%d]interface{}, got %T",
-			encodedDictionaryStaticTypeLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1380,9 +1392,10 @@ func (d *DecoderV4) decodeDictionaryStaticType(v interface{}) (StaticType, error
 
 func (d *DecoderV4) decodeRestrictedStaticType(v interface{}) (StaticType, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedRestrictedStaticTypeLength {
+	const expectedLength = encodedRestrictedStaticTypeLength
+	if !ok || len(encoded) != expectedLength {
 		return nil, fmt.Errorf("invalid restricted static type encoding: expected [%d]interface{}, got %T",
-			encodedRestrictedStaticTypeLength,
+			expectedLength,
 			v,
 		)
 	}
@@ -1419,9 +1432,10 @@ func (d *DecoderV4) decodeRestrictedStaticType(v interface{}) (StaticType, error
 
 func (d *DecoderV4) decodeType(v interface{}) (TypeValue, error) {
 	encoded, ok := v.(cborArray)
-	if !ok || len(encoded) != encodedTypeValueTypeLength {
+	const expectedLength = encodedTypeValueTypeLength
+	if !ok || len(encoded) != expectedLength {
 		return TypeValue{}, fmt.Errorf("invalid type encoding: expected [%d]interface{}, got %T",
-			encodedTypeValueTypeLength,
+			expectedLength,
 			v,
 		)
 	}

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -466,25 +466,6 @@ func (d *DecoderV4) decodeIdentifierLocation(v interface{}) (common.Location, er
 }
 
 func (d *DecoderV4) decodeAddressLocation(v interface{}) (common.Location, error) {
-
-	// If the encoded location is just a byte slice,
-	// it is the address and no name is provided
-
-	encodedAddress, ok := v.([]byte)
-	if ok {
-		err := d.checkAddressLength(encodedAddress)
-		if err != nil {
-			return nil, err
-		}
-
-		return common.AddressLocation{
-			Address: common.BytesToAddress(encodedAddress),
-		}, nil
-	}
-
-	// Otherwise, the encoded location is expected to be an array,
-	// which includes both address and name
-
 	encoded, ok := v.(cborArray)
 	const expectedLength = encodedAddressLocationLength
 	if !ok || len(encoded) != expectedLength {
@@ -497,7 +478,7 @@ func (d *DecoderV4) decodeAddressLocation(v interface{}) (common.Location, error
 	// Address
 
 	field1 := encoded[encodedAddressLocationAddressFieldKey]
-	encodedAddress, ok = field1.([]byte)
+	encodedAddress, ok := field1.([]byte)
 	if !ok {
 		return nil, fmt.Errorf("invalid address location address encoding: %T", field1)
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -974,20 +974,12 @@ func (e *Encoder) prepareLocation(l common.Location) (interface{}, error) {
 		}, nil
 
 	case common.AddressLocation:
-		var content interface{}
-
-		if l.Name == "" {
-			content = l.Address.Bytes()
-		} else {
-			content = cborArray{
+		return cbor.Tag{
+			Number: cborTagAddressLocation,
+			Content: cborArray{
 				encodedAddressLocationAddressFieldKey: l.Address.Bytes(),
 				encodedAddressLocationNameFieldKey:    l.Name,
-			}
-		}
-
-		return cbor.Tag{
-			Number:  cborTagAddressLocation,
-			Content: content,
+			},
 		}, nil
 
 	default:

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -33,8 +33,6 @@ import (
 
 type cborArray = []interface{}
 
-type cborMap = map[uint64]interface{}
-
 // Cadence needs to encode different kinds of objects in CBOR, for instance,
 // dictionaries, structs, resources, etc.
 //
@@ -865,12 +863,18 @@ const (
 	encodedStorageReferenceValueAuthorizedFieldKey           uint64 = 0
 	encodedStorageReferenceValueTargetStorageAddressFieldKey uint64 = 1
 	encodedStorageReferenceValueTargetKeyFieldKey            uint64 = 2
+
+	// !!! *WARNING* !!!
+	//
+	// encodedStorageReferenceValueLength MUST be updated when new element is added.
+	// It is used to verify encoded storage reference length during decoding.
+	encodedStorageReferenceValueLength int = 3
 )
 
 func (e *Encoder) prepareStorageReferenceValue(v *StorageReferenceValue) interface{} {
 	return cbor.Tag{
 		Number: cborTagStorageReferenceValue,
-		Content: cborMap{
+		Content: cborArray{
 			encodedStorageReferenceValueAuthorizedFieldKey:           v.Authorized,
 			encodedStorageReferenceValueTargetStorageAddressFieldKey: v.TargetStorageAddress.Bytes(),
 			encodedStorageReferenceValueTargetKeyFieldKey:            v.TargetKey,
@@ -889,12 +893,18 @@ func (e *Encoder) prepareAddressValue(v AddressValue) cbor.Tag {
 const (
 	encodedPathValueDomainFieldKey     uint64 = 0
 	encodedPathValueIdentifierFieldKey uint64 = 1
+
+	// !!! *WARNING* !!!
+	//
+	// encodedPathValueLength MUST be updated when new element is added.
+	// It is used to verify encoded path length during decoding.
+	encodedPathValueLength int = 2
 )
 
 func (e *Encoder) preparePathValue(v PathValue) cbor.Tag {
 	return cbor.Tag{
 		Number: cborTagPathValue,
-		Content: cborMap{
+		Content: cborArray{
 			encodedPathValueDomainFieldKey:     uint(v.Domain),
 			encodedPathValueIdentifierFieldKey: v.Identifier,
 		},
@@ -906,6 +916,12 @@ const (
 	encodedCapabilityValueAddressFieldKey    uint64 = 0
 	encodedCapabilityValuePathFieldKey       uint64 = 1
 	encodedCapabilityValueBorrowTypeFieldKey uint64 = 2
+
+	// !!! *WARNING* !!!
+	//
+	// encodedCapabilityValueLength MUST be updated when new element is added.
+	// It is used to verify encoded capability length during decoding.
+	encodedCapabilityValueLength int = 3
 )
 
 func (e *Encoder) prepareCapabilityValue(v CapabilityValue) (interface{}, error) {
@@ -922,7 +938,7 @@ func (e *Encoder) prepareCapabilityValue(v CapabilityValue) (interface{}, error)
 
 	return cbor.Tag{
 		Number: cborTagCapabilityValue,
-		Content: cborMap{
+		Content: cborArray{
 			encodedCapabilityValueAddressFieldKey:    e.prepareAddressValue(v.Address),
 			encodedCapabilityValuePathFieldKey:       e.preparePathValue(v.Path),
 			encodedCapabilityValueBorrowTypeFieldKey: preparedBorrowType,
@@ -934,6 +950,12 @@ func (e *Encoder) prepareCapabilityValue(v CapabilityValue) (interface{}, error)
 const (
 	encodedAddressLocationAddressFieldKey uint64 = 0
 	encodedAddressLocationNameFieldKey    uint64 = 1
+
+	// !!! *WARNING* !!!
+	//
+	// encodedAddressLocationLength MUST be updated when new element is added.
+	// It is used to verify encoded address location length during decoding.
+	encodedAddressLocationLength int = 2
 )
 
 func (e *Encoder) prepareLocation(l common.Location) (interface{}, error) {
@@ -957,7 +979,7 @@ func (e *Encoder) prepareLocation(l common.Location) (interface{}, error) {
 		if l.Name == "" {
 			content = l.Address.Bytes()
 		} else {
-			content = cborMap{
+			content = cborArray{
 				encodedAddressLocationAddressFieldKey: l.Address.Bytes(),
 				encodedAddressLocationNameFieldKey:    l.Name,
 			}
@@ -977,6 +999,12 @@ func (e *Encoder) prepareLocation(l common.Location) (interface{}, error) {
 const (
 	encodedLinkValueTargetPathFieldKey uint64 = 0
 	encodedLinkValueTypeFieldKey       uint64 = 1
+
+	// !!! *WARNING* !!!
+	//
+	// encodedLinkValueLength MUST be updated when new element is added.
+	// It is used to verify encoded link length during decoding.
+	encodedLinkValueLength int = 2
 )
 
 func (e *Encoder) prepareLinkValue(v LinkValue) (interface{}, error) {
@@ -986,7 +1014,7 @@ func (e *Encoder) prepareLinkValue(v LinkValue) (interface{}, error) {
 	}
 	return cbor.Tag{
 		Number: cborTagLinkValue,
-		Content: cborMap{
+		Content: cborArray{
 			encodedLinkValueTargetPathFieldKey: e.preparePathValue(v.TargetPath),
 			encodedLinkValueTypeFieldKey:       staticType,
 		},
@@ -1054,6 +1082,12 @@ const (
 	encodedCompositeStaticTypeLocationFieldKey            uint64 = 0
 	encodedCompositeStaticTypeTypeIDFieldKey              uint64 = 1
 	encodedCompositeStaticTypeQualifiedIdentifierFieldKey uint64 = 2
+
+	// !!! *WARNING* !!!
+	//
+	// encodedCompositeStaticTypeLength MUST be updated when new element is added.
+	// It is used to verify encoded composite static type length during decoding.
+	encodedCompositeStaticTypeLength int = 3
 )
 
 func (e *Encoder) prepareCompositeStaticType(v CompositeStaticType) (interface{}, error) {
@@ -1064,7 +1098,7 @@ func (e *Encoder) prepareCompositeStaticType(v CompositeStaticType) (interface{}
 
 	return cbor.Tag{
 		Number: cborTagCompositeStaticType,
-		Content: cborMap{
+		Content: cborArray{
 			encodedCompositeStaticTypeLocationFieldKey:            location,
 			encodedCompositeStaticTypeQualifiedIdentifierFieldKey: v.QualifiedIdentifier,
 		},
@@ -1076,6 +1110,12 @@ const (
 	encodedInterfaceStaticTypeLocationFieldKey            uint64 = 0
 	encodedInterfaceStaticTypeTypeIDFieldKey              uint64 = 1
 	encodedInterfaceStaticTypeQualifiedIdentifierFieldKey uint64 = 2
+
+	// !!! *WARNING* !!!
+	//
+	// encodedInterfaceStaticTypeLength MUST be updated when new element is added.
+	// It is used to verify encoded interface static type length during decoding.
+	encodedInterfaceStaticTypeLength int = 3
 )
 
 func (e *Encoder) prepareInterfaceStaticType(v InterfaceStaticType) (interface{}, error) {
@@ -1086,7 +1126,7 @@ func (e *Encoder) prepareInterfaceStaticType(v InterfaceStaticType) (interface{}
 
 	return cbor.Tag{
 		Number: cborTagInterfaceStaticType,
-		Content: cborMap{
+		Content: cborArray{
 			encodedInterfaceStaticTypeLocationFieldKey:            location,
 			encodedInterfaceStaticTypeQualifiedIdentifierFieldKey: v.QualifiedIdentifier,
 		},
@@ -1109,6 +1149,12 @@ func (e *Encoder) prepareVariableSizedStaticType(v VariableSizedStaticType) (int
 const (
 	encodedConstantSizedStaticTypeSizeFieldKey uint64 = 0
 	encodedConstantSizedStaticTypeTypeFieldKey uint64 = 1
+
+	// !!! *WARNING* !!!
+	//
+	// encodedConstantSizedStaticTypeLength MUST be updated when new element is added.
+	// It is used to verify encoded constant sized static type length during decoding.
+	encodedConstantSizedStaticTypeLength int = 2
 )
 
 func (e *Encoder) prepareConstantSizedStaticType(v ConstantSizedStaticType) (interface{}, error) {
@@ -1119,7 +1165,7 @@ func (e *Encoder) prepareConstantSizedStaticType(v ConstantSizedStaticType) (int
 
 	return cbor.Tag{
 		Number: cborTagConstantSizedStaticType,
-		Content: cborMap{
+		Content: cborArray{
 			encodedConstantSizedStaticTypeSizeFieldKey: v.Size,
 			encodedConstantSizedStaticTypeTypeFieldKey: staticType,
 		},
@@ -1130,6 +1176,12 @@ func (e *Encoder) prepareConstantSizedStaticType(v ConstantSizedStaticType) (int
 const (
 	encodedReferenceStaticTypeAuthorizedFieldKey uint64 = 0
 	encodedReferenceStaticTypeTypeFieldKey       uint64 = 1
+
+	// !!! *WARNING* !!!
+	//
+	// encodedReferenceStaticTypeLength MUST be updated when new element is added.
+	// It is used to verify encoded reference static type length during decoding.
+	encodedReferenceStaticTypeLength int = 2
 )
 
 func (e *Encoder) prepareReferenceStaticType(v ReferenceStaticType) (interface{}, error) {
@@ -1140,7 +1192,7 @@ func (e *Encoder) prepareReferenceStaticType(v ReferenceStaticType) (interface{}
 
 	return cbor.Tag{
 		Number: cborTagReferenceStaticType,
-		Content: cborMap{
+		Content: cborArray{
 			encodedReferenceStaticTypeAuthorizedFieldKey: v.Authorized,
 			encodedReferenceStaticTypeTypeFieldKey:       staticType,
 		},
@@ -1151,6 +1203,12 @@ func (e *Encoder) prepareReferenceStaticType(v ReferenceStaticType) (interface{}
 const (
 	encodedDictionaryStaticTypeKeyTypeFieldKey   uint64 = 0
 	encodedDictionaryStaticTypeValueTypeFieldKey uint64 = 1
+
+	// !!! *WARNING* !!!
+	//
+	// encodedDictionaryStaticTypeLength MUST be updated when new element is added.
+	// It is used to verify encoded dictionary static type length during decoding.
+	encodedDictionaryStaticTypeLength int = 2
 )
 
 func (e *Encoder) prepareDictionaryStaticType(v DictionaryStaticType) (interface{}, error) {
@@ -1166,7 +1224,7 @@ func (e *Encoder) prepareDictionaryStaticType(v DictionaryStaticType) (interface
 
 	return cbor.Tag{
 		Number: cborTagDictionaryStaticType,
-		Content: cborMap{
+		Content: cborArray{
 			encodedDictionaryStaticTypeKeyTypeFieldKey:   keyType,
 			encodedDictionaryStaticTypeValueTypeFieldKey: valueType,
 		},
@@ -1177,6 +1235,12 @@ func (e *Encoder) prepareDictionaryStaticType(v DictionaryStaticType) (interface
 const (
 	encodedRestrictedStaticTypeTypeFieldKey         uint64 = 0
 	encodedRestrictedStaticTypeRestrictionsFieldKey uint64 = 1
+
+	// !!! *WARNING* !!!
+	//
+	// encodedRestrictedStaticTypeLength MUST be updated when new element is added.
+	// It is used to verify encoded restricted static type length during decoding.
+	encodedRestrictedStaticTypeLength int = 2
 )
 
 func (e *Encoder) prepareRestrictedStaticType(v *RestrictedStaticType) (interface{}, error) {
@@ -1197,7 +1261,7 @@ func (e *Encoder) prepareRestrictedStaticType(v *RestrictedStaticType) (interfac
 
 	return cbor.Tag{
 		Number: cborTagRestrictedStaticType,
-		Content: cborMap{
+		Content: cborArray{
 			encodedRestrictedStaticTypeTypeFieldKey:         restrictedType,
 			encodedRestrictedStaticTypeRestrictionsFieldKey: encodedRestrictions,
 		},
@@ -1207,25 +1271,33 @@ func (e *Encoder) prepareRestrictedStaticType(v *RestrictedStaticType) (interfac
 // NOTE: NEVER change, only add/increment; ensure uint64
 const (
 	encodedTypeValueTypeFieldKey uint64 = 0
+
+	// !!! *WARNING* !!!
+	//
+	// encodedTypeValueTypeLength MUST be updated when new element is added.
+	// It is used to verify encoded type length during decoding.
+	encodedTypeValueTypeLength int = 1
 )
 
 func (e *Encoder) prepareTypeValue(v TypeValue) (interface{}, error) {
 
-	content := cborMap{}
+	var preparedStaticType interface{}
 
-	staticType := v.Type
-	if staticType != nil {
-		preparedStaticType, err := e.prepareStaticType(staticType)
+	if v.Type != nil {
+		staticType := v.Type
+
+		var err error
+		preparedStaticType, err = e.prepareStaticType(staticType)
 		if err != nil {
 			return nil, err
 		}
-
-		content[encodedTypeValueTypeFieldKey] = preparedStaticType
 	}
 
 	return cbor.Tag{
-		Number:  cborTagTypeValue,
-		Content: content,
+		Number: cborTagTypeValue,
+		Content: cborArray{
+			encodedTypeValueTypeFieldKey: preparedStaticType,
+		},
 	}, nil
 }
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -994,15 +994,11 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 			// tag
 			0xd8, cborTagAddressLocation,
-			// map, 2 pairs of items follow
-			0xa2,
-			// key 0
-			0x0,
+			// array, 2 items follow
+			0x82,
 			// byte sequence, length 1
 			0x41,
 			// positive integer 1
-			0x1,
-			// key 1
 			0x1,
 			// UTF-8 string, length 10
 			0x6a,
@@ -3227,70 +3223,129 @@ func TestEncodeDecodeStorageReferenceValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("not-authorized", func(t *testing.T) {
+		value := &StorageReferenceValue{
+			Authorized:           false,
+			TargetKey:            "test-key1",
+			TargetStorageAddress: common.BytesToAddress([]byte{0x11}),
+		}
+
+		encoded := []byte{
+			// tag
+			0xd8, cborTagStorageReferenceValue,
+			// array, 3 items follow
+			0x83,
+			// false
+			0xf4,
+			// byte sequence, length 1
+			0x41,
+			// positive integer 0x11
+			0x11,
+			// UTF-8 string, 9 bytes follow
+			0x69,
+			// t, e, s, t, -, k, e, y, 1
+			0x74, 0x65, 0x73, 0x74, 0x2d, 0x6b, 0x65, 0x79, 0x31,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagStorageReferenceValue,
+			// map, 3 pairs of items follow
+			0xa3,
+			// key 0
+			0x0,
+			// false
+			0xf4,
+			// key 1
+			0x1,
+			// byte sequence, length 1
+			0x41,
+			// positive integer 0x11
+			0x11,
+			// key2
+			0x2,
+			// UTF-8 string, 9 bytes follow
+			0x69,
+			// t, e, s, t, -, k, e, y, 1
+			0x74, 0x65, 0x73, 0x74, 0x2d, 0x6b, 0x65, 0x79, 0x31,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: &StorageReferenceValue{
-					Authorized:           false,
-					TargetKey:            "test-key1",
-					TargetStorageAddress: common.BytesToAddress([]byte{0x11}),
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagStorageReferenceValue,
-					// map, 3 pairs of items follow
-					0xa3,
-					// key 0
-					0x0,
-					// false
-					0xf4,
-					// key 1
-					0x1,
-					// byte sequence, length 1
-					0x41,
-					// positive integer 0x11
-					0x11,
-					// key2
-					0x2,
-					// UTF-8 string, 9 bytes follow
-					0x69,
-					// t, e, s, t, -, k, e, y, 1
-					0x74, 0x65, 0x73, 0x74, 0x2d, 0x6b, 0x65, 0x79, 0x31,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("authorized", func(t *testing.T) {
+		value := &StorageReferenceValue{
+			Authorized:           true,
+			TargetKey:            "test-key2",
+			TargetStorageAddress: common.BytesToAddress([]byte{0x12}),
+		}
+
+		encoded := []byte{
+			// tag
+			0xd8, cborTagStorageReferenceValue,
+			// array, 3 items follow
+			0x83,
+			// true
+			0xf5,
+			// byte sequence, length 1
+			0x41,
+			// positive integer 0x12
+			0x12,
+			// UTF-8 string, 9 bytes follow
+			0x69,
+			// t, e, s, t, -, k, e, y, 2
+			0x74, 0x65, 0x73, 0x74, 0x2d, 0x6b, 0x65, 0x79, 0x32,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagStorageReferenceValue,
+			// map, 3 pairs of items follow
+			0xa3,
+			// key 0
+			0x0,
+			// true
+			0xf5,
+			// key 1
+			0x1,
+			// byte sequence, length 1
+			0x41,
+			// positive integer 0x12
+			0x12,
+			// key 2
+			0x2,
+			// UTF-8 string, 9 bytes follow
+			0x69,
+			// t, e, s, t, -, k, e, y, 2
+			0x74, 0x65, 0x73, 0x74, 0x2d, 0x6b, 0x65, 0x79, 0x32,
+		}
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: &StorageReferenceValue{
-					Authorized:           true,
-					TargetKey:            "test-key2",
-					TargetStorageAddress: common.BytesToAddress([]byte{0x12}),
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagStorageReferenceValue,
-					// map, 3 pairs of items follow
-					0xa3,
-					// key 0
-					0x0,
-					// true
-					0xf5,
-					// key 1
-					0x1,
-					// byte sequence, length 1
-					0x41,
-					// positive integer 0x12
-					0x12,
-					// key 2
-					0x2,
-					// UTF-8 string, 9 bytes follow
-					0x69,
-					// t, e, s, t, -, k, e, y, 2
-					0x74, 0x65, 0x73, 0x74, 0x2d, 0x6b, 0x65, 0x79, 0x32,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 }
@@ -3395,50 +3450,98 @@ func TestEncodeDecodePathValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("private", func(t *testing.T) {
+		encoded := []byte{
+			// tag
+			0xd8, cborTagPathValue,
+			// array, 2 items follow
+			0x82,
+			// positive integer 2
+			0x2,
+			// UTF-8 string, 3 bytes follow
+			0x63,
+			// f, o, o
+			0x66, 0x6f, 0x6f,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagPathValue,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// positive integer 2
+			0x2,
+			// key 1
+			0x1,
+			// UTF-8 string, 3 bytes follow
+			0x63,
+			// f, o, o
+			0x66, 0x6f, 0x6f,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: privatePathValue,
-				encoded: []byte{
-					// tag
-					0xd8, cborTagPathValue,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// positive integer 2
-					0x2,
-					// key 1
-					0x1,
-					// UTF-8 string, 3 bytes follow
-					0x63,
-					// f, o, o
-					0x66, 0x6f, 0x6f,
-				},
+				value:   privatePathValue,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   privatePathValue,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("public", func(t *testing.T) {
+		encoded := []byte{
+			// tag
+			0xd8, cborTagPathValue,
+			// array, 2 items follow
+			0x82,
+			// positive integer 3
+			0x3,
+			// UTF-8 string, 3 bytes follow
+			0x63,
+			// b, a, r
+			0x62, 0x61, 0x72,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagPathValue,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// positive integer 3
+			0x3,
+			// key 1
+			0x1,
+			// UTF-8 string, 3 bytes follow
+			0x63,
+			// b, a, r
+			0x62, 0x61, 0x72,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: publicPathValue,
-				encoded: []byte{
-					// tag
-					0xd8, cborTagPathValue,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// positive integer 3
-					0x3,
-					// key 1
-					0x1,
-					// UTF-8 string, 3 bytes follow
-					0x63,
-					// b, a, r
-					0x62, 0x61, 0x72,
-				},
+				value:   publicPathValue,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   publicPathValue,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 }
@@ -3449,47 +3552,85 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 
 	t.Run("private path, untyped capability, new format", func(t *testing.T) {
 
+		value := CapabilityValue{
+			Address: NewAddressValueFromBytes([]byte{0x2}),
+			Path:    privatePathValue,
+		}
+
+		encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// array, 3 items follow
+			0x83,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x02,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// array, 2 items follow
+			0x82,
+			// positive integer 2
+			0x2,
+			// UTF-8 string, length 3
+			0x63,
+			// f, o, o
+			0x66, 0x6f, 0x6f,
+			// nil
+			0xf6,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// map, 3 pairs of items follow
+			0xa3,
+			// key 0
+			0x0,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x02,
+			// key 1
+			0x1,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// positive integer 2
+			0x2,
+			// key 1
+			0x1,
+			// UTF-8 string, length 3
+			0x63,
+			// f, o, o
+			0x66, 0x6f, 0x6f,
+			// key 2
+			0x2,
+			// nil
+			0xf6,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: CapabilityValue{
-					Address: NewAddressValueFromBytes([]byte{0x2}),
-					Path:    privatePathValue,
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagCapabilityValue,
-					// map, 3 pairs of items follow
-					0xa3,
-					// key 0
-					0x0,
-					// tag for address
-					0xd8, cborTagAddressValue,
-					// byte sequence, length 1
-					0x41,
-					// address
-					0x02,
-					// key 1
-					0x1,
-					// tag for address
-					0xd8, cborTagPathValue,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// positive integer 2
-					0x2,
-					// key 1
-					0x1,
-					// UTF-8 string, length 3
-					0x63,
-					// f, o, o
-					0x66, 0x6f, 0x6f,
-					// key 2
-					0x2,
-					// nil
-					0xf6,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
@@ -3497,7 +3638,9 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly: true,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
 				value: CapabilityValue{
 					Address: NewAddressValueFromBytes([]byte{0x2}),
 					Path:    privatePathValue,
@@ -3538,145 +3681,262 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 
 	t.Run("private path, typed capability", func(t *testing.T) {
 
+		value := CapabilityValue{
+			Address:    NewAddressValueFromBytes([]byte{0x2}),
+			Path:       privatePathValue,
+			BorrowType: PrimitiveStaticTypeBool,
+		}
+
+		encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// array, 3 items follow
+			0x83,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x02,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// aray, 2 items follow
+			0x82,
+			// positive integer 2
+			0x2,
+			// UTF-8 string, length 3
+			0x63,
+			// f, o, o
+			0x66, 0x6f, 0x6f,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// bool
+			0x6,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// map, 3 pairs of items follow
+			0xa3,
+			// key 0
+			0x0,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x02,
+			// key 1
+			0x1,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// positive integer 2
+			0x2,
+			// key 1
+			0x1,
+			// UTF-8 string, length 3
+			0x63,
+			// f, o, o
+			0x66, 0x6f, 0x6f,
+			// key 2
+			0x2,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// bool
+			0x6,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: CapabilityValue{
-					Address:    NewAddressValueFromBytes([]byte{0x2}),
-					Path:       privatePathValue,
-					BorrowType: PrimitiveStaticTypeBool,
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagCapabilityValue,
-					// map, 3 pairs of items follow
-					0xa3,
-					// key 0
-					0x0,
-					// tag for address
-					0xd8, cborTagAddressValue,
-					// byte sequence, length 1
-					0x41,
-					// address
-					0x02,
-					// key 1
-					0x1,
-					// tag for address
-					0xd8, cborTagPathValue,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// positive integer 2
-					0x2,
-					// key 1
-					0x1,
-					// UTF-8 string, length 3
-					0x63,
-					// f, o, o
-					0x66, 0x6f, 0x6f,
-					// key 2
-					0x2,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					// bool
-					0x6,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("public path, untyped capability, new format", func(t *testing.T) {
+		value := CapabilityValue{
+			Address: NewAddressValueFromBytes([]byte{0x3}),
+			Path:    publicPathValue,
+		}
+
+		encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// array, 3 items follow
+			0x83,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x03,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// array, 2 items follow
+			0x82,
+			// positive integer 3
+			0x3,
+			// UTF-8 string, length 3
+			0x63,
+			// b, a, r
+			0x62, 0x61, 0x72,
+			// nil
+			0xf6,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// map, 3 pairs of items follow
+			0xa3,
+			// key 0
+			0x0,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x03,
+			// key 1
+			0x1,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// positive integer 3
+			0x3,
+			// key 1
+			0x1,
+			// UTF-8 string, length 3
+			0x63,
+			// b, a, r
+			0x62, 0x61, 0x72,
+			// key 2
+			0x2,
+			// nil
+			0xf6,
+		}
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: CapabilityValue{
-					Address: NewAddressValueFromBytes([]byte{0x3}),
-					Path:    publicPathValue,
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagCapabilityValue,
-					// map, 3 pairs of items follow
-					0xa3,
-					// key 0
-					0x0,
-					// tag for address
-					0xd8, cborTagAddressValue,
-					// byte sequence, length 1
-					0x41,
-					// address
-					0x03,
-					// key 1
-					0x1,
-					// tag for address
-					0xd8, cborTagPathValue,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// positive integer 3
-					0x3,
-					// key 1
-					0x1,
-					// UTF-8 string, length 3
-					0x63,
-					// b, a, r
-					0x62, 0x61, 0x72,
-					// key 2
-					0x2,
-					// nil
-					0xf6,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("public path, typed capability", func(t *testing.T) {
 
+		value := CapabilityValue{
+			Address:    NewAddressValueFromBytes([]byte{0x3}),
+			Path:       publicPathValue,
+			BorrowType: PrimitiveStaticTypeBool,
+		}
+
+		encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// array, 3 items follow
+			0x83,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x03,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// array, 2 items follow
+			0x82,
+			// positive integer 3
+			0x3,
+			// UTF-8 string, length 3
+			0x63,
+			// b, a, r
+			0x62, 0x61, 0x72,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// bool
+			0x6,
+		}
+
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagCapabilityValue,
+			// map, 3 pairs of items follow
+			0xa3,
+			// key 0
+			0x0,
+			// tag for address
+			0xd8, cborTagAddressValue,
+			// byte sequence, length 1
+			0x41,
+			// address
+			0x03,
+			// key 1
+			0x1,
+			// tag for address
+			0xd8, cborTagPathValue,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// positive integer 3
+			0x3,
+			// key 1
+			0x1,
+			// UTF-8 string, length 3
+			0x63,
+			// b, a, r
+			0x62, 0x61, 0x72,
+			// key 2
+			0x2,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// bool
+			0x6,
+		}
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: CapabilityValue{
-					Address:    NewAddressValueFromBytes([]byte{0x3}),
-					Path:       publicPathValue,
-					BorrowType: PrimitiveStaticTypeBool,
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagCapabilityValue,
-					// map, 3 pairs of items follow
-					0xa3,
-					// key 0
-					0x0,
-					// tag for address
-					0xd8, cborTagAddressValue,
-					// byte sequence, length 1
-					0x41,
-					// address
-					0x03,
-					// key 1
-					0x1,
-					// tag for address
-					0xd8, cborTagPathValue,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// positive integer 3
-					0x3,
-					// key 1
-					0x1,
-					// UTF-8 string, length 3
-					0x63,
-					// b, a, r
-					0x62, 0x61, 0x72,
-					// key 2
-					0x2,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					// bool
-					0x6,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
@@ -3684,7 +3944,9 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly: true,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
 				value: CapabilityValue{
 					Address: NewAddressValueFromBytes([]byte{0x3}),
 					Path:    publicPathValue,
@@ -3731,6 +3993,22 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 	expectedLinkEncodingPrefix := []byte{
 		// tag
 		0xd8, cborTagLinkValue,
+		// array, 2 items follow
+		0x82,
+		0xd8, cborTagPathValue,
+		// array, 2 items follow
+		0x82,
+		// positive integer 3
+		0x3,
+		// UTF-8 string, length 3
+		0x63,
+		// b, a, r
+		0x62, 0x61, 0x72,
+	}
+
+	expectedVersion3LinkEncodingPrefix := []byte{
+		// tag
+		0xd8, cborTagLinkValue,
 		// map, 2 pairs of items follow
 		0xa2,
 		// key 0
@@ -3753,82 +4031,150 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 	}
 
 	t.Run("primitive, Bool", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type:       ConvertSemaToPrimitiveStaticType(sema.BoolType),
+		}
+
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
+
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
+
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type:       ConvertSemaToPrimitiveStaticType(sema.BoolType),
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("optional, primitive, bool", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: OptionalStaticType{
+				Type: PrimitiveStaticTypeBool,
+			},
+		}
+		encodedType := []byte{
+			// tag
+			0xd8, cborTagOptionalStaticType,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			encodedType...,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			encodedType...,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: OptionalStaticType{
-						Type: PrimitiveStaticTypeBool,
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagOptionalStaticType,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("composite, struct, qualified identifier", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: CompositeStaticType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "SimpleStruct",
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagCompositeStaticType,
+			// array, 3 items follow
+			0x83,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// nil
+			0xf6,
+			// UTF-8 string, length 12
+			0x6c,
+			// SimpleStruct
+			0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagCompositeStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 1
+			0x2,
+			// UTF-8 string, length 12
+			0x6c,
+			// SimpleStruct
+			0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: CompositeStaticType{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "SimpleStruct",
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagCompositeStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagStringLocation,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 1
-					0x2,
-					// UTF-8 string, length 12
-					0x6c,
-					// SimpleStruct
-					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("composite, struct, type ID", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly: true,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: CompositeStaticType{
@@ -3837,7 +4183,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					},
 				},
 				encoded: append(
-					expectedLinkEncodingPrefix[:],
+					expectedVersion3LinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagCompositeStaticType,
 					// map, 2 pairs of items follow
@@ -3866,7 +4212,9 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 	t.Run("composite, struct, address location without name", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly: true,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: CompositeStaticType{
@@ -3878,7 +4226,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					},
 				},
 				encoded: append(
-					expectedLinkEncodingPrefix[:],
+					expectedVersion3LinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagCompositeStaticType,
 					// map, 2 pairs of items follow
@@ -3908,44 +4256,75 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 	})
 
 	t.Run("interface, struct, qualified identifier", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: InterfaceStaticType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "SimpleInterface",
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagInterfaceStaticType,
+			// array, 3 items follow
+			0x83,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// nil
+			0xf6,
+			// UTF-8 string, length 22
+			0x6F,
+			// SimpleInterface
+			0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagInterfaceStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 1
+			0x2,
+			// UTF-8 string, length 22
+			0x6F,
+			// SimpleInterface
+			0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: InterfaceStaticType{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "SimpleInterface",
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagInterfaceStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagStringLocation,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 1
-					0x2,
-					// UTF-8 string, length 22
-					0x6F,
-					// SimpleInterface
-					0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x66, 0x61, 0x63, 0x65,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("interface, struct, type ID", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly: true,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: InterfaceStaticType{
@@ -3954,7 +4333,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					},
 				},
 				encoded: append(
-					expectedLinkEncodingPrefix[:],
+					expectedVersion3LinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagInterfaceStaticType,
 					// map, 2 pairs of items follow
@@ -3985,7 +4364,9 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 	t.Run("interface, struct, address location without name", func(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				decodeOnly: true,
+				decodeVersionOverride: true,
+				decodeVersion:         3,
+				decodeOnly:            true,
 				decodedValue: LinkValue{
 					TargetPath: publicPathValue,
 					Type: InterfaceStaticType{
@@ -3997,7 +4378,7 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 					},
 				},
 				encoded: append(
-					expectedLinkEncodingPrefix[:],
+					expectedVersion3LinkEncodingPrefix[:],
 					// tag
 					0xd8, cborTagInterfaceStaticType,
 					// map, 2 pairs of items follow
@@ -4027,276 +4408,485 @@ func TestEncodeDecodeLinkValue(t *testing.T) {
 	})
 
 	t.Run("variable-sized, bool", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: VariableSizedStaticType{
+				Type: PrimitiveStaticTypeBool,
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagVariableSizedStaticType,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagVariableSizedStaticType,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: VariableSizedStaticType{
-						Type: PrimitiveStaticTypeBool,
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagVariableSizedStaticType,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("constant-sized, bool", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: ConstantSizedStaticType{
+				Type: PrimitiveStaticTypeBool,
+				Size: 42,
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagConstantSizedStaticType,
+			// array, 2 items follow
+			0x82,
+			// positive integer 42
+			0x18, 0x2A,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagConstantSizedStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// positive integer 42
+			0x18, 0x2A,
+			// key 1
+			0x1,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: ConstantSizedStaticType{
-						Type: PrimitiveStaticTypeBool,
-						Size: 42,
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagConstantSizedStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// positive integer 42
-					0x18, 0x2A,
-					// key 1
-					0x1,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("reference type, authorized, bool", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: ReferenceStaticType{
+				Authorized: true,
+				Type:       PrimitiveStaticTypeBool,
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagReferenceStaticType,
+			// array, 2 items follow
+			0x82,
+			// true
+			0xf5,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagReferenceStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// true
+			0xf5,
+			// key 1
+			0x1,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: ReferenceStaticType{
-						Authorized: true,
-						Type:       PrimitiveStaticTypeBool,
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagReferenceStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// true
-					0xf5,
-					// key 1
-					0x1,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("reference type, unauthorized, bool", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: ReferenceStaticType{
+				Authorized: false,
+				Type:       PrimitiveStaticTypeBool,
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagReferenceStaticType,
+			// array, 2 items follow
+			0x82,
+			// false
+			0xf4,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagReferenceStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// false
+			0xf4,
+			// key 1
+			0x1,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: ReferenceStaticType{
-						Authorized: false,
-						Type:       PrimitiveStaticTypeBool,
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagReferenceStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// false
-					0xf4,
-					// key 1
-					0x1,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("dictionary, bool, string", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeBool,
+				ValueType: PrimitiveStaticTypeString,
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagDictionaryStaticType,
+			// array, 2 items follow
+			0x82,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x8,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagDictionaryStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+			// key 1
+			0x1,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x8,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: DictionaryStaticType{
-						KeyType:   PrimitiveStaticTypeBool,
-						ValueType: PrimitiveStaticTypeString,
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagDictionaryStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-					// key 1
-					0x1,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x8,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("restricted", func(t *testing.T) {
-		testEncodeDecode(t,
-			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: &RestrictedStaticType{
-						Type: CompositeStaticType{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "S",
-						},
-						Restrictions: []InterfaceStaticType{
-							{
-								Location:            utils.TestLocation,
-								QualifiedIdentifier: "I1",
-							},
-							{
-								Location:            utils.TestLocation,
-								QualifiedIdentifier: "I2",
-							},
-						},
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: &RestrictedStaticType{
+				Type: CompositeStaticType{
+					Location:            utils.TestLocation,
+					QualifiedIdentifier: "S",
+				},
+				Restrictions: []InterfaceStaticType{
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "I1",
+					},
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "I2",
 					},
 				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagRestrictedStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagCompositeStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagStringLocation,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 2
-					0x2,
-					// UTF-8 string, length 1
-					0x61,
-					// S
-					0x53,
-					// key 1
-					0x1,
-					// array, length 2
-					0x82,
-					// tag
-					0xd8, cborTagInterfaceStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagStringLocation,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 2
-					0x2,
-					// UTF-8 string, length 2
-					0x62,
-					// I1
-					0x49, 0x31,
-					// tag
-					0xd8, cborTagInterfaceStaticType,
-					// map, 2 pairs of items follow
-					0xa2,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagStringLocation,
-					// UTF-8 string, length 4
-					0x64,
-					// t, e, s, t
-					0x74, 0x65, 0x73, 0x74,
-					// key 2
-					0x2,
-					// UTF-8 string, length 2
-					0x62,
-					// I2
-					0x49, 0x32,
-				),
 			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagRestrictedStaticType,
+			// array, 2 items follow
+			0x82,
+			// tag
+			0xd8, cborTagCompositeStaticType,
+			// array, 3 items follow
+			0x83,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// nil
+			0xf6,
+			// UTF-8 string, length 1
+			0x61,
+			// S
+			0x53,
+			// array, length 2
+			0x82,
+			// tag
+			0xd8, cborTagInterfaceStaticType,
+			// array, 3 items follow
+			0x83,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// nil
+			0xf6,
+			// UTF-8 string, length 2
+			0x62,
+			// I1
+			0x49, 0x31,
+			// tag
+			0xd8, cborTagInterfaceStaticType,
+			// array, 3 items follow
+			0x83,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// nil
+			0xf6,
+			// UTF-8 string, length 2
+			0x62,
+			// I2
+			0x49, 0x32,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagRestrictedStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagCompositeStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 2
+			0x2,
+			// UTF-8 string, length 1
+			0x61,
+			// S
+			0x53,
+			// key 1
+			0x1,
+			// array, length 2
+			0x82,
+			// tag
+			0xd8, cborTagInterfaceStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 2
+			0x2,
+			// UTF-8 string, length 2
+			0x62,
+			// I1
+			0x49, 0x31,
+			// tag
+			0xd8, cborTagInterfaceStaticType,
+			// map, 2 pairs of items follow
+			0xa2,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagStringLocation,
+			// UTF-8 string, length 4
+			0x64,
+			// t, e, s, t
+			0x74, 0x65, 0x73, 0x74,
+			// key 2
+			0x2,
+			// UTF-8 string, length 2
+			0x62,
+			// I2
+			0x49, 0x32,
+		)
+		testEncodeDecode(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("capability, none", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type:       CapabilityStaticType{},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagCapabilityStaticType,
+			// null
+			0xf6,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagCapabilityStaticType,
+			// null
+			0xf6,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type:       CapabilityStaticType{},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagCapabilityStaticType,
-					// null
-					0xf6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("capability, primitive, bool", func(t *testing.T) {
+		value := LinkValue{
+			TargetPath: publicPathValue,
+			Type: CapabilityStaticType{
+				BorrowType: PrimitiveStaticTypeBool,
+			},
+		}
+		encoded := append(
+			expectedLinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagCapabilityStaticType,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
+		version3Encoded := append(
+			expectedVersion3LinkEncodingPrefix[:],
+			// tag
+			0xd8, cborTagCapabilityStaticType,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			0x6,
+		)
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: LinkValue{
-					TargetPath: publicPathValue,
-					Type: CapabilityStaticType{
-						BorrowType: PrimitiveStaticTypeBool,
-					},
-				},
-				encoded: append(
-					expectedLinkEncodingPrefix[:],
-					// tag
-					0xd8, cborTagCapabilityStaticType,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					0x6,
-				),
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 }
@@ -4522,62 +5112,120 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("primitive, Bool", func(t *testing.T) {
+		value := TypeValue{
+			Type: ConvertSemaToPrimitiveStaticType(sema.BoolType),
+		}
+		encoded := []byte{
+			// tag
+			0xd8, cborTagTypeValue,
+			// array, 1 items follow
+			0x81,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// positive integer 0
+			0x6,
+		}
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagTypeValue,
+			// map, 1 pair of items follow
+			0xa1,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// positive integer 0
+			0x6,
+		}
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: TypeValue{
-					Type: ConvertSemaToPrimitiveStaticType(sema.BoolType),
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagTypeValue,
-					// map, 1 pair of items follow
-					0xa1,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					// positive integer 0
-					0x6,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("primitive, Int", func(t *testing.T) {
+		value := TypeValue{
+			Type: ConvertSemaToPrimitiveStaticType(&sema.IntType{}),
+		}
+		encoded := []byte{
+			// tag
+			0xd8, cborTagTypeValue,
+			// array, 1 items follow
+			0x81,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// positive integer 36
+			0x18, 0x24,
+		}
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagTypeValue,
+			// map, 1 pair of items follow
+			0xa1,
+			// key 0
+			0x0,
+			// tag
+			0xd8, cborTagPrimitiveStaticType,
+			// positive integer 36
+			0x18, 0x24,
+		}
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: TypeValue{
-					Type: ConvertSemaToPrimitiveStaticType(&sema.IntType{}),
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagTypeValue,
-					// map, 1 pair of items follow
-					0xa1,
-					// key 0
-					0x0,
-					// tag
-					0xd8, cborTagPrimitiveStaticType,
-					// positive integer 36
-					0x18, 0x24,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 
 	t.Run("without static type", func(t *testing.T) {
+		value := TypeValue{
+			Type: nil,
+		}
+		encoded := []byte{
+			// tag
+			0xd8, cborTagTypeValue,
+			// array, 1 items follow
+			0x81,
+			// nil
+			0xf6,
+		}
+		version3Encoded := []byte{
+			// tag
+			0xd8, cborTagTypeValue,
+			// map, 0 pairs of items follow
+			0xa0,
+		}
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: TypeValue{
-					Type: nil,
-				},
-				encoded: []byte{
-					// tag
-					0xd8, cborTagTypeValue,
-					// map, 0 pairs of items follow
-					0xa0,
-				},
+				value:   value,
+				encoded: encoded,
 			},
+		)
+		testEncodeDecodeOldFormat(t,
+			encodeDecodeTest{
+				value:   value,
+				encoded: encoded,
+			},
+			3,
+			version3Encoded,
 		)
 	})
 }


### PR DESCRIPTION
Closes #764

## Description

Optimize encoding by replacing CBOR map with CBOR array for 12 Value types.

Comparisons using a 167 byte LinkValue (that doesn't contain composites and dictionaries) show:

- encoding is faster by 49.41%, alloc/op (kB) reduced by 57.82%, allocs/op reduced by 54.46%
- decoding is faster by 26.87%, alloc/op (kB) reduced by 47.60%, allocs/op unchanged

Comparisons using a 776,155 byte value with composites, dictionaries, etc. show:

- encoding is faster by 48.37%, alloc/op (kB) reduced by 47.13%, allocs/op reduced by 51.56%
- decoding is faster by 36.01%, alloc/op (kB) reduced by 31.26%, allocs/op reduced by 18.56%

<details>
  <summary> Comparisons using LinkValue :rocket:  </summary><p>

#### Encoding LinkValue

```
name                        old time/op    new time/op    delta
EncodeLink/link_167bytes-4    18.7µs ± 0%     9.5µs ± 0%  -49.41%  (p=0.000 n=10+10)
EncodeLink/link_192bytes-4    19.1µs ± 0%     9.4µs ± 0%  -50.56%  (p=0.000 n=10+10)

name                        old alloc/op   new alloc/op   delta
EncodeLink/link_167bytes-4    5.18kB ± 0%    2.18kB ± 0%  -57.82%  (p=0.000 n=10+10)
EncodeLink/link_192bytes-4    5.50kB ± 0%    2.17kB ± 0%  -60.61%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
EncodeLink/link_167bytes-4       101 ± 0%        46 ± 0%  -54.46%  (p=0.000 n=10+10)
EncodeLink/link_192bytes-4       101 ± 0%        46 ± 0%  -54.46%  (p=0.000 n=10+10)
```

#### Decoding LinkValue

```
name                        old time/op    new time/op    delta
DecodeLink/link_167bytes-4    10.6µs ± 0%     7.7µs ± 1%  -26.87%  (p=0.000 n=10+9)
DecodeLink/link_192bytes-4    10.5µs ± 0%     7.7µs ± 0%  -27.02%  (p=0.000 n=10+10)

name                        old alloc/op   new alloc/op   delta
DecodeLink/link_167bytes-4    4.50kB ± 0%    2.36kB ± 0%  -47.60%  (p=0.000 n=10+10)
DecodeLink/link_192bytes-4    4.50kB ± 0%    2.36kB ± 0%  -47.60%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
DecodeLink/link_167bytes-4      55.0 ± 0%      55.0 ± 0%     ~     (all equal)
DecodeLink/link_192bytes-4      55.0 ± 0%      55.0 ± 0%     ~     (all equal)
```
</details>

<details>
  <summary> Comparisons using composites, dictionaries, etc. :rocket:  </summary><p>

#### Encoding
```
name                                           old time/op    new time/op    delta
EncodeComposite/1comp_0dict_139bytes-4           15.9µs ± 1%     8.3µs ± 0%  -47.81%  (p=0.000 n=10+10)
EncodeComposite/2comp_0dict_160bytes-4           20.7µs ± 2%    11.7µs ± 0%  -43.62%  (p=0.000 n=10+9)
EncodeComposite/104comp_0dict_14850bytes-4        894µs ± 1%     485µs ± 1%  -45.79%  (p=0.000 n=9+10)
EncodeComposite/870comp_837dict_776155bytes-4    34.9ms ± 1%    18.0ms ± 1%  -48.37%  (p=0.000 n=10+10)

name                                           old alloc/op   new alloc/op   delta
EncodeComposite/1comp_0dict_139bytes-4           3.78kB ± 1%    1.62kB ± 0%  -57.24%  (p=0.000 n=10+10)
EncodeComposite/2comp_0dict_160bytes-4           4.87kB ± 3%    2.40kB ± 0%  -50.68%  (p=0.000 n=9+10)
EncodeComposite/104comp_0dict_14850bytes-4        247kB ± 1%     138kB ± 0%  -44.27%  (p=0.000 n=10+10)
EncodeComposite/870comp_837dict_776155bytes-4    7.46MB ± 3%    3.94MB ± 0%  -47.13%  (p=0.000 n=10+10)

name                                           old allocs/op  new allocs/op  delta
EncodeComposite/1comp_0dict_139bytes-4             76.0 ± 0%      37.0 ± 0%  -51.32%  (p=0.000 n=10+10)
EncodeComposite/2comp_0dict_160bytes-4              103 ± 0%        55 ± 0%  -46.60%  (p=0.000 n=7+10)
EncodeComposite/104comp_0dict_14850bytes-4        5.02k ± 0%     2.54k ± 0%  -49.47%  (p=0.000 n=9+10)
EncodeComposite/870comp_837dict_776155bytes-4      141k ± 0%       68k ± 0%  -51.56%  (p=0.000 n=9+10)
```

#### Decoding
```
name                                           old time/op    new time/op    delta
DecodeComposite/1comp_0dict_139bytes-4           11.5µs ± 1%     8.0µs ± 1%  -30.63%  (p=0.000 n=9+10)
DecodeComposite/2comp_0dict_160bytes-4           16.8µs ± 1%    11.6µs ± 1%  -30.90%  (p=0.000 n=10+10)
DecodeComposite/104comp_0dict_14850bytes-4        759µs ± 1%     522µs ± 1%  -31.19%  (p=0.000 n=10+10)
DecodeComposite/870comp_837dict_776155bytes-4    40.3ms ± 1%    25.8ms ± 1%  -36.01%  (p=0.000 n=10+10)

name                                           old alloc/op   new alloc/op   delta
DecodeComposite/1comp_0dict_139bytes-4           3.90kB ± 0%    2.55kB ± 0%  -34.50%  (p=0.000 n=10+10)
DecodeComposite/2comp_0dict_160bytes-4           5.54kB ± 0%    3.84kB ± 0%  -30.74%  (p=0.000 n=10+10)
DecodeComposite/104comp_0dict_14850bytes-4        296kB ± 0%     211kB ± 0%  -28.97%  (p=0.000 n=10+10)
DecodeComposite/870comp_837dict_776155bytes-4    15.0MB ± 0%    10.3MB ± 0%  -31.26%  (p=0.000 n=10+9)

name                                           old allocs/op  new allocs/op  delta
DecodeComposite/1comp_0dict_139bytes-4             56.0 ± 0%      53.0 ± 0%   -5.36%  (p=0.000 n=10+10)
DecodeComposite/2comp_0dict_160bytes-4             97.0 ± 0%      89.0 ± 0%   -8.25%  (p=0.000 n=10+10)
DecodeComposite/104comp_0dict_14850bytes-4        5.05k ± 0%     4.65k ± 0%   -7.98%  (p=0.000 n=10+10)
DecodeComposite/870comp_837dict_776155bytes-4      265k ± 0%      216k ± 0%  -18.56%  (p=0.000 n=10+10)
```

</details>

### Changes

- [x] Optimize encoding by switching from CBOR map to CBOR array for:
  - [x] StorageReferenceValue
  - [x] PathValue
  - [x] CapabilityValue
  - [x] common.AddressLocation (__see Caveats__)
  - [x] LinkValue
  - [x] CompositeStaticType
  - [x] InterfaceStaticType
  - [x] ConstantSizedStaticType
  - [x] ReferenceStaticType
  - [x] DictionaryStaticType
  - [x] RestrictedStaticType
  - [x] TypeValue (__see Caveats__)
- [x] Remove old backwards-compatibility decoding of type id in decodeCompositeStaticType() and decodeInterfaceStaticType().
- [x] Add tests, including round-trip for decoding old format and encoding new format.

### Caveats

Other CBOR representations are available and were considered for AddressLocation and TypeValue.  Simplicity and consistency were prioritized over stored data size.  My decision should be reviewed by someone more familiar with Cadence.

Benchmarks used linux_amd64 with Go 1.15.10 using production data (a snapshot of mainnet).  Other platforms, wasm, etc. may show different gains.  Potential gains from I/O reduction (from reduced stored data size) were not measured.

______

For contributor use:

- [x] Targeted PR against `feature/storage-optimizations` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
