### PR TITLE
Prevent cyclic imports

### DIFF
--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -95,7 +95,7 @@ func PrepareChecker(
 		sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 		sema.WithPredeclaredTypes(typeDeclarations),
 		sema.WithImportHandler(
-			func(checker *sema.Checker, importedLocation common.Location) (sema.Import, error) {
+			func(checker *sema.Checker, importedLocation common.Location, importRange ast.Range) (sema.Import, error) {
 				stringLocation, ok := importedLocation.(common.StringLocation)
 
 				if !ok {

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -1,0 +1,119 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+func TestRuntimeCyclicImport(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewInterpreterRuntime()
+
+	imported1 := []byte(`
+      import p2
+    `)
+
+	imported2 := []byte(`
+      import p1
+    `)
+
+	script := []byte(`
+      import p1
+
+      pub fun main() {}
+    `)
+
+	var checkCount int
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(location Location) (bytes []byte, err error) {
+			switch location {
+			case common.IdentifierLocation("p1"):
+				return imported1, nil
+			case common.IdentifierLocation("p2"):
+				return imported2, nil
+			default:
+				return nil, fmt.Errorf("unknown import location: %s", location)
+			}
+		},
+		programChecked: func(location common.Location, duration time.Duration) {
+			checkCount += 1
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	location := nextTransactionLocation()
+	context := Context{
+		Interface: runtimeInterface,
+		Location:  location,
+	}
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		context,
+	)
+	require.Error(t, err)
+
+	// Script
+
+	var checkerErr *sema.CheckerError
+	require.ErrorAs(t, err, &checkerErr)
+
+	require.Len(t, checkerErr.ChildErrors(), 1)
+	childErr := checkerErr.ChildErrors()[0]
+
+	var importedProgramErr *sema.ImportedProgramError
+	require.ErrorAs(t, childErr, &importedProgramErr)
+
+	// P1
+
+	var checkerErr2 *sema.CheckerError
+	require.ErrorAs(t, importedProgramErr.Err, &checkerErr2)
+
+	require.Len(t, checkerErr2.ChildErrors(), 1)
+	childErr2 := checkerErr2.ChildErrors()[0]
+
+	var importedProgramErr2 *sema.ImportedProgramError
+	require.ErrorAs(t, childErr2, &importedProgramErr2)
+
+	// P2
+
+	var checkerErr3 *sema.CheckerError
+	require.ErrorAs(t, importedProgramErr2.Err, &checkerErr3)
+
+	require.Len(t, checkerErr3.ChildErrors(), 1)
+	childErr3 := checkerErr3.ChildErrors()[0]
+
+	var importedProgramErr3 *sema.ImportedProgramError
+	require.ErrorAs(t, childErr3, &importedProgramErr3)
+
+	require.IsType(t, importedProgramErr3.Err, &sema.CyclicImportsError{})
+}

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -62,7 +62,7 @@ func NewREPL(
 			sema.WithPredeclaredTypes(typeDeclarations),
 			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
 			sema.WithImportHandler(
-				func(checker *sema.Checker, importedLocation common.Location) (sema.Import, error) {
+				func(checker *sema.Checker, importedLocation common.Location, importRange ast.Range) (sema.Import, error) {
 					stringLocation, ok := importedLocation.(common.StringLocation)
 
 					if !ok {

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -62,7 +62,7 @@ func NewREPL(
 			sema.WithPredeclaredTypes(typeDeclarations),
 			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
 			sema.WithImportHandler(
-				func(checker *sema.Checker, importedLocation common.Location, importRange ast.Range) (sema.Import, error) {
+				func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					stringLocation, ok := importedLocation.(common.StringLocation)
 
 					if !ok {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -705,23 +705,25 @@ func (r *interpreterRuntime) check(
 					},
 				),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(checker *sema.Checker, importedLocation common.Location, importRange ast.Range) (sema.Import, error) {
+
 						var elaboration *sema.Elaboration
-						switch location {
+						switch importedLocation {
 						case stdlib.CryptoChecker.Location:
 							elaboration = stdlib.CryptoChecker.Elaboration
 
 						default:
-							context := startContext.WithLocation(location)
+							context := startContext.WithLocation(importedLocation)
 
 							// Check for cyclic imports
-							if checkedImports[location.ID()] {
+							if checkedImports[importedLocation.ID()] {
 								return nil, &sema.CyclicImportsError{
-									Location: location,
+									Location: importedLocation,
+									Range:    importRange,
 								}
 							} else {
-								checkedImports[location.ID()] = true
-								defer delete(checkedImports, location.ID())
+								checkedImports[importedLocation.ID()] = true
+								defer delete(checkedImports, importedLocation.ID())
 							}
 
 							program, err := r.getProgram(context, functions, values, checkerOptions, checkedImports)
@@ -753,9 +755,6 @@ func (r *interpreterRuntime) check(
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: set elaboration *before* checking,
-	// so it is returned when there is a cyclic import
 
 	elaboration = checker.Elaboration
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -74,7 +74,7 @@ type ResolvedLocation struct {
 
 type LocationHandlerFunc func(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
 
-type ImportHandlerFunc func(checker *Checker, location common.Location) (Import, error)
+type ImportHandlerFunc func(checker *Checker, importedLocation common.Location, importRange ast.Range) (Import, error)
 
 // Checker
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1131,11 +1131,7 @@ func (e *ImportedProgramError) ImportLocation() common.Location {
 }
 
 func (e *ImportedProgramError) ChildErrors() []error {
-	parentErr, ok := e.Err.(errors.ParentError)
-	if !ok {
-		return nil
-	}
-	return parentErr.ChildErrors()
+	return []error{e.Err}
 }
 
 func (*ImportedProgramError) isSemanticError() {}

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -1642,7 +1642,7 @@ func TestCheckAccessImportGlobalValue(t *testing.T) {
 						Options: []sema.Option{
 							sema.WithAccessCheckMode(checkMode),
 							sema.WithImportHandler(
-								func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+								func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 									return sema.ElaborationImport{
 										Elaboration: importedChecker.Elaboration,
 									}, nil
@@ -1849,7 +1849,7 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
 					Options: []sema.Option{
 						sema.WithAccessCheckMode(checkMode),
 						sema.WithImportHandler(
-							func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 								return sema.ElaborationImport{
 									Elaboration: imported.Elaboration,
 								}, nil
@@ -1895,7 +1895,7 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: imported.Elaboration,
 						}, nil
@@ -2382,7 +2382,7 @@ func TestCheckAccountAccess(t *testing.T) {
 									Options: []sema.Option{
 										sema.WithAccessCheckMode(checkMode),
 										sema.WithImportHandler(
-											func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+											func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 												return sema.ElaborationImport{
 													Elaboration: importedChecker.Elaboration,
 												}, nil

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/tests/utils"
@@ -266,7 +267,7 @@ func TestCheckEmitEvent(t *testing.T) {
 			ParseAndCheckOptions{
 				Options: []sema.Option{
 					sema.WithImportHandler(
-						func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+						func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 							return sema.ElaborationImport{
 								Elaboration: importedChecker.Elaboration,
 							}, nil

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -69,7 +69,7 @@ func TestCheckRepeatedImport(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -145,8 +145,8 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 					},
 				),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
-						addressLocation := location.(common.AddressLocation)
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+						addressLocation := importedLocation.(common.AddressLocation)
 						var importedChecker *sema.Checker
 						switch addressLocation.Name {
 						case "x":
@@ -189,7 +189,7 @@ func TestCheckInvalidRepeatedImport(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -267,8 +267,8 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 					},
 				),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
-						addressLocation := location.(common.AddressLocation)
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+						addressLocation := importedLocation.(common.AddressLocation)
 						var importedChecker *sema.Checker
 						switch addressLocation.Name {
 						case "x":
@@ -314,7 +314,7 @@ func TestCheckImportAll(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -351,7 +351,7 @@ func TestCheckInvalidImportUnexported(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -394,7 +394,7 @@ func TestCheckImportSome(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -423,7 +423,7 @@ func TestCheckInvalidImportedError(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return nil, importedErr
 					},
 				),
@@ -496,7 +496,7 @@ func TestCheckImportTypes(t *testing.T) {
 				ParseAndCheckOptions{
 					Options: []sema.Option{
 						sema.WithImportHandler(
-							func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 								return sema.ElaborationImport{
 									Elaboration: importedChecker.Elaboration,
 								}, nil
@@ -543,15 +543,15 @@ func TestCheckInvalidImportCycleSelf(t *testing.T) {
 				Location: location,
 				Options: []sema.Option{
 					sema.WithImportHandler(
-						func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+						func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 
-							elaboration, ok := elaborations[location.ID()]
+							elaboration, ok := elaborations[importedLocation.ID()]
 							if !ok {
-								subChecker, err := checker.SubChecker(importedProgram, location)
+								subChecker, err := checker.SubChecker(importedProgram, importedLocation)
 								if err != nil {
 									return nil, err
 								}
-								elaborations[location.ID()] = subChecker.Elaboration
+								elaborations[importedLocation.ID()] = subChecker.Elaboration
 								err = subChecker.Check()
 								if err != nil {
 									return nil, err
@@ -575,10 +575,12 @@ func TestCheckInvalidImportCycleSelf(t *testing.T) {
 	errs := ExpectCheckerErrors(t, err, 1)
 
 	require.IsType(t, &sema.ImportedProgramError{}, errs[0])
-	childErrs := errs[0].(*sema.ImportedProgramError).ChildErrors()
 
-	require.Len(t, childErrs, 1)
-	assert.IsType(t, &sema.CyclicImportsError{}, childErrs[0])
+	importedProgramError := errs[0].(*sema.ImportedProgramError).Err
+
+	errs = ExpectCheckerErrors(t, importedProgramError, 1)
+
+	require.IsType(t, &sema.CyclicImportsError{}, errs[0])
 }
 
 func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
@@ -634,16 +636,16 @@ func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
 			Location: common.StringLocation("even"),
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
-						importedProgram := getProgram(location)
+					func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+						importedProgram := getProgram(importedLocation)
 
-						elaboration, ok := elaborations[location.ID()]
+						elaboration, ok := elaborations[importedLocation.ID()]
 						if !ok {
-							subChecker, err := checker.SubChecker(importedProgram, location)
+							subChecker, err := checker.SubChecker(importedProgram, importedLocation)
 							if err != nil {
 								return nil, err
 							}
-							elaborations[location.ID()] = subChecker.Elaboration
+							elaborations[importedLocation.ID()] = subChecker.Elaboration
 							err = subChecker.Check()
 							if err != nil {
 								return nil, err
@@ -722,7 +724,7 @@ func TestCheckImportVirtual(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.VirtualImport{
 							ValueElements: valueElements,
 						}, nil

--- a/runtime/tests/checker/predeclaredvalues_test.go
+++ b/runtime/tests/checker/predeclaredvalues_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
@@ -185,9 +186,9 @@ func TestCheckPredeclaredValues(t *testing.T) {
 				Options: []sema.Option{
 					predeclaredValuesOption,
 					sema.WithImportHandler(
-						func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+						func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 
-							importedChecker, importErr := getChecker(location)
+							importedChecker, importErr := getChecker(importedLocation)
 							if importErr != nil {
 								return nil, importErr
 							}

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -1468,7 +1468,7 @@ func TestCheckInvalidCreateImportedResource(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -107,7 +107,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 			},
 			CheckerOptions: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 
 						return sema.VirtualImport{
 							ValueElements: valueElements,
@@ -216,9 +216,9 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 					},
 				),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
-						require.IsType(t, common.AddressLocation{}, location)
-						addressLocation := location.(common.AddressLocation)
+					func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+						require.IsType(t, common.AddressLocation{}, importedLocation)
+						addressLocation := importedLocation.(common.AddressLocation)
 
 						assert.Equal(t, address, addressLocation.Address)
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -3261,10 +3261,10 @@ func TestInterpretImport(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{
@@ -3348,10 +3348,10 @@ func TestInterpretImportError(t *testing.T) {
 			Options: []sema.Option{
 				sema.WithPredeclaredValues(valueDeclarations),
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{
@@ -4808,10 +4808,10 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{
@@ -6330,10 +6330,10 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -72,10 +72,10 @@ func TestInterpretStatementHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{
@@ -198,10 +198,10 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{
@@ -335,10 +335,10 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							utils.ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -65,10 +66,10 @@ func TestInterpretResourceUUID(t *testing.T) {
 		checker.ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithImportHandler(
-					func(checker *sema.Checker, location common.Location) (sema.Import, error) {
+					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						assert.Equal(t,
 							ImportedLocation,
-							location,
+							importedLocation,
 						)
 
 						return sema.ElaborationImport{


### PR DESCRIPTION
Detect cyclic imports while checking and reject them.

In addition to the bugfix PR for v0.14.5, this PR also fixes error messages for cyclic imports, by pointing to the correct location.

Thanks to @SupunS for implementing the cycle detection 🙏 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
