### PR TITLE
Pre-allocate and reuse value-path for encoding

### DIFF
--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -793,8 +793,13 @@ func (e *Encoder) encodeArray(
 		return err
 	}
 
+	// Pre-allocate and reuse valuePath.
+	valuePath := append(path, "")
+
+	lastIndex := len(path)
+
 	for i, value := range v.Values {
-		valuePath := append(path[:], strconv.Itoa(i))
+		valuePath[lastIndex] = strconv.Itoa(i)
 		err := e.Encode(value, valuePath, deferrals)
 		if err != nil {
 			return err
@@ -843,7 +848,7 @@ func (e *Encoder) encodeDictionaryValue(
 		return err
 	}
 
-	keysPath := append(path[:], dictionaryKeyPathPrefix)
+	keysPath := append(path, dictionaryKeyPathPrefix)
 
 	// Encode keys (as array) at array index encodedDictionaryValueKeysFieldKey
 	err = e.encodeArray(v.Keys, keysPath, deferrals)
@@ -882,10 +887,15 @@ func (e *Encoder) encodeDictionaryValue(
 		return err
 	}
 
+	// Pre-allocate and reuse valuePath.
+	valuePath := append(path, dictionaryValuePathPrefix, "")
+
+	lastIndex := len(path) + 1
+
 	for _, keyValue := range v.Keys.Values {
 		key := dictionaryKey(keyValue)
 		entryValue, _ := v.Entries.Get(key)
-		valuePath := append(path[:], dictionaryValuePathPrefix, key)
+		valuePath[lastIndex] = key
 
 		if deferred {
 
@@ -1006,6 +1016,11 @@ func (e *Encoder) encodeCompositeValue(
 		return err
 	}
 
+	// Pre-allocate and reuse valuePath.
+	valuePath := append(path, "")
+
+	lastIndex := len(path)
+
 	for pair := v.Fields.Oldest(); pair != nil; pair = pair.Next() {
 		fieldName := pair.Key
 
@@ -1017,7 +1032,7 @@ func (e *Encoder) encodeCompositeValue(
 
 		value := pair.Value
 
-		valuePath := append(path[:], fieldName)
+		valuePath[lastIndex] = fieldName
 
 		// Encode value as fields array element
 		err = e.Encode(value, valuePath, deferrals)


### PR DESCRIPTION
Closes #742

## Description

Pre-allocate and reuse value-path during encoding to prevent reslicing.

Thanks @SupunS  for suggesting this optimization!

### Benchmark Comparisons

Comparison to commit affa4a197b4a59e3e74bc6ae8841fa138d37c4fd shows speed improved by 1.5% to over 27% depending on data encoded.

Memory allocs/op improved by 7-48%.

```
name                                               old time/op    new time/op    delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      152µs ± 3%     110µs ± 1%  -27.69%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       4.34µs ± 0%    3.98µs ± 1%   -8.39%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       3.22µs ± 0%    3.17µs ± 1%   -1.65%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    7.02ms ± 0%    6.38ms ± 1%   -9.03%  (p=0.000 n=9+10)

name                                               old alloc/op   new alloc/op   delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4     75.4kB ± 0%    59.4kB ± 0%  -21.21%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       1.26kB ± 0%    1.17kB ± 0%   -7.59%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4         864B ± 0%      848B ± 0%   -1.85%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    1.96MB ± 0%    1.78MB ± 0%   -9.57%  (p=0.000 n=10+9)

name                                               old allocs/op  new allocs/op  delta
EncodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4        620 ± 0%       320 ± 0%  -48.39%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4         19.0 ± 0%      15.0 ± 0%  -21.05%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4         14.0 ± 0%      13.0 ± 0%   -7.14%  (p=0.000 n=10+10)
EncodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4     5.95k ± 0%     3.24k ± 0%  -45.56%  (p=0.000 n=10+10)

```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
