### PR TITLE
Pre-allocate and reuse value-path for decoding

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -284,10 +284,10 @@ func (d *DecoderV4) decodeArray(v []interface{}, path []string) (*ArrayValue, er
 	// Pre-allocate and reuse valuePath.
 	valuePath := append(path, "")
 
-	lastIndex := len(path)
+	lastValuePathIndex := len(path)
 
 	for i, value := range v {
-		valuePath[lastIndex] = strconv.Itoa(i)
+		valuePath[lastValuePathIndex] = strconv.Itoa(i)
 
 		res, err := d.decodeValue(value, valuePath)
 		if err != nil {
@@ -391,7 +391,7 @@ func (d *DecoderV4) decodeDictionary(v interface{}, path []string) (*DictionaryV
 		// Pre-allocate and reuse valuePath.
 		valuePath := append(path, dictionaryValuePathPrefix, "")
 
-		lastIndex := len(path) + 1
+		lastValuePathIndex := len(path) + 1
 
 		keyIndex := 0
 
@@ -407,7 +407,7 @@ func (d *DecoderV4) decodeDictionary(v interface{}, path []string) (*DictionaryV
 			}
 
 			keyString := keyStringValue.KeyString()
-			valuePath[lastIndex] = keyString
+			valuePath[lastValuePathIndex] = keyString
 
 			value := encodedEntries[keyIndex]
 
@@ -586,7 +586,7 @@ func (d *DecoderV4) decodeComposite(v interface{}, path []string) (*CompositeVal
 	// Pre-allocate and reuse valuePath.
 	valuePath := append(path, "")
 
-	lastIndex := len(path)
+	lastValuePathIndex := len(path)
 
 	for i := 0; i < len(encodedFields); i += 2 {
 
@@ -604,7 +604,7 @@ func (d *DecoderV4) decodeComposite(v interface{}, path []string) (*CompositeVal
 		// field value
 		value := encodedFields[i+1]
 
-		valuePath[lastIndex] = fieldName
+		valuePath[lastValuePathIndex] = fieldName
 
 		decodedValue, err := d.decodeValue(value, valuePath)
 		if err != nil {

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -792,10 +792,11 @@ func (e *Encoder) encodeArray(
 	// Pre-allocate and reuse valuePath.
 	valuePath := append(path, "")
 
-	lastIndex := len(path)
+	lastValuePathIndex := len(path)
 
 	for i, value := range v.Values {
-		valuePath[lastIndex] = strconv.Itoa(i)
+		valuePath[lastValuePathIndex] = strconv.Itoa(i)
+
 		err := e.Encode(value, valuePath, deferrals)
 		if err != nil {
 			return err
@@ -886,12 +887,12 @@ func (e *Encoder) encodeDictionaryValue(
 	// Pre-allocate and reuse valuePath.
 	valuePath := append(path, dictionaryValuePathPrefix, "")
 
-	lastIndex := len(path) + 1
+	lastValuePathIndex := len(path) + 1
 
 	for _, keyValue := range v.Keys.Values {
 		key := dictionaryKey(keyValue)
 		entryValue, _ := v.Entries.Get(key)
-		valuePath[lastIndex] = key
+		valuePath[lastValuePathIndex] = key
 
 		if deferred {
 
@@ -1015,7 +1016,7 @@ func (e *Encoder) encodeCompositeValue(
 	// Pre-allocate and reuse valuePath.
 	valuePath := append(path, "")
 
-	lastIndex := len(path)
+	lastValuePathIndex := len(path)
 
 	for pair := v.Fields.Oldest(); pair != nil; pair = pair.Next() {
 		fieldName := pair.Key
@@ -1028,7 +1029,7 @@ func (e *Encoder) encodeCompositeValue(
 
 		value := pair.Value
 
-		valuePath[lastIndex] = fieldName
+		valuePath[lastValuePathIndex] = fieldName
 
 		// Encode value as fields array element
 		err = e.Encode(value, valuePath, deferrals)


### PR DESCRIPTION
## Description

Just like in #858 for the encoder, pre-allocate the path and re-use it in the decoder.

Also, improve the naming a bit to avoid accidental confusion of the various "indices" that are declared and used for different purposes.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
