### PR TITLE
Add type inferring for func-args when there are no generics

### DIFF
--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -518,35 +518,44 @@ func (checker *Checker) checkInvocationRequiredArgument(
 ) {
 	argument := arguments[argumentIndex]
 
-	// TODO: pass the expected type to support type inferring for parameters
-	argumentType := checker.VisitExpression(argument.Expression, nil)
+	parameter := functionType.Parameters[argumentIndex]
+	parameterType = parameter.TypeAnnotation.Type
+
+	var argumentType Type
+
+	if len(functionType.TypeParameters) == 0 {
+		// If the function doesn't use generic types, then the
+		// param types can be used to infer the types for arguments.
+		argumentType = checker.VisitExpression(argument.Expression, parameterType)
+	} else {
+		// TODO: pass the expected type to support for parameters
+		argumentType = checker.VisitExpression(argument.Expression, nil)
+
+		// Try to unify the parameter type with the argument type.
+		// If unification fails, fall back to the parameter type for now.
+
+		argumentRange := ast.NewRangeFromPositioned(argument.Expression)
+
+		if parameterType.Unify(argumentType, typeParameters, checker.report, argumentRange) {
+			parameterType = parameterType.Resolve(typeParameters)
+			if parameterType == nil {
+				parameterType = InvalidType
+			}
+		}
+
+		// Check that the type of the argument matches the type of the parameter.
+
+		// TODO: remove this once type inferring support for parameters is added
+		checker.checkInvocationArgumentParameterTypeCompatibility(
+			argument.Expression,
+			argumentType,
+			parameterType,
+		)
+	}
+
 	argumentTypes[argumentIndex] = argumentType
 
 	checker.checkInvocationArgumentMove(argument.Expression, argumentType)
-
-	parameter := functionType.Parameters[argumentIndex]
-
-	// Try to unify the parameter type with the argument type.
-	// If unification fails, fall back to the parameter type for now.
-
-	argumentRange := ast.NewRangeFromPositioned(argument.Expression)
-
-	parameterType = parameter.TypeAnnotation.Type
-	if parameterType.Unify(argumentType, typeParameters, checker.report, argumentRange) {
-		parameterType = parameterType.Resolve(typeParameters)
-		if parameterType == nil {
-			parameterType = InvalidType
-		}
-	}
-
-	// Check that the type of the argument matches the type of the parameter.
-
-	// TODO: remove this once type inferring support for parameters is added
-	checker.checkInvocationArgumentParameterTypeCompatibility(
-		argument.Expression,
-		argumentType,
-		parameterType,
-	)
 
 	return parameterType
 }

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -322,32 +322,91 @@ func TestCheckFunctionArgumentTypeInference(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheck(t, `
-      let x = foo(a: [1, 2, 3])
+	t.Run("required args", func(t *testing.T) {
+		t.Parallel()
 
-      fun foo(a: [Int8]) {}
-    `)
+		_, err := ParseAndCheck(t, `
+            let x = foo(a: [1, 2, 3])
 
-	// Type inferring for function arguments is not supported yet.
-	errs := ExpectCheckerErrors(t, err, 1)
+            fun foo(a: [Int8]) {}
+        `)
 
-	require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		require.NoError(t, err)
+	})
 
-	typeMismatchErr := errs[0].(*sema.TypeMismatchError)
+	t.Run("with generics", func(t *testing.T) {
 
-	assert.Equal(t,
-		&sema.VariableSizedType{
-			Type: sema.Int8Type,
-		},
-		typeMismatchErr.ExpectedType,
-	)
+		t.Parallel()
 
-	assert.Equal(t,
-		&sema.VariableSizedType{
-			Type: sema.IntType,
-		},
-		typeMismatchErr.ActualType,
-	)
+		typeParameter := &sema.TypeParameter{
+			Name:      "T",
+			TypeBound: nil,
+		}
+
+		_, err := parseAndCheckWithTestValue(t,
+			`
+              let res = test<[Int8]>([1, 2, 3])
+            `,
+			&sema.FunctionType{
+				TypeParameters: []*sema.TypeParameter{
+					typeParameter,
+				},
+				Parameters: []*sema.Parameter{
+					{
+						Label:      sema.ArgumentLabelNotRequired,
+						Identifier: "value",
+						TypeAnnotation: sema.NewTypeAnnotation(
+							&sema.GenericType{
+								TypeParameter: typeParameter,
+							},
+						),
+					},
+				},
+				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
+				RequiredArgumentCount: nil,
+			},
+		)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+
+		require.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
+		typeParamMismatchErr := errs[0].(*sema.TypeParameterTypeMismatchError)
+		assert.Equal(
+			t,
+			&sema.VariableSizedType{
+				Type: sema.Int8Type,
+			},
+			typeParamMismatchErr.ExpectedType,
+		)
+
+		assert.Equal(
+			t,
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
+			typeParamMismatchErr.ActualType,
+		)
+
+		require.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		typeMismatchErr := errs[1].(*sema.TypeMismatchError)
+
+		assert.Equal(
+			t,
+			&sema.VariableSizedType{
+				Type: sema.Int8Type,
+			},
+			typeMismatchErr.ExpectedType,
+		)
+
+		assert.Equal(
+			t,
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
+			typeMismatchErr.ActualType,
+		)
+
+	})
 }
 
 func TestCheckBinaryExpressionTypeInference(t *testing.T) {


### PR DESCRIPTION
Work towards #512

## Description

With this PR, the only scenario where the non-local type inferring not supported is function arguments with generics.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
