### PR TITLE
Add function docs formatting support

### DIFF
--- a/tools/docgen/gen/templates/composite-full-template
+++ b/tools/docgen/gen/templates/composite-full-template
@@ -17,7 +17,7 @@
 ```
 
 {{- if .DocString}}
-{{ .DocString -}}
+{{formatDoc .DocString -}}
 {{- end -}}
 
 {{- if hasConformance . -}}

--- a/tools/docgen/gen/templates/composite-template
+++ b/tools/docgen/gen/templates/composite-template
@@ -10,7 +10,7 @@
 ```
 
 {{- if .DocString}}
-{{ .DocString}}
+{{formatDoc .DocString}}
 {{- end}}
 
 [More...]({{fileName .}})

--- a/tools/docgen/gen/templates/enum-template
+++ b/tools/docgen/gen/templates/enum-template
@@ -15,6 +15,6 @@ enum {{.DeclarationIdentifier}}
 ```
 
 {{- if .DocString}}
-{{ .DocString}}
+{{formatDoc .DocString}}
 {{- end}}
 {{end}}

--- a/tools/docgen/gen/templates/function-template
+++ b/tools/docgen/gen/templates/function-template
@@ -13,6 +13,6 @@ func {{.DeclarationIdentifier}}(
 ```
 
 {{- if .DocString}}
-{{ .DocString}}
+{{formatFuncDoc .DocString}}
 {{- end}}
 {{end}}

--- a/tools/docgen/gen/templates/initializer-template
+++ b/tools/docgen/gen/templates/initializer-template
@@ -10,5 +10,5 @@ func {{.DeclarationIdentifier}}(
 {{- if $returnType}}: {{$returnType.Type.String}} {{end}}
 ```
 
-{{if .DocString}}{{.DocString}}{{end}}
+{{if .DocString}}{{formatDoc .DocString}}{{end}}
 {{end}}

--- a/tools/docgen/test/doc_gen_test.go
+++ b/tools/docgen/test/doc_gen_test.go
@@ -39,7 +39,7 @@ func TestDocGen(t *testing.T) {
 	// Don't run this as a test
 	t.Skip()
 
-	content, err := ioutil.ReadFile("samples/sample1.cdc")
+	content, err := ioutil.ReadFile(path.Join("samples", "sample2.cdc"))
 	require.NoError(t, err)
 
 	err = os.MkdirAll("outputs", os.ModePerm)
@@ -52,7 +52,7 @@ func TestDocGen(t *testing.T) {
 }
 
 func TestDocGenForMultiDeclarationFile(t *testing.T) {
-	content, err := ioutil.ReadFile("samples/sample1.cdc")
+	content, err := ioutil.ReadFile(path.Join("samples", "sample1.cdc"))
 	require.NoError(t, err)
 
 	docGen := gen.NewDocGenerator()
@@ -71,7 +71,7 @@ func TestDocGenForMultiDeclarationFile(t *testing.T) {
 
 func TestDocGenForSingleContractFile(t *testing.T) {
 
-	content, err := ioutil.ReadFile("samples/sample2.cdc")
+	content, err := ioutil.ReadFile(path.Join("samples", "sample2.cdc"))
 	require.NoError(t, err)
 
 	docGen := gen.NewDocGenerator()
@@ -116,4 +116,20 @@ func TestDocGenErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.IsType(t, err, &os.PathError{})
 	})
+}
+
+func TestFunctionDocFormatting(t *testing.T) {
+
+	content, err := ioutil.ReadFile(path.Join("samples", "sample3.cdc"))
+	require.NoError(t, err)
+
+	docGen := gen.NewDocGenerator()
+
+	docFiles, err := docGen.GenerateInMemory(string(content))
+	require.NoError(t, err)
+	require.Len(t, docFiles, 1)
+
+	expectedContent, err := ioutil.ReadFile(path.Join("outputs", "sample3_output.md"))
+
+	assert.Equal(t, string(expectedContent), string(docFiles["index.md"]))
 }

--- a/tools/docgen/test/outputs/Color.md
+++ b/tools/docgen/test/outputs/Color.md
@@ -4,4 +4,4 @@
 enum Color: Int8 {
 }
 ```
- This is an Enum, with explicit type conformance.
+This is an Enum, with explicit type conformance.

--- a/tools/docgen/test/outputs/Direction.md
+++ b/tools/docgen/test/outputs/Direction.md
@@ -4,4 +4,4 @@
 enum Direction {
 }
 ```
- This is an Enum without type conformance.
+This is an Enum without type conformance.

--- a/tools/docgen/test/outputs/NFT.md
+++ b/tools/docgen/test/outputs/NFT.md
@@ -8,8 +8,7 @@ contract NFT
     field2:  String
 }
 ```
- NFT is a dummy non-fungible token contract.
-
+NFT is a dummy non-fungible token contract.
 Implemented Interfaces:
  - `Token`
 
@@ -20,8 +19,8 @@ Implemented Interfaces:
 ```cadence
 func foo(a Int, b String):  
 ```
- This is a foo function,
- This doesn't have a return type.
+This is a foo function,
+This doesn't have a return type.
 
 ---
 
@@ -30,10 +29,13 @@ func foo(a Int, b String):
 ```cadence
 func bar(name String, bytes [Int8]): bool 
 ```
- This is a bar function, with a return type
- @param name: The name. Must be a string
- @param bytes: Content
- @returns Validity
+This is a bar function, with a return type
+
+Parameters:
+  - name : _The name. Must be a string_
+  - bytes : _Content to be validated_
+
+Returns: Validity of the content
 
 ---
 
@@ -56,9 +58,9 @@ struct SomeStruct {
     y:  {Int: AnyStruct}
 }
 ```
- This is some struct. It has
- @field x: a string field
- @field y: a map of int and any-struct
+This is some struct. It has
+@field x: a string field
+@field y: a map of int and any-struct
 
 [More...](NFT_SomeStruct.md)
 
@@ -72,7 +74,7 @@ enum Direction {
     case RIGHT
 }
 ```
- This is an Enum without type conformance.
+This is an Enum without type conformance.
 
 ---
 ### enum `Color`
@@ -83,6 +85,6 @@ enum Color: Int8 {
     case Blue
 }
 ```
- This is an Enum, with explicit type conformance.
+This is an Enum, with explicit type conformance.
 
 ---

--- a/tools/docgen/test/outputs/NFT_Color.md
+++ b/tools/docgen/test/outputs/NFT_Color.md
@@ -4,4 +4,4 @@
 enum Color: Int8 {
 }
 ```
- This is an Enum, with explicit type conformance.
+This is an Enum, with explicit type conformance.

--- a/tools/docgen/test/outputs/NFT_Direction.md
+++ b/tools/docgen/test/outputs/NFT_Direction.md
@@ -4,4 +4,4 @@
 enum Direction {
 }
 ```
- This is an Enum without type conformance.
+This is an Enum without type conformance.

--- a/tools/docgen/test/outputs/NFT_SomeStruct.md
+++ b/tools/docgen/test/outputs/NFT_SomeStruct.md
@@ -8,9 +8,9 @@ struct SomeStruct
     y:  {Int: AnyStruct}
 }
 ```
- This is some struct. It has
- @field x: a string field
- @field y: a map of int and any-struct
+This is some struct. It has
+@field x: a string field
+@field y: a map of int and any-struct
 
 ### Initializer
 
@@ -31,7 +31,7 @@ struct InnerStruct {
     b:  String
 }
 ```
- This is a nested struct.
+This is a nested struct.
 
 [More...](NFT_SomeStruct_InnerStruct.md)
 

--- a/tools/docgen/test/outputs/NFT_SomeStruct_InnerStruct.md
+++ b/tools/docgen/test/outputs/NFT_SomeStruct_InnerStruct.md
@@ -8,4 +8,4 @@ struct InnerStruct
     b:  String
 }
 ```
- This is a nested struct.
+This is a nested struct.

--- a/tools/docgen/test/outputs/SomeStruct.md
+++ b/tools/docgen/test/outputs/SomeStruct.md
@@ -8,9 +8,9 @@ struct SomeStruct
     y:  {Int: AnyStruct}
 }
 ```
- This is some struct. It has
- @field x: a string field
- @field y: a map of int and any-struct
+This is some struct. It has
+@field x: a string field
+@field y: a map of int and any-struct
 Implemented Interfaces:
  - `SomeInterface`
 
@@ -34,7 +34,7 @@ struct InnerStruct {
     b:  String
 }
 ```
- This is a nested struct.
+This is a nested struct.
 
 [More...](SomeStruct_InnerStruct.md)
 

--- a/tools/docgen/test/outputs/SomeStruct_InnerStruct.md
+++ b/tools/docgen/test/outputs/SomeStruct_InnerStruct.md
@@ -8,4 +8,4 @@ struct InnerStruct
     b:  String
 }
 ```
- This is a nested struct.
+This is a nested struct.

--- a/tools/docgen/test/outputs/index.md
+++ b/tools/docgen/test/outputs/index.md
@@ -12,10 +12,13 @@ func foo(a Int, b String):
 ```cadence
 func bar(name String, bytes [Int8]): bool 
 ```
- This is a bar function, with a return type
- @param name: The name. Must be a string
- @param bytes: Content
- @returns Validity
+This is a bar function, with a return type
+
+Parameters:
+  - name : _The name. Must be a string_
+  - bytes : _Content to be validated_
+
+Returns: Validity of the content
 
 ---
 
@@ -37,9 +40,9 @@ struct SomeStruct {
     y:  {Int: AnyStruct}
 }
 ```
- This is some struct. It has
- @field x: a string field
- @field y: a map of int and any-struct
+This is some struct. It has
+@field x: a string field
+@field y: a map of int and any-struct
 
 [More...](SomeStruct.md)
 
@@ -53,7 +56,7 @@ enum Direction {
     case RIGHT
 }
 ```
- This is an Enum without type conformance.
+This is an Enum without type conformance.
 
 ---
 ### enum `Color`
@@ -64,6 +67,6 @@ enum Color: Int8 {
     case Blue
 }
 ```
- This is an Enum, with explicit type conformance.
+This is an Enum, with explicit type conformance.
 
 ---

--- a/tools/docgen/test/outputs/sample3_output.md
+++ b/tools/docgen/test/outputs/sample3_output.md
@@ -1,0 +1,58 @@
+
+### fun `func_1()`
+
+```cadence
+func func_1(name String, bytes [Int8]): bool 
+```
+This is a function, with too many spaces in docs.
+
+Parameters:
+  - name : _The name. Must be a string_
+  - bytes : _Content to be validated_
+
+Returns: Validity of the content
+
+---
+
+### fun `func_2()`
+
+```cadence
+func func_2(name String, bytes [Int8]): bool 
+```
+This function doc contains mixed params and doc lines.
+
+Some doc line in the middle of parameters.
+
+Another doc line at the end.
+
+Parameters:
+  - name : _The name. Must be a string_
+  - bytes : _Content to be validated_
+
+Returns: Validity of the content
+
+---
+
+### fun `func_3()`
+
+```cadence
+func func_3():  
+```
+param1's name is missing.
+@param : The param1. Must be a string
+
+param2's colon is missing.
+@param param2 Content to be validated
+
+param3's description is missing
+
+param4's description is missing including colon
+@param param4
+
+param5's everything is missing
+@param
+
+Parameters:
+  - param3
+
+---

--- a/tools/docgen/test/samples/sample1.cdc
+++ b/tools/docgen/test/samples/sample1.cdc
@@ -14,8 +14,8 @@ fun foo(a: Int, b: String) {
 
 /// This is a bar function, with a return type
 /// @param name: The name. Must be a string
-/// @param bytes: Content
-/// @returns Validity
+/// @param bytes: Content to be validated
+/// @return Validity of the content
 fun bar(name: String, bytes: [Int8]): bool {
 }
 

--- a/tools/docgen/test/samples/sample2.cdc
+++ b/tools/docgen/test/samples/sample2.cdc
@@ -17,8 +17,8 @@ pub contract NFT: Token {
 
     /// This is a bar function, with a return type
     /// @param name: The name. Must be a string
-    /// @param bytes: Content
-    /// @returns Validity
+    /// @param bytes: Content to be validated
+    /// @return Validity of the content
     fun bar(name: String, bytes: [Int8]): bool {
     }
 

--- a/tools/docgen/test/samples/sample3.cdc
+++ b/tools/docgen/test/samples/sample3.cdc
@@ -1,0 +1,51 @@
+///
+///      This is a function, with too many spaces in docs.
+///
+///
+///@param name: The name. Must be a string
+///
+///
+///
+///        @param bytes: Content to be validated
+///
+///         @return Validity of the content
+///
+///
+fun func_1(name: String, bytes: [Int8]): bool {
+}
+
+
+///
+/// This function doc contains mixed params and doc lines.
+///
+/// @param name: The name. Must be a string
+///
+/// Some doc line in the middle of parameters.
+///
+/// @param bytes: Content to be validated
+///
+/// @return Validity of the content
+///
+/// Another doc line at the end.
+///
+fun func_2(name: String, bytes: [Int8]): bool {
+}
+
+///
+/// param1's name is missing.
+/// @param : The param1. Must be a string
+///
+/// param2's colon is missing.
+/// @param param2 Content to be validated
+///
+/// param3's description is missing
+/// @param param3 :
+///
+/// param4's description is missing including colon
+/// @param param4
+///
+/// param5's everything is missing
+/// @param
+///
+fun func_3() {
+}


### PR DESCRIPTION
Work towards #339

## Description

Add function documentation formatting support.
- Extracting param and return type info
  - Parameters must follow the format: `@param paramName: Param description
  - Return type must follow the format: `@return The return type description`
  - Tagging using `@` follows the same approach as [solidity](https://docs.soliditylang.org/en/develop/natspec-format.html#tags), [kotlin](https://kotlinlang.org/docs/kotlin-doc.html#param-name) and [java](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#tag)
- Removes leading and trailing whitespaces.
- Preserves at most one blank line in the middle of docs in the generated md file.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
