### PR TITLE
Add deferred decoding for array values

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -169,9 +169,10 @@ func exportSomeValue(v *interpreter.SomeValue, inter *interpreter.Interpreter, r
 }
 
 func exportArrayValue(v *interpreter.ArrayValue, inter *interpreter.Interpreter, results exportResults) cadence.Array {
-	values := make([]cadence.Value, len(v.Values))
+	elements := v.Elements()
+	values := make([]cadence.Value, len(elements))
 
-	for i, value := range v.Values {
+	for i, value := range elements {
 		values[i] = exportValueWithInterpreter(value, inter, results)
 	}
 
@@ -247,7 +248,7 @@ func exportDictionaryValue(
 
 	pairs := make([]cadence.KeyValuePair, v.Count())
 
-	for i, keyValue := range v.Keys.Values {
+	for i, keyValue := range v.Keys.Elements() {
 
 		// NOTE: use `Get` instead of accessing `Entries`,
 		// so that the potentially deferred values are loaded from storage

--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -94,7 +94,7 @@ func (v BlockValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, 
 
 func (v BlockValue) IDAsByteArray() [sema.BlockIDSize]byte {
 	var byteArray [sema.BlockIDSize]byte
-	for i, b := range v.ID.Values {
+	for i, b := range v.ID.Elements() {
 		byteArray[i] = byte(b.(UInt8Value))
 	}
 	return byteArray

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -29,8 +29,10 @@ func ByteArrayValueToByteSlice(value Value) ([]byte, error) {
 		return nil, errors.New("value is not an array")
 	}
 
-	result := make([]byte, len(array.Values))
-	for i, element := range array.Values {
+	elements := array.Elements()
+	result := make([]byte, len(elements))
+
+	for i, element := range elements {
 
 		b, err := ByteValueToByte(element)
 		if err != nil {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1826,6 +1826,7 @@ func decodeArrayElements(array *ArrayValue, elementContent []byte) error {
 	values := make([]Value, size)
 
 	// Pre-allocate and reuse valuePath.
+	//nolint:gocritic
 	valuePath := append(array.valuePath, "")
 
 	lastValuePathIndex := len(array.valuePath)

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -359,7 +359,7 @@ func (d *DecoderV4) decodeArray(path []string) (*ArrayValue, error) {
 	}
 
 	return &ArrayValue{
-		Values:   values,
+		values:   values,
 		Owner:    d.owner,
 		modified: false,
 	}, nil
@@ -445,7 +445,7 @@ func (d *DecoderV4) decodeDictionary(path []string) (*DictionaryValue, error) {
 		deferred = orderedmap.NewStringStructOrderedMap()
 		deferredOwner = d.owner
 		deferredStorageKeyBase = joinPath(append(path, dictionaryValuePathPrefix))
-		for _, keyValue := range keys.Values {
+		for _, keyValue := range keys.Elements() {
 			key := dictionaryKey(keyValue)
 			deferred.Set(key, struct{}{})
 		}
@@ -460,7 +460,7 @@ func (d *DecoderV4) decodeDictionary(path []string) (*DictionaryValue, error) {
 
 		keyIndex := 0
 
-		for _, keyValue := range keys.Values {
+		for _, keyValue := range keys.Elements() {
 			keyStringValue, ok := keyValue.(HasKeyString)
 			if !ok {
 				return nil, fmt.Errorf(

--- a/runtime/interpreter/decode_v3.go
+++ b/runtime/interpreter/decode_v3.go
@@ -300,7 +300,7 @@ func (d *DecoderV3) decodeArray(v []interface{}, path []string) (*ArrayValue, er
 	}
 
 	return &ArrayValue{
-		Values:   values,
+		values:   values,
 		Owner:    d.owner,
 		modified: false,
 	}, nil
@@ -364,7 +364,7 @@ func (d *DecoderV3) decodeDictionary(v interface{}, path []string) (*DictionaryV
 	var hasAddressValueKeyInWrongPre3Format bool
 
 	if d.version <= 2 {
-		for _, keyValue := range keys.Values {
+		for _, keyValue := range keys.Elements() {
 			keyAddressValue, ok := keyValue.(AddressValue)
 			if !ok {
 				continue
@@ -437,7 +437,7 @@ func (d *DecoderV3) decodeDictionary(v interface{}, path []string) (*DictionaryV
 		deferred = orderedmap.NewStringStructOrderedMap()
 		deferredOwner = d.owner
 		deferredStorageKeyBase = joinPath(append(path[:], dictionaryValuePathPrefix))
-		for _, keyValue := range keys.Values {
+		for _, keyValue := range keys.Elements() {
 			key := dictionaryKey(keyValue)
 			deferred.Set(key, struct{}{})
 		}
@@ -446,7 +446,7 @@ func (d *DecoderV3) decodeDictionary(v interface{}, path []string) (*DictionaryV
 
 		index := 0
 
-		for _, keyValue := range keys.Values {
+		for _, keyValue := range keys.Elements() {
 			keyStringValue, ok := keyValue.(HasKeyString)
 			if !ok {
 				return nil, fmt.Errorf(

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -782,7 +782,8 @@ func (e *Encoder) encodeArray(
 	path []string,
 	deferrals *EncodingDeferrals,
 ) error {
-	err := e.enc.EncodeArrayHead(uint64(len(v.Values)))
+	elements := v.Elements()
+	err := e.enc.EncodeArrayHead(uint64(len(elements)))
 	if err != nil {
 		return err
 	}
@@ -793,7 +794,7 @@ func (e *Encoder) encodeArray(
 
 	lastValuePathIndex := len(path)
 
-	for i, value := range v.Values {
+	for i, value := range elements {
 		valuePath[lastValuePathIndex] = strconv.Itoa(i)
 
 		err := e.Encode(value, valuePath, deferrals)
@@ -873,7 +874,8 @@ func (e *Encoder) encodeDictionaryValue(
 
 	// entries is empty if encoding of values is deferred,
 	// otherwise entries size is the same as keys size.
-	entriesLength := len(v.Keys.Values)
+	keys := v.Keys.Elements()
+	entriesLength := len(keys)
 	if deferred {
 		entriesLength = 0
 	}
@@ -890,7 +892,7 @@ func (e *Encoder) encodeDictionaryValue(
 
 	lastValuePathIndex := len(path) + 1
 
-	for _, keyValue := range v.Keys.Values {
+	for _, keyValue := range keys {
 		key := dictionaryKey(keyValue)
 		entryValue, _ := v.Entries.Get(key)
 		valuePath[lastValuePathIndex] = key

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -782,6 +782,16 @@ func (e *Encoder) encodeArray(
 	path []string,
 	deferrals *EncodingDeferrals,
 ) error {
+
+	if v.content != nil {
+		err := e.enc.EncodeRawBytes(v.content)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 	elements := v.Elements()
 	err := e.enc.EncodeArrayHead(uint64(len(elements)))
 	if err != nil {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -86,7 +86,7 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 		require.NoError(t, err)
 
 		// Make sure the content is built.
-		_ = decoded.String()
+		_ = decoded.String(StringResults{})
 
 		if !test.deferred || (test.deferred && test.decodedValue != nil) {
 			expectedValue := test.value
@@ -5338,7 +5338,7 @@ func TestDecodeCallback(t *testing.T) {
 	require.NoError(t, err)
 
 	// build the content
-	_ = decoded.String()
+	_ = decoded.String(StringResults{})
 
 	require.Equal(t,
 		[]decodeCallback{

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -5291,7 +5291,7 @@ func TestEncodePrepareCallback(t *testing.T) {
 				path:  nil,
 			},
 			{
-				value: value.Values[0],
+				value: value.Elements()[0],
 				path:  []string{"0"},
 			},
 		},

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -86,7 +86,7 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 		require.NoError(t, err)
 
 		// Make sure the content is built.
-		decoded.String()
+		_ = decoded.String()
 
 		if !test.deferred || (test.deferred && test.decodedValue != nil) {
 			expectedValue := test.value
@@ -5338,7 +5338,7 @@ func TestDecodeCallback(t *testing.T) {
 	require.NoError(t, err)
 
 	// build the content
-	decoded.String()
+	_ = decoded.String()
 
 	require.Equal(t,
 		[]decodeCallback{

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -86,9 +86,7 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 		require.NoError(t, err)
 
 		// Make sure the content is built.
-		if composite, ok := decoded.(*CompositeValue); ok {
-			composite.Fields()
-		}
+		decoded.String()
 
 		if !test.deferred || (test.deferred && test.decodedValue != nil) {
 			expectedValue := test.value
@@ -5331,7 +5329,7 @@ func TestDecodeCallback(t *testing.T) {
 
 	var decodeCallbacks []decodeCallback
 
-	_, err := DecodeValue(data, nil, nil, CurrentEncodingVersion, func(value interface{}, path []string) {
+	decoded, err := DecodeValue(data, nil, nil, CurrentEncodingVersion, func(value interface{}, path []string) {
 		decodeCallbacks = append(decodeCallbacks, decodeCallback{
 			value: value,
 			path:  path,
@@ -5339,17 +5337,20 @@ func TestDecodeCallback(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// build the content
+	decoded.String()
+
 	require.Equal(t,
 		[]decodeCallback{
 			{
-				value: Int8Value(42),
-				path:  []string{"0"},
-			},
-			{
 				value: &ArrayValue{
-					Values: []Value{Int8Value(42)},
+					values: []Value{Int8Value(42)},
 				},
 				path: nil,
+			},
+			{
+				value: Int8Value(42),
+				path:  []string{"0"},
 			},
 		},
 		decodeCallbacks,

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -231,7 +231,7 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 		nil,
 	)
 
-	values := interpreter.evalExpression(statement.Value).(*ArrayValue).Values[:]
+	values := interpreter.evalExpression(statement.Value).(*ArrayValue).Elements()[:]
 
 	for _, value := range values {
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -527,15 +527,15 @@ type ArrayValue struct {
 	content []byte
 
 	// Value's path to be used during decoding.
-	// Only available for decoded values that are not loaded yet.
+	// Only available for decoded values who's elements are not loaded yet.
 	valuePath []string
 
-	// Callback function to be invoked when decoding the fields of this composite value.
-	// Only available for decoded values who's fields are not loaded yet.
+	// Callback function to be invoked when decoding the elements of this array value.
+	// Only available for decoded values who's elements are not loaded yet.
 	decodeCallback DecodingCallback
 
-	// Encoding version of the raw content and raw fieldsContent of this value.
-	// Only available for decoded values who's fields are not loaded yet.
+	// Encoding version of the raw content of the elements of this value.
+	// Only available for decoded values who's elements are not loaded yet.
 	encodingVersion uint16
 }
 
@@ -726,8 +726,8 @@ func (v *ArrayValue) Append(element Value) {
 
 	element.SetOwner(v.Owner)
 
-	//nolint:gocritic
-	v.values = append(v.Elements(), element)
+	v.ensureElementsLoaded()
+	v.values = append(v.values, element)
 }
 
 func (v *ArrayValue) AppendAll(other AllAppendableValue) {
@@ -740,8 +740,8 @@ func (v *ArrayValue) AppendAll(other AllAppendableValue) {
 		element.SetOwner(v.Owner)
 	}
 
-	//nolint:gocritic
-	v.values = append(v.Elements(), otherElements...)
+	v.ensureElementsLoaded()
+	v.values = append(v.values, otherElements...)
 }
 
 func (v *ArrayValue) Insert(i int, element Value) {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -726,8 +726,8 @@ func (v *ArrayValue) Append(element Value) {
 
 	element.SetOwner(v.Owner)
 
-	elements := v.Elements()
-	v.values = append(elements, element)
+	//nolint:gocritic
+	v.values = append(v.Elements(), element)
 }
 
 func (v *ArrayValue) AppendAll(other AllAppendableValue) {
@@ -740,8 +740,8 @@ func (v *ArrayValue) AppendAll(other AllAppendableValue) {
 		element.SetOwner(v.Owner)
 	}
 
-	elements := v.Elements()
-	v.values = append(elements, otherElements...)
+	//nolint:gocritic
+	v.values = append(v.Elements(), otherElements...)
 }
 
 func (v *ArrayValue) Insert(i int, element Value) {
@@ -750,6 +750,8 @@ func (v *ArrayValue) Insert(i int, element Value) {
 	element.SetOwner(v.Owner)
 
 	elements := v.Elements()
+
+	//nolint:gocritic
 	v.values = append(elements[:i], append([]Value{element}, elements[i:]...)...)
 }
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -87,7 +87,7 @@ func TestSetOwnerArrayCopy(t *testing.T) {
 	array.SetOwner(&newOwner)
 
 	arrayCopy := array.Copy().(*ArrayValue)
-	valueCopy := arrayCopy.Values[0]
+	valueCopy := arrayCopy.Elements()[0]
 
 	assert.Nil(t, arrayCopy.GetOwner())
 	assert.Nil(t, valueCopy.GetOwner())

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2479,7 +2479,7 @@ func NewBlockValue(block Block) interpreter.BlockValue {
 	for i, b := range block.Hash {
 		values[i] = interpreter.UInt8Value(b)
 	}
-	idValue := &interpreter.ArrayValue{Values: values}
+	idValue := interpreter.NewArrayValue(values)
 
 	// timestamp
 	// TODO: verify

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -551,7 +551,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 			interpreter.NewIntValueFromInt64(0),
 			interpreter.NewIntValueFromInt64(2),
 		},
-		actualArray.(*interpreter.ArrayValue).Values,
+		actualArray.(*interpreter.ArrayValue).Elements(),
 	)
 }
 
@@ -3599,7 +3599,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 		[]interpreter.Value{
 			interpreter.NewStringValue("abc"),
 		},
-		actualDict.Keys.Values,
+		actualDict.Keys.Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -3665,7 +3665,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 			interpreter.NewStringValue("def"),
 			interpreter.NewStringValue("abc"),
 		},
-		actualDict.Keys.Values,
+		actualDict.Keys.Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -3728,7 +3728,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 		[]interpreter.Value{
 			interpreter.NewStringValue("abc"),
 		},
-		actualDict.Keys.Values,
+		actualDict.Keys.Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -3948,7 +3948,7 @@ func TestInterpretArrayAppend(t *testing.T) {
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(4),
 		},
-		actualArray.(*interpreter.ArrayValue).Values,
+		actualArray.(*interpreter.ArrayValue).Elements(),
 	)
 }
 
@@ -4145,7 +4145,7 @@ func TestInterpretArrayInsert(t *testing.T) {
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 		},
-		actualArray.(*interpreter.ArrayValue).Values,
+		actualArray.(*interpreter.ArrayValue).Elements(),
 	)
 }
 
@@ -4179,7 +4179,7 @@ func TestInterpretArrayRemove(t *testing.T) {
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(3),
 		},
-		actualArray.(*interpreter.ArrayValue).Values,
+		actualArray.(*interpreter.ArrayValue).Elements(),
 	)
 
 	assert.Equal(t,
@@ -4218,7 +4218,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 		},
-		actualArray.(*interpreter.ArrayValue).Values,
+		actualArray.(*interpreter.ArrayValue).Elements(),
 	)
 
 	assert.Equal(t,
@@ -4257,7 +4257,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 		},
-		actualArray.(*interpreter.ArrayValue).Values,
+		actualArray.(*interpreter.ArrayValue).Elements(),
 	)
 
 	assert.Equal(t,
@@ -4413,7 +4413,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 		[]interpreter.Value{
 			interpreter.NewStringValue("def"),
 		},
-		actualDict.Keys.Values,
+		actualDict.Keys.Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -4467,7 +4467,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 			interpreter.NewStringValue("abc"),
 			interpreter.NewStringValue("def"),
 		},
-		actualDict.Keys.Values,
+		actualDict.Keys.Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -5775,7 +5775,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		value,
 	)
 
-	values := value.(*interpreter.ArrayValue).Values
+	values := value.(*interpreter.ArrayValue).Elements()
 
 	require.IsType(t,
 		&interpreter.SomeValue{},
@@ -7203,7 +7203,7 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 
 		test.SetModified(false)
 		test.Keys.SetModified(false)
-		for _, key := range test.Keys.Values {
+		for _, key := range test.Keys.Elements() {
 			stringKey := key.(*interpreter.StringValue)
 			stringKey.SetModified(false)
 		}

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -305,7 +305,7 @@ func TestInterpretTransactions(t *testing.T) {
 				interpreter.BoolValue(true),
 				interpreter.NewIntValueFromInt64(1),
 			},
-			values.(*interpreter.ArrayValue).Values,
+			values.(*interpreter.ArrayValue).Elements(),
 		)
 	})
 

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -125,10 +125,12 @@ func TestInterpretResourceUUID(t *testing.T) {
 	array := value.(*interpreter.ArrayValue)
 
 	const length = 2
-	require.Len(t, array.Values, length)
+
+	elements := array.Elements()
+	require.Len(t, elements, length)
 
 	for i := 0; i < length; i++ {
-		element := array.Values[i]
+		element := elements[i]
 
 		require.IsType(t, &interpreter.CompositeValue{}, element)
 		res := element.(*interpreter.CompositeValue)


### PR DESCRIPTION
Closes #846

## Description

Adds a getter for array elements, that ensures the elements are loaded before accessing them.

This loads all elements of the array, even if one of the elements is accessed. Can be further improved to load only up to that element.

### Performance:
For an ArrayValue with 100 elements, where each element is a struct:
(_Note this includes the performance improvements gained by lazily-loading the composite values as well._)

```
name                                            old time/op    new time/op    delta
ArrayDeferredDecoding/Simply_decode-12             502µs ±20%      41µs ± 0%  -91.80%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Get_first_element-12         514µs ±16%      99µs ± 3%  -80.75%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Get_last_element-12          487µs ± 6%     100µs ± 4%  -79.45%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Re-encode_decoded-12         139µs ±16%       5µs ± 0%  -96.46%  (p=0.008 n=5+5)

name                                            old alloc/op   new alloc/op   delta
ArrayDeferredDecoding/Simply_decode-12             231kB ± 0%       0kB ± 0%  -99.80%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Get_first_element-12         231kB ± 0%      23kB ± 0%  -89.93%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Get_last_element-12          231kB ± 0%      23kB ± 0%  -89.93%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Re-encode_decoded-12        64.6kB ± 0%    33.3kB ± 0%  -48.44%  (p=0.008 n=5+5)

name                                            old allocs/op  new allocs/op  delta
ArrayDeferredDecoding/Simply_decode-12             6.21k ± 0%     0.01k ± 0%  -99.90%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Get_first_element-12         6.21k ± 0%     0.21k ± 0%  -96.59%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Get_last_element-12          6.21k ± 0%     0.21k ± 0%  -96.57%  (p=0.008 n=5+5)
ArrayDeferredDecoding/Re-encode_decoded-12           318 ± 0%        10 ± 0%  -96.86%  (p=0.008 n=5+5)
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
