### PR TITLE
Optimize encoding by using CBOR lib's StreamEncoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytecodealliance/wasmtime-go v0.22.0
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/cheekybits/genny v1.0.0
-	github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803
+	github.com/fxamacker/cbor/v2 v2.2.1-0.20210422030233-6fd2b2e8c63f
 	github.com/go-test/deep v1.0.5
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/rivo/uniseg v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803 h1:CS/w4nHgzo/lk+H/b5BRnfGRCKw/0DBdRjIRULZWLsg=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20210422030233-6fd2b2e8c63f h1:tofpxjWlKtxKvu7NRgzMRIJwQnEFT0Xm1BCR3jgqNS0=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20210422030233-6fd2b2e8c63f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -420,6 +420,13 @@ func (e *Encoder) Encode(
 	}
 }
 
+// cborVoidValue represents the CBOR value:
+//
+// 	cbor.Tag{
+// 		Number: cborTagVoidValue,
+// 		Content: nil
+// 	}
+//
 var cborVoidValue = []byte{
 	// tag
 	0xd8, cborTagVoidValue,
@@ -427,11 +434,8 @@ var cborVoidValue = []byte{
 	0xf6,
 }
 
-// encodeVoid returns
-// cbor.Tag{
-//		Number: cborTagVoidValue,
-// 		Content: nil
-// }
+// encodeVoid writes a value of type Void to the encoder
+//
 func (e *Encoder) encodeVoid() error {
 
 	// TODO: optimize: use 0xf7, but decoded by github.com/fxamacker/cbor/v2 as Go `nil`:

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -446,7 +446,10 @@ func (e *Encoder) encodeVoid() error {
 //		Content: *big.Int(v.BigInt),
 // }
 func (e *Encoder) encodeInt(v IntValue) error {
-	err := e.enc.EncodeTagHead(cborTagIntValue)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagIntValue,
+	})
 	if err != nil {
 		return err
 	}
@@ -459,7 +462,10 @@ func (e *Encoder) encodeInt(v IntValue) error {
 //		Content: int8(v),
 // }
 func (e *Encoder) encodeInt8(v Int8Value) error {
-	err := e.enc.EncodeTagHead(cborTagInt8Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagInt8Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -472,7 +478,10 @@ func (e *Encoder) encodeInt8(v Int8Value) error {
 //		Content: int16(v),
 // }
 func (e *Encoder) encodeInt16(v Int16Value) error {
-	err := e.enc.EncodeTagHead(cborTagInt16Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagInt16Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -485,7 +494,10 @@ func (e *Encoder) encodeInt16(v Int16Value) error {
 //		Content: int32(v),
 // }
 func (e *Encoder) encodeInt32(v Int32Value) error {
-	err := e.enc.EncodeTagHead(cborTagInt32Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagInt32Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -498,7 +510,10 @@ func (e *Encoder) encodeInt32(v Int32Value) error {
 //		Content: int64(v),
 // }
 func (e *Encoder) encodeInt64(v Int64Value) error {
-	err := e.enc.EncodeTagHead(cborTagInt64Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagInt64Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -511,7 +526,10 @@ func (e *Encoder) encodeInt64(v Int64Value) error {
 //		Content: *big.Int(v.BigInt),
 // }
 func (e *Encoder) encodeInt128(v Int128Value) error {
-	err := e.enc.EncodeTagHead(cborTagInt128Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagInt128Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -524,7 +542,10 @@ func (e *Encoder) encodeInt128(v Int128Value) error {
 //		Content: *big.Int(v.BigInt),
 // }
 func (e *Encoder) encodeInt256(v Int256Value) error {
-	err := e.enc.EncodeTagHead(cborTagInt256Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagInt256Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -537,7 +558,10 @@ func (e *Encoder) encodeInt256(v Int256Value) error {
 //		Content: *big.Int(v.BigInt),
 // }
 func (e *Encoder) encodeUInt(v UIntValue) error {
-	err := e.enc.EncodeTagHead(cborTagUIntValue)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUIntValue,
+	})
 	if err != nil {
 		return err
 	}
@@ -550,7 +574,10 @@ func (e *Encoder) encodeUInt(v UIntValue) error {
 //		Content: uint8(v),
 // }
 func (e *Encoder) encodeUInt8(v UInt8Value) error {
-	err := e.enc.EncodeTagHead(cborTagUInt8Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt8Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -563,7 +590,10 @@ func (e *Encoder) encodeUInt8(v UInt8Value) error {
 //		Content: uint16(v),
 // }
 func (e *Encoder) encodeUInt16(v UInt16Value) error {
-	err := e.enc.EncodeTagHead(cborTagUInt16Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt16Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -576,7 +606,10 @@ func (e *Encoder) encodeUInt16(v UInt16Value) error {
 //		Content: uint32(v),
 // }
 func (e *Encoder) encodeUInt32(v UInt32Value) error {
-	err := e.enc.EncodeTagHead(cborTagUInt32Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt32Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -589,7 +622,10 @@ func (e *Encoder) encodeUInt32(v UInt32Value) error {
 //		Content: uint64(v),
 // }
 func (e *Encoder) encodeUInt64(v UInt64Value) error {
-	err := e.enc.EncodeTagHead(cborTagUInt64Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt64Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -602,7 +638,10 @@ func (e *Encoder) encodeUInt64(v UInt64Value) error {
 //		Content: *big.Int(v.BigInt),
 // }
 func (e *Encoder) encodeUInt128(v UInt128Value) error {
-	err := e.enc.EncodeTagHead(cborTagUInt128Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt128Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -615,7 +654,10 @@ func (e *Encoder) encodeUInt128(v UInt128Value) error {
 //		Content: *big.Int(v.BigInt),
 // }
 func (e *Encoder) encodeUInt256(v UInt256Value) error {
-	err := e.enc.EncodeTagHead(cborTagUInt256Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt256Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -628,7 +670,10 @@ func (e *Encoder) encodeUInt256(v UInt256Value) error {
 //		Content: uint8(v),
 // }
 func (e *Encoder) encodeWord8(v Word8Value) error {
-	err := e.enc.EncodeTagHead(cborTagWord8Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagWord8Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -641,7 +686,10 @@ func (e *Encoder) encodeWord8(v Word8Value) error {
 //		Content: uint16(v),
 // }
 func (e *Encoder) encodeWord16(v Word16Value) error {
-	err := e.enc.EncodeTagHead(cborTagWord16Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagWord16Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -654,7 +702,10 @@ func (e *Encoder) encodeWord16(v Word16Value) error {
 //		Content: uint32(v),
 // }
 func (e *Encoder) encodeWord32(v Word32Value) error {
-	err := e.enc.EncodeTagHead(cborTagWord32Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagWord32Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -667,7 +718,10 @@ func (e *Encoder) encodeWord32(v Word32Value) error {
 //		Content: uint64(v),
 // }
 func (e *Encoder) encodeWord64(v Word64Value) error {
-	err := e.enc.EncodeTagHead(cborTagWord64Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagWord64Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -680,7 +734,10 @@ func (e *Encoder) encodeWord64(v Word64Value) error {
 //		Content: int64(v),
 // }
 func (e *Encoder) encodeFix64(v Fix64Value) error {
-	err := e.enc.EncodeTagHead(cborTagFix64Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagFix64Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -693,7 +750,10 @@ func (e *Encoder) encodeFix64(v Fix64Value) error {
 //		Content: uint64(v),
 // }
 func (e *Encoder) encodeUFix64(v UFix64Value) error {
-	err := e.enc.EncodeTagHead(cborTagUFix64Value)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUFix64Value,
+	})
 	if err != nil {
 		return err
 	}
@@ -768,14 +828,13 @@ func (e *Encoder) encodeDictionaryValue(
 	path []string,
 	deferrals *EncodingDeferrals,
 ) error {
-	// Encode CBOR tag head
-	err := e.enc.EncodeTagHead(cborTagDictionaryValue)
-	if err != nil {
-		return err
-	}
-
-	// Encode CBOR array head with 2 elements
-	err = e.enc.EncodeArrayHead(encodedDictionaryValueLength)
+	// Encode CBOR tag head and array head
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagDictionaryValue,
+		// array, 2 items follow
+		0x82,
+	})
 	if err != nil {
 		return err
 	}
@@ -911,13 +970,12 @@ func (e *Encoder) encodeCompositeValue(
 	deferrals *EncodingDeferrals,
 ) error {
 	// Encode CBOR tag head
-	err := e.enc.EncodeTagHead(cborTagCompositeValue)
-	if err != nil {
-		return err
-	}
-
-	// Encode CBOR array head with 5 elements
-	err = e.enc.EncodeArrayHead(encodedCompositeValueLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagCompositeValue,
+		// array, 5 items follow
+		0x85,
+	})
 	if err != nil {
 		return err
 	}
@@ -983,7 +1041,10 @@ func (e *Encoder) encodeSomeValue(
 	path []string,
 	deferrals *EncodingDeferrals,
 ) error {
-	err := e.enc.EncodeTagHead(cborTagSomeValue)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagSomeValue,
+	})
 	if err != nil {
 		return err
 	}
@@ -996,7 +1057,10 @@ func (e *Encoder) encodeSomeValue(
 //		Content: []byte(v.ToAddress().Bytes()),
 // }
 func (e *Encoder) encodeAddressValue(v AddressValue) error {
-	err := e.enc.EncodeTagHead(cborTagAddressValue)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagAddressValue,
+	})
 	if err != nil {
 		return err
 	}
@@ -1024,12 +1088,12 @@ const (
 //			},
 // }
 func (e *Encoder) encodePathValue(v PathValue) error {
-	err := e.enc.EncodeTagHead(cborTagPathValue)
-	if err != nil {
-		return err
-	}
-
-	err = e.enc.EncodeArrayHead(encodedPathValueLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagPathValue,
+		// array, 2 items follow
+		0x82,
+	})
 	if err != nil {
 		return err
 	}
@@ -1065,12 +1129,12 @@ const (
 // 				},
 // }
 func (e *Encoder) encodeCapabilityValue(v CapabilityValue) error {
-	err := e.enc.EncodeTagHead(cborTagCapabilityValue)
-	if err != nil {
-		return err
-	}
-
-	err = e.enc.EncodeArrayHead(encodedCapabilityValueLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagCapabilityValue,
+		// array, 3 items follow
+		0x83,
+	})
 	if err != nil {
 		return err
 	}
@@ -1109,7 +1173,10 @@ func (e *Encoder) encodeLocation(l common.Location) error {
 		//		Number:  cborTagStringLocation,
 		//		Content: string(l),
 		// }
-		err := e.enc.EncodeTagHead(cborTagStringLocation)
+		err := e.enc.EncodeRawBytes([]byte{
+			// tag number
+			0xd8, cborTagStringLocation,
+		})
 		if err != nil {
 			return err
 		}
@@ -1121,7 +1188,10 @@ func (e *Encoder) encodeLocation(l common.Location) error {
 		//		Number:  cborTagIdentifierLocation,
 		//		Content: string(l),
 		// }
-		err := e.enc.EncodeTagHead(cborTagIdentifierLocation)
+		err := e.enc.EncodeRawBytes([]byte{
+			// tag number
+			0xd8, cborTagIdentifierLocation,
+		})
 		if err != nil {
 			return err
 		}
@@ -1136,11 +1206,12 @@ func (e *Encoder) encodeLocation(l common.Location) error {
 		//			encodedAddressLocationNameFieldKey:    string(l.Name),
 		//		},
 		// }
-		err := e.enc.EncodeTagHead(cborTagAddressLocation)
-		if err != nil {
-			return err
-		}
-		err = e.enc.EncodeArrayHead(2)
+		err := e.enc.EncodeRawBytes([]byte{
+			// tag number
+			0xd8, cborTagAddressLocation,
+			// array, 2 items follow
+			0x82,
+		})
 		if err != nil {
 			return err
 		}
@@ -1175,11 +1246,12 @@ const (
 //			},
 // }
 func (e *Encoder) encodeLinkValue(v LinkValue) error {
-	err := e.enc.EncodeTagHead(cborTagLinkValue)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedLinkValueLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagLinkValue,
+		// array, 2 items follow
+		0x82,
+	})
 	if err != nil {
 		return err
 	}
@@ -1237,7 +1309,10 @@ func (e *Encoder) encodeStaticType(t StaticType) error {
 //		Content: uint(v),
 // }
 func (e *Encoder) encodePrimitiveStaticType(v PrimitiveStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagPrimitiveStaticType)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagPrimitiveStaticType,
+	})
 	if err != nil {
 		return err
 	}
@@ -1250,7 +1325,10 @@ func (e *Encoder) encodePrimitiveStaticType(v PrimitiveStaticType) error {
 //		Content: StaticType(v.Type),
 // }
 func (e *Encoder) encodeOptionalStaticType(v OptionalStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagOptionalStaticType)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagOptionalStaticType,
+	})
 	if err != nil {
 		return err
 	}
@@ -1280,11 +1358,12 @@ const (
 //		},
 // }
 func (e *Encoder) encodeCompositeStaticType(v CompositeStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagCompositeStaticType)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedCompositeStaticTypeLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagCompositeStaticType,
+		// array, 3 items follow
+		0x83,
+	})
 	if err != nil {
 		return err
 	}
@@ -1322,11 +1401,12 @@ const (
 //		},
 // }
 func (e *Encoder) encodeInterfaceStaticType(v InterfaceStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagInterfaceStaticType)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedInterfaceStaticTypeLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagInterfaceStaticType,
+		// array, 3 items follow
+		0x83,
+	})
 	if err != nil {
 		return err
 	}
@@ -1347,7 +1427,10 @@ func (e *Encoder) encodeInterfaceStaticType(v InterfaceStaticType) error {
 //		Content: StaticType(v.Type),
 // }
 func (e *Encoder) encodeVariableSizedStaticType(v VariableSizedStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagVariableSizedStaticType)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagVariableSizedStaticType,
+	})
 	if err != nil {
 		return err
 	}
@@ -1375,11 +1458,12 @@ const (
 //		},
 // }
 func (e *Encoder) encodeConstantSizedStaticType(v ConstantSizedStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagConstantSizedStaticType)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedConstantSizedStaticTypeLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagConstantSizedStaticType,
+		// array, 2 items follow
+		0x82,
+	})
 	if err != nil {
 		return err
 	}
@@ -1411,11 +1495,12 @@ const (
 //		},
 //	}
 func (e *Encoder) encodeReferenceStaticType(v ReferenceStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagReferenceStaticType)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedReferenceStaticTypeLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagReferenceStaticType,
+		// array, 2 items follow
+		0x82,
+	})
 	if err != nil {
 		return err
 	}
@@ -1447,11 +1532,12 @@ const (
 //		},
 // }
 func (e *Encoder) encodeDictionaryStaticType(v DictionaryStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagDictionaryStaticType)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedDictionaryStaticTypeLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagDictionaryStaticType,
+		// array, 2 items follow
+		0x82,
+	})
 	if err != nil {
 		return err
 	}
@@ -1483,11 +1569,12 @@ const (
 //		},
 // }
 func (e *Encoder) encodeRestrictedStaticType(v *RestrictedStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagRestrictedStaticType)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedRestrictedStaticTypeLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagRestrictedStaticType,
+		// array, 2 items follow
+		0x82,
+	})
 	if err != nil {
 		return err
 	}
@@ -1527,11 +1614,12 @@ const (
 //			},
 //	}
 func (e *Encoder) encodeTypeValue(v TypeValue) error {
-	err := e.enc.EncodeTagHead(cborTagTypeValue)
-	if err != nil {
-		return err
-	}
-	err = e.enc.EncodeArrayHead(encodedTypeValueTypeLength)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagTypeValue,
+		// array, 1 item follow
+		0x81,
+	})
 	if err != nil {
 		return err
 	}
@@ -1544,7 +1632,10 @@ func (e *Encoder) encodeTypeValue(v TypeValue) error {
 //		Content: StaticType(v.BorrowType),
 // }
 func (e *Encoder) encodeCapabilityStaticType(v CapabilityStaticType) error {
-	err := e.enc.EncodeTagHead(cborTagCapabilityStaticType)
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagCapabilityStaticType,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #794 (epic)
Closes #796
Closes #807

## Description

- Use streaming mode for encoding to eliminate intermediate objects being created when encoding large composites and dictionaries.

- Use low-level API for encoding to reduce CBOR library's internal calls to Go's reflect package (to boost speed).

- Modify go.mod to use fxamacker/cbor branch feature/stream-mode before it's merged to master.

## Cumulative Benchmark Comparisons

These comparisons are cumulative vs commit 3bbc8c8, so they include performance gains from switching to v4 storage format (issue #738) and other optimizations by the Flow team.

<details><summary>Original PR before hard coding tag numbers and array lengths</summary>

```
name                                               old time/op    new time/op    delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      885µs ± 1%     151µs ± 1%  -82.96%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       20.7µs ± 1%     4.4µs ± 1%  -78.93%  (p=0.000 n=9+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       15.9µs ± 1%     3.3µs ± 0%  -79.32%  (p=0.000 n=10+9)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    35.0ms ± 1%     6.9ms ± 1%  -80.22%  (p=0.000 n=9+10)

name                                               old alloc/op   new alloc/op   delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      247kB ± 1%      75kB ± 0%  -69.49%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       4.85kB ± 2%    1.26kB ± 0%  -73.92%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       3.78kB ± 1%    0.86kB ± 0%  -77.15%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    7.47MB ± 4%    1.96MB ± 0%  -73.72%  (p=0.000 n=9+10)

name                                               old allocs/op  new allocs/op  delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      5.02k ± 0%     0.62k ± 0%  -87.66%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4          103 ± 1%        19 ± 0%  -81.50%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4         76.0 ± 0%      14.0 ± 0%  -81.58%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4      141k ± 0%        6k ± 0%  -95.79%  (p=0.000 n=8+10)

--------------------------------------------

name                                            old time/op    new time/op    delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    20.3µs ± 1%     3.4µs ± 0%  -83.41%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    20.6µs ± 1%     3.4µs ± 1%  -83.66%  (p=0.000 n=10+10)

name                                            old alloc/op   new alloc/op   delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    5.18kB ± 0%    1.17kB ± 0%  -77.44%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    5.50kB ± 0%    1.15kB ± 0%  -79.06%  (p=0.000 n=10+10)

name                                            old allocs/op  new allocs/op  delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4       101 ± 0%        13 ± 0%  -87.13%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4       101 ± 0%        13 ± 0%  -87.13%  (p=0.000 n=10+10)
```

</details>

After hard coding tag number and array length where feasible (thanks @turbolent).
```
name                                               old time/op    new time/op    delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      898µs ± 1%     147µs ± 1%  -83.62%  (p=0.000 n=10+9)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       21.0µs ± 1%     4.3µs ± 1%  -79.58%  (p=0.000 n=10+9)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       16.1µs ± 0%     3.2µs ± 1%  -80.23%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    35.5ms ± 1%     7.0ms ± 0%  -80.44%  (p=0.000 n=8+10)

name                                               old alloc/op   new alloc/op   delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      247kB ± 2%      75kB ± 0%  -69.45%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       4.84kB ± 1%    1.26kB ± 0%  -73.90%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       3.78kB ± 1%    0.86kB ± 0%  -77.17%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    7.48MB ± 4%    1.96MB ± 0%  -73.76%  (p=0.000 n=9+10)

name                                               old allocs/op  new allocs/op  delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      5.02k ± 1%     0.62k ± 0%  -87.65%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4          103 ± 0%        19 ± 0%  -81.55%  (p=0.002 n=8+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4         76.0 ± 0%      14.0 ± 0%  -81.58%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4      141k ± 0%        6k ± 0%  -95.79%  (p=0.000 n=9+10)

---------------------

name                                            old time/op    new time/op    delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    20.5µs ± 1%     3.3µs ± 1%  -84.00%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    20.9µs ± 1%     3.3µs ± 1%  -84.32%  (p=0.000 n=10+10)

name                                            old alloc/op   new alloc/op   delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    5.18kB ± 0%    1.17kB ± 0%  -77.44%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    5.50kB ± 0%    1.15kB ± 0%  -79.06%  (p=0.002 n=8+10)

name                                            old allocs/op  new allocs/op  delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4       101 ± 0%        13 ± 0%  -87.13%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4       101 ± 0%        13 ± 0%  -87.13%  (p=0.000 n=10+10)
```

## Caveats

This requires fxamacker/cbor branch feature-stream-mode, not the master branch.

I initially preferred 2 PRs for this but it seems easier to review because the same files are changed.  I'm open to suggestions if we need to split this up into multiple PR.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
