### PR TITLE
No need for checking resource loss when function definitely halted

### DIFF
--- a/runtime/sema/function_activations.go
+++ b/runtime/sema/function_activations.go
@@ -51,14 +51,14 @@ func (a *FunctionActivations) IsLocal() bool {
 	return currentFunctionDepth > 0
 }
 
-func (a *FunctionActivations) EnterFunction(functionType *FunctionType, valueActivationDepth int) {
-	a.activations = append(a.activations,
-		&FunctionActivation{
-			ReturnType:           functionType.ReturnTypeAnnotation.Type,
-			ValueActivationDepth: valueActivationDepth,
-			ReturnInfo:           &ReturnInfo{},
-		},
-	)
+func (a *FunctionActivations) EnterFunction(functionType *FunctionType, valueActivationDepth int) *FunctionActivation {
+	activation := &FunctionActivation{
+		ReturnType:           functionType.ReturnTypeAnnotation.Type,
+		ValueActivationDepth: valueActivationDepth,
+		ReturnInfo:           &ReturnInfo{},
+	}
+	a.activations = append(a.activations, activation)
+	return activation
 }
 
 func (a *FunctionActivations) LeaveFunction() {
@@ -66,10 +66,14 @@ func (a *FunctionActivations) LeaveFunction() {
 	a.activations = a.activations[:lastIndex]
 }
 
-func (a *FunctionActivations) WithFunction(functionType *FunctionType, valueActivationDepth int, f func()) {
-	a.EnterFunction(functionType, valueActivationDepth)
+func (a *FunctionActivations) WithFunction(
+	functionType *FunctionType,
+	valueActivationDepth int,
+	f func(activation *FunctionActivation),
+) {
+	activation := a.EnterFunction(functionType, valueActivationDepth)
 	defer a.LeaveFunction()
-	f()
+	f(activation)
 }
 
 func (a *FunctionActivations) Current() *FunctionActivation {

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -4918,3 +4918,40 @@ func TestCheckInvalidationInPostCondition(t *testing.T) {
 
 	assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
 }
+
+func TestCheckFunctionDefinitelyHaltedNoResourceLoss(t *testing.T) {
+
+	t.Parallel()
+
+	// A function which definitely halts does not lead to a resource loss error
+
+	t.Run("panic statement", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithPanic(t, `
+          fun duplicate(_ r: @AnyResource) {
+              panic("")
+          }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("if statement", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithPanic(t, `
+          fun duplicate(_ r: @AnyResource, x: Bool) {
+              if x {
+                  panic("true")
+              } else {
+                  panic("false")
+              }
+          }
+        `)
+
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

Reported by @joshuahannan 🙏:

When a function is determined to have definitely halted, then there is no need to check for a resource loss.

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
