### PR TITLE
Cache type ID for composite types

### DIFF
--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -71,7 +71,7 @@ var AuthAccountContractsType = func() *CompositeType {
 
 func init() {
 	// Set the container type after initializing the `AuthAccountContractsType`, to avoid initializing loop.
-	AuthAccountContractsType.ContainerType = AuthAccountType
+	AuthAccountContractsType.SetContainerType(AuthAccountType)
 }
 
 const authAccountContractsTypeAddFunctionDocString = `

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -600,7 +600,7 @@ var authAccountKeysTypeRevokeFunctionType = &FunctionType{
 
 func init() {
 	// Set the container type after initializing the AccountKeysTypes, to avoid initializing loop.
-	AuthAccountKeysType.ContainerType = AuthAccountType
+	AuthAccountKeysType.SetContainerType(AuthAccountType)
 }
 
 const AccountKeysTypeName = "Keys"

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -853,7 +853,7 @@ func (checker *Checker) explicitInterfaceConformances(
 ) []*InterfaceType {
 
 	var interfaceTypes []*InterfaceType
-	seenConformances := map[TypeID]bool{}
+	seenConformances := map[*InterfaceType]bool{}
 
 	for _, conformance := range declaration.Conformances {
 		convertedType := checker.ConvertType(conformance)
@@ -861,9 +861,7 @@ func (checker *Checker) explicitInterfaceConformances(
 		if interfaceType, ok := convertedType.(*InterfaceType); ok {
 			interfaceTypes = append(interfaceTypes, interfaceType)
 
-			typeID := interfaceType.ID()
-
-			if seenConformances[typeID] {
+			if seenConformances[interfaceType] {
 				checker.report(
 					&DuplicateConformanceError{
 						CompositeType: compositeType,
@@ -873,7 +871,7 @@ func (checker *Checker) explicitInterfaceConformances(
 				)
 			}
 
-			seenConformances[typeID] = true
+			seenConformances[interfaceType] = true
 
 		} else if !convertedType.IsInvalidType() {
 			checker.report(

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -466,12 +466,12 @@ func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclarati
 
 	for _, nestedInterfaceType := range nestedInterfaceTypes {
 		compositeType.nestedTypes.Set(nestedInterfaceType.Identifier, nestedInterfaceType)
-		nestedInterfaceType.ContainerType = compositeType
+		nestedInterfaceType.SetContainerType(compositeType)
 	}
 
 	for _, nestedCompositeType := range nestedCompositeTypes {
 		compositeType.nestedTypes.Set(nestedCompositeType.Identifier, nestedCompositeType)
-		nestedCompositeType.ContainerType = compositeType
+		nestedCompositeType.SetContainerType(compositeType)
 	}
 
 	return compositeType

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -259,12 +259,12 @@ func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclarati
 
 	for _, nestedInterfaceType := range nestedInterfaceTypes {
 		interfaceType.nestedTypes.Set(nestedInterfaceType.Identifier, nestedInterfaceType)
-		nestedInterfaceType.ContainerType = interfaceType
+		nestedInterfaceType.SetContainerType(interfaceType)
 	}
 
 	for _, nestedCompositeType := range nestedCompositeTypes {
 		interfaceType.nestedTypes.Set(nestedCompositeType.Identifier, nestedCompositeType)
-		nestedCompositeType.ContainerType = interfaceType
+		nestedCompositeType.SetContainerType(interfaceType)
 	}
 
 	return interfaceType

--- a/runtime/sema/checker_test.go
+++ b/runtime/sema/checker_test.go
@@ -70,10 +70,10 @@ func TestCompositeType_ID(t *testing.T) {
 			&CompositeType{
 				Location:   location,
 				Identifier: "C",
-				ContainerType: &CompositeType{
+				containerType: &CompositeType{
 					Location:   location,
 					Identifier: "B",
-					ContainerType: &CompositeType{
+					containerType: &CompositeType{
 						Location:   location,
 						Identifier: "A",
 					},
@@ -92,10 +92,10 @@ func TestCompositeType_ID(t *testing.T) {
 			&CompositeType{
 				Location:   location,
 				Identifier: "C",
-				ContainerType: &InterfaceType{
+				containerType: &InterfaceType{
 					Location:   location,
 					Identifier: "B",
-					ContainerType: &CompositeType{
+					containerType: &CompositeType{
 						Location:   location,
 						Identifier: "A",
 					},
@@ -121,10 +121,10 @@ func TestInterfaceType_ID(t *testing.T) {
 			&InterfaceType{
 				Location:   location,
 				Identifier: "C",
-				ContainerType: &CompositeType{
+				containerType: &CompositeType{
 					Location:   location,
 					Identifier: "B",
-					ContainerType: &CompositeType{
+					containerType: &CompositeType{
 						Location:   location,
 						Identifier: "A",
 					},
@@ -143,10 +143,10 @@ func TestInterfaceType_ID(t *testing.T) {
 			&InterfaceType{
 				Location:   location,
 				Identifier: "C",
-				ContainerType: &InterfaceType{
+				containerType: &InterfaceType{
 					Location:   location,
 					Identifier: "B",
-					ContainerType: &CompositeType{
+					containerType: &CompositeType{
 						Location:   location,
 						Identifier: "A",
 					},

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -128,7 +128,7 @@ var PublicAccountKeysType = func() *CompositeType {
 
 func init() {
 	// Set the container type after initializing the AccountKeysTypes, to avoid initializing loop.
-	PublicAccountKeysType.ContainerType = PublicAccountType
+	PublicAccountKeysType.SetContainerType(PublicAccountType)
 }
 
 const publicAccountTypeGetLinkTargetFunctionDocString = `

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3507,6 +3507,11 @@ type InterfaceType struct {
 	InitializerParameters []*Parameter
 	ContainerType         Type
 	nestedTypes           *StringTypeOrderedMap
+	cachedIdentifiers     struct {
+		TypeID              TypeID
+		QualifiedIdentifier string
+	}
+	cachedIdentifiersOnce sync.Once
 }
 
 func (*InterfaceType) IsType() {}
@@ -3532,11 +3537,25 @@ func (t *InterfaceType) GetLocation() common.Location {
 }
 
 func (t *InterfaceType) QualifiedIdentifier() string {
-	return qualifiedIdentifier(t.Identifier, t.ContainerType)
+	t.initializeIdentifiers()
+	return t.cachedIdentifiers.QualifiedIdentifier
 }
 
 func (t *InterfaceType) ID() TypeID {
-	return t.Location.TypeID(t.QualifiedIdentifier())
+	t.initializeIdentifiers()
+	return t.cachedIdentifiers.TypeID
+}
+
+func (t *InterfaceType) initializeIdentifiers() {
+	t.cachedIdentifiersOnce.Do(func() {
+		t.cachedIdentifiers.QualifiedIdentifier = qualifiedIdentifier(t.Identifier, t.ContainerType)
+
+		if t.Location == nil {
+			t.cachedIdentifiers.TypeID = TypeID(t.cachedIdentifiers.QualifiedIdentifier)
+		} else {
+			t.cachedIdentifiers.TypeID = t.Location.TypeID(t.cachedIdentifiers.QualifiedIdentifier)
+		}
+	})
 }
 
 func (t *InterfaceType) Equal(other Type) bool {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3149,26 +3149,29 @@ func (t *CompositeType) GetContainerType() Type {
 }
 
 func (t *CompositeType) SetContainerType(containerType Type) {
+	t.checkIdentifiersCached()
 	t.containerType = containerType
-	t.clearIdentifiers()
 }
 
-func (t *CompositeType) clearIdentifiers() {
+func (t *CompositeType) checkIdentifiersCached() {
 	t.cachedIdentifiersLock.Lock()
 	defer t.cachedIdentifiersLock.Unlock()
 
-	t.cachedIdentifiers = nil
+	if t.cachedIdentifiers != nil {
+		panic(errors.NewUnreachableError())
+	}
+
 	if t.nestedTypes != nil {
-		t.nestedTypes.Foreach(clearIdentifiers)
+		t.nestedTypes.Foreach(checkIdentifiersCached)
 	}
 }
 
-func clearIdentifiers(_ string, typ Type) {
+func checkIdentifiersCached(_ string, typ Type) {
 	switch semaType := typ.(type) {
 	case *CompositeType:
-		semaType.clearIdentifiers()
+		semaType.checkIdentifiersCached()
 	case *InterfaceType:
-		semaType.clearIdentifiers()
+		semaType.checkIdentifiersCached()
 	}
 }
 
@@ -3568,17 +3571,20 @@ func (t *InterfaceType) GetContainerType() Type {
 }
 
 func (t *InterfaceType) SetContainerType(containerType Type) {
+	t.checkIdentifiersCached()
 	t.containerType = containerType
-	t.clearIdentifiers()
 }
 
-func (t *InterfaceType) clearIdentifiers() {
+func (t *InterfaceType) checkIdentifiersCached() {
 	t.cachedIdentifiersLock.Lock()
 	defer t.cachedIdentifiersLock.Unlock()
 
-	t.cachedIdentifiers = nil
+	if t.cachedIdentifiers != nil {
+		panic(errors.NewUnreachableError())
+	}
+
 	if t.nestedTypes != nil {
-		t.nestedTypes.Foreach(clearIdentifiers)
+		t.nestedTypes.Foreach(checkIdentifiersCached)
 	}
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -74,10 +74,10 @@ func containerTypeNames(typ Type, level int) (typeNames []string, bufSize int) {
 	switch typedContainerType := typ.(type) {
 	case *InterfaceType:
 		typeName = typedContainerType.Identifier
-		containerType = typedContainerType.ContainerType
+		containerType = typedContainerType.containerType
 	case *CompositeType:
 		typeName = typedContainerType.Identifier
-		containerType = typedContainerType.ContainerType
+		containerType = typedContainerType.containerType
 	default:
 		panic(errors.NewUnreachableError())
 	}
@@ -187,6 +187,7 @@ type MemberResolver struct {
 type ContainedType interface {
 	Type
 	GetContainerType() Type
+	SetContainerType(containerType Type)
 }
 
 // ContainerType is a type which might have nested types
@@ -3101,14 +3102,14 @@ type CompositeType struct {
 	// TODO: add support for overloaded initializers
 	ConstructorParameters []*Parameter
 	nestedTypes           *StringTypeOrderedMap
-	ContainerType         Type
+	containerType         Type
 	EnumRawType           Type
 	hasComputedMembers    bool
-	cachedIdentifiers     struct {
+	cachedIdentifiers     *struct {
 		TypeID              TypeID
 		QualifiedIdentifier string
 	}
-	cachedIdentifiersOnce sync.Once
+	cachedIdentifiersLock sync.RWMutex
 }
 
 func (t *CompositeType) ExplicitInterfaceConformanceSet() *InterfaceSet {
@@ -3144,7 +3145,31 @@ func (t *CompositeType) QualifiedString() string {
 }
 
 func (t *CompositeType) GetContainerType() Type {
-	return t.ContainerType
+	return t.containerType
+}
+
+func (t *CompositeType) SetContainerType(containerType Type) {
+	t.containerType = containerType
+	t.clearIdentifiers()
+}
+
+func (t *CompositeType) clearIdentifiers() {
+	t.cachedIdentifiersLock.Lock()
+	defer t.cachedIdentifiersLock.Unlock()
+
+	t.cachedIdentifiers = nil
+	if t.nestedTypes != nil {
+		t.nestedTypes.Foreach(clearIdentifiers)
+	}
+}
+
+func clearIdentifiers(_ string, typ Type) {
+	switch semaType := typ.(type) {
+	case *CompositeType:
+		semaType.clearIdentifiers()
+	case *InterfaceType:
+		semaType.clearIdentifiers()
+	}
 }
 
 func (t *CompositeType) GetCompositeKind() common.CompositeKind {
@@ -3166,15 +3191,29 @@ func (t *CompositeType) ID() TypeID {
 }
 
 func (t *CompositeType) initializeIdentifiers() {
-	t.cachedIdentifiersOnce.Do(func() {
-		t.cachedIdentifiers.QualifiedIdentifier = qualifiedIdentifier(t.Identifier, t.ContainerType)
+	t.cachedIdentifiersLock.Lock()
+	defer t.cachedIdentifiersLock.Unlock()
 
-		if t.Location == nil {
-			t.cachedIdentifiers.TypeID = TypeID(t.cachedIdentifiers.QualifiedIdentifier)
-		} else {
-			t.cachedIdentifiers.TypeID = t.Location.TypeID(t.cachedIdentifiers.QualifiedIdentifier)
-		}
-	})
+	if t.cachedIdentifiers != nil {
+		return
+	}
+
+	identifier := qualifiedIdentifier(t.Identifier, t.containerType)
+
+	var typeID TypeID
+	if t.Location == nil {
+		typeID = TypeID(identifier)
+	} else {
+		typeID = t.Location.TypeID(identifier)
+	}
+
+	t.cachedIdentifiers = &struct {
+		TypeID              TypeID
+		QualifiedIdentifier string
+	}{
+		TypeID:              typeID,
+		QualifiedIdentifier: identifier,
+	}
 }
 
 func (t *CompositeType) Equal(other Type) bool {
@@ -3278,7 +3317,7 @@ func (t *CompositeType) InterfaceType() *InterfaceType {
 		Members:               t.Members,
 		Fields:                t.Fields,
 		InitializerParameters: t.ConstructorParameters,
-		ContainerType:         t.ContainerType,
+		containerType:         t.containerType,
 		nestedTypes:           t.nestedTypes,
 	}
 }
@@ -3287,7 +3326,7 @@ func (t *CompositeType) TypeRequirements() []*CompositeType {
 
 	var typeRequirements []*CompositeType
 
-	if containerComposite, ok := t.ContainerType.(*CompositeType); ok {
+	if containerComposite, ok := t.containerType.(*CompositeType); ok {
 		for _, conformance := range containerComposite.ExplicitInterfaceConformances {
 			ty, ok := conformance.nestedTypes.Get(t.Identifier)
 			if !ok {
@@ -3505,13 +3544,13 @@ type InterfaceType struct {
 	Fields              []string
 	// TODO: add support for overloaded initializers
 	InitializerParameters []*Parameter
-	ContainerType         Type
+	containerType         Type
 	nestedTypes           *StringTypeOrderedMap
-	cachedIdentifiers     struct {
+	cachedIdentifiers     *struct {
 		TypeID              TypeID
 		QualifiedIdentifier string
 	}
-	cachedIdentifiersOnce sync.Once
+	cachedIdentifiersLock sync.RWMutex
 }
 
 func (*InterfaceType) IsType() {}
@@ -3525,7 +3564,22 @@ func (t *InterfaceType) QualifiedString() string {
 }
 
 func (t *InterfaceType) GetContainerType() Type {
-	return t.ContainerType
+	return t.containerType
+}
+
+func (t *InterfaceType) SetContainerType(containerType Type) {
+	t.containerType = containerType
+	t.clearIdentifiers()
+}
+
+func (t *InterfaceType) clearIdentifiers() {
+	t.cachedIdentifiersLock.Lock()
+	defer t.cachedIdentifiersLock.Unlock()
+
+	t.cachedIdentifiers = nil
+	if t.nestedTypes != nil {
+		t.nestedTypes.Foreach(clearIdentifiers)
+	}
 }
 
 func (t *InterfaceType) GetCompositeKind() common.CompositeKind {
@@ -3547,15 +3601,29 @@ func (t *InterfaceType) ID() TypeID {
 }
 
 func (t *InterfaceType) initializeIdentifiers() {
-	t.cachedIdentifiersOnce.Do(func() {
-		t.cachedIdentifiers.QualifiedIdentifier = qualifiedIdentifier(t.Identifier, t.ContainerType)
+	t.cachedIdentifiersLock.Lock()
+	defer t.cachedIdentifiersLock.Unlock()
 
-		if t.Location == nil {
-			t.cachedIdentifiers.TypeID = TypeID(t.cachedIdentifiers.QualifiedIdentifier)
-		} else {
-			t.cachedIdentifiers.TypeID = t.Location.TypeID(t.cachedIdentifiers.QualifiedIdentifier)
-		}
-	})
+	if t.cachedIdentifiers != nil {
+		return
+	}
+
+	identifier := qualifiedIdentifier(t.Identifier, t.containerType)
+
+	var typeID TypeID
+	if t.Location == nil {
+		typeID = TypeID(identifier)
+	} else {
+		typeID = t.Location.TypeID(identifier)
+	}
+
+	t.cachedIdentifiers = &struct {
+		TypeID              TypeID
+		QualifiedIdentifier string
+	}{
+		TypeID:              typeID,
+		QualifiedIdentifier: identifier,
+	}
 }
 
 func (t *InterfaceType) Equal(other Type) bool {

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -548,7 +548,7 @@ func TestQualifiedIdentifierCreation(t *testing.T) {
 			Location:      common.StringLocation("a"),
 			Fields:        []string{},
 			Members:       NewStringMemberOrderedMap(),
-			ContainerType: a,
+			containerType: a,
 		}
 
 		c := &CompositeType{
@@ -557,7 +557,7 @@ func TestQualifiedIdentifierCreation(t *testing.T) {
 			Location:      common.StringLocation("a"),
 			Fields:        []string{},
 			Members:       NewStringMemberOrderedMap(),
-			ContainerType: b,
+			containerType: b,
 		}
 
 		identifier := qualifiedIdentifier("foo", c)
@@ -591,7 +591,7 @@ func BenchmarkQualifiedIdentifierCreation(b *testing.B) {
 		Location:      common.StringLocation("a"),
 		Fields:        []string{},
 		Members:       NewStringMemberOrderedMap(),
-		ContainerType: foo,
+		containerType: foo,
 	}
 
 	b.Run("One level", func(b *testing.B) {

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/parser2"
 )
 
 func TestConstantSizedType_String(t *testing.T) {
@@ -609,4 +610,95 @@ func BenchmarkQualifiedIdentifierCreation(b *testing.B) {
 			qualifiedIdentifier("baz", bar)
 		}
 	})
+}
+
+func TestIdentifierCacheUpdate(t *testing.T) {
+
+	code := `
+          pub contract interface Test {
+
+              pub struct interface NestedInterface {
+                  pub fun test(): Bool
+              }
+
+              pub struct Nested: NestedInterface {}
+          }
+
+          pub contract TestImpl {
+
+              pub struct Nested {
+                  pub fun test(): Bool {
+                      return true
+                  }
+              }
+          }
+	`
+
+	program, err := parser2.ParseProgram(code)
+	require.NoError(t, err)
+
+	checker, err := NewChecker(
+		program,
+		common.StringLocation("test"),
+	)
+	require.NoError(t, err)
+
+	err = checker.Check()
+	require.NoError(t, err)
+
+	checker.typeActivations.ForEachVariableDeclaredInAndBelow(
+		0,
+		func(_ string, value *Variable) {
+			typ := value.Type
+
+			var checkIdentifiers func(t *testing.T, typ Type)
+
+			checkNestedTypes := func(nestedTypes *StringTypeOrderedMap) {
+				if nestedTypes != nil {
+					nestedTypes.Foreach(
+						func(_ string, typ Type) {
+							checkIdentifiers(t, typ)
+						},
+					)
+				}
+			}
+
+			checkIdentifiers = func(t *testing.T, typ Type) {
+				switch semaType := typ.(type) {
+				case *CompositeType:
+					cachedQualifiedID := semaType.QualifiedIdentifier()
+					cachedID := semaType.ID()
+
+					// clear cached identifiers for one level
+					semaType.cachedIdentifiers = nil
+
+					recalculatedQualifiedID := semaType.QualifiedIdentifier()
+					recalculatedID := semaType.ID()
+
+					assert.Equal(t, recalculatedQualifiedID, cachedQualifiedID)
+					assert.Equal(t, recalculatedID, cachedID)
+
+					// Recursively check for nested types
+					checkNestedTypes(semaType.nestedTypes)
+
+				case *InterfaceType:
+					cachedQualifiedID := semaType.QualifiedIdentifier()
+					cachedID := semaType.ID()
+
+					// clear cached identifiers for one level
+					semaType.cachedIdentifiers = nil
+
+					recalculatedQualifiedID := semaType.QualifiedIdentifier()
+					recalculatedID := semaType.ID()
+
+					assert.Equal(t, recalculatedQualifiedID, cachedQualifiedID)
+					assert.Equal(t, recalculatedID, cachedID)
+
+					// Recursively check for nested types
+					checkNestedTypes(semaType.nestedTypes)
+				}
+			}
+
+			checkIdentifiers(t, typ)
+		})
 }


### PR DESCRIPTION
## Description

Cache type ID for composite types, so that it doesn't have to recalculate again and again. This was showing up on the profiler.

Benchmarking shows it could gain up to 25% improvement for certain methods. e.g: declareNonEnumCompositeValue

_Note: These benchmark results are on top of #948. Improvement against the direct master-branch is even higher._

```
name                           old time/op    new time/op    delta
DeclareNonEnumCompositeValue   58.2µs ±40%    43.2µs ±29%  -25.77%  (p=0.040 n=10+5)

name                           old alloc/op   new alloc/op   delta
DeclareNonEnumCompositeValue    30.0kB ± 0%    27.3kB ± 0%   -9.01%  (p=0.000 n=9+5)

name                           old allocs/op  new allocs/op  delta
DeclareNonEnumCompositeValue       576 ± 0%       485 ± 0%  -15.80%  (p=0.000 n=10+5)
```
<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
