### PR TITLE
Remove call to Valid() during encoding to boost speed by about 13-18%

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytecodealliance/wasmtime-go v0.22.0
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/cheekybits/genny v1.0.0
-	github.com/fxamacker/cbor/v2 v2.2.1-0.20210422030233-6fd2b2e8c63f
+	github.com/fxamacker/cbor/v2 v2.2.1-0.20210428011003-7ceed0a5d02f
 	github.com/go-test/deep v1.0.5
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/rivo/uniseg v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20210422030233-6fd2b2e8c63f h1:tofpxjWlKtxKvu7NRgzMRIJwQnEFT0Xm1BCR3jgqNS0=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20210422030233-6fd2b2e8c63f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20210428011003-7ceed0a5d02f h1:OKT+0u9yHS7vfkQ65zYqAuoLohWaMtxd9+W6/R79gWw=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20210428011003-7ceed0a5d02f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"math/bits"
 	"strconv"
 	"strings"
 
@@ -45,6 +46,9 @@ type DecoderV4 struct {
 	version        uint16
 	decodeCallback DecodingCallback
 }
+
+// maxInt is math.MaxInt32 or math.MaxInt64 depending on arch.
+const maxInt = 1<<(bits.UintSize-1) - 1
 
 // DecodeValue returns a value decoded from its CBOR-encoded representation,
 // for the given owner (can be `nil`).  It can decode storage format
@@ -104,9 +108,9 @@ func NewDecoder(
 var decMode = func() cbor.DecMode {
 	decMode, err := cbor.DecOptions{
 		IntDec:           cbor.IntDecConvertNone,
-		MaxArrayElements: 512 * 1024,
-		MaxMapPairs:      512 * 1024,
-		MaxNestedLevels:  256,
+		MaxArrayElements: maxInt,
+		MaxMapPairs:      maxInt,
+		MaxNestedLevels:  math.MaxInt16,
 	}.DecMode()
 	if err != nil {
 		panic(err)

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -241,10 +241,6 @@ func EncodeValue(value Value, path []string, deferred bool, prepareCallback Enco
 	}
 
 	data := w.Bytes()
-	err = decMode.Valid(data)
-	if err != nil {
-		return nil, nil, fmt.Errorf("encoder produced invalid data: %w", err)
-	}
 
 	return data, deferrals, nil
 }


### PR DESCRIPTION
Closes #851

## Description

- [x] eliminate call to Valid() in the encoder
- [x] increase max limits in decoder to eliminate one reason for encoder to call Valid().

Thanks @turbolent for suggesting this optimization last week.

### Benchmark Comparisons

Speed improved by 13% to almost 18%.  Memory use is unchanged. 

```
name                                               old time/op    new time/op    delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      148µs ± 1%     121µs ± 1%  -17.97%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       4.33µs ± 1%    3.65µs ± 1%  -15.68%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       3.22µs ± 1%    2.74µs ± 1%  -14.89%  (p=0.000 n=10+9)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    7.04ms ± 1%    6.12ms ± 0%  -13.09%  (p=0.000 n=10+10)

------

name                                            old time/op    new time/op    delta
EncodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    3.30µs ± 2%    2.72µs ± 1%  -17.52%  (p=0.000 n=10+9)
EncodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    3.31µs ± 1%    2.75µs ± 2%  -17.04%  (p=0.000 n=9+10)
```
Benchmarks used Go 1.15.11 on linux_amd64.

### Caveats

:warning: WARNING:  Max limits for array size, etc. are increased -- if adversaries can cause excessively large CBOR data to be decoded, they can launch resource exhaustion attacks.

Max limit for nested level is set to MaxInt16 because MaxInt32 would allow nested levels that would crash Go because of the 1 GB stack size limit of Go.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
