### PR TITLE
Add deferred decoding support for composite values

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -193,9 +193,10 @@ func exportCompositeValue(v *interpreter.CompositeValue, inter *interpreter.Inte
 	fieldNames := t.CompositeFields()
 	fields := make([]cadence.Value, len(fieldNames))
 
+	fieldsMap := v.Fields()
 	for i, field := range fieldNames {
 		fieldName := field.Identifier
-		fieldValue, ok := v.Fields.Get(fieldName)
+		fieldValue, ok := fieldsMap.Get(fieldName)
 
 		if !ok && v.ComputedFields != nil {
 			if computedField, ok := v.ComputedFields.Get(fieldName); ok {

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -44,7 +44,7 @@ func NewAuthAccountContractsValue(
 	}
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountContractsType.Kind,
 		fields:              fields,
 		stringer:            stringer,

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -46,7 +46,7 @@ func NewAuthAccountContractsValue(
 	return &CompositeValue{
 		QualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountContractsType.Kind,
-		Fields:              fields,
+		fields:              fields,
 		stringer:            stringer,
 	}
 }

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -45,7 +45,7 @@ func NewAuthAccountContractsValue(
 
 	return &CompositeValue{
 		qualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
-		Kind:                sema.AuthAccountContractsType.Kind,
+		kind:                sema.AuthAccountContractsType.Kind,
 		fields:              fields,
 		stringer:            stringer,
 	}

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1713,8 +1713,6 @@ func decodeCompositeMetaInfo(v *CompositeValue, content []byte) error {
 		return err
 	}
 
-	v.fieldsContent = fieldsContent
-
 	// Qualified identifier
 
 	// Decode qualified identifier at array index encodedCompositeValueQualifiedIdentifierFieldKey
@@ -1733,6 +1731,7 @@ func decodeCompositeMetaInfo(v *CompositeValue, content []byte) error {
 	v.location = location
 	v.qualifiedIdentifier = qualifiedIdentifier
 	v.kind = kind
+	v.fieldsContent = fieldsContent
 
 	return nil
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1777,6 +1777,7 @@ func decodeCompositeFields(v *CompositeValue, content []byte) error {
 	fields := NewStringValueOrderedMap()
 
 	// Pre-allocate and reuse valuePath.
+	//nolint:gocritic
 	valuePath := append(v.valuePath, "")
 
 	lastValuePathIndex := len(v.valuePath)

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -628,9 +628,7 @@ func (d *DecoderV4) decodeComposite(path []string) (*CompositeValue, error) {
 	valuePath := make([]string, len(path))
 	copy(valuePath, path)
 
-	compositeValue := NewDeferredCompositeValue(valuePath, content, d.owner)
-	compositeValue.modified = false
-	return compositeValue, nil
+	return NewDeferredCompositeValue(valuePath, content, d.owner, d.decodeCallback), nil
 }
 
 var bigOne = big.NewInt(1)
@@ -1640,7 +1638,7 @@ func (d *DecoderV4) decodeCapabilityStaticType() (StaticType, error) {
 // This also extracts out the fields raw content and cache it separately inside the value.
 //
 func decodeCompositeMetaInfo(v *CompositeValue, content []byte) error {
-	d, err := NewByteDecoder(content, v.Owner, CurrentEncodingVersion, nil)
+	d, err := NewByteDecoder(content, v.Owner, CurrentEncodingVersion, v.decodeCallback)
 	if err != nil {
 		return err
 	}
@@ -1743,7 +1741,7 @@ func decodeCompositeMetaInfo(v *CompositeValue, content []byte) error {
 // decodeCompositeFields decodes fields from the byte content and updates the composite value.
 //
 func decodeCompositeFields(v *CompositeValue, content []byte) error {
-	d, err := NewByteDecoder(content, v.Owner, CurrentEncodingVersion, nil)
+	d, err := NewByteDecoder(content, v.Owner, CurrentEncodingVersion, v.decodeCallback)
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/deferred_decoding_test.go
+++ b/runtime/interpreter/deferred_decoding_test.go
@@ -1,0 +1,140 @@
+package interpreter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestDeferredDecoding(t *testing.T) {
+
+	t.Parallel()
+
+	stringValue := NewStringValue("")
+	stringValue.modified = false
+
+	members := NewStringValueOrderedMap()
+	members.Set("a", stringValue)
+	members.Set("b", BoolValue(true))
+
+	value := NewCompositeValue(
+		utils.TestLocation,
+		"TestResource",
+		common.CompositeKindResource,
+		members,
+		nil,
+	)
+
+	encoded, _, err := EncodeValue(value, nil, true, nil)
+	require.NoError(t, err)
+
+	decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+	require.NoError(t, err)
+
+	require.IsType(t, &CompositeValue{}, decoded)
+	compositeValue := decoded.(*CompositeValue)
+
+	// Check the content is available
+	assert.NotNil(t, compositeValue.content)
+
+	// And the meta-info and fields raw content are not loaded yet
+	assert.Nil(t, compositeValue.fieldsContent)
+	assert.Empty(t, compositeValue.location)
+	assert.Empty(t, compositeValue.qualifiedIdentifier)
+	assert.Equal(t, common.CompositeKindUnknown, compositeValue.kind)
+
+	// Use the Getters and see whether the meta-info are loaded
+	assert.Equal(t, value.Location(), compositeValue.Location())
+	assert.Equal(t, value.QualifiedIdentifier(), compositeValue.QualifiedIdentifier())
+	assert.Equal(t, value.Kind(), compositeValue.Kind())
+
+	// Now the content must be cleared
+	assert.Nil(t, compositeValue.content)
+
+	// And the fields raw content must be available
+	assert.NotNil(t, compositeValue.fieldsContent)
+
+	// Check all the fields using getters
+
+	decodedFields := compositeValue.Fields()
+	require.Equal(t, 2, decodedFields.Len())
+
+	decodeFieldValue, contains := decodedFields.Get("a")
+	assert.True(t, contains)
+	assert.Equal(t, stringValue, decodeFieldValue)
+
+	decodeFieldValue, contains = decodedFields.Get("b")
+	assert.True(t, contains)
+	assert.Equal(t, BoolValue(true), decodeFieldValue)
+
+	// Once all the fields are loaded, the fields raw content must be cleared
+	assert.Nil(t, compositeValue.fieldsContent)
+}
+
+func BenchmarkName(b *testing.B) {
+
+	b.ReportAllocs()
+
+	encodedValues := make([][]byte, len(valueArray))
+	for i, value := range valueArray {
+		encoded, _, err := EncodeValue(value, nil, true, nil)
+		require.NoError(b, err)
+
+		encodedValues[i] = encoded
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, encoded := range encodedValues {
+			_, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+			require.NoError(b, err)
+		}
+	}
+}
+
+const SIZE = 100_000
+
+var valueArray = func() []Value {
+
+	values := make([]Value, SIZE)
+
+	for i := 0; i < SIZE; i++ {
+
+		addressFields := NewStringValueOrderedMap()
+		addressFields.Set("street", NewStringValue(fmt.Sprintf("No: %d", i)))
+		addressFields.Set("city", NewStringValue("Vancouver"))
+		addressFields.Set("state", NewStringValue("BC"))
+		addressFields.Set("country", NewStringValue("Canada"))
+
+		address := NewCompositeValue(
+			utils.TestLocation,
+			"Address",
+			common.CompositeKindResource,
+			addressFields,
+			nil,
+		)
+
+		members := NewStringValueOrderedMap()
+		members.Set("fname", NewStringValue("John"))
+		members.Set("lname", NewStringValue("Doe"))
+		members.Set("age", NewIntValueFromInt64(999))
+		members.Set("status", NewStringValue("unknown"))
+		members.Set("address", address)
+
+		values[i] = NewCompositeValue(
+			utils.TestLocation,
+			"TestResource",
+			common.CompositeKindResource,
+			members,
+			nil,
+		)
+	}
+
+	return values
+}()

--- a/runtime/interpreter/deferred_decoding_test.go
+++ b/runtime/interpreter/deferred_decoding_test.go
@@ -11,130 +11,190 @@ import (
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
-func TestDeferredDecoding(t *testing.T) {
+func TestCompositeDeferredDecoding(t *testing.T) {
 
 	t.Parallel()
 
-	stringValue := NewStringValue("")
-	stringValue.modified = false
+	t.Run("Simple composite", func(t *testing.T) {
 
-	members := NewStringValueOrderedMap()
-	members.Set("a", stringValue)
-	members.Set("b", BoolValue(true))
-
-	value := NewCompositeValue(
-		utils.TestLocation,
-		"TestResource",
-		common.CompositeKindResource,
-		members,
-		nil,
-	)
-
-	encoded, _, err := EncodeValue(value, nil, true, nil)
-	require.NoError(t, err)
-
-	decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
-	require.NoError(t, err)
-
-	require.IsType(t, &CompositeValue{}, decoded)
-	compositeValue := decoded.(*CompositeValue)
-
-	// Check the content is available
-	assert.NotNil(t, compositeValue.content)
-
-	// And the meta-info and fields raw content are not loaded yet
-	assert.Nil(t, compositeValue.fieldsContent)
-	assert.Empty(t, compositeValue.location)
-	assert.Empty(t, compositeValue.qualifiedIdentifier)
-	assert.Equal(t, common.CompositeKindUnknown, compositeValue.kind)
-
-	// Use the Getters and see whether the meta-info are loaded
-	assert.Equal(t, value.Location(), compositeValue.Location())
-	assert.Equal(t, value.QualifiedIdentifier(), compositeValue.QualifiedIdentifier())
-	assert.Equal(t, value.Kind(), compositeValue.Kind())
-
-	// Now the content must be cleared
-	assert.Nil(t, compositeValue.content)
-
-	// And the fields raw content must be available
-	assert.NotNil(t, compositeValue.fieldsContent)
-
-	// Check all the fields using getters
-
-	decodedFields := compositeValue.Fields()
-	require.Equal(t, 2, decodedFields.Len())
-
-	decodeFieldValue, contains := decodedFields.Get("a")
-	assert.True(t, contains)
-	assert.Equal(t, stringValue, decodeFieldValue)
-
-	decodeFieldValue, contains = decodedFields.Get("b")
-	assert.True(t, contains)
-	assert.Equal(t, BoolValue(true), decodeFieldValue)
-
-	// Once all the fields are loaded, the fields raw content must be cleared
-	assert.Nil(t, compositeValue.fieldsContent)
-}
-
-func BenchmarkName(b *testing.B) {
-
-	b.ReportAllocs()
-
-	encodedValues := make([][]byte, len(valueArray))
-	for i, value := range valueArray {
-		encoded, _, err := EncodeValue(value, nil, true, nil)
-		require.NoError(b, err)
-
-		encodedValues[i] = encoded
-	}
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		for _, encoded := range encodedValues {
-			_, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
-			require.NoError(b, err)
-		}
-	}
-}
-
-const SIZE = 100_000
-
-var valueArray = func() []Value {
-
-	values := make([]Value, SIZE)
-
-	for i := 0; i < SIZE; i++ {
-
-		addressFields := NewStringValueOrderedMap()
-		addressFields.Set("street", NewStringValue(fmt.Sprintf("No: %d", i)))
-		addressFields.Set("city", NewStringValue("Vancouver"))
-		addressFields.Set("state", NewStringValue("BC"))
-		addressFields.Set("country", NewStringValue("Canada"))
-
-		address := NewCompositeValue(
-			utils.TestLocation,
-			"Address",
-			common.CompositeKindResource,
-			addressFields,
-			nil,
-		)
+		stringValue := NewStringValue("hello")
+		stringValue.modified = false
 
 		members := NewStringValueOrderedMap()
-		members.Set("fname", NewStringValue("John"))
-		members.Set("lname", NewStringValue("Doe"))
-		members.Set("age", NewIntValueFromInt64(999))
-		members.Set("status", NewStringValue("unknown"))
-		members.Set("address", address)
+		members.Set("a", stringValue)
+		members.Set("b", BoolValue(true))
 
-		values[i] = NewCompositeValue(
+		value := NewCompositeValue(
 			utils.TestLocation,
 			"TestResource",
 			common.CompositeKindResource,
 			members,
 			nil,
 		)
-	}
 
-	return values
-}()
+		encoded, _, err := EncodeValue(value, nil, true, nil)
+		require.NoError(t, err)
+
+		decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+		require.NoError(t, err)
+
+		require.IsType(t, &CompositeValue{}, decoded)
+		compositeValue := decoded.(*CompositeValue)
+
+		// Value must not be loaded. i.e: the content is available
+		assert.NotNil(t, compositeValue.content)
+
+		// The meta-info and fields raw content are not loaded yet
+		assert.Nil(t, compositeValue.fieldsContent)
+		assert.Empty(t, compositeValue.location)
+		assert.Empty(t, compositeValue.qualifiedIdentifier)
+		assert.Equal(t, common.CompositeKindUnknown, compositeValue.kind)
+
+		// Use the Getters and see whether the meta-info are loaded
+		assert.Equal(t, value.Location(), compositeValue.Location())
+		assert.Equal(t, value.QualifiedIdentifier(), compositeValue.QualifiedIdentifier())
+		assert.Equal(t, value.Kind(), compositeValue.Kind())
+
+		// Now the content must be cleared
+		assert.Nil(t, compositeValue.content)
+
+		// And the fields raw content must be available
+		assert.NotNil(t, compositeValue.fieldsContent)
+
+		// Check all the fields using getters
+
+		decodedFields := compositeValue.Fields()
+		require.Equal(t, 2, decodedFields.Len())
+
+		decodeFieldValue, contains := decodedFields.Get("a")
+		assert.True(t, contains)
+		assert.Equal(t, stringValue, decodeFieldValue)
+
+		decodeFieldValue, contains = decodedFields.Get("b")
+		assert.True(t, contains)
+		assert.Equal(t, BoolValue(true), decodeFieldValue)
+
+		// Once all the fields are loaded, the fields raw content must be cleared
+		assert.Nil(t, compositeValue.fieldsContent)
+	})
+
+	t.Run("Nested composite", func(t *testing.T) {
+		value := newTestLargeCompositeValue(0)
+
+		encoded, _, err := EncodeValue(value, nil, true, nil)
+		require.NoError(t, err)
+
+		decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+		require.NoError(t, err)
+
+		require.IsType(t, &CompositeValue{}, decoded)
+		compositeValue := decoded.(*CompositeValue)
+
+		address, ok := compositeValue.Fields().Get("address")
+		assert.True(t, ok)
+
+		require.IsType(t, &CompositeValue{}, address)
+		nestedCompositeValue := address.(*CompositeValue)
+
+		// Inner composite value must not be loaded
+		assert.NotNil(t, nestedCompositeValue.content)
+	})
+
+	t.Run("Field update", func(t *testing.T) {
+		value := newTestLargeCompositeValue(0)
+
+		encoded, _, err := EncodeValue(value, nil, true, nil)
+		require.NoError(t, err)
+
+		decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+		require.NoError(t, err)
+
+		require.IsType(t, &CompositeValue{}, decoded)
+		compositeValue := decoded.(*CompositeValue)
+
+		newValue := NewStringValue("green")
+		compositeValue.SetMember(nil, nil, "status", newValue)
+
+		// Composite value must be loaded
+		assert.Nil(t, compositeValue.content)
+
+		// check updated value
+		fieldValue, contains := compositeValue.Fields().Get("status")
+		assert.True(t, contains)
+		assert.Equal(t, newValue, fieldValue)
+	})
+}
+
+func BenchmarkCompositeDeferredDecoding(b *testing.B) {
+
+	encoded, _, err := EncodeValue(newTestLargeCompositeValue(0), nil, true, nil)
+	require.NoError(b, err)
+
+	b.Run("Simply decode", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("Access identifier", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+			require.NoError(b, err)
+
+			composite := decoded.(*CompositeValue)
+			composite.QualifiedIdentifier()
+		}
+	})
+
+	b.Run("Access field", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+			require.NoError(b, err)
+
+			composite := decoded.(*CompositeValue)
+			_, ok := composite.Fields().Get("fname")
+			require.True(b, ok)
+		}
+	})
+}
+
+var newTestLargeCompositeValue = func(id int) *CompositeValue {
+	addressFields := NewStringValueOrderedMap()
+	addressFields.Set("street", NewStringValue(fmt.Sprintf("No: %d", id)))
+	addressFields.Set("city", NewStringValue("Vancouver"))
+	addressFields.Set("state", NewStringValue("BC"))
+	addressFields.Set("country", NewStringValue("Canada"))
+
+	address := NewCompositeValue(
+		utils.TestLocation,
+		"Address",
+		common.CompositeKindResource,
+		addressFields,
+		nil,
+	)
+
+	members := NewStringValueOrderedMap()
+	members.Set("fname", NewStringValue("John"))
+	members.Set("lname", NewStringValue("Doe"))
+	members.Set("age", NewIntValueFromInt64(999))
+	members.Set("status", NewStringValue("unknown"))
+	members.Set("address", address)
+
+	return NewCompositeValue(
+		utils.TestLocation,
+		"TestResource",
+		common.CompositeKindResource,
+		members,
+		nil,
+	)
+}

--- a/runtime/interpreter/deferred_decoding_test.go
+++ b/runtime/interpreter/deferred_decoding_test.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package interpreter
 
 import (

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -991,7 +991,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode location at array index encodedCompositeValueLocationFieldKey
-	err = e.encodeLocation(v.Location)
+	err = e.encodeLocation(v.location)
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1042,7 +1042,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode qualified identifier at array index encodedCompositeValueQualifiedIdentifierFieldKey
-	err = e.enc.EncodeString(v.QualifiedIdentifier)
+	err = e.enc.EncodeString(v.qualifiedIdentifier)
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1009,7 +1009,8 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode fields (as array) at array index encodedCompositeValueFieldsFieldKey
-	err = e.enc.EncodeArrayHead(uint64(v.Fields.Len() * 2))
+	fields := v.Fields()
+	err = e.enc.EncodeArrayHead(uint64(fields.Len() * 2))
 	if err != nil {
 		return err
 	}
@@ -1020,7 +1021,7 @@ func (e *Encoder) encodeCompositeValue(
 
 	lastValuePathIndex := len(path)
 
-	for pair := v.Fields.Oldest(); pair != nil; pair = pair.Next() {
+	for pair := fields.Oldest(); pair != nil; pair = pair.Next() {
 		fieldName := pair.Key
 
 		// Encode field name as fields array element

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -980,18 +980,18 @@ func (e *Encoder) encodeCompositeValue(
 	deferrals *EncodingDeferrals,
 ) error {
 
+	// Encode CBOR tag number
+	err := e.enc.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagCompositeValue,
+	})
+
+	if err != nil {
+		return err
+	}
+
 	// If the value is not loaded, dump the raw content as it is.
 	if v.content != nil {
-		// Encode CBOR tag number
-		err := e.enc.EncodeRawBytes([]byte{
-			// tag number
-			0xd8, cborTagCompositeValue,
-		})
-
-		if err != nil {
-			return err
-		}
-
 		err = e.enc.EncodeRawBytes(v.content)
 		if err != nil {
 			return err
@@ -1000,10 +1000,8 @@ func (e *Encoder) encodeCompositeValue(
 		return nil
 	}
 
-	// Encode CBOR tag number and array head
-	err := e.enc.EncodeRawBytes([]byte{
-		// tag number
-		0xd8, cborTagCompositeValue,
+	// Encode array head
+	err = e.enc.EncodeRawBytes([]byte{
 		// array, 5 items follow
 		0x85,
 	})

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1042,9 +1042,9 @@ func (e *Encoder) encodeCompositeValue(
 			return err
 		}
 
-	// Pre-allocate and reuse valuePath.
-	//nolint:gocritic
-	valuePath := append(path, "")
+		// Pre-allocate and reuse valuePath.
+		//nolint:gocritic
+		valuePath := append(path, "")
 
 		lastValuePathIndex := len(path)
 

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -991,7 +991,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode location at array index encodedCompositeValueLocationFieldKey
-	err = e.encodeLocation(v.location)
+	err = e.encodeLocation(v.Location())
 	if err != nil {
 		return err
 	}
@@ -1003,7 +1003,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode kind at array index encodedCompositeValueKindFieldKey
-	err = e.enc.EncodeUint(uint(v.kind))
+	err = e.enc.EncodeUint(uint(v.Kind()))
 	if err != nil {
 		return err
 	}
@@ -1042,7 +1042,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode qualified identifier at array index encodedCompositeValueQualifiedIdentifierFieldKey
-	err = e.enc.EncodeString(v.qualifiedIdentifier)
+	err = e.enc.EncodeString(v.QualifiedIdentifier())
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -864,7 +864,7 @@ func (e *Encoder) encodeDictionaryValue(
 
 		for pair := v.Entries.Oldest(); pair != nil; pair = pair.Next() {
 			compositeValue, ok := pair.Value.(*CompositeValue)
-			if !ok || compositeValue.Kind != common.CompositeKindResource {
+			if !ok || compositeValue.Kind() != common.CompositeKindResource {
 				deferred = false
 				break
 			}
@@ -1003,7 +1003,7 @@ func (e *Encoder) encodeCompositeValue(
 	}
 
 	// Encode kind at array index encodedCompositeValueKindFieldKey
-	err = e.enc.EncodeUint(uint(v.Kind))
+	err = e.enc.EncodeUint(uint(v.kind))
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -979,6 +979,27 @@ func (e *Encoder) encodeCompositeValue(
 	path []string,
 	deferrals *EncodingDeferrals,
 ) error {
+
+	// If the value is not loaded, dump the raw content as it is.
+	if v.content != nil {
+		// Encode CBOR tag number
+		err := e.enc.EncodeRawBytes([]byte{
+			// tag number
+			0xd8, cborTagCompositeValue,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		err = e.enc.EncodeRawBytes(v.content)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 	// Encode CBOR tag number and array head
 	err := e.enc.EncodeRawBytes([]byte{
 		// tag number
@@ -988,16 +1009,6 @@ func (e *Encoder) encodeCompositeValue(
 	})
 	if err != nil {
 		return err
-	}
-
-	// If the value is not loaded, dump the raw content as it is.
-	if v.content != nil {
-		err := e.enc.EncodeRawBytes(v.content)
-		if err != nil {
-			return err
-		}
-
-		return nil
 	}
 
 	// Encode location at array index encodedCompositeValueLocationFieldKey

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1030,7 +1030,7 @@ func (e *Encoder) encodeCompositeValue(
 	// Encode fields (as array) at array index encodedCompositeValueFieldsFieldKey
 
 	// If the fields are not loaded, dump the raw fields content as it is.
-	if v.content != nil {
+	if v.fieldsContent != nil {
 		err := e.enc.EncodeRawBytes(v.fieldsContent)
 		if err != nil {
 			return err

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -85,8 +85,10 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 	} else {
 		require.NoError(t, err)
 
-		// Just to make sure the content is built.
-		decoded.String()
+		// Make sure the content is built.
+		if composite, ok := decoded.(*CompositeValue); ok {
+			composite.ensureFieldsLoaded()
+		}
 
 		if !test.deferred || (test.deferred && test.decodedValue != nil) {
 			expectedValue := test.value

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -87,7 +87,7 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 
 		// Make sure the content is built.
 		if composite, ok := decoded.(*CompositeValue); ok {
-			composite.ensureFieldsLoaded()
+			composite.Fields()
 		}
 
 		if !test.deferred || (test.deferred && test.decodedValue != nil) {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -85,6 +85,9 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 	} else {
 		require.NoError(t, err)
 
+		// Just to make sure the content is built.
+		decoded.String()
+
 		if !test.deferred || (test.deferred && test.decodedValue != nil) {
 			expectedValue := test.value
 			if test.decodedValue != nil {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1307,7 +1307,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 
 			value := &CompositeValue{
 				location:            location,
-				QualifiedIdentifier: qualifiedIdentifier,
+				qualifiedIdentifier: qualifiedIdentifier,
 				Kind:                declaration.CompositeKind,
 				fields:              fields,
 				InjectedFields:      injectedFields,
@@ -1403,7 +1403,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 		caseValue := &CompositeValue{
 			location:            location,
-			QualifiedIdentifier: qualifiedIdentifier,
+			qualifiedIdentifier: qualifiedIdentifier,
 			Kind:                declaration.CompositeKind,
 			fields:              caseValueFields,
 			// NOTE: new value has no owner

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1192,7 +1192,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			func(invocation Invocation) Value {
 				for i, argument := range invocation.Arguments {
 					parameter := compositeType.ConstructorParameters[i]
-					invocation.Self.Fields.Set(parameter.Identifier, argument)
+					invocation.Self.Fields().Set(parameter.Identifier, argument)
 				}
 				return nil
 			},
@@ -1309,7 +1309,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 				Location:            location,
 				QualifiedIdentifier: qualifiedIdentifier,
 				Kind:                declaration.CompositeKind,
-				Fields:              fields,
+				fields:              fields,
 				InjectedFields:      injectedFields,
 				Functions:           functions,
 				Destructor:          destructorFunction,
@@ -1405,7 +1405,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 			Location:            location,
 			QualifiedIdentifier: qualifiedIdentifier,
 			Kind:                declaration.CompositeKind,
-			Fields:              caseValueFields,
+			fields:              caseValueFields,
 			// NOTE: new value has no owner
 			Owner:    nil,
 			modified: true,
@@ -1431,7 +1431,7 @@ func EnumConstructorFunction(caseValues []*CompositeValue, nestedVariables *Stri
 	lookupTable := make(map[string]*CompositeValue)
 
 	for _, caseValue := range caseValues {
-		rawValue, ok := caseValue.Fields.Get(sema.EnumRawValueFieldName)
+		rawValue, ok := caseValue.Fields().Get(sema.EnumRawValueFieldName)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1306,7 +1306,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			}
 
 			value := &CompositeValue{
-				Location:            location,
+				location:            location,
 				QualifiedIdentifier: qualifiedIdentifier,
 				Kind:                declaration.CompositeKind,
 				fields:              fields,
@@ -1402,7 +1402,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 		caseValueFields.Set(sema.EnumRawValueFieldName, rawValue)
 
 		caseValue := &CompositeValue{
-			Location:            location,
+			location:            location,
 			QualifiedIdentifier: qualifiedIdentifier,
 			Kind:                declaration.CompositeKind,
 			fields:              caseValueFields,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1308,7 +1308,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			value := &CompositeValue{
 				location:            location,
 				qualifiedIdentifier: qualifiedIdentifier,
-				Kind:                declaration.CompositeKind,
+				kind:                declaration.CompositeKind,
 				fields:              fields,
 				InjectedFields:      injectedFields,
 				Functions:           functions,
@@ -1404,7 +1404,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 		caseValue := &CompositeValue{
 			location:            location,
 			qualifiedIdentifier: qualifiedIdentifier,
-			Kind:                declaration.CompositeKind,
+			kind:                declaration.CompositeKind,
 			fields:              caseValueFields,
 			// NOTE: new value has no owner
 			Owner:    nil,

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -52,7 +52,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 		interpreter.Program.Elaboration.PostConditionsRewrite[declaration.PostConditions]
 
 	self := &CompositeValue{
-		Location: interpreter.Location,
+		location: interpreter.Location,
 		fields:   NewStringValueOrderedMap(),
 		modified: true,
 	}

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -53,7 +53,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 
 	self := &CompositeValue{
 		Location: interpreter.Location,
-		Fields:   NewStringValueOrderedMap(),
+		fields:   NewStringValueOrderedMap(),
 		modified: true,
 	}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6082,6 +6082,10 @@ type CompositeValue struct {
 	// Callback function to be invoked when decoding the fields of this composite value.
 	// Only available for decoded values who's fields are not loaded yet.
 	decodeCallback DecodingCallback
+
+	// Encoding version of the raw content and raw fieldsContent of this value.
+	// Only available for decoded values who's fields are not loaded yet.
+	encodingVersion uint16
 }
 
 type ComputedField func(*Interpreter) Value
@@ -6113,13 +6117,15 @@ func NewDeferredCompositeValue(
 	content []byte,
 	owner *common.Address,
 	decodeCallback DecodingCallback,
+	version uint16,
 ) *CompositeValue {
 	return &CompositeValue{
-		Owner:          owner,
-		content:        content,
-		valuePath:      path,
-		decodeCallback: decodeCallback,
-		modified:       false,
+		Owner:           owner,
+		content:         content,
+		valuePath:       path,
+		decodeCallback:  decodeCallback,
+		modified:        false,
+		encodingVersion: version,
 	}
 }
 
@@ -6201,12 +6207,13 @@ func (v *CompositeValue) Copy() Value {
 			Destructor:          v.Destructor,
 			destroyed:           v.destroyed,
 			// NOTE: new value has no owner
-			Owner:          nil,
-			modified:       true,
-			content:        v.content,
-			fieldsContent:  v.fieldsContent,
-			valuePath:      v.valuePath,
-			decodeCallback: v.decodeCallback,
+			Owner:           nil,
+			modified:        true,
+			content:         v.content,
+			fieldsContent:   v.fieldsContent,
+			valuePath:       v.valuePath,
+			decodeCallback:  v.decodeCallback,
+			encodingVersion: v.encodingVersion,
 		}
 	}
 
@@ -6229,12 +6236,13 @@ func (v *CompositeValue) Copy() Value {
 		Destructor:          v.Destructor,
 		destroyed:           v.destroyed,
 		// NOTE: new value has no owner
-		Owner:          nil,
-		modified:       true,
-		content:        v.content,
-		fieldsContent:  v.fieldsContent,
-		valuePath:      v.valuePath,
-		decodeCallback: v.decodeCallback,
+		Owner:           nil,
+		modified:        true,
+		content:         v.content,
+		fieldsContent:   v.fieldsContent,
+		valuePath:       v.valuePath,
+		decodeCallback:  v.decodeCallback,
+		encodingVersion: v.encodingVersion,
 	}
 }
 
@@ -6614,10 +6622,11 @@ func (v *CompositeValue) ensureFieldsLoaded() {
 	}
 
 	// Path and the fields-content are no longer needed.
-	// Clear the cache and free-up the memory.
+	// Reset the cache and free-up the memory.
 	v.valuePath = nil
 	v.fieldsContent = nil
 	v.decodeCallback = nil
+	v.encodingVersion = 0
 }
 
 // DictionaryValue

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6210,6 +6210,7 @@ func (v *CompositeValue) Copy() Value {
 			Owner:           nil,
 			modified:        true,
 			content:         v.content,
+			stringer:        v.stringer,
 			fieldsContent:   v.fieldsContent,
 			valuePath:       v.valuePath,
 			decodeCallback:  v.decodeCallback,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6067,8 +6067,8 @@ type CompositeValue struct {
 	stringer        func() string
 
 	// Raw-content cache for decoded values. Maintains the meta info and field content separately.
-	metaContent  []byte
-	fieldContent []byte
+	metaContent   []byte
+	fieldsContent []byte
 }
 
 type ComputedField func(*Interpreter) Value
@@ -6095,16 +6095,14 @@ func NewCompositeValue(
 	}
 }
 
-func NewDeferredCompositeValue(fieldContent, metaContent []byte) *CompositeValue {
+func NewDeferredCompositeValue(fieldsContent, metaContent []byte) *CompositeValue {
 	return &CompositeValue{
-		fieldContent: fieldContent,
-		metaContent:  metaContent,
+		fieldsContent: fieldsContent,
+		metaContent:   metaContent,
 	}
 }
 
 func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func() LocationRange) {
-	v.loadMeta()
-
 	interpreter = v.getInterpreter(interpreter)
 
 	// if composite was deserialized, dynamically link in the destructor
@@ -6138,35 +6136,28 @@ func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 		return
 	}
 
-	v.loadFields()
-	v.fields.Foreach(func(_ string, value Value) {
+	v.Fields().Foreach(func(_ string, value Value) {
 		value.Accept(interpreter, visitor)
 	})
 }
 
 func (v *CompositeValue) DynamicType(interpreter *Interpreter, _ DynamicTypeResults) DynamicType {
-	v.loadMeta()
-
-	staticType := interpreter.getCompositeType(v.location, v.qualifiedIdentifier)
+	staticType := interpreter.getCompositeType(v.Location(), v.QualifiedIdentifier())
 	return CompositeDynamicType{
 		StaticType: staticType,
 	}
 }
 
 func (v *CompositeValue) StaticType() StaticType {
-	v.loadMeta()
-
 	return CompositeStaticType{
-		Location:            v.location,
-		QualifiedIdentifier: v.qualifiedIdentifier,
+		Location:            v.Location(),
+		QualifiedIdentifier: v.QualifiedIdentifier(),
 	}
 }
 
 func (v *CompositeValue) Copy() Value {
-	v.loadMeta()
-
 	// Resources and contracts are not copied
-	switch v.kind {
+	switch v.Kind() {
 	case common.CompositeKindResource, common.CompositeKindContract:
 		return v
 
@@ -6174,19 +6165,39 @@ func (v *CompositeValue) Copy() Value {
 		break
 	}
 
-	v.loadFields()
+	// If fields are not loaded, then no need to load them.
+	// Return a copy with raw-content for fields.
+	if v.fieldsContent != nil {
+		return &CompositeValue{
+			location:            v.Location(),
+			qualifiedIdentifier: v.QualifiedIdentifier(),
+			kind:                v.Kind(),
+			fields:              nil,
+			InjectedFields:      v.InjectedFields,
+			ComputedFields:      v.ComputedFields,
+			NestedVariables:     v.NestedVariables,
+			Functions:           v.Functions,
+			Destructor:          v.Destructor,
+			destroyed:           v.destroyed,
+			// NOTE: new value has no owner
+			Owner:         nil,
+			modified:      true,
+			metaContent:   v.metaContent,
+			fieldsContent: v.fieldsContent,
+		}
+	}
 
 	newFields := NewStringValueOrderedMap()
-	v.fields.Foreach(func(fieldName string, value Value) {
+	v.Fields().Foreach(func(fieldName string, value Value) {
 		newFields.Set(fieldName, value.Copy())
 	})
 
 	// NOTE: not copying functions or destructor – they are linked in
 
 	return &CompositeValue{
-		location:            v.location,
-		qualifiedIdentifier: v.qualifiedIdentifier,
-		kind:                v.kind,
+		location:            v.Location(),
+		qualifiedIdentifier: v.QualifiedIdentifier(),
+		kind:                v.Kind(),
 		fields:              newFields,
 		InjectedFields:      v.InjectedFields,
 		ComputedFields:      v.ComputedFields,
@@ -6195,17 +6206,17 @@ func (v *CompositeValue) Copy() Value {
 		Destructor:          v.Destructor,
 		destroyed:           v.destroyed,
 		// NOTE: new value has no owner
-		Owner:    nil,
-		modified: true,
+		Owner:         nil,
+		modified:      true,
+		metaContent:   v.metaContent,
+		fieldsContent: v.fieldsContent,
 	}
 }
 
-// NOTE: This method is assumed to be used for local uses only, and doesnt ensure the meta-info
-// of the value is loaded. Make sure to call `v.loadMeta()` before calling this method.
 func (v *CompositeValue) checkStatus(getLocationRange func() LocationRange) {
 	if v.destroyed {
 		panic(DestroyedCompositeError{
-			CompositeKind: v.kind,
+			CompositeKind: v.Kind(),
 			LocationRange: getLocationRange(),
 		})
 	}
@@ -6216,15 +6227,13 @@ func (v *CompositeValue) GetOwner() *common.Address {
 }
 
 func (v *CompositeValue) SetOwner(owner *common.Address) {
-	v.loadFields()
-
 	if v.Owner == owner {
 		return
 	}
 
 	v.Owner = owner
 
-	v.fields.Foreach(func(_ string, value Value) {
+	v.Fields().Foreach(func(_ string, value Value) {
 		value.SetOwner(owner)
 	})
 }
@@ -6234,9 +6243,7 @@ func (v *CompositeValue) IsModified() bool {
 		return true
 	}
 
-	v.loadFields()
-
-	for pair := v.fields.Oldest(); pair != nil; pair = pair.Next() {
+	for pair := v.Fields().Oldest(); pair != nil; pair = pair.Next() {
 		if pair.Value.IsModified() {
 			return true
 		}
@@ -6266,18 +6273,15 @@ func (v *CompositeValue) SetModified(modified bool) {
 }
 
 func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
-	v.loadMeta()
 	v.checkStatus(getLocationRange)
 
-	if v.kind == common.CompositeKindResource &&
+	if v.Kind() == common.CompositeKindResource &&
 		name == sema.ResourceOwnerFieldName {
 
 		return v.OwnerValue(interpreter)
 	}
 
-	v.loadFields()
-
-	value, ok := v.fields.Get(name)
+	value, ok := v.Fields().Get(name)
 	if ok {
 		return value
 	}
@@ -6305,9 +6309,9 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if v.InjectedFields == nil && interpreter.injectedCompositeFieldsHandler != nil {
 		v.InjectedFields = interpreter.injectedCompositeFieldsHandler(
 			interpreter,
-			v.location,
-			v.qualifiedIdentifier,
-			v.kind,
+			v.Location(),
+			v.QualifiedIdentifier(),
+			v.Kind(),
 		)
 	}
 
@@ -6329,14 +6333,14 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	return nil
 }
 
-// NOTE: This method is assumed to be used for local uses only, and doesnt ensure the meta-info
-// of the value is loaded. Make sure to call `v.loadMeta()` before calling this method.
 func (v *CompositeValue) getInterpreter(interpreter *Interpreter) *Interpreter {
 
 	// Get the correct interpreter. The program code might need to be loaded.
 	// NOTE: standard library values have no location
 
-	if v.location == nil || common.LocationsMatch(interpreter.Location, v.location) {
+	location := v.Location()
+
+	if location == nil || common.LocationsMatch(interpreter.Location, location) {
 		return interpreter
 	}
 
@@ -6376,16 +6380,13 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter) OptionalValue {
 }
 
 func (v *CompositeValue) SetMember(_ *Interpreter, getLocationRange func() LocationRange, name string, value Value) {
-	v.loadMeta()
-	v.loadFields()
-
 	v.checkStatus(getLocationRange)
 
 	v.modified = true
 
 	value.SetOwner(v.Owner)
 
-	v.fields.Set(name, value)
+	v.Fields().Set(name, value)
 }
 
 func (v *CompositeValue) String() string {
@@ -6393,8 +6394,7 @@ func (v *CompositeValue) String() string {
 		return v.stringer()
 	}
 
-	v.loadFields()
-	return formatComposite(string(v.TypeID()), v.fields)
+	return formatComposite(string(v.TypeID()), v.Fields())
 }
 
 func formatComposite(typeId string, fields *StringValueOrderedMap) string {
@@ -6419,8 +6419,7 @@ func formatComposite(typeId string, fields *StringValueOrderedMap) string {
 }
 
 func (v *CompositeValue) GetField(name string) Value {
-	v.loadFields()
-	value, _ := v.fields.Get(name)
+	value, _ := v.Fields().Get(name)
 	return value
 }
 
@@ -6430,19 +6429,17 @@ func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, loadDeferr
 		return false
 	}
 
-	v.loadMeta()
-	v.loadFields()
-
+	fields := v.Fields()
 	otherFields := otherComposite.Fields()
 
 	if !v.StaticType().Equal(otherComposite.StaticType()) ||
-		v.kind != otherComposite.kind ||
-		v.fields.Len() != otherFields.Len() {
+		v.Kind() != otherComposite.Kind() ||
+		fields.Len() != otherFields.Len() {
 
 		return false
 	}
 
-	for pair := v.fields.Oldest(); pair != nil; pair = pair.Next() {
+	for pair := fields.Oldest(); pair != nil; pair = pair.Next() {
 		key := pair.Key
 		value := pair.Value
 
@@ -6461,11 +6458,8 @@ func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, loadDeferr
 }
 
 func (v *CompositeValue) KeyString() string {
-	v.loadMeta()
-	v.loadFields()
-
-	if v.kind == common.CompositeKindEnum {
-		rawValue, _ := v.fields.Get(sema.EnumRawValueFieldName)
+	if v.Kind() == common.CompositeKindEnum {
+		rawValue, _ := v.Fields().Get(sema.EnumRawValueFieldName)
 		return rawValue.String()
 	}
 
@@ -6473,13 +6467,12 @@ func (v *CompositeValue) KeyString() string {
 }
 
 func (v *CompositeValue) TypeID() common.TypeID {
-	v.loadMeta()
-
-	if v.location == nil {
-		return common.TypeID(v.qualifiedIdentifier)
+	location := v.Location()
+	if location == nil {
+		return common.TypeID(v.QualifiedIdentifier())
 	}
 
-	return v.location.TypeID(v.qualifiedIdentifier)
+	return location.TypeID(v.QualifiedIdentifier())
 }
 
 func (v *CompositeValue) ConformsToDynamicType(
@@ -6493,29 +6486,24 @@ func (v *CompositeValue) ConformsToDynamicType(
 	}
 
 	compositeType, ok := compositeDynamicType.StaticType.(*sema.CompositeType)
-	if !ok {
-		return false
-	}
-
-	v.loadMeta()
-
-	if v.kind != compositeType.Kind ||
-		v.qualifiedIdentifier != compositeType.QualifiedIdentifier() ||
-		v.location.ID() != compositeType.Location.ID() {
+	if !ok ||
+		v.Kind() != compositeType.Kind ||
+		v.QualifiedIdentifier() != compositeType.QualifiedIdentifier() ||
+		v.Location().ID() != compositeType.Location.ID() {
 
 		return false
 	}
 
-	v.loadFields()
+	fields := v.Fields()
 
 	// Here it is assumed that imported values can only have static fields values,
 	// but not computed field values.
-	if v.fields.Len() != len(compositeType.Fields) {
+	if fields.Len() != len(compositeType.Fields) {
 		return false
 	}
 
 	for _, fieldName := range compositeType.Fields {
-		field, ok := v.fields.Get(fieldName)
+		field, ok := fields.Get(fieldName)
 		if !ok {
 			return false
 		}
@@ -6541,49 +6529,49 @@ func (v *CompositeValue) ConformsToDynamicType(
 }
 
 func (v *CompositeValue) Fields() *StringValueOrderedMap {
-	v.loadFields()
+	v.ensureFieldsLoaded()
 	return v.fields
 }
 
 func (v *CompositeValue) Location() common.Location {
-	v.loadMeta()
+	v.ensureMetaInfoLoaded()
 	return v.location
 }
 
 func (v *CompositeValue) QualifiedIdentifier() string {
-	v.loadMeta()
+	v.ensureMetaInfoLoaded()
 	return v.qualifiedIdentifier
 }
 
 func (v *CompositeValue) Kind() common.CompositeKind {
-	v.loadMeta()
+	v.ensureMetaInfoLoaded()
 	return v.kind
 }
 
 // Ensures the fields of this composite value are loaded.
-func (v *CompositeValue) loadFields() {
-	if v.fieldContent == nil {
+func (v *CompositeValue) ensureFieldsLoaded() {
+	if v.fieldsContent == nil {
 		return
 	}
 
-	// TODO: otherwise decode
+	// TODO: decode the content and update the fields
 
 	// Clear the byte cache
-	v.fieldContent = nil
+	v.fieldsContent = nil
 }
 
-// Ensures the meta information about the composite value is loaded.
+// Ensures the meta information of the composite value is loaded.
 // Meta info includes:
-//  - location
-//	- qualifiedIdentifier
-//	- kind
+//    - location
+//    - qualifiedIdentifier
+//    - kind
 //
-func (v *CompositeValue) loadMeta() {
+func (v *CompositeValue) ensureMetaInfoLoaded() {
 	if v.metaContent == nil {
 		return
 	}
 
-	// TODO: otherwise decode
+	// TODO: decode the content and update the fields
 
 	// Clear the byte cache
 	v.metaContent = nil

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6051,7 +6051,7 @@ func (v UFix64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTy
 
 type CompositeValue struct {
 	location            common.Location
-	QualifiedIdentifier string
+	qualifiedIdentifier string
 	Kind                common.CompositeKind
 	fields              *StringValueOrderedMap
 	InjectedFields      *StringValueOrderedMap
@@ -6082,9 +6082,10 @@ func NewCompositeValue(
 	if fields == nil {
 		fields = NewStringValueOrderedMap()
 	}
+
 	return &CompositeValue{
 		location:            location,
-		QualifiedIdentifier: qualifiedIdentifier,
+		qualifiedIdentifier: qualifiedIdentifier,
 		Kind:                kind,
 		fields:              fields,
 		Owner:               owner,
@@ -6144,7 +6145,7 @@ func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 func (v *CompositeValue) DynamicType(interpreter *Interpreter, _ DynamicTypeResults) DynamicType {
 	v.loadMeta()
 
-	staticType := interpreter.getCompositeType(v.location, v.QualifiedIdentifier)
+	staticType := interpreter.getCompositeType(v.location, v.qualifiedIdentifier)
 	return CompositeDynamicType{
 		StaticType: staticType,
 	}
@@ -6155,7 +6156,7 @@ func (v *CompositeValue) StaticType() StaticType {
 
 	return CompositeStaticType{
 		Location:            v.location,
-		QualifiedIdentifier: v.QualifiedIdentifier,
+		QualifiedIdentifier: v.qualifiedIdentifier,
 	}
 }
 
@@ -6182,7 +6183,7 @@ func (v *CompositeValue) Copy() Value {
 
 	return &CompositeValue{
 		location:            v.location,
-		QualifiedIdentifier: v.QualifiedIdentifier,
+		qualifiedIdentifier: v.qualifiedIdentifier,
 		Kind:                v.Kind,
 		fields:              newFields,
 		InjectedFields:      v.InjectedFields,
@@ -6303,7 +6304,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 		v.InjectedFields = interpreter.injectedCompositeFieldsHandler(
 			interpreter,
 			v.location,
-			v.QualifiedIdentifier,
+			v.qualifiedIdentifier,
 			v.Kind,
 		)
 	}
@@ -6473,10 +6474,10 @@ func (v *CompositeValue) TypeID() common.TypeID {
 	v.loadMeta()
 
 	if v.location == nil {
-		return common.TypeID(v.QualifiedIdentifier)
+		return common.TypeID(v.qualifiedIdentifier)
 	}
 
-	return v.location.TypeID(v.QualifiedIdentifier)
+	return v.location.TypeID(v.qualifiedIdentifier)
 }
 
 func (v *CompositeValue) ConformsToDynamicType(
@@ -6497,7 +6498,7 @@ func (v *CompositeValue) ConformsToDynamicType(
 	v.loadMeta()
 
 	if v.Kind != compositeType.Kind ||
-		v.QualifiedIdentifier != compositeType.QualifiedIdentifier() ||
+		v.qualifiedIdentifier != compositeType.QualifiedIdentifier() ||
 		v.location.ID() != compositeType.Location.ID() {
 
 		return false
@@ -6547,9 +6548,9 @@ func (v *CompositeValue) Location() common.Location {
 	return v.location
 }
 
-func (v *CompositeValue) WithFields(fields *StringValueOrderedMap) *CompositeValue {
-	v.fields = fields
-	return v
+func (v *CompositeValue) QualifiedIdentifier() string {
+	v.loadMeta()
+	return v.qualifiedIdentifier
 }
 
 // Ensures the fields of this composite value are loaded.
@@ -7837,7 +7838,7 @@ func NewAuthAccountValue(
 	}
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AuthAccountType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AuthAccountType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountType.Kind,
 		fields:              fields,
 		ComputedFields:      computedFields,
@@ -7921,7 +7922,7 @@ func NewPublicAccountValue(
 	}
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.PublicAccountType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.PublicAccountType.QualifiedIdentifier(),
 		Kind:                sema.PublicAccountType.Kind,
 		fields:              fields,
 		ComputedFields:      computedFields,
@@ -8237,7 +8238,7 @@ func NewAccountKeyValue(
 	fields.Set(sema.AccountKeyIsRevokedField, isRevoked)
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AccountKeyType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AccountKeyType.QualifiedIdentifier(),
 		Kind:                sema.AccountKeyType.Kind,
 		fields:              fields,
 	}
@@ -8267,7 +8268,7 @@ func NewPublicKeyValue(
 	}
 
 	publicKeyValue := &CompositeValue{
-		QualifiedIdentifier: sema.PublicKeyType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.PublicKeyType.QualifiedIdentifier(),
 		Kind:                sema.PublicKeyType.Kind,
 		fields:              fields,
 		ComputedFields:      computedFields,
@@ -8289,7 +8290,7 @@ func NewAuthAccountKeysValue(addFunction FunctionValue, getFunction FunctionValu
 	fields.Set(sema.AccountKeysRevokeFunctionName, revokeFunction)
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.AuthAccountKeysType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.AuthAccountKeysType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountKeysType.Kind,
 		fields:              fields,
 	}
@@ -8301,7 +8302,7 @@ func NewPublicAccountKeysValue(getFunction FunctionValue) *CompositeValue {
 	fields.Set(sema.AccountKeysGetFunctionName, getFunction)
 
 	return &CompositeValue{
-		QualifiedIdentifier: sema.PublicAccountKeysType.QualifiedIdentifier(),
+		qualifiedIdentifier: sema.PublicAccountKeysType.QualifiedIdentifier(),
 		Kind:                sema.PublicAccountKeysType.Kind,
 		fields:              fields,
 	}
@@ -8312,7 +8313,7 @@ func NewCryptoAlgorithmEnumCaseValue(enumType *sema.CompositeType, rawValue uint
 	fields.Set(sema.EnumRawValueFieldName, UInt8Value(rawValue))
 
 	return &CompositeValue{
-		QualifiedIdentifier: enumType.QualifiedIdentifier(),
+		qualifiedIdentifier: enumType.QualifiedIdentifier(),
 		Kind:                enumType.Kind,
 		fields:              fields,
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6050,7 +6050,7 @@ func (v UFix64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTy
 // CompositeValue
 
 type CompositeValue struct {
-	Location            common.Location
+	location            common.Location
 	QualifiedIdentifier string
 	Kind                common.CompositeKind
 	fields              *StringValueOrderedMap
@@ -6063,28 +6063,10 @@ type CompositeValue struct {
 	destroyed           bool
 	modified            bool
 	stringer            func() string
-	rawContent          []byte
-}
 
-func (v *CompositeValue) Fields() *StringValueOrderedMap {
-	v.ensureLoaded()
-	return v.fields
-}
-
-func (v *CompositeValue) WithFields(fields *StringValueOrderedMap) *CompositeValue {
-	v.fields = fields
-	return v
-}
-
-func (v *CompositeValue) ensureLoaded() {
-	if v.rawContent == nil {
-		return
-	}
-
-	// TODO: otherwise decode
-
-	// Clear the byte cache
-	v.rawContent = nil
+	// Key the meta info and field content separately
+	metaContent  []byte
+	fieldContent []byte
 }
 
 type ComputedField func(*Interpreter) Value
@@ -6101,7 +6083,7 @@ func NewCompositeValue(
 		fields = NewStringValueOrderedMap()
 	}
 	return &CompositeValue{
-		Location:            location,
+		location:            location,
 		QualifiedIdentifier: qualifiedIdentifier,
 		Kind:                kind,
 		fields:              fields,
@@ -6110,13 +6092,15 @@ func NewCompositeValue(
 	}
 }
 
-func NewDeferredCompositeValue(content []byte) *CompositeValue {
+func NewDeferredCompositeValue(fieldContent, metaContent []byte) *CompositeValue {
 	return &CompositeValue{
-		rawContent: content,
+		fieldContent: fieldContent,
+		metaContent:  metaContent,
 	}
 }
 
 func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func() LocationRange) {
+	v.loadMeta()
 
 	interpreter = v.getInterpreter(interpreter)
 
@@ -6146,33 +6130,37 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 func (*CompositeValue) IsValue() {}
 
 func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
-	v.ensureLoaded()
 	descend := visitor.VisitCompositeValue(interpreter, v)
 	if !descend {
 		return
 	}
 
+	v.loadFields()
 	v.fields.Foreach(func(_ string, value Value) {
 		value.Accept(interpreter, visitor)
 	})
 }
 
 func (v *CompositeValue) DynamicType(interpreter *Interpreter, _ DynamicTypeResults) DynamicType {
-	staticType := interpreter.getCompositeType(v.Location, v.QualifiedIdentifier)
+	v.loadMeta()
+
+	staticType := interpreter.getCompositeType(v.location, v.QualifiedIdentifier)
 	return CompositeDynamicType{
 		StaticType: staticType,
 	}
 }
 
 func (v *CompositeValue) StaticType() StaticType {
+	v.loadMeta()
+
 	return CompositeStaticType{
-		Location:            v.Location,
+		Location:            v.location,
 		QualifiedIdentifier: v.QualifiedIdentifier,
 	}
 }
 
 func (v *CompositeValue) Copy() Value {
-	v.ensureLoaded()
+	v.loadMeta()
 
 	// Resources and contracts are not copied
 	switch v.Kind {
@@ -6183,6 +6171,8 @@ func (v *CompositeValue) Copy() Value {
 		break
 	}
 
+	v.loadFields()
+
 	newFields := NewStringValueOrderedMap()
 	v.fields.Foreach(func(fieldName string, value Value) {
 		newFields.Set(fieldName, value.Copy())
@@ -6191,7 +6181,7 @@ func (v *CompositeValue) Copy() Value {
 	// NOTE: not copying functions or destructor – they are linked in
 
 	return &CompositeValue{
-		Location:            v.Location,
+		location:            v.location,
 		QualifiedIdentifier: v.QualifiedIdentifier,
 		Kind:                v.Kind,
 		fields:              newFields,
@@ -6207,8 +6197,8 @@ func (v *CompositeValue) Copy() Value {
 	}
 }
 
-// NOTE: This method is assumed to be used for local uses only, and doesnt ensure the value is loaded.
-// Make sure to call `v.ensureLoaded()` before calling this method.
+// NOTE: This method is assumed to be used for local uses only, and doesnt ensure the meta-info
+// of the value is loaded. Make sure to call `v.loadMeta()` before calling this method.
 func (v *CompositeValue) checkStatus(getLocationRange func() LocationRange) {
 	if v.destroyed {
 		panic(DestroyedCompositeError{
@@ -6223,7 +6213,7 @@ func (v *CompositeValue) GetOwner() *common.Address {
 }
 
 func (v *CompositeValue) SetOwner(owner *common.Address) {
-	v.ensureLoaded()
+	v.loadFields()
 
 	if v.Owner == owner {
 		return
@@ -6241,7 +6231,7 @@ func (v *CompositeValue) IsModified() bool {
 		return true
 	}
 
-	v.ensureLoaded()
+	v.loadFields()
 
 	for pair := v.fields.Oldest(); pair != nil; pair = pair.Next() {
 		if pair.Value.IsModified() {
@@ -6273,7 +6263,7 @@ func (v *CompositeValue) SetModified(modified bool) {
 }
 
 func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
-	v.ensureLoaded()
+	v.loadMeta()
 	v.checkStatus(getLocationRange)
 
 	if v.Kind == common.CompositeKindResource &&
@@ -6281,6 +6271,8 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 
 		return v.OwnerValue(interpreter)
 	}
+
+	v.loadFields()
 
 	value, ok := v.fields.Get(name)
 	if ok {
@@ -6310,7 +6302,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if v.InjectedFields == nil && interpreter.injectedCompositeFieldsHandler != nil {
 		v.InjectedFields = interpreter.injectedCompositeFieldsHandler(
 			interpreter,
-			v.Location,
+			v.location,
 			v.QualifiedIdentifier,
 			v.Kind,
 		)
@@ -6334,16 +6326,18 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	return nil
 }
 
+// NOTE: This method is assumed to be used for local uses only, and doesnt ensure the meta-info
+// of the value is loaded. Make sure to call `v.loadMeta()` before calling this method.
 func (v *CompositeValue) getInterpreter(interpreter *Interpreter) *Interpreter {
 
 	// Get the correct interpreter. The program code might need to be loaded.
 	// NOTE: standard library values have no location
 
-	if v.Location == nil || common.LocationsMatch(interpreter.Location, v.Location) {
+	if v.location == nil || common.LocationsMatch(interpreter.Location, v.location) {
 		return interpreter
 	}
 
-	return interpreter.EnsureLoaded(v.Location)
+	return interpreter.EnsureLoaded(v.location)
 }
 
 func (v *CompositeValue) InitializeFunctions(interpreter *Interpreter) {
@@ -6379,7 +6373,9 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter) OptionalValue {
 }
 
 func (v *CompositeValue) SetMember(_ *Interpreter, getLocationRange func() LocationRange, name string, value Value) {
-	v.ensureLoaded()
+	v.loadMeta()
+	v.loadFields()
+
 	v.checkStatus(getLocationRange)
 
 	v.modified = true
@@ -6394,7 +6390,7 @@ func (v *CompositeValue) String() string {
 		return v.stringer()
 	}
 
-	v.ensureLoaded()
+	v.loadFields()
 	return formatComposite(string(v.TypeID()), v.fields)
 }
 
@@ -6420,7 +6416,7 @@ func formatComposite(typeId string, fields *StringValueOrderedMap) string {
 }
 
 func (v *CompositeValue) GetField(name string) Value {
-	v.ensureLoaded()
+	v.loadFields()
 	value, _ := v.fields.Get(name)
 	return value
 }
@@ -6431,7 +6427,8 @@ func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, loadDeferr
 		return false
 	}
 
-	v.ensureLoaded()
+	v.loadMeta()
+	v.loadFields()
 
 	otherFields := otherComposite.Fields()
 
@@ -6461,7 +6458,8 @@ func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, loadDeferr
 }
 
 func (v *CompositeValue) KeyString() string {
-	v.ensureLoaded()
+	v.loadMeta()
+	v.loadFields()
 
 	if v.Kind == common.CompositeKindEnum {
 		rawValue, _ := v.fields.Get(sema.EnumRawValueFieldName)
@@ -6472,11 +6470,13 @@ func (v *CompositeValue) KeyString() string {
 }
 
 func (v *CompositeValue) TypeID() common.TypeID {
-	if v.Location == nil {
+	v.loadMeta()
+
+	if v.location == nil {
 		return common.TypeID(v.QualifiedIdentifier)
 	}
 
-	return v.Location.TypeID(v.QualifiedIdentifier)
+	return v.location.TypeID(v.QualifiedIdentifier)
 }
 
 func (v *CompositeValue) ConformsToDynamicType(
@@ -6494,13 +6494,16 @@ func (v *CompositeValue) ConformsToDynamicType(
 		return false
 	}
 
-	v.ensureLoaded()
+	v.loadMeta()
+
 	if v.Kind != compositeType.Kind ||
 		v.QualifiedIdentifier != compositeType.QualifiedIdentifier() ||
-		v.Location.ID() != compositeType.Location.ID() {
+		v.location.ID() != compositeType.Location.ID() {
 
 		return false
 	}
+
+	v.loadFields()
 
 	// Here it is assumed that imported values can only have static fields values,
 	// but not computed field values.
@@ -6532,6 +6535,50 @@ func (v *CompositeValue) ConformsToDynamicType(
 	}
 
 	return true
+}
+
+func (v *CompositeValue) Fields() *StringValueOrderedMap {
+	v.loadFields()
+	return v.fields
+}
+
+func (v *CompositeValue) Location() common.Location {
+	v.loadMeta()
+	return v.location
+}
+
+func (v *CompositeValue) WithFields(fields *StringValueOrderedMap) *CompositeValue {
+	v.fields = fields
+	return v
+}
+
+// Ensures the fields of this composite value are loaded.
+func (v *CompositeValue) loadFields() {
+	if v.fieldContent == nil {
+		return
+	}
+
+	// TODO: otherwise decode
+
+	// Clear the byte cache
+	v.fieldContent = nil
+}
+
+// Ensures the meta information about the composite value is loaded.
+// Meta info includes:
+//  - location
+//	- qualifiedIdentifier
+//	- kind
+//
+func (v *CompositeValue) loadMeta() {
+	if v.metaContent == nil {
+		return
+	}
+
+	// TODO: otherwise decode
+
+	// Clear the byte cache
+	v.metaContent = nil
 }
 
 // DictionaryValue

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6077,7 +6077,7 @@ type CompositeValue struct {
 
 	// Value's path to be used during decoding.
 	// Only available for decoded values that are not loaded yet.
-	decodePath []string
+	valuePath []string
 }
 
 type ComputedField func(*Interpreter) Value
@@ -6106,9 +6106,9 @@ func NewCompositeValue(
 
 func NewDeferredCompositeValue(path []string, content []byte, owner *common.Address) *CompositeValue {
 	return &CompositeValue{
-		Owner:      owner,
-		content:    content,
-		decodePath: path,
+		Owner:     owner,
+		content:   content,
+		valuePath: path,
 	}
 }
 
@@ -6194,6 +6194,7 @@ func (v *CompositeValue) Copy() Value {
 			modified:      true,
 			content:       v.content,
 			fieldsContent: v.fieldsContent,
+			valuePath:     v.valuePath,
 		}
 	}
 
@@ -6220,6 +6221,7 @@ func (v *CompositeValue) Copy() Value {
 		modified:      true,
 		content:       v.content,
 		fieldsContent: v.fieldsContent,
+		valuePath:     v.valuePath,
 	}
 }
 
@@ -6600,7 +6602,7 @@ func (v *CompositeValue) ensureFieldsLoaded() {
 
 	// Path and the fields-content are no longer needed.
 	// Clear the cache and free-up the memory.
-	v.decodePath = nil
+	v.valuePath = nil
 	v.fieldsContent = nil
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6053,7 +6053,7 @@ type CompositeValue struct {
 	Location            common.Location
 	QualifiedIdentifier string
 	Kind                common.CompositeKind
-	Fields              *StringValueOrderedMap
+	fields              *StringValueOrderedMap
 	InjectedFields      *StringValueOrderedMap
 	ComputedFields      *StringComputedFieldOrderedMap
 	NestedVariables     *StringVariableOrderedMap
@@ -6063,6 +6063,28 @@ type CompositeValue struct {
 	destroyed           bool
 	modified            bool
 	stringer            func() string
+	rawContent          []byte
+}
+
+func (v *CompositeValue) Fields() *StringValueOrderedMap {
+	v.ensureLoaded()
+	return v.fields
+}
+
+func (v *CompositeValue) WithFields(fields *StringValueOrderedMap) *CompositeValue {
+	v.fields = fields
+	return v
+}
+
+func (v *CompositeValue) ensureLoaded() {
+	if v.rawContent == nil {
+		return
+	}
+
+	// TODO: otherwise decode
+
+	// Clear the byte cache
+	v.rawContent = nil
 }
 
 type ComputedField func(*Interpreter) Value
@@ -6082,9 +6104,15 @@ func NewCompositeValue(
 		Location:            location,
 		QualifiedIdentifier: qualifiedIdentifier,
 		Kind:                kind,
-		Fields:              fields,
+		fields:              fields,
 		Owner:               owner,
 		modified:            true,
+	}
+}
+
+func NewDeferredCompositeValue(content []byte) *CompositeValue {
+	return &CompositeValue{
+		rawContent: content,
 	}
 }
 
@@ -6118,12 +6146,13 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 func (*CompositeValue) IsValue() {}
 
 func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	v.ensureLoaded()
 	descend := visitor.VisitCompositeValue(interpreter, v)
 	if !descend {
 		return
 	}
 
-	v.Fields.Foreach(func(_ string, value Value) {
+	v.fields.Foreach(func(_ string, value Value) {
 		value.Accept(interpreter, visitor)
 	})
 }
@@ -6143,6 +6172,8 @@ func (v *CompositeValue) StaticType() StaticType {
 }
 
 func (v *CompositeValue) Copy() Value {
+	v.ensureLoaded()
+
 	// Resources and contracts are not copied
 	switch v.Kind {
 	case common.CompositeKindResource, common.CompositeKindContract:
@@ -6153,7 +6184,7 @@ func (v *CompositeValue) Copy() Value {
 	}
 
 	newFields := NewStringValueOrderedMap()
-	v.Fields.Foreach(func(fieldName string, value Value) {
+	v.fields.Foreach(func(fieldName string, value Value) {
 		newFields.Set(fieldName, value.Copy())
 	})
 
@@ -6163,7 +6194,7 @@ func (v *CompositeValue) Copy() Value {
 		Location:            v.Location,
 		QualifiedIdentifier: v.QualifiedIdentifier,
 		Kind:                v.Kind,
-		Fields:              newFields,
+		fields:              newFields,
 		InjectedFields:      v.InjectedFields,
 		ComputedFields:      v.ComputedFields,
 		NestedVariables:     v.NestedVariables,
@@ -6176,6 +6207,8 @@ func (v *CompositeValue) Copy() Value {
 	}
 }
 
+// NOTE: This method is assumed to be used for local uses only, and doesnt ensure the value is loaded.
+// Make sure to call `v.ensureLoaded()` before calling this method.
 func (v *CompositeValue) checkStatus(getLocationRange func() LocationRange) {
 	if v.destroyed {
 		panic(DestroyedCompositeError{
@@ -6190,13 +6223,15 @@ func (v *CompositeValue) GetOwner() *common.Address {
 }
 
 func (v *CompositeValue) SetOwner(owner *common.Address) {
+	v.ensureLoaded()
+
 	if v.Owner == owner {
 		return
 	}
 
 	v.Owner = owner
 
-	v.Fields.Foreach(func(_ string, value Value) {
+	v.fields.Foreach(func(_ string, value Value) {
 		value.SetOwner(owner)
 	})
 }
@@ -6206,7 +6241,9 @@ func (v *CompositeValue) IsModified() bool {
 		return true
 	}
 
-	for pair := v.Fields.Oldest(); pair != nil; pair = pair.Next() {
+	v.ensureLoaded()
+
+	for pair := v.fields.Oldest(); pair != nil; pair = pair.Next() {
 		if pair.Value.IsModified() {
 			return true
 		}
@@ -6236,6 +6273,7 @@ func (v *CompositeValue) SetModified(modified bool) {
 }
 
 func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
+	v.ensureLoaded()
 	v.checkStatus(getLocationRange)
 
 	if v.Kind == common.CompositeKindResource &&
@@ -6244,7 +6282,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 		return v.OwnerValue(interpreter)
 	}
 
-	value, ok := v.Fields.Get(name)
+	value, ok := v.fields.Get(name)
 	if ok {
 		return value
 	}
@@ -6341,13 +6379,14 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter) OptionalValue {
 }
 
 func (v *CompositeValue) SetMember(_ *Interpreter, getLocationRange func() LocationRange, name string, value Value) {
+	v.ensureLoaded()
 	v.checkStatus(getLocationRange)
 
 	v.modified = true
 
 	value.SetOwner(v.Owner)
 
-	v.Fields.Set(name, value)
+	v.fields.Set(name, value)
 }
 
 func (v *CompositeValue) String() string {
@@ -6355,7 +6394,8 @@ func (v *CompositeValue) String() string {
 		return v.stringer()
 	}
 
-	return formatComposite(string(v.TypeID()), v.Fields)
+	v.ensureLoaded()
+	return formatComposite(string(v.TypeID()), v.fields)
 }
 
 func formatComposite(typeId string, fields *StringValueOrderedMap) string {
@@ -6380,7 +6420,8 @@ func formatComposite(typeId string, fields *StringValueOrderedMap) string {
 }
 
 func (v *CompositeValue) GetField(name string) Value {
-	value, _ := v.Fields.Get(name)
+	v.ensureLoaded()
+	value, _ := v.fields.Get(name)
 	return value
 }
 
@@ -6390,18 +6431,22 @@ func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, loadDeferr
 		return false
 	}
 
+	v.ensureLoaded()
+
+	otherFields := otherComposite.Fields()
+
 	if !v.StaticType().Equal(otherComposite.StaticType()) ||
 		v.Kind != otherComposite.Kind ||
-		v.Fields.Len() != otherComposite.Fields.Len() {
+		v.fields.Len() != otherFields.Len() {
 
 		return false
 	}
 
-	for pair := v.Fields.Oldest(); pair != nil; pair = pair.Next() {
+	for pair := v.fields.Oldest(); pair != nil; pair = pair.Next() {
 		key := pair.Key
 		value := pair.Value
 
-		otherValue, ok := otherComposite.Fields.Get(key)
+		otherValue, ok := otherFields.Get(key)
 		if !ok {
 			return false
 		}
@@ -6416,8 +6461,10 @@ func (v *CompositeValue) Equal(other Value, interpreter *Interpreter, loadDeferr
 }
 
 func (v *CompositeValue) KeyString() string {
+	v.ensureLoaded()
+
 	if v.Kind == common.CompositeKindEnum {
-		rawValue, _ := v.Fields.Get(sema.EnumRawValueFieldName)
+		rawValue, _ := v.fields.Get(sema.EnumRawValueFieldName)
 		return rawValue.String()
 	}
 
@@ -6443,8 +6490,12 @@ func (v *CompositeValue) ConformsToDynamicType(
 	}
 
 	compositeType, ok := compositeDynamicType.StaticType.(*sema.CompositeType)
-	if !ok ||
-		v.Kind != compositeType.Kind ||
+	if !ok {
+		return false
+	}
+
+	v.ensureLoaded()
+	if v.Kind != compositeType.Kind ||
 		v.QualifiedIdentifier != compositeType.QualifiedIdentifier() ||
 		v.Location.ID() != compositeType.Location.ID() {
 
@@ -6453,12 +6504,12 @@ func (v *CompositeValue) ConformsToDynamicType(
 
 	// Here it is assumed that imported values can only have static fields values,
 	// but not computed field values.
-	if v.Fields.Len() != len(compositeType.Fields) {
+	if v.fields.Len() != len(compositeType.Fields) {
 		return false
 	}
 
 	for _, fieldName := range compositeType.Fields {
-		field, ok := v.Fields.Get(fieldName)
+		field, ok := v.fields.Get(fieldName)
 		if !ok {
 			return false
 		}
@@ -7741,7 +7792,7 @@ func NewAuthAccountValue(
 	return &CompositeValue{
 		QualifiedIdentifier: sema.AuthAccountType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountType.Kind,
-		Fields:              fields,
+		fields:              fields,
 		ComputedFields:      computedFields,
 		stringer:            stringer,
 	}
@@ -7825,7 +7876,7 @@ func NewPublicAccountValue(
 	return &CompositeValue{
 		QualifiedIdentifier: sema.PublicAccountType.QualifiedIdentifier(),
 		Kind:                sema.PublicAccountType.Kind,
-		Fields:              fields,
+		fields:              fields,
 		ComputedFields:      computedFields,
 		stringer:            stringer,
 	}
@@ -8141,7 +8192,7 @@ func NewAccountKeyValue(
 	return &CompositeValue{
 		QualifiedIdentifier: sema.AccountKeyType.QualifiedIdentifier(),
 		Kind:                sema.AccountKeyType.Kind,
-		Fields:              fields,
+		fields:              fields,
 	}
 }
 
@@ -8171,13 +8222,13 @@ func NewPublicKeyValue(
 	publicKeyValue := &CompositeValue{
 		QualifiedIdentifier: sema.PublicKeyType.QualifiedIdentifier(),
 		Kind:                sema.PublicKeyType.Kind,
-		Fields:              fields,
+		fields:              fields,
 		ComputedFields:      computedFields,
 		Functions:           functions,
 	}
 
 	// Validate the public key, and initialize 'isValid' field.
-	publicKeyValue.Fields.Set(sema.PublicKeyIsValidField, validationFunction(publicKeyValue))
+	publicKeyValue.fields.Set(sema.PublicKeyIsValidField, validationFunction(publicKeyValue))
 
 	return publicKeyValue
 
@@ -8193,7 +8244,7 @@ func NewAuthAccountKeysValue(addFunction FunctionValue, getFunction FunctionValu
 	return &CompositeValue{
 		QualifiedIdentifier: sema.AuthAccountKeysType.QualifiedIdentifier(),
 		Kind:                sema.AuthAccountKeysType.Kind,
-		Fields:              fields,
+		fields:              fields,
 	}
 }
 
@@ -8205,7 +8256,7 @@ func NewPublicAccountKeysValue(getFunction FunctionValue) *CompositeValue {
 	return &CompositeValue{
 		QualifiedIdentifier: sema.PublicAccountKeysType.QualifiedIdentifier(),
 		Kind:                sema.PublicAccountKeysType.Kind,
-		Fields:              fields,
+		fields:              fields,
 	}
 }
 
@@ -8216,6 +8267,6 @@ func NewCryptoAlgorithmEnumCaseValue(enumType *sema.CompositeType, rawValue uint
 	return &CompositeValue{
 		QualifiedIdentifier: enumType.QualifiedIdentifier(),
 		Kind:                enumType.Kind,
-		Fields:              fields,
+		fields:              fields,
 	}
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -346,7 +346,7 @@ func TestSetOwnerComposite(t *testing.T) {
 
 	const fieldName = "test"
 
-	composite.Fields.Set(fieldName, value)
+	composite.fields.Set(fieldName, value)
 
 	composite.SetOwner(&newOwner)
 
@@ -365,10 +365,10 @@ func TestSetOwnerCompositeCopy(t *testing.T) {
 
 	const fieldName = "test"
 
-	composite.Fields.Set(fieldName, value)
+	composite.fields.Set(fieldName, value)
 
 	compositeCopy := composite.Copy().(*CompositeValue)
-	valueCopy, _ := compositeCopy.Fields.Get(fieldName)
+	valueCopy, _ := compositeCopy.fields.Get(fieldName)
 
 	assert.Nil(t, compositeCopy.GetOwner())
 	assert.Nil(t, valueCopy.GetOwner())

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1334,7 +1334,7 @@ func (r *interpreterRuntime) newCreateAccountFunction(
 
 		payer := invocation.Arguments[0].(*interpreter.CompositeValue)
 
-		if payer.QualifiedIdentifier != sema.AuthAccountType.QualifiedIdentifier() {
+		if payer.QualifiedIdentifier() != sema.AuthAccountType.QualifiedIdentifier() {
 			panic(fmt.Sprintf(
 				"%[1]s requires the first argument (payer) to be an %[1]s",
 				sema.AuthAccountType,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1268,8 +1268,9 @@ func (r *interpreterRuntime) emitEvent(
 ) error {
 	fields := make([]exportableValue, len(eventType.ConstructorParameters))
 
+	eventFields := event.Fields()
 	for i, parameter := range eventType.ConstructorParameters {
-		value, _ := event.Fields.Get(parameter.Identifier)
+		value, _ := eventFields.Get(parameter.Identifier)
 		fields[i] = newExportableValue(value, inter)
 	}
 
@@ -1340,7 +1341,7 @@ func (r *interpreterRuntime) newCreateAccountFunction(
 			))
 		}
 
-		payerAddressValue, ok := payer.Fields.Get(sema.AuthAccountAddressField)
+		payerAddressValue, ok := payer.Fields().Get(sema.AuthAccountAddressField)
 		if !ok {
 			panic("address is not set")
 		}
@@ -2626,14 +2627,14 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 	}
 
 	// sign algo field
-	signAlgoField, ok := publicKey.Fields.Get(sema.PublicKeySignAlgoField)
+	signAlgoField, ok := publicKey.Fields().Get(sema.PublicKeySignAlgoField)
 	if !ok {
 		panic("sign algorithm is not set")
 	}
 
 	signAlgoValue := signAlgoField.(*interpreter.CompositeValue)
 
-	rawValue, ok := signAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := signAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find sign algorithm raw value")
 	}
@@ -2677,7 +2678,7 @@ func NewAccountKeyValue(accountKey *AccountKey, runtimeInterface Interface) *int
 func NewHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 	hashAlgoValue := value.(*interpreter.CompositeValue)
 
-	rawValue, ok := hashAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := hashAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find hash algorithm raw value")
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2611,6 +2611,8 @@ func (r *interpreterRuntime) newPublicAccountKeys(addressValue interpreter.Addre
 
 func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 
+	fields := publicKey.Fields()
+
 	// publicKey field
 	publicKeyFieldGetter, ok := publicKey.ComputedFields.Get(sema.PublicKeyPublicKeyField)
 	if !ok {
@@ -2627,7 +2629,7 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 	}
 
 	// sign algo field
-	signAlgoField, ok := publicKey.Fields().Get(sema.PublicKeySignAlgoField)
+	signAlgoField, ok := fields.Get(sema.PublicKeySignAlgoField)
 	if !ok {
 		panic("sign algorithm is not set")
 	}
@@ -2643,7 +2645,7 @@ func NewPublicKeyFromValue(publicKey *interpreter.CompositeValue) *PublicKey {
 
 	// `valid` and `validated` fields
 	var valid, validated bool
-	validField, validated := publicKey.Fields.Get(sema.PublicKeyIsValidField)
+	validField, validated := fields.Get(sema.PublicKeyIsValidField)
 	if validated {
 		valid = bool(validField.(interpreter.BoolValue))
 	}

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -280,7 +280,7 @@ func NewCryptoContract(
 
 func getHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 	hashAlgoValue, ok := value.(*interpreter.CompositeValue)
-	if !ok || hashAlgoValue.QualifiedIdentifier != sema.HashAlgorithmTypeName {
+	if !ok || hashAlgoValue.QualifiedIdentifier() != sema.HashAlgorithmTypeName {
 		panic(fmt.Sprintf("hash algorithm value must be of type %s", sema.HashAlgorithmType))
 	}
 
@@ -299,7 +299,7 @@ func getHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 
 func getSignatureAlgorithmFromValue(value interpreter.Value) SignatureAlgorithm {
 	signAlgoValue, ok := value.(*interpreter.CompositeValue)
-	if !ok || signAlgoValue.QualifiedIdentifier != sema.SignatureAlgorithmTypeName {
+	if !ok || signAlgoValue.QualifiedIdentifier() != sema.SignatureAlgorithmTypeName {
 		panic(fmt.Sprintf("signature algorithm value must be of type %s", sema.SignatureAlgorithmType))
 	}
 

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -284,7 +284,7 @@ func getHashAlgorithmFromValue(value interpreter.Value) HashAlgorithm {
 		panic(fmt.Sprintf("hash algorithm value must be of type %s", sema.HashAlgorithmType))
 	}
 
-	rawValue, ok := hashAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := hashAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find hash algorithm raw value")
 	}
@@ -303,7 +303,7 @@ func getSignatureAlgorithmFromValue(value interpreter.Value) SignatureAlgorithm 
 		panic(fmt.Sprintf("signature algorithm value must be of type %s", sema.SignatureAlgorithmType))
 	}
 
-	rawValue, ok := signAlgoValue.Fields.Get(sema.EnumRawValueFieldName)
+	rawValue, ok := signAlgoValue.Fields().Get(sema.EnumRawValueFieldName)
 	if !ok {
 		panic("cannot find signature algorithm raw value")
 	}

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -90,7 +90,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 	))
 
 	value := &interpreter.CompositeValue{
-		Location:            utils.TestLocation,
+		location:            utils.TestLocation,
 		QualifiedIdentifier: fruitType.Identifier,
 		Kind:                common.CompositeKindStructure,
 		ComputedFields:      interpreter.NewStringComputedFieldOrderedMap(),

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -93,11 +93,13 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		Location:            utils.TestLocation,
 		QualifiedIdentifier: fruitType.Identifier,
 		Kind:                common.CompositeKindStructure,
-		Fields:              interpreter.NewStringValueOrderedMap(),
 		ComputedFields:      interpreter.NewStringComputedFieldOrderedMap(),
 	}
 
-	value.Fields.Set("name", interpreter.NewStringValue("Apple"))
+	fields := interpreter.NewStringValueOrderedMap()
+	fields.Set("name", interpreter.NewStringValue("Apple"))
+	value = value.WithFields(fields)
+
 	value.ComputedFields.Set("color", func(*interpreter.Interpreter) interpreter.Value {
 		return interpreter.NewStringValue("Red")
 	})

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -89,23 +89,24 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		"This is the color",
 	))
 
-	value := &interpreter.CompositeValue{
-		location:            utils.TestLocation,
-		QualifiedIdentifier: fruitType.Identifier,
-		Kind:                common.CompositeKindStructure,
-		ComputedFields:      interpreter.NewStringComputedFieldOrderedMap(),
-	}
-
 	fields := interpreter.NewStringValueOrderedMap()
 	fields.Set("name", interpreter.NewStringValue("Apple"))
-	value = value.WithFields(fields)
 
+	value := interpreter.NewCompositeValue(
+		utils.TestLocation,
+		fruitType.Identifier,
+		common.CompositeKindStructure,
+		fields,
+		nil,
+	)
+
+	value.ComputedFields = interpreter.NewStringComputedFieldOrderedMap()
 	value.ComputedFields.Set("color", func(*interpreter.Interpreter) interpreter.Value {
 		return interpreter.NewStringValue("Red")
 	})
 
 	customStructValue := stdlib.StandardLibraryValue{
-		Name:  value.QualifiedIdentifier,
+		Name:  value.QualifiedIdentifier(),
 		Type:  fruitType,
 		Value: value,
 		Kind:  common.DeclarationKindConstant,

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -63,7 +63,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
 
 	assert.Equal(t,
 		common.CompositeKindEnum,
-		a.(*interpreter.CompositeValue).Kind,
+		a.(*interpreter.CompositeValue).Kind(),
 	)
 
 	b := inter.Globals["b"].GetValue()
@@ -74,7 +74,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
 
 	assert.Equal(t,
 		common.CompositeKindEnum,
-		b.(*interpreter.CompositeValue).Kind,
+		b.(*interpreter.CompositeValue).Kind(),
 	)
 }
 

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -206,13 +206,13 @@ func TestInterpretEnumInContract(t *testing.T) {
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 
-	eValue, present := contract.Fields.Get("e")
+	eValue, present := contract.Fields().Get("e")
 	require.True(t, present)
 
 	require.IsType(t, &interpreter.CompositeValue{}, eValue)
 	enumCase := eValue.(*interpreter.CompositeValue)
 
-	rawValue, present := enumCase.Fields.Get("rawValue")
+	rawValue, present := enumCase.Fields().Get("rawValue")
 	require.True(t, present)
 
 	require.Equal(t,

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -80,7 +80,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 						)
 
 						value := &interpreter.CompositeValue{
-							Location:            location,
+							location:            location,
 							QualifiedIdentifier: "Foo",
 							Kind:                common.CompositeKindContract,
 							Functions: map[string]interpreter.FunctionValue{

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -79,26 +79,29 @@ func TestInterpretVirtualImport(t *testing.T) {
 							location,
 						)
 
+						value := &interpreter.CompositeValue{
+							Location:            location,
+							QualifiedIdentifier: "Foo",
+							Kind:                common.CompositeKindContract,
+							Functions: map[string]interpreter.FunctionValue{
+								"bar": interpreter.NewHostFunctionValue(
+									func(invocation interpreter.Invocation) interpreter.Value {
+										return interpreter.UInt64Value(42)
+									},
+								),
+							},
+						}
+
+						value = value.WithFields(interpreter.NewStringValueOrderedMap())
+
 						return interpreter.VirtualImport{
 							Globals: []struct {
 								Name  string
 								Value interpreter.Value
 							}{
 								{
-									Name: "Foo",
-									Value: &interpreter.CompositeValue{
-										Location:            location,
-										QualifiedIdentifier: "Foo",
-										Kind:                common.CompositeKindContract,
-										Fields:              interpreter.NewStringValueOrderedMap(),
-										Functions: map[string]interpreter.FunctionValue{
-											"bar": interpreter.NewHostFunctionValue(
-												func(invocation interpreter.Invocation) interpreter.Value {
-													return interpreter.UInt64Value(42)
-												},
-											),
-										},
-									},
+									Name:  "Foo",
+									Value: value,
 								},
 							},
 						}

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -79,20 +79,21 @@ func TestInterpretVirtualImport(t *testing.T) {
 							location,
 						)
 
-						value := &interpreter.CompositeValue{
-							location:            location,
-							QualifiedIdentifier: "Foo",
-							Kind:                common.CompositeKindContract,
-							Functions: map[string]interpreter.FunctionValue{
-								"bar": interpreter.NewHostFunctionValue(
-									func(invocation interpreter.Invocation) interpreter.Value {
-										return interpreter.UInt64Value(42)
-									},
-								),
-							},
-						}
+						value := interpreter.NewCompositeValue(
+							location,
+							"Foo",
+							common.CompositeKindContract,
+							interpreter.NewStringValueOrderedMap(),
+							nil,
+						)
 
-						value = value.WithFields(interpreter.NewStringValueOrderedMap())
+						value.Functions = map[string]interpreter.FunctionValue{
+							"bar": interpreter.NewHostFunctionValue(
+								func(invocation interpreter.Invocation) interpreter.Value {
+									return interpreter.UInt64Value(42)
+								},
+							),
+						}
 
 						return interpreter.VirtualImport{
 							Globals: []struct {

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -133,7 +133,7 @@ func TestInterpretResourceUUID(t *testing.T) {
 		require.IsType(t, &interpreter.CompositeValue{}, element)
 		res := element.(*interpreter.CompositeValue)
 
-		uuidValue, present := res.Fields.Get(sema.ResourceUUIDFieldName)
+		uuidValue, present := res.Fields().Get(sema.ResourceUUIDFieldName)
 		require.True(t, present)
 		require.Equal(t,
 			interpreter.UInt64Value(i),


### PR DESCRIPTION
Closes #845

## Description

Composite values have four storable properties:
- location
- qualified-Identifier
- kind
- fields

When reading a value from storage, only these four properties are decoded. Once the decoding is delayed, these properties may not have been properly initialized for a value returned from the decoder. Hence accessing them directly is unsafe.

This PR introduces a getter for each of the four properties. The getter function ensures the property is decoded and properly loaded.

### Approach:
- Composite value has two new extra properties:
  - `content` - Holds the raw content. Contains meta-info +  fields-content.
  - `fieldsContent` - Initially `nil`. Gets populated when the meta info is loaded. Hold the raw byte content related to composite value's fields
- When one of the meta info fields is accessed, all the meta info is loaded. At the same time, fields-content is also extracted out from the `content` and cached in `fieldsContent`.
- One drawback is accessing a field will also load the meta-info. This is a limitation in the storage format.

### Overhead
- There are two overheads:
  - Now we have to make a function call instead of directly using a field.
  - Function call always does a nil check.
    - Alternative is to store the getter as a local-field (function pointer) in the composite value, and replace it with a direct-field-returning function after the first invocation.
    - But the benchmarking showed that invoking a nil-checking static function is 5x faster than invoking a function pointer.
- However, both of these turned out to be very **trivial** at `go` level. It doesn't impact the overall performance of the runtime.

### Performance
For a composite value of `Foo` type, where :
```kotlin
struct Foo {
  var fname:   String
  var lname:   String
  var age:     Int
  var status:  String
  var address: Address
} 

struct Address {
  var street:  String
  var city:    String
  var state:   String
  var country: String
} 
```
Decoding perf numbers are:
```
name                                            old time/op    new time/op    delta
CompositeDeferredDecoding/Simply_decode-12        5.33µs ± 6%    1.45µs ± 5%  -72.86%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Access_identifier-12    5.69µs ± 7%    2.23µs ±15%  -60.87%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Access_field-12         5.91µs ± 2%    5.44µs ± 4%   -7.91%  (p=0.016 n=4+5)
CompositeDeferredDecoding/Re-encode_decoded-12    2.43µs ±26%    1.76µs ±13%  -27.68%  (p=0.008 n=5+5)

name                                            old alloc/op   new alloc/op   delta
CompositeDeferredDecoding/Simply_decode-12        2.61kB ± 0%    0.55kB ± 0%  -78.83%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Access_identifier-12    2.61kB ± 0%    0.86kB ± 0%  -66.87%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Access_field-12         2.82kB ± 0%    2.42kB ± 0%  -14.20%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Re-encode_decoded-12    1.16kB ± 0%    0.96kB ± 0%  -17.24%  (p=0.008 n=5+5)

name                                            old allocs/op  new allocs/op  delta
CompositeDeferredDecoding/Simply_decode-12          67.0 ± 0%       6.0 ± 0%  -91.04%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Access_identifier-12      67.0 ± 0%      13.0 ± 0%  -80.60%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Access_field-12           69.0 ± 0%      48.0 ± 0%  -30.43%  (p=0.008 n=5+5)
CompositeDeferredDecoding/Re-encode_decoded-12      14.0 ± 0%      10.0 ± 0%  -28.57%  (p=0.008 n=5+5)
```
_*'Simply_decode' - Only decode the value. Doesn't access the content of the value, like fields, type, etc._
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
