### PR TITLE
Provide documentation for range completion items

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1480,6 +1480,8 @@ func (s *Server) maybeResolveRange(uri protocol.DocumentUri, id string, result *
 		)
 	}
 
+	result.Documentation = r.DocString
+
 	return true
 }
 


### PR DESCRIPTION

## Description

Just like for members, also include docstrings as documentation for range completion items, e.g. top-level variables and functions, both user-defined and built-in:

<img width="936" alt="Screen Shot 2021-05-18 at 8 39 03 PM" src="https://user-images.githubusercontent.com/51661/118753191-4c603a00-b819-11eb-9b02-82d41a563966.png">

<img width="1012" alt="Screen Shot 2021-05-18 at 8 38 28 PM" src="https://user-images.githubusercontent.com/51661/118753197-4ec29400-b819-11eb-8125-9c9424043287.png">

______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
