### PR TITLE
Include wrapped error in InvalidEntryPointArgumentError message

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -122,7 +122,7 @@ func (e InvalidTransactionAuthorizerCountError) Error() string {
 }
 
 // InvalidEntryPointArgumentError
-
+//
 type InvalidEntryPointArgumentError struct {
 	Index int
 	Err   error
@@ -133,7 +133,11 @@ func (e *InvalidEntryPointArgumentError) Unwrap() error {
 }
 
 func (e *InvalidEntryPointArgumentError) Error() string {
-	return fmt.Sprintf("invalid argument at index %d: %v", e.Index, e.Err)
+	return fmt.Sprintf(
+		"invalid argument at index %d: %s",
+		e.Index,
+		e.Err.Error(),
+	)
 }
 
 // MalformedValueError

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -157,11 +157,6 @@ func (e *MalformedValueError) Error() string {
 //
 type InvalidValueTypeError struct {
 	ExpectedType sema.Type
-	Err          error
-}
-
-func (e *InvalidValueTypeError) Unwrap() error {
-	return e.Err
 }
 
 func (e *InvalidValueTypeError) Error() string {

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -133,7 +133,7 @@ func (e *InvalidEntryPointArgumentError) Unwrap() error {
 }
 
 func (e *InvalidEntryPointArgumentError) Error() string {
-	return fmt.Sprintf("invalid argument at index %d", e.Index)
+	return fmt.Sprintf("invalid argument at index %d: %v", e.Index, e.Err)
 }
 
 // MalformedValueError


### PR DESCRIPTION
While trying to debug issues passing struct args to scripts and transactions using fcl (documented here: https://github.com/onflow/flow-js-sdk/issues/607), I discovered that the root cause of invalid arguments has been obscured and difficult to debug because `runtime.InvalidEntryPointArgumentError` wasn't including wrapped errors in its Error() string. This PR adds the wrapped error to the Error() string so that the underlying cause is passed downstream (e.g. to the emulator output).

Emulator output without this change:
```
WARN[23896] ❗  Script reverted                            scriptID=0d00027[...]
WARN[23896] ERR [0d0002] [Error Code: 1101] cadence runtime error Execution failed:
error: invalid argument at index 0
--> 0d00027[...]
```

Emulator output with this change:
```
WARN[0007] ❗  Script reverted                            scriptID=0d00027[...]
WARN[0007] ERR [0d0002] [Error Code: 1101] cadence runtime error Execution failed:
error: invalid argument at index 0: decodeing argument failed: [Error Code: 1052]
transaction arguments are invalid: (argument is not json decodable: failed to decode
value: invalid JSON Cadence structure. invalid type ID: `0xf8d6e0586b0a20c7.Rawr.Foo`)
--> 0d00027[...]
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
