### PR TITLE
Optimize qualified identifier creation

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -79,16 +79,7 @@ func containerTypeNames(typ Type, level int) (typeNames []string, bufSize int) {
 		typeName = typedContainerType.Identifier
 		containerType = typedContainerType.ContainerType
 	default:
-		switch typ {
-		case PublicAccountType:
-			typeName = string(typedContainerType.ID())
-			containerType = nil
-		case AuthAccountType:
-			typeName = string(typedContainerType.ID())
-			containerType = nil
-		default:
-			panic(errors.NewUnreachableError())
-		}
+		panic(errors.NewUnreachableError())
 	}
 
 	typeNames, bufSize = containerTypeNames(containerType, level+1)

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -529,3 +529,71 @@ func TestBeforeType_Strings(t *testing.T) {
 		beforeType.QualifiedString(),
 	)
 }
+
+func TestQualifiedIdentifierCreation(t *testing.T) {
+
+	a := &CompositeType{
+		Kind:       common.CompositeKindStructure,
+		Identifier: "A",
+		Location:   common.StringLocation("a"),
+		Fields:     []string{},
+		Members:    NewStringMemberOrderedMap(),
+	}
+
+	b := &CompositeType{
+		Kind:          common.CompositeKindStructure,
+		Identifier:    "B",
+		Location:      common.StringLocation("a"),
+		Fields:        []string{},
+		Members:       NewStringMemberOrderedMap(),
+		ContainerType: a,
+	}
+
+	c := &CompositeType{
+		Kind:          common.CompositeKindStructure,
+		Identifier:    "C",
+		Location:      common.StringLocation("a"),
+		Fields:        []string{},
+		Members:       NewStringMemberOrderedMap(),
+		ContainerType: b,
+	}
+
+	identifier := qualifiedIdentifier("foo", c)
+	assert.Equal(t, "A.B.C.foo", identifier)
+}
+
+func BenchmarkQualifiedIdentifierCreation(b *testing.B) {
+
+	foo := &CompositeType{
+		Kind:       common.CompositeKindStructure,
+		Identifier: "foo",
+		Location:   common.StringLocation("a"),
+		Fields:     []string{},
+		Members:    NewStringMemberOrderedMap(),
+	}
+
+	bar := &CompositeType{
+		Kind:          common.CompositeKindStructure,
+		Identifier:    "bar",
+		Location:      common.StringLocation("a"),
+		Fields:        []string{},
+		Members:       NewStringMemberOrderedMap(),
+		ContainerType: foo,
+	}
+
+	b.Run("One level", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			qualifiedIdentifier("baz", nil)
+		}
+	})
+
+	b.Run("Three levels", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			qualifiedIdentifier("baz", bar)
+		}
+	})
+}

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -532,34 +532,42 @@ func TestBeforeType_Strings(t *testing.T) {
 
 func TestQualifiedIdentifierCreation(t *testing.T) {
 
-	a := &CompositeType{
-		Kind:       common.CompositeKindStructure,
-		Identifier: "A",
-		Location:   common.StringLocation("a"),
-		Fields:     []string{},
-		Members:    NewStringMemberOrderedMap(),
-	}
+	t.Run("with containers", func(t *testing.T) {
 
-	b := &CompositeType{
-		Kind:          common.CompositeKindStructure,
-		Identifier:    "B",
-		Location:      common.StringLocation("a"),
-		Fields:        []string{},
-		Members:       NewStringMemberOrderedMap(),
-		ContainerType: a,
-	}
+		a := &CompositeType{
+			Kind:       common.CompositeKindStructure,
+			Identifier: "A",
+			Location:   common.StringLocation("a"),
+			Fields:     []string{},
+			Members:    NewStringMemberOrderedMap(),
+		}
 
-	c := &CompositeType{
-		Kind:          common.CompositeKindStructure,
-		Identifier:    "C",
-		Location:      common.StringLocation("a"),
-		Fields:        []string{},
-		Members:       NewStringMemberOrderedMap(),
-		ContainerType: b,
-	}
+		b := &CompositeType{
+			Kind:          common.CompositeKindStructure,
+			Identifier:    "B",
+			Location:      common.StringLocation("a"),
+			Fields:        []string{},
+			Members:       NewStringMemberOrderedMap(),
+			ContainerType: a,
+		}
 
-	identifier := qualifiedIdentifier("foo", c)
-	assert.Equal(t, "A.B.C.foo", identifier)
+		c := &CompositeType{
+			Kind:          common.CompositeKindStructure,
+			Identifier:    "C",
+			Location:      common.StringLocation("a"),
+			Fields:        []string{},
+			Members:       NewStringMemberOrderedMap(),
+			ContainerType: b,
+		}
+
+		identifier := qualifiedIdentifier("foo", c)
+		assert.Equal(t, "A.B.C.foo", identifier)
+	})
+
+	t.Run("without containers", func(t *testing.T) {
+		identifier := qualifiedIdentifier("foo", nil)
+		assert.Equal(t, "foo", identifier)
+	})
 }
 
 func BenchmarkQualifiedIdentifierCreation(b *testing.B) {

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -568,6 +568,11 @@ func TestQualifiedIdentifierCreation(t *testing.T) {
 		identifier := qualifiedIdentifier("foo", nil)
 		assert.Equal(t, "foo", identifier)
 	})
+
+	t.Run("public account container", func(t *testing.T) {
+		identifier := qualifiedIdentifier("foo", PublicAccountType)
+		assert.Equal(t, "PublicAccount.foo", identifier)
+	})
 }
 
 func BenchmarkQualifiedIdentifierCreation(b *testing.B) {


### PR DESCRIPTION
## Description

A micro-optimization:
- Simply return the identifier, if there are no containers.
- Avoid appending by creating the identifier-array at the lowest level of the chain (when the size is known).
- Calculate the buffer size on the fly, and grow the string-builder buffer at once.

```
name                                                  old time/op    new time/op    delta
QualifiedIdentifierCreation/One_level-12              24.6ns ± 4%     2.0ns ± 1%   -91.96%  (p=0.008 n=5+5)
QualifiedIdentifierCreation/Three_levels-12            197ns ± 4%     105ns ± 7%   -46.93%  (p=0.008 n=5+5)

name                                                  old alloc/op   new alloc/op   delta
QualifiedIdentifierCreation/One_level-12               8.00B ± 0%     0.00B       -100.00%  (p=0.008 n=5+5)
QualifiedIdentifierCreation/Three_levels-12             120B ± 0%       64B ± 0%   -46.67%  (p=0.008 n=5+5)

name                                                  old allocs/op  new allocs/op  delta
QualifiedIdentifierCreation/One_level-12                1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
QualifiedIdentifierCreation/Three_levels-12             4.00 ± 0%      2.00 ± 0%   -50.00%  (p=0.008 n=5+5)

```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
