### PR TITLE
Add functions to read stored and linked values

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -378,10 +378,7 @@ func importValue(value cadence.Value) interpreter.Value {
 			v.Fields,
 		)
 	case cadence.Path:
-		return interpreter.PathValue{
-			Domain:     common.PathDomainFromIdentifier(v.Domain),
-			Identifier: v.Identifier,
-		}
+		return importPathValue(v)
 	case cadence.Enum:
 		return importCompositeValue(
 			common.CompositeKindEnum,
@@ -393,6 +390,13 @@ func importValue(value cadence.Value) interpreter.Value {
 	}
 
 	panic(fmt.Sprintf("cannot import value of type %T", value))
+}
+
+func importPathValue(v cadence.Path) interpreter.PathValue {
+	return interpreter.PathValue{
+		Domain:     common.PathDomainFromIdentifier(v.Domain),
+		Identifier: v.Identifier,
+	}
 }
 
 func importOptionalValue(v cadence.Optional) interpreter.Value {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -298,7 +298,7 @@ func (e OverwriteError) Error() string {
 // CyclicLinkError
 //
 type CyclicLinkError struct {
-	Address AddressValue
+	Address common.Address
 	Paths   []PathValue
 	LocationRange
 }
@@ -315,7 +315,7 @@ func (e CyclicLinkError) Error() string {
 
 	return fmt.Sprintf(
 		"cyclic link in account %s: %s",
-		e.Address,
+		e.Address.ShortHexWithPrefix(),
 		paths,
 	)
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -582,7 +582,9 @@ func (interpreter *Interpreter) Interpret() (err error) {
 		err = internalErr
 	})
 
-	interpreter.Program.Program.Accept(interpreter)
+	if interpreter.Program != nil {
+		interpreter.Program.Program.Accept(interpreter)
+	}
 
 	interpreter.interpreted = true
 
@@ -2136,7 +2138,7 @@ func (interpreter *Interpreter) storedValueExists(storageAddress common.Address,
 	return interpreter.storageExistenceHandler(interpreter, storageAddress, key)
 }
 
-func (interpreter *Interpreter) readStored(storageAddress common.Address, key string, deferred bool) OptionalValue {
+func (interpreter *Interpreter) ReadStored(storageAddress common.Address, key string, deferred bool) OptionalValue {
 	return interpreter.storageReadHandler(interpreter, storageAddress, key, deferred)
 }
 
@@ -2599,12 +2601,12 @@ func IsSubType(subType DynamicType, superType sema.Type) bool {
 	return false
 }
 
-// storageKey returns the storage identifier with the proper prefix
+// StorageKey returns the storage identifier with the proper prefix
 // for the given path.
 //
 // \x1F = Information Separator One
 //
-func storageKey(path PathValue) string {
+func StorageKey(path PathValue) string {
 	return fmt.Sprintf("%s\x1F%s", path.Domain.Identifier(), path.Identifier)
 }
 
@@ -2615,7 +2617,7 @@ func (interpreter *Interpreter) authAccountSaveFunction(addressValue AddressValu
 		path := invocation.Arguments[1].(PathValue)
 
 		address := addressValue.ToAddress()
-		key := storageKey(path)
+		key := StorageKey(path)
 
 		// Prevent an overwrite
 
@@ -2656,9 +2658,9 @@ func (interpreter *Interpreter) authAccountReadFunction(addressValue AddressValu
 		address := addressValue.ToAddress()
 
 		path := invocation.Arguments[0].(PathValue)
-		key := storageKey(path)
+		key := StorageKey(path)
 
-		value := interpreter.readStored(address, key, false)
+		value := interpreter.ReadStored(address, key, false)
 
 		switch value := value.(type) {
 		case NilValue:
@@ -2704,7 +2706,7 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 		address := addressValue.ToAddress()
 
 		path := invocation.Arguments[0].(PathValue)
-		key := storageKey(path)
+		key := StorageKey(path)
 
 		typeParameterPair := invocation.TypeParameterTypes.Oldest()
 		if typeParameterPair == nil {
@@ -2749,7 +2751,7 @@ func (interpreter *Interpreter) authAccountLinkFunction(addressValue AddressValu
 		newCapabilityPath := invocation.Arguments[0].(PathValue)
 		targetPath := invocation.Arguments[1].(PathValue)
 
-		newCapabilityKey := storageKey(newCapabilityPath)
+		newCapabilityKey := StorageKey(newCapabilityPath)
 
 		if interpreter.storedValueExists(address, newCapabilityKey) {
 			return NilValue{}
@@ -2789,9 +2791,9 @@ func (interpreter *Interpreter) accountGetLinkTargetFunction(addressValue Addres
 
 		capabilityPath := invocation.Arguments[0].(PathValue)
 
-		capabilityKey := storageKey(capabilityPath)
+		capabilityKey := StorageKey(capabilityPath)
 
-		value := interpreter.readStored(address, capabilityKey, false)
+		value := interpreter.ReadStored(address, capabilityKey, false)
 
 		switch value := value.(type) {
 		case NilValue:
@@ -2818,7 +2820,7 @@ func (interpreter *Interpreter) authAccountUnlinkFunction(addressValue AddressVa
 		address := addressValue.ToAddress()
 
 		capabilityPath := invocation.Arguments[0].(PathValue)
-		capabilityKey := storageKey(capabilityPath)
+		capabilityKey := StorageKey(capabilityPath)
 
 		// Write new value
 
@@ -2853,19 +2855,22 @@ func (interpreter *Interpreter) capabilityBorrowFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			targetStorageKey, authorized :=
-				interpreter.getCapabilityFinalTargetStorageKey(
-					addressValue,
+			address := addressValue.ToAddress()
+
+			targetStorageKey, authorized, err :=
+				interpreter.GetCapabilityFinalTargetStorageKey(
+					address,
 					pathValue,
 					borrowType,
 					invocation.GetLocationRange,
 				)
+			if err != nil {
+				panic(err)
+			}
 
 			if targetStorageKey == "" {
 				return NilValue{}
 			}
-
-			address := addressValue.ToAddress()
 
 			reference := &StorageReferenceValue{
 				Authorized:           authorized,
@@ -2909,19 +2914,22 @@ func (interpreter *Interpreter) capabilityCheckFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			targetStorageKey, authorized :=
-				interpreter.getCapabilityFinalTargetStorageKey(
-					addressValue,
+			address := addressValue.ToAddress()
+
+			targetStorageKey, authorized, err :=
+				interpreter.GetCapabilityFinalTargetStorageKey(
+					address,
 					pathValue,
 					borrowType,
 					invocation.GetLocationRange,
 				)
+			if err != nil {
+				panic(err)
+			}
 
 			if targetStorageKey == "" {
 				return BoolValue(false)
 			}
-
-			address := addressValue.ToAddress()
 
 			reference := &StorageReferenceValue{
 				Authorized:           authorized,
@@ -2943,18 +2951,17 @@ func (interpreter *Interpreter) capabilityCheckFunction(
 	)
 }
 
-func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
-	addressValue AddressValue,
+func (interpreter *Interpreter) GetCapabilityFinalTargetStorageKey(
+	address common.Address,
 	path PathValue,
 	wantedBorrowType *sema.ReferenceType,
 	getLocationRange func() LocationRange,
 ) (
 	finalStorageKey string,
 	authorized bool,
+	err error,
 ) {
-	address := addressValue.ToAddress()
-
-	key := storageKey(path)
+	key := StorageKey(path)
 
 	wantedReferenceType := wantedBorrowType
 
@@ -2965,20 +2972,20 @@ func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
 		// Detect cyclic links
 
 		if _, ok := seenKeys[key]; ok {
-			panic(CyclicLinkError{
-				Address:       addressValue,
+			return "", false, CyclicLinkError{
+				Address:       address,
 				Paths:         paths,
 				LocationRange: getLocationRange(),
-			})
+			}
 		} else {
 			seenKeys[key] = struct{}{}
 		}
 
-		value := interpreter.readStored(address, key, false)
+		value := interpreter.ReadStored(address, key, false)
 
 		switch value := value.(type) {
 		case NilValue:
-			return "", false
+			return "", false, nil
 
 		case *SomeValue:
 
@@ -2987,15 +2994,15 @@ func (interpreter *Interpreter) getCapabilityFinalTargetStorageKey(
 				allowedType := interpreter.ConvertStaticToSemaType(link.Type)
 
 				if !sema.IsSubType(allowedType, wantedBorrowType) {
-					return "", false
+					return "", false, nil
 				}
 
 				targetPath := link.TargetPath
 				paths = append(paths, targetPath)
-				key = storageKey(targetPath)
+				key = StorageKey(targetPath)
 
 			} else {
-				return key, wantedReferenceType.Authorized
+				return key, wantedReferenceType.Authorized, nil
 			}
 
 		default:

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6109,7 +6109,7 @@ func (v *DictionaryValue) Get(inter *Interpreter, _ func() LocationRange, keyVal
 			}
 			v.prevDeferredKeys.Set(key, struct{}{})
 
-			storedValue := inter.readStored(*v.DeferredOwner, storageKey, true)
+			storedValue := inter.ReadStored(*v.DeferredOwner, storageKey, true)
 			v.Entries.Set(key, storedValue.(*SomeValue).Value)
 
 			// NOTE: *not* writing nil to the storage key,
@@ -6703,7 +6703,7 @@ func (*StorageReferenceValue) SetModified(_ bool) {
 }
 
 func (v *StorageReferenceValue) ReferencedValue(interpreter *Interpreter) *Value {
-	switch referenced := interpreter.readStored(v.TargetStorageAddress, v.TargetKey, false).(type) {
+	switch referenced := interpreter.ReadStored(v.TargetStorageAddress, v.TargetKey, false).(type) {
 	case *SomeValue:
 		value := referenced.Value
 


### PR DESCRIPTION
## Description

The host environment may want to read stored and linked values without having to resort to re-implementing the translation of storage paths to storage/ledger/register keys.

Add functions that all reading stored and linked values.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
