### PR TITLE
Deny removing contracts if contract update validation is enabled

### DIFF
--- a/docs/contract-updatability.md
+++ b/docs/contract-updatability.md
@@ -25,6 +25,20 @@ However, it **does not** ensure:
   - Then any program that uses that field/function will get semantic errors.
 
 ## Updating a Contract
+Changes to contracts can be introduced by adding new contracts, removing existing contracts, or updating existing
+contracts. However, some of these changes may lead to data inconsistencies as stated above.
+
+#### Valid Changes
+- Adding a new contract is valid.
+- Removing a contract/contract-interface that doesn't have enum declarations is valid.
+- Updating a contract is valid, under the restrictions described in the below sections.
+
+#### Invalid Changes
+- Removing a contract/contract-interface that contains enum declarations is not valid.
+  - Removing a contract allows adding a new contract with the same name.
+  - The new contract could potentially have enum declarations with the same names as in the old contract, but with
+    different structures.
+  - This could change the meaning of the already stored values of those enum types.
 
 A contract may consist of fields and other declarations such as composite types, functions, constructors, etc.
 When an existing contract is updated, all its inner declarations are also validated.

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -53,6 +53,18 @@ func TestContractUpdateValidation(t *testing.T) {
 		))
 	}
 
+	newContractRemovalTransaction := func(contractName string) []byte {
+		return []byte(fmt.Sprintf(`
+			transaction {
+				prepare(signer: AuthAccount) {
+					signer.contracts.%s(name: "%s")
+				}
+			}`,
+			sema.AuthAccountContractsTypeRemoveFunctionName,
+			contractName,
+		))
+	}
+
 	accountCode := map[common.LocationID][]byte{}
 	var events []cadence.Event
 	runtimeInterface := getMockedRuntimeInterfaceForTxUpdate(t, accountCode, events)
@@ -1488,6 +1500,168 @@ func TestContractUpdateValidation(t *testing.T) {
 
 		assertFieldTypeMismatchError(t, cause, "TestStruct", "a", "Int", "String")
 	})
+
+	t.Run("Rename struct", func(t *testing.T) {
+		const oldCode = `
+			pub contract Test33 {
+
+				pub struct TestStruct {
+					pub let a: Int
+					pub var b: Int
+
+					init() {
+						self.a = 123
+						self.b = 456
+					}
+				}
+			}`
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: newDeployTransaction(
+					sema.AuthAccountContractsTypeAddFunctionName,
+					"Test33",
+					oldCode),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.NoError(t, err)
+
+		// Rename the struct
+
+		const newCode = `
+			pub contract Test33 {
+
+				pub struct TestStructRenamed {
+					pub let a: Int
+					pub var b: Int
+
+					init() {
+						self.a = 123
+						self.b = 456
+					}
+				}
+			}`
+
+		err = runtime.ExecuteTransaction(
+			Script{
+				Source: newDeployTransaction(
+					sema.AuthAccountContractsTypeUpdateExperimentalFunctionName,
+					"Test33",
+					newCode,
+				),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.Error(t, err)
+		cause := getErrorCause(t, err, "Test33")
+		assertMissingCompositeDeclarationError(t, cause, "TestStruct")
+	})
+
+	t.Run("Remove and Add Contract", func(t *testing.T) {
+		// Add contract
+		const oldCode = `
+			pub contract Test34 {
+				pub struct TestStruct {
+					pub let a: Int
+
+					init() {
+						self.a = 123
+					}
+				}
+			}`
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: newDeployTransaction(
+					sema.AuthAccountContractsTypeAddFunctionName,
+					"Test34",
+					oldCode,
+				),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.NoError(t, err)
+
+		// Remove the added contract.
+		err = runtime.ExecuteTransaction(
+			Script{
+				Source: newContractRemovalTransaction("Test34"),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.Error(t, err)
+		require.IsType(t, Error{}, err)
+		runtimeError := err.(Error)
+
+		require.IsType(t, interpreter.Error{}, runtimeError.Err)
+		interpreterError := runtimeError.Err.(interpreter.Error)
+		cause := interpreterError.Err
+
+		require.IsType(t, &ContractRemovalError{}, cause)
+		contractRemovalError := cause.(*ContractRemovalError)
+
+		assert.Equal(
+			t,
+			fmt.Sprintf("cannot remove contract `%s`", "Test34"),
+			contractRemovalError.Error(),
+		)
+
+		// Add a new contract with the same name, but with different content.
+
+		const newCode = `
+			pub contract Test34 {
+				pub struct TestStruct {
+					pub let a: String    // type of the nested field is changed
+
+					init() {
+						self.a = "hello"
+					}
+				}
+			}`
+
+		err = runtime.ExecuteTransaction(
+			Script{
+				Source: newDeployTransaction(
+					sema.AuthAccountContractsTypeAddFunctionName,
+					"Test34",
+					newCode,
+				),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.Error(t, err)
+		require.IsType(t, Error{}, err)
+		runtimeError = err.(Error)
+
+		require.IsType(t, interpreter.Error{}, runtimeError.Err)
+		interpreterError = runtimeError.Err.(interpreter.Error)
+
+		assert.Equal(
+			t,
+			"cannot overwrite existing contract with name \"Test34\" in account 0x42",
+			interpreterError.Err.Error())
+	})
 }
 
 func assertDeclTypeChangeError(
@@ -1658,12 +1832,20 @@ func getMockedRuntimeInterfaceForTxUpdate(
 			}
 			return accountCodes[location.ID()], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
 			}
 			accountCodes[location.ID()] = code
+			return nil
+		},
+		removeAccountContractCode: func(address Address, name string) error {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			delete(accountCodes, location.ID())
 			return nil
 		},
 		emitEvent: func(event cadence.Event) error {

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -250,6 +250,17 @@ func (e *InvalidContractDeploymentError) Unwrap() error {
 	return e.Err
 }
 
+// ContractRemovalError
+//
+type ContractRemovalError struct {
+	Name string
+	interpreter.LocationRange
+}
+
+func (e *ContractRemovalError) Error() string {
+	return fmt.Sprintf("cannot remove contract `%s`", e.Name)
+}
+
 // InvalidContractDeploymentOriginError
 //
 type InvalidContractDeploymentOriginError struct {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2166,8 +2166,17 @@ func (r *interpreterRuntime) newAuthAccountContractsRemoveFunction(
 				// NOTE: *DO NOT* call SetProgram – the program removal
 				// should not be effective during the execution, only after
 
-				// Deny removing a contract, if the contract validation is enabled.
-				if r.contractUpdateValidationEnabled {
+				// Deny removing a contract, if the contract validation is enabled, and
+				// the existing code contains enums.
+				existingProgram, err := parser2.ParseProgram(string(code))
+				if err != nil {
+					panic(&ContractRemovalError{
+						Name:          nameArgument,
+						LocationRange: invocation.GetLocationRange(),
+					})
+				}
+
+				if r.contractUpdateValidationEnabled && containsEnumsInProgram(existingProgram) {
 					panic(&ContractRemovalError{
 						Name:          nameArgument,
 						LocationRange: invocation.GetLocationRange(),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2166,6 +2166,14 @@ func (r *interpreterRuntime) newAuthAccountContractsRemoveFunction(
 				// NOTE: *DO NOT* call SetProgram – the program removal
 				// should not be effective during the execution, only after
 
+				// Deny removing a contract, if the contract validation is enabled.
+				if r.contractUpdateValidationEnabled {
+					panic(&ContractRemovalError{
+						Name:          nameArgument,
+						LocationRange: invocation.GetLocationRange(),
+					})
+				}
+
 				wrapPanic(func() {
 					err = runtimeInterface.RemoveAccountContractCode(address, nameArgument)
 				})

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2168,19 +2168,18 @@ func (r *interpreterRuntime) newAuthAccountContractsRemoveFunction(
 
 				// Deny removing a contract, if the contract validation is enabled, and
 				// the existing code contains enums.
-				existingProgram, err := parser2.ParseProgram(string(code))
-				if err != nil {
-					panic(&ContractRemovalError{
-						Name:          nameArgument,
-						LocationRange: invocation.GetLocationRange(),
-					})
-				}
+				if r.contractUpdateValidationEnabled {
 
-				if r.contractUpdateValidationEnabled && containsEnumsInProgram(existingProgram) {
-					panic(&ContractRemovalError{
-						Name:          nameArgument,
-						LocationRange: invocation.GetLocationRange(),
-					})
+					existingProgram, err := parser2.ParseProgram(string(code))
+
+					// If the existing code is not parsable (i.e: `err != nil`), that shouldn't be a reason to
+					// fail the contract removal. Therefore, validate only if the code is a valid one.
+					if err == nil && containsEnumsInProgram(existingProgram) {
+						panic(&ContractRemovalError{
+							Name:          nameArgument,
+							LocationRange: invocation.GetLocationRange(),
+						})
+					}
 				}
 
 				wrapPanic(func() {


### PR DESCRIPTION
Closes #791

## Description

$subject to avoid inconsistencies at the storage when decoding already stored data. 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
