### PR TITLE
[Optimization] Make dynamic types singleton for simple types

### DIFF
--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -41,8 +41,10 @@ func (v BlockValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitValue(interpreter, v)
 }
 
+var blockDynamicType DynamicType = BlockDynamicType{}
+
 func (BlockValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return BlockDynamicType{}
+	return blockDynamicType
 }
 
 func (BlockValue) StaticType() StaticType {

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -40,8 +40,10 @@ func (v DeployedContractValue) Accept(interpreter *Interpreter, visitor Visitor)
 	visitor.VisitDeployedContractValue(interpreter, v)
 }
 
+var deployedContractDynamicType DynamicType = DeployedContractDynamicType{}
+
 func (DeployedContractValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return DeployedContractDynamicType{}
+	return deployedContractDynamicType
 }
 
 func (DeployedContractValue) StaticType() StaticType {

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -69,8 +69,10 @@ func (f InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visit
 	visitor.VisitInterpretedFunctionValue(interpreter, f)
 }
 
+var functionDynamicType DynamicType = FunctionDynamicType{}
+
 func (InterpretedFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return FunctionDynamicType{}
+	return functionDynamicType
 }
 
 func (f InterpretedFunctionValue) StaticType() StaticType {
@@ -158,8 +160,10 @@ func (f HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitHostFunctionValue(interpreter, f)
 }
 
+var hostFunctionDynamicType DynamicType = FunctionDynamicType{}
+
 func (HostFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return FunctionDynamicType{}
+	return hostFunctionDynamicType
 }
 
 func (HostFunctionValue) StaticType() StaticType {
@@ -236,8 +240,10 @@ func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitBoundFunctionValue(interpreter, f)
 }
 
+var boundFunctionDynamicType DynamicType = FunctionDynamicType{}
+
 func (BoundFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return FunctionDynamicType{}
+	return boundFunctionDynamicType
 }
 
 func (f BoundFunctionValue) StaticType() StaticType {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1203,8 +1203,10 @@ func (v IntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitIntValue(interpreter, v)
 }
 
+var intDynamicType DynamicType = NumberDynamicType{sema.IntType}
+
 func (IntValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.IntType}
+	return intDynamicType
 }
 
 func (IntValue) StaticType() StaticType {
@@ -1419,8 +1421,10 @@ func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt8Value(interpreter, v)
 }
 
+var int8DynamicType DynamicType = NumberDynamicType{sema.Int8Type}
+
 func (Int8Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Int8Type}
+	return int8DynamicType
 }
 
 func (Int8Value) StaticType() StaticType {
@@ -1716,8 +1720,10 @@ func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt16Value(interpreter, v)
 }
 
+var int16DynamicType DynamicType = NumberDynamicType{sema.Int16Type}
+
 func (Int16Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Int16Type}
+	return int16DynamicType
 }
 
 func (Int16Value) StaticType() StaticType {
@@ -2015,8 +2021,10 @@ func (v Int32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt32Value(interpreter, v)
 }
 
+var int32DynamicType DynamicType = NumberDynamicType{sema.Int32Type}
+
 func (Int32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Int32Type}
+	return int32DynamicType
 }
 
 func (Int32Value) StaticType() StaticType {
@@ -2314,8 +2322,10 @@ func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt64Value(interpreter, v)
 }
 
+var int64DynamicType DynamicType = NumberDynamicType{sema.Int64Type}
+
 func (Int64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Int64Type}
+	return int64DynamicType
 }
 
 func (Int64Value) StaticType() StaticType {
@@ -2621,8 +2631,10 @@ func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt128Value(interpreter, v)
 }
 
+var int128DynamicType DynamicType = NumberDynamicType{sema.Int128Type}
+
 func (Int128Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Int128Type}
+	return int128DynamicType
 }
 
 func (Int128Value) StaticType() StaticType {
@@ -2989,8 +3001,10 @@ func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt256Value(interpreter, v)
 }
 
+var int256DynamicType DynamicType = NumberDynamicType{sema.Int256Type}
+
 func (Int256Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Int256Type}
+	return int256DynamicType
 }
 
 func (Int256Value) StaticType() StaticType {
@@ -3378,8 +3392,10 @@ func (v UIntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUIntValue(interpreter, v)
 }
 
+var uintDynamicType DynamicType = NumberDynamicType{sema.UIntType}
+
 func (UIntValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UIntType}
+	return uintDynamicType
 }
 
 func (UIntValue) StaticType() StaticType {
@@ -3605,8 +3621,10 @@ func (v UInt8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt8Value(interpreter, v)
 }
 
+var uint8DynamicType DynamicType = NumberDynamicType{sema.UInt8Type}
+
 func (UInt8Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UInt8Type}
+	return uint8DynamicType
 }
 
 func (UInt8Value) StaticType() StaticType {
@@ -3833,8 +3851,10 @@ func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt16Value(interpreter, v)
 }
 
+var uint16DynamicType DynamicType = NumberDynamicType{sema.UInt16Type}
+
 func (UInt16Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UInt16Type}
+	return uint16DynamicType
 }
 
 func (UInt16Value) StaticType() StaticType {
@@ -4061,8 +4081,10 @@ func (v UInt32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt32Value(interpreter, v)
 }
 
+var uint32DynamicType DynamicType = NumberDynamicType{sema.UInt32Type}
+
 func (UInt32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UInt32Type}
+	return uint32DynamicType
 }
 
 func (UInt32Value) StaticType() StaticType {
@@ -4290,8 +4312,10 @@ func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt64Value(interpreter, v)
 }
 
+var uint64DynamicType DynamicType = NumberDynamicType{sema.UInt64Type}
+
 func (UInt64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UInt64Type}
+	return uint64DynamicType
 }
 
 func (UInt64Value) StaticType() StaticType {
@@ -4532,8 +4556,10 @@ func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt128Value(interpreter, v)
 }
 
+var uint128DynamicType DynamicType = NumberDynamicType{sema.UInt128Type}
+
 func (UInt128Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UInt128Type}
+	return uint128DynamicType
 }
 
 func (UInt128Value) StaticType() StaticType {
@@ -4842,8 +4868,10 @@ func (v UInt256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt256Value(interpreter, v)
 }
 
+var uint256DynamicType DynamicType = NumberDynamicType{sema.UInt256Type}
+
 func (UInt256Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UInt256Type}
+	return uint256DynamicType
 }
 
 func (UInt256Value) StaticType() StaticType {
@@ -5142,8 +5170,10 @@ func (v Word8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord8Value(interpreter, v)
 }
 
+var word8DynamicType DynamicType = NumberDynamicType{sema.Word8Type}
+
 func (Word8Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Word8Type}
+	return word8DynamicType
 }
 
 func (Word8Value) StaticType() StaticType {
@@ -5315,8 +5345,10 @@ func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord16Value(interpreter, v)
 }
 
+var word16DynamicType DynamicType = NumberDynamicType{sema.Word16Type}
+
 func (Word16Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Word16Type}
+	return word16DynamicType
 }
 
 func (Word16Value) StaticType() StaticType {
@@ -5488,8 +5520,10 @@ func (v Word32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord32Value(interpreter, v)
 }
 
+var word32DynamicType DynamicType = NumberDynamicType{sema.Word32Type}
+
 func (Word32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Word32Type}
+	return word32DynamicType
 }
 
 func (Word32Value) StaticType() StaticType {
@@ -5663,8 +5697,10 @@ func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord64Value(interpreter, v)
 }
 
+var word64DynamicType DynamicType = NumberDynamicType{sema.Word64Type}
+
 func (Word64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Word64Type}
+	return word64DynamicType
 }
 
 func (Word64Value) StaticType() StaticType {
@@ -5853,8 +5889,10 @@ func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitFix64Value(interpreter, v)
 }
 
+var fix64DynamicType DynamicType = NumberDynamicType{sema.Fix64Type}
+
 func (Fix64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.Fix64Type}
+	return fix64DynamicType
 }
 
 func (Fix64Value) StaticType() StaticType {
@@ -6125,8 +6163,10 @@ func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUFix64Value(interpreter, v)
 }
 
+var ufix64DynamicType DynamicType = NumberDynamicType{sema.UFix64Type}
+
 func (UFix64Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NumberDynamicType{sema.UFix64Type}
+	return ufix64DynamicType
 }
 
 func (UFix64Value) StaticType() StaticType {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -123,8 +123,10 @@ func (v TypeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitTypeValue(interpreter, v)
 }
 
+var metaTypeDynamicType DynamicType = MetaTypeDynamicType{}
+
 func (TypeValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return MetaTypeDynamicType{}
+	return metaTypeDynamicType
 }
 
 func (TypeValue) StaticType() StaticType {
@@ -217,8 +219,10 @@ func (v VoidValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitVoidValue(interpreter, v)
 }
 
+var voidDynamicType DynamicType = VoidDynamicType{}
+
 func (VoidValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return VoidDynamicType{}
+	return voidDynamicType
 }
 
 func (VoidValue) StaticType() StaticType {
@@ -269,8 +273,10 @@ func (v BoolValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitBoolValue(interpreter, v)
 }
 
+var boolDynamicType DynamicType = BoolDynamicType{}
+
 func (BoolValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return BoolDynamicType{}
+	return boolDynamicType
 }
 
 func (BoolValue) StaticType() StaticType {
@@ -364,8 +370,10 @@ func (v *StringValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitStringValue(interpreter, v)
 }
 
+var stringDynamicType DynamicType = StringDynamicType{}
+
 func (*StringValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return StringDynamicType{}
+	return stringDynamicType
 }
 
 func (*StringValue) StaticType() StaticType {
@@ -7720,8 +7728,10 @@ func (v NilValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitNilValue(interpreter, v)
 }
 
+var nilDynamicType DynamicType = NilDynamicType{}
+
 func (NilValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return NilDynamicType{}
+	return nilDynamicType
 }
 
 func (NilValue) StaticType() StaticType {
@@ -8396,8 +8406,10 @@ func (v AddressValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitAddressValue(interpreter, v)
 }
 
+var addressDynamicType DynamicType = AddressDynamicType{}
+
 func (AddressValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
-	return AddressDynamicType{}
+	return addressDynamicType
 }
 
 func (AddressValue) StaticType() StaticType {
@@ -8662,14 +8674,18 @@ func (v PathValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitPathValue(interpreter, v)
 }
 
+var storagePathDynamicType DynamicType = StoragePathDynamicType{}
+var publicPathDynamicType DynamicType = PublicPathDynamicType{}
+var privatePathDynamicType DynamicType = PrivatePathDynamicType{}
+
 func (v PathValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
 	switch v.Domain {
 	case common.PathDomainStorage:
-		return StoragePathDynamicType{}
+		return storagePathDynamicType
 	case common.PathDomainPublic:
-		return PublicPathDynamicType{}
+		return publicPathDynamicType
 	case common.PathDomainPrivate:
-		return PrivatePathDynamicType{}
+		return privatePathDynamicType
 	default:
 		panic(errors.NewUnreachableError())
 	}


### PR DESCRIPTION
## Description

$subject. 

The gain is more significant during runtime type checking for homogenous arrays of simple types. e.g: Large byte arrays, etc.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
