### PR TITLE
Use actions/setup-go@v2 to speed up CI by ~10 secs and specify Go 1.15.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.10'
+        go-version: '1.15.x'
     - uses: actions/setup-node@v2
       with:
         node-version: '15'


### PR DESCRIPTION
Closes #970 

## Description

`actions/setup-go@v1` has a performance bug which can cost an extra ~10 secs to install Go.

`actions/setup-go@v2` fixes the performance bug and supports ".x" in the version string.

With v2, specifying "1.15.x" will install the latest 1.15 available.

 - [x] Use actions/setup-go@v2.
 - [x] Specify go-version: '1.15.x'.

See https://github.com/actions/setup-go/issues/39
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
