### PR TITLE
Auto update flow-go github action

### DIFF
--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -61,7 +61,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.REMOTE_REPO_PAT }}
-          commit-message: update cadence to commit ${{ github.event.pull_request.head.sha }}
+          commit-message: update Cadence to commit ${{ github.event.pull_request.head.sha }}
           title: Auto-Update ${{ env.LOCAL_REPO_NAME }} - ${{ github.event.pull_request.title }}
           body: |
               Auto generated PR to update Cadence version.

--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -1,0 +1,70 @@
+# Open a PR in flow-go when a PR in cadence is merged
+# The PR in flow-go is based on the last opened `auto-cadence-upgrade/*` if it exists, otherwise on the master branch
+
+
+# Only run on pull requests merged to master
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  sync-flow-go:
+    runs-on: ubuntu-latest
+    # the PR could have been closed otherwise. Only run if it has actually ben merged
+    if: github.event.pull_request.merged == true
+    steps:
+      # Central place for some constants so they are not scattered around
+      - name: Set Parameters
+        id: step_one
+        run: |
+          echo "REMOTE_REPO=onflow/flow-go" >> $GITHUB_ENV
+          echo "LOCAL_REPO_NAME=cadence" >> $GITHUB_ENV
+    
+      # checkout the repo we are going to be updating with fetch depth of 0 to get all the branches fro the next step
+      - name: Checkout ${{ env.REMOTE_REPO }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.REMOTE_REPO_PAT }}
+          repository: ${{ env.REMOTE_REPO }}
+
+      # get the latest update branch name to base the PR on that branch
+      - name: Get ${{ env.REMOTE_REPO }} base branch name
+        run: |
+          BRANCH=$(git branch -r -l "origin/auto-{{ $LOCAL_REPO_NAME }}-upgrade*" --format "%(refname:lstrip=3)" --sort=-committerdate | head -n 1)
+          [ -z $BRANCH ] && BRANCH=master
+          echo "BASE_BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      # checkout the correct branch of the remote repo
+      - name: Checkout ${{ env.REMOTE_REPO }} branch
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.REMOTE_REPO_PAT }}
+          repository: ${{ env.REMOTE_REPO }}
+          ref: ${{ env.BASE_BRANCH }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+
+      - name: Update Cadence
+        run: go get github.com/onflow/cadence@${{ github.event.pull_request.head.sha }}
+      
+      - name: Make tidy
+        run: make tidy
+
+      # create the pull request
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.REMOTE_REPO_PAT }}
+          commit-message: update cadence to commit ${{ github.event.pull_request.head.sha }}
+          title: Auto-Update ${{ env.LOCAL_REPO_NAME }} - ${{ github.event.pull_request.title }}
+          body: |
+              Auto generated PR to update Cadence version.
+
+              References: ${{ github.event.pull_request.html_url }}
+          branch: auto-${{ env.LOCAL_REPO_NAME }}-upgrade/${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Closes https://github.com/dapperlabs/flow-internal/issues/1517

## Description

A github action that creates a PR in flow-go to update cadence version every time a PR is merged into master in cadence. The PRs in flow-go are based on the master branch or the latest `auto-cadence-upgrade/*` branch if it exists

I tested this on private repos, but it might still need some tweaking on the `go get && make tidy` part.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
