### PR TITLE
Remove unused storage key handler

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -124,14 +124,6 @@ type StorageWriteHandlerFunc func(
 	value OptionalValue,
 )
 
-// StorageKeyHandlerFunc is a function that handles storage indexing types.
-//
-type StorageKeyHandlerFunc func(
-	inter *Interpreter,
-	storageAddress common.Address,
-	indexingType sema.Type,
-) string
-
 // InjectedCompositeFieldsHandlerFunc is a function that handles storage reads.
 //
 type InjectedCompositeFieldsHandlerFunc func(
@@ -237,7 +229,6 @@ type Interpreter struct {
 	storageExistenceHandler        StorageExistenceHandlerFunc
 	storageReadHandler             StorageReadHandlerFunc
 	storageWriteHandler            StorageWriteHandlerFunc
-	storageKeyHandler              StorageKeyHandlerFunc
 	injectedCompositeFieldsHandler InjectedCompositeFieldsHandlerFunc
 	contractValueHandler           ContractValueHandlerFunc
 	importLocationHandler          ImportLocationHandlerFunc
@@ -336,16 +327,6 @@ func WithStorageReadHandler(handler StorageReadHandlerFunc) Option {
 func WithStorageWriteHandler(handler StorageWriteHandlerFunc) Option {
 	return func(interpreter *Interpreter) error {
 		interpreter.SetStorageWriteHandler(handler)
-		return nil
-	}
-}
-
-// WithStorageKeyHandler returns an interpreter option which sets the given function
-// as the function that is used when a stored value is written.
-//
-func WithStorageKeyHandler(handler StorageKeyHandlerFunc) Option {
-	return func(interpreter *Interpreter) error {
-		interpreter.SetStorageKeyHandler(handler)
 		return nil
 	}
 }
@@ -490,12 +471,6 @@ func (interpreter *Interpreter) SetStorageReadHandler(function StorageReadHandle
 //
 func (interpreter *Interpreter) SetStorageWriteHandler(function StorageWriteHandlerFunc) {
 	interpreter.storageWriteHandler = function
-}
-
-// SetStorageKeyHandler sets the function that is used when a storage is indexed.
-//
-func (interpreter *Interpreter) SetStorageKeyHandler(function StorageKeyHandlerFunc) {
-	interpreter.storageKeyHandler = function
 }
 
 // SetInjectedCompositeFieldsHandler sets the function that is used to initialize
@@ -2112,7 +2087,6 @@ func (interpreter *Interpreter) NewSubInterpreter(
 		WithStorageExistenceHandler(interpreter.storageExistenceHandler),
 		WithStorageReadHandler(interpreter.storageReadHandler),
 		WithStorageWriteHandler(interpreter.storageWriteHandler),
-		WithStorageKeyHandler(interpreter.storageKeyHandler),
 		WithInjectedCompositeFieldsHandler(interpreter.injectedCompositeFieldsHandler),
 		WithContractValueHandler(interpreter.contractValueHandler),
 		WithImportLocationHandler(interpreter.importLocationHandler),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -778,11 +778,6 @@ func (r *interpreterRuntime) newInterpreter(
 				return r.emitEvent(inter, context.Interface, eventValue, eventType)
 			},
 		),
-		interpreter.WithStorageKeyHandler(
-			func(_ *interpreter.Interpreter, _ common.Address, indexingType sema.Type) string {
-				return string(indexingType.ID())
-			},
-		),
 		interpreter.WithInjectedCompositeFieldsHandler(
 			r.injectedCompositeFieldsHandler(context, runtimeStorage, interpreterOptions, checkerOptions),
 		),

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6816,11 +6816,6 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 				interpreter.WithStorageExistenceHandler(checker),
 				interpreter.WithStorageReadHandler(getter),
 				interpreter.WithStorageWriteHandler(setter),
-				interpreter.WithStorageKeyHandler(
-					func(_ *interpreter.Interpreter, _ common.Address, indexingType sema.Type) string {
-						return string(indexingType.ID())
-					},
-				),
 				interpreter.WithAccountHandlerFunc(
 					func(address interpreter.AddressValue) *interpreter.CompositeValue {
 						return interpreter.NewPublicAccountValue(


### PR DESCRIPTION
## Description

The storage API of an older version of Cadence used to be based on indexing into account storage using types, so the concept of a storage key handler existed.

Remove the code related to the storage key handler as it is not used anymore.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
