### PR TITLE
Simplify function types

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -57,8 +57,6 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return exportReferenceType(t, results)
 		case *sema.RestrictedType:
 			return exportRestrictedType(t, results)
-		case *sema.CheckedFunctionType:
-			return exportFunctionType(t.FunctionType, results)
 		case *sema.CapabilityType:
 			return exportCapabilityType(t, results)
 		}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1437,7 +1437,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 	}
 
 	initializer = initializers[0]
-	functionType := interpreter.Program.Elaboration.SpecialFunctionTypes[initializer].FunctionType
+	functionType := interpreter.Program.Elaboration.ConstructorFunctionTypes[initializer].FunctionType
 
 	parameterList := initializer.FunctionDeclaration.ParameterList
 

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -672,7 +672,7 @@ func (checker *Checker) declareCompositeMembersAndValue(
 
 func (checker *Checker) declareCompositeConstructor(
 	declaration *ast.CompositeDeclaration,
-	constructorType *SpecialFunctionType,
+	constructorType *ConstructorFunctionType,
 	constructorArgumentLabels []string,
 ) {
 	// Resource and event constructors are effectively always private,
@@ -738,7 +738,7 @@ func (checker *Checker) declareEnumConstructor(
 		constructorOrigins = make(map[string]*Origin, len(enumCases))
 	}
 
-	constructorType := &SpecialFunctionType{
+	constructorType := &ConstructorFunctionType{
 		FunctionType: &FunctionType{
 			Parameters: []*Parameter{
 				{
@@ -751,8 +751,8 @@ func (checker *Checker) declareEnumConstructor(
 					Type: compositeType,
 				},
 			),
+			Members: constructorMembers,
 		},
-		Members: constructorMembers,
 	}
 
 	memberCaseTypeAnnotation := NewTypeAnnotation(compositeType)
@@ -1271,11 +1271,11 @@ func (checker *Checker) compositeConstructorType(
 	compositeDeclaration *ast.CompositeDeclaration,
 	compositeType *CompositeType,
 ) (
-	constructorFunctionType *SpecialFunctionType,
+	constructorFunctionType *ConstructorFunctionType,
 	argumentLabels []string,
 ) {
 
-	constructorFunctionType = &SpecialFunctionType{
+	constructorFunctionType = &ConstructorFunctionType{
 		FunctionType: &FunctionType{
 			ReturnTypeAnnotation: NewTypeAnnotation(compositeType),
 		},
@@ -1297,8 +1297,8 @@ func (checker *Checker) compositeConstructorType(
 		// NOTE: Don't use `constructorFunctionType`, as it has a return type.
 		//   The initializer itself has a `Void` return type.
 
-		checker.Elaboration.SpecialFunctionTypes[firstInitializer] =
-			&SpecialFunctionType{
+		checker.Elaboration.ConstructorFunctionTypes[firstInitializer] =
+			&ConstructorFunctionType{
 				FunctionType: &FunctionType{
 					Parameters:           constructorFunctionType.Parameters,
 					ReturnTypeAnnotation: NewTypeAnnotation(VoidType),

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -207,7 +207,7 @@ func (checker *Checker) checkConstructorInvocationWithResourceResult(
 	returnType Type,
 	inCreate bool,
 ) {
-	if _, ok := invokableType.(*SpecialFunctionType); !ok {
+	if _, ok := invokableType.(*ConstructorFunctionType); !ok {
 		return
 	}
 

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -39,7 +39,7 @@ type Elaboration struct {
 	AssignmentStatementValueTypes       map[*ast.AssignmentStatement]Type
 	AssignmentStatementTargetTypes      map[*ast.AssignmentStatement]Type
 	CompositeDeclarationTypes           map[*ast.CompositeDeclaration]*CompositeType
-	SpecialFunctionTypes                map[*ast.SpecialFunctionDeclaration]*SpecialFunctionType
+	ConstructorFunctionTypes            map[*ast.SpecialFunctionDeclaration]*ConstructorFunctionType
 	FunctionExpressionFunctionType      map[*ast.FunctionExpression]*FunctionType
 	InvocationExpressionArgumentTypes   map[*ast.InvocationExpression][]Type
 	InvocationExpressionParameterTypes  map[*ast.InvocationExpression][]Type
@@ -88,7 +88,7 @@ func NewElaboration() *Elaboration {
 		AssignmentStatementValueTypes:       map[*ast.AssignmentStatement]Type{},
 		AssignmentStatementTargetTypes:      map[*ast.AssignmentStatement]Type{},
 		CompositeDeclarationTypes:           map[*ast.CompositeDeclaration]*CompositeType{},
-		SpecialFunctionTypes:                map[*ast.SpecialFunctionDeclaration]*SpecialFunctionType{},
+		ConstructorFunctionTypes:            map[*ast.SpecialFunctionDeclaration]*ConstructorFunctionType{},
 		FunctionExpressionFunctionType:      map[*ast.FunctionExpression]*FunctionType{},
 		InvocationExpressionArgumentTypes:   map[*ast.InvocationExpression][]Type{},
 		InvocationExpressionParameterTypes:  map[*ast.InvocationExpression][]Type{},

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -186,7 +186,7 @@ var HashAlgorithmValue = StandardLibraryValue{
 	Kind:  common.DeclarationKindEnum,
 }
 
-func cryptoAlgorithmEnumType(enumType *sema.CompositeType, enumCases []sema.CryptoAlgorithm) *sema.SpecialFunctionType {
+func cryptoAlgorithmEnumType(enumType *sema.CompositeType, enumCases []sema.CryptoAlgorithm) *sema.ConstructorFunctionType {
 	members := make([]*sema.Member, len(enumCases))
 	for i, algo := range enumCases {
 		members[i] = sema.NewPublicEnumCaseMember(
@@ -196,7 +196,7 @@ func cryptoAlgorithmEnumType(enumType *sema.CompositeType, enumCases []sema.Cryp
 		)
 	}
 
-	constructorType := &sema.SpecialFunctionType{
+	constructorType := &sema.ConstructorFunctionType{
 		FunctionType: &sema.FunctionType{
 			Parameters: []*sema.Parameter{
 				{
@@ -209,8 +209,8 @@ func cryptoAlgorithmEnumType(enumType *sema.CompositeType, enumCases []sema.Cryp
 					Type: enumType,
 				},
 			),
+			Members: sema.GetMembersAsMap(members),
 		},
-		Members: sema.GetMembersAsMap(members),
 	}
 
 	return constructorType


### PR DESCRIPTION
## Description

- Remove `CheckedFunctionType` wrapper, move functionality to `FunctionType`
- Rename `SpecialFunctionTypes` to the more descriptive `ConstructorFunctionType`
- Move the functionality of special function types to have members to `FunctionType`

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
