### PR TITLE
Extend the source compatibility suite

### DIFF
--- a/.github/workflows/compat.yaml
+++ b/.github/workflows/compat.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+    inputs:
+      goTestRef:
 
 
 jobs:
@@ -29,4 +31,4 @@ jobs:
       run: pip3 install -r requirements.txt
     - name: Check
       working-directory: compat
-      run: python3 main.py --format=pretty --check
+      run: "python3 main.py --format=pretty --check --go-test --go-test-ref ${{ github.event.inputs.goTestRef }}"

--- a/compat/main.py
+++ b/compat/main.py
@@ -64,10 +64,13 @@ class File:
         with path.open(mode="r") as f:
             source = f.read()
 
-        variables = {"source": source}
+        def replace(pattern, replacement):
+            nonlocal source
+            source = re.sub(pattern, replacement, source)
+
+        variables = {"replace": replace}
         with cwd(str(path.parent.absolute())):
             exec(self.prepare, variables)
-        source = variables["source"]
 
         with path.open(mode="w") as f:
             f.write(source)

--- a/compat/main.py
+++ b/compat/main.py
@@ -53,6 +53,7 @@ def cwd(path):
 class File:
     path: str
     prepare: Optional[str]
+    member_account_access: List[str] = field(default_factory=list)
 
     def rewrite(self, path: Path):
         if not isinstance(self.prepare, str):
@@ -79,16 +80,27 @@ class File:
     def parse(cls, path: Path, use_json: bool, bench: bool) -> (bool, Optional):
         return cls._run(PARSER_PATH, "Parsing", path, use_json, bench)
 
-    @classmethod
-    def check(cls, path: Path, use_json: bool, bench: bool) -> (bool, Optional):
-        return cls._run(CHECKER_PATH, "Checking", path, use_json, bench)
+    def check(self, path: Path, use_json: bool, bench: bool) -> (bool, Optional):
+        extra_args = [
+            f"-memberAccountAccess=S.{path}:S.{(path.parent / Path(other_path)).resolve()}"
+            for other_path in self.member_account_access
+        ]
+        return self._run(CHECKER_PATH, "Checking", path, use_json, bench, extra_args)
 
     @staticmethod
-    def _run(tool_path: Path, verb: str, path: Path, use_json: bool, bench: bool) -> (bool, Optional):
+    def _run(
+            tool_path: Path,
+            verb: str,
+            path: Path,
+            use_json: bool,
+            bench: bool,
+            extra_args: List[str] = None
+    ) -> (bool, Optional):
         logger.info(f"{verb} {path}")
         json_args = ["-json"] if use_json else []
         bench_args = ["-bench"] if bench else []
-        args = json_args + bench_args
+        args = json_args + bench_args + (extra_args or [])
+
         completed_process = subprocess.run(
             [tool_path, *args, path],
             cwd=str(path.parent),
@@ -110,13 +122,16 @@ class GoTest:
     path: str
     command: str
 
-    def run(self, working_dir: Path, prepare: bool) -> bool:
+    def run(self, working_dir: Path, prepare: bool, go_test_ref: Optional[str]) -> bool:
+        if go_test_ref:
+            replacement = f'github.com/onflow/cadence@{go_test_ref}'
+        else:
+            replacement = shlex.quote(str(Path.cwd().parent.absolute()))
 
-        cadence_path = shlex.quote(str(Path.cwd().parent.absolute()))
         with cwd(working_dir / self.path):
             if prepare:
                 subprocess.run([
-                    "go", "mod", "edit", "-replace", f'github.com/onflow/cadence={cadence_path}',
+                    "go", "mod", "edit", "-replace", f'github.com/onflow/cadence={replacement}',
                 ])
                 subprocess.run([
                     "go", "get", "-t", ".",
@@ -159,6 +174,11 @@ class Result:
     check_result: Optional[CheckResult] = field(default=None)
 
 
+def load_index(path: Path) -> List[str]:
+    with path.open(mode="r") as f:
+        return yaml.safe_load(f)
+
+
 @dataclass
 class Description:
     description: str
@@ -194,6 +214,7 @@ class Description:
         bench: bool,
         check: bool,
         go_test: bool,
+        go_test_ref: Optional[str],
     ) -> (bool, List[Result]):
 
         working_dir = SUITE_PATH / name
@@ -209,7 +230,7 @@ class Description:
         go_tests_succeeded = True
         if go_test:
             for test in self.go_tests:
-                if not test.run(working_dir, prepare=prepare):
+                if not test.run(working_dir, prepare=prepare, go_test_ref=go_test_ref):
                     go_tests_succeeded = False
 
         succeeded = check_succeeded and go_tests_succeeded
@@ -241,7 +262,7 @@ class Description:
                 continue
 
             check_succeeded, check_results = \
-                File.check(path, use_json=use_json, bench=bench)
+                file.check(path, use_json=use_json, bench=bench)
             if check_results:
                 result.check_result = CheckResult.from_dict(check_results[0])
             if use_json:
@@ -258,7 +279,7 @@ class Git:
     @staticmethod
     def clone(url: str, branch: str, working_dir: Path):
         subprocess.run([
-            "git", "clone", "--single-branch", "--branch",
+            "git", "clone", "--depth", "1", "--branch",
             branch, url, working_dir
         ])
 
@@ -676,6 +697,11 @@ def build_all():
     help="Run the suite Go tests"
 )
 @click.option(
+    "--go-test-ref",
+    default=None,
+    help="Git ref of Cadence for Go tests"
+)
+@click.option(
     "--output",
     default=None,
     type=click.File("w"),
@@ -702,6 +728,7 @@ def main(
         bench: bool,
         check: bool,
         go_test: bool,
+        go_test_ref: Optional[str],
         output: Optional[LazyFile],
         other_ref: Optional[str],
         delta_threshold: float,
@@ -726,6 +753,7 @@ def main(
         bench=bench,
         check=check,
         go_test=go_test,
+        go_test_ref=go_test_ref,
         names=names
     )
 
@@ -770,14 +798,22 @@ def main(
         exit(1)
 
 
-def run(prepare: bool, use_json: bool, bench: bool, check: bool, go_test: bool, names: Collection[str]) -> (
-bool, List[Result]):
+def run(
+        prepare: bool,
+        use_json: bool,
+        bench: bool,
+        check: bool,
+        go_test: bool,
+        go_test_ref: Optional[str],
+        names: Collection[str]
+) -> (bool, List[Result]):
+
     build_all()
 
     all_succeeded = True
 
     if not len(names):
-        names = [description_path.stem for description_path in SUITE_PATH.glob("*.yaml")]
+        names = load_index(SUITE_PATH / "index.yaml")
 
     all_results: List[Result] = []
 
@@ -792,6 +828,7 @@ bool, List[Result]):
             bench=bench,
             check=check,
             go_test=go_test,
+            go_test_ref=go_test_ref,
         )
 
         if not run_succeeded:

--- a/compat/suite/flow-core-contracts.yaml
+++ b/compat/suite/flow-core-contracts.yaml
@@ -1,0 +1,139 @@
+description: Flow Core Contracts
+maintainers:
+- bastian@dapperlabs.com
+- joshua.hannan@dapperlabs.com
+url: https://github.com/onflow/flow-core-contracts.git
+branch: master
+go_tests:
+- path: lib/go/test
+  command: make test
+files:
+- path: contracts/FlowToken.cdc
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
+  prepare: |
+    from pathlib import Path
+
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
+    )
+
+- path: contracts/FlowFees.cdc
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
+  prepare: |
+    from pathlib import Path
+
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowToken from 0xFLOWTOKENADDRESS',
+      f'import FlowToken from "{Path("FlowToken.cdc").resolve()}"'
+    )
+
+- path: contracts/FlowIDTableStaking.cdc
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
+  prepare: |
+    from pathlib import Path
+
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowToken from 0xFLOWTOKENADDRESS',
+      f'import FlowToken from "{Path("FlowToken.cdc").resolve()}"'
+    )
+
+- path: contracts/FlowStorageFees.cdc
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
+  prepare: |
+    from pathlib import Path
+
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowToken from 0xFLOWTOKENADDRESS',
+      f'import FlowToken from "{Path("FlowToken.cdc").resolve()}"'
+    )
+
+- path: contracts/FlowServiceAccount.cdc
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
+  prepare: |
+    from pathlib import Path
+
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowToken from 0xFLOWTOKENADDRESS',
+      f'import FlowToken from "{Path("FlowToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowFees from 0xFLOWFEESADDRESS',
+      f'import FlowFees from "{Path("FlowFees.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowStorageFees from 0xFLOWSTORAGEFEESADDRESS',
+      f'import FlowStorageFees from "{Path("FlowStorageFees.cdc").resolve()}"'
+    )
+
+- path: contracts/StakingProxy.cdc
+
+- path: contracts/LockedTokens.cdc
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
+  prepare: |
+    from pathlib import Path
+
+    replace(
+      'import FlowToken from 0xFLOWTOKENADDRESS',
+      f'import FlowToken from "{Path("FlowToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowIDTableStaking from 0xFLOWIDTABLESTAKINGADDRESS',
+      f'import FlowIDTableStaking from "{Path("FlowIDTableStaking.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowStorageFees from 0xFLOWSTORAGEFEESADDRESS',
+      f'import FlowStorageFees from "{Path("FlowStorageFees.cdc").resolve()}"'
+    )
+    replace(
+      'import StakingProxy from 0xSTAKINGPROXYADDRESS',
+      f'import StakingProxy from "{Path("StakingProxy.cdc").resolve()}"'
+    )
+
+- path: contracts/FlowStakingCollection.cdc
+  member_account_access:
+    - 'LockedTokens.cdc'
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
+  prepare: |
+    from pathlib import Path
+
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowToken from 0xFLOWTOKENADDRESS',
+      f'import FlowToken from "{Path("FlowToken.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowIDTableStaking from 0xFLOWIDTABLESTAKINGADDRESS',
+      f'import FlowIDTableStaking from "{Path("FlowIDTableStaking.cdc").resolve()}"'
+    )
+    replace(
+      'import LockedTokens from 0xLOCKEDTOKENSADDRESS',
+      f'import LockedTokens from "{Path("LockedTokens.cdc").resolve()}"'
+    )
+    replace(
+      'import FlowStorageFees from 0xFLOWSTORAGEFEESADDRESS',
+      f'import FlowStorageFees from "{Path("FlowStorageFees.cdc").resolve()}"'
+    )

--- a/compat/suite/flow-ft.yaml
+++ b/compat/suite/flow-ft.yaml
@@ -10,95 +10,79 @@ go_tests:
 files:
 - path: contracts/FungibleToken.cdc
 - path: contracts/utilityContracts/TokenForwarding.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-        f'import FungibleToken from "{Path("../FungibleToken.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../FungibleToken.cdc").resolve()}"'
+    )
 
 - path: contracts/ExampleToken.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-        f'import FungibleToken from "{Path("FungibleToken.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("FungibleToken.cdc").resolve()}"'
+    )
 
 - path: transactions/transfer_tokens.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-        f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"',
-        source,
-      )
-      source = re.sub(
-        'import ExampleToken from 0xTOKENADDRESS',
-        f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import ExampleToken from 0xTOKENADDRESS',
+      f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"'
+    )
 
 - path: transactions/setup_account.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-        f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"',
-        source,
-      )
-      source = re.sub(
-        'import ExampleToken from 0xTOKENADDRESS',
-        f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import ExampleToken from 0xTOKENADDRESS',
+      f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"'
+    )
 
 - path: transactions/mint_tokens.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-        f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"',
-        source,
-      )
-      source = re.sub(
-        'import ExampleToken from 0xTOKENADDRESS',
-        f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import ExampleToken from 0xTOKENADDRESS',
+      f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"'
+    )
 
 
 - path: transactions/burn_tokens.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-        f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"',
-        source,
-      )
-      source = re.sub(
-        'import ExampleToken from 0xTOKENADDRESS',
-        f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
+      f'import FungibleToken from "{Path("../contracts/FungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import ExampleToken from 0xTOKENADDRESS',
+      f'import ExampleToken from "{Path("../contracts/ExampleToken.cdc").resolve()}"'
+    )
 

--- a/compat/suite/flow-nft.yaml
+++ b/compat/suite/flow-nft.yaml
@@ -10,65 +10,54 @@ go_tests:
 files:
 - path: contracts/NonFungibleToken.cdc
 - path: contracts/ExampleNFT.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import NonFungibleToken from 0x02',
-        f'import NonFungibleToken from "{Path("NonFungibleToken.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import NonFungibleToken from 0x02',
+      f'import NonFungibleToken from "{Path("NonFungibleToken.cdc").resolve()}"'
+    )
 
 
 - path: transactions/mint_nft.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import NonFungibleToken from 0xNFTADDRESS',
-        f'import NonFungibleToken from "{Path("../contracts/NonFungibleToken.cdc").resolve()}"',
-        source,
-      )
-      source = re.sub(
-        'import ExampleNFT from 0xNFTCONTRACTADDRESS',
-        f'import ExampleNFT from "{Path("../contracts/ExampleNFT.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import NonFungibleToken from 0xNFTADDRESS',
+      f'import NonFungibleToken from "{Path("../contracts/NonFungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import ExampleNFT from 0xNFTCONTRACTADDRESS',
+      f'import ExampleNFT from "{Path("../contracts/ExampleNFT.cdc").resolve()}"'
+    )
 
 - path: transactions/setup_account.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import NonFungibleToken from 0xNFTADDRESS',
-        f'import NonFungibleToken from "{Path("../contracts/NonFungibleToken.cdc").resolve()}"',
-        source,
-      )
-      source = re.sub(
-        'import ExampleNFT from 0xNFTCONTRACTADDRESS',
-        f'import ExampleNFT from "{Path("../contracts/ExampleNFT.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import NonFungibleToken from 0xNFTADDRESS',
+      f'import NonFungibleToken from "{Path("../contracts/NonFungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import ExampleNFT from 0xNFTCONTRACTADDRESS',
+      f'import ExampleNFT from "{Path("../contracts/ExampleNFT.cdc").resolve()}"'
+    )
 
 - path: transactions/transfer_nft.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-      import re
-      from pathlib import Path
+    from pathlib import Path
 
-      source = re.sub(
-        'import NonFungibleToken from 0xNFTADDRESS',
-        f'import NonFungibleToken from "{Path("../contracts/NonFungibleToken.cdc").resolve()}"',
-        source,
-      )
-      source = re.sub(
-        'import ExampleNFT from 0xNFTCONTRACTADDRESS',
-        f'import ExampleNFT from "{Path("../contracts/ExampleNFT.cdc").resolve()}"',
-        source,
-      )
+    replace(
+      'import NonFungibleToken from 0xNFTADDRESS',
+      f'import NonFungibleToken from "{Path("../contracts/NonFungibleToken.cdc").resolve()}"'
+    )
+    replace(
+      'import ExampleNFT from 0xNFTCONTRACTADDRESS',
+      f'import ExampleNFT from "{Path("../contracts/ExampleNFT.cdc").resolve()}"'
+    )

--- a/compat/suite/index.yaml
+++ b/compat/suite/index.yaml
@@ -1,0 +1,4 @@
+- flow-ft
+- flow-nft
+- flow-core-contracts
+- nba-smart-contracts

--- a/compat/suite/nba-smart-contracts.yaml
+++ b/compat/suite/nba-smart-contracts.yaml
@@ -9,98 +9,82 @@ go_tests:
   command: make test
 files:
 - path: contracts/TopShot.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-    import re
     from pathlib import Path
 
-    source = re.sub(
+    replace(
       'import NonFungibleToken from 0xNFTADDRESS',
-      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"',
-      source,
+      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"'
     )
 
 - path: contracts/MarketTopShot.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-    import re
     from pathlib import Path
 
-    source = re.sub(
+    replace(
       'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"',
-      source,
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
     )
 
-    source = re.sub(
+    replace(
       'import NonFungibleToken from 0xNFTADDRESS',
-      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"',
-      source,
+      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"'
     )
 
-    source = re.sub(
+    replace(
       'import TopShot from 0xTOPSHOTADDRESS',
-      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"',
-      source,
+      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"'
     )
 
 - path: contracts/TopShotMarketV2.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-    import re
     from pathlib import Path
 
-    source = re.sub(
+    replace(
       'import FungibleToken from 0xFUNGIBLETOKENADDRESS',
-      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"',
-      source,
+      f'import FungibleToken from "{Path("../../flow-ft/contracts/FungibleToken.cdc").resolve()}"'
     )
 
-    source = re.sub(
+    replace(
       'import NonFungibleToken from 0xNFTADDRESS',
-      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"',
-      source,
+      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"'
     )
 
-    source = re.sub(
+    replace(
       'import TopShot from 0xTOPSHOTADDRESS',
-      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"',
-      source,
+      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"'
     )
 
 - path: contracts/TopShotShardedCollection.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-    import re
     from pathlib import Path
 
-    source = re.sub(
+    replace(
       'import NonFungibleToken from 0xNFTADDRESS',
-      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"',
-      source,
+      f'import NonFungibleToken from "{Path("../../flow-nft/contracts/NonFungibleToken.cdc").resolve()}"'
     )
 
-    source = re.sub(
+    replace(
       'import TopShot from 0xTOPSHOTADDRESS',
-      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"',
-      source,
+      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"'
     )
 
 - path: contracts/TopshotAdminReceiver.cdc
-  # language=Python prefix=source=''\n
+  # language=Python prefix="replace: Callable[[str, str], None]\n"
   prepare: |
-    import re
     from pathlib import Path
 
-    source = re.sub(
+    replace(
       'import TopShotShardedCollection from 0xSHARDEDADDRESS',
-      f'import TopShotShardedCollection from "{Path("TopShotShardedCollection.cdc").resolve()}"',
-      source,
+      f'import TopShotShardedCollection from "{Path("TopShotShardedCollection.cdc").resolve()}"'
     )
 
-    source = re.sub(
+    replace(
       'import TopShot from 0xTOPSHOTADDRESS',
-      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"',
-      source,
+      f'import TopShot from  "{Path("TopShot.cdc").resolve()}"'
     )
 

--- a/runtime/cmd/compile/main.go
+++ b/runtime/cmd/compile/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	program, must := cmd.PrepareProgramFromFile(location, codes)
 
-	checker, must := cmd.PrepareChecker(program, location, codes, must)
+	checker, must := cmd.PrepareChecker(program, location, codes, nil, must)
 
 	must(checker.Check())
 

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -294,6 +294,10 @@ func (checker *Checker) isReadableMember(member *Member) bool {
 		if common.LocationsInSameAccount(checker.Location, location) {
 			return true
 		}
+
+		if checker.memberAccountAccessHandler != nil {
+			return checker.memberAccountAccessHandler(checker, location)
+		}
 	}
 
 	return false

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -76,6 +76,8 @@ type LocationHandlerFunc func(identifiers []ast.Identifier, location common.Loca
 
 type ImportHandlerFunc func(checker *Checker, importedLocation common.Location, importRange ast.Range) (Import, error)
 
+type MemberAccountAccessHandlerFunc func(checker *Checker, memberLocation common.Location) bool
+
 // Checker
 
 type Checker struct {
@@ -112,6 +114,7 @@ type Checker struct {
 	importHandler                      ImportHandlerFunc
 	checkHandler                       CheckHandlerFunc
 	expectedType                       Type
+	memberAccountAccessHandler         MemberAccountAccessHandlerFunc
 }
 
 type Option func(*Checker) error
@@ -196,6 +199,17 @@ func WithLocationHandler(handler LocationHandlerFunc) Option {
 func WithImportHandler(handler ImportHandlerFunc) Option {
 	return func(checker *Checker) error {
 		checker.importHandler = handler
+		return nil
+	}
+}
+
+// WithMemberAccountAccessHandler returns a checker option which sets
+// the given handler as function which is used to determine
+// if the access of a member with account access modifier is valid.
+//
+func WithMemberAccountAccessHandler(handler MemberAccountAccessHandlerFunc) Option {
+	return func(checker *Checker) error {
+		checker.memberAccountAccessHandler = handler
 		return nil
 	}
 }


### PR DESCRIPTION
Closes #974 

## Description

- Read all suite names from an `index.yaml` file by default (instead of searching for .yaml files).
  This allows a guaranteed order, and thus suites to depend on earlier suites to be prepared 
- Simplify the suite file prepare blocks: Pass a `replace` function
- Add a handler option to the checker that allows customizing if a member with account access maybe read
- Allow specifying the member account access for suite files
- Add the Flow core contracts as a suite
- Run the Go tests on CI
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
