### PR TITLE
Fix borrowing

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -391,3 +391,19 @@ type MissingMemberValueError struct {
 func (e MissingMemberValueError) Error() string {
 	return fmt.Sprintf("missing value for member `%s`", e.Name)
 }
+
+// InvocationArgumentTypeError
+
+type InvocationArgumentTypeError struct {
+	Index         int
+	ParameterType sema.Type
+	LocationRange
+}
+
+func (e InvocationArgumentTypeError) Error() string {
+	return fmt.Sprintf(
+		"invalid invocation with argument at index %d: expected %s",
+		e.Index,
+		e.ParameterType.QualifiedString(),
+	)
+}

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -105,12 +105,7 @@ func (f InterpretedFunctionValue) Invoke(invocation Invocation) Value {
 
 	// Check arguments' dynamic types match parameter types
 
-	parameterCount := len(f.Type.Parameters)
-
 	for i, argument := range invocation.Arguments {
-		if i >= parameterCount {
-			break
-		}
 		parameterType := f.Type.Parameters[i].TypeAnnotation.Type
 
 		argumentDynamicType := argument.DynamicType(f.Interpreter)

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -102,6 +102,28 @@ func (InterpretedFunctionValue) SetModified(_ bool) {
 func (InterpretedFunctionValue) isFunctionValue() {}
 
 func (f InterpretedFunctionValue) Invoke(invocation Invocation) Value {
+
+	// Check arguments' dynamic types match parameter types
+
+	parameterCount := len(f.Type.Parameters)
+
+	for i, argument := range invocation.Arguments {
+		if i >= parameterCount {
+			break
+		}
+		parameterType := f.Type.Parameters[i].TypeAnnotation.Type
+
+		argumentDynamicType := argument.DynamicType(f.Interpreter)
+
+		if !IsSubType(argumentDynamicType, parameterType) {
+			panic(InvocationArgumentTypeError{
+				Index:         i,
+				ParameterType: parameterType,
+				LocationRange: invocation.GetLocationRange(),
+			})
+		}
+	}
+
 	return f.Interpreter.invokeInterpretedFunction(f, invocation)
 }
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -749,6 +749,7 @@ func (interpreter *Interpreter) prepareInvoke(
 		GetLocationRange: ReturnEmptyLocationRange,
 		Interpreter:      interpreter,
 	}
+
 	return functionValue.Invoke(invocation), nil
 }
 
@@ -793,10 +794,12 @@ func (interpreter *Interpreter) recoverErrors(onError func(error)) {
 			// wrap the error with position information if needed
 
 			_, ok := err.(ast.HasPosition)
-			if !ok {
+			if !ok && interpreter.statement != nil {
+				r := ast.NewRangeFromPositioned(interpreter.statement)
+
 				err = PositionedError{
 					Err:   err,
-					Range: ast.NewRangeFromPositioned(interpreter.statement),
+					Range: r,
 				}
 			}
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2560,42 +2560,31 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 		path := invocation.Arguments[0].(PathValue)
 		key := storageKey(path)
 
-		value := interpreter.readStored(address, key, false)
-
-		switch value := value.(type) {
-		case NilValue:
-			return value
-
-		case *SomeValue:
-
-			// If there is value stored for the given path,
-			// check that it satisfies the type given as the type argument.
-
-			typeParameterPair := invocation.TypeParameterTypes.Oldest()
-			if typeParameterPair == nil {
-				panic(errors.NewUnreachableError())
-			}
-
-			ty := typeParameterPair.Value
-
-			referenceType := ty.(*sema.ReferenceType)
-
-			dynamicType := value.Value.DynamicType(interpreter)
-			if !IsSubType(dynamicType, referenceType.Type) {
-				return NilValue{}
-			}
-
-			reference := &StorageReferenceValue{
-				Authorized:           referenceType.Authorized,
-				TargetStorageAddress: address,
-				TargetKey:            key,
-			}
-
-			return NewSomeValueOwningNonCopying(reference)
-
-		default:
+		typeParameterPair := invocation.TypeParameterTypes.Oldest()
+		if typeParameterPair == nil {
 			panic(errors.NewUnreachableError())
 		}
+
+		ty := typeParameterPair.Value
+
+		referenceType := ty.(*sema.ReferenceType)
+
+		reference := &StorageReferenceValue{
+			Authorized:           referenceType.Authorized,
+			TargetStorageAddress: address,
+			TargetKey:            key,
+			BorrowedType:         referenceType.Type,
+		}
+
+		// Attempt to dereference,
+		// which reads the stored value
+		// and performs a dynamic type check
+
+		if reference.ReferencedValue(interpreter) == nil {
+			return NilValue{}
+		}
+
+		return NewSomeValueOwningNonCopying(reference)
 	})
 }
 
@@ -2736,6 +2725,15 @@ func (interpreter *Interpreter) capabilityBorrowFunction(
 				Authorized:           authorized,
 				TargetStorageAddress: address,
 				TargetKey:            targetStorageKey,
+				BorrowedType:         borrowType.Type,
+			}
+
+			// Attempt to dereference,
+			// which reads the stored value
+			// and performs a dynamic type check
+
+			if reference.ReferencedValue(interpreter) == nil {
+				return NilValue{}
 			}
 
 			return NewSomeValueOwningNonCopying(reference)
@@ -2765,7 +2763,7 @@ func (interpreter *Interpreter) capabilityCheckFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			targetStorageKey, _ :=
+			targetStorageKey, authorized :=
 				interpreter.getCapabilityFinalTargetStorageKey(
 					addressValue,
 					pathValue,
@@ -2773,9 +2771,28 @@ func (interpreter *Interpreter) capabilityCheckFunction(
 					invocation.GetLocationRange,
 				)
 
-			isValid := targetStorageKey != ""
+			if targetStorageKey == "" {
+				return BoolValue(false)
+			}
 
-			return BoolValue(isValid)
+			address := addressValue.ToAddress()
+
+			reference := &StorageReferenceValue{
+				Authorized:           authorized,
+				TargetStorageAddress: address,
+				TargetKey:            targetStorageKey,
+				BorrowedType:         borrowType.Type,
+			}
+
+			// Attempt to dereference,
+			// which reads the stored value
+			// and performs a dynamic type check
+
+			if reference.ReferencedValue(interpreter) == nil {
+				return BoolValue(false)
+			}
+
+			return BoolValue(true)
 		},
 	)
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6522,6 +6522,7 @@ type StorageReferenceValue struct {
 	Authorized           bool
 	TargetStorageAddress common.Address
 	TargetKey            string
+	BorrowedType         sema.Type
 }
 
 func (*StorageReferenceValue) IsValue() {}
@@ -6558,6 +6559,7 @@ func (v *StorageReferenceValue) Copy() Value {
 		Authorized:           v.Authorized,
 		TargetStorageAddress: v.TargetStorageAddress,
 		TargetKey:            v.TargetKey,
+		BorrowedType:         v.BorrowedType,
 	}
 }
 
@@ -6581,9 +6583,20 @@ func (*StorageReferenceValue) SetModified(_ bool) {
 func (v *StorageReferenceValue) ReferencedValue(interpreter *Interpreter) *Value {
 	switch referenced := interpreter.readStored(v.TargetStorageAddress, v.TargetKey, false).(type) {
 	case *SomeValue:
-		return &referenced.Value
+		value := referenced.Value
+
+		if v.BorrowedType != nil {
+			dynamicType := value.DynamicType(interpreter)
+			if !IsSubType(dynamicType, v.BorrowedType) {
+				return nil
+			}
+		}
+
+		return &value
+
 	case NilValue:
 		return nil
+
 	default:
 		panic(errors.NewUnreachableError())
 	}

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -144,13 +144,9 @@ func newCryptoContractVerifySignatureFunction(signatureVerifier CryptoSignatureV
 }
 
 func newCryptoContractSignatureVerifier(signatureVerifier CryptoSignatureVerifier) *interpreter.CompositeValue {
-	implIdentifier := CryptoChecker.Location.
-		QualifiedIdentifier(cryptoContractInitializerTypes[0].ID()) +
-		"Impl"
-
 	result := interpreter.NewCompositeValue(
 		CryptoChecker.Location,
-		implIdentifier,
+		"Crypto.SignatureVerifierImpl",
 		common.CompositeKindStructure,
 		nil,
 		nil,
@@ -185,13 +181,10 @@ func newCryptoContractHashFunction(hasher CryptoHasher) interpreter.FunctionValu
 }
 
 func newCryptoContractHasher(hasher CryptoHasher) *interpreter.CompositeValue {
-	implIdentifier := CryptoChecker.Location.
-		QualifiedIdentifier(cryptoContractInitializerTypes[1].ID()) +
-		"Impl"
 
 	result := interpreter.NewCompositeValue(
 		CryptoChecker.Location,
-		implIdentifier,
+		"Crypto.HasherImpl",
 		common.CompositeKindStructure,
 		nil,
 		nil,

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -91,6 +91,48 @@ var cryptoContractType = func() *sema.CompositeType {
 	return variable.Type.(*sema.CompositeType)
 }()
 
+const cryptoSignatureVerifierImplIdentifier = "SignatureVerifierImpl"
+
+const cryptoHasherImplIdentifier = "HasherImpl"
+
+func registerCheckerElaborationCompositeType(
+	identifier string,
+	explicitConformances []*sema.InterfaceType,
+) {
+	typeID := CryptoChecker.Location.TypeID(identifier)
+	CryptoChecker.Elaboration.CompositeTypes[typeID] = &sema.CompositeType{
+		Location:                      CryptoChecker.Location,
+		Identifier:                    identifier,
+		Kind:                          common.CompositeKindStructure,
+		ExplicitInterfaceConformances: explicitConformances,
+	}
+}
+
+func init() {
+	signatureVerifierVariable, ok := CryptoChecker.Elaboration.GlobalTypes.Get("SignatureVerifier")
+	if !ok {
+		panic(errors2.NewUnreachableError())
+	}
+
+	registerCheckerElaborationCompositeType(
+		cryptoSignatureVerifierImplIdentifier,
+		[]*sema.InterfaceType{
+			signatureVerifierVariable.Type.(*sema.InterfaceType),
+		},
+	)
+
+	hasherVariable, ok := CryptoChecker.Elaboration.GlobalTypes.Get("Hasher")
+	if !ok {
+		panic(errors2.NewUnreachableError())
+	}
+	registerCheckerElaborationCompositeType(
+		cryptoHasherImplIdentifier,
+		[]*sema.InterfaceType{
+			hasherVariable.Type.(*sema.InterfaceType),
+		},
+	)
+}
+
 var cryptoContractInitializerTypes = func() (result []sema.Type) {
 	result = make([]sema.Type, len(cryptoContractType.ConstructorParameters))
 	for i, parameter := range cryptoContractType.ConstructorParameters {
@@ -146,7 +188,7 @@ func newCryptoContractVerifySignatureFunction(signatureVerifier CryptoSignatureV
 func newCryptoContractSignatureVerifier(signatureVerifier CryptoSignatureVerifier) *interpreter.CompositeValue {
 	result := interpreter.NewCompositeValue(
 		CryptoChecker.Location,
-		"Crypto.SignatureVerifierImpl",
+		cryptoSignatureVerifierImplIdentifier,
 		common.CompositeKindStructure,
 		nil,
 		nil,
@@ -184,7 +226,7 @@ func newCryptoContractHasher(hasher CryptoHasher) *interpreter.CompositeValue {
 
 	result := interpreter.NewCompositeValue(
 		CryptoChecker.Location,
-		"Crypto.HasherImpl",
+		cryptoHasherImplIdentifier,
 		common.CompositeKindStructure,
 		nil,
 		nil,

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -19,6 +19,7 @@
 package runtime
 
 import (
+	"encoding/hex"
 	"strconv"
 	"testing"
 
@@ -438,7 +439,7 @@ func TestRuntimeMagic(t *testing.T) {
 	)
 }
 
-func TestAccountStorageStorage(t *testing.T) {
+func TestRuntimeAccountStorage(t *testing.T) {
 	runtime := NewInterpreterRuntime()
 
 	script := []byte(`
@@ -492,4 +493,355 @@ func TestAccountStorageStorage(t *testing.T) {
 		[]string{"true"},
 		loggedMessages,
 	)
+}
+
+func TestRuntimePublicCapabilityBorrowTypeConfusion(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewInterpreterRuntime()
+
+	addressString, err := hex.DecodeString("aad3e26e406987c2")
+	require.NoError(t, err)
+
+	signingAddress := common.BytesToAddress(addressString)
+
+	deployFTContractTx := utils.DeploymentTransaction("FungibleToken", []byte(realFungibleTokenContractInterface))
+
+	const ducContract = `
+      import FungibleToken from 0xaad3e26e406987c2
+
+      pub contract DapperUtilityCoin: FungibleToken {
+
+    // Total supply of DapperUtilityCoins in existence
+    pub var totalSupply: UFix64
+
+    // Event that is emitted when the contract is created
+    pub event TokensInitialized(initialSupply: UFix64)
+
+    // Event that is emitted when tokens are withdrawn from a Vault
+    pub event TokensWithdrawn(amount: UFix64, from: Address?)
+
+    // Event that is emitted when tokens are deposited to a Vault
+    pub event TokensDeposited(amount: UFix64, to: Address?)
+
+    // Event that is emitted when new tokens are minted
+    pub event TokensMinted(amount: UFix64)
+
+    // Event that is emitted when tokens are destroyed
+    pub event TokensBurned(amount: UFix64)
+
+    // Event that is emitted when a new minter resource is created
+    pub event MinterCreated(allowedAmount: UFix64)
+
+    // Event that is emitted when a new burner resource is created
+    pub event BurnerCreated()
+
+    // Vault
+    //
+    // Each user stores an instance of only the Vault in their storage
+    // The functions in the Vault and governed by the pre and post conditions
+    // in FungibleToken when they are called.
+    // The checks happen at runtime whenever a function is called.
+    //
+    // Resources can only be created in the context of the contract that they
+    // are defined in, so there is no way for a malicious user to create Vaults
+    // out of thin air. A special Minter resource needs to be defined to mint
+    // new tokens.
+    //
+    pub resource Vault: FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance {
+
+        // holds the balance of a users tokens
+        pub var balance: UFix64
+
+        // initialize the balance at resource creation time
+        init(balance: UFix64) {
+            self.balance = balance
+        }
+
+        // withdraw
+        //
+        // Function that takes an integer amount as an argument
+        // and withdraws that amount from the Vault.
+        // It creates a new temporary Vault that is used to hold
+        // the money that is being transferred. It returns the newly
+        // created Vault to the context that called so it can be deposited
+        // elsewhere.
+        //
+        pub fun withdraw(amount: UFix64): @FungibleToken.Vault {
+            self.balance = self.balance - amount
+            emit TokensWithdrawn(amount: amount, from: self.owner?.address)
+            return <-create Vault(balance: amount)
+        }
+
+        // deposit
+        //
+        // Function that takes a Vault object as an argument and adds
+        // its balance to the balance of the owners Vault.
+        // It is allowed to destroy the sent Vault because the Vault
+        // was a temporary holder of the tokens. The Vault's balance has
+        // been consumed and therefore can be destroyed.
+        pub fun deposit(from: @FungibleToken.Vault) {
+            let vault <- from as! @DapperUtilityCoin.Vault
+            self.balance = self.balance + vault.balance
+            emit TokensDeposited(amount: vault.balance, to: self.owner?.address)
+            vault.balance = 0.0
+            destroy vault
+        }
+
+        destroy() {
+            DapperUtilityCoin.totalSupply = DapperUtilityCoin.totalSupply - self.balance
+        }
+    }
+
+    // createEmptyVault
+    //
+    // Function that creates a new Vault with a balance of zero
+    // and returns it to the calling context. A user must call this function
+    // and store the returned Vault in their storage in order to allow their
+    // account to be able to receive deposits of this token type.
+    //
+    pub fun createEmptyVault(): @FungibleToken.Vault {
+        return <-create Vault(balance: 0.0)
+    }
+
+    pub resource Administrator {
+        // createNewMinter
+        //
+        // Function that creates and returns a new minter resource
+        //
+        pub fun createNewMinter(allowedAmount: UFix64): @Minter {
+            emit MinterCreated(allowedAmount: allowedAmount)
+            return <-create Minter(allowedAmount: allowedAmount)
+        }
+
+        // createNewBurner
+        //
+        // Function that creates and returns a new burner resource
+        //
+        pub fun createNewBurner(): @Burner {
+            emit BurnerCreated()
+            return <-create Burner()
+        }
+    }
+
+    // Minter
+    //
+    // Resource object that token admin accounts can hold to mint new tokens.
+    //
+    pub resource Minter {
+
+        // the amount of tokens that the minter is allowed to mint
+        pub var allowedAmount: UFix64
+
+        // mintTokens
+        //
+        // Function that mints new tokens, adds them to the total supply,
+        // and returns them to the calling context.
+        //
+        pub fun mintTokens(amount: UFix64): @DapperUtilityCoin.Vault {
+            pre {
+                amount > UFix64(0): "Amount minted must be greater than zero"
+                amount <= self.allowedAmount: "Amount minted must be less than the allowed amount"
+            }
+            DapperUtilityCoin.totalSupply = DapperUtilityCoin.totalSupply + amount
+            self.allowedAmount = self.allowedAmount - amount
+            emit TokensMinted(amount: amount)
+            return <-create Vault(balance: amount)
+        }
+
+        init(allowedAmount: UFix64) {
+            self.allowedAmount = allowedAmount
+        }
+    }
+
+    // Burner
+    //
+    // Resource object that token admin accounts can hold to burn tokens.
+    //
+    pub resource Burner {
+
+        // burnTokens
+        //
+        // Function that destroys a Vault instance, effectively burning the tokens.
+        //
+        // Note: the burned tokens are automatically subtracted from the
+        // total supply in the Vault destructor.
+        //
+        pub fun burnTokens(from: @FungibleToken.Vault) {
+            let vault <- from as! @DapperUtilityCoin.Vault
+            let amount = vault.balance
+            destroy vault
+            emit TokensBurned(amount: amount)
+        }
+    }
+
+    init() {
+        // we're using a high value as the balance here to make it look like we've got a ton of money,
+        // just in case some contract manually checks that our balance is sufficient to pay for stuff
+        self.totalSupply = 999999999.0
+
+        let admin <- create Administrator()
+        let minter <- admin.createNewMinter(allowedAmount: self.totalSupply)
+        self.account.save(<-admin, to: /storage/dapperUtilityCoinAdmin)
+
+        // mint tokens
+        let tokenVault <- minter.mintTokens(amount: self.totalSupply)
+        self.account.save(<-tokenVault, to: /storage/dapperUtilityCoinVault)
+        destroy minter
+
+        // Create a public capability to the stored Vault that only exposes
+        // the balance field through the Balance interface
+        self.account.link<&DapperUtilityCoin.Vault{FungibleToken.Balance}>(
+            /public/dapperUtilityCoinBalance,
+            target: /storage/dapperUtilityCoinVault
+        )
+
+        // Create a public capability to the stored Vault that only exposes
+        // the deposit method through the Receiver interface
+        self.account.link<&{FungibleToken.Receiver}>(
+            /public/dapperUtilityCoinReceiver,
+            target: /storage/dapperUtilityCoinVault
+        )
+
+        // Emit an event that shows that the contract was initialized
+        emit TokensInitialized(initialSupply: self.totalSupply)
+    }
+}
+
+    `
+
+	deployDucContractTx := utils.DeploymentTransaction("DapperUtilityCoin", []byte(ducContract))
+
+	const testContract = `
+      access(all) contract TestContract{
+        pub struct fake{
+          pub(set) var balance: UFix64
+
+          init(){
+            self.balance = 0.0
+          }
+        }
+        pub resource resourceConverter{
+          pub fun convert(b: fake): AnyStruct {
+            b.balance = 100.0
+            return b
+          }
+        }
+        pub resource resourceConverter2{
+          pub fun convert(b: @AnyResource): AnyStruct {
+            destroy b
+            return ""
+          }
+        }
+        access(all) fun createConverter():  @resourceConverter{
+            return <- create resourceConverter();
+        }
+      }
+    `
+
+	deployTestContractTx := utils.DeploymentTransaction("TestContract", []byte(testContract))
+
+	accountCodes := map[common.LocationID][]byte{}
+	var events []cadence.Event
+	var loggedMessages []string
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestStorage(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{signingAddress}, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			accountCodes[location.ID()] = code
+			return nil
+		},
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			code = accountCodes[location.ID()]
+			return code, nil
+		},
+		emitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
+		},
+		log: func(message string) {
+			loggedMessages = append(loggedMessages, message)
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	// Deploy contracts
+
+	for _, deployTx := range [][]byte{
+		deployFTContractTx,
+		deployDucContractTx,
+		deployTestContractTx,
+	} {
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: deployTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+	}
+
+	// Run test transaction
+
+	const testTx = `
+import TestContract from 0xaad3e26e406987c2
+import DapperUtilityCoin from 0xaad3e26e406987c2
+
+transaction {
+  prepare(acct: AuthAccount) {
+
+    var tokens <- DapperUtilityCoin.createEmptyVault()
+
+    let rc <- TestContract.createConverter()
+    acct.save(<-rc, to: /storage/rc)
+
+    acct.link<&TestContract.resourceConverter2>(/public/rc, target: /storage/rc)
+
+    var cap=getAccount(0xaad3e26e406987c2).getCapability(/public/rc).borrow<&TestContract.resourceConverter2>()!
+
+    var vaultx = cap.convert(b: <-tokens)
+
+    acct.save(vaultx, to: /storage/v1)
+
+    acct.link<&DapperUtilityCoin.Vault>(/public/v1, target: /storage/v1)
+
+    var cap3=getAccount(0xaad3e26e406987c2).getCapability(/public/v1).borrow<&DapperUtilityCoin.Vault>()!
+
+    log(cap3.balance)
+  }
+}
+`
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: []byte(testTx),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+
+	require.Error(t, err)
+
+	require.Contains(t, err.Error(), "unexpectedly found nil while forcing an Optional value")
 }

--- a/runtime/tests/interpreter/invocation_test.go
+++ b/runtime/tests/interpreter/invocation_test.go
@@ -1,0 +1,43 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+)
+
+func TestInterpretFunctionInvocationCheckArgumentTypes(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+       fun test(_ x: Int): Int {
+           return x
+       }
+   `)
+
+	_, err := inter.Invoke("test", interpreter.BoolValue(true))
+	require.Error(t, err)
+
+	require.ErrorAs(t, err, &interpreter.InvocationArgumentTypeError{})
+}


### PR DESCRIPTION
(Port of #785, itself a port of dapperlabs/cadence-internal#1)

## Description

- Always check dynamic type when borrowing, checking, and dereferencing storage references
- Check the dynamic type of all arguments against parameter types on each invocation

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
