### PR TITLE
Don't check missing program

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1794,6 +1794,11 @@ func (s *Server) getDiagnostics(
 						if err != nil {
 							return nil, err
 						}
+						if importedProgram == nil {
+							return nil, &sema.CheckerError{
+								Errors: []error{fmt.Errorf("cannot import %s", importedLocation)},
+							}
+						}
 
 						importedChecker, err = checker.SubChecker(importedProgram, importedLocation)
 						if err != nil {

--- a/runtime/ast/function_declaration.go
+++ b/runtime/ast/function_declaration.go
@@ -55,7 +55,9 @@ func (d *FunctionDeclaration) Accept(visitor Visitor) Repr {
 func (d *FunctionDeclaration) Walk(walkChild func(Element)) {
 	// TODO: walk parameters
 	// TODO: walk return type
-	walkChild(d.FunctionBlock)
+	if d.FunctionBlock != nil {
+		walkChild(d.FunctionBlock)
+	}
 }
 
 func (*FunctionDeclaration) isDeclaration() {}

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -41,7 +41,9 @@ func (s *ReturnStatement) Accept(visitor Visitor) Repr {
 }
 
 func (s *ReturnStatement) Walk(walkChild func(Element)) {
-	walkChild(s.Expression)
+	if s.Expression != nil {
+		walkChild(s.Expression)
+	}
 }
 
 func (s *ReturnStatement) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Closes #996

## Description

https://github.com/Bhawana15/Kitty-Auction-House/blob/main/cadence/contracts/Auction.cdc is a good stress test, it uncovered a few issues:

- If an import cannot be resolved in the language server, the empty program was still checked, leading to a crash
- The AST walking implementations for function declarations and return statements didn't handle nil-cases properly, leading to a crash

After applying these changes, the language server is able to check the program and does not crash anymore.

______

<!-- Complete: -->
 
- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
