### PR TITLE
Improve coverage calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
       run: make build
     - name: Test
       run: make test
-    - name: Check tidy
-      run: make check-tidy
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.txt
         flags: unittests
+    - name: Check tidy
+      run: make check-tidy
 
   lint:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,12 @@ GOPATH ?= $(HOME)/go
 # Ensure go bin path is in path (Especially for CI)
 PATH := $(PATH):$(GOPATH)/bin
 
+COVERPKGS := $(shell go list ./... | grep -v /cmd | grep -v /runtime/test | tr "\n" "," | sed 's/,*$$//')
+
 .PHONY: test
 test:
 	# test all packages
-	GO111MODULE=on go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race ./...
+	GO111MODULE=on go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race -coverpkg $(COVERPKGS) ./...
 	cd ./languageserver && make test
 
 .PHONY: build


### PR DESCRIPTION
## Description

The coverage calculations are off, because most of the tests for the checker and interpreter are in other packages.

Specify the cover packages explicitly. Ideally we would just specify `./...`, but then Go fails all tests because of:

```
go build github.com/onflow/cadence/runtime/tests/interpreter: no non-test Go files in runtime/tests/interpreter
go build github.com/onflow/cadence/runtime/tests/fuzz: no non-test Go files in untime/tests/fuzz
```
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
