### PR TITLE
Implement `StaticType` for `StorageReferenceValue` and `EphemeralReferenceValue`

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7586,8 +7586,10 @@ func (v *StorageReferenceValue) DynamicType(interpreter *Interpreter, results Dy
 }
 
 func (v *StorageReferenceValue) StaticType() StaticType {
-	// TODO:
-	return nil
+	return ReferenceStaticType{
+		Authorized: v.Authorized,
+		Type:       ConvertSemaToStaticType(v.BorrowedType),
+	}
 }
 
 func (v *StorageReferenceValue) Copy() Value {
@@ -7751,8 +7753,10 @@ func (v *EphemeralReferenceValue) DynamicType(interpreter *Interpreter, results 
 }
 
 func (v *EphemeralReferenceValue) StaticType() StaticType {
-	// TODO:
-	return nil
+	return ReferenceStaticType{
+		Authorized: v.Authorized,
+		Type:       ConvertSemaToStaticType(v.BorrowedType),
+	}
 }
 
 func (v *EphemeralReferenceValue) Copy() Value {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4035,7 +4035,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 			return variable.Type
 		}
 
-		// Inject a function that return a storage reference value,
+		// Inject a function that returns a storage reference value,
 		// which is borrowed as:
 		// - `&R{RI}` (unauthorized, if argument for parameter `authorized` == false)
 		// - `auth &R{RI}` (authorized, if argument for parameter `authorized` == true)


### PR DESCRIPTION

Closes #748 

______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
