### PR TITLE
Fix dynamic subtype test for reference values 

### DIFF
--- a/runtime/interpreter/dynamictype.go
+++ b/runtime/interpreter/dynamictype.go
@@ -31,6 +31,7 @@ type ReferenceDynamicType interface {
 	isReferenceType()
 	Authorized() bool
 	InnerType() DynamicType
+	BorrowedType() sema.Type
 }
 
 // MetaTypeDynamicType
@@ -106,8 +107,9 @@ func (SomeDynamicType) IsDynamicType() {}
 // StorageReferenceDynamicType
 
 type StorageReferenceDynamicType struct {
-	authorized bool
-	innerType  DynamicType
+	authorized   bool
+	innerType    DynamicType
+	borrowedType sema.Type
 }
 
 func (StorageReferenceDynamicType) IsDynamicType() {}
@@ -122,11 +124,16 @@ func (t StorageReferenceDynamicType) InnerType() DynamicType {
 	return t.innerType
 }
 
+func (t StorageReferenceDynamicType) BorrowedType() sema.Type {
+	return t.borrowedType
+}
+
 // EphemeralReferenceDynamicType
 
 type EphemeralReferenceDynamicType struct {
-	authorized bool
-	innerType  DynamicType
+	authorized   bool
+	innerType    DynamicType
+	borrowedType sema.Type
 }
 
 func (EphemeralReferenceDynamicType) IsDynamicType() {}
@@ -139,6 +146,10 @@ func (t EphemeralReferenceDynamicType) Authorized() bool {
 
 func (t EphemeralReferenceDynamicType) InnerType() DynamicType {
 	return t.innerType
+}
+
+func (t EphemeralReferenceDynamicType) BorrowedType() sema.Type {
+	return t.borrowedType
 }
 
 // AddressDynamicType

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -984,7 +984,8 @@ func (interpreter *Interpreter) visitFunctionBody(
 		var resultValue Value
 		if returnType.IsResourceType() {
 			resultValue = &EphemeralReferenceValue{
-				Value: returnValue,
+				Value:        returnValue,
+				BorrowedType: returnType,
 			}
 		} else {
 			resultValue = returnValue
@@ -2583,13 +2584,32 @@ func IsSubType(subType DynamicType, superType sema.Type) bool {
 
 	case ReferenceDynamicType:
 		if typedSuperType, ok := superType.(*sema.ReferenceType); ok {
-			if typedSubType.Authorized() {
-				return IsSubType(typedSubType.InnerType(), typedSuperType.Type)
-			} else {
-				// NOTE: Allowing all casts for casting unauthorized references is intentional:
-				// all invalid cases have already been rejected statically
+
+			// First, check that the dynamic type of the referenced value
+			// is a subtype of the super type
+
+			if !IsSubType(typedSubType.InnerType(), typedSuperType.Type) {
+				return false
+			}
+
+			// If the reference value is authorized it may be downcasted
+
+			authorized := typedSubType.Authorized()
+
+			if authorized {
 				return true
 			}
+
+			// If the reference value is not authorized,
+			// it may not be downcasted
+
+			return sema.IsSubType(
+				&sema.ReferenceType{
+					Authorized: authorized,
+					Type:       typedSubType.BorrowedType(),
+				},
+				typedSuperType,
+			)
 		}
 
 		return superType == sema.AnyStructType

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -682,13 +682,14 @@ func (interpreter *Interpreter) VisitDestroyExpression(expression *ast.DestroyEx
 
 func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *ast.ReferenceExpression) ast.Repr {
 
-	authorized := referenceExpression.Type.(*ast.ReferenceType).Authorized
+	borrowType := interpreter.Program.Elaboration.ReferenceExpressionBorrowTypes[referenceExpression]
 
 	result := interpreter.evalExpression(referenceExpression.Expression)
 
 	return &EphemeralReferenceValue{
-		Authorized: authorized,
-		Value:      result,
+		Authorized:   borrowType.Authorized,
+		Value:        result,
+		BorrowedType: borrowType.Type,
 	}
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7509,8 +7509,9 @@ func (v *StorageReferenceValue) DynamicType(interpreter *Interpreter, results Dy
 	innerType := (*referencedValue).DynamicType(interpreter, results)
 
 	return StorageReferenceDynamicType{
-		authorized: v.Authorized,
-		innerType:  innerType,
+		authorized:   v.Authorized,
+		innerType:    innerType,
+		borrowedType: v.BorrowedType,
 	}
 }
 
@@ -7622,7 +7623,8 @@ func (v *StorageReferenceValue) Equal(other Value, _ *Interpreter, _ bool) bool 
 
 	return v.TargetStorageAddress == otherReference.TargetStorageAddress &&
 		v.TargetKey == otherReference.TargetKey &&
-		v.Authorized == otherReference.Authorized
+		v.Authorized == otherReference.Authorized &&
+		v.BorrowedType.Equal(otherReference.BorrowedType)
 }
 
 func (v *StorageReferenceValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
@@ -7633,8 +7635,9 @@ func (v *StorageReferenceValue) ConformsToDynamicType(_ *Interpreter, dynamicTyp
 // EphemeralReferenceValue
 
 type EphemeralReferenceValue struct {
-	Authorized bool
-	Value      Value
+	Authorized   bool
+	Value        Value
+	BorrowedType sema.Type
 }
 
 func (*EphemeralReferenceValue) IsValue() {}
@@ -7667,8 +7670,9 @@ func (v *EphemeralReferenceValue) DynamicType(interpreter *Interpreter, results 
 	innerType := (*referencedValue).DynamicType(interpreter, results)
 
 	result := EphemeralReferenceDynamicType{
-		authorized: v.Authorized,
-		innerType:  innerType,
+		authorized:   v.Authorized,
+		innerType:    innerType,
+		borrowedType: v.BorrowedType,
 	}
 
 	results[v] = result
@@ -7769,7 +7773,8 @@ func (v *EphemeralReferenceValue) Equal(other Value, _ *Interpreter, _ bool) boo
 	}
 
 	return v.Value == otherReference.Value &&
-		v.Authorized == otherReference.Authorized
+		v.Authorized == otherReference.Authorized &&
+		v.BorrowedType.Equal(otherReference.BorrowedType)
 }
 
 func (v *EphemeralReferenceValue) ConformsToDynamicType(

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6329,7 +6329,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRuntime(t *testing.T) {
+func TestRuntimeExecuteScriptArguments(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -96,5 +96,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 		return InvalidType
 	}
 
+	checker.Elaboration.ReferenceExpressionBorrowTypes[referenceExpression] = referenceType
+
 	return referenceType
 }

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -78,6 +78,7 @@ type Elaboration struct {
 	EffectivePredeclaredValues          map[string]ValueDeclaration
 	EffectivePredeclaredTypes           map[string]TypeDeclaration
 	isChecking                          bool
+	ReferenceExpressionBorrowTypes      map[*ast.ReferenceExpression]*ReferenceType
 }
 
 func NewElaboration() *Elaboration {
@@ -126,6 +127,7 @@ func NewElaboration() *Elaboration {
 		GlobalTypes:                         NewStringVariableOrderedMap(),
 		EffectivePredeclaredValues:          map[string]ValueDeclaration{},
 		EffectivePredeclaredTypes:           map[string]TypeDeclaration{},
+		ReferenceExpressionBorrowTypes:      map[*ast.ReferenceExpression]*ReferenceType{},
 	}
 }
 


### PR DESCRIPTION
## Description

Check the reference dynamic type's (i.e. reference value's) borrowed type in the dynamic subtype test.

This requires including the borrowed type in ephemeral reference values. A previous PR had already added the borrowed type to storage reference values.

This is a port of the fix from the internal repo:
- dapperlabs/cadence-internal#6
- Part of dapperlabs/cadence-internal#8

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
