### PR TITLE
added balance fields on accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ language/tools/vscode-extension/out/*
 crashers
 corpus
 suppressions
+
+languageserver/test/languageserver

--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -11,6 +11,10 @@ Every account can be accessed through two types:
   struct PublicAccount {
 
       let address: Address
+      // The FLOW balance of the default vault of this account
+      let balance: UFix64
+      // The FLOW balance of the default vault of this account that is available to be moved
+      let availableBalance: UFix64
       let storageUsed: UInt64
       let storageCapacity: UInt64
 
@@ -51,6 +55,10 @@ Every account can be accessed through two types:
   struct AuthAccount {
 
       let address: Address
+      // The FLOW balance of the default vault of this account
+      let balance: UFix64
+      // The FLOW balance of the default vault of this account that is available to be moved
+      let availableBalance: UFix64
       let storageUsed: UInt64
       let storageCapacity: UInt64
 

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -103,6 +103,10 @@ type Interface interface {
 	) (bool, error)
 	// Hash returns the digest of hashing the given data with using the given hash algorithm
 	Hash(data []byte, hashAlgorithm HashAlgorithm) ([]byte, error)
+	// GetAccountBalance gets accounts default flow token balance.
+	GetAccountBalance(address common.Address) (value uint64, err error)
+	// GetAccountAvailableBalance gets accounts default flow token balance - balance that is reserved for storage.
+	GetAccountAvailableBalance(address common.Address) (value uint64, err error)
 	// GetStorageUsed gets storage used in bytes by the address at the moment of the function call.
 	GetStorageUsed(address Address) (value uint64, err error)
 	// GetStorageCapacity gets storage capacity in bytes on the address.
@@ -275,6 +279,14 @@ func (i *emptyRuntimeInterface) Hash(
 	_ HashAlgorithm,
 ) ([]byte, error) {
 	return nil, nil
+}
+
+func (i emptyRuntimeInterface) GetAccountBalance(_ Address) (uint64, error) {
+	return 0, nil
+}
+
+func (i emptyRuntimeInterface) GetAccountAvailableBalance(_ Address) (uint64, error) {
+	return 0, nil
 }
 
 func (i emptyRuntimeInterface) GetStorageUsed(_ Address) (uint64, error) {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7086,7 +7086,7 @@ func (v AddressValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicT
 func NewAuthAccountValue(
 	address AddressValue,
 	accountBalanceGet func() UFix64Value,
-	accountAvailableBalanceGet func(interpreter *Interpreter) UFix64Value,
+	accountAvailableBalanceGet func() UFix64Value,
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
 	storageCapacityGet func() UInt64Value,
 	addPublicKeyFunction FunctionValue,
@@ -7110,8 +7110,8 @@ func NewAuthAccountValue(
 		return accountBalanceGet()
 	})
 
-	computedFields.Set(sema.AuthAccountAvailableBalanceField, func(inter *Interpreter) Value {
-		return accountAvailableBalanceGet(inter)
+	computedFields.Set(sema.AuthAccountAvailableBalanceField, func(*Interpreter) Value {
+		return accountAvailableBalanceGet()
 	})
 
 	computedFields.Set(sema.AuthAccountStorageUsedField, func(inter *Interpreter) Value {
@@ -7199,7 +7199,7 @@ func accountGetCapabilityFunction(
 func NewPublicAccountValue(
 	address AddressValue,
 	accountBalanceGet func() UFix64Value,
-	accountAvailableBalanceGet func(interpreter *Interpreter) UFix64Value,
+	accountAvailableBalanceGet func() UFix64Value,
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
 	storageCapacityGet func() UInt64Value,
 	keys *CompositeValue,
@@ -7217,8 +7217,8 @@ func NewPublicAccountValue(
 		return accountBalanceGet()
 	})
 
-	computedFields.Set(sema.PublicAccountAvailableBalanceField, func(inter *Interpreter) Value {
-		return accountAvailableBalanceGet(inter)
+	computedFields.Set(sema.PublicAccountAvailableBalanceField, func(*Interpreter) Value {
+		return accountAvailableBalanceGet()
 	})
 
 	computedFields.Set(sema.PublicAccountStorageUsedField, func(inter *Interpreter) Value {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7085,6 +7085,8 @@ func (v AddressValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicT
 // NewAuthAccountValue constructs an auth account value.
 func NewAuthAccountValue(
 	address AddressValue,
+	accountBalanceGet func() UFix64Value,
+	accountAvailableBalanceGet func(interpreter *Interpreter) UFix64Value,
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
 	storageCapacityGet func() UInt64Value,
 	addPublicKeyFunction FunctionValue,
@@ -7103,6 +7105,14 @@ func NewAuthAccountValue(
 
 	// Computed fields
 	computedFields := NewStringComputedFieldOrderedMap()
+
+	computedFields.Set(sema.AuthAccountBalanceField, func(*Interpreter) Value {
+		return accountBalanceGet()
+	})
+
+	computedFields.Set(sema.AuthAccountAvailableBalanceField, func(inter *Interpreter) Value {
+		return accountAvailableBalanceGet(inter)
+	})
 
 	computedFields.Set(sema.AuthAccountStorageUsedField, func(inter *Interpreter) Value {
 		return storageUsedGet(inter)
@@ -7188,6 +7198,8 @@ func accountGetCapabilityFunction(
 // NewPublicAccountValue constructs a public account value.
 func NewPublicAccountValue(
 	address AddressValue,
+	accountBalanceGet func() UFix64Value,
+	accountAvailableBalanceGet func(interpreter *Interpreter) UFix64Value,
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
 	storageCapacityGet func() UInt64Value,
 	keys *CompositeValue,
@@ -7200,6 +7212,14 @@ func NewPublicAccountValue(
 
 	// Computed fields
 	computedFields := NewStringComputedFieldOrderedMap()
+
+	computedFields.Set(sema.PublicAccountBalanceField, func(*Interpreter) Value {
+		return accountBalanceGet()
+	})
+
+	computedFields.Set(sema.PublicAccountAvailableBalanceField, func(inter *Interpreter) Value {
+		return accountAvailableBalanceGet(inter)
+	})
 
 	computedFields.Set(sema.PublicAccountStorageUsedField, func(inter *Interpreter) Value {
 		return storageUsedGet(inter)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -322,7 +322,7 @@ func (r *interpreterRuntime) newAuthAccountValue(
 	return interpreter.NewAuthAccountValue(
 		addressValue,
 		accountBalanceGetFunction(addressValue, context.Interface),
-		accountAvailableBalanceGetFunction(addressValue, context.Interface, runtimeStorage),
+		accountAvailableBalanceGetFunction(addressValue, context.Interface),
 		storageUsedGetFunction(addressValue, context.Interface, runtimeStorage),
 		storageCapacityGetFunction(addressValue, context.Interface),
 		r.newAddPublicKeyFunction(addressValue, context.Interface),
@@ -1225,15 +1225,9 @@ func accountBalanceGetFunction(
 func accountAvailableBalanceGetFunction(
 	addressValue interpreter.AddressValue,
 	runtimeInterface Interface,
-	runtimeStorage *runtimeStorage,
-) func(inter *interpreter.Interpreter) interpreter.UFix64Value {
+) func() interpreter.UFix64Value {
 	address := addressValue.ToAddress()
-	return func(inter *interpreter.Interpreter) interpreter.UFix64Value {
-
-		// NOTE: flush the cached values, so the host environment
-		// can properly calculate the amount of storage used by the account and thus the available balance
-		runtimeStorage.writeCached(inter)
-
+	return func() interpreter.UFix64Value {
 		var balance uint64
 		var err error
 		wrapPanic(func() {
@@ -1577,7 +1571,7 @@ func (r *interpreterRuntime) getPublicAccount(
 	return interpreter.NewPublicAccountValue(
 		accountAddress,
 		accountBalanceGetFunction(accountAddress, runtimeInterface),
-		accountAvailableBalanceGetFunction(accountAddress, runtimeInterface, runtimeStorage),
+		accountAvailableBalanceGetFunction(accountAddress, runtimeInterface),
 		storageUsedGetFunction(accountAddress, runtimeInterface, runtimeStorage),
 		storageCapacityGetFunction(accountAddress, runtimeInterface),
 		r.newPublicAccountKeys(accountAddress, runtimeInterface),

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -24,6 +24,8 @@ import (
 
 const AuthAccountTypeName = "AuthAccount"
 const AuthAccountAddressField = "address"
+const AuthAccountBalanceField = "balance"
+const AuthAccountAvailableBalanceField = "availableBalance"
 const AuthAccountStorageUsedField = "storageUsed"
 const AuthAccountStorageCapacityField = "storageCapacity"
 const AuthAccountAddPublicKeyField = "addPublicKey"
@@ -64,6 +66,18 @@ var AuthAccountType = func() *CompositeType {
 			AuthAccountAddressField,
 			&AddressType{},
 			accountTypeAddressFieldDocString,
+		),
+		NewPublicConstantFieldMember(
+			authAccountType,
+			AuthAccountBalanceField,
+			UFix64Type,
+			accountTypeAccountBalanceFieldDocString,
+		),
+		NewPublicConstantFieldMember(
+			authAccountType,
+			AuthAccountAvailableBalanceField,
+			UFix64Type,
+			accountTypeAccountAvailableBalanceFieldDocString,
 		),
 		NewPublicConstantFieldMember(
 			authAccountType,
@@ -604,6 +618,14 @@ The address of the account
 
 const accountTypeContractsFieldDocString = `
 The contracts of the account
+`
+
+const accountTypeAccountBalanceFieldDocString = `
+The FLOW balance of the default vault of this account
+`
+
+const accountTypeAccountAvailableBalanceFieldDocString = `
+The FLOW balance of the default vault of this account that is available to be moved
 `
 
 const accountTypeStorageUsedFieldDocString = `

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -24,6 +24,8 @@ import (
 
 const PublicAccountTypeName = "PublicAccount"
 const PublicAccountAddressField = "address"
+const PublicAccountBalanceField = "balance"
+const PublicAccountAvailableBalanceField = "availableBalance"
 const PublicAccountStorageUsedField = "storageUsed"
 const PublicAccountStorageCapacityField = "storageCapacity"
 const PublicAccountGetCapabilityField = "getCapability"
@@ -52,6 +54,18 @@ var PublicAccountType = func() *CompositeType {
 			PublicAccountAddressField,
 			&AddressType{},
 			accountTypeAddressFieldDocString,
+		),
+		NewPublicConstantFieldMember(
+			publicAccountType,
+			PublicAccountBalanceField,
+			UFix64Type,
+			accountTypeAccountBalanceFieldDocString,
+		),
+		NewPublicConstantFieldMember(
+			publicAccountType,
+			PublicAccountAvailableBalanceField,
+			UFix64Type,
+			accountTypeAccountAvailableBalanceFieldDocString,
 		),
 		NewPublicConstantFieldMember(
 			publicAccountType,

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1255,6 +1255,53 @@ func TestCheckAccount_getCapability(t *testing.T) {
 	}
 }
 
+func TestCheckAccount_BalanceFields(t *testing.T) {
+	t.Parallel()
+
+	for accountType, accountVariable := range map[string]string{
+		"AuthAccount":   "authAccount",
+		"PublicAccount": "publicAccount",
+	} {
+
+		for _, fieldName := range []string{
+			"balance",
+			"availableBalance",
+		} {
+
+			testName := fmt.Sprintf(
+				"%s.%s",
+				accountType,
+				fieldName,
+			)
+
+			t.Run(testName, func(t *testing.T) {
+
+				code := fmt.Sprintf(
+					`
+	                      fun test(): UFix64 {
+	                          return %s.%s
+	                      }
+
+                          let amount = test()
+	                    `,
+					accountVariable,
+					fieldName,
+				)
+				checker, err := ParseAndCheckAccount(
+					t,
+					code,
+				)
+
+				require.NoError(t, err)
+
+				amountType := RequireGlobalValue(t, checker.Elaboration, "amount")
+
+				assert.Equal(t, sema.UFix64Type, amountType)
+			})
+		}
+	}
+}
+
 func TestCheckAccount_StorageFields(t *testing.T) {
 	t.Parallel()
 

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -50,10 +50,14 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		Type: sema.AuthAccountType,
 		Value: interpreter.NewAuthAccountValue(
 			address,
+			returnZeroUFix64,
+			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+				return 0
+			},
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
-			returnZero,
+			returnZeroUInt64,
 			panicFunction,
 			panicFunction,
 			&interpreter.CompositeValue{},
@@ -70,10 +74,14 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		Type: sema.PublicAccountType,
 		Value: interpreter.NewPublicAccountValue(
 			address,
+			returnZeroUFix64,
+			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+				return 0
+			},
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
-			returnZero,
+			returnZeroUInt64,
 			interpreter.NewPublicAccountKeysValue(
 				nil,
 			),
@@ -138,8 +146,12 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 	return inter, storedValues
 }
 
-func returnZero() interpreter.UInt64Value {
+func returnZeroUInt64() interpreter.UInt64Value {
 	return interpreter.UInt64Value(0)
+}
+
+func returnZeroUFix64() interpreter.UFix64Value {
+	return interpreter.UFix64Value(0)
 }
 
 func TestInterpretAuthAccount_save(t *testing.T) {
@@ -1407,6 +1419,50 @@ func TestInterpretAccount_getCapability(t *testing.T) {
 					}
 				})
 			}
+		}
+	}
+}
+
+func TestCheckAccount_BalanceFields(t *testing.T) {
+	t.Parallel()
+
+	for accountType, auth := range map[string]bool{
+		"AuthAccount":   true,
+		"PublicAccount": false,
+	} {
+
+		for _, fieldName := range []string{
+			"balance",
+			"availableBalance",
+		} {
+
+			testName := fmt.Sprintf(
+				"%s.%s",
+				accountType,
+				fieldName,
+			)
+
+			t.Run(testName, func(t *testing.T) {
+
+				code := fmt.Sprintf(
+					`
+	                      fun test(): UFix64 {
+	                          return account.%s
+	                      }
+	                    `,
+					fieldName,
+				)
+				inter, _ := testAccount(
+					t,
+					auth,
+					code,
+				)
+
+				value, err := inter.Invoke("test")
+				require.NoError(t, err)
+
+				assert.Equal(t, interpreter.UFix64Value(0), value)
+			})
 		}
 	}
 }

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -51,9 +51,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		Value: interpreter.NewAuthAccountValue(
 			address,
 			returnZeroUFix64,
-			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-				return 0
-			},
+			returnZeroUFix64,
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
@@ -75,9 +73,7 @@ func testAccount(t *testing.T, auth bool, code string) (*interpreter.Interpreter
 		Value: interpreter.NewPublicAccountValue(
 			address,
 			returnZeroUFix64,
-			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-				return 0
-			},
+			returnZeroUFix64,
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6265,9 +6265,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 							interpreter.NewAuthAccountValue(
 								addressValue,
 								returnZeroUFix64,
-								func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-									return 0
-								},
+								returnZeroUFix64,
 								func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 									return 0
 								},
@@ -6790,9 +6788,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		Value: interpreter.NewAuthAccountValue(
 			addressValue,
 			returnZeroUFix64,
-			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-				return 0
-			},
+			returnZeroUFix64,
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
@@ -6830,9 +6826,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 						return interpreter.NewPublicAccountValue(
 							address,
 							returnZeroUFix64,
-							func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-								return 0
-							},
+							returnZeroUFix64,
 							func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 								panic(errors.NewUnreachableError())
 							},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6264,10 +6264,14 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 							"account",
 							interpreter.NewAuthAccountValue(
 								addressValue,
+								returnZeroUFix64,
+								func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+									return 0
+								},
 								func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 									return 0
 								},
-								returnZero,
+								returnZeroUInt64,
 								panicFunction,
 								panicFunction,
 								&interpreter.CompositeValue{},
@@ -6785,10 +6789,14 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		Type: sema.AuthAccountType,
 		Value: interpreter.NewAuthAccountValue(
 			addressValue,
+			returnZeroUFix64,
+			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+				return 0
+			},
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
-			returnZero,
+			returnZeroUInt64,
 			panicFunction,
 			panicFunction,
 			&interpreter.CompositeValue{},
@@ -6821,6 +6829,10 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 					func(address interpreter.AddressValue) *interpreter.CompositeValue {
 						return interpreter.NewPublicAccountValue(
 							address,
+							returnZeroUFix64,
+							func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+								return 0
+							},
 							func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 								panic(errors.NewUnreachableError())
 							},

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -220,10 +220,14 @@ func TestInterpretTransactions(t *testing.T) {
 
 		signer1 := interpreter.NewAuthAccountValue(
 			interpreter.AddressValue{0, 0, 0, 0, 0, 0, 0, 1},
+			returnZeroUFix64,
+			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+				return 0
+			},
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
-			returnZero,
+			returnZeroUInt64,
 			panicFunction,
 			panicFunction,
 			&interpreter.CompositeValue{},
@@ -231,10 +235,14 @@ func TestInterpretTransactions(t *testing.T) {
 		)
 		signer2 := interpreter.NewAuthAccountValue(
 			interpreter.AddressValue{0, 0, 0, 0, 0, 0, 0, 2},
+			returnZeroUFix64,
+			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+				return 0
+			},
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
-			returnZero,
+			returnZeroUInt64,
 			panicFunction,
 			panicFunction,
 			&interpreter.CompositeValue{},
@@ -273,10 +281,14 @@ func TestInterpretTransactions(t *testing.T) {
 		prepareArguments := []interpreter.Value{
 			interpreter.NewAuthAccountValue(
 				interpreter.AddressValue{},
+				returnZeroUFix64,
+				func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
+					return 0
+				},
 				func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 					return 0
 				},
-				returnZero,
+				returnZeroUInt64,
 				panicFunction,
 				panicFunction,
 				&interpreter.CompositeValue{},

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -221,9 +221,7 @@ func TestInterpretTransactions(t *testing.T) {
 		signer1 := interpreter.NewAuthAccountValue(
 			interpreter.AddressValue{0, 0, 0, 0, 0, 0, 0, 1},
 			returnZeroUFix64,
-			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-				return 0
-			},
+			returnZeroUFix64,
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
@@ -236,9 +234,7 @@ func TestInterpretTransactions(t *testing.T) {
 		signer2 := interpreter.NewAuthAccountValue(
 			interpreter.AddressValue{0, 0, 0, 0, 0, 0, 0, 2},
 			returnZeroUFix64,
-			func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-				return 0
-			},
+			returnZeroUFix64,
 			func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 				return 0
 			},
@@ -282,9 +278,7 @@ func TestInterpretTransactions(t *testing.T) {
 			interpreter.NewAuthAccountValue(
 				interpreter.AddressValue{},
 				returnZeroUFix64,
-				func(interpreter *interpreter.Interpreter) interpreter.UFix64Value {
-					return 0
-				},
+				returnZeroUFix64,
 				func(interpreter *interpreter.Interpreter) interpreter.UInt64Value {
 					return 0
 				},


### PR DESCRIPTION
ref: https://github.com/dapperlabs/flow-internal/issues/1499

## Description

Added convenience fields to AuthAccount and PublicAccount.

- `balance` returns the FLOW balance of the accounts default vault
- `availableBalance` returns the FLOW balance of the accounts default vault minus the amount reserved for storage.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
