### PR TITLE
Validate UTF-8 compatibility in string value constructor

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1411,7 +1411,8 @@ func TestNonUTF8StringEncoding(t *testing.T) {
 	// Make sure it is an invalid utf8 string
 	assert.False(t, utf8.ValidString(nonUTF8String))
 
-	stringValue := cadence.NewString(nonUTF8String)
+	// Avoid using the `NewString()` constructor to skip the validation
+	stringValue := cadence.String(nonUTF8String)
 
 	encodedValue, err := json.Encode(stringValue)
 	require.NoError(t, err)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1808,7 +1808,8 @@ func TestStringValueImport(t *testing.T) {
 		nonUTF8String := "\xbd\xb2\x3d\xbc\x20\xe2"
 		require.False(t, utf8.ValidString(nonUTF8String))
 
-		stringValue := cadence.NewString(nonUTF8String)
+		// Avoid using the `NewString()` constructor to skip the validation
+		stringValue := cadence.String(nonUTF8String)
 
 		script := `
             pub fun main(s: String) {

--- a/values.go
+++ b/values.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"unicode/utf8"
 
 	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/runtime/common"
@@ -136,6 +137,10 @@ func (v Bool) String() string {
 type String string
 
 func NewString(s string) String {
+	if !utf8.ValidString(s) {
+		panic(fmt.Errorf("invalid UTF-8 in string: %s", s))
+	}
+
 	return String(s)
 }
 

--- a/values_test.go
+++ b/values_test.go
@@ -21,6 +21,7 @@ package cadence
 import (
 	"fmt"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -493,4 +494,23 @@ func TestOptional_Type(t *testing.T) {
 			}.Type(),
 		)
 	})
+}
+
+func TestNonUTF8String(t *testing.T) {
+	nonUTF8String := "\xbd\xb2\x3d\xbc\x20\xe2"
+
+	// Make sure it is an invalid utf8 string
+	assert.False(t, utf8.ValidString(nonUTF8String))
+
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+
+		err, isError := r.(error)
+		require.True(t, isError)
+
+		assert.Contains(t, err.Error(), "invalid UTF-8 in string")
+	}()
+
+	_ = NewString(nonUTF8String)
 }


### PR DESCRIPTION
Closes #966

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
