### PR TITLE
Improve type inferrence for binary expressions

### DIFF
--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -105,7 +105,9 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 		// let character = string[index + 1]
 		// ```
 
-		if expectedType == nil || IsProperSubType(leftType, expectedType) {
+		if expectedType == nil ||
+			(leftType != expectedType && IsProperSubType(leftType, expectedType)) {
+
 			expectedType = leftType
 		}
 

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -46,7 +46,9 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 	// is done based on the operation kind.
 
 	var expectedType Type
-	if operationKind == BinaryOperationKindArithmetic {
+	switch operationKind {
+	case BinaryOperationKindArithmetic,
+		BinaryOperationKindBitwise:
 		expectedType = UnwrapOptionalType(checker.expectedType)
 	}
 
@@ -73,9 +75,42 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 
 		// Right hand side will always be evaluated
 
-		// Visit the expression, with contextually expected type. Use the expected type
-		// only for inferring wherever possible, but do not check for compatibility.
+		// Visit the expression, with contextually expected type.
+		// Use the expected type only for inferring wherever possible,
+		// but do not check for compatibility.
 		// Compatibility is checked separately for each operand kind.
+		//
+		// If there is no contextually expected type,
+		// then expect the right type to have the type of the left side.
+		// For example, this allows a declaration like this to type-check:
+		//
+		// ```
+		// let x = 1 as UInt8
+		// let y = x + 1
+		// ```
+		//
+		// Also, if there is a contextually expected type,
+		// but the left type is a subtype and more specific (i.e not the same),
+		// then use it instead as the expected type for the right type.
+		// For example, this allows declarations like the following to type-check:
+		//
+		// ```
+		// let x = 1 as UInt8
+		// let y: Integer = x + 1
+		// ```
+		//
+		// ```
+		// let string = "this is a test"
+		// let index = 1 as UInt8
+		// let character = string[index + 1]
+		// ```
+
+		if expectedType == nil ||
+			(IsSubType(leftType, expectedType) && !leftType.Equal(expectedType)) {
+
+			expectedType = leftType
+		}
+
 		rightType := checker.VisitExpressionWithForceType(expression.Right, expectedType, false)
 
 		rightIsInvalid := rightType.IsInvalidType()

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -105,9 +105,7 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 		// let character = string[index + 1]
 		// ```
 
-		if expectedType == nil ||
-			(IsSubType(leftType, expectedType) && !leftType.Equal(expectedType)) {
-
+		if expectedType == nil || IsProperSubType(leftType, expectedType) {
 			expectedType = leftType
 		}
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4273,6 +4273,32 @@ func IsSubType(subType Type, superType Type) bool {
 		return true
 	}
 
+	return checkSubTypeWithoutEquality(subType, superType)
+}
+
+// IsProperSubType is similar to IsSubType,
+// i.e. it determines if the given subtype is a subtype
+// of the given supertype, but returns false
+// if the subtype and supertype refer to the same type.
+//
+func IsProperSubType(subType Type, superType Type) bool {
+
+	if subType.Equal(superType) {
+		return false
+	}
+
+	return checkSubTypeWithoutEquality(subType, superType)
+}
+
+// checkSubTypeWithoutEquality determines if the given subtype
+// is a subtype of the given supertype, BUT it does NOT check
+// the equality of the two types, so does NOT return a specific
+// value when the two types are equal or are not.
+//
+// Consider using IsSubType or IsProperSubType
+//
+func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
+
 	if subType == NeverType {
 		return true
 	}


### PR DESCRIPTION
## Description

I wrote a Base64 encoding function for Cadence here:
https://forum.onflow.org/t/base64-encode-in-cadence/1915/7

This currently requires a lot of static type annotations and casts and could be much simplified through the following observations and changes.

- Currently the contextually expected type (if any) is only used for arithmetic binary expressions.
  
  However, bitwise binary expressions have the same property that the resulting type must be compatible with the operands.

- Currently the left expression and the right expression are type checked individually, and each side is provided with the contextually expected type (if any).
  
  However, the both sides of arithmetic, logical, etc. expressions must have the same type, so if no contextually expected type is present, use the left type as the expected type when checking the right side.

- The contextually expected type might be less specific. For example, the indexing type for arrays and strings is `Integer`. This causes an expression like `let x = 1 as UInt8; "abc"[x + 1]` to fail to type check.

With the following changes, this portion of the example program can be significantly simplified:

  - Before:

    ```kotlin
    let n = (UInt32(data[i]) << 16 as UInt32)
        + (UInt32(data[i + 1 as Int]) << 8 as UInt32)
        + UInt32(data[i + 2 as Int])

    let n1 = (n >> 18 as UInt32) & 63 as UInt32
    let n2 = (n >> 12 as UInt32) & 63 as UInt32
    let n3 = (n >> 6 as UInt32) & 63 as UInt32
    let n4 = n & 63 as UInt32
    ```

  - After:
  
    ```kotlin
    let n = UInt32(data[i]) << 16
        + UInt32(data[i + 1]) << 8
        + UInt32(data[i + 2])

    let n1 = (n >> 18) & 63
    let n2 = (n >> 12) & 63
    let n3 = (n >> 6) & 63
    let n4 = n & 63
    ```

Also, improve the tests by
- Removing the wrapper functions
- Adding assertions for the resulting types

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
