### PR TITLE
Extend defensive run-time checking to all value transfers

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -180,7 +180,9 @@ func exportArrayValue(v *interpreter.ArrayValue, inter *interpreter.Interpreter,
 
 func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Interpreter, results exportResults) cadence.Value {
 
-	dynamicType := v.DynamicType(inter).(interpreter.CompositeDynamicType)
+	dynamicTypeResults := interpreter.DynamicTypeResults{}
+
+	dynamicType := v.DynamicType(inter, dynamicTypeResults).(interpreter.CompositeDynamicType)
 	staticType := dynamicType.StaticType.(*sema.CompositeType)
 	// TODO: consider making the results map "global", by moving it up to exportValueWithInterpreter
 	t := exportCompositeType(staticType, map[sema.TypeID]cadence.Type{})

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -268,7 +268,7 @@ func TestExportFixedPointValuesFromScript(t *testing.T) {
 
 	t.Parallel()
 
-	test := func(fixedPointType sema.Type) {
+	test := func(fixedPointType sema.Type, literal string) {
 
 		t.Run(fixedPointType.String(), func(t *testing.T) {
 
@@ -277,10 +277,11 @@ func TestExportFixedPointValuesFromScript(t *testing.T) {
 			script := fmt.Sprintf(
 				`
                   pub fun main(): %s {
-                      return 1.23
+                      return %s
                   }
                 `,
 				fixedPointType,
+				literal,
 			)
 
 			assert.NotPanics(t, func() {
@@ -290,7 +291,15 @@ func TestExportFixedPointValuesFromScript(t *testing.T) {
 	}
 
 	for _, fixedPointType := range sema.AllFixedPointTypes {
-		test(fixedPointType)
+
+		var literal string
+		if sema.IsSubType(fixedPointType, &sema.SignedFixedPointType{}) {
+			literal = "-1.23"
+		} else {
+			literal = "1.23"
+		}
+
+		test(fixedPointType, literal)
 	}
 }
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -293,7 +293,7 @@ func TestExportFixedPointValuesFromScript(t *testing.T) {
 	for _, fixedPointType := range sema.AllFixedPointTypes {
 
 		var literal string
-		if sema.IsSubType(fixedPointType, &sema.SignedFixedPointType{}) {
+		if sema.IsSubType(fixedPointType, sema.SignedFixedPointType) {
 			literal = "-1.23"
 		} else {
 			literal = "1.23"

--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -41,7 +41,7 @@ func (v BlockValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitValue(interpreter, v)
 }
 
-func (BlockValue) DynamicType(_ *Interpreter) DynamicType {
+func (BlockValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return BlockDynamicType{}
 }
 

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -40,7 +40,7 @@ func (v DeployedContractValue) Accept(interpreter *Interpreter, visitor Visitor)
 	visitor.VisitDeployedContractValue(interpreter, v)
 }
 
-func (DeployedContractValue) DynamicType(_ *Interpreter) DynamicType {
+func (DeployedContractValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return DeployedContractDynamicType{}
 }
 

--- a/runtime/interpreter/dynamictype.go
+++ b/runtime/interpreter/dynamictype.go
@@ -190,3 +190,16 @@ func (DeployedContractDynamicType) IsDynamicType() {}
 type BlockDynamicType struct{}
 
 func (BlockDynamicType) IsDynamicType() {}
+
+// UnwrapOptionalDynamicType returns the type if it is not an optional type,
+// or the inner-most type if it is (optional types are repeatedly unwrapped)
+//
+func UnwrapOptionalDynamicType(ty DynamicType) DynamicType {
+	for {
+		someDynamicType, ok := ty.(SomeDynamicType)
+		if !ok {
+			return ty
+		}
+		ty = someDynamicType.InnerType
+	}
+}

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -407,3 +407,17 @@ func (e InvocationArgumentTypeError) Error() string {
 		e.ParameterType.QualifiedString(),
 	)
 }
+
+// ValueTransferTypeError
+
+type ValueTransferTypeError struct {
+	TargetType sema.Type
+	LocationRange
+}
+
+func (e ValueTransferTypeError) Error() string {
+	return fmt.Sprintf(
+		"invalid transfer of value: expected %s",
+		e.TargetType.QualifiedString(),
+	)
+}

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -69,7 +69,7 @@ func (f InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visit
 	visitor.VisitInterpretedFunctionValue(interpreter, f)
 }
 
-func (InterpretedFunctionValue) DynamicType(_ *Interpreter) DynamicType {
+func (InterpretedFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return FunctionDynamicType{}
 }
 
@@ -154,7 +154,7 @@ func (f HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitHostFunctionValue(interpreter, f)
 }
 
-func (HostFunctionValue) DynamicType(_ *Interpreter) DynamicType {
+func (HostFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return FunctionDynamicType{}
 }
 
@@ -227,7 +227,7 @@ func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitBoundFunctionValue(interpreter, f)
 }
 
-func (BoundFunctionValue) DynamicType(_ *Interpreter) DynamicType {
+func (BoundFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return FunctionDynamicType{}
 }
 

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -108,9 +108,7 @@ func (f InterpretedFunctionValue) Invoke(invocation Invocation) Value {
 	for i, argument := range invocation.Arguments {
 		parameterType := f.Type.Parameters[i].TypeAnnotation.Type
 
-		argumentDynamicType := argument.DynamicType(f.Interpreter)
-
-		if !IsSubType(argumentDynamicType, parameterType) {
+		if !f.Interpreter.checkValueTransferTargetType(argument, parameterType) {
 			panic(InvocationArgumentTypeError{
 				Index:         i,
 				ParameterType: parameterType,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1615,7 +1615,9 @@ func (interpreter *Interpreter) checkValueTransferTargetType(value Value, target
 		return true
 	}
 
-	valueDynamicType := value.DynamicType(interpreter)
+	dynamicTypeResults := DynamicTypeResults{}
+
+	valueDynamicType := value.DynamicType(interpreter, dynamicTypeResults)
 	if IsSubType(valueDynamicType, targetType) {
 		return true
 	}
@@ -2593,7 +2595,9 @@ func (interpreter *Interpreter) authAccountReadFunction(addressValue AddressValu
 
 			ty := typeParameterPair.Value
 
-			dynamicType := value.Value.DynamicType(interpreter)
+			dynamicTypeResults := DynamicTypeResults{}
+
+			dynamicType := value.Value.DynamicType(interpreter, dynamicTypeResults)
 			if !IsSubType(dynamicType, ty) {
 				return NilValue{}
 			}
@@ -3063,7 +3067,8 @@ func (interpreter *Interpreter) isInstanceFunction(self Value) HostFunctionValue
 
 			semaType := interpreter.ConvertStaticToSemaType(staticType)
 			// NOTE: not invocation.Self, as that is only set for composite values
-			dynamicType := self.DynamicType(interpreter)
+			dynamicTypeResults := DynamicTypeResults{}
+			dynamicType := self.DynamicType(interpreter, dynamicTypeResults)
 			result := IsSubType(dynamicType, semaType)
 			return BoolValue(result)
 		},

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1030,7 +1030,7 @@ func (interpreter *Interpreter) visitAssignment(
 		// The latter case exists when the force-move assignment is the initialization of a field
 		// in an initializer, in which case there is no prior value for the field.
 
-		if _, ok := target.(NilValue); !ok {
+		if _, ok := target.(NilValue); !ok && target != nil {
 			getLocationRange := locationRangeGetter(interpreter.Location, position)
 			panic(ForceAssignmentToNonNilResourceError{
 				LocationRange: getLocationRange(),

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -569,7 +569,8 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 
 	switch expression.Operation {
 	case ast.OperationFailableCast, ast.OperationForceCast:
-		dynamicType := value.DynamicType(interpreter)
+		dynamicTypeResults := DynamicTypeResults{}
+		dynamicType := value.DynamicType(interpreter, dynamicTypeResults)
 		isSubType := IsSubType(dynamicType, expectedType)
 
 		switch expression.Operation {

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -42,6 +42,7 @@ func (interpreter *Interpreter) InvokeFunctionValue(
 	return interpreter.invokeFunctionValue(
 		function,
 		arguments,
+		nil,
 		argumentTypes,
 		parameterTypes,
 		nil,
@@ -52,6 +53,7 @@ func (interpreter *Interpreter) InvokeFunctionValue(
 func (interpreter *Interpreter) invokeFunctionValue(
 	function FunctionValue,
 	arguments []Value,
+	expressions []ast.Expression,
 	argumentTypes []sema.Type,
 	parameterTypes []sema.Type,
 	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
@@ -65,7 +67,16 @@ func (interpreter *Interpreter) invokeFunctionValue(
 		argumentType := argumentTypes[i]
 		if i < parameterTypeCount {
 			parameterType := parameterTypes[i]
-			argumentCopies[i] = interpreter.copyAndConvert(argument, argumentType, parameterType)
+
+			var locationPos ast.HasPosition
+			if i < len(expressions) {
+				locationPos = expressions[i]
+			} else {
+				locationPos = invocationPosition
+			}
+
+			getLocationRange := locationRangeGetter(interpreter.Location, locationPos)
+			argumentCopies[i] = interpreter.copyAndConvert(argument, argumentType, parameterType, getLocationRange)
 		} else {
 			argumentCopies[i] = argument.Copy()
 		}

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -65,8 +65,10 @@ func (interpreter *Interpreter) VisitReturnStatement(statement *ast.ReturnStatem
 		valueType := interpreter.Program.Elaboration.ReturnStatementValueTypes[statement]
 		returnType := interpreter.Program.Elaboration.ReturnStatementReturnTypes[statement]
 
+		getLocationRange := locationRangeGetter(interpreter.Location, statement.Expression)
+
 		// NOTE: copy on return
-		value = interpreter.copyAndConvert(value, valueType, returnType)
+		value = interpreter.copyAndConvert(value, valueType, returnType, getLocationRange)
 	}
 
 	return functionReturn{value}
@@ -121,7 +123,8 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 
 		targetType := interpreter.Program.Elaboration.VariableDeclarationTargetTypes[declaration]
 		valueType := interpreter.Program.Elaboration.VariableDeclarationValueTypes[declaration]
-		unwrappedValueCopy := interpreter.copyAndConvert(someValue.Value, valueType, targetType)
+		getLocationRange := locationRangeGetter(interpreter.Location, declaration.Value)
+		unwrappedValueCopy := interpreter.copyAndConvert(someValue.Value, valueType, targetType, getLocationRange)
 
 		interpreter.activations.PushNewWithCurrent()
 		defer interpreter.activations.Pop()
@@ -286,7 +289,9 @@ func (interpreter *Interpreter) VisitVariableDeclaration(declaration *ast.Variab
 
 	result := interpreter.visitPotentialStorageRemoval(declaration.Value)
 
-	valueCopy := interpreter.copyAndConvert(result, valueType, targetType)
+	getLocationRange := locationRangeGetter(interpreter.Location, declaration.Value)
+
+	valueCopy := interpreter.copyAndConvert(result, valueType, targetType, getLocationRange)
 
 	interpreter.declareVariable(
 		declaration.Identifier.Identifier,
@@ -354,8 +359,11 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) ast.
 	// Add right value to left target
 	// and left value to right target
 
-	rightValueCopy := interpreter.copyAndConvert(rightValue, rightType, leftType)
-	leftValueCopy := interpreter.copyAndConvert(leftValue, leftType, rightType)
+	getLocationRange := locationRangeGetter(interpreter.Location, swap.Right)
+	rightValueCopy := interpreter.copyAndConvert(rightValue, rightType, leftType, getLocationRange)
+
+	getLocationRange = locationRangeGetter(interpreter.Location, swap.Left)
+	leftValueCopy := interpreter.copyAndConvert(leftValue, leftType, rightType, getLocationRange)
 
 	leftGetterSetter.set(rightValueCopy)
 	rightGetterSetter.set(leftValueCopy)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -37,13 +37,15 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
+type DynamicTypeResults map[Value]DynamicType
+
 // Value
 
 type Value interface {
 	fmt.Stringer
 	IsValue()
 	Accept(interpreter *Interpreter, visitor Visitor)
-	DynamicType(interpreter *Interpreter) DynamicType
+	DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType
 	Copy() Value
 	GetOwner() *common.Address
 	SetOwner(address *common.Address)
@@ -110,7 +112,7 @@ func (v TypeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitTypeValue(interpreter, v)
 }
 
-func (TypeValue) DynamicType(_ *Interpreter) DynamicType {
+func (TypeValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return MetaTypeDynamicType{}
 }
 
@@ -203,7 +205,7 @@ func (v VoidValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitVoidValue(interpreter, v)
 }
 
-func (VoidValue) DynamicType(_ *Interpreter) DynamicType {
+func (VoidValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return VoidDynamicType{}
 }
 
@@ -251,7 +253,7 @@ func (v BoolValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitBoolValue(interpreter, v)
 }
 
-func (BoolValue) DynamicType(_ *Interpreter) DynamicType {
+func (BoolValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return BoolDynamicType{}
 }
 
@@ -328,7 +330,7 @@ func (v *StringValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitStringValue(interpreter, v)
 }
 
-func (*StringValue) DynamicType(_ *Interpreter) DynamicType {
+func (*StringValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return StringDynamicType{}
 }
 
@@ -546,11 +548,11 @@ func (v *ArrayValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	}
 }
 
-func (v *ArrayValue) DynamicType(interpreter *Interpreter) DynamicType {
+func (v *ArrayValue) DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType {
 	elementTypes := make([]DynamicType, len(v.Values))
 
 	for i, value := range v.Values {
-		elementTypes[i] = value.DynamicType(interpreter)
+		elementTypes[i] = value.DynamicType(interpreter, results)
 	}
 
 	return ArrayDynamicType{
@@ -891,7 +893,7 @@ func (v IntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitIntValue(interpreter, v)
 }
 
-func (IntValue) DynamicType(_ *Interpreter) DynamicType {
+func (IntValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.IntType}
 }
 
@@ -1104,7 +1106,7 @@ func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt8Value(interpreter, v)
 }
 
-func (Int8Value) DynamicType(_ *Interpreter) DynamicType {
+func (Int8Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Int8Type}
 }
 
@@ -1345,7 +1347,7 @@ func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt16Value(interpreter, v)
 }
 
-func (Int16Value) DynamicType(_ *Interpreter) DynamicType {
+func (Int16Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Int16Type}
 }
 
@@ -1588,7 +1590,7 @@ func (v Int32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt32Value(interpreter, v)
 }
 
-func (Int32Value) DynamicType(_ *Interpreter) DynamicType {
+func (Int32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Int32Type}
 }
 
@@ -1831,7 +1833,7 @@ func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt64Value(interpreter, v)
 }
 
-func (Int64Value) DynamicType(_ *Interpreter) DynamicType {
+func (Int64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Int64Type}
 }
 
@@ -2082,7 +2084,7 @@ func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt128Value(interpreter, v)
 }
 
-func (Int128Value) DynamicType(_ *Interpreter) DynamicType {
+func (Int128Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Int128Type}
 }
 
@@ -2383,7 +2385,7 @@ func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt256Value(interpreter, v)
 }
 
-func (Int256Value) DynamicType(_ *Interpreter) DynamicType {
+func (Int256Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Int256Type}
 }
 
@@ -2705,7 +2707,7 @@ func (v UIntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUIntValue(interpreter, v)
 }
 
-func (UIntValue) DynamicType(_ *Interpreter) DynamicType {
+func (UIntValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UIntType}
 }
 
@@ -2921,7 +2923,7 @@ func (v UInt8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt8Value(interpreter, v)
 }
 
-func (UInt8Value) DynamicType(_ *Interpreter) DynamicType {
+func (UInt8Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UInt8Type}
 }
 
@@ -3130,7 +3132,7 @@ func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt16Value(interpreter, v)
 }
 
-func (UInt16Value) DynamicType(_ *Interpreter) DynamicType {
+func (UInt16Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UInt16Type}
 }
 
@@ -3339,7 +3341,7 @@ func (v UInt32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt32Value(interpreter, v)
 }
 
-func (UInt32Value) DynamicType(_ *Interpreter) DynamicType {
+func (UInt32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UInt32Type}
 }
 
@@ -3550,7 +3552,7 @@ func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt64Value(interpreter, v)
 }
 
-func (UInt64Value) DynamicType(_ *Interpreter) DynamicType {
+func (UInt64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UInt64Type}
 }
 
@@ -3774,7 +3776,7 @@ func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt128Value(interpreter, v)
 }
 
-func (UInt128Value) DynamicType(_ *Interpreter) DynamicType {
+func (UInt128Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UInt128Type}
 }
 
@@ -4044,7 +4046,7 @@ func (v UInt256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt256Value(interpreter, v)
 }
 
-func (UInt256Value) DynamicType(_ *Interpreter) DynamicType {
+func (UInt256Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UInt256Type}
 }
 
@@ -4305,7 +4307,7 @@ func (v Word8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord8Value(interpreter, v)
 }
 
-func (Word8Value) DynamicType(_ *Interpreter) DynamicType {
+func (Word8Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Word8Type}
 }
 
@@ -4475,7 +4477,7 @@ func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord16Value(interpreter, v)
 }
 
-func (Word16Value) DynamicType(_ *Interpreter) DynamicType {
+func (Word16Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Word16Type}
 }
 
@@ -4645,7 +4647,7 @@ func (v Word32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord32Value(interpreter, v)
 }
 
-func (Word32Value) DynamicType(_ *Interpreter) DynamicType {
+func (Word32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Word32Type}
 }
 
@@ -4817,7 +4819,7 @@ func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord64Value(interpreter, v)
 }
 
-func (Word64Value) DynamicType(_ *Interpreter) DynamicType {
+func (Word64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Word64Type}
 }
 
@@ -5004,7 +5006,7 @@ func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitFix64Value(interpreter, v)
 }
 
-func (Fix64Value) DynamicType(_ *Interpreter) DynamicType {
+func (Fix64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.Fix64Type}
 }
 
@@ -5224,7 +5226,7 @@ func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUFix64Value(interpreter, v)
 }
 
-func (UFix64Value) DynamicType(_ *Interpreter) DynamicType {
+func (UFix64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NumberDynamicType{sema.UFix64Type}
 }
 
@@ -5506,7 +5508,7 @@ func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	})
 }
 
-func (v *CompositeValue) DynamicType(interpreter *Interpreter) DynamicType {
+func (v *CompositeValue) DynamicType(interpreter *Interpreter, _ DynamicTypeResults) DynamicType {
 	staticType := interpreter.getCompositeType(v.Location, v.QualifiedIdentifier)
 	return CompositeDynamicType{
 		StaticType: staticType,
@@ -5708,7 +5710,11 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter) OptionalValue {
 	ownerAccount := interpreter.accountHandler(address)
 
 	// Owner must be of `PublicAccount` type.
-	compositeDynamicType, ok := ownerAccount.DynamicType(interpreter).(CompositeDynamicType)
+
+	dynamicTypeResults := DynamicTypeResults{}
+	dynamicType := ownerAccount.DynamicType(interpreter, dynamicTypeResults)
+
+	compositeDynamicType, ok := dynamicType.(CompositeDynamicType)
 
 	if !ok || !sema.PublicAccountType.Equal(compositeDynamicType.StaticType) {
 		panic(&TypeMismatchError{
@@ -5831,7 +5837,8 @@ func (v *CompositeValue) ConformsToDynamicType(interpreter *Interpreter, dynamic
 			return false
 		}
 
-		fieldDynamicType := field.DynamicType(interpreter)
+		dynamicTypeResults := DynamicTypeResults{}
+		fieldDynamicType := field.DynamicType(interpreter, dynamicTypeResults)
 
 		if !IsSubType(fieldDynamicType, member.TypeAnnotation.Type) {
 			return false
@@ -5912,7 +5919,7 @@ func (v *DictionaryValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	}
 }
 
-func (v *DictionaryValue) DynamicType(interpreter *Interpreter) DynamicType {
+func (v *DictionaryValue) DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType {
 	entryTypes := make([]struct{ KeyType, ValueType DynamicType }, len(v.Keys.Values))
 
 	for i, key := range v.Keys.Values {
@@ -5921,8 +5928,8 @@ func (v *DictionaryValue) DynamicType(interpreter *Interpreter) DynamicType {
 		value := v.Get(interpreter, ReturnEmptyLocationRange, key).(*SomeValue).Value
 		entryTypes[i] =
 			struct{ KeyType, ValueType DynamicType }{
-				KeyType:   key.DynamicType(interpreter),
-				ValueType: value.DynamicType(interpreter),
+				KeyType:   key.DynamicType(interpreter, results),
+				ValueType: value.DynamicType(interpreter, results),
 			}
 	}
 
@@ -6336,7 +6343,7 @@ func (v NilValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitNilValue(interpreter, v)
 }
 
-func (NilValue) DynamicType(_ *Interpreter) DynamicType {
+func (NilValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return NilDynamicType{}
 }
 
@@ -6425,8 +6432,8 @@ func (v *SomeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	v.Value.Accept(interpreter, visitor)
 }
 
-func (v *SomeValue) DynamicType(interpreter *Interpreter) DynamicType {
-	innerType := v.Value.DynamicType(interpreter)
+func (v *SomeValue) DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType {
+	innerType := v.Value.DynamicType(interpreter, results)
 	return SomeDynamicType{InnerType: innerType}
 }
 
@@ -6535,13 +6542,13 @@ func (v *StorageReferenceValue) String() string {
 	return "StorageReference()"
 }
 
-func (v *StorageReferenceValue) DynamicType(interpreter *Interpreter) DynamicType {
+func (v *StorageReferenceValue) DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{})
 	}
 
-	innerType := (*referencedValue).DynamicType(interpreter)
+	innerType := (*referencedValue).DynamicType(interpreter, results)
 
 	return StorageReferenceDynamicType{
 		authorized: v.Authorized,
@@ -6586,7 +6593,8 @@ func (v *StorageReferenceValue) ReferencedValue(interpreter *Interpreter) *Value
 		value := referenced.Value
 
 		if v.BorrowedType != nil {
-			dynamicType := value.DynamicType(interpreter)
+			dynamicTypeResults := DynamicTypeResults{}
+			dynamicType := value.DynamicType(interpreter, dynamicTypeResults)
 			if !IsSubType(dynamicType, v.BorrowedType) {
 				return nil
 			}
@@ -6681,18 +6689,28 @@ func (v *EphemeralReferenceValue) String() string {
 	return v.Value.String()
 }
 
-func (v *EphemeralReferenceValue) DynamicType(interpreter *Interpreter) DynamicType {
+func (v *EphemeralReferenceValue) DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType {
 	referencedValue := v.ReferencedValue()
 	if referencedValue == nil {
 		panic(DereferenceError{})
 	}
 
-	innerType := (*referencedValue).DynamicType(interpreter)
+	if result, ok := results[v]; ok {
+		return result
+	}
 
-	return EphemeralReferenceDynamicType{
+	results[v] = nil
+
+	innerType := (*referencedValue).DynamicType(interpreter, results)
+
+	result := EphemeralReferenceDynamicType{
 		authorized: v.Authorized,
 		innerType:  innerType,
 	}
+
+	results[v] = result
+
+	return result
 }
 
 func (v *EphemeralReferenceValue) StaticType() StaticType {
@@ -6843,7 +6861,7 @@ func (v AddressValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitAddressValue(interpreter, v)
 }
 
-func (AddressValue) DynamicType(_ *Interpreter) DynamicType {
+func (AddressValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return AddressDynamicType{}
 }
 
@@ -7085,7 +7103,7 @@ func (v PathValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitPathValue(interpreter, v)
 }
 
-func (v PathValue) DynamicType(_ *Interpreter) DynamicType {
+func (v PathValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	switch v.Domain {
 	case common.PathDomainStorage:
 		return StoragePathDynamicType{}
@@ -7178,7 +7196,7 @@ func (v CapabilityValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitCapabilityValue(interpreter, v)
 }
 
-func (v CapabilityValue) DynamicType(inter *Interpreter) DynamicType {
+func (v CapabilityValue) DynamicType(inter *Interpreter, _ DynamicTypeResults) DynamicType {
 	var borrowType *sema.ReferenceType
 	if v.BorrowType != nil {
 		borrowType = inter.ConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
@@ -7277,7 +7295,7 @@ func (v LinkValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitLinkValue(interpreter, v)
 }
 
-func (LinkValue) DynamicType(_ *Interpreter) DynamicType {
+func (LinkValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	return nil
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -529,7 +529,9 @@ func validateArgumentParams(
 
 		arg := importValue(value)
 
-		dynamicType := arg.DynamicType(inter)
+		dynamicTypeResults := interpreter.DynamicTypeResults{}
+
+		dynamicType := arg.DynamicType(inter, dynamicTypeResults)
 
 		// Check that decoded value is a subtype of static parameter type
 		if !interpreter.IsSubType(dynamicType, parameterType) {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3924,15 +3924,14 @@ func IsSubType(subType Type, superType Type) bool {
 	case IntegerType:
 		switch subType {
 		case IntegerType, SignedIntegerType,
-			IntType, UIntType,
-			Int8Type, Int16Type, Int32Type, Int64Type, Int128Type, Int256Type,
+			UIntType,
 			UInt8Type, UInt16Type, UInt32Type, UInt64Type, UInt128Type, UInt256Type,
 			Word8Type, Word16Type, Word32Type, Word64Type:
 
 			return true
 
 		default:
-			return false
+			return IsSubType(subType, SignedIntegerType)
 		}
 
 	case SignedIntegerType:
@@ -3950,12 +3949,12 @@ func IsSubType(subType Type, superType Type) bool {
 	case FixedPointType:
 		switch subType {
 		case FixedPointType, SignedFixedPointType,
-			Fix64Type, UFix64Type:
+			UFix64Type:
 
 			return true
 
 		default:
-			return false
+			return IsSubType(subType, SignedFixedPointType)
 		}
 
 	case SignedFixedPointType:

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3961,7 +3961,6 @@ func IsSubType(subType Type, superType Type) bool {
 	case SignedFixedPointType:
 		switch subType {
 		case SignedFixedPointType, Fix64Type:
-
 			return true
 
 		default:

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -162,14 +162,29 @@ func TestCheckReturnWithoutExpression(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCheckAnyReturnType(t *testing.T) {
+func TestCheckFunctionUseInsideFunction(t *testing.T) {
 
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-      fun foo(): AnyStruct {
-          return foo
+      fun foo() {
+          foo()
       }
+    `)
+
+	require.NoError(t, err)
+}
+
+func TestCheckFunctionReturnFunction(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun foo(): ((Int): Void) {
+          return bar
+      }
+
+      fun bar(_ n: Int) {}
     `)
 
 	require.NoError(t, err)

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -70,7 +70,7 @@ func TestInterpretToString(t *testing.T) {
 
 			var literal string
 
-			isSigned := sema.IsSubType(ty, &sema.SignedFixedPointType{})
+			isSigned := sema.IsSubType(ty, sema.SignedFixedPointType)
 
 			if isSigned {
 				literal = "-12.34"

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -69,13 +69,16 @@ func TestInterpretToString(t *testing.T) {
 		t.Run(ty.String(), func(t *testing.T) {
 
 			var literal string
-
+ 			var expected interpreter.Value
+ 			
 			isSigned := sema.IsSubType(ty, sema.SignedFixedPointType)
 
 			if isSigned {
 				literal = "-12.34"
+				expected = interpreter.NewStringValue("-12.34000000")
 			} else {
 				literal = "12.34"
+				expected = interpreter.NewStringValue("12.34000000")
 			}
 
 			inter := parseCheckAndInterpret(t,
@@ -88,13 +91,6 @@ func TestInterpretToString(t *testing.T) {
 					literal,
 				),
 			)
-
-			var expected interpreter.Value
-			if isSigned {
-				expected = interpreter.NewStringValue("-12.34000000")
-			} else {
-				expected = interpreter.NewStringValue("12.34000000")
-			}
 
 			assert.Equal(t,
 				expected,

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -68,18 +68,36 @@ func TestInterpretToString(t *testing.T) {
 
 		t.Run(ty.String(), func(t *testing.T) {
 
+			var literal string
+
+			isSigned := sema.IsSubType(ty, &sema.SignedFixedPointType{})
+
+			if isSigned {
+				literal = "-12.34"
+			} else {
+				literal = "12.34"
+			}
+
 			inter := parseCheckAndInterpret(t,
 				fmt.Sprintf(
 					`
-                      let x: %s = 12.34
+                      let x: %s = %s
                       let y = x.toString()
                     `,
 					ty,
+					literal,
 				),
 			)
 
+			var expected interpreter.Value
+			if isSigned {
+				expected = interpreter.NewStringValue("-12.34000000")
+			} else {
+				expected = interpreter.NewStringValue("12.34000000")
+			}
+
 			assert.Equal(t,
-				interpreter.NewStringValue("12.34000000"),
+				expected,
 				inter.Globals["y"].GetValue(),
 			)
 		})

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -94,7 +94,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 										Functions: map[string]interpreter.FunctionValue{
 											"bar": interpreter.NewHostFunctionValue(
 												func(invocation interpreter.Invocation) interpreter.Value {
-													return interpreter.NewIntValueFromInt64(42)
+													return interpreter.UInt64Value(42)
 												},
 											),
 										},
@@ -122,7 +122,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.UInt64Value(42),
 		value,
 	)
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4551,7 +4551,16 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 	}
 
 	for _, fixedPointType := range sema.AllFixedPointTypes {
-		tests[fixedPointType.String()] = `1.23`
+
+		var literal string
+
+		if sema.IsSubType(fixedPointType, &sema.SignedFixedPointType{}) {
+			literal = "-1.23"
+		} else {
+			literal = "1.23"
+		}
+
+		tests[fixedPointType.String()] = literal
 	}
 
 	for ty, code := range tests {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -1489,7 +1489,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 				},
 			},
 			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				sema.IntType,
+				sema.VoidType,
 			),
 			RequiredArgumentCount: sema.RequiredArgumentCount(1),
 		},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4554,7 +4554,7 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 
 		var literal string
 
-		if sema.IsSubType(fixedPointType, &sema.SignedFixedPointType{}) {
+		if sema.IsSubType(fixedPointType, sema.SignedFixedPointType) {
 			literal = "-1.23"
 		} else {
 			literal = "1.23"
@@ -6923,7 +6923,7 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		require.ErrorAs(t, err, &interpreter.ForceAssignmentToNonNilResourceError{})
 	})
 
-	t.Run("new to non-nil", func(t *testing.T) {
+	t.Run("force-assignment initialization", func(t *testing.T) {
 
 		inter := parseCheckAndInterpret(t, `
 	     resource X {}

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -291,7 +291,7 @@ func TestInterpretTransactions(t *testing.T) {
 
 		values := inter.Globals["values"].GetValue()
 
-		require.IsType(t, values, &interpreter.ArrayValue{})
+		require.IsType(t, &interpreter.ArrayValue{}, values)
 
 		assert.Equal(t,
 			[]interpreter.Value{

--- a/runtime/tests/interpreter/transfer_test.go
+++ b/runtime/tests/interpreter/transfer_test.go
@@ -1,0 +1,82 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestInterpretTransferCheck(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &sema.CompositeType{
+		Location:   utils.TestLocation,
+		Identifier: "Fruit",
+		Kind:       common.CompositeKindStructure,
+	}
+
+	valueDeclarations := stdlib.StandardLibraryValues{
+		{
+			Name: "fruit",
+			Type: ty,
+			// NOTE: not an instance of the type
+			Value: interpreter.NewStringValue("fruit"),
+			Kind:  common.DeclarationKindConstant,
+		},
+	}
+
+	typeDeclarations := stdlib.StandardLibraryTypes{
+		{
+			Name: ty.Identifier,
+			Type: ty,
+			Kind: common.DeclarationKindStructure,
+		},
+	}
+
+	inter := parseCheckAndInterpretWithOptions(t,
+		`
+          fun test() {
+            let alsoFruit: Fruit = fruit
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			CheckerOptions: []sema.Option{
+				sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
+				sema.WithPredeclaredTypes(typeDeclarations.ToTypeDeclarations()),
+			},
+			Options: []interpreter.Option{
+				interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
+			},
+		},
+	)
+
+	_, err := inter.Invoke("test")
+	require.Error(t, err)
+
+	require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
+}


### PR DESCRIPTION
Port of dapperlabs/cadence-internal#3

## Description

- Extend the defensive run-time check that argument's dynamic type are a subtype to all value transfers, e.g. assignments. So e.g. when we copy what we believe to be a struct in e.g. an assignment (`=`), we also include a sanity check that we aren’t actually copying a resource.

  From Dete:
  > we should be liberal in including checks like this; we can optimize them out later But we should always focus on safety over performance … until we see performance problems, and then we can optimize the situations that come up while being mindful of safety."

- This detected a few bugs:
  - `SignedNumber` was accidentally a subtype of `SignedFixedPoint`. This was a "copy-and-paste typo" and should be the type itself, `SignedFixedPoint`
  - Some tests / host functions returned values of other types
  - Getting the dynamic type of an ephemeral reference didn't handle potential recursive reference

______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
