### PR TITLE
[Optimization] Re-use converter functions across interpreters

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -455,7 +455,14 @@ func NewInterpreter(program *Program, location common.Location, options ...Optio
 
 	interpreter.defineBaseFunctions()
 
-	for _, option := range append(defaultOptions, options...) {
+	for _, option := range defaultOptions {
+		err := option(interpreter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, option := range options {
 		err := option(interpreter)
 		if err != nil {
 			return nil, err
@@ -2415,8 +2422,18 @@ func (interpreter *Interpreter) defineBaseFunctions() {
 	interpreter.defineTypeFunction()
 }
 
-func (interpreter *Interpreter) defineConverterFunctions() {
-	for _, declaration := range converterDeclarations {
+type converterFunction struct {
+	name      string
+	converter HostFunctionValue
+}
+
+// Converter functions are stateless functions. Hence they can be re-used across interpreters.
+//
+var converterFunctionValues = func() []converterFunction {
+
+	converterFuncValues := make([]converterFunction, len(converterDeclarations))
+
+	for index, declaration := range converterDeclarations {
 		// NOTE: declare in loop, as captured in closure below
 		convert := declaration.convert
 		converterFunctionValue := NewHostFunctionValue(
@@ -2440,7 +2457,18 @@ func (interpreter *Interpreter) defineConverterFunctions() {
 			addMember(sema.NumberTypeMaxFieldName, declaration.max)
 		}
 
-		err := interpreter.ImportValue(declaration.name, converterFunctionValue)
+		converterFuncValues[index] = converterFunction{
+			name:      declaration.name,
+			converter: converterFunctionValue,
+		}
+	}
+
+	return converterFuncValues
+}()
+
+func (interpreter *Interpreter) defineConverterFunctions() {
+	for _, converterFunc := range converterFunctionValues {
+		err := interpreter.ImportValue(converterFunc.name, converterFunc.converter)
 		if err != nil {
 			panic(errors.NewUnreachableError())
 		}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -8247,3 +8247,30 @@ func TestInterpretMissingMember(t *testing.T) {
 
 	require.Equal(t, "y", missingMemberError.Name)
 }
+
+func BenchmarkNewInterpreter(b *testing.B) {
+
+	b.Run("new interpreter", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			_, err := interpreter.NewInterpreter(nil, nil)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("new sub-interpreter", func(b *testing.B) {
+		b.ReportAllocs()
+
+		inter, err := interpreter.NewInterpreter(nil, nil)
+		require.NoError(b, err)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := inter.NewSubInterpreter(nil, nil)
+			require.NoError(b, err)
+		}
+	})
+}


### PR DESCRIPTION
## Description

Creating new interpreters/sub-interpreters can be optimized by reusing the converter functions across interpreters.

I assumed it is safe to re-use them since: 
- They are stateless functions
- Nested variables are read-only

### Performance

```
name                                   old time/op    new time/op    delta
NewInterpreter/new_interpreter-12        20.6µs ±16%     7.7µs ±16%  -62.84%  (p=0.008 n=5+5)
NewInterpreter/new_sub-interpreter-12    20.8µs ±23%     7.7µs ±12%  -62.88%  (p=0.008 n=5+5)

name                                   old alloc/op   new alloc/op   delta
NewInterpreter/new_interpreter-12        15.9kB ± 0%     5.3kB ± 0%  -66.62%  (p=0.008 n=5+5)
NewInterpreter/new_sub-interpreter-12    16.3kB ± 0%     5.6kB ± 0%  -65.71%  (p=0.008 n=5+5)

name                                   old allocs/op  new allocs/op  delta
NewInterpreter/new_interpreter-12           274 ± 0%        66 ± 0%  -75.91%  (p=0.008 n=5+5)
NewInterpreter/new_sub-interpreter-12       292 ± 0%        83 ± 0%  -71.58%  (p=0.008 n=5+5)

```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
