### PR TITLE
Fix the initialization order in the interpreter

### DIFF
--- a/runtime/ast/program.go
+++ b/runtime/ast/program.go
@@ -89,6 +89,10 @@ func (p *Program) TransactionDeclarations() []*TransactionDeclaration {
 	return p.indices.transactionDeclarations(p.declarations)
 }
 
+func (p *Program) VariableDeclarations() []*VariableDeclaration {
+	return p.indices.variableDeclarations(p.declarations)
+}
+
 // SoleContractDeclaration returns the sole contract declaration, if any,
 // and if there are no other actionable declarations.
 //

--- a/runtime/ast/programindices.go
+++ b/runtime/ast/programindices.go
@@ -38,6 +38,8 @@ type programIndices struct {
 	_functionDeclarations []*FunctionDeclaration
 	// Use `transactionDeclarations()` instead
 	_transactionDeclarations []*TransactionDeclaration
+	// Use `variableDeclarations()` instead
+	_variableDeclarations []*VariableDeclaration
 }
 
 func (i *programIndices) pragmaDeclarations(declarations []Declaration) []*PragmaDeclaration {
@@ -68,6 +70,11 @@ func (i *programIndices) functionDeclarations(declarations []Declaration) []*Fun
 func (i *programIndices) transactionDeclarations(declarations []Declaration) []*TransactionDeclaration {
 	i.once.Do(i.initializer(declarations))
 	return i._transactionDeclarations
+}
+
+func (i *programIndices) variableDeclarations(declarations []Declaration) []*VariableDeclaration {
+	i.once.Do(i.initializer(declarations))
+	return i._variableDeclarations
 }
 
 func (i *programIndices) initializer(declarations []Declaration) func() {
@@ -107,6 +114,9 @@ func (i *programIndices) init(declarations []Declaration) {
 
 		case *TransactionDeclaration:
 			i._transactionDeclarations = append(i._transactionDeclarations, declaration)
+
+		case *VariableDeclaration:
+			i._variableDeclarations = append(i._variableDeclarations, declaration)
 		}
 	}
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -643,33 +643,6 @@ func (interpreter *Interpreter) Interpret() (err error) {
 	return nil
 }
 
-func (interpreter *Interpreter) prepareInterpretation() {
-	program := interpreter.Program.Program
-
-	// Pre-declare empty variables for all interfaces, composites, and function declarations
-	for _, declaration := range program.InterfaceDeclarations() {
-		interpreter.declareVariable(declaration.Identifier.Identifier, nil)
-	}
-
-	for _, declaration := range program.CompositeDeclarations() {
-		interpreter.declareVariable(declaration.Identifier.Identifier, nil)
-	}
-
-	for _, declaration := range program.FunctionDeclarations() {
-		interpreter.declareVariable(declaration.Identifier.Identifier, nil)
-	}
-
-	// TODO:
-	// Register top-level interface declarations, as their functions' conditions
-	// need to be included in conforming composites' functions
-}
-
-func (interpreter *Interpreter) visitGlobalDeclarations(declarations []ast.Declaration) {
-	for _, declaration := range declarations {
-		interpreter.visitGlobalDeclaration(declaration)
-	}
-}
-
 // visitGlobalDeclaration firsts interprets the global declaration,
 // then finds the declaration and adds it to the globals
 //
@@ -881,9 +854,30 @@ func (interpreter *Interpreter) RecoverErrors(onError func(error)) {
 }
 
 func (interpreter *Interpreter) VisitProgram(program *ast.Program) ast.Repr {
-	interpreter.prepareInterpretation()
 
-	interpreter.visitGlobalDeclarations(program.Declarations())
+	for _, declaration := range program.ImportDeclarations() {
+		interpreter.visitGlobalDeclaration(declaration)
+	}
+
+	for _, declaration := range program.InterfaceDeclarations() {
+		interpreter.visitGlobalDeclaration(declaration)
+	}
+
+	for _, declaration := range program.CompositeDeclarations() {
+		interpreter.visitGlobalDeclaration(declaration)
+	}
+
+	for _, declaration := range program.FunctionDeclarations() {
+		interpreter.visitGlobalDeclaration(declaration)
+	}
+
+	for _, declaration := range program.TransactionDeclarations() {
+		interpreter.visitGlobalDeclaration(declaration)
+	}
+
+	for _, declaration := range program.VariableDeclarations() {
+		interpreter.visitGlobalDeclaration(declaration)
+	}
 
 	return nil
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -916,8 +916,7 @@ func (interpreter *Interpreter) VisitProgram(program *ast.Program) ast.Repr {
 		declaration := declaration
 
 		identifier := declaration.Identifier.Identifier
-		var variable *Variable
-		variable = NewVariableWithGetter(func() Value {
+		variable := NewVariableWithGetter(func() Value {
 			var result Value
 			interpreter.visitVariableDeclaration(declaration, func(_ string, value Value) {
 				result = value

--- a/runtime/tests/interpreter/declaration_test.go
+++ b/runtime/tests/interpreter/declaration_test.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/tests/interpreter/declaration_test.go
+++ b/runtime/tests/interpreter/declaration_test.go
@@ -1,0 +1,75 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+)
+
+func TestInterpretForwardReferenceCall(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("variable before composite", func(t *testing.T) {
+
+		t.Parallel()
+
+		_ = parseCheckAndInterpret(t,
+			`
+              let s = S()
+
+              struct S {}
+	    `)
+	})
+
+	t.Run("variable before function", func(t *testing.T) {
+
+		t.Parallel()
+
+		_ = parseCheckAndInterpret(t,
+			`
+              let g = f()
+
+              fun f() {}
+	    `)
+	})
+
+	t.Run("indirect forward reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Here, x has a forward reference to y,
+		// through f and g
+
+		_ = parseCheckAndInterpret(t,
+			`
+              fun f(): Int {
+                  return g()
+              }
+
+              let x = f()
+              let y = 0
+
+              fun g(): Int {
+                  return y
+              }
+	    `)
+	})
+
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -112,12 +112,17 @@ func parseCheckAndInterpretWithOptions(
 			err = internalErr
 		})
 
-		// Ensure that all global declarations are evaluated:
 		// Contract declarations are evaluated lazily,
 		// so force the contract value handler to be called
 
-		for _, variable := range inter.Globals {
-			_ = variable.GetValue()
+		for _, compositeDeclaration := range checker.Program.CompositeDeclarations() {
+			if compositeDeclaration.CompositeKind != common.CompositeKindContract {
+				continue
+			}
+
+			contractVariable := inter.Globals[compositeDeclaration.Identifier.Identifier]
+
+			_ = contractVariable.GetValue()
 		}
 	}
 
@@ -6269,30 +6274,6 @@ func TestInterpretReferenceDereferenceFailure(t *testing.T) {
 	_, err := inter.Invoke("test")
 
 	require.ErrorAs(t, err, &interpreter.DestroyedCompositeError{})
-}
-
-func TestInterpretInvalidForwardReferenceCall(t *testing.T) {
-
-	t.Parallel()
-
-	// TODO: improve:
-	//   - call to `g` should succeed, but access to `y` should fail with error
-	//   - maybe make this a static error
-
-	assert.Panics(t, func() {
-		_ = parseCheckAndInterpret(t, `
-          fun f(): Int {
-             return g()
-          }
-
-          let x = f()
-          let y = 0
-
-          fun g(): Int {
-              return y
-          }
-        `)
-	})
 }
 
 func TestInterpretVariableDeclarationSecondValue(t *testing.T) {


### PR DESCRIPTION
## Description

Initialize declarations in the same order as they are initialized in the checker.

In addition, change global variables to be initialized lazily, so that potential forward references, through e.g. functions, work properly.

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
