### PR TITLE
Replace `IsSubType` check with `IsSameTypeKind` check where necessary

### DIFF
--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -318,13 +318,13 @@ func LiteralValue(expression ast.Expression, ty sema.Type) (cadence.Value, error
 	}
 
 	switch {
-	case sema.IsSubType(ty, sema.IntegerType):
+	case sema.IsSameTypeKind(ty, sema.IntegerType):
 		return integerLiteralValue(expression, ty)
 
-	case sema.IsSubType(ty, sema.FixedPointType):
+	case sema.IsSameTypeKind(ty, sema.FixedPointType):
 		return fixedPointLiteralValue(expression, ty)
 
-	case sema.IsSubType(ty, sema.PathType):
+	case sema.IsSameTypeKind(ty, sema.PathType):
 		return pathLiteralValue(expression, ty)
 	}
 

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -212,8 +212,8 @@ func (checker *Checker) checkBinaryExpressionArithmeticOrNonEqualityComparisonOr
 		panic(errors.NewUnreachableError())
 	}
 
-	leftIsNumber := IsSubType(leftType, expectedSuperType)
-	rightIsNumber := IsSubType(rightType, expectedSuperType)
+	leftIsNumber := IsSameTypeKind(leftType, expectedSuperType)
+	rightIsNumber := IsSameTypeKind(rightType, expectedSuperType)
 
 	reportedInvalidOperands := false
 
@@ -325,8 +325,8 @@ func (checker *Checker) checkBinaryExpressionBooleanLogic(
 ) Type {
 	// check both types are boolean subtypes
 
-	leftIsBool := IsSubType(leftType, BoolType)
-	rightIsBool := IsSubType(rightType, BoolType)
+	leftIsBool := IsSameTypeKind(leftType, BoolType)
+	rightIsBool := IsSameTypeKind(rightType, BoolType)
 
 	if !leftIsBool && !rightIsBool {
 		if !anyInvalid {

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -942,7 +942,7 @@ func (checker *Checker) enumRawType(declaration *ast.CompositeDeclaration) Type 
 	rawType := checker.ConvertType(conformance)
 
 	if !rawType.IsInvalidType() &&
-		!IsSubType(rawType, IntegerType) {
+		!IsSameTypeKind(rawType, IntegerType) {
 
 		checker.report(
 			&InvalidEnumRawTypeError{

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -114,8 +114,8 @@ func IsValidDictionaryKeyType(keyType Type) bool {
 		case NeverType, BoolType, CharacterType, StringType, MetaType:
 			return true
 		default:
-			return IsSubType(keyType, NumberType) ||
-				IsSubType(keyType, PathType)
+			return IsSameTypeKind(keyType, NumberType) ||
+				IsSameTypeKind(keyType, PathType)
 		}
 	}
 }

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -92,7 +92,7 @@ func IsValidEventParameterType(t Type, results map[*Member]bool) bool {
 
 	default:
 		switch t {
-		case MetaType, BoolType, CharacterType, StringType, NeverType:
+		case MetaType, BoolType, CharacterType, StringType:
 			return true
 		}
 

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -92,11 +92,11 @@ func IsValidEventParameterType(t Type, results map[*Member]bool) bool {
 
 	default:
 		switch t {
-		case MetaType, BoolType, CharacterType, StringType:
+		case MetaType, BoolType, CharacterType, StringType, NeverType:
 			return true
 		}
 
-		return IsSubType(t, NumberType) ||
-			IsSubType(t, PathType)
+		return IsSameTypeKind(t, NumberType) ||
+			IsSameTypeKind(t, PathType)
 	}
 }

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -170,11 +170,9 @@ func (checker *Checker) VisitIntegerExpression(expression *ast.IntegerExpression
 	isAddress := false
 
 	// If the contextually expected type is a subtype of Integer or Address, then take that.
-	if expectedType == nil || IsSubType(expectedType, NeverType) {
-		actualType = IntType
-	} else if IsSubType(expectedType, IntegerType) {
+	if IsSameTypeKind(expectedType, IntegerType) {
 		actualType = expectedType
-	} else if IsSubType(expectedType, &AddressType{}) {
+	} else if IsSameTypeKind(expectedType, &AddressType{}) {
 		isAddress = true
 		CheckAddressLiteral(expression, checker.report)
 		actualType = expectedType
@@ -202,9 +200,7 @@ func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpr
 
 	var actualType Type
 
-	if expectedType != nil &&
-		!IsSubType(expectedType, NeverType) &&
-		IsSubType(expectedType, FixedPointType) {
+	if IsSameTypeKind(expectedType, FixedPointType) {
 		actualType = expectedType
 	} else if expression.Negative {
 		actualType = Fix64Type
@@ -222,7 +218,7 @@ func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpr
 func (checker *Checker) VisitStringExpression(expression *ast.StringExpression) ast.Repr {
 	expectedType := UnwrapOptionalType(checker.expectedType)
 
-	if expectedType != nil && IsSubType(expectedType, CharacterType) {
+	if IsSameTypeKind(expectedType, CharacterType) {
 		checker.checkCharacterLiteral(expression)
 		return expectedType
 	}

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -208,7 +208,7 @@ func (checker *Checker) checkTransactionPrepareFunctionParameters(
 		parameterType := parameters[i].TypeAnnotation.Type
 
 		if !parameterType.IsInvalidType() &&
-			!IsSubType(parameterType, AuthAccountType) {
+			!IsSameTypeKind(parameterType, AuthAccountType) {
 
 			checker.report(
 				&InvalidTransactionPrepareParameterTypeError{

--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -46,7 +46,7 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) as
 	switch expression.Operation {
 	case ast.OperationNegate:
 		expectedType := BoolType
-		if !IsSubType(valueType, expectedType) {
+		if !IsSameTypeKind(valueType, expectedType) {
 			reportInvalidUnaryOperator(expectedType)
 			return InvalidType
 		}
@@ -54,7 +54,7 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) as
 
 	case ast.OperationMinus:
 		expectedType := SignedNumberType
-		if !IsSubType(valueType, expectedType) {
+		if !IsSameTypeKind(valueType, expectedType) {
 			reportInvalidUnaryOperator(expectedType)
 			return InvalidType
 		}

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -25,20 +25,7 @@ import (
 
 func (checker *Checker) VisitWhileStatement(statement *ast.WhileStatement) ast.Repr {
 
-	testExpression := statement.Test
-	testType := checker.VisitExpression(testExpression, nil)
-
-	if !testType.IsInvalidType() &&
-		!IsSubType(testType, BoolType) {
-
-		checker.report(
-			&TypeMismatchError{
-				ExpectedType: BoolType,
-				ActualType:   testType,
-				Range:        ast.NewRangeFromPositioned(testExpression),
-			},
-		)
-	}
+	checker.VisitExpression(statement.Test, BoolType)
 
 	// The body of the loop will maybe be evaluated.
 	// That means that resource invalidations and

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -601,9 +601,8 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 	case *ast.FixedPointExpression:
 		unwrappedTargetType := UnwrapOptionalType(targetType)
 
-		valueTypeOK := CheckFixedPointLiteral(typedExpression, valueType, checker.report)
-
 		if IsSameTypeKind(unwrappedTargetType, FixedPointType) {
+			valueTypeOK := CheckFixedPointLiteral(typedExpression, valueType, checker.report)
 			if valueTypeOK {
 				CheckFixedPointLiteral(typedExpression, unwrappedTargetType, checker.report)
 			}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -587,19 +587,12 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 	case *ast.IntegerExpression:
 		unwrappedTargetType := UnwrapOptionalType(targetType)
 
-		// If the target type is `Never`, the checks below will be performed
-		// (as `Never` is the subtype of all types), but the checks are not valid
-
-		if IsSubType(unwrappedTargetType, NeverType) {
-			break
-		}
-
-		if IsSubType(unwrappedTargetType, IntegerType) {
+		if IsSameTypeKind(unwrappedTargetType, IntegerType) {
 			CheckIntegerLiteral(typedExpression, unwrappedTargetType, checker.report)
 
 			return true
 
-		} else if IsSubType(unwrappedTargetType, &AddressType{}) {
+		} else if IsSameTypeKind(unwrappedTargetType, &AddressType{}) {
 			CheckAddressLiteral(typedExpression, checker.report)
 
 			return true
@@ -608,16 +601,9 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 	case *ast.FixedPointExpression:
 		unwrappedTargetType := UnwrapOptionalType(targetType)
 
-		// If the target type is `Never`, the checks below will be performed
-		// (as `Never` is the subtype of all types), but the checks are not valid
-
-		if IsSubType(unwrappedTargetType, NeverType) {
-			break
-		}
-
 		valueTypeOK := CheckFixedPointLiteral(typedExpression, valueType, checker.report)
 
-		if IsSubType(unwrappedTargetType, FixedPointType) {
+		if IsSameTypeKind(unwrappedTargetType, FixedPointType) {
 			if valueTypeOK {
 				CheckFixedPointLiteral(typedExpression, unwrappedTargetType, checker.report)
 			}
@@ -662,7 +648,7 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 	case *ast.StringExpression:
 		unwrappedTargetType := UnwrapOptionalType(targetType)
 
-		if IsSubType(unwrappedTargetType, CharacterType) {
+		if IsSameTypeKind(unwrappedTargetType, CharacterType) {
 			checker.checkCharacterLiteral(typedExpression)
 
 			return true

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3208,12 +3208,12 @@ func suggestIntegerLiteralConversionReplacement(
 ) {
 	negative := argument.Value.Sign() < 0
 
-	if IsSubType(targetType, FixedPointType) {
+	if IsSameTypeKind(targetType, FixedPointType) {
 
 		// If the integer literal is converted to a fixed-point type,
 		// suggest replacing it with a fixed-point literal
 
-		signed := IsSubType(targetType, SignedFixedPointType)
+		signed := IsSameTypeKind(targetType, SignedFixedPointType)
 
 		var hintExpression ast.Expression = &ast.FixedPointExpression{
 			Negative:        negative,
@@ -3248,7 +3248,7 @@ func suggestIntegerLiteralConversionReplacement(
 			},
 		)
 
-	} else if IsSubType(targetType, IntegerType) {
+	} else if IsSameTypeKind(targetType, IntegerType) {
 
 		// If the integer literal is converted to an integer type,
 		// suggest replacing it with a fixed-point literal
@@ -3260,7 +3260,7 @@ func suggestIntegerLiteralConversionReplacement(
 		// as all integer literals (positive and negative)
 		// are inferred to be of type `Int`
 
-		if !IsSubType(targetType, IntType) {
+		if !IsSameTypeKind(targetType, IntType) {
 			hintExpression = &ast.CastingExpression{
 				Expression: hintExpression,
 				Operation:  ast.OperationCast,
@@ -3293,12 +3293,12 @@ func suggestFixedPointLiteralConversionReplacement(
 	// If the fixed-point literal is converted to a fixed-point type,
 	// suggest replacing it with a fixed-point literal
 
-	if !IsSubType(targetType, FixedPointType) {
+	if !IsSameTypeKind(targetType, FixedPointType) {
 		return
 	}
 
 	negative := argument.Negative
-	signed := IsSubType(targetType, SignedFixedPointType)
+	signed := IsSameTypeKind(targetType, SignedFixedPointType)
 
 	if (!negative && !signed) || (negative && signed) {
 		checker.hint(

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4709,11 +4709,31 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 //
 func IsSubType(subType Type, superType Type) bool {
 
+	if subType == nil {
+		return false
+	}
+
 	if subType.Equal(superType) {
 		return true
 	}
 
 	return checkSubTypeWithoutEquality(subType, superType)
+}
+
+// IsSameTypeKind determines if the given subtype belongs to the
+// same kind as the supertype.
+//
+// e.g: 'Never' type is a subtype of 'Integer', but not of the
+// same kind as 'Int'. Whereas, 'Int8' is both a subtype
+// as well as of same kind as 'Integer'.
+//
+func IsSameTypeKind(subType Type, superType Type) bool {
+
+	if subType == NeverType {
+		return false
+	}
+
+	return IsSubType(subType, superType)
 }
 
 // IsProperSubType is similar to IsSubType,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4708,9 +4708,17 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 // Types are subtypes of themselves.
 //
 // NOTE: This method can be used to check the assignability of `subType` to `superType`.
-// However, to check if a type *strictly* belongs to a certain category, then
-// consider using `IsSameTypeKind` method. e.g: "Is type `T` an Integer type?". Using
-// this method for the later use-case may produce incorrect results.
+// However, to check if a type *strictly* belongs to a certain category, then consider
+// using `IsSameTypeKind` method. e.g: "Is type `T` an Integer type?". Using this method
+// for the later use-case may produce incorrect results.
+//   * IsSubType()      - To check the assignability. e.g: Is argument type T is a sub-type
+//                        of parameter type R. This is the more frequent use-case.
+//   * IsSameTypeKind() - To check if a type strictly belongs to a certain category. e.g: Is the
+//                        expression type T is any of the integer types, but nothing else.
+//                        Another way to check is, asking the question of "if the subType is Never,
+//                        should the check still pass?". A common code-smell for potential incorrect
+//                        usage is, using IsSubType() method with a constant/pre-defined superType.
+//                        e.g: IsSubType(<<someType>>, FixedPointType)
 //
 func IsSubType(subType Type, superType Type) bool {
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4707,6 +4707,11 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 //
 // Types are subtypes of themselves.
 //
+// NOTE: This method can be used to check the assignability of `subType` to `superType`.
+// However, to check if a type *strictly* belongs to a certain category, then
+// consider using `IsSameTypeKind` method. e.g: "Is type `T` an Integer type?". Using
+// this method for the later use-case may produce incorrect results.
+//
 func IsSubType(subType Type, superType Type) bool {
 
 	if subType == nil {
@@ -4724,8 +4729,8 @@ func IsSubType(subType Type, superType Type) bool {
 // same kind as the supertype.
 //
 // e.g: 'Never' type is a subtype of 'Integer', but not of the
-// same kind as 'Int'. Whereas, 'Int8' is both a subtype
-// as well as of same kind as 'Integer'.
+// same kind as 'Integer'. Whereas, 'Int8' is both a subtype
+// and also of same kind as 'Integer'.
 //
 func IsSameTypeKind(subType Type, superType Type) bool {
 

--- a/runtime/tests/checker/never_test.go
+++ b/runtime/tests/checker/never_test.go
@@ -21,20 +21,176 @@ package checker
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 func TestCheckNever(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheckWithPanic(t,
-		`
+	t.Run("never return", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckWithPanic(t,
+			`
             pub fun test(): Int {
                 return panic("XXX")
             }
         `,
-	)
+		)
 
-	require.NoError(t, err)
+		require.NoError(t, err)
+	})
+
+	t.Run("numeric compatibility", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                pub fun test() {
+                    var x: Never = 5
+                }
+            `,
+		)
+
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.TypeMismatchError{}, errors[0])
+		typeMismatchErr := errors[0].(*sema.TypeMismatchError)
+
+		assert.Equal(t, sema.NeverType, typeMismatchErr.ExpectedType)
+		assert.Equal(t, sema.IntType, typeMismatchErr.ActualType)
+	})
+
+	t.Run("character compatibility", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                pub fun test() {
+                    var x: Never = "c"
+                }
+            `,
+		)
+
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.TypeMismatchError{}, errors[0])
+		typeMismatchErr := errors[0].(*sema.TypeMismatchError)
+
+		assert.Equal(t, sema.NeverType, typeMismatchErr.ExpectedType)
+		assert.Equal(t, sema.StringType, typeMismatchErr.ActualType)
+	})
+
+	t.Run("string compatibility", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                pub fun test() {
+                    var x: Never = "hello"
+                }
+            `,
+		)
+
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.TypeMismatchError{}, errors[0])
+		typeMismatchErr := errors[0].(*sema.TypeMismatchError)
+
+		assert.Equal(t, sema.NeverType, typeMismatchErr.ExpectedType)
+		assert.Equal(t, sema.StringType, typeMismatchErr.ActualType)
+	})
+
+	t.Run("binary op", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                pub fun test(a: Never, b: Never) {
+                    var x: Int = a + b
+                }
+            `,
+		)
+
+		errors := ExpectCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.InvalidBinaryOperandsError{}, errors[0])
+		binaryOpErr := errors[0].(*sema.InvalidBinaryOperandsError)
+
+		assert.Equal(t, sema.NeverType, binaryOpErr.LeftType)
+		assert.Equal(t, sema.NeverType, binaryOpErr.RightType)
+	})
+
+	t.Run("unary op", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                pub fun test(a: Never) {
+                    var x: Bool = !a
+                }
+            `,
+		)
+
+		errors := ExpectCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.InvalidUnaryOperandError{}, errors[0])
+		unaryOpErr := errors[0].(*sema.InvalidUnaryOperandError)
+
+		assert.Equal(t, sema.BoolType, unaryOpErr.ExpectedType)
+		assert.Equal(t, sema.NeverType, unaryOpErr.ActualType)
+	})
+
+	t.Run("nil-coalescing", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                pub fun test(a: Never?) {
+                    var x: Int = a ?? 4
+                }
+            `,
+		)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("enum raw type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                enum Foo: Never {
+                }
+            `,
+		)
+
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.InvalidEnumRawTypeError{}, errors[0])
+		typeMismatchErr := errors[0].(*sema.InvalidEnumRawTypeError)
+
+		assert.Equal(t, sema.NeverType, typeMismatchErr.Type)
+	})
+
+	t.Run("tx prepare arg", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+                transaction {
+                    prepare(acct: Never) {}
+                }
+            `,
+		)
+
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.InvalidTransactionPrepareParameterTypeError{}, errors[0])
+		typeMismatchErr := errors[0].(*sema.InvalidTransactionPrepareParameterTypeError)
+
+		assert.Equal(t, sema.NeverType, typeMismatchErr.Type)
+	})
 }

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -459,13 +459,6 @@ func TestCheckNeverInvocationExits(t *testing.T) {
 				exits:             false,
 				valueDeclarations: valueDeclarations,
 			},
-			{
-				body: `
-                  false || panic("")
-                `,
-				exits:             false,
-				valueDeclarations: valueDeclarations,
-			},
 		},
 	)
 }


### PR DESCRIPTION
Closes #1031 

## Description

- Introduce a method to check whether a given type 'belongs' to the same kind as a given type. 
  - Same as IsSubType, but doesn't treat `Never` as 'not' belongs to the same kind.
- Replace the usages where strictly 'same kind types' check is needed.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
