### PR TITLE
Fix optional type ID, add tests

### DIFF
--- a/types.go
+++ b/types.go
@@ -68,7 +68,7 @@ type OptionalType struct {
 func (OptionalType) isType() {}
 
 func (t OptionalType) ID() string {
-	return fmt.Sprintf("%s?", t.Type)
+	return fmt.Sprintf("%s?", t.Type.ID())
 }
 
 // Variable

--- a/types.go
+++ b/types.go
@@ -805,30 +805,6 @@ func (t ResourcePointer) ID() string {
 	return t.TypeName
 }
 
-// StructPointer
-
-type StructPointer struct {
-	TypeName string
-}
-
-func (StructPointer) isType() {}
-
-func (t StructPointer) ID() string {
-	return t.TypeName
-}
-
-// EventPointer
-
-type EventPointer struct {
-	TypeName string
-}
-
-func (EventPointer) isType() {}
-
-func (t EventPointer) ID() string {
-	return t.TypeName
-}
-
 // ReferenceType
 
 type ReferenceType struct {

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,165 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cadence
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestType_ID(t *testing.T) {
+
+	t.Parallel()
+
+	type testCase struct {
+		ty       Type
+		expected string
+	}
+
+	stringerTests := []testCase{
+		{AnyType{}, "Any"},
+		{AnyStructType{}, "AnyStruct"},
+		{AnyResourceType{}, "AnyResource"},
+		{NumberType{}, "Number"},
+		{SignedNumberType{}, "SignedNumber"},
+		{IntegerType{}, "Integer"},
+		{SignedIntegerType{}, "SignedInteger"},
+		{FixedPointType{}, "FixedPoint"},
+		{SignedFixedPointType{}, "SignedFixedPoint"},
+		{UIntType{}, "UInt"},
+		{UInt8Type{}, "UInt8"},
+		{UInt16Type{}, "UInt16"},
+		{UInt32Type{}, "UInt32"},
+		{UInt64Type{}, "UInt64"},
+		{UInt128Type{}, "UInt128"},
+		{UInt256Type{}, "UInt256"},
+		{IntType{}, "Int"},
+		{Int8Type{}, "Int8"},
+		{Int16Type{}, "Int16"},
+		{Int32Type{}, "Int32"},
+		{Int64Type{}, "Int64"},
+		{Int128Type{}, "Int128"},
+		{Int256Type{}, "Int256"},
+		{Word8Type{}, "Word8"},
+		{Word16Type{}, "Word16"},
+		{Word32Type{}, "Word32"},
+		{Word64Type{}, "Word64"},
+		{UFix64Type{}, "UFix64"},
+		{Fix64Type{}, "Fix64"},
+		{VoidType{}, "Void"},
+		{BoolType{}, "Bool"},
+		{CharacterType{}, "Character"},
+		{NeverType{}, "Never"},
+		{StringType{}, "String"},
+		{BytesType{}, "Bytes"},
+		{AddressType{}, "Address"},
+		{PathType{}, "Path"},
+		{StoragePathType{}, "StoragePath"},
+		{CapabilityPathType{}, "CapabilityPath"},
+		{PublicPathType{}, "PublicPath"},
+		{PrivatePathType{}, "PrivatePath"},
+		{BlockType{}, "Block"},
+		{MetaType{}, "Type"},
+		{
+			CapabilityType{}.
+				WithID("Capability"),
+			"Capability",
+		},
+		{
+			CapabilityType{
+				BorrowType: IntType{},
+			}.WithID("Capability<Int>"),
+			"Capability<Int>",
+		},
+		{
+			OptionalType{
+				Type: StringType{},
+			},
+			"String?",
+		},
+		{
+			VariableSizedArrayType{
+				ElementType: StringType{},
+			},
+			"[String]",
+		},
+		{
+			ConstantSizedArrayType{
+				ElementType: StringType{},
+				Size:        2,
+			},
+			"[String;2]",
+		},
+		{
+			DictionaryType{
+				KeyType:     StringType{},
+				ElementType: IntType{},
+			},
+			"{String:Int}",
+		},
+		{
+			&StructType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "Foo",
+			},
+			"S.test.Foo",
+		},
+		{
+			&StructInterfaceType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "FooI",
+			},
+			"S.test.FooI",
+		},
+		{
+			&ResourceType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "Foo",
+			},
+			"S.test.Foo",
+		},
+		{
+			&ResourceInterfaceType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "FooI",
+			},
+			"S.test.FooI",
+		},
+		{
+			RestrictedType{}.WithID("S.test.Foo{S.test.FooI}"),
+			"S.test.Foo{S.test.FooI}",
+		},
+	}
+
+	test := func(ty Type, expected string) {
+
+		id := ty.ID()
+
+		t.Run(id, func(t *testing.T) {
+
+			assert.Equal(t, expected, id)
+		})
+	}
+
+	for _, testCase := range stringerTests {
+		test(testCase.ty, testCase.expected)
+	}
+}

--- a/values_test.go
+++ b/values_test.go
@@ -70,6 +70,10 @@ func TestStringer(t *testing.T) {
 			value:    NewUInt256(256),
 			expected: "256",
 		},
+		"Int": {
+			value:    NewInt(1000000),
+			expected: "1000000",
+		},
 		"Int8": {
 			value:    NewInt8(-8),
 			expected: "-8",


### PR DESCRIPTION
## Description

- Fix the type ID for optional types. Add tests for all type IDs
- Remove `StructPointer` and `EventPointer`. They are not used
- Add a missing test case

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
