### PR TITLE
Optimize decoding by using CBOR StreamDecoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytecodealliance/wasmtime-go v0.22.0
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/cheekybits/genny v1.0.0
-	github.com/fxamacker/cbor/v2 v2.2.1-0.20210428011003-7ceed0a5d02f
+	github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8
 	github.com/go-test/deep v1.0.5
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/rivo/uniseg v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20210428011003-7ceed0a5d02f h1:OKT+0u9yHS7vfkQ65zYqAuoLohWaMtxd9+W6/R79gWw=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20210428011003-7ceed0a5d02f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8 h1:bnGFnszovskZqVUvShEj89u5xyiXYj6cQhwy0XUMEfk=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1267,14 +1267,16 @@ func (d *DecoderV4) decodeLink() (LinkValue, error) {
 	}
 
 	// Decode path at array index encodedLinkValueTargetPathFieldKey
-	decodedPath, err := d.decodeValue(nil)
+	num, err := d.decoder.DecodeTagNumber()
 	if err != nil {
 		return LinkValue{}, fmt.Errorf("invalid link target path encoding: %w", err)
 	}
-
-	pathValue, ok := decodedPath.(PathValue)
-	if !ok {
-		return LinkValue{}, fmt.Errorf("invalid link target path encoding: %T", decodedPath)
+	if num != cborTagPathValue {
+		return LinkValue{}, fmt.Errorf("invalid link target path encoding: expected CBOR tag %d, got %d", cborTagPathValue, num)
+	}
+	pathValue, err := d.decodePath()
+	if err != nil {
+		return LinkValue{}, fmt.Errorf("invalid link target path encoding: %w", err)
 	}
 
 	// Decode type at array index encodedLinkValueTypeFieldKey

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1284,7 +1284,9 @@ func (d *DecoderV4) decodeStaticType() (StaticType, error) {
 
 			// CBOR nil is interpreted as nil static type.
 			if e.ActualType == cbor.NilType {
-				d.decoder.Skip()
+				if err := d.decoder.Skip(); err != nil {
+					return nil, err
+				}
 				return nil, nil
 			}
 

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1187,14 +1187,17 @@ func (d *DecoderV4) decodeCapability() (CapabilityValue, error) {
 	// address
 
 	// Decode address at array index encodedCapabilityValueAddressFieldKey
-	field1Value, err := d.decodeValue(nil)
+	var num uint64
+	num, err = d.decoder.DecodeTagNumber()
 	if err != nil {
 		return CapabilityValue{}, fmt.Errorf("invalid capability address: %w", err)
 	}
-
-	address, ok := field1Value.(AddressValue)
-	if !ok {
-		return CapabilityValue{}, fmt.Errorf("invalid capability address: %T", address)
+	if num != cborTagAddressValue {
+		return CapabilityValue{}, fmt.Errorf("invalid capability address: wrong tag %d", num)
+	}
+	address, err := d.decodeAddress()
+	if err != nil {
+		return CapabilityValue{}, fmt.Errorf("invalid capability address: %w", err)
 	}
 
 	// path

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1203,14 +1203,16 @@ func (d *DecoderV4) decodeCapability() (CapabilityValue, error) {
 	// path
 
 	// Decode path at array index encodedCapabilityValuePathFieldKey
-	field2Value, err := d.decodeValue(nil)
+	num, err = d.decoder.DecodeTagNumber()
 	if err != nil {
 		return CapabilityValue{}, fmt.Errorf("invalid capability path: %w", err)
 	}
-
-	path, ok := field2Value.(PathValue)
-	if !ok {
-		return CapabilityValue{}, fmt.Errorf("invalid capability path: %T", path)
+	if num != cborTagPathValue {
+		return CapabilityValue{}, fmt.Errorf("invalid capability path: wrong tag %d", num)
+	}
+	path, err := d.decodePath()
+	if err != nil {
+		return CapabilityValue{}, fmt.Errorf("invalid capability path: %w", err)
 	}
 
 	// Decode borrow type at array index encodedCapabilityValueBorrowTypeFieldKey

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -303,11 +303,15 @@ func (d *DecoderV4) decodeValue(path []string) (Value, error) {
 		)
 	}
 
+	if err != nil {
+		return value, err
+	}
+
 	if d.decodeCallback != nil {
 		d.decodeCallback(value, path)
 	}
 
-	return value, err
+	return value, nil
 }
 
 func (d *DecoderV4) decodeString(v string) Value {
@@ -951,7 +955,7 @@ func (d *DecoderV4) decodeUInt128() (UInt128Value, error) {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return UInt128Value{}, fmt.Errorf("invalid UInt128 encoding: %s", e.ActualType.String())
 		}
-		return UInt128Value{}, nil
+		return UInt128Value{}, err
 	}
 
 	if bigInt.Sign() < 0 {
@@ -972,7 +976,7 @@ func (d *DecoderV4) decodeUInt256() (UInt256Value, error) {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return UInt256Value{}, fmt.Errorf("invalid UInt256 encoding: %s", e.ActualType.String())
 		}
-		return UInt256Value{}, nil
+		return UInt256Value{}, err
 	}
 
 	if bigInt.Sign() < 0 {
@@ -1100,7 +1104,7 @@ func (d *DecoderV4) decodeAddress() (AddressValue, error) {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return AddressValue{}, fmt.Errorf("invalid address encoding: %s", e.ActualType.String())
 		}
-		return AddressValue{}, nil
+		return AddressValue{}, err
 	}
 
 	err = d.checkAddressLength(addressBytes)

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -135,12 +135,7 @@ var decMode = func() cbor.DecMode {
 // Decode reads CBOR-encoded bytes and decodes them to a value.
 //
 func (d *DecoderV4) Decode(path []string) (Value, error) {
-	v, err := d.decodeValue(path)
-	if err != nil {
-		return nil, err
-	}
-
-	return v, nil
+	return d.decodeValue(path)
 }
 
 func (d *DecoderV4) decodeValue(path []string) (Value, error) {
@@ -1145,7 +1140,7 @@ func (d *DecoderV4) decodePath() (PathValue, error) {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return PathValue{}, fmt.Errorf("invalid path domain encoding: %s", e.ActualType.String())
 		}
-		return PathValue{}, nil
+		return PathValue{}, err
 	}
 
 	// Decode identifier at array index encodedPathValueIdentifierFieldKey
@@ -1154,7 +1149,7 @@ func (d *DecoderV4) decodePath() (PathValue, error) {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return PathValue{}, fmt.Errorf("invalid path identifier encoding: %s", e.ActualType.String())
 		}
-		return PathValue{}, nil
+		return PathValue{}, err
 	}
 
 	return PathValue{

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1219,7 +1219,15 @@ func (d *DecoderV4) decodeCapability() (CapabilityValue, error) {
 	//
 	// The decoding must be backwards-compatible and support both capability values
 	// with a borrow type and ones without
-	borrowType, err := d.decodeStaticType()
+
+	var borrowType StaticType
+
+	// Optional borrow type can be CBOR nil.
+	err = d.decoder.DecodeNil()
+	if _, ok := err.(*cbor.WrongTypeError); ok {
+		borrowType, err = d.decodeStaticType()
+	}
+
 	if err != nil {
 		return CapabilityValue{}, fmt.Errorf("invalid capability borrow type encoding: %w", err)
 	}
@@ -1280,15 +1288,6 @@ func (d *DecoderV4) decodeStaticType() (StaticType, error) {
 	number, err := d.decoder.DecodeTagNumber()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
-
-			// CBOR nil is interpreted as nil static type.
-			if e.ActualType == cbor.NilType {
-				if err := d.decoder.Skip(); err != nil {
-					return nil, err
-				}
-				return nil, nil
-			}
-
 			return nil, fmt.Errorf("invalid static type encoding: %s", e.ActualType.String())
 		}
 		return nil, err
@@ -1683,7 +1682,14 @@ func (d *DecoderV4) decodeType() (TypeValue, error) {
 	}
 
 	// Decode type at array index encodedTypeValueTypeFieldKey
-	staticType, err := d.decodeStaticType()
+	var staticType StaticType
+
+	// Optional type can be CBOR nil.
+	err = d.decoder.DecodeNil()
+	if _, ok := err.(*cbor.WrongTypeError); ok {
+		staticType, err = d.decodeStaticType()
+	}
+
 	if err != nil {
 		return TypeValue{}, fmt.Errorf("invalid type encoding: %w", err)
 	}
@@ -1694,7 +1700,14 @@ func (d *DecoderV4) decodeType() (TypeValue, error) {
 }
 
 func (d *DecoderV4) decodeCapabilityStaticType() (StaticType, error) {
-	borrowStaticType, err := d.decodeStaticType()
+	var borrowStaticType StaticType
+
+	// Optional borrow type can be CBOR nil.
+	err := d.decoder.DecodeNil()
+	if _, ok := err.(*cbor.WrongTypeError); ok {
+		borrowStaticType, err = d.decodeStaticType()
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("invalid capability static type borrow type encoding: %w", err)
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -24,7 +24,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
@@ -5269,20 +5268,14 @@ func TestDecodeCallback(t *testing.T) {
 	require.Equal(t,
 		[]decodeCallback{
 			{
-				value: []interface{}{
-					cbor.Tag{
-						Number:  cborTagInt8Value,
-						Content: uint64(42),
-					},
-				},
-				path: nil,
+				value: Int8Value(42),
+				path:  []string{"0"},
 			},
 			{
-				value: cbor.Tag{
-					Number:  cborTagInt8Value,
-					Content: uint64(42),
+				value: &ArrayValue{
+					Values: []Value{Int8Value(42)},
 				},
-				path: []string{"0"},
+				path: nil,
 			},
 		},
 		decodeCallbacks,


### PR DESCRIPTION
Closes #863

## Description

### Changes
 - [x] Optimize decoding of Value objects by using StreamDecoder and low-level API in fxamacker/cbor
 - [x] Modify tests

Types using StreamDecoder  include:  ArrayValue, CompositeValue, DictionaryValue, StorageReferenceValue, PathValue, CapabilityValue, common.AddressLocation, LinkValue, CompositeStaticType, InterfaceStaticType, ConstantSizedStaticType, ReferenceStaticType, DictionaryStaticType, RestrictedStaticType, TypeValue, and etc.

</details>

### Benchmark comparisons

Benchmarks using sample data from a mainnet snapshot, show:
 - Decoding time reduced by about 22% - 52%.
 - Memory alloc/op reduced by about 29% - 64%.
 - Memory allocs/op reduced by about 29% - 62%.
 
<details><summary>Composite values from mainnet (136-byte to 776155-byte)</summary>

```
name                                               old time/op    new time/op    delta
DecodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      485µs ± 1%     284µs ± 1%  -41.42%  (p=0.000 n=9+9)
DecodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       11.4µs ± 1%     6.9µs ± 1%  -39.65%  (p=0.000 n=10+10)
DecodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       8.05µs ± 1%    4.68µs ± 1%  -41.86%  (p=0.000 n=9+9)
DecodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    25.6ms ± 1%    20.0ms ± 1%  -21.89%  (p=0.000 n=9+9)

name                                               old alloc/op   new alloc/op   delta
DecodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      196kB ± 0%     102kB ± 0%  -47.85%  (p=0.000 n=9+10)
DecodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4       3.78kB ± 0%    2.10kB ± 0%  -44.49%  (p=0.000 n=10+10)
DecodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4       2.55kB ± 0%    1.30kB ± 0%  -49.22%  (p=0.000 n=10+10)
DecodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4    10.1MB ± 0%     7.1MB ± 0%  -29.97%  (p=0.000 n=9+10)

name                                               old allocs/op  new allocs/op  delta
DecodeCBOR/comp_v2_96d7e06eaf4b3fcf_14850bytes-4      4.35k ± 0%     2.43k ± 0%  -44.23%  (p=0.000 n=10+10)
DecodeCBOR/comp_v3_99dc360eee32dcec_160bytes-4         85.0 ± 0%      47.0 ± 0%  -44.71%  (p=0.000 n=10+10)
DecodeCBOR/comp_v3_b52a33b7e56868f6_139bytes-4         52.0 ± 0%      28.0 ± 0%  -46.15%  (p=0.000 n=10+10)
DecodeCBOR/comp_v3_d99d7e6b4dad41e1_776155bytes-4      213k ± 0%      151k ± 0%  -29.31%  (p=0.000 n=9+10)
```

</details>

<details><summary>Link values from mainnet (167-byte, 192-byte)</summary>

```
name                                            old time/op    new time/op    delta
DecodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    8.13µs ± 1%    3.91µs ± 0%  -51.92%  (p=0.000 n=10+10)
DecodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    8.13µs ± 1%    3.91µs ± 1%  -51.92%  (p=0.000 n=9+9)

name                                            old alloc/op   new alloc/op   delta
DecodeCBOR/link_v3_2392f05c3b72f235_167bytes-4    2.36kB ± 0%    0.84kB ± 0%  -64.41%  (p=0.000 n=10+10)
DecodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4    2.36kB ± 0%    0.84kB ± 0%  -64.41%  (p=0.000 n=10+10)

name                                            old allocs/op  new allocs/op  delta
DecodeCBOR/link_v3_2392f05c3b72f235_167bytes-4      55.0 ± 0%      21.0 ± 0%  -61.82%  (p=0.000 n=10+10)
DecodeCBOR/link_v3_3a791fe1b8243e73_192bytes-4      55.0 ± 0%      21.0 ± 0%  -61.82%  (p=0.000 n=10+10)
```

</details>

### Caveats

DecodingCallback function used for debugging has changed:
 - The sequence of calls to the callback used to be top-down (parent then child).  Now they are bottom-up (child then parent).
 - The data passed to the callback used to be parsed by CBOR (to CBOR tags or native Go types).  Now the data is Value object.
 - TestDecodeCallback is updated to handle the new callback behavior.


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
