### PR TITLE
Fix for auto-update flow-go: no fail on tidy

### DIFF
--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -51,10 +51,18 @@ jobs:
           go-version: '1.15'
 
       - name: Update Cadence
-        run: go get github.com/onflow/cadence@${{ github.event.pull_request.head.sha }}
+        run: |
+          go get github.com/onflow/cadence@${{ github.event.pull_request.head.sha }}
+          cd integration
+          go get github.com/onflow/cadence@${{ github.event.pull_request.head.sha }}
+          cd ..
       
       - name: go mod tidy
-        run: go mod tidy
+        run: |
+          go mod tidy
+          cd integration
+          go mod tidy
+          cd ..
 
       # create the pull request
       - name: Create Pull Request

--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Update Cadence
         run: go get github.com/onflow/cadence@${{ github.event.pull_request.head.sha }}
       
-      - name: Make tidy
-        run: make tidy
+      - name: go mod tidy
+        run: go mod tidy
 
       # create the pull request
       - name: Create Pull Request


### PR DESCRIPTION
References https://github.com/dapperlabs/flow-internal/issues/1517

## Description

`make tidy` fails the pipeline use go mod tidy instead.

Also update and tidy flow-go/integration.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
