### PR TITLE
Test equal for nil value, in comparison and switch

### DIFF
--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -107,4 +107,19 @@ func TestInterpretEquality(t *testing.T) {
 			inter.Globals["res2"].GetValue(),
 		)
 	})
+
+	t.Run("nil", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          let n: Int? = 1
+          let res = nil == n
+		`)
+
+		assert.Equal(t,
+			interpreter.BoolValue(false),
+			inter.Globals["res"].GetValue(),
+		)
+	})
 }


### PR DESCRIPTION
Closes #860

## Description

Add more test cases for the equality function of the nil value.

The reported missing implementation was already implemented earlier https://github.com/onflow/cadence/commit/d846317792d9ca4beffb4f9a45bdabc20729c4e4#diff-424575c293dc2bc3a28aab845829d7656fa83a7be4e026de8906935e23bbd52eR6503-R6507
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
