### PR TITLE
Fix dictionary deferred owner

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1844,7 +1844,6 @@ func decodeDictionaryEntries(v *DictionaryValue, content []byte) error {
 	entries := NewStringValueOrderedMap()
 
 	var deferred *orderedmap.StringStructOrderedMap
-	var deferredOwner *common.Address
 	var deferredStorageKeyBase string
 
 	// Are the values in the dictionary deferred, i.e. are they encoded
@@ -1855,7 +1854,6 @@ func decodeDictionaryEntries(v *DictionaryValue, content []byte) error {
 	if isDeferred {
 
 		deferred = orderedmap.NewStringStructOrderedMap()
-		deferredOwner = d.owner
 		deferredStorageKeyBase = joinPath(append(v.valuePath, dictionaryValuePathPrefix))
 		for _, keyValue := range keys.Elements() {
 			key := dictionaryKey(keyValue)
@@ -1900,11 +1898,12 @@ func decodeDictionaryEntries(v *DictionaryValue, content []byte) error {
 
 			keyIndex++
 		}
+
+		v.deferredOwner = nil
 	}
 
 	v.keys = keys
 	v.entries = entries
-	v.deferredOwner = deferredOwner
 	v.deferredKeys = deferred
 	v.deferredStorageKeyBase = deferredStorageKeyBase
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7215,6 +7215,7 @@ func NewDeferredDictionaryValue(
 ) *DictionaryValue {
 	return &DictionaryValue{
 		Owner:           owner,
+		deferredOwner:   owner,
 		modified:        false,
 		valuePath:       path,
 		content:         content,


### PR DESCRIPTION
## Description

Keep the initial owner of the dictionary at initialization time, so that by the time the dictionary entries are decoded it is still available, and not the potentially different owner is used as  the deferred owner.
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
