### PR TITLE
Declare post-condition result variable as reference if return type is a resource

### DIFF
--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -327,10 +327,20 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 		checker.declareBefore()
 	}
 
-	// If there is a return type, declare the constant `result` which has the return type
+	// If there is a return type, declare the constant `result`.
+	// If it is a resource type, the constant has the same type as a referecne to the return type.
+	// If it is not a resource type, the constant has the same type as the return type.
 
 	if returnType != VoidType {
-		checker.declareResult(returnType)
+		var resultType Type
+		if returnType.IsResourceType() {
+			resultType = &ReferenceType{
+				Type: returnType,
+			}
+		} else {
+			resultType = returnType
+		}
+		checker.declareResult(resultType)
 	}
 
 	if rewrittenPostConditions != nil {

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -458,7 +458,7 @@ func TestCheckFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
+func TestCheckFunctionWithPostConditionAndResourceResult(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -492,8 +492,7 @@ func TestCheckFunctionWithPostConditionAndResourceResult(t *testing.T) {
         }
     `)
 
-	errs := ExpectCheckerErrors(t, err, 2)
+	errs := ExpectCheckerErrors(t, err, 1)
 
 	require.IsType(t, &sema.InvalidMoveOperationError{}, errs[0])
-	require.IsType(t, &sema.TypeMismatchError{}, errs[1])
 }

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -4894,7 +4894,6 @@ func TestCheckInvalidationInPostConditionBefore(t *testing.T) {
 	assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
 }
 
-
 func TestCheckInvalidationInPostCondition(t *testing.T) {
 
 	t.Parallel()
@@ -4919,4 +4918,3 @@ func TestCheckInvalidationInPostCondition(t *testing.T) {
 
 	assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
 }
-


### PR DESCRIPTION
## Description

Function post-conditions may use the special variable `result`, which is the value that is returned from the function. 

When the return type of a function is a resource type, then declare the type of the special variable `result` to be a reference type.

This is a port of
- dapperlabs/cadence-internal#4
- a part of dapperlabs/cadence-internal#8

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
