### PR TITLE
Optimize Address.Bytes() to inline fast path

### DIFF
--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -56,7 +56,19 @@ func (a *Address) SetBytes(b []byte) {
 	copy(a[AddressLength-len(b):], b)
 }
 
+// Bytes returns address without leading zeros.
+// The fast path is inlined and handles the most common
+// scenario of address having no leading zeros.  Otherwise,
+// bytes() is called to trim leading zeros.
 func (a Address) Bytes() []byte {
+	if a[0] != 0 {
+		return a[:]
+	}
+	return a.bytes()
+}
+
+// bytes returns address bytes after trimming leading zeros.
+func (a *Address) bytes() []byte {
 	// Trim leading zeros
 	leadingZeros := 0
 	for _, b := range a {


### PR DESCRIPTION
Closes #838

## Description

Make `func (a Address) Bytes() []byte` inline and optimize for the most common scenario of AddressLocation.Address and AddressValue not containing any leading zeros (in bytes).  A 10 GB snapshot of mainnet showed only 1216 addresses had 1 or more leading zeros (out of ~20 million addresses).

The private function `func (a *Address) bytes() []byte` is the slow path used for trimming leading zeros.  It uses a pointer to address to avoid an extra allocation.


Benchmark comparisons vs commit affa4a197b4a59e3e74bc6ae8841fa138d37c4fd shows improvements in speed and memory use.
```
name                                               old time/op    new time/op    delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      151µs ± 1%     145µs ± 1%   -3.75%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       4.49µs ± 2%    4.31µs ± 1%   -4.02%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       3.28µs ± 1%    3.17µs ± 1%   -3.20%  (p=0.000 n=9+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    7.19ms ± 1%    7.13ms ± 0%   -0.72%  (p=0.005 n=10+10)

name                                               old alloc/op   new alloc/op   delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4     75.4kB ± 0%    73.7kB ± 0%   -2.13%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       1.26kB ± 0%    1.25kB ± 0%   -1.27%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4         864B ± 0%      848B ± 0%   -1.85%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    1.96MB ± 0%    1.95MB ± 0%   -0.53%  (p=0.000 n=10+10)

name                                               old allocs/op  new allocs/op  delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4        620 ± 0%       419 ± 0%  -32.42%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4         19.0 ± 0%      17.0 ± 0%  -10.53%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4         14.0 ± 0%      12.0 ± 0%  -14.29%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4     5.95k ± 0%     5.08k ± 0%  -14.62%  (p=0.000 n=10+10)

------

name                                            old time/op    new time/op    delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    3.36µs ± 1%    3.26µs ± 1%   -2.79%  (p=0.000 n=9+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    3.38µs ± 0%    3.26µs ± 1%   -3.64%  (p=0.000 n=8+10)

name                                            old alloc/op   new alloc/op   delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    1.17kB ± 0%    1.15kB ± 0%   -1.37%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    1.15kB ± 0%    1.14kB ± 0%   -1.39%  (p=0.000 n=10+10)

name                                            old allocs/op  new allocs/op  delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4      13.0 ± 0%      11.0 ± 0%  -15.38%  (p=0.000 n=10+10)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4      13.0 ± 0%      11.0 ± 0%  -15.38%  (p=0.000 n=10+10)

```
Benchmarks used Go 1.15.11 on linux_amd64.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
