### PR TITLE
Remove additional check for builtin values during import resolving

### DIFF
--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -78,11 +78,6 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 			}
 		}
 
-		// don't import base values
-		if sema.BaseValueActivation.Find(name) != nil {
-			continue
-		}
-
 		interpreter.setVariable(name, variable)
 		interpreter.Globals.Set(name, variable)
 	}


### PR DESCRIPTION
## Description

With the changes of #1018 and #1022, builtin-values are no longer available in the `interpreter.Globals`. Hence this check at import resolving is no longer required.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
