### PR TITLE
Add saturation arithmetic

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1222,20 +1222,24 @@ func (v Int8Value) Mul(other NumberValue) NumberValue {
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
+			// positive * positive = positive. overflow?
 			if v > (math.MaxInt8 / o) {
 				panic(OverflowError{})
 			}
 		} else {
+			// positive * negative = negative. underflow?
 			if o < (math.MinInt8 / v) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		}
 	} else {
 		if o > 0 {
+			// negative * positive = negative. underflow?
 			if v < (math.MinInt8 / o) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		} else {
+			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt8 / v)) {
 				panic(OverflowError{})
 			}
@@ -1463,20 +1467,24 @@ func (v Int16Value) Mul(other NumberValue) NumberValue {
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
+			// positive * positive = positive. overflow?
 			if v > (math.MaxInt16 / o) {
 				panic(OverflowError{})
 			}
 		} else {
+			// positive * negative = negative. underflow?
 			if o < (math.MinInt16 / v) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		}
 	} else {
 		if o > 0 {
+			// negative * positive = negative. underflow?
 			if v < (math.MinInt16 / o) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		} else {
+			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt16 / v)) {
 				panic(OverflowError{})
 			}
@@ -1706,20 +1714,24 @@ func (v Int32Value) Mul(other NumberValue) NumberValue {
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
+			// positive * positive = positive. overflow?
 			if v > (math.MaxInt32 / o) {
 				panic(OverflowError{})
 			}
 		} else {
+			// positive * negative = negative. underflow?
 			if o < (math.MinInt32 / v) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		}
 	} else {
 		if o > 0 {
+			// negative * positive = negative. underflow?
 			if v < (math.MinInt32 / o) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		} else {
+			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt32 / v)) {
 				panic(OverflowError{})
 			}
@@ -1953,20 +1965,24 @@ func (v Int64Value) Mul(other NumberValue) NumberValue {
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
+			// positive * positive = positive. overflow?
 			if v > (math.MaxInt64 / o) {
 				panic(OverflowError{})
 			}
 		} else {
+			// positive * negative = negative. underflow?
 			if o < (math.MinInt64 / v) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		}
 	} else {
 		if o > 0 {
+			// negative * positive = negative. underflow?
 			if v < (math.MinInt64 / o) {
-				panic(OverflowError{})
+				panic(UnderflowError{})
 			}
 		} else {
+			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt64 / v)) {
 				panic(OverflowError{})
 			}
@@ -5111,7 +5127,9 @@ func (v Fix64Value) Mul(other NumberValue) NumberValue {
 	result := new(big.Int).Mul(a, b)
 	result.Div(result, sema.Fix64FactorBig)
 
-	if !result.IsInt64() {
+	if result.Cmp(minInt64Big) < 0 {
+		panic(UnderflowError{})
+	} else if result.Cmp(maxInt64Big) > 0 {
 		panic(OverflowError{})
 	}
 
@@ -5127,7 +5145,9 @@ func (v Fix64Value) Div(other NumberValue) NumberValue {
 	result := new(big.Int).Mul(a, sema.Fix64FactorBig)
 	result.Div(result, b)
 
-	if !result.IsInt64() {
+	if result.Cmp(minInt64Big) < 0 {
+		panic(UnderflowError{})
+	} else if result.Cmp(maxInt64Big) > 0 {
 		panic(OverflowError{})
 	}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1197,6 +1197,17 @@ func (v Int8Value) Plus(other NumberValue) NumberValue {
 	return v + o
 }
 
+func (v Int8Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(Int8Value)
+	// INT32-C
+	if (o > 0) && (v > (math.MaxInt8 - o)) {
+		return Int8Value(math.MaxInt8)
+	} else if (o < 0) && (v < (math.MinInt8 - o)) {
+		return Int8Value(math.MinInt8)
+	}
+	return v + o
+}
+
 func (v Int8Value) Minus(other NumberValue) NumberValue {
 	o := other.(Int8Value)
 	// INT32-C
@@ -1204,6 +1215,17 @@ func (v Int8Value) Minus(other NumberValue) NumberValue {
 		panic(OverflowError{})
 	} else if (o < 0) && (v > (math.MaxInt8 + o)) {
 		panic(UnderflowError{})
+	}
+	return v - o
+}
+
+func (v Int8Value) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(Int8Value)
+	// INT32-C
+	if (o > 0) && (v < (math.MinInt8 + o)) {
+		return Int8Value(math.MaxInt8)
+	} else if (o < 0) && (v > (math.MaxInt8 + o)) {
+		return Int8Value(math.MinInt8)
 	}
 	return v - o
 }
@@ -1248,6 +1270,37 @@ func (v Int8Value) Mul(other NumberValue) NumberValue {
 	return v * o
 }
 
+func (v Int8Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(Int8Value)
+	// INT32-C
+	if v > 0 {
+		if o > 0 {
+			// positive * positive = positive. overflow?
+			if v > (math.MaxInt8 / o) {
+				return Int8Value(math.MaxInt8)
+			}
+		} else {
+			// positive * negative = negative. underflow?
+			if o < (math.MinInt8 / v) {
+				return Int8Value(math.MinInt8)
+			}
+		}
+	} else {
+		if o > 0 {
+			// negative * positive = negative. underflow?
+			if v < (math.MinInt8 / o) {
+				return Int8Value(math.MinInt8)
+			}
+		} else {
+			// negative * negative = positive. overflow?
+			if (v != 0) && (o < (math.MaxInt8 / v)) {
+				return Int8Value(math.MaxInt8)
+			}
+		}
+	}
+	return v * o
+}
+
 func (v Int8Value) Div(other NumberValue) NumberValue {
 	o := other.(Int8Value)
 	// INT33-C
@@ -1256,6 +1309,18 @@ func (v Int8Value) Div(other NumberValue) NumberValue {
 		panic(DivisionByZeroError{})
 	} else if (v == math.MinInt8) && (o == -1) {
 		panic(OverflowError{})
+	}
+	return v / o
+}
+
+func (v Int8Value) SaturatingDiv(other NumberValue) NumberValue {
+	o := other.(Int8Value)
+	// INT33-C
+	// https://golang.org/ref/spec#Integer_operators
+	if o == 0 {
+		panic(DivisionByZeroError{})
+	} else if (v == math.MinInt8) && (o == -1) {
+		return Int8Value(math.MaxInt8)
 	}
 	return v / o
 }
@@ -1442,6 +1507,17 @@ func (v Int16Value) Plus(other NumberValue) NumberValue {
 	return v + o
 }
 
+func (v Int16Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(Int16Value)
+	// INT32-C
+	if (o > 0) && (v > (math.MaxInt16 - o)) {
+		return Int16Value(math.MaxInt16)
+	} else if (o < 0) && (v < (math.MinInt16 - o)) {
+		return Int16Value(math.MinInt16)
+	}
+	return v + o
+}
+
 func (v Int16Value) Minus(other NumberValue) NumberValue {
 	o := other.(Int16Value)
 	// INT32-C
@@ -1449,6 +1525,17 @@ func (v Int16Value) Minus(other NumberValue) NumberValue {
 		panic(OverflowError{})
 	} else if (o < 0) && (v > (math.MaxInt16 + o)) {
 		panic(UnderflowError{})
+	}
+	return v - o
+}
+
+func (v Int16Value) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(Int16Value)
+	// INT32-C
+	if (o > 0) && (v < (math.MinInt16 + o)) {
+		return Int16Value(math.MaxInt16)
+	} else if (o < 0) && (v > (math.MaxInt16 + o)) {
+		return Int16Value(math.MinInt16)
 	}
 	return v - o
 }
@@ -1493,6 +1580,37 @@ func (v Int16Value) Mul(other NumberValue) NumberValue {
 	return v * o
 }
 
+func (v Int16Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(Int16Value)
+	// INT32-C
+	if v > 0 {
+		if o > 0 {
+			// positive * positive = positive. overflow?
+			if v > (math.MaxInt16 / o) {
+				return Int16Value(math.MaxInt16)
+			}
+		} else {
+			// positive * negative = negative. underflow?
+			if o < (math.MinInt16 / v) {
+				return Int16Value(math.MinInt16)
+			}
+		}
+	} else {
+		if o > 0 {
+			// negative * positive = negative. underflow?
+			if v < (math.MinInt16 / o) {
+				return Int16Value(math.MinInt16)
+			}
+		} else {
+			// negative * negative = positive. overflow?
+			if (v != 0) && (o < (math.MaxInt16 / v)) {
+				return Int16Value(math.MaxInt16)
+			}
+		}
+	}
+	return v * o
+}
+
 func (v Int16Value) Div(other NumberValue) NumberValue {
 	o := other.(Int16Value)
 	// INT33-C
@@ -1501,6 +1619,18 @@ func (v Int16Value) Div(other NumberValue) NumberValue {
 		panic(DivisionByZeroError{})
 	} else if (v == math.MinInt16) && (o == -1) {
 		panic(OverflowError{})
+	}
+	return v / o
+}
+
+func (v Int16Value) SaturatingDiv(other NumberValue) NumberValue {
+	o := other.(Int16Value)
+	// INT33-C
+	// https://golang.org/ref/spec#Integer_operators
+	if o == 0 {
+		panic(DivisionByZeroError{})
+	} else if (v == math.MinInt16) && (o == -1) {
+		return Int16Value(math.MaxInt16)
 	}
 	return v / o
 }
@@ -1689,6 +1819,17 @@ func (v Int32Value) Plus(other NumberValue) NumberValue {
 	return v + o
 }
 
+func (v Int32Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(Int32Value)
+	// INT32-C
+	if (o > 0) && (v > (math.MaxInt32 - o)) {
+		return Int32Value(math.MaxInt32)
+	} else if (o < 0) && (v < (math.MinInt32 - o)) {
+		return Int32Value(math.MinInt32)
+	}
+	return v + o
+}
+
 func (v Int32Value) Minus(other NumberValue) NumberValue {
 	o := other.(Int32Value)
 	// INT32-C
@@ -1696,6 +1837,17 @@ func (v Int32Value) Minus(other NumberValue) NumberValue {
 		panic(OverflowError{})
 	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
 		panic(UnderflowError{})
+	}
+	return v - o
+}
+
+func (v Int32Value) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(Int32Value)
+	// INT32-C
+	if (o > 0) && (v < (math.MinInt32 + o)) {
+		return Int32Value(math.MaxInt32)
+	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
+		return Int32Value(math.MinInt32)
 	}
 	return v - o
 }
@@ -1740,6 +1892,37 @@ func (v Int32Value) Mul(other NumberValue) NumberValue {
 	return v * o
 }
 
+func (v Int32Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(Int32Value)
+	// INT32-C
+	if v > 0 {
+		if o > 0 {
+			// positive * positive = positive. overflow?
+			if v > (math.MaxInt32 / o) {
+				return Int32Value(math.MaxInt32)
+			}
+		} else {
+			// positive * negative = negative. underflow?
+			if o < (math.MinInt32 / v) {
+				return Int32Value(math.MinInt32)
+			}
+		}
+	} else {
+		if o > 0 {
+			// negative * positive = negative. underflow?
+			if v < (math.MinInt32 / o) {
+				return Int32Value(math.MinInt32)
+			}
+		} else {
+			// negative * negative = positive. overflow?
+			if (v != 0) && (o < (math.MaxInt32 / v)) {
+				return Int32Value(math.MaxInt32)
+			}
+		}
+	}
+	return v * o
+}
+
 func (v Int32Value) Div(other NumberValue) NumberValue {
 	o := other.(Int32Value)
 	// INT33-C
@@ -1748,6 +1931,18 @@ func (v Int32Value) Div(other NumberValue) NumberValue {
 		panic(DivisionByZeroError{})
 	} else if (v == math.MinInt32) && (o == -1) {
 		panic(OverflowError{})
+	}
+	return v / o
+}
+
+func (v Int32Value) SaturatingDiv(other NumberValue) NumberValue {
+	o := other.(Int32Value)
+	// INT33-C
+	// https://golang.org/ref/spec#Integer_operators
+	if o == 0 {
+		panic(DivisionByZeroError{})
+	} else if (v == math.MinInt32) && (o == -1) {
+		return Int32Value(math.MaxInt32)
 	}
 	return v / o
 }
@@ -1940,6 +2135,17 @@ func (v Int64Value) Plus(other NumberValue) NumberValue {
 	return Int64Value(safeAddInt64(int64(v), int64(o)))
 }
 
+func (v Int64Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(Int64Value)
+	// INT32-C
+	if (o > 0) && (v > (math.MaxInt64 - o)) {
+		return Int64Value(math.MaxInt64)
+	} else if (o < 0) && (v < (math.MinInt64 - o)) {
+		return Int64Value(math.MinInt64)
+	}
+	return v + o
+}
+
 func (v Int64Value) Minus(other NumberValue) NumberValue {
 	o := other.(Int64Value)
 	// INT32-C
@@ -1947,6 +2153,17 @@ func (v Int64Value) Minus(other NumberValue) NumberValue {
 		panic(OverflowError{})
 	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
 		panic(UnderflowError{})
+	}
+	return v - o
+}
+
+func (v Int64Value) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(Int64Value)
+	// INT32-C
+	if (o > 0) && (v < (math.MinInt64 + o)) {
+		return Int64Value(math.MaxInt64)
+	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
+		return Int64Value(math.MinInt64)
 	}
 	return v - o
 }
@@ -1991,6 +2208,37 @@ func (v Int64Value) Mul(other NumberValue) NumberValue {
 	return v * o
 }
 
+func (v Int64Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(Int64Value)
+	// INT32-C
+	if v > 0 {
+		if o > 0 {
+			// positive * positive = positive. overflow?
+			if v > (math.MaxInt64 / o) {
+				return Int64Value(math.MaxInt64)
+			}
+		} else {
+			// positive * negative = negative. underflow?
+			if o < (math.MinInt64 / v) {
+				return Int64Value(math.MinInt64)
+			}
+		}
+	} else {
+		if o > 0 {
+			// negative * positive = negative. underflow?
+			if v < (math.MinInt64 / o) {
+				return Int64Value(math.MinInt64)
+			}
+		} else {
+			// negative * negative = positive. overflow?
+			if (v != 0) && (o < (math.MaxInt64 / v)) {
+				return Int64Value(math.MaxInt64)
+			}
+		}
+	}
+	return v * o
+}
+
 func (v Int64Value) Div(other NumberValue) NumberValue {
 	o := other.(Int64Value)
 	// INT33-C
@@ -1999,6 +2247,18 @@ func (v Int64Value) Div(other NumberValue) NumberValue {
 		panic(DivisionByZeroError{})
 	} else if (v == math.MinInt64) && (o == -1) {
 		panic(OverflowError{})
+	}
+	return v / o
+}
+
+func (v Int64Value) SaturatingDiv(other NumberValue) NumberValue {
+	o := other.(Int64Value)
+	// INT33-C
+	// https://golang.org/ref/spec#Integer_operators
+	if o == 0 {
+		panic(DivisionByZeroError{})
+	} else if (v == math.MinInt64) && (o == -1) {
+		return Int64Value(math.MaxInt64)
 	}
 	return v / o
 }
@@ -2212,6 +2472,30 @@ func (v Int128Value) Plus(other NumberValue) NumberValue {
 	return Int128Value{res}
 }
 
+func (v Int128Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(Int128Value)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just add and check the range of the result.
+	//
+	// If Go gains a native int128 type and we switch this value
+	// to be based on it, then we need to follow INT32-C:
+	//
+	//   if (o > 0) && (v > (Int128TypeMaxIntBig - o)) {
+	//       ...
+	//   } else if (o < 0) && (v < (Int128TypeMinIntBig - o)) {
+	//       ...
+	//   }
+	//
+	res := new(big.Int)
+	res.Add(v.BigInt, o.BigInt)
+	if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
+		return Int128Value{sema.Int128TypeMinIntBig}
+	} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
+		return Int128Value{sema.Int128TypeMaxIntBig}
+	}
+	return Int128Value{res}
+}
+
 func (v Int128Value) Minus(other NumberValue) NumberValue {
 	o := other.(Int128Value)
 	// Given that this value is backed by an arbitrary size integer,
@@ -2232,6 +2516,30 @@ func (v Int128Value) Minus(other NumberValue) NumberValue {
 		panic(UnderflowError{})
 	} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
 		panic(OverflowError{})
+	}
+	return Int128Value{res}
+}
+
+func (v Int128Value) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(Int128Value)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just subtract and check the range of the result.
+	//
+	// If Go gains a native int128 type and we switch this value
+	// to be based on it, then we need to follow INT32-C:
+	//
+	//   if (o > 0) && (v < (Int128TypeMinIntBig + o)) {
+	// 	     ...
+	//   } else if (o < 0) && (v > (Int128TypeMaxIntBig + o)) {
+	//       ...
+	//   }
+	//
+	res := new(big.Int)
+	res.Sub(v.BigInt, o.BigInt)
+	if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
+		return Int128Value{sema.Int128TypeMinIntBig}
+	} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
+		return Int128Value{sema.Int128TypeMaxIntBig}
 	}
 	return Int128Value{res}
 }
@@ -2259,6 +2567,18 @@ func (v Int128Value) Mul(other NumberValue) NumberValue {
 	return Int128Value{res}
 }
 
+func (v Int128Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(Int128Value)
+	res := new(big.Int)
+	res.Mul(v.BigInt, o.BigInt)
+	if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
+		return Int128Value{sema.Int128TypeMinIntBig}
+	} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
+		return Int128Value{sema.Int128TypeMaxIntBig}
+	}
+	return Int128Value{res}
+}
+
 func (v Int128Value) Div(other NumberValue) NumberValue {
 	o := other.(Int128Value)
 	res := new(big.Int)
@@ -2274,6 +2594,26 @@ func (v Int128Value) Div(other NumberValue) NumberValue {
 	res.SetInt64(-1)
 	if (v.BigInt.Cmp(sema.Int128TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
 		panic(OverflowError{})
+	}
+	res.Div(v.BigInt, o.BigInt)
+	return Int128Value{res}
+}
+
+func (v Int128Value) SaturatingDiv(other NumberValue) NumberValue {
+	o := other.(Int128Value)
+	res := new(big.Int)
+	// INT33-C:
+	//   if o == 0 {
+	//       ...
+	//   } else if (v == Int128TypeMinIntBig) && (o == -1) {
+	//       ...
+	//   }
+	if o.BigInt.Cmp(res) == 0 {
+		panic(DivisionByZeroError{})
+	}
+	res.SetInt64(-1)
+	if (v.BigInt.Cmp(sema.Int128TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
+		return Int128Value{sema.Int128TypeMaxIntBig}
 	}
 	res.Div(v.BigInt, o.BigInt)
 	return Int128Value{res}
@@ -2513,6 +2853,30 @@ func (v Int256Value) Plus(other NumberValue) NumberValue {
 	return Int256Value{res}
 }
 
+func (v Int256Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(Int256Value)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just add and check the range of the result.
+	//
+	// If Go gains a native int256 type and we switch this value
+	// to be based on it, then we need to follow INT32-C:
+	//
+	//   if (o > 0) && (v > (Int256TypeMaxIntBig - o)) {
+	//       ...
+	//   } else if (o < 0) && (v < (Int256TypeMinIntBig - o)) {
+	//       ...
+	//   }
+	//
+	res := new(big.Int)
+	res.Add(v.BigInt, o.BigInt)
+	if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
+		return Int256Value{sema.Int256TypeMinIntBig}
+	} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
+		return Int256Value{sema.Int256TypeMaxIntBig}
+	}
+	return Int256Value{res}
+}
+
 func (v Int256Value) Minus(other NumberValue) NumberValue {
 	o := other.(Int256Value)
 	// Given that this value is backed by an arbitrary size integer,
@@ -2533,6 +2897,30 @@ func (v Int256Value) Minus(other NumberValue) NumberValue {
 		panic(UnderflowError{})
 	} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
 		panic(OverflowError{})
+	}
+	return Int256Value{res}
+}
+
+func (v Int256Value) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(Int256Value)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just subtract and check the range of the result.
+	//
+	// If Go gains a native int256 type and we switch this value
+	// to be based on it, then we need to follow INT32-C:
+	//
+	//   if (o > 0) && (v < (Int256TypeMinIntBig + o)) {
+	// 	     ...
+	//   } else if (o < 0) && (v > (Int256TypeMaxIntBig + o)) {
+	//       ...
+	//   }
+	//
+	res := new(big.Int)
+	res.Sub(v.BigInt, o.BigInt)
+	if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
+		return Int256Value{sema.Int256TypeMinIntBig}
+	} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
+		return Int256Value{sema.Int256TypeMaxIntBig}
 	}
 	return Int256Value{res}
 }
@@ -2560,6 +2948,18 @@ func (v Int256Value) Mul(other NumberValue) NumberValue {
 	return Int256Value{res}
 }
 
+func (v Int256Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(Int256Value)
+	res := new(big.Int)
+	res.Mul(v.BigInt, o.BigInt)
+	if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
+		return Int256Value{sema.Int256TypeMinIntBig}
+	} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
+		return Int256Value{sema.Int256TypeMaxIntBig}
+	}
+	return Int256Value{res}
+}
+
 func (v Int256Value) Div(other NumberValue) NumberValue {
 	o := other.(Int256Value)
 	res := new(big.Int)
@@ -2575,6 +2975,26 @@ func (v Int256Value) Div(other NumberValue) NumberValue {
 	res.SetInt64(-1)
 	if (v.BigInt.Cmp(sema.Int256TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
 		panic(OverflowError{})
+	}
+	res.Div(v.BigInt, o.BigInt)
+	return Int256Value{res}
+}
+
+func (v Int256Value) SaturatingDiv(other NumberValue) NumberValue {
+	o := other.(Int256Value)
+	res := new(big.Int)
+	// INT33-C:
+	//   if o == 0 {
+	//       ...
+	//   } else if (v == Int256TypeMinIntBig) && (o == -1) {
+	//       ...
+	//   }
+	if o.BigInt.Cmp(res) == 0 {
+		panic(DivisionByZeroError{})
+	}
+	res.SetInt64(-1)
+	if (v.BigInt.Cmp(sema.Int256TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
+		return Int256Value{sema.Int256TypeMaxIntBig}
 	}
 	res.Div(v.BigInt, o.BigInt)
 	return Int256Value{res}
@@ -2815,8 +3235,20 @@ func (v UIntValue) Minus(other NumberValue) NumberValue {
 	o := other.(UIntValue)
 	res := new(big.Int)
 	res.Sub(v.BigInt, o.BigInt)
+	// INT30-C
 	if res.Sign() < 0 {
 		panic(UnderflowError{})
+	}
+	return UIntValue{res}
+}
+
+func (v UIntValue) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(UIntValue)
+	res := new(big.Int)
+	res.Sub(v.BigInt, o.BigInt)
+	// INT30-C
+	if res.Sign() < 0 {
+		return UIntValue{sema.UIntTypeMin}
 	}
 	return UIntValue{res}
 }
@@ -3024,11 +3456,29 @@ func (v UInt8Value) Plus(other NumberValue) NumberValue {
 	return sum
 }
 
+func (v UInt8Value) SaturatingPlus(other NumberValue) NumberValue {
+	sum := v + other.(UInt8Value)
+	// INT30-C
+	if sum < v {
+		return UInt8Value(math.MaxUint8)
+	}
+	return sum
+}
+
 func (v UInt8Value) Minus(other NumberValue) NumberValue {
 	diff := v - other.(UInt8Value)
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
+	}
+	return diff
+}
+
+func (v UInt8Value) SaturatingMinus(other NumberValue) NumberValue {
+	diff := v - other.(UInt8Value)
+	// INT30-C
+	if diff > v {
+		return UInt8Value(0)
 	}
 	return diff
 }
@@ -3043,8 +3493,18 @@ func (v UInt8Value) Mod(other NumberValue) NumberValue {
 
 func (v UInt8Value) Mul(other NumberValue) NumberValue {
 	o := other.(UInt8Value)
+	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint8 / o)) {
 		panic(OverflowError{})
+	}
+	return v * o
+}
+
+func (v UInt8Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(UInt8Value)
+	// INT30-C
+	if (v > 0) && (o > 0) && (v > (math.MaxUint8 / o)) {
+		return UInt8Value(math.MaxUint8)
 	}
 	return v * o
 }
@@ -3231,11 +3691,29 @@ func (v UInt16Value) Plus(other NumberValue) NumberValue {
 	return sum
 }
 
+func (v UInt16Value) SaturatingPlus(other NumberValue) NumberValue {
+	sum := v + other.(UInt16Value)
+	// INT30-C
+	if sum < v {
+		return UInt16Value(math.MaxUint16)
+	}
+	return sum
+}
+
 func (v UInt16Value) Minus(other NumberValue) NumberValue {
 	diff := v - other.(UInt16Value)
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
+	}
+	return diff
+}
+
+func (v UInt16Value) SaturatingMinus(other NumberValue) NumberValue {
+	diff := v - other.(UInt16Value)
+	// INT30-C
+	if diff > v {
+		return UInt16Value(0)
 	}
 	return diff
 }
@@ -3250,8 +3728,18 @@ func (v UInt16Value) Mod(other NumberValue) NumberValue {
 
 func (v UInt16Value) Mul(other NumberValue) NumberValue {
 	o := other.(UInt16Value)
+	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint16 / o)) {
 		panic(OverflowError{})
+	}
+	return v * o
+}
+
+func (v UInt16Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(UInt16Value)
+	// INT30-C
+	if (v > 0) && (o > 0) && (v > (math.MaxUint16 / o)) {
+		return UInt16Value(math.MaxUint16)
 	}
 	return v * o
 }
@@ -3442,11 +3930,29 @@ func (v UInt32Value) Plus(other NumberValue) NumberValue {
 	return sum
 }
 
+func (v UInt32Value) SaturatingPlus(other NumberValue) NumberValue {
+	sum := v + other.(UInt32Value)
+	// INT30-C
+	if sum < v {
+		return UInt32Value(math.MaxUint32)
+	}
+	return sum
+}
+
 func (v UInt32Value) Minus(other NumberValue) NumberValue {
 	diff := v - other.(UInt32Value)
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
+	}
+	return diff
+}
+
+func (v UInt32Value) SaturatingMinus(other NumberValue) NumberValue {
+	diff := v - other.(UInt32Value)
+	// INT30-C
+	if diff > v {
+		return UInt32Value(0)
 	}
 	return diff
 }
@@ -3463,6 +3969,15 @@ func (v UInt32Value) Mul(other NumberValue) NumberValue {
 	o := other.(UInt32Value)
 	if (v > 0) && (o > 0) && (v > (math.MaxUint32 / o)) {
 		panic(OverflowError{})
+	}
+	return v * o
+}
+
+func (v UInt32Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(UInt32Value)
+	// INT30-C
+	if (v > 0) && (o > 0) && (v > (math.MaxUint32 / o)) {
+		return UInt32Value(math.MaxUint32)
 	}
 	return v * o
 }
@@ -3658,11 +4173,29 @@ func (v UInt64Value) Plus(other NumberValue) NumberValue {
 	return UInt64Value(safeAddUint64(uint64(v), uint64(o)))
 }
 
+func (v UInt64Value) SaturatingPlus(other NumberValue) NumberValue {
+	sum := v + other.(UInt64Value)
+	// INT30-C
+	if sum < v {
+		return UInt64Value(math.MaxUint64)
+	}
+	return sum
+}
+
 func (v UInt64Value) Minus(other NumberValue) NumberValue {
 	diff := v - other.(UInt64Value)
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
+	}
+	return diff
+}
+
+func (v UInt64Value) SaturatingMinus(other NumberValue) NumberValue {
+	diff := v - other.(UInt64Value)
+	// INT30-C
+	if diff > v {
+		return UInt64Value(0)
 	}
 	return diff
 }
@@ -3679,6 +4212,15 @@ func (v UInt64Value) Mul(other NumberValue) NumberValue {
 	o := other.(UInt64Value)
 	if (v > 0) && (o > 0) && (v > (math.MaxUint64 / o)) {
 		panic(OverflowError{})
+	}
+	return v * o
+}
+
+func (v UInt64Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(UInt64Value)
+	// INT30-C
+	if (v > 0) && (o > 0) && (v > (math.MaxUint64 / o)) {
+		return UInt64Value(math.MaxUint64)
 	}
 	return v * o
 }
@@ -3892,6 +4434,25 @@ func (v UInt128Value) Plus(other NumberValue) NumberValue {
 	return UInt128Value{sum}
 }
 
+func (v UInt128Value) SaturatingPlus(other NumberValue) NumberValue {
+	sum := new(big.Int)
+	sum.Add(v.BigInt, other.(UInt128Value).BigInt)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just add and check the range of the result.
+	//
+	// If Go gains a native uint128 type and we switch this value
+	// to be based on it, then we need to follow INT30-C:
+	//
+	//  if sum < v {
+	//      ...
+	//  }
+	//
+	if sum.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
+		return UInt128Value{sema.UInt128TypeMaxIntBig}
+	}
+	return UInt128Value{sum}
+}
+
 func (v UInt128Value) Minus(other NumberValue) NumberValue {
 	diff := new(big.Int)
 	diff.Sub(v.BigInt, other.(UInt128Value).BigInt)
@@ -3907,6 +4468,25 @@ func (v UInt128Value) Minus(other NumberValue) NumberValue {
 	//
 	if diff.Cmp(sema.UInt128TypeMinIntBig) < 0 {
 		panic(UnderflowError{})
+	}
+	return UInt128Value{diff}
+}
+
+func (v UInt128Value) SaturatingMinus(other NumberValue) NumberValue {
+	diff := new(big.Int)
+	diff.Sub(v.BigInt, other.(UInt128Value).BigInt)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just subtract and check the range of the result.
+	//
+	// If Go gains a native uint128 type and we switch this value
+	// to be based on it, then we need to follow INT30-C:
+	//
+	//   if diff > v {
+	// 	     ...
+	//   }
+	//
+	if diff.Cmp(sema.UInt128TypeMinIntBig) < 0 {
+		return UInt128Value{sema.UInt128TypeMinIntBig}
 	}
 	return UInt128Value{diff}
 }
@@ -3927,6 +4507,16 @@ func (v UInt128Value) Mul(other NumberValue) NumberValue {
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
 		panic(OverflowError{})
+	}
+	return UInt128Value{res}
+}
+
+func (v UInt128Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(UInt128Value)
+	res := new(big.Int)
+	res.Mul(v.BigInt, o.BigInt)
+	if res.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
+		return UInt128Value{sema.UInt128TypeMaxIntBig}
 	}
 	return UInt128Value{res}
 }
@@ -4162,6 +4752,25 @@ func (v UInt256Value) Plus(other NumberValue) NumberValue {
 	return UInt256Value{sum}
 }
 
+func (v UInt256Value) SaturatingPlus(other NumberValue) NumberValue {
+	sum := new(big.Int)
+	sum.Add(v.BigInt, other.(UInt256Value).BigInt)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just add and check the range of the result.
+	//
+	// If Go gains a native uint256 type and we switch this value
+	// to be based on it, then we need to follow INT30-C:
+	//
+	//  if sum < v {
+	//      ...
+	//  }
+	//
+	if sum.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
+		return UInt256Value{sema.UInt256TypeMaxIntBig}
+	}
+	return UInt256Value{sum}
+}
+
 func (v UInt256Value) Minus(other NumberValue) NumberValue {
 	diff := new(big.Int)
 	diff.Sub(v.BigInt, other.(UInt256Value).BigInt)
@@ -4177,6 +4786,25 @@ func (v UInt256Value) Minus(other NumberValue) NumberValue {
 	//
 	if diff.Cmp(sema.UInt256TypeMinIntBig) < 0 {
 		panic(UnderflowError{})
+	}
+	return UInt256Value{diff}
+}
+
+func (v UInt256Value) SaturatingMinus(other NumberValue) NumberValue {
+	diff := new(big.Int)
+	diff.Sub(v.BigInt, other.(UInt256Value).BigInt)
+	// Given that this value is backed by an arbitrary size integer,
+	// we can just subtract and check the range of the result.
+	//
+	// If Go gains a native uint256 type and we switch this value
+	// to be based on it, then we need to follow INT30-C:
+	//
+	//   if diff > v {
+	// 	     ...
+	//   }
+	//
+	if diff.Cmp(sema.UInt256TypeMinIntBig) < 0 {
+		return UInt256Value{sema.UInt256TypeMinIntBig}
 	}
 	return UInt256Value{diff}
 }
@@ -4197,6 +4825,16 @@ func (v UInt256Value) Mul(other NumberValue) NumberValue {
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
 		panic(OverflowError{})
+	}
+	return UInt256Value{res}
+}
+
+func (v UInt256Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(UInt256Value)
+	res := new(big.Int)
+	res.Mul(v.BigInt, o.BigInt)
+	if res.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
+		return UInt256Value{sema.UInt256TypeMaxIntBig}
 	}
 	return UInt256Value{res}
 }
@@ -5107,6 +5745,17 @@ func (v Fix64Value) Plus(other NumberValue) NumberValue {
 	return Fix64Value(safeAddInt64(int64(v), int64(o)))
 }
 
+func (v Fix64Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(Fix64Value)
+	// INT32-C
+	if (o > 0) && (v > (math.MaxInt64 - o)) {
+		return Fix64Value(math.MaxInt64)
+	} else if (o < 0) && (v < (math.MinInt64 - o)) {
+		return Fix64Value(math.MinInt64)
+	}
+	return v + o
+}
+
 func (v Fix64Value) Minus(other NumberValue) NumberValue {
 	o := other.(Fix64Value)
 	// INT32-C
@@ -5117,6 +5766,20 @@ func (v Fix64Value) Minus(other NumberValue) NumberValue {
 	}
 	return v - o
 }
+
+func (v Fix64Value) SaturatingMinus(other NumberValue) NumberValue {
+	o := other.(Fix64Value)
+	// INT32-C
+	if (o > 0) && (v < (math.MinInt64 + o)) {
+		return Fix64Value(math.MaxInt64)
+	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
+		return Fix64Value(math.MinInt64)
+	}
+	return v - o
+}
+
+var minInt64Big = big.NewInt(math.MinInt64)
+var maxInt64Big = big.NewInt(math.MaxInt64)
 
 func (v Fix64Value) Mul(other NumberValue) NumberValue {
 	o := other.(Fix64Value)
@@ -5136,6 +5799,24 @@ func (v Fix64Value) Mul(other NumberValue) NumberValue {
 	return Fix64Value(result.Int64())
 }
 
+func (v Fix64Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(Fix64Value)
+
+	a := new(big.Int).SetInt64(int64(v))
+	b := new(big.Int).SetInt64(int64(o))
+
+	result := new(big.Int).Mul(a, b)
+	result.Div(result, sema.Fix64FactorBig)
+
+	if result.Cmp(minInt64Big) < 0 {
+		return Fix64Value(math.MinInt64)
+	} else if result.Cmp(maxInt64Big) > 0 {
+		return Fix64Value(math.MaxInt64)
+	}
+
+	return Fix64Value(result.Int64())
+}
+
 func (v Fix64Value) Div(other NumberValue) NumberValue {
 	o := other.(Fix64Value)
 
@@ -5149,6 +5830,24 @@ func (v Fix64Value) Div(other NumberValue) NumberValue {
 		panic(UnderflowError{})
 	} else if result.Cmp(maxInt64Big) > 0 {
 		panic(OverflowError{})
+	}
+
+	return Fix64Value(result.Int64())
+}
+
+func (v Fix64Value) SaturatingDiv(other NumberValue) NumberValue {
+	o := other.(Fix64Value)
+
+	a := new(big.Int).SetInt64(int64(v))
+	b := new(big.Int).SetInt64(int64(o))
+
+	result := new(big.Int).Mul(a, sema.Fix64FactorBig)
+	result.Div(result, b)
+
+	if result.Cmp(minInt64Big) < 0 {
+		return Fix64Value(math.MinInt64)
+	} else if result.Cmp(maxInt64Big) > 0 {
+		return Fix64Value(math.MaxInt64)
 	}
 
 	return Fix64Value(result.Int64())
@@ -5327,11 +6026,30 @@ func (v UFix64Value) Plus(other NumberValue) NumberValue {
 	return UFix64Value(safeAddUint64(uint64(v), uint64(o)))
 }
 
+func (v UFix64Value) SaturatingPlus(other NumberValue) NumberValue {
+	o := other.(UFix64Value)
+	sum := v + o
+	// INT30-C
+	if sum < v {
+		return UFix64Value(math.MaxUint64)
+	}
+	return sum
+}
+
 func (v UFix64Value) Minus(other NumberValue) NumberValue {
 	diff := v - other.(UFix64Value)
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
+	}
+	return diff
+}
+
+func (v UFix64Value) SaturatingMinus(other NumberValue) NumberValue {
+	diff := v - other.(UFix64Value)
+	// INT30-C
+	if diff > v {
+		return UFix64Value(0)
 	}
 	return diff
 }
@@ -5352,6 +6070,22 @@ func (v UFix64Value) Mul(other NumberValue) NumberValue {
 	return UFix64Value(result.Uint64())
 }
 
+func (v UFix64Value) SaturatingMul(other NumberValue) NumberValue {
+	o := other.(UFix64Value)
+
+	a := new(big.Int).SetUint64(uint64(v))
+	b := new(big.Int).SetUint64(uint64(o))
+
+	result := new(big.Int).Mul(a, b)
+	result.Div(result, sema.Fix64FactorBig)
+
+	if !result.IsUint64() {
+		return UFix64Value(math.MaxUint64)
+	}
+
+	return UFix64Value(result.Uint64())
+}
+
 func (v UFix64Value) Div(other NumberValue) NumberValue {
 	o := other.(UFix64Value)
 
@@ -5360,10 +6094,6 @@ func (v UFix64Value) Div(other NumberValue) NumberValue {
 
 	result := new(big.Int).Mul(a, sema.Fix64FactorBig)
 	result.Div(result, b)
-
-	if !result.IsUint64() {
-		panic(OverflowError{})
-	}
 
 	return UFix64Value(result.Uint64())
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1419,6 +1419,38 @@ func (v Int8Value) GetMember(_ *Interpreter, _ func() LocationRange, name string
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingDivideFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingDiv(other)
+			},
+		)
 	}
 
 	return nil
@@ -1727,6 +1759,38 @@ func (v Int16Value) GetMember(_ *Interpreter, _ func() LocationRange, name strin
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
+			},
+		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingDivideFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingDiv(other)
 			},
 		)
 	}
@@ -2041,6 +2105,38 @@ func (v Int32Value) GetMember(_ *Interpreter, _ func() LocationRange, name strin
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingDivideFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingDiv(other)
+			},
+		)
 	}
 
 	return nil
@@ -2350,6 +2446,38 @@ func (v Int64Value) GetMember(_ *Interpreter, _ func() LocationRange, name strin
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
+			},
+		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingDivideFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingDiv(other)
 			},
 		)
 	}
@@ -2734,6 +2862,38 @@ func (v Int128Value) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingDivideFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingDiv(other)
+			},
+		)
 	}
 
 	return nil
@@ -3115,6 +3275,38 @@ func (v Int256Value) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingDivideFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingDiv(other)
+			},
+		)
 	}
 
 	return nil
@@ -3374,6 +3566,14 @@ func (v UIntValue) GetMember(_ *Interpreter, _ func() LocationRange, name string
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
 	}
 
 	return nil
@@ -3611,6 +3811,30 @@ func (v UInt8Value) GetMember(_ *Interpreter, _ func() LocationRange, name strin
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
 	}
 
 	return nil
@@ -3844,6 +4068,30 @@ func (v UInt16Value) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
+			},
+		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
 			},
 		)
 	}
@@ -4082,6 +4330,30 @@ func (v UInt32Value) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
+			},
+		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
 			},
 		)
 	}
@@ -4323,6 +4595,30 @@ func (v UInt64Value) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
+			},
+		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
 			},
 		)
 	}
@@ -4645,6 +4941,30 @@ func (v UInt128Value) GetMember(_ *Interpreter, _ func() LocationRange, name str
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
 	}
 
 	return nil
@@ -4962,6 +5282,30 @@ func (v UInt256Value) GetMember(_ *Interpreter, _ func() LocationRange, name str
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
+			},
+		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
 			},
 		)
 	}
@@ -5936,6 +6280,38 @@ func (v Fix64Value) GetMember(_ *Interpreter, _ func() LocationRange, name strin
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
 			},
 		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingDivideFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingDiv(other)
+			},
+		)
 	}
 
 	return nil
@@ -6186,6 +6562,30 @@ func (v UFix64Value) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(v.ToBigEndianBytes())
+			},
+		)
+
+	case sema.NumericTypeSaturatingAddFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingPlus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingSubtractFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMinus(other)
+			},
+		)
+
+	case sema.NumericTypeSaturatingMultiplyFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				other := invocation.Arguments[0].(NumberValue)
+				return v.SaturatingMul(other)
 			},
 		)
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1223,9 +1223,9 @@ func (v Int8Value) SaturatingMinus(other NumberValue) NumberValue {
 	o := other.(Int8Value)
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt8 + o)) {
-		return Int8Value(math.MaxInt8)
-	} else if (o < 0) && (v > (math.MaxInt8 + o)) {
 		return Int8Value(math.MinInt8)
+	} else if (o < 0) && (v > (math.MaxInt8 + o)) {
+		return Int8Value(math.MaxInt8)
 	}
 	return v - o
 }
@@ -1565,9 +1565,9 @@ func (v Int16Value) SaturatingMinus(other NumberValue) NumberValue {
 	o := other.(Int16Value)
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt16 + o)) {
-		return Int16Value(math.MaxInt16)
-	} else if (o < 0) && (v > (math.MaxInt16 + o)) {
 		return Int16Value(math.MinInt16)
+	} else if (o < 0) && (v > (math.MaxInt16 + o)) {
+		return Int16Value(math.MaxInt16)
 	}
 	return v - o
 }
@@ -1909,9 +1909,9 @@ func (v Int32Value) SaturatingMinus(other NumberValue) NumberValue {
 	o := other.(Int32Value)
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt32 + o)) {
-		return Int32Value(math.MaxInt32)
-	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
 		return Int32Value(math.MinInt32)
+	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
+		return Int32Value(math.MaxInt32)
 	}
 	return v - o
 }
@@ -2257,9 +2257,9 @@ func (v Int64Value) SaturatingMinus(other NumberValue) NumberValue {
 	o := other.(Int64Value)
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
-		return Int64Value(math.MaxInt64)
-	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
 		return Int64Value(math.MinInt64)
+	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
+		return Int64Value(math.MaxInt64)
 	}
 	return v - o
 }
@@ -6115,9 +6115,9 @@ func (v Fix64Value) SaturatingMinus(other NumberValue) NumberValue {
 	o := other.(Fix64Value)
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
-		return Fix64Value(math.MaxInt64)
-	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
 		return Fix64Value(math.MinInt64)
+	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
+		return Fix64Value(math.MaxInt64)
 	}
 	return v - o
 }

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -361,9 +361,7 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 			_, err := ParseAndCheckWithPanic(t,
 				fmt.Sprintf(
 					`
-                      fun test(): %[1]s {
-                          let a: %[1]s = panic("")
-                          let b: %[1]s = panic("")
+                      fun test(a: %[1]s, b: %[1]s): %[1]s {
                           return a.%[2]s(b)
                       }
                     `,
@@ -373,14 +371,11 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 			)
 
 			if expected {
+				require.NoError(t, err)
+			} else {
 				errs := ExpectCheckerErrors(t, err, 1)
 
-				assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
-			} else {
-				errs := ExpectCheckerErrors(t, err, 2)
-
-				assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
-				assert.IsType(t, &sema.NotDeclaredMemberError{}, errs[1])
+				assert.IsType(t, &sema.NotDeclaredMemberError{}, errs[0])
 			}
 		})
 	}

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -808,7 +808,7 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 				require.NoError(t, err)
 
 				require.True(t,
-					bool(call.expected.Equal(inter, result)),
+					bool(call.expected.Equal(result, inter, false)),
 					fmt.Sprintf(
 						"%s(%s, %s) = %s != %s",
 						method, call.left, call.right, result, call.expected,

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -20,9 +20,12 @@ package interpreter_test
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -198,5 +201,627 @@ func TestInterpretModOperator(t *testing.T) {
 				inter.Globals["c"].GetValue(),
 			)
 		})
+	}
+}
+
+func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
+
+	t.Parallel()
+
+	type testCall struct {
+		left, right interpreter.Value
+		expected    interpreter.EquatableValue
+	}
+
+	type testCalls struct {
+		underflow, overflow testCall
+	}
+
+	type testCase struct {
+		add, subtract, multiply, divide testCalls
+	}
+
+	testCases := map[sema.Type]testCase{
+		sema.Int8Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.Int8Value(math.MaxInt8),
+					interpreter.Int8Value(2),
+					interpreter.Int8Value(math.MaxInt8),
+				},
+				underflow: testCall{
+					interpreter.Int8Value(math.MinInt8),
+					interpreter.Int8Value(-2),
+					interpreter.Int8Value(math.MinInt8),
+				},
+			},
+			subtract: testCalls{
+				overflow: testCall{
+					interpreter.Int8Value(math.MaxInt8),
+					interpreter.Int8Value(-2),
+					interpreter.Int8Value(math.MaxInt8),
+				},
+				underflow: testCall{
+					interpreter.Int8Value(math.MinInt8),
+					interpreter.Int8Value(2),
+					interpreter.Int8Value(math.MinInt8),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.Int8Value(math.MaxInt8),
+					interpreter.Int8Value(2),
+					interpreter.Int8Value(math.MaxInt8),
+				},
+				underflow: testCall{
+					interpreter.Int8Value(math.MinInt8),
+					interpreter.Int8Value(2),
+					interpreter.Int8Value(math.MinInt8),
+				},
+			},
+			divide: testCalls{
+				overflow: testCall{
+					interpreter.Int8Value(math.MinInt8),
+					interpreter.Int8Value(-1),
+					interpreter.Int8Value(math.MaxInt8),
+				},
+			},
+		},
+		sema.Int16Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.Int16Value(math.MaxInt16),
+					interpreter.Int16Value(2),
+					interpreter.Int16Value(math.MaxInt16),
+				},
+				underflow: testCall{
+					interpreter.Int16Value(math.MinInt16),
+					interpreter.Int16Value(-2),
+					interpreter.Int16Value(math.MinInt16),
+				},
+			},
+			subtract: testCalls{
+				overflow: testCall{
+					interpreter.Int16Value(math.MaxInt16),
+					interpreter.Int16Value(-2),
+					interpreter.Int16Value(math.MaxInt16),
+				},
+				underflow: testCall{
+					interpreter.Int16Value(math.MinInt16),
+					interpreter.Int16Value(2),
+					interpreter.Int16Value(math.MinInt16),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.Int16Value(math.MaxInt16),
+					interpreter.Int16Value(2),
+					interpreter.Int16Value(math.MaxInt16),
+				},
+				underflow: testCall{
+					interpreter.Int16Value(math.MinInt16),
+					interpreter.Int16Value(2),
+					interpreter.Int16Value(math.MinInt16),
+				},
+			},
+			divide: testCalls{
+				overflow: testCall{
+					interpreter.Int16Value(math.MinInt16),
+					interpreter.Int16Value(-1),
+					interpreter.Int16Value(math.MaxInt16),
+				},
+			},
+		},
+		sema.Int32Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.Int32Value(math.MaxInt32),
+					interpreter.Int32Value(2),
+					interpreter.Int32Value(math.MaxInt32),
+				},
+				underflow: testCall{
+					interpreter.Int32Value(math.MinInt32),
+					interpreter.Int32Value(-2),
+					interpreter.Int32Value(math.MinInt32),
+				},
+			},
+			subtract: testCalls{
+				overflow: testCall{
+					interpreter.Int32Value(math.MaxInt32),
+					interpreter.Int32Value(-2),
+					interpreter.Int32Value(math.MaxInt32),
+				},
+				underflow: testCall{
+					interpreter.Int32Value(math.MinInt32),
+					interpreter.Int32Value(2),
+					interpreter.Int32Value(math.MinInt32),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.Int32Value(math.MaxInt32),
+					interpreter.Int32Value(2),
+					interpreter.Int32Value(math.MaxInt32),
+				},
+				underflow: testCall{
+					interpreter.Int32Value(math.MinInt32),
+					interpreter.Int32Value(2),
+					interpreter.Int32Value(math.MinInt32),
+				},
+			},
+			divide: testCalls{
+				overflow: testCall{
+					interpreter.Int32Value(math.MinInt32),
+					interpreter.Int32Value(-1),
+					interpreter.Int32Value(math.MaxInt32),
+				},
+			},
+		},
+		sema.Int64Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.Int64Value(math.MaxInt64),
+					interpreter.Int64Value(2),
+					interpreter.Int64Value(math.MaxInt64),
+				},
+				underflow: testCall{
+					interpreter.Int64Value(math.MinInt64),
+					interpreter.Int64Value(-2),
+					interpreter.Int64Value(math.MinInt64),
+				},
+			},
+			subtract: testCalls{
+				overflow: testCall{
+					interpreter.Int64Value(math.MaxInt64),
+					interpreter.Int64Value(-2),
+					interpreter.Int64Value(math.MaxInt64),
+				},
+				underflow: testCall{
+					interpreter.Int64Value(math.MinInt64),
+					interpreter.Int64Value(2),
+					interpreter.Int64Value(math.MinInt64),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.Int64Value(math.MaxInt64),
+					interpreter.Int64Value(2),
+					interpreter.Int64Value(math.MaxInt64),
+				},
+				underflow: testCall{
+					interpreter.Int64Value(math.MinInt64),
+					interpreter.Int64Value(2),
+					interpreter.Int64Value(math.MinInt64),
+				},
+			},
+			divide: testCalls{
+				overflow: testCall{
+					interpreter.Int64Value(math.MinInt64),
+					interpreter.Int64Value(-1),
+					interpreter.Int64Value(math.MaxInt64),
+				},
+			},
+		},
+		sema.Int128Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+					interpreter.NewInt128ValueFromInt64(2),
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+				},
+				underflow: testCall{
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+					interpreter.NewInt128ValueFromInt64(-2),
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+				},
+			},
+			subtract: testCalls{
+				overflow: testCall{
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+					interpreter.NewInt128ValueFromInt64(-2),
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+				},
+				underflow: testCall{
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+					interpreter.NewInt128ValueFromInt64(2),
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+					interpreter.NewInt128ValueFromInt64(2),
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+				},
+				underflow: testCall{
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+					interpreter.NewInt128ValueFromInt64(2),
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+				},
+			},
+			divide: testCalls{
+				overflow: testCall{
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+					interpreter.NewInt128ValueFromInt64(-1),
+					interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+				},
+			},
+		},
+		sema.Int256Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+					interpreter.NewInt256ValueFromInt64(2),
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+				},
+				underflow: testCall{
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+					interpreter.NewInt256ValueFromInt64(-2),
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+				},
+			},
+			subtract: testCalls{
+				overflow: testCall{
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+					interpreter.NewInt256ValueFromInt64(-2),
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+				},
+				underflow: testCall{
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+					interpreter.NewInt256ValueFromInt64(2),
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+					interpreter.NewInt256ValueFromInt64(2),
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+				},
+				underflow: testCall{
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+					interpreter.NewInt256ValueFromInt64(2),
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+				},
+			},
+			divide: testCalls{
+				overflow: testCall{
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+					interpreter.NewInt256ValueFromInt64(-1),
+					interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+				},
+			},
+		},
+		sema.Fix64Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.Fix64Value(math.MaxInt64),
+					interpreter.NewFix64ValueWithInteger(2),
+					interpreter.Fix64Value(math.MaxInt64),
+				},
+				underflow: testCall{
+					interpreter.Fix64Value(math.MinInt64),
+					interpreter.NewFix64ValueWithInteger(-2),
+					interpreter.Fix64Value(math.MinInt64),
+				},
+			},
+			subtract: testCalls{
+				overflow: testCall{
+					interpreter.Fix64Value(math.MaxInt64),
+					interpreter.NewFix64ValueWithInteger(-2),
+					interpreter.Fix64Value(math.MaxInt64),
+				},
+				underflow: testCall{
+					interpreter.Fix64Value(math.MinInt64),
+					interpreter.NewFix64ValueWithInteger(2),
+					interpreter.Fix64Value(math.MinInt64),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.Fix64Value(math.MaxInt64),
+					interpreter.NewFix64ValueWithInteger(2),
+					interpreter.Fix64Value(math.MaxInt64),
+				},
+				underflow: testCall{
+					interpreter.Fix64Value(math.MinInt64),
+					interpreter.NewFix64ValueWithInteger(2),
+					interpreter.Fix64Value(math.MinInt64),
+				},
+			},
+			divide: testCalls{
+				overflow: testCall{
+					interpreter.Fix64Value(math.MinInt64),
+					interpreter.NewFix64ValueWithInteger(-1),
+					interpreter.Fix64Value(math.MaxInt64),
+				},
+			},
+		},
+		sema.UIntType: {
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.NewUIntValueFromBigInt(sema.UIntTypeMin),
+					interpreter.NewUIntValueFromUint64(2),
+					interpreter.NewUIntValueFromBigInt(sema.UIntTypeMin),
+				},
+			},
+		},
+		sema.UInt8Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.UInt8Value(math.MaxUint8),
+					interpreter.UInt8Value(2),
+					interpreter.UInt8Value(math.MaxUint8),
+				},
+			},
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.UInt8Value(0),
+					interpreter.UInt8Value(2),
+					interpreter.UInt8Value(0),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.UInt8Value(math.MaxUint8),
+					interpreter.UInt8Value(2),
+					interpreter.UInt8Value(math.MaxUint8),
+				},
+			},
+		},
+		sema.UInt16Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.UInt16Value(math.MaxUint16),
+					interpreter.UInt16Value(2),
+					interpreter.UInt16Value(math.MaxUint16),
+				},
+			},
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.UInt16Value(0),
+					interpreter.UInt16Value(2),
+					interpreter.UInt16Value(0),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.UInt16Value(math.MaxUint16),
+					interpreter.UInt16Value(2),
+					interpreter.UInt16Value(math.MaxUint16),
+				},
+			},
+		},
+		sema.UInt32Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.UInt32Value(math.MaxUint32),
+					interpreter.UInt32Value(2),
+					interpreter.UInt32Value(math.MaxUint32),
+				},
+			},
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.UInt32Value(0),
+					interpreter.UInt32Value(2),
+					interpreter.UInt32Value(0),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.UInt32Value(math.MaxUint32),
+					interpreter.UInt32Value(2),
+					interpreter.UInt32Value(math.MaxUint32),
+				},
+			},
+		},
+		sema.UInt64Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.UInt64Value(math.MaxUint64),
+					interpreter.UInt64Value(2),
+					interpreter.UInt64Value(math.MaxUint64),
+				},
+			},
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.UInt64Value(0),
+					interpreter.UInt64Value(2),
+					interpreter.UInt64Value(0),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.UInt64Value(math.MaxUint64),
+					interpreter.UInt64Value(2),
+					interpreter.UInt64Value(math.MaxUint64),
+				},
+			},
+		},
+		sema.UInt128Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.NewUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+					interpreter.NewUInt128ValueFromUint64(2),
+					interpreter.NewUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+				},
+			},
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.NewUInt128ValueFromBigInt(sema.UInt128TypeMinIntBig),
+					interpreter.NewUInt128ValueFromUint64(2),
+					interpreter.NewUInt128ValueFromBigInt(sema.UInt128TypeMinIntBig),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.NewUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+					interpreter.NewUInt128ValueFromUint64(2),
+					interpreter.NewUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+				},
+			},
+		},
+		sema.UInt256Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.NewUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+					interpreter.NewUInt256ValueFromUint64(2),
+					interpreter.NewUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+				},
+			},
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.NewUInt256ValueFromBigInt(sema.UInt256TypeMinIntBig),
+					interpreter.NewUInt256ValueFromUint64(2),
+					interpreter.NewUInt256ValueFromBigInt(sema.UInt256TypeMinIntBig),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.NewUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+					interpreter.NewUInt256ValueFromUint64(2),
+					interpreter.NewUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+				},
+			},
+		},
+		sema.UFix64Type: {
+			add: testCalls{
+				overflow: testCall{
+					interpreter.UFix64Value(math.MaxUint64),
+					interpreter.NewUFix64ValueWithInteger(2),
+					interpreter.UFix64Value(math.MaxUint64),
+				},
+			},
+			subtract: testCalls{
+				underflow: testCall{
+					interpreter.UFix64Value(0),
+					interpreter.NewUFix64ValueWithInteger(2),
+					interpreter.UFix64Value(0),
+				},
+			},
+			multiply: testCalls{
+				overflow: testCall{
+					interpreter.UFix64Value(math.MaxUint64),
+					interpreter.NewUFix64ValueWithInteger(2),
+					interpreter.UFix64Value(math.MaxUint64),
+				},
+			},
+		},
+	}
+
+	// Verify all test cases exist
+
+	for _, ty := range append(
+		sema.AllSignedIntegerTypes[:],
+		sema.AllSignedFixedPointTypes...,
+	) {
+
+		testCase, ok := testCases[ty]
+
+		if ty == sema.IntType {
+			require.False(t, ok, "invalid test case for %s", ty)
+		} else {
+			require.True(t, ok, "missing test case for %s", ty)
+
+			require.NotNil(t, testCase.add.overflow.expected)
+			require.NotNil(t, testCase.add.underflow.expected)
+
+			require.NotNil(t, testCase.subtract.overflow.expected)
+			require.NotNil(t, testCase.subtract.underflow.expected)
+
+			require.NotNil(t, testCase.multiply.overflow.expected)
+			require.NotNil(t, testCase.multiply.underflow.expected)
+
+			require.NotNil(t, testCase.divide.overflow.expected)
+			require.Nil(t, testCase.divide.underflow.expected)
+		}
+	}
+
+	for _, ty := range append(
+		sema.AllUnsignedIntegerTypes[:],
+		sema.AllUnsignedFixedPointTypes...,
+	) {
+
+		if strings.HasPrefix(ty.String(), "Word") {
+			continue
+		}
+
+		testCase, ok := testCases[ty]
+		require.True(t, ok, "missing test case for %s", ty)
+
+		if ty == sema.UIntType {
+
+			require.Nil(t, testCase.add.overflow.expected)
+			require.Nil(t, testCase.add.underflow.expected)
+
+			require.Nil(t, testCase.subtract.overflow.expected)
+			require.NotNil(t, testCase.subtract.underflow.expected)
+
+			require.Nil(t, testCase.multiply.overflow.expected)
+			require.Nil(t, testCase.multiply.underflow.expected)
+
+			require.Nil(t, testCase.divide.overflow.expected)
+			require.Nil(t, testCase.divide.underflow.expected)
+		} else {
+			require.NotNil(t, testCase.add.overflow.expected)
+			require.Nil(t, testCase.add.underflow.expected)
+
+			require.Nil(t, testCase.subtract.overflow.expected)
+			require.NotNil(t, testCase.subtract.underflow.expected)
+
+			require.NotNil(t, testCase.multiply.overflow.expected)
+			require.Nil(t, testCase.multiply.underflow.expected)
+
+			require.Nil(t, testCase.divide.overflow.expected)
+			require.Nil(t, testCase.divide.underflow.expected)
+		}
+	}
+
+	test := func(ty sema.Type, method string, calls testCalls) {
+
+		method = fmt.Sprintf("saturating%s", method)
+
+		for kind, call := range map[string]testCall{
+			"overflow":  calls.overflow,
+			"underflow": calls.underflow,
+		} {
+
+			if call.expected == nil {
+				continue
+			}
+
+			t.Run(fmt.Sprintf("%s %s %s", ty, method, kind), func(t *testing.T) {
+
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+                          fun test(a: %[1]s, b: %[1]s): %[1]s {
+                              return a.%[2]s(b)
+                          }
+                        `,
+						ty,
+						method,
+					),
+				)
+
+				result, err := inter.Invoke("test", call.left, call.right)
+				require.NoError(t, err)
+
+				require.True(t,
+					bool(call.expected.Equal(inter, result)),
+					fmt.Sprintf(
+						"%s(%s, %s) = %s != %s",
+						method, call.left, call.right, result, call.expected,
+					),
+				)
+			})
+		}
+	}
+
+	for ty, testCase := range testCases {
+		test(ty, "Add", testCase.add)
+		test(ty, "Subtract", testCase.subtract)
+		test(ty, "Multiply", testCase.multiply)
+		test(ty, "Divide", testCase.divide)
 	}
 }


### PR DESCRIPTION
Closes #801 

## Description

Add saturation arithmetic functions:

- `Int8`, `Int16`, `Int32`, `Int64`, `Int128`, `Int256`:  
  - `saturatingAdd`
  - `saturatingSubtract`
  - `saturatingMultiply`
  - `saturatingDivide`

- `UInt`:
  - `saturatingSubtract`

- `Int`: 
  none

- `UInt8`, `UInt16`, `UInt32`, `UInt64`, `UInt128`, `UInt256`:  
  - `saturatingAdd`
  - `saturatingSubtract`
  - `saturatingMultiply`

- `Fix64`:  
  - `saturatingAdd`
  - `saturatingSubtract`
  - `saturatingMultiply`
  - `saturatingDivide`

- `UFix64`:  
  - `saturatingAdd`
  - `saturatingSubtract`
  - `saturatingMultiply`

Also, correctly return underflow errors in multiplication functions

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
