### PR TITLE
Check storability when value is written (before it is encoded)

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -439,3 +439,16 @@ func (e *MissingCompositeDeclarationError) Error() string {
 		e.Name,
 	)
 }
+
+// NonStorableValueWriteError
+//
+type NonStorableValueWriteError struct {
+	Value interpreter.Value
+}
+
+func (e NonStorableValueWriteError) Error() string {
+	return fmt.Sprintf(
+		"cannot write non-storable value: %s",
+		e.Value,
+	)
+}

--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -114,3 +114,7 @@ func (v BlockValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTyp
 	_, ok := dynamicType.(BlockDynamicType)
 	return ok
 }
+
+func (BlockValue) IsStorable() bool {
+	return false
+}

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -105,3 +105,7 @@ func (v DeployedContractValue) ConformsToDynamicType(_ *Interpreter, dynamicType
 	_, ok := dynamicType.(DeployedContractDynamicType)
 	return ok
 }
+
+func (DeployedContractValue) IsStorable() bool {
+	return false
+}

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -126,6 +126,10 @@ func (f InterpretedFunctionValue) ConformsToDynamicType(_ *Interpreter, _ Dynami
 	return false
 }
 
+func (InterpretedFunctionValue) IsStorable() bool {
+	return false
+}
+
 // HostFunctionValue
 
 type HostFunction func(invocation Invocation) Value
@@ -199,7 +203,7 @@ func (f HostFunctionValue) GetMember(_ *Interpreter, _ func() LocationRange, nam
 	return nil
 }
 
-func (f HostFunctionValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (HostFunctionValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -207,6 +211,11 @@ func (f HostFunctionValue) ConformsToDynamicType(_ *Interpreter, _ DynamicType, 
 	// TODO: once HostFunctionValue has static function type,
 	//   and FunctionDynamicType has parameter and return type info,
 	//   check they match
+
+	return false
+}
+
+func (HostFunctionValue) IsStorable() bool {
 	return false
 }
 
@@ -269,4 +278,8 @@ func (f BoundFunctionValue) ConformsToDynamicType(
 	results TypeConformanceResults,
 ) bool {
 	return f.Function.ConformsToDynamicType(interpreter, dynamicType, results)
+}
+
+func (BoundFunctionValue) IsStorable() bool {
+	return false
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6851,6 +6851,14 @@ func (v *CompositeValue) ConformsToDynamicType(
 
 func (v *CompositeValue) IsStorable() bool {
 
+	// Composite value's of native/built-in types are not storable for now
+	if v.Location() == nil {
+		return false
+	}
+
+	// If this composite value has a field which is non-storable,
+	// then the composite value is not storable.
+
 	// TODO: only check decoded fields
 	//   and assume still encoded fields are storable?
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -62,6 +62,7 @@ type Value interface {
 	StaticType() StaticType
 	ConformsToDynamicType(interpreter *Interpreter, dynamicType DynamicType, results TypeConformanceResults) bool
 	String(results StringResults) string
+	IsStorable() bool
 }
 
 // ValueIndexableValue
@@ -192,13 +193,17 @@ func (v TypeValue) GetMember(inter *Interpreter, _ func() LocationRange, name st
 	return nil
 }
 
-func (v TypeValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (TypeValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
 	panic(errors.NewUnreachableError())
 }
 
 func (v TypeValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	_, ok := dynamicType.(MetaTypeDynamicType)
 	return ok
+}
+
+func (TypeValue) IsStorable() bool {
+	return true
 }
 
 // VoidValue
@@ -247,6 +252,10 @@ func (VoidValue) String(_ StringResults) string {
 func (v VoidValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	_, ok := dynamicType.(VoidDynamicType)
 	return ok
+}
+
+func (VoidValue) IsStorable() bool {
+	return true
 }
 
 // BoolValue
@@ -314,6 +323,10 @@ func (v BoolValue) KeyString() string {
 func (v BoolValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	_, ok := dynamicType.(BoolDynamicType)
 	return ok
+}
+
+func (BoolValue) IsStorable() bool {
+	return true
 }
 
 // StringValue
@@ -527,6 +540,10 @@ func (v *StringValue) Length() int {
 		v.length = length
 	}
 	return v.length
+}
+
+func (*StringValue) IsStorable() bool {
+	return true
 }
 
 // DecodeHex hex-decodes this string and returns an array of UInt8 values
@@ -983,6 +1000,20 @@ func (v *ArrayValue) ConformsToDynamicType(
 	return true
 }
 
+func (v *ArrayValue) IsStorable() bool {
+
+	// TODO: only check decoded values
+	//   and assume still encoded values are storable?
+
+	for _, value := range v.Elements() {
+		if !value.IsStorable() {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (v *ArrayValue) Equal(other Value, interpreter *Interpreter, loadDeferred bool) bool {
 	otherArray, ok := other.(*ArrayValue)
 	if !ok {
@@ -1359,6 +1390,10 @@ func (v IntValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType,
 	return ok && sema.IntType.Equal(numberType.StaticType)
 }
 
+func (IntValue) IsStorable() bool {
+	return true
+}
+
 // Int8Value
 
 type Int8Value int8
@@ -1650,6 +1685,10 @@ func (v Int8Value) ToBigEndianBytes() []byte {
 func (v Int8Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.Int8Type.Equal(numberType.StaticType)
+}
+
+func (Int8Value) IsStorable() bool {
+	return true
 }
 
 // Int16Value
@@ -1947,6 +1986,10 @@ func (v Int16Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTyp
 	return ok && sema.Int16Type.Equal(numberType.StaticType)
 }
 
+func (Int16Value) IsStorable() bool {
+	return true
+}
+
 // Int32Value
 
 type Int32Value int32
@@ -2242,6 +2285,10 @@ func (v Int32Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTyp
 	return ok && sema.Int32Type.Equal(numberType.StaticType)
 }
 
+func (Int32Value) IsStorable() bool {
+	return true
+}
+
 // Int64Value
 
 type Int64Value int64
@@ -2534,6 +2581,10 @@ func (v Int64Value) ToBigEndianBytes() []byte {
 func (v Int64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.Int64Type.Equal(numberType.StaticType)
+}
+
+func (Int64Value) IsStorable() bool {
+	return true
 }
 
 // Int128Value
@@ -2897,6 +2948,10 @@ func (v Int128Value) ToBigEndianBytes() []byte {
 func (v Int128Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.Int128Type.Equal(numberType.StaticType)
+}
+
+func (Int128Value) IsStorable() bool {
+	return true
 }
 
 // Int256Value
@@ -3263,6 +3318,10 @@ func (v Int256Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTy
 	return ok && sema.Int256Type.Equal(numberType.StaticType)
 }
 
+func (Int256Value) IsStorable() bool {
+	return true
+}
+
 // UIntValue
 
 type UIntValue struct {
@@ -3517,6 +3576,10 @@ func (v UIntValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType
 	return ok && sema.UIntType.Equal(numberType.StaticType)
 }
 
+func (UIntValue) IsStorable() bool {
+	return true
+}
+
 // UInt8Value
 
 type UInt8Value uint8
@@ -3739,6 +3802,10 @@ func (v UInt8Value) ToBigEndianBytes() []byte {
 func (v UInt8Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.UInt8Type.Equal(numberType.StaticType)
+}
+
+func (UInt8Value) IsStorable() bool {
+	return true
 }
 
 // UInt16Value
@@ -3965,6 +4032,10 @@ func (v UInt16Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTy
 	return ok && sema.UInt16Type.Equal(numberType.StaticType)
 }
 
+func (UInt16Value) IsStorable() bool {
+	return true
+}
+
 // UInt32Value
 
 type UInt32Value uint32
@@ -4188,6 +4259,10 @@ func (v UInt32Value) ToBigEndianBytes() []byte {
 func (v UInt32Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.UInt32Type.Equal(numberType.StaticType)
+}
+
+func (UInt32Value) IsStorable() bool {
+	return true
 }
 
 // UInt64Value
@@ -4416,6 +4491,10 @@ func (v UInt64Value) ToBigEndianBytes() []byte {
 func (v UInt64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.UInt64Type.Equal(numberType.StaticType)
+}
+
+func (UInt64Value) IsStorable() bool {
+	return true
 }
 
 // UInt128Value
@@ -4724,6 +4803,10 @@ func (v UInt128Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicT
 	return ok && sema.UInt128Type.Equal(numberType.StaticType)
 }
 
+func (UInt128Value) IsStorable() bool {
+	return true
+}
+
 // UInt256Value
 
 type UInt256Value struct {
@@ -5030,6 +5113,10 @@ func (v UInt256Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicT
 	return ok && sema.UInt256Type.Equal(numberType.StaticType)
 }
 
+func (UInt256Value) IsStorable() bool {
+	return true
+}
+
 // Word8Value
 
 type Word8Value uint8
@@ -5199,6 +5286,10 @@ func (v Word8Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTyp
 	return ok && sema.Word8Type.Equal(numberType.StaticType)
 }
 
+func (Word8Value) IsStorable() bool {
+	return true
+}
+
 // Word16Value
 
 type Word16Value uint16
@@ -5366,6 +5457,10 @@ func (v Word16Value) ToBigEndianBytes() []byte {
 func (v Word16Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.Word16Type.Equal(numberType.StaticType)
+}
+
+func (Word16Value) IsStorable() bool {
+	return true
 }
 
 // Word32Value
@@ -5539,6 +5634,10 @@ func (v Word32Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTy
 	return ok && sema.Word32Type.Equal(numberType.StaticType)
 }
 
+func (Word32Value) IsStorable() bool {
+	return true
+}
+
 // Word64Value
 
 type Word64Value uint64
@@ -5708,6 +5807,10 @@ func (v Word64Value) ToBigEndianBytes() []byte {
 func (v Word64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.Word64Type.Equal(numberType.StaticType)
+}
+
+func (Word64Value) IsStorable() bool {
+	return true
 }
 
 // Fix64Value
@@ -5983,6 +6086,10 @@ func (v Fix64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTyp
 	return ok && sema.Fix64Type.Equal(numberType.StaticType)
 }
 
+func (Fix64Value) IsStorable() bool {
+	return true
+}
+
 // UFix64Value
 //
 type UFix64Value uint64
@@ -6220,6 +6327,10 @@ func (v UFix64Value) ToBigEndianBytes() []byte {
 func (v UFix64Value) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	numberType, ok := dynamicType.(NumberDynamicType)
 	return ok && sema.UFix64Type.Equal(numberType.StaticType)
+}
+
+func (UFix64Value) IsStorable() bool {
+	return true
 }
 
 // CompositeValue
@@ -6731,6 +6842,20 @@ func (v *CompositeValue) ConformsToDynamicType(
 		}
 
 		if !field.ConformsToDynamicType(interpreter, fieldDynamicType, results) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (v *CompositeValue) IsStorable() bool {
+
+	// TODO: only check decoded fields
+	//   and assume still encoded fields are storable?
+
+	for pair := v.Fields().Oldest(); pair != nil; pair = pair.Next() {
+		if !pair.Value.IsStorable() {
 			return false
 		}
 	}
@@ -7252,6 +7377,26 @@ func writeDeferredKeys(
 	}
 }
 
+func (v *DictionaryValue) IsStorable() bool {
+
+	// TODO: only check decoded keys
+	//   and assume still encoded keys are storable?
+
+	for _, keyValue := range v.Keys.Elements() {
+		if !keyValue.IsStorable() {
+			return false
+		}
+	}
+
+	for pair := v.Entries.Oldest(); pair != nil; pair = pair.Next() {
+		if !pair.Value.IsStorable() {
+			return false
+		}
+	}
+
+	return true
+}
+
 type DictionaryEntryValues struct {
 	Key   Value
 	Value Value
@@ -7418,6 +7563,10 @@ func (v NilValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 	return ok
 }
 
+func (NilValue) IsStorable() bool {
+	return true
+}
+
 // SomeValue
 
 type SomeValue struct {
@@ -7549,6 +7698,10 @@ func (v *SomeValue) Equal(other Value, interpreter *Interpreter, loadDeferred bo
 	}
 
 	return equatableValue.Equal(otherSome.Value, interpreter, loadDeferred)
+}
+
+func (v *SomeValue) IsStorable() bool {
+	return v.Value.IsStorable()
 }
 
 // StorageReferenceValue
@@ -7764,6 +7917,10 @@ func (v *StorageReferenceValue) ConformsToDynamicType(
 	return result
 }
 
+func (*StorageReferenceValue) IsStorable() bool {
+	return false
+}
+
 // EphemeralReferenceValue
 
 type EphemeralReferenceValue struct {
@@ -7970,6 +8127,10 @@ func (v *EphemeralReferenceValue) ConformsToDynamicType(
 	return result
 }
 
+func (*EphemeralReferenceValue) IsStorable() bool {
+	return false
+}
+
 // AddressValue
 
 type AddressValue common.Address
@@ -8090,6 +8251,10 @@ func (AddressValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, 
 func (v AddressValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	_, ok := dynamicType.(AddressDynamicType)
 	return ok
+}
+
+func (AddressValue) IsStorable() bool {
+	return true
 }
 
 // NewAuthAccountValue constructs an auth account value.
@@ -8359,6 +8524,10 @@ func (v PathValue) Equal(other Value, _ *Interpreter, _ bool) bool {
 		otherPath.Domain == v.Domain
 }
 
+func (PathValue) IsStorable() bool {
+	return true
+}
+
 // CapabilityValue
 
 type CapabilityValue struct {
@@ -8479,6 +8648,10 @@ func (v CapabilityValue) Equal(other Value, interpreter *Interpreter, loadDeferr
 		otherCapability.Path.Equal(v.Path, interpreter, loadDeferred)
 }
 
+func (CapabilityValue) IsStorable() bool {
+	return true
+}
+
 // LinkValue
 
 type LinkValue struct {
@@ -8547,6 +8720,10 @@ func (v LinkValue) Equal(other Value, interpreter *Interpreter, loadDeferred boo
 
 	return otherLink.TargetPath.Equal(v.TargetPath, interpreter, loadDeferred) &&
 		otherLink.Type.Equal(v.Type)
+}
+
+func (LinkValue) IsStorable() bool {
+	return true
 }
 
 // NewAccountKeyValue constructs an AccountKey value.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6851,6 +6851,20 @@ func (v *CompositeValue) ConformsToDynamicType(
 
 func (v *CompositeValue) IsStorable() bool {
 
+	// Only structures, resources, enums, and contracts can be stored.
+	// Contracts are not directly storable by programs,
+	// but they are still stored in storage by the interpreter
+
+	switch v.Kind() {
+	case common.CompositeKindStructure,
+		common.CompositeKindResource,
+		common.CompositeKindEnum,
+		common.CompositeKindContract:
+		break
+	default:
+		return false
+	}
+
 	// Composite value's of native/built-in types are not storable for now
 	if v.Location() == nil {
 		return false

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -451,7 +451,10 @@ func (r *interpreterRuntime) InvokeContractFunction(
 	}
 
 	// Write back all stored values, which were actually just cached, back into storage
-	runtimeStorage.writeCached(inter)
+	err = runtimeStorage.writeCached(inter)
+	if err != nil {
+		return nil, newError(err, context)
+	}
 
 	return ExportValue(value, inter), nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -255,7 +255,10 @@ func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (cade
 	// Even though this function is `ExecuteScript`, that doesn't imply the changes
 	// to storage will be actually persisted
 
-	runtimeStorage.writeCached(inter)
+	err = runtimeStorage.writeCached(inter)
+	if err != nil {
+		return nil, newError(err, context)
+	}
 
 	return exportValue(value), nil
 }
@@ -580,7 +583,10 @@ func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) 
 	}
 
 	// Write back all stored values, which were actually just cached, back into storage
-	runtimeStorage.writeCached(inter)
+	err = runtimeStorage.writeCached(inter)
+	if err != nil {
+		return newError(err, context)
+	}
 
 	return nil
 }
@@ -1423,10 +1429,12 @@ func storageUsedGetFunction(
 
 		// NOTE: flush the cached values, so the host environment
 		// can properly calculate the amount of storage used by the account
-		runtimeStorage.writeCached(inter)
+		err := runtimeStorage.writeCached(inter)
+		if err != nil {
+			panic(err)
+		}
 
 		var capacity uint64
-		var err error
 		wrapPanic(func() {
 			capacity, err = runtimeInterface.GetStorageUsed(address)
 		})

--- a/runtime/runtime_storage.go
+++ b/runtime/runtime_storage.go
@@ -246,7 +246,7 @@ type writeItem struct {
 
 // writeCached serializes/saves all values in the cache in storage (through the runtime interface).
 //
-func (s *runtimeStorage) writeCached(inter *interpreter.Interpreter) {
+func (s *runtimeStorage) writeCached(inter *interpreter.Interpreter) error {
 
 	var items []writeItem
 
@@ -327,6 +327,8 @@ func (s *runtimeStorage) writeCached(inter *interpreter.Interpreter) {
 		}
 		batch = newBatch
 	}
+
+	return nil
 }
 
 type encodedResult struct {
@@ -441,6 +443,12 @@ func (s *runtimeStorage) processEncodedItem(item writeItem, encoded *encodedResu
 	var newData []byte
 	if encoded != nil && len(encoded.newData) > 0 {
 		newData = interpreter.PrependMagic(encoded.newData, interpreter.CurrentEncodingVersion)
+	}
+
+	if item.value != nil && !item.value.IsStorable() {
+		return nil, NonStorableValueWriteError{
+			Value: item.value,
+		}
 	}
 
 	var err error

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -80,7 +80,9 @@ func TestRuntimeStorageWriteCached(t *testing.T) {
 	const arrayElementCount = 100
 	const storageItemCount = 100
 	withWritesToStorage(arrayElementCount, storageItemCount, onWrite, func(runtimeStorage *runtimeStorage) {
-		runtimeStorage.writeCached(nil)
+		err := runtimeStorage.writeCached(nil)
+		require.NoError(t, err)
+
 		require.Len(t, writes, storageItemCount)
 	})
 }
@@ -102,7 +104,9 @@ func TestRuntimeStorageWriteCachedIsDeterministic(t *testing.T) {
 	const arrayElementCount = 100
 	const storageItemCount = 100
 	withWritesToStorage(arrayElementCount, storageItemCount, onWrite, func(runtimeStorage *runtimeStorage) {
-		runtimeStorage.writeCached(nil)
+		err := runtimeStorage.writeCached(nil)
+		require.NoError(t, err)
+
 		previousWrites := make([]testWrite, len(writes))
 		copy(previousWrites, writes)
 
@@ -110,7 +114,9 @@ func TestRuntimeStorageWriteCachedIsDeterministic(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			// test that writing again should produce the same result
 			writes = nil
-			runtimeStorage.writeCached(nil)
+			err := runtimeStorage.writeCached(nil)
+			require.NoError(t, err)
+
 			for i, previousWrite := range previousWrites {
 				// compare the new write with the old write
 				require.Equal(t, previousWrite, writes[i])
@@ -141,7 +147,8 @@ func BenchmarkRuntimeStorageWriteCached(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			writes = nil
-			runtimeStorage.writeCached(nil)
+			err := runtimeStorage.writeCached(nil)
+			require.NoError(b, err)
 
 			require.Len(b, writes, storageItemCount)
 		}


### PR DESCRIPTION
## Description

Values which are saved directly using the storage API (using the `save` function) or indirectly by mutating a stored value, may be non-storable, as the types `AnyStruct` and `AnyResource` are currently storable. The static check, the argument of the type parameter for the function `save` to be a subtype of the type `Storable` only ensures that the types are definitely not-storable – we still need a run-time check that the stored value is storable.

Currently the storage of non-storable values is already indirectly done by the encoding/preparation function, which returns an error when a value cannot be encoded:

https://github.com/onflow/cadence/blob/ca1e6400714f4b412688add73ddaf72b945c9562/runtime/interpreter/encode.go#L409-L413

However, this eventually is treated further up as an implementation error (and correctly so: the error indicates e.g. we forgot to implement encoding for an actually storable value), so leads to a crash.

Implement this check properly / handle this gracefully by adding a function `IsStorable` for all types conforming to `interpreter.Value`, and using it when writing all stored values.

This is a port of the fix in the internal repo:
- dapperlabs/cadence-internal#7
- Part of dapperlabs/cadence-internal#8

In addition, this PR contains follow-up fixes, a port of cadence-internal#9:

- 1adf652: An error return value was added to `runtimeStorage.writeCached`.
  Check the error in the tests

- 3af7759: The function `Value.IsStorable` was added. It was implemented to return false for the types `AuthAccountValue`, `PublicAccountValue` and `AuthAccountContractsValue`.
  In Cadence v0.15 these Go types got replaced and are now all backed by `CompositeValue`.
  Re-apply the notion of these and other built-in composite values not being non-storable


______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
