### PR TITLE
Add deferred decoding support for dictionary values

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -248,7 +248,7 @@ func exportDictionaryValue(
 
 	pairs := make([]cadence.KeyValuePair, v.Count())
 
-	for i, keyValue := range v.Keys.Elements() {
+	for i, keyValue := range v.Keys().Elements() {
 
 		// NOTE: use `Get` instead of accessing `Entries`,
 		// so that the potentially deferred values are loaded from storage

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -376,7 +376,7 @@ func (d *DecoderV4) decodeDictionary(path []string) (*DictionaryValue, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid array encoding (@ %s): %s",
+				"invalid dictionary encoding (@ %s): %s",
 				strings.Join(path, "."),
 				e.ActualType.String(),
 			)
@@ -1904,11 +1904,9 @@ func decodeDictionaryEntries(v *DictionaryValue, content []byte) error {
 
 	v.keys = keys
 	v.entries = entries
-	v.Owner = d.owner
-	v.modified = false
-	v.DeferredOwner = deferredOwner
-	v.DeferredKeys = deferred
-	v.DeferredStorageKeyBase = deferredStorageKeyBase
+	v.deferredOwner = deferredOwner
+	v.deferredKeys = deferred
+	v.deferredStorageKeyBase = deferredStorageKeyBase
 
 	return nil
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1902,8 +1902,8 @@ func decodeDictionaryEntries(v *DictionaryValue, content []byte) error {
 		}
 	}
 
-	v.Keys = keys
-	v.Entries = entries
+	v.keys = keys
+	v.entries = entries
 	v.Owner = d.owner
 	v.modified = false
 	v.DeferredOwner = deferredOwner

--- a/runtime/interpreter/decode_v3.go
+++ b/runtime/interpreter/decode_v3.go
@@ -489,9 +489,9 @@ func (d *DecoderV3) decodeDictionary(v interface{}, path []string) (*DictionaryV
 		entries:                entries,
 		Owner:                  d.owner,
 		modified:               false,
-		DeferredOwner:          deferredOwner,
-		DeferredKeys:           deferred,
-		DeferredStorageKeyBase: deferredStorageKeyBase,
+		deferredOwner:          deferredOwner,
+		deferredKeys:           deferred,
+		deferredStorageKeyBase: deferredStorageKeyBase,
 	}, nil
 }
 

--- a/runtime/interpreter/decode_v3.go
+++ b/runtime/interpreter/decode_v3.go
@@ -485,8 +485,8 @@ func (d *DecoderV3) decodeDictionary(v interface{}, path []string) (*DictionaryV
 	}
 
 	return &DictionaryValue{
-		Keys:                   keys,
-		Entries:                entries,
+		keys:                   keys,
+		entries:                entries,
 		Owner:                  d.owner,
 		modified:               false,
 		DeferredOwner:          deferredOwner,

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -859,7 +859,7 @@ func (e *Encoder) encodeDictionaryValue(
 	keysPath := append(path, dictionaryKeyPathPrefix)
 
 	// Encode keys (as array) at array index encodedDictionaryValueKeysFieldKey
-	err = e.encodeArray(v.Keys, keysPath, deferrals)
+	err = e.encodeArray(v.Keys(), keysPath, deferrals)
 	if err != nil {
 		return err
 	}
@@ -873,7 +873,7 @@ func (e *Encoder) encodeDictionaryValue(
 		// Iterating over the map in a non-deterministic way is OK,
 		// we only determine check if all values are resources.
 
-		for pair := v.Entries.Oldest(); pair != nil; pair = pair.Next() {
+		for pair := v.Entries().Oldest(); pair != nil; pair = pair.Next() {
 			compositeValue, ok := pair.Value.(*CompositeValue)
 			if !ok || compositeValue.Kind() != common.CompositeKindResource {
 				deferred = false
@@ -884,7 +884,7 @@ func (e *Encoder) encodeDictionaryValue(
 
 	// entries is empty if encoding of values is deferred,
 	// otherwise entries size is the same as keys size.
-	keys := v.Keys.Elements()
+	keys := v.Keys().Elements()
 	entriesLength := len(keys)
 	if deferred {
 		entriesLength = 0
@@ -904,7 +904,7 @@ func (e *Encoder) encodeDictionaryValue(
 
 	for _, keyValue := range keys {
 		key := dictionaryKey(keyValue)
-		entryValue, _ := v.Entries.Get(key)
+		entryValue, _ := v.Entries().Get(key)
 		valuePath[lastValuePathIndex] = key
 
 		if deferred {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -282,7 +282,7 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		expected := NewDictionaryValueUnownedNonCopying()
 		expected.modified = false
-		expected.Keys.modified = false
+		expected.Keys().modified = false
 
 		encoded := []byte{
 			// tag
@@ -344,7 +344,7 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 		)
 
 		expected.modified = false
-		expected.Keys.modified = false
+		expected.Keys().modified = false
 
 		value1.modified = false
 
@@ -446,7 +446,7 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 			NewAddressValueFromBytes([]byte{0x42}),
 			Int8Value(42),
 		)
-		expected.Keys.modified = false
+		expected.Keys().modified = false
 		expected.modified = false
 
 		testEncodeDecode(t,
@@ -4943,7 +4943,7 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 			key2, value2,
 		)
 		expected.modified = false
-		expected.Keys.modified = false
+		expected.Keys().modified = false
 
 		deferredKeys := orderedmap.NewStringStructOrderedMap()
 		deferredKeys.Set("test", struct{}{})
@@ -4963,8 +4963,8 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 		}
 
 		decodedValue := &DictionaryValue{
-			Keys:                   expected.Keys,
-			Entries:                NewStringValueOrderedMap(),
+			keys:                   expected.Keys(),
+			entries:                NewStringValueOrderedMap(),
 			DeferredOwner:          &testOwner,
 			DeferredKeys:           deferredKeys,
 			DeferredStorageKeyBase: "v",
@@ -5044,7 +5044,7 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 			key2, value2,
 		)
 		expected.modified = false
-		expected.Keys.modified = false
+		expected.Keys().modified = false
 
 		deferrals := &EncodingDeferrals{}
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -4965,9 +4965,9 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 		decodedValue := &DictionaryValue{
 			keys:                   expected.Keys(),
 			entries:                NewStringValueOrderedMap(),
-			DeferredOwner:          &testOwner,
-			DeferredKeys:           deferredKeys,
-			DeferredStorageKeyBase: "v",
+			deferredOwner:          &testOwner,
+			deferredKeys:           deferredKeys,
+			deferredStorageKeyBase: "v",
 		}
 
 		encoded := []byte{

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6977,6 +6977,22 @@ type DictionaryValue struct {
 	// prevDeferredKeys are the keys which are deferred and have been loaded from storage,
 	// i.e. they are keys that were previously in DeferredKeys.
 	prevDeferredKeys *orderedmap.StringStructOrderedMap
+
+	// Raw element content cache for decoded values.
+	// Only available for decoded values who's entries are not loaded yet.
+	content []byte
+
+	// Value's path to be used during decoding.
+	// Only available for decoded values who's entries are not loaded yet.
+	valuePath []string
+
+	// Callback function to be invoked when decoding the entries of this dictionary value.
+	// Only available for decoded values who's entries are not loaded yet.
+	decodeCallback DecodingCallback
+
+	// Encoding version of the raw content of the entries of this value.
+	// Only available for decoded values who's entries are not loaded yet.
+	encodingVersion uint16
 }
 
 func NewDictionaryValueUnownedNonCopying(keysAndValues ...Value) *DictionaryValue {
@@ -7002,6 +7018,23 @@ func NewDictionaryValueUnownedNonCopying(keysAndValues ...Value) *DictionaryValu
 	}
 
 	return result
+}
+
+func NewDeferredDictionaryValue(
+	path []string,
+	content []byte,
+	owner *common.Address,
+	decodeCallback DecodingCallback,
+	version uint16,
+) *DictionaryValue {
+	return &DictionaryValue{
+		Owner:           owner,
+		modified:        false,
+		valuePath:       path,
+		content:         content,
+		decodeCallback:  decodeCallback,
+		encodingVersion: version,
+	}
 }
 
 func (*DictionaryValue) IsValue() {}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -211,7 +211,7 @@ func TestSetOwnerDictionaryCopy(t *testing.T) {
 	dictionary.SetOwner(&newOwner)
 
 	dictionaryCopy := dictionary.Copy().(*DictionaryValue)
-	valueCopy, _ := dictionaryCopy.Entries.Get(keyValue.KeyString())
+	valueCopy, _ := dictionaryCopy.Entries().Get(keyValue.KeyString())
 
 	assert.Nil(t, dictionaryCopy.GetOwner())
 	assert.Nil(t, valueCopy.GetOwner())
@@ -632,11 +632,11 @@ func TestStringer(t *testing.T) {
 					UInt8Value(42),
 				)
 				return &DictionaryValue{
-					Keys: NewArrayValueUnownedNonCopying(
+					keys: NewArrayValueUnownedNonCopying(
 						NewStringValue("a"),
 						NewStringValue("b"),
 					),
-					Entries: entries,
+					entries: entries,
 				}
 			}(),
 			expected: `{"a": 42, "b": ...}`,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -3720,14 +3720,14 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 
 	assert.Equal(t,
 		expectedEntries,
-		actualDict.Entries,
+		actualDict.Entries(),
 	)
 
 	assert.Equal(t,
 		[]interpreter.Value{
 			interpreter.NewStringValue("abc"),
 		},
-		actualDict.Keys.Elements(),
+		actualDict.Keys().Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -3785,7 +3785,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 
 	assert.Equal(t,
 		expectedEntries,
-		actualDict.Entries,
+		actualDict.Entries(),
 	)
 
 	assert.Equal(t,
@@ -3793,7 +3793,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 			interpreter.NewStringValue("def"),
 			interpreter.NewStringValue("abc"),
 		},
-		actualDict.Keys.Elements(),
+		actualDict.Keys().Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -3849,14 +3849,14 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 
 	assert.Equal(t,
 		expectedEntries,
-		actualDict.Entries,
+		actualDict.Entries(),
 	)
 
 	assert.Equal(t,
 		[]interpreter.Value{
 			interpreter.NewStringValue("abc"),
 		},
-		actualDict.Keys.Elements(),
+		actualDict.Keys().Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -4940,14 +4940,14 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 
 	assert.Equal(t,
 		expectedEntries,
-		actualDict.Entries,
+		actualDict.Entries(),
 	)
 
 	assert.Equal(t,
 		[]interpreter.Value{
 			interpreter.NewStringValue("def"),
 		},
-		actualDict.Keys.Elements(),
+		actualDict.Keys().Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -4993,7 +4993,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 
 	assert.Equal(t,
 		expectedEntries,
-		actualDict.Entries,
+		actualDict.Entries(),
 	)
 
 	assert.Equal(t,
@@ -5001,7 +5001,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 			interpreter.NewStringValue("abc"),
 			interpreter.NewStringValue("def"),
 		},
-		actualDict.Keys.Elements(),
+		actualDict.Keys().Elements(),
 	)
 
 	assert.True(t, actualDict.IsModified())
@@ -7735,9 +7735,12 @@ func TestInterpretDictionaryValueEncodingOrder(t *testing.T) {
 		decoded, err := decoder.Decode(path)
 		require.NoError(t, err)
 
+		// ensure the value is loaded
+		_ = decoded.String(interpreter.StringResults{})
+
 		test.SetModified(false)
-		test.Keys.SetModified(false)
-		for _, key := range test.Keys.Elements() {
+		test.Keys().SetModified(false)
+		for _, key := range test.Keys().Elements() {
 			stringKey := key.(*interpreter.StringValue)
 			stringKey.SetModified(false)
 		}


### PR DESCRIPTION
Closes #844
Closes #924

## Description

$subject.

### Performance
Performance for a dictionary with `String` keys and `String` values (`{String:String}`) of size 100:
```
name                                             old time/op    new time/op    delta
DictionaryDeferredDecoding/Simply_decode-12        57.4µs ±19%     3.2µs ± 1%  -94.48%  (p=0.016 n=5+4)
DictionaryDeferredDecoding/Get_value-12            50.2µs ± 9%    56.1µs ±29%     ~     (p=0.222 n=5+5)
DictionaryDeferredDecoding/Re-encode_decoded-12    14.0µs ±10%     1.8µs ± 7%  -87.20%  (p=0.008 n=5+5)

name                                             old alloc/op   new alloc/op   delta
DictionaryDeferredDecoding/Simply_decode-12        27.9kB ± 0%     0.5kB ± 0%  -98.19%  (p=0.008 n=5+5)
DictionaryDeferredDecoding/Get_value-12            27.9kB ± 0%    28.1kB ± 0%   +0.75%  (p=0.008 n=5+5)
DictionaryDeferredDecoding/Re-encode_decoded-12    6.47kB ± 0%    3.46kB ± 0%  -46.54%  (p=0.008 n=5+5)

name                                             old allocs/op  new allocs/op  delta
DictionaryDeferredDecoding/Simply_decode-12           622 ± 0%         6 ± 0%  -99.04%  (p=0.008 n=5+5)
DictionaryDeferredDecoding/Get_value-12               623 ± 0%       626 ± 0%   +0.48%  (p=0.008 n=5+5)
DictionaryDeferredDecoding/Re-encode_decoded-12      17.0 ± 0%      10.0 ± 0%  -41.18%  (p=0.008 n=5+5)
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
