### PR TITLE
Fix parsing of negative fractional fixed-point strings

### DIFF
--- a/fixedpoint/parse.go
+++ b/fixedpoint/parse.go
@@ -104,7 +104,7 @@ func parseFixedPoint(v string) (
 
 	scale = uint(len(fractionalStr))
 
-	negative = false
+	negative = len(v) > 0 && v[0] == '-'
 
 	integer, ok := new(big.Int).SetString(integerStr, 10)
 	if !ok {
@@ -127,7 +127,6 @@ func parseFixedPoint(v string) (
 	}
 
 	if integer.Sign() < 0 {
-		negative = true
 		unsignedInteger = integer.Neg(integer)
 	} else {
 		unsignedInteger = integer

--- a/fixedpoint/parse_test.go
+++ b/fixedpoint/parse_test.go
@@ -1,0 +1,59 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixedpoint
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFixedPoint(t *testing.T) {
+
+	t.Parallel()
+
+	type result struct {
+		negative        bool
+		unsignedInteger *big.Int
+		fractional      *big.Int
+		scale           uint
+		err             error
+	}
+
+	for input, expectedResult := range map[string]result{
+		"0.1":    {false, big.NewInt(0), big.NewInt(1), 1, nil},
+		"-0.1":   {true, big.NewInt(0), big.NewInt(1), 1, nil},
+		"1.0":    {false, big.NewInt(1), big.NewInt(0), 1, nil},
+		"01.0":   {false, big.NewInt(1), big.NewInt(0), 1, nil},
+		"-01.0":  {true, big.NewInt(1), big.NewInt(0), 1, nil},
+		"1.23":   {false, big.NewInt(1), big.NewInt(23), 2, nil},
+		"01.23":  {false, big.NewInt(1), big.NewInt(23), 2, nil},
+		"-01.23": {true, big.NewInt(1), big.NewInt(23), 2, nil},
+	} {
+		t.Run(input, func(t *testing.T) {
+			negative, unsignedInteger, fractional, parsedScale, err := parseFixedPoint(input)
+			assert.Equal(t, negative, expectedResult.negative)
+			assert.Equal(t, unsignedInteger, expectedResult.unsignedInteger)
+			assert.Equal(t, fractional, expectedResult.fractional)
+			assert.Equal(t, parsedScale, expectedResult.scale)
+			assert.Equal(t, err, expectedResult.err)
+		})
+	}
+}


### PR DESCRIPTION
Closes #934 

## Description

A bug in `parseFixedPoint` was causing the function to return positive values for strings like "-0.1" because it was only checking if the integer component is less than zero. This PR fixes the bug by ensuring the return value is negative if the string begins with '-'.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
