### PR TITLE
Track origin's occurrences

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -873,7 +873,7 @@ var containerCompletionItems = []*protocol.CompletionItem{
 // Completion is called to compute completion items at a given cursor position.
 //
 func (s *Server) Completion(
-	conn protocol.Conn,
+	_ protocol.Conn,
 	params *protocol.CompletionParams,
 ) (
 	items []*protocol.CompletionItem,

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -873,7 +873,7 @@ var containerCompletionItems = []*protocol.CompletionItem{
 // Completion is called to compute completion items at a given cursor position.
 //
 func (s *Server) Completion(
-	_ protocol.Conn,
+	conn protocol.Conn,
 	params *protocol.CompletionParams,
 ) (
 	items []*protocol.CompletionItem,

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -780,8 +780,6 @@ func (checker *Checker) declareEnumConstructor(
 			constructorOrigins[caseName] =
 				checker.recordFieldDeclarationOrigin(
 					enumCase.Identifier,
-					enumCase.Identifier.StartPosition(),
-					enumCase.Identifier.EndPosition(),
 					compositeType,
 				)
 		}
@@ -1419,8 +1417,6 @@ func (checker *Checker) defaultMembersAndOrigins(
 			origins[identifier] =
 				checker.recordFieldDeclarationOrigin(
 					field.Identifier,
-					field.StartPos,
-					field.EndPos,
 					fieldTypeAnnotation.Type,
 				)
 		}
@@ -1527,8 +1523,6 @@ func (checker *Checker) eventMembersAndOrigins(
 			origins[identifier.Identifier] =
 				checker.recordFieldDeclarationOrigin(
 					identifier,
-					parameter.StartPos,
-					parameter.EndPos,
 					typeAnnotation.Type,
 				)
 		}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1392,7 +1392,6 @@ func (checker *Checker) recordVariableDeclarationOccurrence(name string, variabl
 
 func (checker *Checker) recordFieldDeclarationOrigin(
 	identifier ast.Identifier,
-	startPos, endPos ast.Position,
 	fieldType Type,
 ) *Origin {
 	if !checker.positionInfoEnabled {
@@ -1410,8 +1409,8 @@ func (checker *Checker) recordFieldDeclarationOrigin(
 	}
 
 	checker.Occurrences.Put(
-		startPos,
-		endPos,
+		startPosition,
+		endPosition,
 		origin,
 	)
 

--- a/runtime/sema/occurrences.go
+++ b/runtime/sema/occurrences.go
@@ -97,13 +97,15 @@ func (o *Occurrences) Put(startPos, endPos ast.Position, origin *Origin) {
 		occurrence.EndPos,
 	)
 	o.tree.Put(interval, occurrence)
-	origin.Occurrences = append(
-		origin.Occurrences,
-		ast.Range{
-			StartPos: startPos,
-			EndPos:   endPos,
-		},
-	)
+	if origin != nil {
+		origin.Occurrences = append(
+			origin.Occurrences,
+			ast.Range{
+				StartPos: startPos,
+				EndPos:   endPos,
+			},
+		)
+	}
 }
 
 type Occurrence struct {

--- a/runtime/sema/occurrences.go
+++ b/runtime/sema/occurrences.go
@@ -129,3 +129,12 @@ func (o *Occurrences) Find(pos Position) *Occurrence {
 	occurrence := value.(Occurrence)
 	return &occurrence
 }
+
+func (o *Occurrences) FindAll(pos Position) []Occurrence {
+	entries := o.tree.SearchAll(pos)
+	occurrences := make([]Occurrence, len(entries))
+	for i, entry := range entries {
+		occurrences[i] = entry.Value.(Occurrence)
+	}
+	return occurrences
+}

--- a/runtime/sema/occurrences.go
+++ b/runtime/sema/occurrences.go
@@ -66,6 +66,7 @@ type Origin struct {
 	DeclarationKind common.DeclarationKind
 	StartPos        *ast.Position
 	EndPos          *ast.Position
+	Occurrences     []ast.Range
 }
 
 type Occurrences struct {
@@ -96,6 +97,13 @@ func (o *Occurrences) Put(startPos, endPos ast.Position, origin *Origin) {
 		occurrence.EndPos,
 	)
 	o.tree.Put(interval, occurrence)
+	origin.Occurrences = append(
+		origin.Occurrences,
+		ast.Range{
+			StartPos: startPos,
+			EndPos:   endPos,
+		},
+	)
 }
 
 type Occurrence struct {

--- a/runtime/sema/ranges.go
+++ b/runtime/sema/ranges.go
@@ -57,7 +57,7 @@ func (r *Ranges) All() []Range {
 	return ranges
 }
 
-func (r *Ranges) Find(pos Position) []Range {
+func (r *Ranges) FindAll(pos Position) []Range {
 	entries := r.tree.SearchAll(pos)
 	ranges := make([]Range, len(entries))
 	for i, entry := range entries {

--- a/runtime/tests/checker/occurrences_test.go
+++ b/runtime/tests/checker/occurrences_test.go
@@ -280,8 +280,8 @@ func TestCheckOccurrencesStructAndInterface(t *testing.T) {
 			DeclarationKind: common.DeclarationKindStructure,
 		},
 		{
-			StartPos:        sema.Position{Line: 5, Column: 8},
-			EndPos:          sema.Position{Line: 5, Column: 17},
+			StartPos:        sema.Position{Line: 5, Column: 12},
+			EndPos:          sema.Position{Line: 5, Column: 12},
 			OriginStartPos:  &sema.Position{Line: 5, Column: 12},
 			OriginEndPos:    &sema.Position{Line: 5, Column: 12},
 			DeclarationKind: common.DeclarationKindField,

--- a/runtime/tests/checker/range_test.go
+++ b/runtime/tests/checker/range_test.go
@@ -180,7 +180,7 @@ func TestCheckRange(t *testing.T) {
 		ranges,
 	)
 
-	ranges = checker.Ranges.Find(sema.Position{Line: 8, Column: 0})
+	ranges = checker.Ranges.FindAll(sema.Position{Line: 8, Column: 0})
 	sortAndFilterRanges()
 	assert.Equal(t,
 		[]sema.Range{
@@ -228,7 +228,7 @@ func TestCheckRange(t *testing.T) {
 		ranges,
 	)
 
-	ranges = checker.Ranges.Find(sema.Position{Line: 8, Column: 100})
+	ranges = checker.Ranges.FindAll(sema.Position{Line: 8, Column: 100})
 	sortAndFilterRanges()
 	assert.Equal(t,
 		[]sema.Range{


### PR DESCRIPTION

## Description

Record occurrences in origins, so that it is possible to get all occurrences from one occurrence.

For example, in the following program:

```kotlin
struct Counter {
    var n: Int

    init() {
        self.n = 0
    }

    fun inc() {
        self.n = self.n + 1
    }
}
```

It is possible to get from one of the occurrences of field `n` in functions `inc` to the origin, the field declaration on line 2, and from there get all occurrences (the one in the initializer, and the other two in the `inc` function.

Also:
- Fix the origin range for field declarations
- Add a function to get all occurrences for a position (multiple checker passes (re)declare occurrences)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
