### PR TITLE
Handle cyclic references in dynamic type conformance check

### DIFF
--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -110,7 +110,7 @@ func (v BlockValue) String() string {
 	)
 }
 
-func (v BlockValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType) bool {
+func (v BlockValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	_, ok := dynamicType.(BlockDynamicType)
 	return ok
 }

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -101,7 +101,7 @@ func (DeployedContractValue) SetMember(_ *Interpreter, _ func() LocationRange, _
 	panic(errors.NewUnreachableError())
 }
 
-func (v DeployedContractValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType) bool {
+func (v DeployedContractValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	_, ok := dynamicType.(DeployedContractDynamicType)
 	return ok
 }

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -120,7 +120,7 @@ func (f InterpretedFunctionValue) Invoke(invocation Invocation) Value {
 	return f.Interpreter.invokeInterpretedFunction(f, invocation)
 }
 
-func (f InterpretedFunctionValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType) bool {
+func (f InterpretedFunctionValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType, _ TypeConformanceResults) bool {
 	// TODO: once FunctionDynamicType has parameter and return type info,
 	//   check it matches InterpretedFunctionValue's static function type
 	return false
@@ -203,7 +203,7 @@ func (f HostFunctionValue) SetMember(_ *Interpreter, _ func() LocationRange, _ s
 	panic(errors.NewUnreachableError())
 }
 
-func (f HostFunctionValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType) bool {
+func (f HostFunctionValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType, _ TypeConformanceResults) bool {
 	// TODO: once HostFunctionValue has static function type,
 	//   and FunctionDynamicType has parameter and return type info,
 	//   check they match
@@ -263,6 +263,10 @@ func (f BoundFunctionValue) Invoke(invocation Invocation) Value {
 	return f.Function.Invoke(invocation)
 }
 
-func (f BoundFunctionValue) ConformsToDynamicType(interpreter *Interpreter, dynamicType DynamicType) bool {
-	return f.Function.ConformsToDynamicType(interpreter, dynamicType)
+func (f BoundFunctionValue) ConformsToDynamicType(
+	interpreter *Interpreter,
+	dynamicType DynamicType,
+	results TypeConformanceResults,
+) bool {
+	return f.Function.ConformsToDynamicType(interpreter, dynamicType, results)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -544,7 +544,8 @@ func validateArgumentParams(
 		}
 
 		// Check whether the decoded value conforms to the type associated with the value
-		if !arg.ConformsToDynamicType(inter, dynamicType) {
+		conformanceResults := interpreter.TypeConformanceResults{}
+		if !arg.ConformsToDynamicType(inter, dynamicType, conformanceResults) {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: i,
 				Err: &MalformedValueError{


### PR DESCRIPTION
Closes #777

## Description

Ephemeral values can have cyclic references. e.g:
```
pub fun main() {
    var foo = Foo()
    var foo_ref = &foo as &Foo

    // Creates cyclic reference
     foo_ref.bar = foo_ref
}

pub struct Foo {

    pub(set) var bar: &Foo?

    init() {
        self.bar = nil
    }
}
```
This could cause the `ConformsToDynamicType` check to get stuck in an infinite recursion.

Even though  it is not possible to pass reference values as arguments to programs at the moment (and `ConformsToDynamicType` is only used in that path for now), this could be a potential problem in the future.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
