### PR TITLE
Add an AST walking function

### DIFF
--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -31,6 +31,10 @@ func (b *Block) Accept(visitor Visitor) Repr {
 	return visitor.VisitBlock(b)
 }
 
+func (b *Block) Walk(walkChild func(Element)) {
+	walkStatements(walkChild, b.Statements)
+}
+
 func (b *Block) MarshalJSON() ([]byte, error) {
 	type Alias Block
 	return json.Marshal(&struct {
@@ -52,6 +56,12 @@ type FunctionBlock struct {
 
 func (b *FunctionBlock) Accept(visitor Visitor) Repr {
 	return visitor.VisitFunctionBlock(b)
+}
+
+func (b *FunctionBlock) Walk(walkChild func(Element)) {
+	// TODO: pre-conditions
+	walkChild(b.Block)
+	// TODO: post-conditions
 }
 
 func (b *FunctionBlock) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/composite.go
+++ b/runtime/ast/composite.go
@@ -42,6 +42,10 @@ func (d *CompositeDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitCompositeDeclaration(d)
 }
 
+func (d *CompositeDeclaration) Walk(walkChild func(Element)) {
+	walkDeclarations(walkChild, d.Members.declarations)
+}
+
 func (*CompositeDeclaration) isDeclaration() {}
 
 // NOTE: statement, so it can be represented in the AST,
@@ -91,6 +95,11 @@ func (d *FieldDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitFieldDeclaration(d)
 }
 
+func (d *FieldDeclaration) Walk(_ func(Element)) {
+	// NO-OP
+	// TODO: walk type
+}
+
 func (*FieldDeclaration) isDeclaration() {}
 
 func (d *FieldDeclaration) DeclarationIdentifier() *Identifier {
@@ -131,6 +140,10 @@ type EnumCaseDeclaration struct {
 
 func (d *EnumCaseDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitEnumCaseDeclaration(d)
+}
+
+func (*EnumCaseDeclaration) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 func (*EnumCaseDeclaration) isDeclaration() {}

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -51,6 +51,10 @@ func (e *BoolExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (*BoolExpression) Walk(_ func(Element)) {
+	// NO-OP
+}
+
 func (e *BoolExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitBoolExpression(e)
 }
@@ -85,6 +89,10 @@ func (*NilExpression) isIfStatementTest() {}
 
 func (e *NilExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (*NilExpression) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 func (e *NilExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -131,6 +139,10 @@ func (e *StringExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (*StringExpression) Walk(_ func(Element)) {
+	// NO-OP
+}
+
 func (e *StringExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitStringExpression(e)
 }
@@ -164,6 +176,10 @@ func (*IntegerExpression) isIfStatementTest() {}
 
 func (e *IntegerExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (*IntegerExpression) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 func (e *IntegerExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -203,6 +219,10 @@ func (*FixedPointExpression) isIfStatementTest() {}
 
 func (e *FixedPointExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (*FixedPointExpression) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 func (e *FixedPointExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -254,6 +274,10 @@ func (e *ArrayExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *ArrayExpression) Walk(walkChild func(Element)) {
+	walkExpressions(walkChild, e.Values)
+}
+
 func (e *ArrayExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitArrayExpression(e)
 }
@@ -295,6 +319,13 @@ func (*DictionaryExpression) isIfStatementTest() {}
 
 func (e *DictionaryExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (e *DictionaryExpression) Walk(walkChild func(Element)) {
+	for _, entry := range e.Entries {
+		walkChild(entry.Key)
+		walkChild(entry.Value)
+	}
 }
 
 func (e *DictionaryExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -355,6 +386,10 @@ func (*IdentifierExpression) isIfStatementTest() {}
 
 func (e *IdentifierExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (*IdentifierExpression) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 func (e *IdentifierExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -418,6 +453,13 @@ func (*InvocationExpression) isIfStatementTest() {}
 
 func (e *InvocationExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (e *InvocationExpression) Walk(walkChild func(Element)) {
+	walkChild(e.InvokedExpression)
+	for _, argument := range e.Arguments {
+		walkChild(argument.Expression)
+	}
 }
 
 func (e *InvocationExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -495,6 +537,10 @@ func (e *MemberExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *MemberExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Expression)
+}
+
 func (e *MemberExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitMemberExpression(e)
 }
@@ -557,6 +603,11 @@ func (e *IndexExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *IndexExpression) Walk(walkChild func(Element)) {
+	walkChild(e.TargetExpression)
+	walkChild(e.IndexingExpression)
+}
+
 func (e *IndexExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitIndexExpression(e)
 }
@@ -592,6 +643,14 @@ func (*ConditionalExpression) isIfStatementTest() {}
 
 func (e *ConditionalExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (e *ConditionalExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Test)
+	walkChild(e.Then)
+	if e.Else != nil {
+		walkChild(e.Else)
+	}
 }
 
 func (e *ConditionalExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -641,6 +700,10 @@ func (e *UnaryExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *UnaryExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Expression)
+}
+
 func (e *UnaryExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitUnaryExpression(e)
 }
@@ -687,6 +750,11 @@ func (*BinaryExpression) isIfStatementTest() {}
 
 func (e *BinaryExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (e *BinaryExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Left)
+	walkChild(e.Right)
 }
 
 func (e *BinaryExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -738,6 +806,12 @@ func (e *FunctionExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *FunctionExpression) Walk(walkChild func(Element)) {
+	// TODO: walk parameters
+	// TODO: walk return type
+	walkChild(e.FunctionBlock)
+}
+
 func (e *FunctionExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitFunctionExpression(e)
 }
@@ -783,6 +857,10 @@ func (*CastingExpression) isIfStatementTest() {}
 
 func (e *CastingExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+func (e *CastingExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Expression)
+	// TODO: also walk type
 }
 
 func (e *CastingExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -832,6 +910,10 @@ func (e *CreateExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *CreateExpression) Walk(walkChild func(Element)) {
+	walkChild(e.InvocationExpression)
+}
+
 func (e *CreateExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitCreateExpression(e)
 }
@@ -877,6 +959,10 @@ func (*DestroyExpression) isIfStatementTest() {}
 
 func (e *DestroyExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (e *DestroyExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Expression)
 }
 
 func (e *DestroyExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -927,6 +1013,11 @@ func (e *ReferenceExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *ReferenceExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Expression)
+	// TODO: walk type
+}
+
 func (e *ReferenceExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitReferenceExpression(e)
 }
@@ -975,6 +1066,10 @@ func (e *ForceExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
 }
 
+func (e *ForceExpression) Walk(walkChild func(Element)) {
+	walkChild(e.Expression)
+}
+
 func (e *ForceExpression) AcceptExp(visitor ExpressionVisitor) Repr {
 	return visitor.VisitForceExpression(e)
 }
@@ -1018,6 +1113,10 @@ func (*PathExpression) isIfStatementTest() {}
 
 func (e *PathExpression) Accept(visitor Visitor) Repr {
 	return e.AcceptExp(visitor)
+}
+
+func (*PathExpression) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 func (e *PathExpression) AcceptExp(visitor ExpressionVisitor) Repr {

--- a/runtime/ast/function_declaration.go
+++ b/runtime/ast/function_declaration.go
@@ -52,6 +52,12 @@ func (d *FunctionDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitFunctionDeclaration(d)
 }
 
+func (d *FunctionDeclaration) Walk(walkChild func(Element)) {
+	// TODO: walk parameters
+	// TODO: walk return type
+	walkChild(d.FunctionBlock)
+}
+
 func (*FunctionDeclaration) isDeclaration() {}
 func (*FunctionDeclaration) isStatement()   {}
 
@@ -110,6 +116,10 @@ func (d *SpecialFunctionDeclaration) EndPosition() Position {
 
 func (d *SpecialFunctionDeclaration) Accept(visitor Visitor) Repr {
 	return d.FunctionDeclaration.Accept(visitor)
+}
+
+func (d *SpecialFunctionDeclaration) Walk(walkChild func(Element)) {
+	d.FunctionDeclaration.Walk(walkChild)
 }
 
 func (*SpecialFunctionDeclaration) isDeclaration() {}

--- a/runtime/ast/import.go
+++ b/runtime/ast/import.go
@@ -41,6 +41,10 @@ func (d *ImportDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitImportDeclaration(d)
 }
 
+func (*ImportDeclaration) Walk(_ func(Element)) {
+	// NO-OP
+}
+
 func (d *ImportDeclaration) DeclarationIdentifier() *Identifier {
 	return nil
 }

--- a/runtime/ast/inspect.go
+++ b/runtime/ast/inspect.go
@@ -1,0 +1,33 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+type inspector func(Element) bool
+
+func (f inspector) Walk(element Element) Walker {
+	if f(element) {
+		return f
+	}
+
+	return nil
+}
+
+func Inspect(element Element, f func(Element) bool) {
+	Walk(inspector(f), element)
+}

--- a/runtime/ast/interface.go
+++ b/runtime/ast/interface.go
@@ -39,6 +39,10 @@ func (d *InterfaceDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitInterfaceDeclaration(d)
 }
 
+func (d *InterfaceDeclaration) Walk(walkChild func(Element)) {
+	walkDeclarations(walkChild, d.Members.declarations)
+}
+
 func (*InterfaceDeclaration) isDeclaration() {}
 
 // NOTE: statement, so it can be represented in the AST,

--- a/runtime/ast/pragma.go
+++ b/runtime/ast/pragma.go
@@ -39,6 +39,10 @@ func (d *PragmaDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitPragmaDeclaration(d)
 }
 
+func (d *PragmaDeclaration) Walk(walkChild func(Element)) {
+	walkChild(d.Expression)
+}
+
 func (d *PragmaDeclaration) DeclarationIdentifier() *Identifier {
 	return nil
 }

--- a/runtime/ast/program.go
+++ b/runtime/ast/program.go
@@ -61,6 +61,10 @@ func (p *Program) Accept(visitor Visitor) Repr {
 	return visitor.VisitProgram(p)
 }
 
+func (d *Program) Walk(walkChild func(Element)) {
+	walkDeclarations(walkChild, d.declarations)
+}
+
 func (p *Program) PragmaDeclarations() []*PragmaDeclaration {
 	return p.indices.pragmaDeclarations(p.declarations)
 }

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -40,6 +40,10 @@ func (s *ReturnStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitReturnStatement(s)
 }
 
+func (s *ReturnStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Expression)
+}
+
 func (s *ReturnStatement) MarshalJSON() ([]byte, error) {
 	type Alias ReturnStatement
 	return json.Marshal(&struct {
@@ -61,6 +65,10 @@ func (*BreakStatement) isStatement() {}
 
 func (s *BreakStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitBreakStatement(s)
+}
+
+func (*BreakStatement) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 func (s *BreakStatement) MarshalJSON() ([]byte, error) {
@@ -86,6 +94,10 @@ func (s *ContinueStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitContinueStatement(s)
 }
 
+func (*ContinueStatement) Walk(_ func(Element)) {
+	// NO-OP
+}
+
 func (s *ContinueStatement) MarshalJSON() ([]byte, error) {
 	type Alias ContinueStatement
 	return json.Marshal(&struct {
@@ -100,6 +112,7 @@ func (s *ContinueStatement) MarshalJSON() ([]byte, error) {
 // IfStatementTest
 
 type IfStatementTest interface {
+	Element
 	isIfStatementTest()
 }
 
@@ -129,6 +142,14 @@ func (s *IfStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitIfStatement(s)
 }
 
+func (s *IfStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Test)
+	walkChild(s.Then)
+	if s.Else != nil {
+		walkChild(s.Else)
+	}
+}
+
 func (s *IfStatement) MarshalJSON() ([]byte, error) {
 	type Alias IfStatement
 	return json.Marshal(&struct {
@@ -154,6 +175,11 @@ func (*WhileStatement) isStatement() {}
 
 func (s *WhileStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitWhileStatement(s)
+}
+
+func (s *WhileStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Test)
+	walkChild(s.Block)
 }
 
 func (s *WhileStatement) StartPosition() Position {
@@ -190,6 +216,11 @@ func (*ForStatement) isStatement() {}
 
 func (s *ForStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitForStatement(s)
+}
+
+func (s *ForStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Value)
+	walkChild(s.Block)
 }
 
 func (s *ForStatement) StartPosition() Position {
@@ -234,6 +265,10 @@ func (s *EmitStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitEmitStatement(s)
 }
 
+func (s *EmitStatement) Walk(walkChild func(Element)) {
+	walkChild(s.InvocationExpression)
+}
+
 func (s *EmitStatement) MarshalJSON() ([]byte, error) {
 	type Alias EmitStatement
 	return json.Marshal(&struct {
@@ -267,6 +302,11 @@ func (*AssignmentStatement) isStatement() {}
 
 func (s *AssignmentStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitAssignmentStatement(s)
+}
+
+func (s *AssignmentStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Target)
+	walkChild(s.Value)
 }
 
 func (s *AssignmentStatement) MarshalJSON() ([]byte, error) {
@@ -303,6 +343,11 @@ func (s *SwapStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitSwapStatement(s)
 }
 
+func (s *SwapStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Left)
+	walkChild(s.Right)
+}
+
 func (s *SwapStatement) MarshalJSON() ([]byte, error) {
 	type Alias SwapStatement
 	return json.Marshal(&struct {
@@ -336,6 +381,10 @@ func (s *ExpressionStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitExpressionStatement(s)
 }
 
+func (s *ExpressionStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Expression)
+}
+
 func (s *ExpressionStatement) MarshalJSON() ([]byte, error) {
 	type Alias ExpressionStatement
 	return json.Marshal(&struct {
@@ -361,6 +410,14 @@ func (*SwitchStatement) isStatement() {}
 
 func (s *SwitchStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitSwitchStatement(s)
+}
+
+func (s *SwitchStatement) Walk(walkChild func(Element)) {
+	walkChild(s.Expression)
+	for _, switchCase := range s.Cases {
+		walkChild(switchCase.Expression)
+		walkStatements(walkChild, switchCase.Statements)
+	}
 }
 
 func (s *SwitchStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/transaction_declaration.go
+++ b/runtime/ast/transaction_declaration.go
@@ -29,14 +29,24 @@ type TransactionDeclaration struct {
 	Fields         []*FieldDeclaration
 	Prepare        *SpecialFunctionDeclaration
 	PreConditions  *Conditions
-	PostConditions *Conditions
 	Execute        *SpecialFunctionDeclaration
+	PostConditions *Conditions
 	DocString      string
 	Range
 }
 
 func (d *TransactionDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitTransactionDeclaration(d)
+}
+
+func (d *TransactionDeclaration) Walk(walkChild func(Element)) {
+	// TODO: walk parameters
+	for _, declaration := range d.Fields {
+		walkChild(declaration)
+	}
+	walkChild(d.Prepare)
+	walkChild(d.Execute)
+	// TODO: walk post-conditions
 }
 
 func (*TransactionDeclaration) isDeclaration() {}

--- a/runtime/ast/variable_declaration.go
+++ b/runtime/ast/variable_declaration.go
@@ -59,6 +59,14 @@ func (d *VariableDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitVariableDeclaration(d)
 }
 
+func (d *VariableDeclaration) Walk(walkChild func(Element)) {
+	// TODO: walk type
+	walkChild(d.Value)
+	if d.SecondValue != nil {
+		walkChild(d.SecondValue)
+	}
+}
+
 func (d *VariableDeclaration) DeclarationIdentifier() *Identifier {
 	return &d.Identifier
 }

--- a/runtime/ast/visitor.go
+++ b/runtime/ast/visitor.go
@@ -23,6 +23,7 @@ type Repr interface{}
 type Element interface {
 	HasPosition
 	Accept(Visitor) Repr
+	Walk(walkChild func(Element))
 }
 
 type NotAnElement struct{}
@@ -38,6 +39,10 @@ func (NotAnElement) StartPosition() Position {
 
 func (NotAnElement) EndPosition() Position {
 	return Position{}
+}
+
+func (NotAnElement) Walk(_ func(Element)) {
+	// NO-OP
 }
 
 type StatementVisitor interface {

--- a/runtime/ast/walk.go
+++ b/runtime/ast/walk.go
@@ -31,6 +31,8 @@ type Walker interface {
 // for each of the non-nil children of the element,
 // followed by a call of Walk(nil) on the returned walker.
 //
+// The initial walker may not be nil.
+//
 func Walk(walker Walker, element Element) {
 	if walker = walker.Walk(element); walker == nil {
 		return

--- a/runtime/ast/walk.go
+++ b/runtime/ast/walk.go
@@ -1,0 +1,62 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+type Walker interface {
+	Walk(element Element) Walker
+}
+
+// Walk traverses an AST in depth-first order:
+// It starts by calling walker.Walk(element);
+// If the returned walker is nil,
+// child elements are not walked.
+// If the returned walker is not-nil,
+// then Walk is invoked recursively on this returned walker
+// for each of the non-nil children of the element,
+// followed by a call of Walk(nil) on the returned walker.
+//
+func Walk(walker Walker, element Element) {
+	if walker = walker.Walk(element); walker == nil {
+		return
+	}
+
+	element.Walk(func(child Element) {
+		Walk(walker, child)
+	})
+
+	walker.Walk(nil)
+}
+
+func walkExpressions(walkChild func(Element), expressions []Expression) {
+	for _, expression := range expressions {
+		walkChild(expression)
+	}
+}
+
+func walkStatements(walkChild func(Element), statements []Statement) {
+	for _, statement := range statements {
+		walkChild(statement)
+	}
+}
+
+func walkDeclarations(walkChild func(Element), declarations []Declaration) {
+	for _, declaration := range declarations {
+		walkChild(declaration)
+	}
+}


### PR DESCRIPTION
## Description

Add a function to walk the AST, similar to Go's function: https://golang.org/src/go/ast/walk.go

The implementation of Walk for the AST elements currently only visits child elements. A future version could also visit more information, such as identifiers, types, etc.

The current implementation is enough to determine the parent element of each element.

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
