### PR TITLE
Fix Codecov "file not found at ./coverage.txt"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PATH := $(PATH):$(GOPATH)/bin
 .PHONY: test
 test:
 	# test all packages
-	GO111MODULE=on go test -coverprofile=cover.txt -covermode=atomic -parallel 8 -race ./...
+	GO111MODULE=on go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race ./...
 	cd ./languageserver && make test
 
 .PHONY: build


### PR DESCRIPTION
Closes #900

## Description

Change "cover.txt" to "coverage.txt" in Makefile.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
