### PR TITLE
Disable the wasmtime VM for now

### DIFF
--- a/runtime/compiler/codegen_test.go
+++ b/runtime/compiler/codegen_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/compiler/ir"
 	"github.com/onflow/cadence/runtime/compiler/wasm"
-	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/vm"
 )
 
 func TestWasmCodeGenSimple(t *testing.T) {
@@ -197,12 +195,4 @@ func TestWasmCodeGenSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	_ = wasm.WASM2WAT(buf.Bytes())
-
-	machine, err := vm.NewVM(buf.Bytes())
-	require.NoError(t, err)
-
-	res, err := machine.Invoke("inc", interpreter.NewIntValueFromInt64(2))
-	require.NoError(t, err)
-
-	require.Equal(t, interpreter.NewIntValueFromInt64(3), res)
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -1,3 +1,5 @@
+// +build wasmtime
+
 /*
  * Cadence - The resource-oriented smart contract programming language
  *


### PR DESCRIPTION
## Description

Put the VM, which uses wasmtime, behind a build flag. Wasmtime does not work on M1 yet

______

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
