### PR TITLE
Check the index bounds for arrays

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -323,16 +323,16 @@ func (e CyclicLinkError) Error() string {
 // ArrayIndexOutOfBoundsError
 //
 type ArrayIndexOutOfBoundsError struct {
-	Index    int
-	MaxIndex int
+	Index int
+	Size  int
 	LocationRange
 }
 
 func (e ArrayIndexOutOfBoundsError) Error() string {
 	return fmt.Sprintf(
-		"array index out of bounds: got %d, expected max %d",
+		"array index out of bounds: %d, but size is %d",
 		e.Index,
-		e.MaxIndex,
+		e.Size,
 	)
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -790,7 +790,9 @@ func (v *ArrayValue) Remove(index int, getLocationRange func() LocationRange) Va
 }
 
 // TODO: unset owner?
-func (v *ArrayValue) RemoveFirst() Value {
+func (v *ArrayValue) RemoveFirst(getLocationRange func() LocationRange) Value {
+	v.checkBounds(0, getLocationRange)
+
 	v.modified = true
 
 	elements := v.Elements()
@@ -875,7 +877,7 @@ func (v *ArrayValue) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 	case "removeFirst":
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
-				return v.RemoveFirst()
+				return v.RemoveFirst(invocation.GetLocationRange)
 			},
 		)
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -803,12 +803,14 @@ func (v *ArrayValue) RemoveFirst(getLocationRange func() LocationRange) Value {
 }
 
 // TODO: unset owner?
-func (v *ArrayValue) RemoveLast() Value {
+func (v *ArrayValue) RemoveLast(getLocationRange func() LocationRange) Value {
+	lastIndex := v.Count() - 1
+	v.checkBounds(lastIndex, getLocationRange)
+
 	v.modified = true
 
 	elements := v.Elements()
 	var lastElement Value
-	lastIndex := len(elements) - 1
 
 	lastElement, v.values = elements[lastIndex], elements[:lastIndex]
 	return lastElement
@@ -884,7 +886,7 @@ func (v *ArrayValue) GetMember(_ *Interpreter, _ func() LocationRange, name stri
 	case "removeLast":
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {
-				return v.RemoveLast()
+				return v.RemoveLast(invocation.GetLocationRange)
 			},
 		)
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -751,7 +751,16 @@ func (v *ArrayValue) AppendAll(other AllAppendableValue) {
 }
 
 func (v *ArrayValue) Insert(index int, element Value, getLocationRange func() LocationRange) {
-	v.checkBounds(index, getLocationRange)
+	count := v.Count()
+
+	// NOTE: index may be equal to count
+	if index < 0 || index > count {
+		panic(ArrayIndexOutOfBoundsError{
+			Index:         index,
+			Size:          count,
+			LocationRange: getLocationRange(),
+		})
+	}
 
 	v.modified = true
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -683,27 +683,38 @@ func (v *ArrayValue) Concat(other ConcatenatableValue) Value {
 }
 
 func (v *ArrayValue) Get(_ *Interpreter, getLocationRange func() LocationRange, key Value) Value {
-	integerKey := key.(NumberValue).ToInt()
+	index := key.(NumberValue).ToInt()
 	count := v.Count()
 
 	// Check bounds
-	if integerKey < 0 || integerKey >= count {
+	if index < 0 || index >= count {
 		panic(ArrayIndexOutOfBoundsError{
-			Index:         integerKey,
-			MaxIndex:      count - 1,
+			Index:         index,
+			Size:          count,
 			LocationRange: getLocationRange(),
 		})
 	}
 
-	return v.Elements()[integerKey]
+	return v.Elements()[index]
 }
 
-func (v *ArrayValue) Set(_ *Interpreter, _ func() LocationRange, key Value, value Value) {
+func (v *ArrayValue) Set(_ *Interpreter, getLocationRange func() LocationRange, key Value, value Value) {
 	index := key.(NumberValue).ToInt()
-	v.SetIndex(index, value)
+	v.SetIndex(index, value, getLocationRange)
 }
 
-func (v *ArrayValue) SetIndex(index int, value Value) {
+func (v *ArrayValue) SetIndex(index int, value Value, getLocationRange func() LocationRange) {
+	count := v.Count()
+
+	// Check bounds
+	if index < 0 || index >= count {
+		panic(ArrayIndexOutOfBoundsError{
+			Index:         index,
+			Size:          count,
+			LocationRange: getLocationRange(),
+		})
+	}
+
 	v.modified = true
 	value.SetOwner(v.Owner)
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -155,7 +155,7 @@ func TestSetOwnerArrayInsert(t *testing.T) {
 	assert.Equal(t, &newOwner, array.GetOwner())
 	assert.Equal(t, &oldOwner, value.GetOwner())
 
-	array.Insert(0, value)
+	array.Insert(0, value, nil)
 
 	assert.Equal(t, &newOwner, array.GetOwner())
 	assert.Equal(t, &newOwner, value.GetOwner())

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -645,7 +645,7 @@ func TestStringer(t *testing.T) {
 			value: func() Value {
 				array := NewArrayValueUnownedNonCopying()
 				arrayRef := &EphemeralReferenceValue{Value: array}
-				array.Insert(0, arrayRef)
+				array.Insert(0, arrayRef, nil)
 				return array
 			}(),
 			expected: `[[...]]`,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4412,7 +4412,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 		interpreter.NewIntValueFromInt64(2),
 		interpreter.NewIntValueFromInt64(3),
 	).Copy().(*interpreter.ArrayValue)
-	expectedArray.RemoveLast()
+	expectedArray.RemoveLast(nil)
 
 	actualArray := inter.Globals["x"].GetValue()
 
@@ -4434,6 +4434,39 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 	assert.Equal(t,
 		interpreter.NewIntValueFromInt64(3),
 		inter.Globals["y"].GetValue(),
+	)
+}
+
+func TestInterpretInvalidArrayRemoveLast(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+       let x: [Int] = []
+
+       fun test() {
+           x.removeLast()
+       }
+    `)
+
+	_, err := inter.Invoke("test")
+
+	var indexErr interpreter.ArrayIndexOutOfBoundsError
+	require.ErrorAs(t, err, &indexErr)
+
+	require.Equal(t,
+		interpreter.ArrayIndexOutOfBoundsError{
+			Index: -1,
+			Size:  0,
+			LocationRange: interpreter.LocationRange{
+				Location: TestLocation,
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 58, Line: 5, Column: 11},
+					EndPos:   ast.Position{Offset: 71, Line: 5, Column: 24},
+				},
+			},
+		},
+		indexErr,
 	)
 }
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4235,7 +4235,7 @@ func TestInterpretInvalidArrayInsert(t *testing.T) {
 
 	for name, index := range map[string]int{
 		"negative":          -1,
-		"larger than count": 3,
+		"larger than count": 4,
 	} {
 
 		t.Run(name, func(t *testing.T) {
@@ -4317,7 +4317,7 @@ func TestInterpretInvalidArrayRemove(t *testing.T) {
 
 	for name, index := range map[string]int{
 		"negative":          -1,
-		"larger than count": 4,
+		"larger than count": 3,
 	} {
 
 		t.Run(name, func(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4340,7 +4340,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 		interpreter.NewIntValueFromInt64(2),
 		interpreter.NewIntValueFromInt64(3),
 	).Copy().(*interpreter.ArrayValue)
-	expectedArray.RemoveFirst()
+	expectedArray.RemoveFirst(nil)
 
 	actualArray := inter.Globals["x"].GetValue()
 
@@ -4362,6 +4362,39 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 	assert.Equal(t,
 		interpreter.NewIntValueFromInt64(1),
 		inter.Globals["y"].GetValue(),
+	)
+}
+
+func TestInterpretInvalidArrayRemoveFirst(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+       let x: [Int] = []
+
+       fun test() {
+           x.removeFirst()
+       }
+    `)
+
+	_, err := inter.Invoke("test")
+
+	var indexErr interpreter.ArrayIndexOutOfBoundsError
+	require.ErrorAs(t, err, &indexErr)
+
+	require.Equal(t,
+		interpreter.ArrayIndexOutOfBoundsError{
+			Index: 0,
+			Size:  0,
+			LocationRange: interpreter.LocationRange{
+				Location: TestLocation,
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 58, Line: 5, Column: 11},
+					EndPos:   ast.Position{Offset: 72, Line: 5, Column: 25},
+				},
+			},
+		},
+		indexErr,
 	)
 }
 


### PR DESCRIPTION
## Description

Just like when reading from an array index, also check the index is in bounds when assigning.

Also check the index for the array functions:

- `insert`. Note that it allows insertion at the end
- `remove`
- `removeFirst`
- `removeLast`

This is a port of these PRs from the internal repo:
- dapperlabs/cadence-internal#11
- dapperlabs/cadence-internal#12

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
