### PR TITLE
Test contract member intialization

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -602,7 +602,7 @@ func (interpreter *Interpreter) Interpret() (err error) {
 	}
 
 	// recover internal panics and return them as an error
-	defer interpreter.recoverErrors(func(internalErr error) {
+	defer interpreter.RecoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
@@ -784,7 +784,7 @@ func (interpreter *Interpreter) prepareInvoke(
 func (interpreter *Interpreter) Invoke(functionName string, arguments ...Value) (value Value, err error) {
 
 	// recover internal panics and return them as an error
-	defer interpreter.recoverErrors(func(internalErr error) {
+	defer interpreter.RecoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
@@ -795,7 +795,7 @@ func (interpreter *Interpreter) Invoke(functionName string, arguments ...Value) 
 func (interpreter *Interpreter) InvokeFunction(function FunctionValue, invocation Invocation) (value Value, err error) {
 
 	// recover internal panics and return them as an error
-	defer interpreter.recoverErrors(func(internalErr error) {
+	defer interpreter.RecoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
@@ -806,7 +806,7 @@ func (interpreter *Interpreter) InvokeFunction(function FunctionValue, invocatio
 func (interpreter *Interpreter) InvokeTransaction(index int, arguments ...Value) (err error) {
 
 	// recover internal panics and return them as an error
-	defer interpreter.recoverErrors(func(internalErr error) {
+	defer interpreter.RecoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
@@ -814,7 +814,7 @@ func (interpreter *Interpreter) InvokeTransaction(index int, arguments ...Value)
 	return err
 }
 
-func (interpreter *Interpreter) recoverErrors(onError func(error)) {
+func (interpreter *Interpreter) RecoverErrors(onError func(error)) {
 	if r := recover(); r != nil {
 		var err error
 		switch r := r.(type) {

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -35,7 +35,7 @@ func (interpreter *Interpreter) InvokeFunctionValue(
 ) {
 
 	// recover internal panics and return them as an error
-	defer interpreter.recoverErrors(func(internalErr error) {
+	defer interpreter.RecoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -28,7 +28,7 @@ func (interpreter *Interpreter) evalStatement(statement ast.Statement) interface
 	// Recover and re-throw a panic, so that this interpreter's location and statement are used,
 	// instead of a potentially calling interpreter's location and statement
 
-	defer interpreter.recoverErrors(func(internalErr error) {
+	defer interpreter.RecoverErrors(func(internalErr error) {
 		panic(internalErr)
 	})
 

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -130,7 +130,7 @@ func testAccount(
 		return value
 	}
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
 			CheckerOptions: []sema.Option{
@@ -144,6 +144,7 @@ func testAccount(
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	return inter, storedValues
 }
@@ -1487,7 +1488,7 @@ func TestInterpretAccount_getCapability(t *testing.T) {
 	}
 }
 
-func TestCheckAccount_BalanceFields(t *testing.T) {
+func TestInterpretAccount_BalanceFields(t *testing.T) {
 	t.Parallel()
 
 	for accountType, auth := range map[string]bool{
@@ -1534,7 +1535,7 @@ func TestCheckAccount_BalanceFields(t *testing.T) {
 	}
 }
 
-func TestCheckAccount_StorageFields(t *testing.T) {
+func TestInterpretAccount_StorageFields(t *testing.T) {
 	t.Parallel()
 
 	for accountType, auth := range map[string]bool{

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
-func TestCompositeValue(t *testing.T) {
+func TestInterpretCompositeValue(t *testing.T) {
 
 	t.Parallel()
 
@@ -114,7 +114,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 
 	valueDeclarations = append(valueDeclarations, customStructValue)
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
 			CheckerOptions: []sema.Option{
@@ -125,6 +125,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	return inter
 }

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -376,7 +376,7 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 
 		t.Run(compositeKind.Keyword(), func(t *testing.T) {
 
-			inter := parseCheckAndInterpretWithOptions(t,
+			inter, err := parseCheckAndInterpretWithOptions(t,
 				fmt.Sprintf(
 					`
                       pub %[1]s interface Test {
@@ -414,8 +414,9 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 					},
 				},
 			)
+			require.NoError(t, err)
 
-			_, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(0))
+			_, err = inter.Invoke("callTest", interpreter.NewIntValueFromInt64(0))
 
 			var conditionErr interpreter.ConditionError
 			require.ErrorAs(t, err, &conditionErr)
@@ -580,7 +581,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
 
           pub struct interface Also {
@@ -623,6 +624,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	t.Run("-1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(-1))
@@ -752,7 +754,7 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
           pub contract interface CI {
 
@@ -797,6 +799,7 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	t.Run("1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
@@ -976,7 +979,7 @@ func TestInterpretIsInstanceCheckInPreCondition(t *testing.T) {
 
 	test := func(condition string) {
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			fmt.Sprintf(
 				`
                    contract interface CI {
@@ -1017,8 +1020,9 @@ func TestInterpretIsInstanceCheckInPreCondition(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("test1")
+		_, err = inter.Invoke("test1")
 		require.NoError(t, err)
 
 		_, err = inter.Invoke("test2")
@@ -1078,7 +1082,7 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 	semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
 	interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
           resource R {}
 
@@ -1129,9 +1133,11 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 			Options: []interpreter.Option{
 				interpreter.WithPredeclaredValues(interpreterValueDeclarations),
 			},
-		})
+		},
+	)
+	require.NoError(t, err)
 
-	_, err := inter.Invoke("test")
+	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 	require.True(t, checkCalled)
 }

--- a/runtime/tests/interpreter/contract_test.go
+++ b/runtime/tests/interpreter/contract_test.go
@@ -33,7 +33,7 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
 
 		t.Parallel()
 
-		_, _ = parseCheckAndInterpretWithOptions(t,
+		_, err := parseCheckAndInterpretWithOptions(t,
 			`
               contract C {
 
@@ -57,6 +57,7 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 	})
 
 	t.Run("constructor of nested type, first qualified ", func(t *testing.T) {

--- a/runtime/tests/interpreter/contract_test.go
+++ b/runtime/tests/interpreter/contract_test.go
@@ -1,0 +1,156 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("constructor of nested type, always qualified ", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, _ = parseCheckAndInterpretWithOptions(t,
+			`
+              contract C {
+
+                  struct S1 {
+
+                      init() {
+                          C.S2()
+                      }
+                  }
+
+                  struct S2 {}
+
+                  init() {
+                      C.S1()
+                  }
+              }
+	        `,
+			ParseCheckAndInterpretOptions{
+				Options: []interpreter.Option{
+					makeContractValueHandler(nil, nil, nil),
+				},
+			},
+		)
+	})
+
+	t.Run("constructor of nested type, first qualified ", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := parseCheckAndInterpretWithOptions(t,
+			`
+              contract C {
+
+                  struct S1 {
+
+                      init() {
+                          S2()
+                      }
+                  }
+
+                  struct S2 {}
+
+                  init() {
+                      C.S1()
+                  }
+              }
+	        `,
+			ParseCheckAndInterpretOptions{
+				Options: []interpreter.Option{
+					makeContractValueHandler(nil, nil, nil),
+				},
+			},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("constructor of nested type, second qualified ", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := parseCheckAndInterpretWithOptions(t,
+			`
+              contract C {
+
+                  struct S1 {
+
+                      init() {
+                          C.S2()
+                      }
+                  }
+
+                  struct S2 {}
+
+                  init() {
+                      S1()
+                  }
+              }
+	        `,
+			ParseCheckAndInterpretOptions{
+				Options: []interpreter.Option{
+					makeContractValueHandler(nil, nil, nil),
+				},
+			},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("field in nested initializer", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := parseCheckAndInterpretWithOptions(t,
+			`
+              contract C {
+
+                  struct S {
+
+                      init() {
+                          // use before initialization
+                          C.x
+                      }
+                  }
+
+                  let x: Int   
+
+                  init() {
+                      S()
+                      self.x = 1
+                  }
+              }
+	        `,
+			ParseCheckAndInterpretOptions{
+				Options: []interpreter.Option{
+					makeContractValueHandler(nil, nil, nil),
+				},
+			},
+		)
+		require.ErrorAs(t, err, &interpreter.MissingMemberValueError{})
+	})
+}

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -2134,7 +2134,6 @@ func testReferenceCastValid(t *testing.T, types, fromType, targetType string, op
 	)
 
 	value, err := inter.Invoke("test")
-
 	require.NoError(t, err)
 
 	switch operation {
@@ -3366,7 +3365,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 
 					t.Run(fmt.Sprintf("valid: from %s to %s", fromType, targetType), func(t *testing.T) {
 
-						inter := parseCheckAndInterpretWithOptions(t,
+						inter, err := parseCheckAndInterpretWithOptions(t,
 							fmt.Sprintf(
 								`
                                   struct S {}
@@ -3379,6 +3378,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 							),
 							options,
 						)
+						require.NoError(t, err)
 
 						assert.Equal(t,
 							capabilityValue,
@@ -3402,7 +3402,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 
 					t.Run(fmt.Sprintf("invalid: from %s to Capability<&%s>", fromType, otherType), func(t *testing.T) {
 
-						inter := parseCheckAndInterpretWithOptions(t,
+						inter, err := parseCheckAndInterpretWithOptions(t,
 							fmt.Sprintf(
 								`
                                   struct S {}
@@ -3418,6 +3418,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 							),
 							options,
 						)
+						require.NoError(t, err)
 
 						result, err := inter.Invoke("test")
 

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -180,7 +180,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
           contract C {
               enum E: UInt8 {
@@ -201,6 +201,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	c := inter.Globals["C"].GetValue()
 	require.IsType(t, &interpreter.CompositeValue{}, c)

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -52,7 +53,7 @@ func TestInterpretEquality(t *testing.T) {
 			Kind:  common.DeclarationKindConstant,
 		}
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               let maybeCapNonNil: Capability? = cap
               let maybeCapNil: Capability? = nil
@@ -72,6 +73,7 @@ func TestInterpretEquality(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t,
 			interpreter.BoolValue(true),

--- a/runtime/tests/interpreter/if_test.go
+++ b/runtime/tests/interpreter/if_test.go
@@ -33,7 +33,7 @@ func TestInterpretIfStatement(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
            pub fun testTrue(): Int {
                if true {
@@ -88,6 +88,7 @@ func TestInterpretIfStatement(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	for name, expected := range map[string]int64{
 		"testTrue":   2,

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -67,7 +67,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 		Type:            fooType,
 	})
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
 			Options: []interpreter.Option{
@@ -121,6 +121,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -122,7 +123,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
 		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               let result = Type<Int>() == unknownType
             `,
@@ -135,6 +136,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t,
 			interpreter.BoolValue(false),
@@ -168,7 +170,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
 		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               let result = unknownType1 == unknownType2
             `,
@@ -181,6 +183,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t,
 			interpreter.BoolValue(false),
@@ -243,7 +246,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
 		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               let identifier = unknownType.identifier
             `,
@@ -256,6 +259,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t,
 			interpreter.NewStringValue(""),
@@ -369,7 +373,7 @@ func TestInterpretIsInstance(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			inter := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
+			inter, err := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(semaValueDeclarations),
 				},
@@ -377,6 +381,7 @@ func TestInterpretIsInstance(t *testing.T) {
 					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
 				},
 			})
+			require.NoError(t, err)
 
 			assert.Equal(t,
 				interpreter.BoolValue(testCase.result),
@@ -517,7 +522,7 @@ func TestInterpretGetType(t *testing.T) {
 			valueDeclarations := standardLibraryFunctions.ToSemaValueDeclarations()
 			values := standardLibraryFunctions.ToInterpreterValueDeclarations()
 
-			inter := parseCheckAndInterpretWithOptions(t,
+			inter, err := parseCheckAndInterpretWithOptions(t,
 				testCase.code,
 				ParseCheckAndInterpretOptions{
 					CheckerOptions: []sema.Option{
@@ -547,6 +552,7 @@ func TestInterpretGetType(t *testing.T) {
 					},
 				},
 			)
+			require.NoError(t, err)
 
 			assert.Equal(t,
 				testCase.result,

--- a/runtime/tests/interpreter/nesting_test.go
+++ b/runtime/tests/interpreter/nesting_test.go
@@ -22,13 +22,14 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInterpretContractWithNestedDeclaration(t *testing.T) {
 
 	t.Parallel()
 
-	_ = parseCheckAndInterpretWithOptions(t,
+	_, err := parseCheckAndInterpretWithOptions(t,
 		`
 	      contract C {
 
@@ -45,4 +46,5 @@ func TestInterpretContractWithNestedDeclaration(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 }

--- a/runtime/tests/interpreter/switch_test.go
+++ b/runtime/tests/interpreter/switch_test.go
@@ -35,7 +35,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("Bool", func(t *testing.T) {
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               fun test(_ x: Bool): Int {
                   switch x {
@@ -57,6 +57,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
 			interpreter.BoolValue(true):  interpreter.NewIntValueFromInt64(1),
@@ -72,7 +73,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("Int", func(t *testing.T) {
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               fun test(_ x: Int): String {
                   switch x {
@@ -94,6 +95,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1): interpreter.NewStringValue("1"),
@@ -111,7 +113,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("break", func(t *testing.T) {
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               fun test(_ x: Int): String {
                   switch x {
@@ -134,6 +136,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1): interpreter.NewStringValue("4"),
@@ -190,7 +193,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("optional", func(t *testing.T) {
 
-		inter := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               fun test(_ x: Int?, _ y: Int?): String {
                   switch x {
@@ -212,6 +215,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		type testCase struct {
 			arguments []interpreter.Value

--- a/runtime/tests/interpreter/transfer_test.go
+++ b/runtime/tests/interpreter/transfer_test.go
@@ -58,7 +58,7 @@ func TestInterpretTransferCheck(t *testing.T) {
 		},
 	}
 
-	inter := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
           fun test() {
             let alsoFruit: Fruit = fruit
@@ -74,8 +74,9 @@ func TestInterpretTransferCheck(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
-	_, err := inter.Invoke("test")
+	_, err = inter.Invoke("test")
 	require.Error(t, err)
 
 	require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})


### PR DESCRIPTION
Closes #312

## Description

Accessing fields before they are initialized does not cause a crash anymore since #768.

Add additional tests for this particular use-case, accessing contract fields before they are initialized.

When adding the tests I realized that in tests, the initializer of a contract is not called.
This is due to an optimization we added a while ago to only lazily load a contract value.
As most tests rely on contract declarations and thus contract initializers being evaluated eagerly, I added this to the parseCheckAndInterpret helper function that is used by all interpreter tests.

______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
