### PR TITLE
Implement equality for storable values and static types

### DIFF
--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -694,5 +694,5 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 		sum = sum.Plus(value).(interpreter.UFix64Value)
 	}
 
-	require.True(b, bool(mintAmountValue.Equal(nil, sum)))
+	require.True(b, bool(mintAmountValue.Equal(sum, nil, true)))
 }

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -238,29 +238,12 @@ func (interpreter *Interpreter) testEqual(left, right Value) BoolValue {
 	left = interpreter.unbox(left)
 	right = interpreter.unbox(right)
 
-	// TODO: add support for arrays and dictionaries
-
-	switch left := left.(type) {
-	case NilValue:
-		_, ok := right.(NilValue)
-		return BoolValue(ok)
-
-	case EquatableValue:
-		// NOTE: might be NilValue
-		right, ok := right.(EquatableValue)
-		if !ok {
-			return false
-		}
-		return BoolValue(left.Equal(right, interpreter, true))
-
-	case *ArrayValue,
-		*DictionaryValue:
-		// TODO:
-		return false
-
-	default:
+	leftEquatable, ok := left.(EquatableValue)
+	if !ok {
 		return false
 	}
+
+	return BoolValue(leftEquatable.Equal(right, interpreter, true))
 }
 
 func (interpreter *Interpreter) VisitUnaryExpression(expression *ast.UnaryExpression) ast.Repr {

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -251,7 +251,7 @@ func (interpreter *Interpreter) testEqual(left, right Value) BoolValue {
 		if !ok {
 			return false
 		}
-		return left.Equal(interpreter, right)
+		return BoolValue(left.Equal(right, interpreter, true))
 
 	case *ArrayValue,
 		*DictionaryValue:

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -184,7 +184,7 @@ func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.Switch
 		// If the test value and case values are equal,
 		// evaluate the case's statements
 
-		if testValue.Equal(interpreter, caseValue) {
+		if testValue.Equal(caseValue, interpreter, true) {
 			return runStatements()
 		}
 

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -29,6 +29,15 @@ import (
 
 type PrimitiveStaticType uint
 
+func (t PrimitiveStaticType) Equal(other StaticType) bool {
+	otherPrimitiveType, ok := other.(PrimitiveStaticType)
+	if !ok {
+		return false
+	}
+
+	return t == otherPrimitiveType
+}
+
 // !!! *WARNING* !!!
 //
 // Only add new types by:

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -206,11 +206,20 @@ func (t *RestrictedStaticType) String() string {
 
 func (t *RestrictedStaticType) Equal(other StaticType) bool {
 	otherRestrictedType, ok := other.(*RestrictedStaticType)
-	if !ok {
+	if !ok || len(t.Restrictions) != len(otherRestrictedType.Restrictions) {
 		return false
 	}
 
-	// TODO: restrictions
+outer:
+	for _, restriction := range t.Restrictions {
+		for _, otherRestriction := range t.Restrictions {
+			if restriction.Equal(otherRestriction) {
+				continue outer
+			}
+		}
+
+		return false
+	}
 
 	return t.Type.Equal(otherRestrictedType.Type)
 }

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -50,11 +50,10 @@ type CompositeStaticType struct {
 func (CompositeStaticType) IsStaticType() {}
 
 func (t CompositeStaticType) String() string {
-	return fmt.Sprintf(
-		"CompositeStaticType(Location: %s, QualifiedIdentifier: %s)",
-		t.Location,
-		t.QualifiedIdentifier,
-	)
+	if t.Location == nil {
+		return t.QualifiedIdentifier
+	}
+	return string(t.Location.TypeID(t.QualifiedIdentifier))
 }
 
 func (t CompositeStaticType) Equal(other StaticType) bool {
@@ -77,11 +76,10 @@ type InterfaceStaticType struct {
 func (InterfaceStaticType) IsStaticType() {}
 
 func (t InterfaceStaticType) String() string {
-	return fmt.Sprintf(
-		"InterfaceStaticType(Location: %s, QualifiedIdentifier: %s)",
-		t.Location,
-		t.QualifiedIdentifier,
-	)
+	if t.Location == nil {
+		return t.QualifiedIdentifier
+	}
+	return string(t.Location.TypeID(t.QualifiedIdentifier))
 }
 
 func (t InterfaceStaticType) Equal(other StaticType) bool {

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -37,6 +37,7 @@ import (
 type StaticType interface {
 	fmt.Stringer
 	IsStaticType()
+	Equal(other StaticType) bool
 }
 
 // CompositeStaticType
@@ -56,6 +57,16 @@ func (t CompositeStaticType) String() string {
 	)
 }
 
+func (t CompositeStaticType) Equal(other StaticType) bool {
+	otherCompositeType, ok := other.(CompositeStaticType)
+	if !ok {
+		return false
+	}
+
+	return common.LocationsMatch(otherCompositeType.Location, t.Location) &&
+		otherCompositeType.QualifiedIdentifier == t.QualifiedIdentifier
+}
+
 // InterfaceStaticType
 
 type InterfaceStaticType struct {
@@ -73,6 +84,16 @@ func (t InterfaceStaticType) String() string {
 	)
 }
 
+func (t InterfaceStaticType) Equal(other StaticType) bool {
+	otherInterfaceType, ok := other.(InterfaceStaticType)
+	if !ok {
+		return false
+	}
+
+	return common.LocationsMatch(otherInterfaceType.Location, t.Location) &&
+		otherInterfaceType.QualifiedIdentifier == t.QualifiedIdentifier
+}
+
 // VariableSizedStaticType
 
 type VariableSizedStaticType struct {
@@ -83,6 +104,15 @@ func (VariableSizedStaticType) IsStaticType() {}
 
 func (t VariableSizedStaticType) String() string {
 	return fmt.Sprintf("[%s]", t.Type)
+}
+
+func (t VariableSizedStaticType) Equal(other StaticType) bool {
+	otherVariableSizedType, ok := other.(VariableSizedStaticType)
+	if !ok {
+		return false
+	}
+
+	return t.Type.Equal(otherVariableSizedType.Type)
 }
 
 // ConstantSizedStaticType
@@ -98,6 +128,16 @@ func (t ConstantSizedStaticType) String() string {
 	return fmt.Sprintf("[%s; %d]", t.Type, t.Size)
 }
 
+func (t ConstantSizedStaticType) Equal(other StaticType) bool {
+	otherConstantSizedType, ok := other.(ConstantSizedStaticType)
+	if !ok {
+		return false
+	}
+
+	return t.Size == otherConstantSizedType.Size &&
+		t.Type.Equal(otherConstantSizedType.Type)
+}
+
 // DictionaryStaticType
 
 type DictionaryStaticType struct {
@@ -111,6 +151,16 @@ func (t DictionaryStaticType) String() string {
 	return fmt.Sprintf("{%s: %s}", t.KeyType, t.ValueType)
 }
 
+func (t DictionaryStaticType) Equal(other StaticType) bool {
+	otherDictionaryType, ok := other.(DictionaryStaticType)
+	if !ok {
+		return false
+	}
+
+	return t.KeyType.Equal(otherDictionaryType.KeyType) &&
+		t.ValueType.Equal(otherDictionaryType.ValueType)
+}
+
 // OptionalStaticType
 
 type OptionalStaticType struct {
@@ -121,6 +171,15 @@ func (OptionalStaticType) IsStaticType() {}
 
 func (t OptionalStaticType) String() string {
 	return fmt.Sprintf("%s?", t.Type)
+}
+
+func (t OptionalStaticType) Equal(other StaticType) bool {
+	otherOptionalType, ok := other.(OptionalStaticType)
+	if !ok {
+		return false
+	}
+
+	return t.Type.Equal(otherOptionalType.Type)
 }
 
 // RestrictedStaticType
@@ -147,6 +206,17 @@ func (t *RestrictedStaticType) String() string {
 	return fmt.Sprintf("%s{%s}", t.Type, strings.Join(restrictions, ", "))
 }
 
+func (t *RestrictedStaticType) Equal(other StaticType) bool {
+	otherRestrictedType, ok := other.(*RestrictedStaticType)
+	if !ok {
+		return false
+	}
+
+	// TODO: restrictions
+
+	return t.Type.Equal(otherRestrictedType.Type)
+}
+
 // ReferenceStaticType
 
 type ReferenceStaticType struct {
@@ -165,6 +235,16 @@ func (t ReferenceStaticType) String() string {
 	return fmt.Sprintf("%s&%s", auth, t.Type)
 }
 
+func (t ReferenceStaticType) Equal(other StaticType) bool {
+	otherReferenceType, ok := other.(ReferenceStaticType)
+	if !ok {
+		return false
+	}
+
+	return t.Authorized == otherReferenceType.Authorized &&
+		t.Type.Equal(otherReferenceType.Type)
+}
+
 // CapabilityStaticType
 
 type CapabilityStaticType struct {
@@ -178,6 +258,22 @@ func (t CapabilityStaticType) String() string {
 		return fmt.Sprintf("Capability<%s>", t.BorrowType)
 	}
 	return "Capability"
+}
+
+func (t CapabilityStaticType) Equal(other StaticType) bool {
+	otherCapabilityType, ok := other.(*CapabilityStaticType)
+	if !ok {
+		return false
+	}
+
+	// The borrow types must either be both nil,
+	// or they must be equal
+
+	if t.BorrowType == nil {
+		return otherCapabilityType.BorrowType == nil
+	}
+
+	return t.BorrowType.Equal(otherCapabilityType.BorrowType)
 }
 
 // Conversion

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -212,7 +212,7 @@ func (t *RestrictedStaticType) Equal(other StaticType) bool {
 
 outer:
 	for _, restriction := range t.Restrictions {
-		for _, otherRestriction := range t.Restrictions {
+		for _, otherRestriction := range otherRestrictedType.Restrictions {
 			if restriction.Equal(otherRestriction) {
 				continue outer
 			}

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -259,7 +259,7 @@ func (t CapabilityStaticType) String() string {
 }
 
 func (t CapabilityStaticType) Equal(other StaticType) bool {
-	otherCapabilityType, ok := other.(*CapabilityStaticType)
+	otherCapabilityType, ok := other.(CapabilityStaticType)
 	if !ok {
 		return false
 	}

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -881,6 +881,41 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 		)
 	})
 
+	t.Run("different restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeInt,
+				Restrictions: []InterfaceStaticType{
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "X",
+					},
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "Y",
+					},
+				},
+			}).Equal(
+				&RestrictedStaticType{
+					Type: PrimitiveStaticTypeInt,
+					Restrictions: []InterfaceStaticType{
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "X",
+						},
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "Z",
+						},
+					},
+				},
+			),
+		)
+	})
+
 	t.Run("different kind", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -1,0 +1,908 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestCapabilityStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal, borrow type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			CapabilityStaticType{
+				BorrowType: PrimitiveStaticTypeString,
+			}.Equal(
+				CapabilityStaticType{
+					BorrowType: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("equal, no borrow type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t, CapabilityStaticType{}.Equal(CapabilityStaticType{}))
+	})
+
+	t.Run("unequal, self no borrow type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CapabilityStaticType{}.Equal(
+				CapabilityStaticType{
+					BorrowType: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("unequal, other no borrow type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CapabilityStaticType{
+				BorrowType: PrimitiveStaticTypeString,
+			}.Equal(
+				CapabilityStaticType{},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CapabilityStaticType{
+				BorrowType: PrimitiveStaticTypeString,
+			}.Equal(
+				ReferenceStaticType{
+					Type: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+}
+
+func TestReferenceStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			ReferenceStaticType{
+				Authorized: false,
+				Type:       PrimitiveStaticTypeString,
+			}.Equal(
+				ReferenceStaticType{
+					Authorized: false,
+					Type:       PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			ReferenceStaticType{
+				Authorized: false,
+				Type:       PrimitiveStaticTypeInt,
+			}.Equal(
+				ReferenceStaticType{
+					Authorized: false,
+					Type:       PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different auth", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			ReferenceStaticType{
+				Authorized: false,
+				Type:       PrimitiveStaticTypeInt,
+			}.Equal(
+				ReferenceStaticType{
+					Authorized: true,
+					Type:       PrimitiveStaticTypeInt,
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			ReferenceStaticType{
+				Type: PrimitiveStaticTypeString,
+			}.Equal(
+				CapabilityStaticType{
+					BorrowType: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+}
+
+func TestCompositeStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			CompositeStaticType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            utils.TestLocation,
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("different name", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CompositeStaticType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            utils.TestLocation,
+					QualifiedIdentifier: "Y",
+				},
+			),
+		)
+	})
+
+	t.Run("different locations, different identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CompositeStaticType{
+				Location:            common.IdentifierLocation("A"),
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            common.IdentifierLocation("B"),
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("different locations, different identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CompositeStaticType{
+				Location:            common.IdentifierLocation("A"),
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            common.StringLocation("A"),
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("no location", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			CompositeStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            nil,
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("no location, different identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CompositeStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            nil,
+					QualifiedIdentifier: "Y",
+				},
+			),
+		)
+	})
+
+	t.Run("one location, same identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CompositeStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            common.StringLocation("B"),
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CompositeStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            nil,
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+}
+
+func TestInterfaceStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			InterfaceStaticType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            utils.TestLocation,
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("different name", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			InterfaceStaticType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            utils.TestLocation,
+					QualifiedIdentifier: "Y",
+				},
+			),
+		)
+	})
+
+	t.Run("different locations, different identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			InterfaceStaticType{
+				Location:            common.IdentifierLocation("A"),
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            common.IdentifierLocation("B"),
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("different locations, different identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			InterfaceStaticType{
+				Location:            common.IdentifierLocation("A"),
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            common.StringLocation("A"),
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("no location", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			InterfaceStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            nil,
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("no location, different identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			InterfaceStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            nil,
+					QualifiedIdentifier: "Y",
+				},
+			),
+		)
+	})
+
+	t.Run("one location, same identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			InterfaceStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				InterfaceStaticType{
+					Location:            common.StringLocation("B"),
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			InterfaceStaticType{
+				Location:            nil,
+				QualifiedIdentifier: "X",
+			}.Equal(
+				CompositeStaticType{
+					Location:            nil,
+					QualifiedIdentifier: "X",
+				},
+			),
+		)
+	})
+}
+
+func TestConstantSizedStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			ConstantSizedStaticType{
+				Type: PrimitiveStaticTypeString,
+				Size: 10,
+			}.Equal(
+				ConstantSizedStaticType{
+					Type: PrimitiveStaticTypeString,
+					Size: 10,
+				},
+			),
+		)
+	})
+
+	t.Run("different sizes", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			ConstantSizedStaticType{
+				Type: PrimitiveStaticTypeString,
+				Size: 20,
+			}.Equal(
+				ConstantSizedStaticType{
+					Type: PrimitiveStaticTypeString,
+					Size: 10,
+				},
+			),
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			ConstantSizedStaticType{
+				Type: PrimitiveStaticTypeInt,
+				Size: 10,
+			}.Equal(
+				ConstantSizedStaticType{
+					Type: PrimitiveStaticTypeString,
+					Size: 10,
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			ConstantSizedStaticType{
+				Type: PrimitiveStaticTypeInt,
+				Size: 10,
+			}.Equal(
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeInt,
+				},
+			),
+		)
+	})
+}
+
+func TestVariableSizedStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			VariableSizedStaticType{
+				Type: PrimitiveStaticTypeString,
+			}.Equal(
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			VariableSizedStaticType{
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				ConstantSizedStaticType{
+					Type: PrimitiveStaticTypeInt,
+					Size: 10,
+				},
+			),
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			VariableSizedStaticType{
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+}
+
+func TestPrimitiveStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			PrimitiveStaticTypeString.
+				Equal(PrimitiveStaticTypeString),
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			PrimitiveStaticTypeInt.
+				Equal(PrimitiveStaticTypeString),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			PrimitiveStaticTypeInt.
+				Equal(CapabilityStaticType{}),
+		)
+	})
+}
+
+func TestOptionalStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			OptionalStaticType{
+				Type: PrimitiveStaticTypeString,
+			}.Equal(
+				OptionalStaticType{
+					Type: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			OptionalStaticType{
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				OptionalStaticType{
+					Type: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			OptionalStaticType{
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeInt,
+				},
+			),
+		)
+	})
+}
+
+func TestDictionaryStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeInt,
+				ValueType: PrimitiveStaticTypeString,
+			}.Equal(
+				DictionaryStaticType{
+					KeyType:   PrimitiveStaticTypeInt,
+					ValueType: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different key types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeInt,
+				ValueType: PrimitiveStaticTypeString,
+			}.Equal(
+				DictionaryStaticType{
+					KeyType:   PrimitiveStaticTypeVoid,
+					ValueType: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different value types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeInt,
+				ValueType: PrimitiveStaticTypeVoid,
+			}.Equal(
+				DictionaryStaticType{
+					KeyType:   PrimitiveStaticTypeInt,
+					ValueType: PrimitiveStaticTypeString,
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeInt,
+				ValueType: PrimitiveStaticTypeVoid,
+			}.Equal(
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeInt,
+				},
+			),
+		)
+	})
+}
+
+func TestRestrictedStaticType_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeInt,
+				Restrictions: []InterfaceStaticType{
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "X",
+					},
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "Y",
+					},
+				},
+			}).Equal(
+				&RestrictedStaticType{
+					Type: PrimitiveStaticTypeInt,
+					Restrictions: []InterfaceStaticType{
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "Y",
+						},
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "X",
+						},
+					},
+				},
+			),
+		)
+	})
+
+	t.Run("equal, no restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			(&RestrictedStaticType{
+				Type:         PrimitiveStaticTypeInt,
+				Restrictions: []InterfaceStaticType{},
+			}).Equal(
+				&RestrictedStaticType{
+					Type:         PrimitiveStaticTypeInt,
+					Restrictions: []InterfaceStaticType{},
+				},
+			),
+		)
+	})
+
+	t.Run("different restricted type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeString,
+				Restrictions: []InterfaceStaticType{
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "X",
+					},
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "Y",
+					},
+				},
+			}).Equal(
+				&RestrictedStaticType{
+					Type: PrimitiveStaticTypeInt,
+					Restrictions: []InterfaceStaticType{
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "Y",
+						},
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "X",
+						},
+					},
+				},
+			),
+		)
+	})
+
+	t.Run("fewer restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeInt,
+				Restrictions: []InterfaceStaticType{
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "X",
+					},
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "Y",
+					},
+				},
+			}).Equal(
+				&RestrictedStaticType{
+					Type: PrimitiveStaticTypeInt,
+					Restrictions: []InterfaceStaticType{
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "Y",
+						},
+					},
+				},
+			),
+		)
+	})
+
+	t.Run("more restrictions", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeInt,
+				Restrictions: []InterfaceStaticType{
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "X",
+					},
+				},
+			}).Equal(
+				&RestrictedStaticType{
+					Type: PrimitiveStaticTypeInt,
+					Restrictions: []InterfaceStaticType{
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "Y",
+						},
+						{
+							Location:            utils.TestLocation,
+							QualifiedIdentifier: "X",
+						},
+					},
+				},
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeInt,
+				Restrictions: []InterfaceStaticType{
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "X",
+					},
+					{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "Y",
+					},
+				},
+			}).Equal(
+				ReferenceStaticType{
+					Type: PrimitiveStaticTypeInt,
+				},
+			),
+		)
+	})
+}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -92,7 +92,7 @@ type AllAppendableValue interface {
 
 type EquatableValue interface {
 	Value
-	Equal(interpreter *Interpreter, other Value) BoolValue
+	Equal(other Value, interpreter *Interpreter, deferred bool) bool
 }
 
 // DestroyableValue
@@ -158,7 +158,7 @@ func (v TypeValue) String() string {
 	return format.TypeValue(typeString)
 }
 
-func (v TypeValue) Equal(inter *Interpreter, other Value) BoolValue {
+func (v TypeValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherTypeValue, ok := other.(TypeValue)
 	if !ok {
 		return false
@@ -173,10 +173,7 @@ func (v TypeValue) Equal(inter *Interpreter, other Value) BoolValue {
 		return false
 	}
 
-	ty := inter.ConvertStaticToSemaType(staticType)
-	otherTy := inter.ConvertStaticToSemaType(otherStaticType)
-
-	return BoolValue(ty.Equal(otherTy))
+	return staticType.Equal(otherStaticType)
 }
 
 func (v TypeValue) GetMember(inter *Interpreter, _ func() LocationRange, name string) Value {
@@ -293,7 +290,7 @@ func (v BoolValue) Negate() BoolValue {
 	return !v
 }
 
-func (v BoolValue) Equal(_ *Interpreter, other Value) BoolValue {
+func (v BoolValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherBool, ok := other.(BoolValue)
 	if !ok {
 		return false
@@ -374,7 +371,7 @@ func (v *StringValue) KeyString() string {
 	return v.Str
 }
 
-func (v *StringValue) Equal(_ *Interpreter, other Value) BoolValue {
+func (v *StringValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherString, ok := other.(*StringValue)
 	if !ok {
 		return false
@@ -726,7 +723,7 @@ func (v *ArrayValue) Contains(needleValue Value) BoolValue {
 	needleEquatable := needleValue.(EquatableValue)
 
 	for _, arrayValue := range v.Values {
-		if needleEquatable.Equal(nil, arrayValue) {
+		if needleEquatable.Equal(arrayValue, nil, true) {
 			return true
 		}
 	}
@@ -829,6 +826,28 @@ func (v *ArrayValue) ConformsToDynamicType(
 
 	for index, element := range v.Values {
 		if !element.ConformsToDynamicType(interpreter, arrayType.ElementTypes[index], results) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (v *ArrayValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+	otherArray, ok := other.(*ArrayValue)
+	if !ok {
+		return false
+	}
+
+	if len(v.Values) != len(otherArray.Values) {
+		return false
+	}
+
+	for i, value := range v.Values {
+		otherValue := otherArray.Values[i]
+
+		equatableValue, ok := value.(EquatableValue)
+		if !ok || !equatableValue.Equal(otherValue, interpreter, deferred) {
 			return false
 		}
 	}
@@ -1018,7 +1037,7 @@ func (v IntValue) GreaterEqual(other NumberValue) BoolValue {
 	return cmp >= 0
 }
 
-func (v IntValue) Equal(_ *Interpreter, other Value) BoolValue {
+func (v IntValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt, ok := other.(IntValue)
 	if !ok {
 		return false
@@ -1253,7 +1272,7 @@ func (v Int8Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Int8Value)
 }
 
-func (v Int8Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Int8Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt8, ok := other.(Int8Value)
 	if !ok {
 		return false
@@ -1494,7 +1513,7 @@ func (v Int16Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Int16Value)
 }
 
-func (v Int16Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Int16Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt16, ok := other.(Int16Value)
 	if !ok {
 		return false
@@ -1737,7 +1756,7 @@ func (v Int32Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Int32Value)
 }
 
-func (v Int32Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Int32Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt32, ok := other.(Int32Value)
 	if !ok {
 		return false
@@ -1984,7 +2003,7 @@ func (v Int64Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Int64Value)
 }
 
-func (v Int64Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Int64Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt64, ok := other.(Int64Value)
 	if !ok {
 		return false
@@ -2264,7 +2283,7 @@ func (v Int128Value) GreaterEqual(other NumberValue) BoolValue {
 	return cmp >= 0
 }
 
-func (v Int128Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Int128Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt, ok := other.(Int128Value)
 	if !ok {
 		return false
@@ -2565,7 +2584,7 @@ func (v Int256Value) GreaterEqual(other NumberValue) BoolValue {
 	return cmp >= 0
 }
 
-func (v Int256Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Int256Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt, ok := other.(Int256Value)
 	if !ok {
 		return false
@@ -2835,7 +2854,7 @@ func (v UIntValue) GreaterEqual(other NumberValue) BoolValue {
 	return cmp >= 0
 }
 
-func (v UIntValue) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UIntValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherUInt, ok := other.(UIntValue)
 	if !ok {
 		return false
@@ -3038,7 +3057,7 @@ func (v UInt8Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(UInt8Value)
 }
 
-func (v UInt8Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UInt8Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherUInt8, ok := other.(UInt8Value)
 	if !ok {
 		return false
@@ -3245,7 +3264,7 @@ func (v UInt16Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(UInt16Value)
 }
 
-func (v UInt16Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UInt16Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherUInt16, ok := other.(UInt16Value)
 	if !ok {
 		return false
@@ -3456,7 +3475,7 @@ func (v UInt32Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(UInt32Value)
 }
 
-func (v UInt32Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UInt32Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherUInt32, ok := other.(UInt32Value)
 	if !ok {
 		return false
@@ -3672,7 +3691,7 @@ func (v UInt64Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(UInt64Value)
 }
 
-func (v UInt64Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UInt64Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherUInt64, ok := other.(UInt64Value)
 	if !ok {
 		return false
@@ -3926,7 +3945,7 @@ func (v UInt128Value) GreaterEqual(other NumberValue) BoolValue {
 	return cmp >= 0
 }
 
-func (v UInt128Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UInt128Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt, ok := other.(UInt128Value)
 	if !ok {
 		return false
@@ -4196,7 +4215,7 @@ func (v UInt256Value) GreaterEqual(other NumberValue) BoolValue {
 	return cmp >= 0
 }
 
-func (v UInt256Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UInt256Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherInt, ok := other.(UInt256Value)
 	if !ok {
 		return false
@@ -4408,7 +4427,7 @@ func (v Word8Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Word8Value)
 }
 
-func (v Word8Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Word8Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherWord8, ok := other.(Word8Value)
 	if !ok {
 		return false
@@ -4576,7 +4595,7 @@ func (v Word16Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Word16Value)
 }
 
-func (v Word16Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Word16Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherWord16, ok := other.(Word16Value)
 	if !ok {
 		return false
@@ -4748,7 +4767,7 @@ func (v Word32Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Word32Value)
 }
 
-func (v Word32Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Word32Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherWord32, ok := other.(Word32Value)
 	if !ok {
 		return false
@@ -4920,7 +4939,7 @@ func (v Word64Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Word64Value)
 }
 
-func (v Word64Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Word64Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherWord64, ok := other.(Word64Value)
 	if !ok {
 		return false
@@ -5139,7 +5158,7 @@ func (v Fix64Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(Fix64Value)
 }
 
-func (v Fix64Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v Fix64Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherFix64, ok := other.(Fix64Value)
 	if !ok {
 		return false
@@ -5353,7 +5372,7 @@ func (v UFix64Value) GreaterEqual(other NumberValue) BoolValue {
 	return v >= other.(UFix64Value)
 }
 
-func (v UFix64Value) Equal(_ *Interpreter, other Value) BoolValue {
+func (v UFix64Value) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherUFix64, ok := other.(UFix64Value)
 	if !ok {
 		return false
@@ -5781,23 +5800,35 @@ func (v *CompositeValue) GetField(name string) Value {
 	return value
 }
 
-func (v *CompositeValue) Equal(interpreter *Interpreter, other Value) BoolValue {
-	// TODO: add support for other composite kinds
-
-	if v.Kind != common.CompositeKindEnum {
-		return false
-	}
-
+func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
 	otherComposite, ok := other.(*CompositeValue)
 	if !ok {
 		return false
 	}
 
-	rawValue, _ := v.Fields.Get(sema.EnumRawValueFieldName)
-	otherRawValue, _ := otherComposite.Fields.Get(sema.EnumRawValueFieldName)
+	if !v.StaticType().Equal(otherComposite.StaticType()) ||
+		v.Kind != otherComposite.Kind ||
+		v.Fields.Len() != otherComposite.Fields.Len() {
 
-	return rawValue.(NumberValue).
-		Equal(interpreter, otherRawValue)
+		return false
+	}
+
+	for pair := v.Fields.Oldest(); pair != nil; pair = pair.Next() {
+		key := pair.Key
+		value := pair.Value
+
+		otherValue, ok := otherComposite.Fields.Get(key)
+		if !ok {
+			return false
+		}
+
+		equatableValue, ok := value.(EquatableValue)
+		if !ok || !equatableValue.Equal(otherValue, interpreter, deferred) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (v *CompositeValue) KeyString() string {
@@ -6347,6 +6378,46 @@ func (v *DictionaryValue) ConformsToDynamicType(
 	return true
 }
 
+func (v *DictionaryValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+	otherDictionary, ok := other.(*DictionaryValue)
+	if !ok {
+		return false
+	}
+
+	if !v.Keys.Equal(otherDictionary.Keys, interpreter, deferred) {
+		return false
+	}
+
+	for i, keyValue := range v.Keys.Values {
+		otherKeyValue := otherDictionary.Keys.Values[i]
+
+		var value, otherValue Value
+		var valueExists, otherValueExists bool
+
+		if deferred {
+			value = v.Get(interpreter, nil, keyValue)
+			valueExists = true
+
+			otherValue = otherDictionary.Get(interpreter, nil, otherKeyValue)
+			otherValueExists = true
+		} else {
+			value, valueExists = v.Entries.Get(dictionaryKey(keyValue))
+			otherValue, otherValueExists = otherDictionary.Entries.Get(dictionaryKey(otherKeyValue))
+		}
+
+		if valueExists {
+			equatableValue, ok := value.(EquatableValue)
+			if !ok || !equatableValue.Equal(otherValue, interpreter, deferred) {
+				return false
+			}
+		} else if otherValueExists {
+			return false
+		}
+	}
+
+	return true
+}
+
 // OptionalValue
 
 type OptionalValue interface {
@@ -6426,6 +6497,11 @@ func (NilValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Va
 
 func (v NilValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	_, ok := dynamicType.(NilDynamicType)
+	return ok
+}
+
+func (v NilValue) Equal(other Value, _ *Interpreter, _ bool) bool {
+	_, ok := other.(NilValue)
 	return ok
 }
 
@@ -6546,6 +6622,20 @@ func (v SomeValue) ConformsToDynamicType(
 ) bool {
 	someType, ok := dynamicType.(SomeDynamicType)
 	return ok && v.Value.ConformsToDynamicType(interpreter, someType.InnerType, results)
+}
+
+func (v *SomeValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+	otherSome, ok := other.(*SomeValue)
+	if !ok {
+		return false
+	}
+
+	equatableValue, ok := v.Value.(EquatableValue)
+	if !ok {
+		return false
+	}
+
+	return equatableValue.Equal(otherSome.Value, interpreter, deferred)
 }
 
 // StorageReferenceValue
@@ -6681,7 +6771,7 @@ func (v *StorageReferenceValue) Set(interpreter *Interpreter, getLocationRange f
 		Set(interpreter, getLocationRange, key, value)
 }
 
-func (v *StorageReferenceValue) Equal(_ *Interpreter, other Value) BoolValue {
+func (v *StorageReferenceValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherReference, ok := other.(*StorageReferenceValue)
 	if !ok {
 		return false
@@ -6824,7 +6914,7 @@ func (v *EphemeralReferenceValue) Set(interpreter *Interpreter, getLocationRange
 		Set(interpreter, getLocationRange, key, value)
 }
 
-func (v *EphemeralReferenceValue) Equal(_ *Interpreter, other Value) BoolValue {
+func (v *EphemeralReferenceValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherReference, ok := other.(*EphemeralReferenceValue)
 	if !ok {
 		return false
@@ -6945,7 +7035,7 @@ func (AddressValue) SetModified(_ bool) {
 	// NO-OP
 }
 
-func (v AddressValue) Equal(_ *Interpreter, other Value) BoolValue {
+func (v AddressValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	otherAddress, ok := other.(AddressValue)
 	if !ok {
 		return false
@@ -7229,6 +7319,16 @@ func (v PathValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType
 	}
 }
 
+func (v PathValue) Equal(other Value, _ *Interpreter, _ bool) bool {
+	otherPath, ok := other.(PathValue)
+	if !ok {
+		return false
+	}
+
+	return otherPath.Identifier == v.Identifier &&
+		otherPath.Domain == v.Domain
+}
+
 // CapabilityValue
 
 type CapabilityValue struct {
@@ -7329,6 +7429,26 @@ func (v CapabilityValue) ConformsToDynamicType(_ *Interpreter, dynamicType Dynam
 	return ok
 }
 
+func (v CapabilityValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+	otherCapability, ok := other.(CapabilityValue)
+	if !ok {
+		return false
+	}
+
+	// BorrowType is optional
+
+	if v.BorrowType == nil {
+		if otherCapability.BorrowType != nil {
+			return false
+		}
+	} else if !v.BorrowType.Equal(otherCapability.BorrowType) {
+		return false
+	}
+
+	return otherCapability.Address.Equal(v.Address, interpreter, deferred) &&
+		otherCapability.Path.Equal(v.Path, interpreter, deferred)
+}
+
 // LinkValue
 
 type LinkValue struct {
@@ -7383,7 +7503,20 @@ func (v LinkValue) String() string {
 }
 
 func (v LinkValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType, _ TypeConformanceResults) bool {
+	// There is no dynamic type for links,
+	// as they are not first-class values in programs,
+	// but only stored
 	return false
+}
+
+func (v LinkValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+	otherLink, ok := other.(LinkValue)
+	if !ok {
+		return false
+	}
+
+	return otherLink.TargetPath.Equal(v.TargetPath, interpreter, deferred) &&
+		otherLink.Type.Equal(v.Type)
 }
 
 // NewAccountKeyValue constructs an AccountKey value.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -92,7 +92,7 @@ type AllAppendableValue interface {
 
 type EquatableValue interface {
 	Value
-	Equal(other Value, interpreter *Interpreter, deferred bool) bool
+	Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool
 }
 
 // DestroyableValue
@@ -833,7 +833,7 @@ func (v *ArrayValue) ConformsToDynamicType(
 	return true
 }
 
-func (v *ArrayValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+func (v *ArrayValue) Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool {
 	otherArray, ok := other.(*ArrayValue)
 	if !ok {
 		return false
@@ -847,7 +847,7 @@ func (v *ArrayValue) Equal(other Value, interpreter *Interpreter, deferred bool)
 		otherValue := otherArray.Values[i]
 
 		equatableValue, ok := value.(EquatableValue)
-		if !ok || !equatableValue.Equal(otherValue, interpreter, deferred) {
+		if !ok || !equatableValue.Equal(otherValue, interpreter, loadDeferred) {
 			return false
 		}
 	}
@@ -5800,7 +5800,7 @@ func (v *CompositeValue) GetField(name string) Value {
 	return value
 }
 
-func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool {
 	otherComposite, ok := other.(*CompositeValue)
 	if !ok {
 		return false
@@ -5823,7 +5823,7 @@ func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, deferred b
 		}
 
 		equatableValue, ok := value.(EquatableValue)
-		if !ok || !equatableValue.Equal(otherValue, interpreter, deferred) {
+		if !ok || !equatableValue.Equal(otherValue, interpreter, loadDeferred) {
 			return false
 		}
 	}
@@ -6378,13 +6378,13 @@ func (v *DictionaryValue) ConformsToDynamicType(
 	return true
 }
 
-func (v *DictionaryValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+func (v *DictionaryValue) Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool {
 	otherDictionary, ok := other.(*DictionaryValue)
 	if !ok {
 		return false
 	}
 
-	if !v.Keys.Equal(otherDictionary.Keys, interpreter, deferred) {
+	if !v.Keys.Equal(otherDictionary.Keys, interpreter, loadDeferred) {
 		return false
 	}
 
@@ -6394,7 +6394,7 @@ func (v *DictionaryValue) Equal(other Value, interpreter *Interpreter, deferred 
 		var value, otherValue Value
 		var valueExists, otherValueExists bool
 
-		if deferred {
+		if loadDeferred {
 			value = v.Get(interpreter, nil, keyValue)
 			valueExists = true
 
@@ -6407,7 +6407,7 @@ func (v *DictionaryValue) Equal(other Value, interpreter *Interpreter, deferred 
 
 		if valueExists {
 			equatableValue, ok := value.(EquatableValue)
-			if !ok || !equatableValue.Equal(otherValue, interpreter, deferred) {
+			if !ok || !equatableValue.Equal(otherValue, interpreter, loadDeferred) {
 				return false
 			}
 		} else if otherValueExists {
@@ -6624,7 +6624,7 @@ func (v SomeValue) ConformsToDynamicType(
 	return ok && v.Value.ConformsToDynamicType(interpreter, someType.InnerType, results)
 }
 
-func (v *SomeValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+func (v *SomeValue) Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool {
 	otherSome, ok := other.(*SomeValue)
 	if !ok {
 		return false
@@ -6635,7 +6635,7 @@ func (v *SomeValue) Equal(other Value, interpreter *Interpreter, deferred bool) 
 		return false
 	}
 
-	return equatableValue.Equal(otherSome.Value, interpreter, deferred)
+	return equatableValue.Equal(otherSome.Value, interpreter, loadDeferred)
 }
 
 // StorageReferenceValue
@@ -7429,7 +7429,7 @@ func (v CapabilityValue) ConformsToDynamicType(_ *Interpreter, dynamicType Dynam
 	return ok
 }
 
-func (v CapabilityValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+func (v CapabilityValue) Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool {
 	otherCapability, ok := other.(CapabilityValue)
 	if !ok {
 		return false
@@ -7445,8 +7445,8 @@ func (v CapabilityValue) Equal(other Value, interpreter *Interpreter, deferred b
 		return false
 	}
 
-	return otherCapability.Address.Equal(v.Address, interpreter, deferred) &&
-		otherCapability.Path.Equal(v.Path, interpreter, deferred)
+	return otherCapability.Address.Equal(v.Address, interpreter, loadDeferred) &&
+		otherCapability.Path.Equal(v.Path, interpreter, loadDeferred)
 }
 
 // LinkValue
@@ -7509,13 +7509,13 @@ func (v LinkValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType, _ TypeCo
 	return false
 }
 
-func (v LinkValue) Equal(other Value, interpreter *Interpreter, deferred bool) bool {
+func (v LinkValue) Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool {
 	otherLink, ok := other.(LinkValue)
 	if !ok {
 		return false
 	}
 
-	return otherLink.TargetPath.Equal(v.TargetPath, interpreter, deferred) &&
+	return otherLink.TargetPath.Equal(v.TargetPath, interpreter, loadDeferred) &&
 		otherLink.Type.Equal(v.Type)
 }
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -19,6 +19,7 @@
 package interpreter
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -906,4 +907,1176 @@ func TestEphemeralReferenceTypeConformance(t *testing.T) {
 	// Check against a non-conforming type
 	conforms = value.ConformsToDynamicType(inter, EphemeralReferenceDynamicType{}, TypeConformanceResults{})
 	assert.False(t, conforms)
+}
+
+func TestCapabilityValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal, borrow type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			CapabilityValue{
+				Address: AddressValue{0x1},
+				Path: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+				BorrowType: PrimitiveStaticTypeInt,
+			}.Equal(
+				CapabilityValue{
+					Address: AddressValue{0x1},
+					Path: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test",
+					},
+					BorrowType: PrimitiveStaticTypeInt,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("equal, no borrow type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			CapabilityValue{
+				Address: AddressValue{0x1},
+				Path: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+			}.Equal(
+				CapabilityValue{
+					Address: AddressValue{0x1},
+					Path: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test",
+					},
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different paths", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CapabilityValue{
+				Address: AddressValue{0x1},
+				Path: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test1",
+				},
+				BorrowType: PrimitiveStaticTypeInt,
+			}.Equal(
+				CapabilityValue{
+					Address: AddressValue{0x1},
+					Path: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test2",
+					},
+					BorrowType: PrimitiveStaticTypeInt,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different addresses", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CapabilityValue{
+				Address: AddressValue{0x1},
+				Path: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+				BorrowType: PrimitiveStaticTypeInt,
+			}.Equal(
+				CapabilityValue{
+					Address: AddressValue{0x2},
+					Path: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test",
+					},
+					BorrowType: PrimitiveStaticTypeInt,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different borrow types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CapabilityValue{
+				Address: AddressValue{0x1},
+				Path: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+				BorrowType: PrimitiveStaticTypeInt,
+			}.Equal(
+				CapabilityValue{
+					Address: AddressValue{0x1},
+					Path: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test",
+					},
+					BorrowType: PrimitiveStaticTypeString,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			CapabilityValue{
+				Address: AddressValue{0x1},
+				Path: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+				BorrowType: PrimitiveStaticTypeInt,
+			}.Equal(
+				NewStringValue("test"),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestAddressValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			AddressValue{0x1}.Equal(
+				AddressValue{0x1},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			AddressValue{0x1}.Equal(
+				AddressValue{0x2},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			AddressValue{0x1}.Equal(
+				UInt8Value(1),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestBoolValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal true", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			BoolValue(true).Equal(
+				BoolValue(true),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("equal false", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			BoolValue(false).Equal(
+				BoolValue(false),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			BoolValue(true).Equal(
+				BoolValue(false),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			BoolValue(true).Equal(
+				UInt8Value(1),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestStringValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			NewStringValue("test").Equal(
+				NewStringValue("test"),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewStringValue("test").Equal(
+				NewStringValue("foo"),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewStringValue("1").Equal(
+				UInt8Value(1),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestNilValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			NilValue{}.Equal(
+				NilValue{},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NilValue{}.Equal(
+				UInt8Value(0),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestSomeValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			NewSomeValueOwningNonCopying(NewStringValue("test")).Equal(
+				NewSomeValueOwningNonCopying(NewStringValue("test")),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewSomeValueOwningNonCopying(NewStringValue("test")).Equal(
+				NewSomeValueOwningNonCopying(NewStringValue("foo")),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewSomeValueOwningNonCopying(NewStringValue("1")).Equal(
+				UInt8Value(1),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestTypeValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			TypeValue{
+				Type: PrimitiveStaticTypeString,
+			}.Equal(
+				TypeValue{
+					Type: PrimitiveStaticTypeString,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			TypeValue{
+				Type: PrimitiveStaticTypeString,
+			}.Equal(
+				TypeValue{
+					Type: PrimitiveStaticTypeInt,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			TypeValue{
+				Type: PrimitiveStaticTypeString,
+			}.Equal(
+				NewStringValue("String"),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestPathValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	for _, domain := range common.AllPathDomains {
+
+		t.Run(fmt.Sprintf("equal, %s", domain), func(t *testing.T) {
+
+			require.True(t,
+				PathValue{
+					Domain:     domain,
+					Identifier: "test",
+				}.Equal(
+					PathValue{
+						Domain:     domain,
+						Identifier: "test",
+					},
+					nil,
+					true,
+				),
+			)
+		})
+	}
+
+	for _, domain := range common.AllPathDomains {
+		for _, otherDomain := range common.AllPathDomains {
+
+			if domain == otherDomain {
+				continue
+			}
+
+			t.Run(fmt.Sprintf("different domains %s %s", domain, otherDomain), func(t *testing.T) {
+
+				require.False(t,
+					PathValue{
+						Domain:     domain,
+						Identifier: "test",
+					}.Equal(
+						PathValue{
+							Domain:     otherDomain,
+							Identifier: "test",
+						},
+						nil,
+						true,
+					),
+				)
+			})
+		}
+	}
+
+	for _, domain := range common.AllPathDomains {
+
+		t.Run(fmt.Sprintf("different identifiers, %s", domain), func(t *testing.T) {
+
+			require.False(t,
+				PathValue{
+					Domain:     domain,
+					Identifier: "test1",
+				}.Equal(
+					PathValue{
+						Domain:     domain,
+						Identifier: "test2",
+					},
+					nil,
+					true,
+				),
+			)
+		})
+	}
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			PathValue{
+				Domain:     common.PathDomainStorage,
+				Identifier: "test",
+			}.Equal(
+				NewStringValue("/storage/test"),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestLinkValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal, borrow type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			LinkValue{
+				TargetPath: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				LinkValue{
+					TargetPath: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test",
+					},
+					Type: PrimitiveStaticTypeInt,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different paths", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			LinkValue{
+				TargetPath: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test1",
+				},
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				LinkValue{
+					TargetPath: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test2",
+					},
+					Type: PrimitiveStaticTypeInt,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			LinkValue{
+				TargetPath: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				LinkValue{
+					TargetPath: PathValue{
+						Domain:     common.PathDomainStorage,
+						Identifier: "test",
+					},
+					Type: PrimitiveStaticTypeString,
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			LinkValue{
+				TargetPath: PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "test",
+				},
+				Type: PrimitiveStaticTypeInt,
+			}.Equal(
+				NewStringValue("test"),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestArrayValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			NewArrayValueUnownedNonCopying(
+				UInt8Value(1),
+				UInt8Value(2),
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					UInt8Value(1),
+					UInt8Value(2),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewArrayValueUnownedNonCopying(
+				UInt8Value(1),
+				UInt8Value(2),
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					UInt8Value(2),
+					UInt8Value(3),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("more elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewArrayValueUnownedNonCopying(
+				UInt8Value(1),
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					UInt8Value(1),
+					UInt8Value(2),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("fewer elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewArrayValueUnownedNonCopying(
+				UInt8Value(1),
+				UInt8Value(2),
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					UInt8Value(1),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewArrayValueUnownedNonCopying(
+				UInt8Value(1),
+			).Equal(
+				UInt8Value(1),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestDictionaryValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			NewDictionaryValueUnownedNonCopying(
+				UInt8Value(1),
+				NewStringValue("1"),
+				UInt8Value(2),
+				NewStringValue("2"),
+			).Equal(
+				NewDictionaryValueUnownedNonCopying(
+					UInt8Value(1),
+					NewStringValue("1"),
+					UInt8Value(2),
+					NewStringValue("2"),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different keys", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewDictionaryValueUnownedNonCopying(
+				UInt8Value(1),
+				NewStringValue("1"),
+				UInt8Value(2),
+				NewStringValue("2"),
+			).Equal(
+				NewDictionaryValueUnownedNonCopying(
+					UInt8Value(2),
+					NewStringValue("1"),
+					UInt8Value(3),
+					NewStringValue("2"),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different values", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewDictionaryValueUnownedNonCopying(
+				UInt8Value(1),
+				NewStringValue("1"),
+				UInt8Value(2),
+				NewStringValue("2"),
+			).Equal(
+				NewDictionaryValueUnownedNonCopying(
+					UInt8Value(1),
+					NewStringValue("2"),
+					UInt8Value(2),
+					NewStringValue("3"),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("more elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewDictionaryValueUnownedNonCopying(
+				UInt8Value(1),
+				NewStringValue("1"),
+			).Equal(
+				NewDictionaryValueUnownedNonCopying(
+					UInt8Value(1),
+					NewStringValue("1"),
+					UInt8Value(2),
+					NewStringValue("2"),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("fewer elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewDictionaryValueUnownedNonCopying(
+				UInt8Value(1),
+				NewStringValue("1"),
+				UInt8Value(2),
+				NewStringValue("2"),
+			).Equal(
+				NewDictionaryValueUnownedNonCopying(
+					UInt8Value(1),
+					NewStringValue("1"),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewDictionaryValueUnownedNonCopying(
+				UInt8Value(1),
+				NewStringValue("1"),
+				UInt8Value(2),
+				NewStringValue("2"),
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					UInt8Value(1),
+					UInt8Value(2),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestCompositeValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+
+		fields2 := NewStringValueOrderedMap()
+		fields2.Set("a", NewStringValue("a"))
+
+		require.True(t,
+			NewCompositeValue(
+				utils.TestLocation,
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewCompositeValue(
+					utils.TestLocation,
+					"X",
+					common.CompositeKindStructure,
+					fields2,
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different location", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+
+		fields2 := NewStringValueOrderedMap()
+		fields2.Set("a", NewStringValue("a"))
+
+		require.False(t,
+			NewCompositeValue(
+				common.IdentifierLocation("A"),
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewCompositeValue(
+					common.IdentifierLocation("B"),
+					"X",
+					common.CompositeKindStructure,
+					fields2,
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+
+		fields2 := NewStringValueOrderedMap()
+		fields2.Set("a", NewStringValue("a"))
+
+		require.False(t,
+			NewCompositeValue(
+				common.IdentifierLocation("A"),
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewCompositeValue(
+					common.IdentifierLocation("A"),
+					"Y",
+					common.CompositeKindStructure,
+					fields2,
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different fields", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+
+		fields2 := NewStringValueOrderedMap()
+		fields2.Set("a", NewStringValue("b"))
+
+		require.False(t,
+			NewCompositeValue(
+				common.IdentifierLocation("A"),
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewCompositeValue(
+					common.IdentifierLocation("A"),
+					"X",
+					common.CompositeKindStructure,
+					fields2,
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("more fields", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+
+		fields2 := NewStringValueOrderedMap()
+		fields2.Set("a", NewStringValue("a"))
+		fields2.Set("b", NewStringValue("b"))
+
+		require.False(t,
+			NewCompositeValue(
+				common.IdentifierLocation("A"),
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewCompositeValue(
+					common.IdentifierLocation("A"),
+					"X",
+					common.CompositeKindStructure,
+					fields2,
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("fewer fields", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+		fields1.Set("b", NewStringValue("b"))
+
+		fields2 := NewStringValueOrderedMap()
+		fields2.Set("a", NewStringValue("a"))
+
+		require.False(t,
+			NewCompositeValue(
+				common.IdentifierLocation("A"),
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewCompositeValue(
+					common.IdentifierLocation("A"),
+					"X",
+					common.CompositeKindStructure,
+					fields2,
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different composite kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+
+		fields2 := NewStringValueOrderedMap()
+		fields2.Set("a", NewStringValue("a"))
+
+		require.False(t,
+			NewCompositeValue(
+				common.IdentifierLocation("A"),
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewCompositeValue(
+					common.IdentifierLocation("A"),
+					"X",
+					common.CompositeKindResource,
+					fields2,
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different composite kind", func(t *testing.T) {
+
+		t.Parallel()
+
+		fields1 := NewStringValueOrderedMap()
+		fields1.Set("a", NewStringValue("a"))
+
+		require.False(t,
+			NewCompositeValue(
+				common.IdentifierLocation("A"),
+				"X",
+				common.CompositeKindStructure,
+				fields1,
+				nil,
+			).Equal(
+				NewStringValue("test"),
+				nil,
+				true,
+			),
+		)
+	})
+}
+
+func TestNumberValue_Equal(t *testing.T) {
+
+	t.Parallel()
+
+	testValues := map[string]EquatableValue{
+		"UInt":    NewUIntValueFromUint64(10),
+		"UInt8":   UInt8Value(8),
+		"UInt16":  UInt16Value(16),
+		"UInt32":  UInt32Value(32),
+		"UInt64":  UInt64Value(64),
+		"UInt128": NewUInt128ValueFromUint64(128),
+		"UInt256": NewUInt256ValueFromUint64(256),
+		"Int8":    Int8Value(-8),
+		"Int16":   Int16Value(-16),
+		"Int32":   Int32Value(-32),
+		"Int64":   Int64Value(-64),
+		"Int128":  NewInt128ValueFromInt64(-128),
+		"Int256":  NewInt256ValueFromInt64(-256),
+		"Word8":   Word8Value(8),
+		"Word16":  Word16Value(16),
+		"Word32":  Word32Value(32),
+		"Word64":  Word64Value(64),
+		"UFix64":  NewUFix64ValueWithInteger(64),
+		"Fix64":   NewFix64ValueWithInteger(-32),
+	}
+
+	for name, value := range testValues {
+
+		t.Run(fmt.Sprintf("equal, %s", name), func(t *testing.T) {
+
+			require.True(t,
+				value.Equal(
+					value,
+					nil,
+					true,
+				),
+			)
+		})
+	}
+
+	for name, value := range testValues {
+		for otherName, otherValue := range testValues {
+
+			if name == otherName {
+				continue
+			}
+
+			t.Run(fmt.Sprintf("unequal, %s %s", name, otherName), func(t *testing.T) {
+
+				require.False(t,
+					value.Equal(
+						otherValue,
+						nil,
+						true,
+					),
+				)
+			})
+		}
+	}
+
+	for name, value := range testValues {
+
+		t.Run(fmt.Sprintf("different kind, %s", name), func(t *testing.T) {
+
+			t.Parallel()
+
+			require.False(t,
+				value.Equal(
+					AddressValue{0x1},
+					nil,
+					true,
+				),
+			)
+		})
+	}
 }

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -112,7 +112,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		}
 	}
 
-	storageGetter := func(_ *interpreter.Interpreter, _ common.Address, key string, deferred bool) interpreter.OptionalValue {
+	storageGetter := func(_ *interpreter.Interpreter, _ common.Address, key string, _ bool) interpreter.OptionalValue {
 		value := storedValues[key]
 		if value == nil {
 			return interpreter.NilValue{}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6738,7 +6738,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		return ok
 	}
 
-	getter := func(_ *interpreter.Interpreter, _ common.Address, key string, deferred bool) interpreter.OptionalValue {
+	getter := func(_ *interpreter.Interpreter, _ common.Address, key string, _ bool) interpreter.OptionalValue {
 		value, ok := storedValues[key]
 		if !ok {
 			return interpreter.NilValue{}


### PR DESCRIPTION
Work towards #780

- Storable Values
  - [x] `AddressValue`
  - [x] `CapabilityValue`
  - [x] Number values
  - [x] `ArrayValue`
  - [x] `DictionaryValue`
  - [x] `PathValue`
  - [x] `BoolValue`
  - [x] `StringValue`
  - [x] `TypeValue`	
  - [x] `CompositeValue`
  - [x] `LinkValue`
  - [x] `SomeValue`
  - [x] `NilValue`

- Static Types:
  - [x] `CapabilityStaticType`
  - [x] `InterfaceStaticType`
  - [x] `CompositeStaticType`
  - [x] `ConstantSizedStaticType`
  - [x] `VariableSizedStaticType`
  - [x] `VariableSizedStaticType`
  - [x] `DictionaryStaticType`
  - [x] `OptionalStaticType`
  - [x] `ReferenceStaticType`
  - [x] `PrimitiveStaticType`
  - [x] `RestrictedStaticType`


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
