### PR TITLE
Cache capability type members

### DIFF
--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -44,10 +44,13 @@ func TestCheckTypeArguments(t *testing.T) {
 
 		require.NoError(t, err)
 
-		assert.Equal(t,
+		capType := RequireGlobalValue(t, checker.Elaboration, "cap")
+
+		require.IsType(t,
 			&sema.CapabilityType{},
-			RequireGlobalValue(t, checker.Elaboration, "cap"),
+			capType,
 		)
+		require.Nil(t, capType.(*sema.CapabilityType).BorrowType)
 	})
 
 	t.Run("capability, instantiation with no arguments", func(t *testing.T) {
@@ -148,18 +151,25 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t,
-			&sema.CapabilityType{
-				BorrowType: &sema.ReferenceType{
-					Type: sema.IntType,
-				},
+		capType := RequireGlobalValue(t, checker.Elaboration, "cap")
+		require.IsType(t,
+			&sema.CapabilityType{},
+			capType,
+		)
+		require.Equal(t,
+			&sema.ReferenceType{
+				Type: sema.IntType,
 			},
-			RequireGlobalValue(t, checker.Elaboration, "cap"),
+			capType.(*sema.CapabilityType).BorrowType,
 		)
 
-		assert.Equal(t,
+		cap2Type := RequireGlobalValue(t, checker.Elaboration, "cap2")
+		require.IsType(t,
 			&sema.CapabilityType{},
-			RequireGlobalValue(t, checker.Elaboration, "cap2"),
+			cap2Type,
+		)
+		require.Nil(t,
+			cap2Type.(*sema.CapabilityType).BorrowType,
 		)
 	})
 
@@ -178,7 +188,6 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 				},
 			},
 		)
-
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -211,19 +220,25 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
             `,
 			&sema.CapabilityType{},
 		)
+		require.NotNil(t, checker)
 
-		assert.Equal(t,
+		capType := RequireGlobalValue(t, checker.Elaboration, "cap")
+		require.IsType(t,
 			&sema.CapabilityType{},
-			RequireGlobalValue(t, checker.Elaboration, "cap"),
+			capType,
 		)
+		require.Nil(t, capType.(*sema.CapabilityType).BorrowType)
 
-		assert.Equal(t,
-			&sema.CapabilityType{
-				BorrowType: &sema.ReferenceType{
-					Type: sema.IntType,
-				},
+		cap2Type := RequireGlobalValue(t, checker.Elaboration, "cap2")
+		require.IsType(t,
+			&sema.CapabilityType{},
+			cap2Type,
+		)
+		require.Equal(t,
+			&sema.ReferenceType{
+				Type: sema.IntType,
 			},
-			RequireGlobalValue(t, checker.Elaboration, "cap2"),
+			cap2Type.(*sema.CapabilityType).BorrowType,
 		)
 
 		errs := ExpectCheckerErrors(t, err, 1)
@@ -246,7 +261,6 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 				},
 			},
 		)
-
 		require.NotNil(t, checker)
 
 		assert.Equal(t,


### PR DESCRIPTION
## Description

Just like for other types, cache the members of capability types.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
