### PR TITLE
Add a String constructor function and a String.encodeHex function

### DIFF
--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -789,7 +789,7 @@ let canadianFlag: Character = "\u{1F1E8}\u{1F1E6}"
 
 ### String Fields and Functions
 
-Strings have multiple built-in functions you can use.
+Strings have multiple built-in functions you can use:
 
 - `cadence•let length: Int`
 
@@ -851,6 +851,18 @@ Strings have multiple built-in functions you can use.
   let example = "436164656e636521"
 
   example.decodeHex()  // is `[67, 97, 100, 101, 110, 99, 101, 33]`
+  ```
+
+The `String` type also provides the following functions:
+
+- `cadence•fun String.encodeHex(_ data: [UInt8]): String`
+
+  Returns a hexadecimal string for the given byte array
+
+  ```cadence
+  let data = [1 as UInt8, 2, 3, 0xCA, 0xDE]
+
+  String.encodeHex(data)  // is `"010203cade"`
   ```
 
 ## Arrays

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -23,6 +23,11 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
+const StringTypeEncodeHexFunctionName = "encodeHex"
+const StringTypeEncodeHexFunctionDocString = `
+Returns a hexadecimal string for the given byte array
+`
+
 // StringType represents the string type
 //
 var StringType = &SimpleType{

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2946,6 +2946,66 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 	}
 }
 
+func init() {
+
+	// Declare a function for the string type.
+	// For now it has no parameters and creates an empty string
+
+	typeName := StringType.String()
+
+	// Check that the function is not accidentally redeclared
+
+	if BaseValueActivation.Find(typeName) != nil {
+		panic(errors.NewUnreachableError())
+	}
+
+	functionType := &FunctionType{
+		ReturnTypeAnnotation: NewTypeAnnotation(StringType),
+	}
+
+	addMember := func(member *Member) {
+		if functionType.Members == nil {
+			functionType.Members = NewStringMemberOrderedMap()
+		}
+		name := member.Identifier.Identifier
+		_, exists := functionType.Members.Get(name)
+		if exists {
+			panic(errors.NewUnreachableError())
+		}
+		functionType.Members.Set(name, member)
+	}
+
+	addMember(NewPublicFunctionMember(
+		functionType,
+		StringTypeEncodeHexFunctionName,
+		&FunctionType{
+			Parameters: []*Parameter{
+				{
+					Label:      ArgumentLabelNotRequired,
+					Identifier: "data",
+					TypeAnnotation: NewTypeAnnotation(
+						&VariableSizedType{
+							Type: UInt8Type,
+						},
+					),
+				},
+			},
+			ReturnTypeAnnotation: NewTypeAnnotation(
+				StringType,
+			),
+		},
+		StringTypeEncodeHexFunctionDocString,
+	))
+
+	BaseValueActivation.Set(
+		typeName,
+		baseFunctionVariable(
+			typeName,
+			functionType,
+		),
+	)
+}
+
 func suggestIntegerLiteralConversionReplacement(
 	checker *Checker,
 	argument *ast.IntegerExpression,

--- a/runtime/tests/checker/composite_test.go
+++ b/runtime/tests/checker/composite_test.go
@@ -67,9 +67,14 @@ func TestCheckInvalidCompositeRedeclaringType(t *testing.T) {
 				),
 			)
 
-			errs := ExpectCheckerErrors(t, err, 1)
+			// Two redeclaration errors:
+			// - One for the type
+			// - Another for the value
+
+			errs := ExpectCheckerErrors(t, err, 2)
 
 			assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+			assert.IsType(t, &sema.RedeclarationError{}, errs[1])
 		})
 	}
 }

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -243,3 +243,53 @@ func TestCheckInvalidStringIndexingAssignmentWithCharacterLiteral(t *testing.T) 
 
 	assert.IsType(t, &sema.NotIndexingAssignableTypeError{}, errs[0])
 }
+
+func TestCheckStringFunction(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+        let x = String()
+	`)
+
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		sema.StringType,
+		RequireGlobalValue(t, checker.Elaboration, "x"),
+	)
+}
+
+func TestCheckStringDecodeHex(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+        let x = "01CADE".decodeHex()
+	`)
+
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		&sema.VariableSizedType{
+			Type: sema.UInt8Type,
+		},
+		RequireGlobalValue(t, checker.Elaboration, "x"),
+	)
+}
+
+func TestCheckStringEncodeHex(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+        let x = String.encodeHex([1 as UInt8, 2, 3, 0xCA, 0xDE])
+	`)
+
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		sema.StringType,
+		RequireGlobalValue(t, checker.Elaboration, "x"),
+	)
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -53,5 +53,65 @@ func TestInterpretRecursiveValueString(t *testing.T) {
 			Get(inter, nil, interpreter.NewStringValue("mapRef")).
 			String(interpreter.StringResults{}),
 	)
+}
 
+func TestInterpretStringFunction(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      fun test(): String {
+          return String()
+      }
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.NewStringValue(""),
+		result,
+	)
+}
+
+func TestInterpretStringDecodeHex(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      fun test(): [UInt8] {
+          return "01CADE".decodeHex()
+      }
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.NewArrayValueUnownedNonCopying(
+			interpreter.UInt8Value(1),
+			interpreter.UInt8Value(0xCA),
+			interpreter.UInt8Value(0xDE),
+		),
+		result,
+	)
+}
+
+func TestInterpretStringEncodeHex(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      fun test(): String {
+          return String.encodeHex([1 as UInt8, 2, 3, 0xCA, 0xDE])
+      }
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.NewStringValue("010203cade"),
+		result,
+	)
 }


### PR DESCRIPTION
Closes #952 

## Description

- Add a function `fun String(): String`, which takes no parameters and returns an empty string.

  This is not very useful for now, but could be extended to perform string conversion in the future, and for now allows adding "static" functions for `String`. This follows the same pattern as for the number conversion functions and the `Type` constructor function.

- Add a function `fun String.encodeHex(_ data: [UInt8]): String`
- Add tests for the existing function `decodeHex`


<img width="413" alt="Screen Shot 2021-05-27 at 6 08 18 PM" src="https://user-images.githubusercontent.com/51661/119916149-d6468c00-bf18-11eb-8744-6391835091ff.png">


______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
