### PR TITLE
Add interpreter tests for common resource reference usages

### DIFF
--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -1,0 +1,83 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpretResourceReferenceInstanceOf(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+        resource R {}
+
+        fun test(): Bool {
+            let r <- create R()
+            let ref = &r as &R
+            let isInstance = ref.isInstance(Type<@R>())
+            destroy r
+            return isInstance
+        }
+    `)
+
+	value, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		interpreter.BoolValue(true),
+		value,
+	)
+}
+
+func TestInterpretResourceReferenceFieldComparison(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+        resource R {
+            let n: Int
+            init() {
+                self.n = 1
+            }
+        }
+
+        fun test(): Bool {
+            let r <- create R()
+            let ref = &r as &R
+            let isOne = ref.n == 1
+            destroy r
+            return isOne
+        }
+    `)
+
+	value, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		interpreter.BoolValue(true),
+		value,
+	)
+}


### PR DESCRIPTION
## Description

Add additional tests that I had written for an earlier fix where the `result` variable in post-conditions was changed to be a reference if the result type is a resource (#905). 

The tests show that post-conditions existing on Mainnet keep working, i.e. ones that access members, and that use `isInstance` with a resource type.

This is a port of a part of dapperlabs/cadence-internal#9

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
