### PR TITLE
Fix close-brace for struct definition docs in docgen tool

### DIFF
--- a/tools/docgen/templates/markdown/composite-full-template
+++ b/tools/docgen/templates/markdown/composite-full-template
@@ -9,6 +9,7 @@
 {{- else}} {
 {{- end -}}
 
+{{- else}} {
 {{- end -}}
 {{- range .Members.Fields -}}
     {{template "field" . -}}

--- a/tools/docgen/test/outputs/NFT.md
+++ b/tools/docgen/test/outputs/NFT.md
@@ -1,7 +1,7 @@
 # Contract `NFT`
 
 ```cadence
-contract NFT
+contract NFT {
 
     field1:  Int
 

--- a/tools/docgen/test/outputs/NFT_SomeStruct.md
+++ b/tools/docgen/test/outputs/NFT_SomeStruct.md
@@ -1,7 +1,7 @@
 # Struct `SomeStruct`
 
 ```cadence
-struct SomeStruct
+struct SomeStruct {
 
     x:  String
 

--- a/tools/docgen/test/outputs/NFT_SomeStruct_InnerStruct.md
+++ b/tools/docgen/test/outputs/NFT_SomeStruct_InnerStruct.md
@@ -1,7 +1,7 @@
 # Struct `InnerStruct`
 
 ```cadence
-struct InnerStruct
+struct InnerStruct {
 
     a:  Int
 

--- a/tools/docgen/test/outputs/SomeInterface.md
+++ b/tools/docgen/test/outputs/SomeInterface.md
@@ -1,7 +1,7 @@
 # Struct Interface `SomeInterface`
 
 ```cadence
-struct interface SomeInterface
+struct interface SomeInterface {
 
     x:  String
 

--- a/tools/docgen/test/outputs/SomeStruct.md
+++ b/tools/docgen/test/outputs/SomeStruct.md
@@ -1,7 +1,7 @@
 # Struct `SomeStruct`
 
 ```cadence
-struct SomeStruct
+struct SomeStruct {
 
     x:  String
 

--- a/tools/docgen/test/outputs/SomeStruct_InnerStruct.md
+++ b/tools/docgen/test/outputs/SomeStruct_InnerStruct.md
@@ -1,7 +1,7 @@
 # Struct `InnerStruct`
 
 ```cadence
-struct InnerStruct
+struct InnerStruct {
 
     a:  Int
 


### PR DESCRIPTION

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
