### PR TITLE
Language Server: Add support for access check mode

### DIFF
--- a/runtime/sema/accesscheckmode.go
+++ b/runtime/sema/accesscheckmode.go
@@ -23,9 +23,16 @@ package sema
 type AccessCheckMode uint
 
 const (
+	// AccessCheckModeStrict indicates that access modifiers are required
+	// and access checks are always enforced
 	AccessCheckModeStrict AccessCheckMode = iota
+	// AccessCheckModeNotSpecifiedRestricted indicates modifiers are optional.
+	// Access is assumed private if not specified
 	AccessCheckModeNotSpecifiedRestricted
+	// AccessCheckModeNotSpecifiedUnrestricted indicates access modifiers are optional.
+	// Access is assumed public if not specified
 	AccessCheckModeNotSpecifiedUnrestricted
+	// AccessCheckModeNone indicates access modifiers are optional and ignored
 	AccessCheckModeNone
 )
 


### PR DESCRIPTION
## Description

The checker has a configuration option that determines if access modifiers are required, how access modifiers are enforced, and the behavior when they are not specified, the "access check mode".

Add support for this option to the language server, so developers can e.g. choose to disable the requirement for access modifiers.

I added the "UI portion", i.e. the configuration option to the Visual Studio Code extension in onflow/vscode-flow#44.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
