### PR TITLE
Add a `String.utf8` field

### DIFF
--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -805,7 +805,7 @@ Strings have multiple built-in functions you can use:
 
 - `cadence•let utf8: [UInt8]`
 
-  Returns the number of characters in the string as an integer.
+  The byte array of the UTF-8 encoding
 
   ```cadence
   let flowers = "Flowers \u{1F490}"

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -803,6 +803,16 @@ Strings have multiple built-in functions you can use:
   // `length` is `5`
   ```
 
+- `cadence•let utf8: [UInt8]`
+
+  Returns the number of characters in the string as an integer.
+
+  ```cadence
+  let flowers = "Flowers \u{1F490}"
+  let bytes = flowers.utf8
+  // `bytes` is `[70, 108, 111, 119, 101, 114, 115, 32, 240, 159, 146, 144]`
+  ```
+
 - `cadence•fun concat(_ other: String): String`
 
   Concatenates the string `other` to the end of the original string,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -501,6 +501,9 @@ func (v *StringValue) GetMember(_ *Interpreter, _ func() LocationRange, name str
 		length := v.Length()
 		return NewIntValueFromInt64(int64(length))
 
+	case "utf8":
+		return ByteSliceToByteArrayValue([]byte(v.Str))
+
 	case "concat":
 		return NewHostFunctionValue(
 			func(invocation Invocation) Value {

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -85,6 +85,19 @@ func init() {
 					)
 				},
 			},
+			"utf8": {
+				Kind: common.DeclarationKindField,
+				Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
+					return NewPublicConstantFieldMember(
+						t,
+						identifier,
+						&VariableSizedType{
+							Type: UInt8Type,
+						},
+						stringTypeUtf8FieldDocString,
+					)
+				},
+			},
 			"length": {
 				Kind: common.DeclarationKindField,
 				Resolve: func(identifier string, _ ast.Range, _ func(error)) *Member {
@@ -158,4 +171,8 @@ If the string is malformed, the program aborts
 
 const stringTypeLengthFieldDocString = `
 The number of characters in the string
+`
+
+const stringTypeUtf8FieldDocString = `
+The byte array of the UTF-8 encoding
 `

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -293,3 +293,22 @@ func TestCheckStringEncodeHex(t *testing.T) {
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }
+
+func TestCheckStringUtf8Field(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+
+      let x = "abc".utf8
+	`)
+
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		&sema.VariableSizedType{
+			Type: sema.UInt8Type,
+		},
+		RequireGlobalValue(t, checker.Elaboration, "x"),
+	)
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -115,3 +115,53 @@ func TestInterpretStringEncodeHex(t *testing.T) {
 		result,
 	)
 }
+
+func TestInterpretStringUtf8Field(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      fun test(): [UInt8] {
+          return "Flowers \u{1F490} are beautiful".utf8
+      }
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.NewArrayValueUnownedNonCopying(
+			// Flowers
+			interpreter.UInt8Value(70),
+			interpreter.UInt8Value(108),
+			interpreter.UInt8Value(111),
+			interpreter.UInt8Value(119),
+			interpreter.UInt8Value(101),
+			interpreter.UInt8Value(114),
+			interpreter.UInt8Value(115),
+			interpreter.UInt8Value(32),
+			// Bouquet
+			interpreter.UInt8Value(240),
+			interpreter.UInt8Value(159),
+			interpreter.UInt8Value(146),
+			interpreter.UInt8Value(144),
+			interpreter.UInt8Value(32),
+			// are
+			interpreter.UInt8Value(97),
+			interpreter.UInt8Value(114),
+			interpreter.UInt8Value(101),
+			interpreter.UInt8Value(32),
+			// beautiful
+			interpreter.UInt8Value(98),
+			interpreter.UInt8Value(101),
+			interpreter.UInt8Value(97),
+			interpreter.UInt8Value(117),
+			interpreter.UInt8Value(116),
+			interpreter.UInt8Value(105),
+			interpreter.UInt8Value(102),
+			interpreter.UInt8Value(117),
+			interpreter.UInt8Value(108),
+		),
+		result,
+	)
+}


### PR DESCRIPTION
## Description

As discussed / requested in https://forum.onflow.org/t/base64-encode-in-cadence/1915

<img width="420" alt="Screen Shot 2021-05-27 at 6 54 21 PM" src="https://user-images.githubusercontent.com/51661/119918276-faa46780-bf1c-11eb-8b51-e5d253d79da9.png">
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
