### PR TITLE
Add test case for invalid utf8 string import

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1402,4 +1403,23 @@ var fooResourceType = &cadence.ResourceType{
 			Type:       cadence.IntType{},
 		},
 	},
+}
+
+func TestNonUTF8StringEncoding(t *testing.T) {
+	nonUTF8String := "\xbd\xb2\x3d\xbc\x20\xe2"
+
+	// Make sure it is an invalid utf8 string
+	assert.False(t, utf8.ValidString(nonUTF8String))
+
+	stringValue := cadence.NewString(nonUTF8String)
+
+	encodedValue, err := json.Encode(stringValue)
+	require.NoError(t, err)
+
+	decodedValue, err := json.Decode(encodedValue)
+	require.NoError(t, err)
+
+	// Decoded value must be a valid utf8 string
+	assert.IsType(t, cadence.String(""), decodedValue)
+	assert.True(t, utf8.ValidString(decodedValue.String()))
 }


### PR DESCRIPTION
Work towards #966

## Description

Added a test case to ensure non-utf8 string values are properly escaped when importing to cadence programs.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
