### PR TITLE
capture computation used for all transactions

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -171,6 +171,9 @@ type SignatureValidationHandlerFunc func(
 	key *CompositeValue,
 ) BoolValue
 
+// ExitHandlerFunc is a function that is called at the end of execution
+type ExitHandlerFunc func() error
+
 // CompositeTypeCode contains the the "prepared" / "callable" "code"
 // for the functions and the destructor of a composite
 // (contract, struct, resource, event).
@@ -248,6 +251,7 @@ type Interpreter struct {
 	uuidHandler                    UUIDHandlerFunc
 	PublicKeyValidationHandler     PublicKeyValidationHandlerFunc
 	SignatureValidationHandler     SignatureValidationHandlerFunc
+	ExitHandler                    ExitHandlerFunc
 	interpreted                    bool
 	statement                      ast.Statement
 }
@@ -415,6 +419,16 @@ func WithSignatureValidationHandler(handler SignatureValidationHandlerFunc) Opti
 	}
 }
 
+// WithExitHandler returns an interpreter option which sets the given
+// function as the function that is used when execution is complete.
+//
+func WithExitHandler(handler ExitHandlerFunc) Option {
+	return func(interpreter *Interpreter) error {
+		interpreter.SetExitHandler(handler)
+		return nil
+	}
+}
+
 // WithAllInterpreters returns an interpreter option which sets
 // the given map of interpreters as the map of all interpreters.
 //
@@ -548,6 +562,12 @@ func (interpreter *Interpreter) SetPublicKeyValidationHandler(function PublicKey
 //
 func (interpreter *Interpreter) SetSignatureValidationHandler(function SignatureValidationHandlerFunc) {
 	interpreter.SignatureValidationHandler = function
+}
+
+// SetExitHandler sets the function that is used to handle end of execution.
+//
+func (interpreter *Interpreter) SetExitHandler(function ExitHandlerFunc) {
+	interpreter.ExitHandler = function
 }
 
 // SetAllInterpreters sets the given map of interpreters as the map of all interpreters.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1062,6 +1062,14 @@ func (r *interpreterRuntime) meteringInterpreterOptions(runtimeInterface Interfa
 			return
 		}
 
+		var err error
+		wrapPanic(func() {
+			err = runtimeInterface.SetComputationUsed(used)
+		})
+		if err != nil {
+			panic(err)
+		}
+
 		panic(ComputationLimitExceededError{
 			Limit: limit,
 		})

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1057,10 +1057,6 @@ func (r *interpreterRuntime) meteringInterpreterOptions(runtimeInterface Interfa
 	checkLimit := func() {
 		used++
 
-		if used <= limit {
-			return
-		}
-
 		var err error
 		wrapPanic(func() {
 			err = runtimeInterface.SetComputationUsed(used)
@@ -1068,6 +1064,11 @@ func (r *interpreterRuntime) meteringInterpreterOptions(runtimeInterface Interfa
 		if err != nil {
 			panic(err)
 		}
+
+		if used <= limit {
+			return
+		}
+
 		panic(ComputationLimitExceededError{
 			Limit: limit,
 		})


### PR DESCRIPTION

## Description

Seems we were only capturing computation used if they pass the limit and not for all transactions.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
