### PR TITLE
Add deferred decoding support for composite values

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -193,8 +193,9 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 	fieldNames := t.CompositeFields()
 	fields := make([]cadence.Value, len(fieldNames))
 
+	fieldsMap := v.Fields()
 	for i, field := range fieldNames {
-		fieldValue, _ := v.Fields.Get(field.Identifier)
+		fieldValue, _ := fieldsMap.Get(field.Identifier)
 		fields[i] = exportValueWithInterpreter(fieldValue, inter, results)
 	}
 

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -193,9 +193,8 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 	fieldNames := t.CompositeFields()
 	fields := make([]cadence.Value, len(fieldNames))
 
-	fieldsMap := v.Fields()
 	for i, field := range fieldNames {
-		fieldValue, _ := fieldsMap.Get(field.Identifier)
+		fieldValue, _ := v.Fields().Get(field.Identifier)
 		fields[i] = exportValueWithInterpreter(fieldValue, inter, results)
 	}
 

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -44,7 +44,7 @@ func NewAuthAccountContractsValue(
 	}
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountContractsType.Kind,
 		fields:              fields,
 		stringer:            stringer,

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -46,7 +46,7 @@ func NewAuthAccountContractsValue(
 	return &CompositeValue{
 		QualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountContractsType.Kind,
-		Fields:              fields,
+		fields:              fields,
 		stringer:            stringer,
 	}
 }

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -45,7 +45,7 @@ func NewAuthAccountContractsValue(
 
 	return &CompositeValue{
 		qualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
-		Kind:                sema.AuthAccountContractsType.Kind,
+		kind:                sema.AuthAccountContractsType.Kind,
 		fields:              fields,
 		stringer:            stringer,
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1024,7 +1024,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode qualified identifier at array index encodedCompositeValueQualifiedIdentifierFieldKey
-	err = e.enc.EncodeString(v.QualifiedIdentifier)
+	err = e.enc.EncodeString(v.qualifiedIdentifier)
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -979,7 +979,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode location at array index encodedCompositeValueLocationFieldKey
-	err = e.encodeLocation(v.Location)
+	err = e.encodeLocation(v.location)
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -858,7 +858,7 @@ func (e *Encoder) encodeDictionaryValue(
 
 		for pair := v.Entries.Oldest(); pair != nil; pair = pair.Next() {
 			compositeValue, ok := pair.Value.(*CompositeValue)
-			if !ok || compositeValue.Kind != common.CompositeKindResource {
+			if !ok || compositeValue.Kind() != common.CompositeKindResource {
 				deferred = false
 				break
 			}
@@ -991,7 +991,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode kind at array index encodedCompositeValueKindFieldKey
-	err = e.enc.EncodeUint(uint(v.Kind))
+	err = e.enc.EncodeUint(uint(v.kind))
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -979,7 +979,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode location at array index encodedCompositeValueLocationFieldKey
-	err = e.encodeLocation(v.location)
+	err = e.encodeLocation(v.Location())
 	if err != nil {
 		return err
 	}
@@ -991,7 +991,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode kind at array index encodedCompositeValueKindFieldKey
-	err = e.enc.EncodeUint(uint(v.kind))
+	err = e.enc.EncodeUint(uint(v.Kind()))
 	if err != nil {
 		return err
 	}
@@ -1024,7 +1024,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode qualified identifier at array index encodedCompositeValueQualifiedIdentifierFieldKey
-	err = e.enc.EncodeString(v.qualifiedIdentifier)
+	err = e.enc.EncodeString(v.QualifiedIdentifier())
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -997,12 +997,13 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode fields (as array) at array index encodedCompositeValueFieldsFieldKey
-	err = e.enc.EncodeArrayHead(uint64(v.Fields.Len() * 2))
+	fields := v.Fields()
+	err = e.enc.EncodeArrayHead(uint64(fields.Len() * 2))
 	if err != nil {
 		return err
 	}
 
-	for pair := v.Fields.Oldest(); pair != nil; pair = pair.Next() {
+	for pair := fields.Oldest(); pair != nil; pair = pair.Next() {
 		fieldName := pair.Key
 
 		// Encode field name as fields array element

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1294,7 +1294,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			}
 
 			value := &CompositeValue{
-				Location:            location,
+				location:            location,
 				QualifiedIdentifier: qualifiedIdentifier,
 				Kind:                declaration.CompositeKind,
 				fields:              fields,
@@ -1390,7 +1390,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 		caseValueFields.Set(sema.EnumRawValueFieldName, rawValue)
 
 		caseValue := &CompositeValue{
-			Location:            location,
+			location:            location,
 			QualifiedIdentifier: qualifiedIdentifier,
 			Kind:                declaration.CompositeKind,
 			fields:              caseValueFields,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1296,7 +1296,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			value := &CompositeValue{
 				location:            location,
 				qualifiedIdentifier: qualifiedIdentifier,
-				Kind:                declaration.CompositeKind,
+				kind:                declaration.CompositeKind,
 				fields:              fields,
 				InjectedFields:      injectedFields,
 				Functions:           functions,
@@ -1392,7 +1392,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 		caseValue := &CompositeValue{
 			location:            location,
 			qualifiedIdentifier: qualifiedIdentifier,
-			Kind:                declaration.CompositeKind,
+			kind:                declaration.CompositeKind,
 			fields:              caseValueFields,
 			// NOTE: new value has no owner
 			Owner:    nil,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1295,7 +1295,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 
 			value := &CompositeValue{
 				location:            location,
-				QualifiedIdentifier: qualifiedIdentifier,
+				qualifiedIdentifier: qualifiedIdentifier,
 				Kind:                declaration.CompositeKind,
 				fields:              fields,
 				InjectedFields:      injectedFields,
@@ -1391,7 +1391,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 		caseValue := &CompositeValue{
 			location:            location,
-			QualifiedIdentifier: qualifiedIdentifier,
+			qualifiedIdentifier: qualifiedIdentifier,
 			Kind:                declaration.CompositeKind,
 			fields:              caseValueFields,
 			// NOTE: new value has no owner

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1180,7 +1180,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			func(invocation Invocation) Value {
 				for i, argument := range invocation.Arguments {
 					parameter := compositeType.ConstructorParameters[i]
-					invocation.Self.Fields.Set(parameter.Identifier, argument)
+					invocation.Self.Fields().Set(parameter.Identifier, argument)
 				}
 				return nil
 			},
@@ -1297,7 +1297,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 				Location:            location,
 				QualifiedIdentifier: qualifiedIdentifier,
 				Kind:                declaration.CompositeKind,
-				Fields:              fields,
+				fields:              fields,
 				InjectedFields:      injectedFields,
 				Functions:           functions,
 				Destructor:          destructorFunction,
@@ -1393,7 +1393,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 			Location:            location,
 			QualifiedIdentifier: qualifiedIdentifier,
 			Kind:                declaration.CompositeKind,
-			Fields:              caseValueFields,
+			fields:              caseValueFields,
 			// NOTE: new value has no owner
 			Owner:    nil,
 			modified: true,
@@ -1419,7 +1419,7 @@ func EnumConstructorFunction(caseValues []*CompositeValue, nestedVariables *Stri
 	lookupTable := make(map[string]*CompositeValue)
 
 	for _, caseValue := range caseValues {
-		rawValue, ok := caseValue.Fields.Get(sema.EnumRawValueFieldName)
+		rawValue, ok := caseValue.Fields().Get(sema.EnumRawValueFieldName)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -52,7 +52,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 		interpreter.Program.Elaboration.PostConditionsRewrite[declaration.PostConditions]
 
 	self := &CompositeValue{
-		Location: interpreter.Location,
+		location: interpreter.Location,
 		fields:   NewStringValueOrderedMap(),
 		modified: true,
 	}

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -53,7 +53,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 
 	self := &CompositeValue{
 		Location: interpreter.Location,
-		Fields:   NewStringValueOrderedMap(),
+		fields:   NewStringValueOrderedMap(),
 		modified: true,
 	}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6050,7 +6050,7 @@ func (v UFix64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTy
 
 type CompositeValue struct {
 	location            common.Location
-	QualifiedIdentifier string
+	qualifiedIdentifier string
 	Kind                common.CompositeKind
 	fields              *StringValueOrderedMap
 	InjectedFields      *StringValueOrderedMap
@@ -6081,9 +6081,10 @@ func NewCompositeValue(
 	if fields == nil {
 		fields = NewStringValueOrderedMap()
 	}
+
 	return &CompositeValue{
 		location:            location,
-		QualifiedIdentifier: qualifiedIdentifier,
+		qualifiedIdentifier: qualifiedIdentifier,
 		Kind:                kind,
 		fields:              fields,
 		Owner:               owner,
@@ -6143,7 +6144,7 @@ func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 func (v *CompositeValue) DynamicType(interpreter *Interpreter, _ DynamicTypeResults) DynamicType {
 	v.loadMeta()
 
-	staticType := interpreter.getCompositeType(v.location, v.QualifiedIdentifier)
+	staticType := interpreter.getCompositeType(v.location, v.qualifiedIdentifier)
 	return CompositeDynamicType{
 		StaticType: staticType,
 	}
@@ -6154,7 +6155,7 @@ func (v *CompositeValue) StaticType() StaticType {
 
 	return CompositeStaticType{
 		Location:            v.location,
-		QualifiedIdentifier: v.QualifiedIdentifier,
+		QualifiedIdentifier: v.qualifiedIdentifier,
 	}
 }
 
@@ -6181,7 +6182,7 @@ func (v *CompositeValue) Copy() Value {
 
 	return &CompositeValue{
 		location:            v.location,
-		QualifiedIdentifier: v.QualifiedIdentifier,
+		qualifiedIdentifier: v.qualifiedIdentifier,
 		Kind:                v.Kind,
 		fields:              newFields,
 		InjectedFields:      v.InjectedFields,
@@ -6302,7 +6303,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 		v.InjectedFields = interpreter.injectedCompositeFieldsHandler(
 			interpreter,
 			v.location,
-			v.QualifiedIdentifier,
+			v.qualifiedIdentifier,
 			v.Kind,
 		)
 	}
@@ -6477,10 +6478,10 @@ func (v *CompositeValue) TypeID() common.TypeID {
 	v.loadMeta()
 
 	if v.location == nil {
-		return common.TypeID(v.QualifiedIdentifier)
+		return common.TypeID(v.qualifiedIdentifier)
 	}
 
-	return v.location.TypeID(v.QualifiedIdentifier)
+	return v.location.TypeID(v.qualifiedIdentifier)
 }
 
 func (v *CompositeValue) ConformsToDynamicType(
@@ -6501,7 +6502,7 @@ func (v *CompositeValue) ConformsToDynamicType(
 	v.loadMeta()
 
 	if v.Kind != compositeType.Kind ||
-		v.QualifiedIdentifier != compositeType.QualifiedIdentifier() ||
+		v.qualifiedIdentifier != compositeType.QualifiedIdentifier() ||
 		v.location.ID() != compositeType.Location.ID() {
 
 		return false
@@ -6551,9 +6552,9 @@ func (v *CompositeValue) Location() common.Location {
 	return v.location
 }
 
-func (v *CompositeValue) WithFields(fields *StringValueOrderedMap) *CompositeValue {
-	v.fields = fields
-	return v
+func (v *CompositeValue) QualifiedIdentifier() string {
+	v.loadMeta()
+	return v.qualifiedIdentifier
 }
 
 // Ensures the fields of this composite value are loaded.
@@ -7841,7 +7842,7 @@ func NewAuthAccountValue(
 	}
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AuthAccountType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AuthAccountType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountType.Kind,
 		fields:              fields,
 		ComputedFields:      computedFields,
@@ -7925,7 +7926,7 @@ func NewPublicAccountValue(
 	}
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.PublicAccountType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.PublicAccountType.QualifiedIdentifier(),
 		Kind:                sema.PublicAccountType.Kind,
 		fields:              fields,
 		ComputedFields:      computedFields,
@@ -8241,7 +8242,7 @@ func NewAccountKeyValue(
 	fields.Set(sema.AccountKeyIsRevokedField, isRevoked)
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AccountKeyType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AccountKeyType.QualifiedIdentifier(),
 		Kind:                sema.AccountKeyType.Kind,
 		fields:              fields,
 	}
@@ -8264,7 +8265,7 @@ func NewPublicKeyValue(
 	}
 
 	publicKeyValue := &CompositeValue{
-		QualifiedIdentifier: sema.PublicKeyType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.PublicKeyType.QualifiedIdentifier(),
 		Kind:                sema.PublicKeyType.Kind,
 		fields:              fields,
 		Functions:           functions,
@@ -8285,7 +8286,7 @@ func NewAuthAccountKeysValue(addFunction FunctionValue, getFunction FunctionValu
 	fields.Set(sema.AccountKeysRevokeFunctionName, revokeFunction)
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AuthAccountKeysType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AuthAccountKeysType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountKeysType.Kind,
 		fields:              fields,
 	}
@@ -8297,7 +8298,7 @@ func NewPublicAccountKeysValue(getFunction FunctionValue) *CompositeValue {
 	fields.Set(sema.AccountKeysGetFunctionName, getFunction)
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.PublicAccountKeysType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.PublicAccountKeysType.QualifiedIdentifier(),
 		Kind:                sema.PublicAccountKeysType.Kind,
 		fields:              fields,
 	}
@@ -8308,7 +8309,7 @@ func NewCryptoAlgorithmEnumCaseValue(enumType *sema.CompositeType, rawValue uint
 	fields.Set(sema.EnumRawValueFieldName, UInt8Value(rawValue))
 
 	return &CompositeValue{
-		QualifiedIdentifier: enumType.QualifiedIdentifier(),
+		qualifiedIdentifier: enumType.QualifiedIdentifier(),
 		Kind:                enumType.Kind,
 		fields:              fields,
 	}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -346,7 +346,7 @@ func TestSetOwnerComposite(t *testing.T) {
 
 	const fieldName = "test"
 
-	composite.Fields.Set(fieldName, value)
+	composite.fields.Set(fieldName, value)
 
 	composite.SetOwner(&newOwner)
 
@@ -365,10 +365,10 @@ func TestSetOwnerCompositeCopy(t *testing.T) {
 
 	const fieldName = "test"
 
-	composite.Fields.Set(fieldName, value)
+	composite.fields.Set(fieldName, value)
 
 	compositeCopy := composite.Copy().(*CompositeValue)
-	valueCopy, _ := compositeCopy.Fields.Get(fieldName)
+	valueCopy, _ := compositeCopy.fields.Get(fieldName)
 
 	assert.Nil(t, compositeCopy.GetOwner())
 	assert.Nil(t, valueCopy.GetOwner())

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1140,8 +1140,9 @@ func (r *interpreterRuntime) emitEvent(
 ) error {
 	fields := make([]exportableValue, len(eventType.ConstructorParameters))
 
+	eventFields := event.Fields()
 	for i, parameter := range eventType.ConstructorParameters {
-		value, _ := event.Fields.Get(parameter.Identifier)
+		value, _ := eventFields.Get(parameter.Identifier)
 		fields[i] = newExportableValue(value, inter)
 	}
 
@@ -1212,7 +1213,7 @@ func (r *interpreterRuntime) newCreateAccountFunction(
 			))
 		}
 
-		payerAddressValue, ok := payer.Fields.Get(sema.AuthAccountAddressField)
+		payerAddressValue, ok := payer.Fields().Get(sema.AuthAccountAddressField)
 		if !ok {
 			panic("address is not set")
 		}
@@ -2492,7 +2493,7 @@ func (r *interpreterRuntime) newPublicAccountKeys(addressValue interpreter.Addre
 func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 
 	// publicKey field
-	key, ok := publicKey.Fields.Get(sema.PublicKeyPublicKeyField)
+	key, ok := publicKey.Fields().Get(sema.PublicKeyPublicKeyField)
 	if !ok {
 		panic("public key value is not set")
 	}
@@ -2503,14 +2504,14 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 	}
 
 	// sign algo field
-	signAlgoField, ok := publicKey.Fields.Get(sema.PublicKeySignAlgoField)
+	signAlgoField, ok := publicKey.Fields().Get(sema.PublicKeySignAlgoField)
 	if !ok {
 		panic("sign algorithm is not set")
 	}
 
 	signAlgoValue := signAlgoField.(*interpreter.CompositeValue)
 
-	rawValue, ok := signAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := signAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find sign algorithm raw value")
 	}
@@ -2554,7 +2555,7 @@ func NewAccountKeyValue(accountKey *AccountKey, runtimeInterface Interface) *int
 func NewHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 	hashAlgoValue := value.(*interpreter.CompositeValue)
 
-	rawValue, ok := hashAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := hashAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find hash algorithm raw value")
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1206,7 +1206,7 @@ func (r *interpreterRuntime) newCreateAccountFunction(
 
 		payer := invocation.Arguments[0].(*interpreter.CompositeValue)
 
-		if payer.QualifiedIdentifier != sema.AuthAccountType.QualifiedIdentifier() {
+		if payer.QualifiedIdentifier() != sema.AuthAccountType.QualifiedIdentifier() {
 			panic(fmt.Sprintf(
 				"%[1]s requires the first argument (payer) to be an %[1]s",
 				sema.AuthAccountType,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2492,8 +2492,10 @@ func (r *interpreterRuntime) newPublicAccountKeys(addressValue interpreter.Addre
 
 func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 
+	fields := publicKey.Fields()
+
 	// publicKey field
-	key, ok := publicKey.Fields().Get(sema.PublicKeyPublicKeyField)
+	key, ok := fields.Get(sema.PublicKeyPublicKeyField)
 	if !ok {
 		panic("public key value is not set")
 	}
@@ -2504,7 +2506,7 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 	}
 
 	// sign algo field
-	signAlgoField, ok := publicKey.Fields().Get(sema.PublicKeySignAlgoField)
+	signAlgoField, ok := fields.Get(sema.PublicKeySignAlgoField)
 	if !ok {
 		panic("sign algorithm is not set")
 	}
@@ -2520,7 +2522,7 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 
 	// `valid` and `validated` fields
 	var valid, validated bool
-	validField, validated := publicKey.Fields.Get(sema.PublicKeyIsValidField)
+	validField, validated := fields.Get(sema.PublicKeyIsValidField)
 	if validated {
 		valid = bool(validField.(interpreter.BoolValue))
 	}

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -280,7 +280,7 @@ func NewCryptoContract(
 
 func getHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 	hashAlgoValue, ok := value.(*interpreter.CompositeValue)
-	if !ok || hashAlgoValue.QualifiedIdentifier != sema.HashAlgorithmTypeName {
+	if !ok || hashAlgoValue.QualifiedIdentifier() != sema.HashAlgorithmTypeName {
 		panic(fmt.Sprintf("hash algorithm value must be of type %s", sema.HashAlgorithmType))
 	}
 
@@ -299,7 +299,7 @@ func getHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 
 func getSignatureAlgorithmFromValue(value interpreter.Value) SignatureAlgorithm {
 	signAlgoValue, ok := value.(*interpreter.CompositeValue)
-	if !ok || signAlgoValue.QualifiedIdentifier != sema.SignatureAlgorithmTypeName {
+	if !ok || signAlgoValue.QualifiedIdentifier() != sema.SignatureAlgorithmTypeName {
 		panic(fmt.Sprintf("signature algorithm value must be of type %s", sema.SignatureAlgorithmType))
 	}
 

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -284,7 +284,7 @@ func getHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 		panic(fmt.Sprintf("hash algorithm value must be of type %s", sema.HashAlgorithmType))
 	}
 
-	rawValue, ok := hashAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := hashAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find hash algorithm raw value")
 	}
@@ -303,7 +303,7 @@ func getSignatureAlgorithmFromValue(value interpreter.Value) SignatureAlgorithm 
 		panic(fmt.Sprintf("signature algorithm value must be of type %s", sema.SignatureAlgorithmType))
 	}
 
-	rawValue, ok := signAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := signAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find signature algorithm raw value")
 	}

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -90,7 +90,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 	))
 
 	value := &interpreter.CompositeValue{
-		Location:            utils.TestLocation,
+		location:            utils.TestLocation,
 		QualifiedIdentifier: fruitType.Identifier,
 		Kind:                common.CompositeKindStructure,
 		ComputedFields:      interpreter.NewStringComputedFieldOrderedMap(),

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -93,11 +93,13 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		Location:            utils.TestLocation,
 		QualifiedIdentifier: fruitType.Identifier,
 		Kind:                common.CompositeKindStructure,
-		Fields:              interpreter.NewStringValueOrderedMap(),
 		ComputedFields:      interpreter.NewStringComputedFieldOrderedMap(),
 	}
 
-	value.Fields.Set("name", interpreter.NewStringValue("Apple"))
+	fields := interpreter.NewStringValueOrderedMap()
+	fields.Set("name", interpreter.NewStringValue("Apple"))
+	value = value.WithFields(fields)
+
 	value.ComputedFields.Set("color", func(*interpreter.Interpreter) interpreter.Value {
 		return interpreter.NewStringValue("Red")
 	})

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -89,23 +89,24 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		"This is the color",
 	))
 
-	value := &interpreter.CompositeValue{
-		location:            utils.TestLocation,
-		QualifiedIdentifier: fruitType.Identifier,
-		Kind:                common.CompositeKindStructure,
-		ComputedFields:      interpreter.NewStringComputedFieldOrderedMap(),
-	}
-
 	fields := interpreter.NewStringValueOrderedMap()
 	fields.Set("name", interpreter.NewStringValue("Apple"))
-	value = value.WithFields(fields)
 
+	value := interpreter.NewCompositeValue(
+		utils.TestLocation,
+		fruitType.Identifier,
+		common.CompositeKindStructure,
+		fields,
+		nil,
+	)
+
+	value.ComputedFields = interpreter.NewStringComputedFieldOrderedMap()
 	value.ComputedFields.Set("color", func(*interpreter.Interpreter) interpreter.Value {
 		return interpreter.NewStringValue("Red")
 	})
 
 	customStructValue := stdlib.StandardLibraryValue{
-		Name:  value.QualifiedIdentifier,
+		Name:  value.QualifiedIdentifier(),
 		Type:  fruitType,
 		Value: value,
 		Kind:  common.DeclarationKindConstant,

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -63,7 +63,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
 
 	assert.Equal(t,
 		common.CompositeKindEnum,
-		a.(*interpreter.CompositeValue).Kind,
+		a.(*interpreter.CompositeValue).Kind(),
 	)
 
 	b := inter.Globals["b"].GetValue()
@@ -74,7 +74,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
 
 	assert.Equal(t,
 		common.CompositeKindEnum,
-		b.(*interpreter.CompositeValue).Kind,
+		b.(*interpreter.CompositeValue).Kind(),
 	)
 }
 

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -206,13 +206,13 @@ func TestInterpretEnumInContract(t *testing.T) {
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 
-	eValue, present := contract.Fields.Get("e")
+	eValue, present := contract.Fields().Get("e")
 	require.True(t, present)
 
 	require.IsType(t, &interpreter.CompositeValue{}, eValue)
 	enumCase := eValue.(*interpreter.CompositeValue)
 
-	rawValue, present := enumCase.Fields.Get("rawValue")
+	rawValue, present := enumCase.Fields().Get("rawValue")
 	require.True(t, present)
 
 	require.Equal(t,

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -80,7 +80,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 						)
 
 						value := &interpreter.CompositeValue{
-							Location:            location,
+							location:            location,
 							QualifiedIdentifier: "Foo",
 							Kind:                common.CompositeKindContract,
 							Functions: map[string]interpreter.FunctionValue{

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -79,26 +79,29 @@ func TestInterpretVirtualImport(t *testing.T) {
 							location,
 						)
 
+						value := &interpreter.CompositeValue{
+							Location:            location,
+							QualifiedIdentifier: "Foo",
+							Kind:                common.CompositeKindContract,
+							Functions: map[string]interpreter.FunctionValue{
+								"bar": interpreter.NewHostFunctionValue(
+									func(invocation interpreter.Invocation) interpreter.Value {
+										return interpreter.UInt64Value(42)
+									},
+								),
+							},
+						}
+
+						value = value.WithFields(interpreter.NewStringValueOrderedMap())
+
 						return interpreter.VirtualImport{
 							Globals: []struct {
 								Name  string
 								Value interpreter.Value
 							}{
 								{
-									Name: "Foo",
-									Value: &interpreter.CompositeValue{
-										Location:            location,
-										QualifiedIdentifier: "Foo",
-										Kind:                common.CompositeKindContract,
-										Fields:              interpreter.NewStringValueOrderedMap(),
-										Functions: map[string]interpreter.FunctionValue{
-											"bar": interpreter.NewHostFunctionValue(
-												func(invocation interpreter.Invocation) interpreter.Value {
-													return interpreter.UInt64Value(42)
-												},
-											),
-										},
-									},
+									Name:  "Foo",
+									Value: value,
 								},
 							},
 						}

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -79,20 +79,21 @@ func TestInterpretVirtualImport(t *testing.T) {
 							location,
 						)
 
-						value := &interpreter.CompositeValue{
-							location:            location,
-							QualifiedIdentifier: "Foo",
-							Kind:                common.CompositeKindContract,
-							Functions: map[string]interpreter.FunctionValue{
-								"bar": interpreter.NewHostFunctionValue(
-									func(invocation interpreter.Invocation) interpreter.Value {
-										return interpreter.UInt64Value(42)
-									},
-								),
-							},
-						}
+						value := interpreter.NewCompositeValue(
+							location,
+							"Foo",
+							common.CompositeKindContract,
+							interpreter.NewStringValueOrderedMap(),
+							nil,
+						)
 
-						value = value.WithFields(interpreter.NewStringValueOrderedMap())
+						value.Functions = map[string]interpreter.FunctionValue{
+							"bar": interpreter.NewHostFunctionValue(
+								func(invocation interpreter.Invocation) interpreter.Value {
+									return interpreter.UInt64Value(42)
+								},
+							),
+						}
 
 						return interpreter.VirtualImport{
 							Globals: []struct {

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -133,7 +133,7 @@ func TestInterpretResourceUUID(t *testing.T) {
 		require.IsType(t, &interpreter.CompositeValue{}, element)
 		res := element.(*interpreter.CompositeValue)
 
-		uuidValue, present := res.Fields.Get(sema.ResourceUUIDFieldName)
+		uuidValue, present := res.Fields().Get(sema.ResourceUUIDFieldName)
 		require.True(t, present)
 		require.Equal(t,
 			interpreter.UInt64Value(i),


### PR DESCRIPTION
Work towards #845

## Description

Composite values have four storable properties:
- location
- qualified-Identifier
- kind
- fields

When reading a value from storage, only these four properties are decoded. Once the decoding is delayed, these properties may not have been properly initialized for a value returned from the decoder. Hence accessing them directly is unsafe.

This PR introduces a getter for each of the four properties. The getter function ensures the property is decoded and properly loaded.

### Overhead
- There are two overheads:
  - Now we have to make a function call instead of directly using a field.
  - Function call always does a nil check.
    - Alternative is to store the getter as a local-field (function pointer) in the composite value, and replace it with a direct-field-returning function after the first invocation.
    - But the benchmarking showed that invoking a nil-checking static function is 5x faster than invoking a function pointer.
- However, both of these turned out to be very **trivial** at `go` level. It doesn't impact the overall performance of the runtime.

### Alternavies
An alternative approach is to introduce a new implementation for `DeferredCompositeValue`. Then make it act as a delegation wrapper for the `CompositeValue`. But the downsides are:
- The `CompositeValue` is used in numerous places in the runtime. We have to add the new `DeferredCompositeValue` also for all such places and duplicate the logic.
- Cannot do the optimization by separating 'meta-content' vs 'fields-content'.

### TODO:
Add the decoding logic once the stream-decoder API is available.

______
For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
