### PR TITLE
Add static types to array values and dictionary values

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -453,7 +453,11 @@ func importDictionaryValue(
 		keysAndValues[i*2+1] = importValue(inter, pair.Value)
 	}
 
-	return interpreter.NewDictionaryValueUnownedNonCopying(keysAndValues...)
+	return interpreter.NewDictionaryValueUnownedNonCopying(
+		// TODO: type
+		&sema.DictionaryType{},
+		keysAndValues...,
+	)
 }
 
 func importCompositeValue(

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -436,7 +436,10 @@ func importArrayValue(
 		values[i] = importValue(inter, element)
 	}
 
-	return interpreter.NewArrayValueUnownedNonCopying(values...)
+	// TODO: type
+	var arrayType sema.ArrayType
+
+	return interpreter.NewArrayValueUnownedNonCopying(arrayType, values...)
 }
 
 func importDictionaryValue(

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -80,17 +80,20 @@ var exportTests = []exportTest{
 		expected: cadence.NewString("foo"),
 	},
 	{
-		label:    "Array empty",
-		value:    interpreter.NewArrayValueUnownedNonCopying([]interpreter.Value{}...),
+		label: "Array empty",
+		value: interpreter.NewArrayValueUnownedNonCopying(
+			// TODO: type
+			nil,
+		),
 		expected: cadence.NewArray([]cadence.Value{}),
 	},
 	{
 		label: "Array non-empty",
 		value: interpreter.NewArrayValueUnownedNonCopying(
-			[]interpreter.Value{
-				interpreter.NewIntValueFromInt64(42),
-				interpreter.NewStringValue("foo"),
-			}...,
+			// TODO: type
+			nil,
+			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewStringValue("foo"),
 		),
 		expected: cadence.NewArray([]cadence.Value{
 			cadence.NewInt(42),

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -21,6 +21,8 @@ package interpreter
 import (
 	"errors"
 	"math"
+
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 func ByteArrayValueToByteSlice(value Value) ([]byte, error) {
@@ -85,5 +87,8 @@ func ByteSliceToByteArrayValue(buf []byte) *ArrayValue {
 		values[i] = UInt8Value(b)
 	}
 
-	return NewArrayValueUnownedNonCopying(values...)
+	return NewArrayValueUnownedNonCopying(
+		sema.ByteArrayType,
+		values...,
+	)
 }

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,8 +37,18 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 		require.True(t, ok)
 
 		invalid := []Value{
-			NewArrayValueUnownedNonCopying(UInt64Value(500)),
-			NewArrayValueUnownedNonCopying(NewInt256ValueFromBigInt(largeBigInt)),
+			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.UInt64Type,
+				},
+				UInt64Value(500),
+			),
+			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.Int256Type,
+				},
+				NewInt256ValueFromBigInt(largeBigInt),
+			),
 			UInt64Value(500),
 			BoolValue(true),
 			NewStringValue("test"),
@@ -52,9 +63,25 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 
 		invalid := map[Value][]byte{
-			NewArrayValueUnownedNonCopying():                                             {},
-			NewArrayValueUnownedNonCopying(UInt64Value(2), NewUInt128ValueFromUint64(3)): {2, 3},
-			NewArrayValueUnownedNonCopying(UInt8Value(4), NewIntValueFromInt64(5)):       {4, 5},
+			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.IntegerType,
+				},
+			): {},
+			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.IntegerType,
+				},
+				UInt64Value(2),
+				NewUInt128ValueFromUint64(3),
+			): {2, 3},
+			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.IntegerType,
+				},
+				UInt8Value(4),
+				NewIntValueFromInt64(5),
+			): {4, 5},
 		}
 
 		for value, expected := range invalid {

--- a/runtime/interpreter/deferred_decoding_test.go
+++ b/runtime/interpreter/deferred_decoding_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -480,7 +481,7 @@ func BenchmarkCompositeDeferredDecoding(b *testing.B) {
 	})
 }
 
-var newTestLargeCompositeValue = func(id int) *CompositeValue {
+func newTestLargeCompositeValue(id int) *CompositeValue {
 	addressFields := NewStringValueOrderedMap()
 	addressFields.Set("street", NewStringValue(fmt.Sprintf("No: %d", id)))
 	addressFields.Set("city", NewStringValue("Vancouver"))
@@ -511,14 +512,19 @@ var newTestLargeCompositeValue = func(id int) *CompositeValue {
 	)
 }
 
-var newTestArrayValue = func(size int) *ArrayValue {
+func newTestArrayValue(size int) *ArrayValue {
 	values := make([]Value, size)
 
 	for i := 0; i < size; i++ {
 		values[i] = newTestLargeCompositeValue(i)
 	}
 
-	return NewArrayValue(values)
+	return NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+		values...,
+	)
 }
 
 func TestArrayDeferredDecoding(t *testing.T) {
@@ -942,7 +948,7 @@ func TestDictionaryDeferredDecoding(t *testing.T) {
 	})
 }
 
-var newTestDictionaryValue = func(size int) *DictionaryValue {
+func newTestDictionaryValue(size int) *DictionaryValue {
 	values := make([]Value, size*2)
 
 	for i := 0; i < size; i++ {

--- a/runtime/interpreter/deferred_decoding_test.go
+++ b/runtime/interpreter/deferred_decoding_test.go
@@ -876,12 +876,25 @@ func TestDictionaryDeferredDecoding(t *testing.T) {
 			nil,
 		)
 
+		testResourceType := &sema.CompositeType{
+			Location:   utils.TestLocation,
+			Identifier: "TestResource",
+			Kind:       common.CompositeKindResource,
+			Members:    sema.NewStringMemberOrderedMap(),
+		}
+
 		for i := 0; i < size; i++ {
 			values[i*2] = NewStringValue(fmt.Sprintf("key%d", i))
 			values[i*2+1] = testResource
 		}
 
-		dictionary := NewDictionaryValueUnownedNonCopying(values...)
+		dictionary := NewDictionaryValueUnownedNonCopying(
+			&sema.DictionaryType{
+				KeyType:   sema.StringType,
+				ValueType: testResourceType,
+			},
+			values...,
+		)
 
 		// Encode
 		encoded, _, err := EncodeValue(dictionary, nil, true, nil)
@@ -956,7 +969,13 @@ func newTestDictionaryValue(size int) *DictionaryValue {
 		values[i*2+1] = NewStringValue(fmt.Sprintf("value%d", i))
 	}
 
-	return NewDictionaryValueUnownedNonCopying(values...)
+	return NewDictionaryValueUnownedNonCopying(
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.StringType,
+		},
+		values...,
+	)
 }
 
 func BenchmarkDictionaryDeferredDecoding(b *testing.B) {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -286,7 +286,10 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 
-		expected := NewDictionaryValueUnownedNonCopying()
+		expected := NewDictionaryValueUnownedNonCopying(
+			// TODO: type
+			&sema.DictionaryType{},
+		)
 		expected.modified = false
 		expected.Keys().modified = false
 
@@ -347,6 +350,8 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 		value3 := NewStringValue("bar")
 
 		expected := NewDictionaryValueUnownedNonCopying(
+			// TODO: type
+			&sema.DictionaryType{},
 			key1, value1,
 			key2, value2,
 			key3, value3,
@@ -452,6 +457,8 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 
 	t.Run("temporary address value key string change in format version 2", func(t *testing.T) {
 		expected := NewDictionaryValueUnownedNonCopying(
+			// TODO: type
+			&sema.DictionaryType{},
 			NewAddressValueFromBytes([]byte{0x42}),
 			Int8Value(42),
 		)
@@ -4948,6 +4955,8 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 		value2.modified = false
 
 		expected := NewDictionaryValueUnownedNonCopying(
+			// TODO: type
+			&sema.DictionaryType{},
 			key1, value1,
 			key2, value2,
 		)
@@ -4972,6 +4981,8 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 		}
 
 		decodedValue := &DictionaryValue{
+			// TODO:
+			Type:                   nil,
 			keys:                   expected.Keys(),
 			entries:                NewStringValueOrderedMap(),
 			deferredOwner:          &testOwner,
@@ -5049,6 +5060,8 @@ func TestEncodeDecodeDictionaryDeferred(t *testing.T) {
 		value2 := BoolValue(false)
 
 		expected := NewDictionaryValueUnownedNonCopying(
+			// TODO: type
+			&sema.DictionaryType{},
 			key1, value1,
 			key2, value2,
 		)
@@ -5393,7 +5406,12 @@ func prepareLargeTestValue() Value {
 		},
 	)
 	for i := 0; i < 100; i++ {
-		dict := NewDictionaryValueUnownedNonCopying()
+		dict := NewDictionaryValueUnownedNonCopying(
+			&sema.DictionaryType{
+				KeyType:   sema.StringType,
+				ValueType: sema.Int256Type,
+			},
+		)
 		for i := 0; i < 100; i++ {
 			key := NewStringValue(fmt.Sprintf("hello world %d", i))
 			value := NewInt256ValueFromInt64(int64(i))

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -235,7 +235,10 @@ func TestEncodeDecodeArray(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
-		expected := NewArrayValueUnownedNonCopying()
+		expected := NewArrayValueUnownedNonCopying(
+			// TODO: type
+			nil,
+		)
 		expected.modified = false
 
 		testEncodeDecode(t,
@@ -252,6 +255,8 @@ func TestEncodeDecodeArray(t *testing.T) {
 		expectedString := NewStringValue("test")
 
 		expected := NewArrayValueUnownedNonCopying(
+			// TODO: type
+			nil,
 			expectedString,
 			BoolValue(true),
 		)
@@ -280,6 +285,7 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
+
 		expected := NewDictionaryValueUnownedNonCopying()
 		expected.modified = false
 		expected.Keys().modified = false
@@ -329,7 +335,10 @@ func TestEncodeDecodeDictionary(t *testing.T) {
 
 	t.Run("non-empty", func(t *testing.T) {
 		key1 := NewStringValue("test")
-		value1 := NewArrayValueUnownedNonCopying()
+		value1 := NewArrayValueUnownedNonCopying(
+			// TODO: type
+			nil,
+		)
 
 		key2 := BoolValue(true)
 		value2 := BoolValue(false)
@@ -5252,7 +5261,11 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 
 func TestEncodePrepareCallback(t *testing.T) {
 
-	value := NewArrayValueUnownedNonCopying(Int8Value(42))
+	value := NewArrayValueUnownedNonCopying(
+		// TODO: type
+		nil,
+		Int8Value(42),
+	)
 
 	type prepareCallback struct {
 		value Value
@@ -5374,7 +5387,11 @@ func BenchmarkDecoding(b *testing.B) {
 }
 
 func prepareLargeTestValue() Value {
-	values := NewArrayValueUnownedNonCopying()
+	values := NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+	)
 	for i := 0; i < 100; i++ {
 		dict := NewDictionaryValueUnownedNonCopying()
 		for i := 0; i < 100; i++ {

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -383,7 +383,8 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 	values := interpreter.visitExpressionsNonCopying(expression.Values)
 
 	argumentTypes := interpreter.Program.Elaboration.ArrayExpressionArgumentTypes[expression]
-	elementType := interpreter.Program.Elaboration.ArrayExpressionElementType[expression]
+	arrayType := interpreter.Program.Elaboration.ArrayExpressionArrayTypes[expression]
+	elementType := arrayType.ElementType(false)
 
 	copies := make([]Value, len(values))
 	for i, argument := range values {
@@ -393,7 +394,7 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 		copies[i] = interpreter.copyAndConvert(argument, argumentType, elementType, getLocationRange)
 	}
 
-	return NewArrayValueUnownedNonCopying(copies...)
+	return NewArrayValueUnownedNonCopying(arrayType, copies...)
 }
 
 func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.DictionaryExpression) ast.Repr {

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -383,7 +383,7 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 	values := interpreter.visitExpressionsNonCopying(expression.Values)
 
 	argumentTypes := interpreter.Program.Elaboration.ArrayExpressionArgumentTypes[expression]
-	arrayType := interpreter.Program.Elaboration.ArrayExpressionArrayTypes[expression]
+	arrayType := interpreter.Program.Elaboration.ArrayExpressionArrayType[expression]
 	elementType := arrayType.ElementType(false)
 
 	copies := make([]Value, len(values))
@@ -403,7 +403,8 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 	entryTypes := interpreter.Program.Elaboration.DictionaryExpressionEntryTypes[expression]
 	dictionaryType := interpreter.Program.Elaboration.DictionaryExpressionType[expression]
 
-	dictionary := NewDictionaryValueUnownedNonCopying()
+	dictionary := NewDictionaryValueUnownedNonCopying(dictionaryType)
+
 	for i, dictionaryEntryValues := range values {
 		entryType := entryTypes[i]
 		entry := expression.Entries[i]

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7583,12 +7583,9 @@ func (v *DictionaryValue) GetMember(interpreter *Interpreter, getLocationRange f
 			i++
 		}
 
-		// TODO: type
-		var valueType sema.Type
-
 		return NewArrayValueUnownedNonCopying(
 			&sema.VariableSizedType{
-				Type: valueType,
+				Type: v.Type.ValueType,
 			},
 			dictionaryValues...,
 		)

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -51,7 +51,12 @@ func TestOwnerNewArray(t *testing.T) {
 
 	assert.Equal(t, &oldOwner, value.GetOwner())
 
-	array := NewArrayValueUnownedNonCopying(value)
+	array := NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+		value,
+	)
 
 	assert.Nil(t, array.GetOwner())
 	assert.Nil(t, value.GetOwner())
@@ -66,7 +71,12 @@ func TestSetOwnerArray(t *testing.T) {
 
 	value := newTestCompositeValue(oldOwner)
 
-	array := NewArrayValueUnownedNonCopying(value)
+	array := NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+		value,
+	)
 
 	array.SetOwner(&newOwner)
 
@@ -83,7 +93,12 @@ func TestSetOwnerArrayCopy(t *testing.T) {
 
 	value := newTestCompositeValue(oldOwner)
 
-	array := NewArrayValueUnownedNonCopying(value)
+	array := NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+		value,
+	)
 
 	array.SetOwner(&newOwner)
 
@@ -105,7 +120,12 @@ func TestSetOwnerArraySetIndex(t *testing.T) {
 	value1 := newTestCompositeValue(oldOwner)
 	value2 := newTestCompositeValue(oldOwner)
 
-	array := NewArrayValueUnownedNonCopying(value1)
+	array := NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+		value1,
+	)
 	array.SetOwner(&newOwner)
 
 	assert.Equal(t, &newOwner, array.GetOwner())
@@ -128,7 +148,11 @@ func TestSetOwnerArrayAppend(t *testing.T) {
 
 	value := newTestCompositeValue(oldOwner)
 
-	array := NewArrayValueUnownedNonCopying()
+	array := NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+	)
 	array.SetOwner(&newOwner)
 
 	assert.Equal(t, &newOwner, array.GetOwner())
@@ -149,7 +173,11 @@ func TestSetOwnerArrayInsert(t *testing.T) {
 
 	value := newTestCompositeValue(oldOwner)
 
-	array := NewArrayValueUnownedNonCopying()
+	array := NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+	)
 	array.SetOwner(&newOwner)
 
 	assert.Equal(t, &newOwner, array.GetOwner())
@@ -523,6 +551,9 @@ func TestStringer(t *testing.T) {
 		},
 		"Array": {
 			value: NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.AnyStructType,
+				},
 				NewIntValueFromInt64(10),
 				NewStringValue("TEST"),
 			),
@@ -633,6 +664,9 @@ func TestStringer(t *testing.T) {
 				)
 				return &DictionaryValue{
 					keys: NewArrayValueUnownedNonCopying(
+						&sema.VariableSizedType{
+							Type: sema.StringType,
+						},
 						NewStringValue("a"),
 						NewStringValue("b"),
 					),
@@ -643,7 +677,11 @@ func TestStringer(t *testing.T) {
 		},
 		"Recursive ephemeral reference (array)": {
 			value: func() Value {
-				array := NewArrayValueUnownedNonCopying()
+				array := NewArrayValueUnownedNonCopying(
+					&sema.VariableSizedType{
+						Type: sema.AnyStructType,
+					},
+				)
 				arrayRef := &EphemeralReferenceValue{Value: array}
 				array.Insert(0, arrayRef, nil)
 				return array
@@ -688,7 +726,12 @@ func TestVisitor(t *testing.T) {
 	var value Value
 	value = NewIntValueFromInt64(42)
 	value = NewSomeValueOwningNonCopying(value)
-	value = NewArrayValueUnownedNonCopying(value)
+	value = NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.AnyStructType,
+		},
+		value,
+	)
 	value = NewDictionaryValueUnownedNonCopying(NewStringValue("42"), value)
 	members := NewStringValueOrderedMap()
 	members.Set("foo", value)
@@ -858,7 +901,7 @@ func TestBlockValue(t *testing.T) {
 	block := BlockValue{
 		Height:    4,
 		View:      5,
-		ID:        NewArrayValueUnownedNonCopying(),
+		ID:        NewArrayValueUnownedNonCopying(sema.ByteArrayType),
 		Timestamp: 5.0,
 	}
 
@@ -1554,10 +1597,16 @@ func TestArrayValue_Equal(t *testing.T) {
 
 		require.True(t,
 			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.UInt8Type,
+				},
 				UInt8Value(1),
 				UInt8Value(2),
 			).Equal(
 				NewArrayValueUnownedNonCopying(
+					&sema.VariableSizedType{
+						Type: sema.UInt8Type,
+					},
 					UInt8Value(1),
 					UInt8Value(2),
 				),
@@ -1573,10 +1622,16 @@ func TestArrayValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.UInt8Type,
+				},
 				UInt8Value(1),
 				UInt8Value(2),
 			).Equal(
 				NewArrayValueUnownedNonCopying(
+					&sema.VariableSizedType{
+						Type: sema.UInt8Type,
+					},
 					UInt8Value(2),
 					UInt8Value(3),
 				),
@@ -1592,9 +1647,15 @@ func TestArrayValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.UInt8Type,
+				},
 				UInt8Value(1),
 			).Equal(
 				NewArrayValueUnownedNonCopying(
+					&sema.VariableSizedType{
+						Type: sema.UInt8Type,
+					},
 					UInt8Value(1),
 					UInt8Value(2),
 				),
@@ -1610,10 +1671,16 @@ func TestArrayValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.UInt8Type,
+				},
 				UInt8Value(1),
 				UInt8Value(2),
 			).Equal(
 				NewArrayValueUnownedNonCopying(
+					&sema.VariableSizedType{
+						Type: sema.UInt8Type,
+					},
 					UInt8Value(1),
 				),
 				nil,
@@ -1628,6 +1695,9 @@ func TestArrayValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewArrayValueUnownedNonCopying(
+				&sema.VariableSizedType{
+					Type: sema.UInt8Type,
+				},
 				UInt8Value(1),
 			).Equal(
 				UInt8Value(1),
@@ -1765,6 +1835,9 @@ func TestDictionaryValue_Equal(t *testing.T) {
 				NewStringValue("2"),
 			).Equal(
 				NewArrayValueUnownedNonCopying(
+					&sema.VariableSizedType{
+						Type: sema.UInt8Type,
+					},
 					UInt8Value(1),
 					UInt8Value(2),
 				),
@@ -2107,6 +2180,9 @@ func TestPublicKeyValue(t *testing.T) {
 		t.Parallel()
 
 		publicKey := NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			NewIntValueFromInt64(1),
 			NewIntValueFromInt64(7),
 			NewIntValueFromInt64(3),

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -200,7 +200,11 @@ func TestOwnerNewDictionary(t *testing.T) {
 
 	assert.Equal(t, &oldOwner, value.GetOwner())
 
-	dictionary := NewDictionaryValueUnownedNonCopying(keyValue, value)
+	dictionary := NewDictionaryValueUnownedNonCopying(
+		// TODO: type
+		&sema.DictionaryType{},
+		keyValue, value,
+	)
 
 	assert.Nil(t, dictionary.GetOwner())
 	// NOTE: keyValue is string, has no owner
@@ -217,7 +221,11 @@ func TestSetOwnerDictionary(t *testing.T) {
 	keyValue := NewStringValue("test")
 	value := newTestCompositeValue(oldOwner)
 
-	dictionary := NewDictionaryValueUnownedNonCopying(keyValue, value)
+	dictionary := NewDictionaryValueUnownedNonCopying(
+		// TODO: type
+		&sema.DictionaryType{},
+		keyValue, value,
+	)
 
 	dictionary.SetOwner(&newOwner)
 
@@ -235,7 +243,11 @@ func TestSetOwnerDictionaryCopy(t *testing.T) {
 	keyValue := NewStringValue("test")
 	value := newTestCompositeValue(oldOwner)
 
-	dictionary := NewDictionaryValueUnownedNonCopying(keyValue, value)
+	dictionary := NewDictionaryValueUnownedNonCopying(
+		// TODO: type
+		&sema.DictionaryType{},
+		keyValue, value,
+	)
 	dictionary.SetOwner(&newOwner)
 
 	dictionaryCopy := dictionary.Copy().(*DictionaryValue)
@@ -256,7 +268,10 @@ func TestSetOwnerDictionarySetIndex(t *testing.T) {
 	keyValue := NewStringValue("test")
 	value := newTestCompositeValue(oldOwner)
 
-	dictionary := NewDictionaryValueUnownedNonCopying()
+	dictionary := NewDictionaryValueUnownedNonCopying(
+		// TODO: type
+		&sema.DictionaryType{},
+	)
 	dictionary.SetOwner(&newOwner)
 
 	assert.Equal(t, &newOwner, dictionary.GetOwner())
@@ -283,7 +298,10 @@ func TestSetOwnerDictionaryInsert(t *testing.T) {
 	keyValue := NewStringValue("test")
 	value := newTestCompositeValue(oldOwner)
 
-	dictionary := NewDictionaryValueUnownedNonCopying()
+	dictionary := NewDictionaryValueUnownedNonCopying(
+		// TODO: type
+		&sema.DictionaryType{},
+	)
 	dictionary.SetOwner(&newOwner)
 
 	assert.Equal(t, &newOwner, dictionary.GetOwner())
@@ -561,6 +579,10 @@ func TestStringer(t *testing.T) {
 		},
 		"Dictionary": {
 			value: NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.StringType,
+					ValueType: sema.StringType,
+				},
 				NewStringValue("key"),
 				NewStringValue("value"),
 			),
@@ -650,6 +672,10 @@ func TestStringer(t *testing.T) {
 		},
 		"Dictionary with non-deferred values": {
 			value: NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.StringType,
+					ValueType: sema.UInt8Type,
+				},
 				NewStringValue("a"), UInt8Value(42),
 				NewStringValue("b"), UInt8Value(99),
 			),
@@ -663,6 +689,10 @@ func TestStringer(t *testing.T) {
 					UInt8Value(42),
 				)
 				return &DictionaryValue{
+					Type: &sema.DictionaryType{
+						KeyType:   sema.StringType,
+						ValueType: sema.UInt8Type,
+					},
 					keys: NewArrayValueUnownedNonCopying(
 						&sema.VariableSizedType{
 							Type: sema.StringType,
@@ -732,7 +762,13 @@ func TestVisitor(t *testing.T) {
 		},
 		value,
 	)
-	value = NewDictionaryValueUnownedNonCopying(NewStringValue("42"), value)
+	value = NewDictionaryValueUnownedNonCopying(
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.AnyType,
+		},
+		NewStringValue("42"), value,
+	)
 	members := NewStringValueOrderedMap()
 	members.Set("foo", value)
 	value = NewCompositeValue(
@@ -1718,12 +1754,20 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 		require.True(t,
 			NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.UInt8Type,
+					ValueType: sema.StringType,
+				},
 				UInt8Value(1),
 				NewStringValue("1"),
 				UInt8Value(2),
 				NewStringValue("2"),
 			).Equal(
 				NewDictionaryValueUnownedNonCopying(
+					&sema.DictionaryType{
+						KeyType:   sema.UInt8Type,
+						ValueType: sema.StringType,
+					},
 					UInt8Value(1),
 					NewStringValue("1"),
 					UInt8Value(2),
@@ -1741,12 +1785,20 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.UInt8Type,
+					ValueType: sema.StringType,
+				},
 				UInt8Value(1),
 				NewStringValue("1"),
 				UInt8Value(2),
 				NewStringValue("2"),
 			).Equal(
 				NewDictionaryValueUnownedNonCopying(
+					&sema.DictionaryType{
+						KeyType:   sema.UInt8Type,
+						ValueType: sema.StringType,
+					},
 					UInt8Value(2),
 					NewStringValue("1"),
 					UInt8Value(3),
@@ -1764,12 +1816,20 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.UInt8Type,
+					ValueType: sema.StringType,
+				},
 				UInt8Value(1),
 				NewStringValue("1"),
 				UInt8Value(2),
 				NewStringValue("2"),
 			).Equal(
 				NewDictionaryValueUnownedNonCopying(
+					&sema.DictionaryType{
+						KeyType:   sema.UInt8Type,
+						ValueType: sema.StringType,
+					},
 					UInt8Value(1),
 					NewStringValue("2"),
 					UInt8Value(2),
@@ -1787,10 +1847,19 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.UInt8Type,
+					ValueType: sema.StringType,
+				},
+
 				UInt8Value(1),
 				NewStringValue("1"),
 			).Equal(
 				NewDictionaryValueUnownedNonCopying(
+					&sema.DictionaryType{
+						KeyType:   sema.UInt8Type,
+						ValueType: sema.StringType,
+					},
 					UInt8Value(1),
 					NewStringValue("1"),
 					UInt8Value(2),
@@ -1808,12 +1877,20 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.UInt8Type,
+					ValueType: sema.StringType,
+				},
 				UInt8Value(1),
 				NewStringValue("1"),
 				UInt8Value(2),
 				NewStringValue("2"),
 			).Equal(
 				NewDictionaryValueUnownedNonCopying(
+					&sema.DictionaryType{
+						KeyType:   sema.UInt8Type,
+						ValueType: sema.StringType,
+					},
 					UInt8Value(1),
 					NewStringValue("1"),
 				),
@@ -1829,6 +1906,10 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 		require.False(t,
 			NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.UInt8Type,
+					ValueType: sema.StringType,
+				},
 				UInt8Value(1),
 				NewStringValue("1"),
 				UInt8Value(2),

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -201,8 +201,10 @@ func TestOwnerNewDictionary(t *testing.T) {
 	assert.Equal(t, &oldOwner, value.GetOwner())
 
 	dictionary := NewDictionaryValueUnownedNonCopying(
-		// TODO: type
-		&sema.DictionaryType{},
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.AnyStructType,
+		},
 		keyValue, value,
 	)
 
@@ -222,8 +224,10 @@ func TestSetOwnerDictionary(t *testing.T) {
 	value := newTestCompositeValue(oldOwner)
 
 	dictionary := NewDictionaryValueUnownedNonCopying(
-		// TODO: type
-		&sema.DictionaryType{},
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.AnyStructType,
+		},
 		keyValue, value,
 	)
 
@@ -244,8 +248,10 @@ func TestSetOwnerDictionaryCopy(t *testing.T) {
 	value := newTestCompositeValue(oldOwner)
 
 	dictionary := NewDictionaryValueUnownedNonCopying(
-		// TODO: type
-		&sema.DictionaryType{},
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.AnyStructType,
+		},
 		keyValue, value,
 	)
 	dictionary.SetOwner(&newOwner)
@@ -269,8 +275,10 @@ func TestSetOwnerDictionarySetIndex(t *testing.T) {
 	value := newTestCompositeValue(oldOwner)
 
 	dictionary := NewDictionaryValueUnownedNonCopying(
-		// TODO: type
-		&sema.DictionaryType{},
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.AnyStructType,
+		},
 	)
 	dictionary.SetOwner(&newOwner)
 
@@ -299,8 +307,10 @@ func TestSetOwnerDictionaryInsert(t *testing.T) {
 	value := newTestCompositeValue(oldOwner)
 
 	dictionary := NewDictionaryValueUnownedNonCopying(
-		// TODO: type
-		&sema.DictionaryType{},
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.AnyStructType,
+		},
 	)
 	dictionary.SetOwner(&newOwner)
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2523,7 +2523,10 @@ func NewBlockValue(block Block) interpreter.BlockValue {
 	for i, b := range block.Hash {
 		values[i] = interpreter.UInt8Value(b)
 	}
-	idValue := interpreter.NewArrayValue(values)
+	idValue := interpreter.NewArrayValueUnownedNonCopying(
+		sema.ByteArrayType,
+		values...,
+	)
 
 	// timestamp
 	// TODO: verify

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2496,9 +2496,7 @@ func (r *interpreterRuntime) ReadLinked(address common.Address, path cadence.Pat
 				&sema.ReferenceType{
 					Type: sema.AnyType,
 				},
-				func() interpreter.LocationRange {
-					return interpreter.LocationRange{}
-				},
+				interpreter.ReturnEmptyLocationRange,
 			)
 			if err != nil {
 				return nil, err

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -103,9 +103,7 @@ var authAccountContractsTypeAddFunctionType = &FunctionType{
 		{
 			Identifier: "code",
 			TypeAnnotation: NewTypeAnnotation(
-				&VariableSizedType{
-					Type: UInt8Type,
-				},
+				ByteArrayType,
 			),
 		},
 	},
@@ -146,9 +144,7 @@ var authAccountContractsTypeUpdateExperimentalFunctionType = &FunctionType{
 		{
 			Identifier: "code",
 			TypeAnnotation: NewTypeAnnotation(
-				&VariableSizedType{
-					Type: UInt8Type,
-				},
+				ByteArrayType,
 			),
 		},
 	},

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -177,9 +177,7 @@ var authAccountTypeAddPublicKeyFunctionType = &FunctionType{
 			Label:      ArgumentLabelNotRequired,
 			Identifier: "key",
 			TypeAnnotation: NewTypeAnnotation(
-				&VariableSizedType{
-					Type: UInt8Type,
-				},
+				ByteArrayType,
 			),
 		},
 	},

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -22,42 +22,43 @@ import "github.com/onflow/cadence/runtime/ast"
 
 func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) ast.Repr {
 
-	inferType := false
-
 	// visit all elements, ensure they are all the same type
 
 	expectedType := UnwrapOptionalType(checker.expectedType)
 
+	inferType := true
+
 	var elementType Type
-	if expectedType != nil {
+	var resultType ArrayType
 
-		switch typ := expectedType.(type) {
+	switch expectedType := expectedType.(type) {
 
-		case *ConstantSizedType:
-			elementType = typ.ElementType(false)
+	case *ConstantSizedType:
+		inferType = false
 
-			literalCount := int64(len(expression.Values))
+		elementType = expectedType.ElementType(false)
+		resultType = expectedType
 
-			if typ.Size != literalCount {
-				checker.report(
-					&ConstantSizedArrayLiteralSizeError{
-						ExpectedSize: typ.Size,
-						ActualSize:   literalCount,
-						Range:        expression.Range,
-					},
-				)
-			}
-
-		case *VariableSizedType:
-			elementType = typ.ElementType(false)
-
-		default:
-			// If the expected type is not an array type, then it could either be an invalid type, or a super type
-			// (like: AnyStruct, etc.). Either case, infer the type from the expression.
-			inferType = true
+		literalCount := int64(len(expression.Values))
+		if expectedType.Size != literalCount {
+			checker.report(
+				&ConstantSizedArrayLiteralSizeError{
+					ExpectedSize: expectedType.Size,
+					ActualSize:   literalCount,
+					Range:        expression.Range,
+				},
+			)
 		}
-	} else {
-		inferType = true
+
+	case *VariableSizedType:
+		inferType = false
+		elementType = expectedType.ElementType(false)
+		resultType = expectedType
+
+	default:
+		// If there is no expected, or the expected type is not an array type,
+		// then it could either be an invalid type, or it is a super type (e.g. AnyStruct).
+		// In either case, infer the type from the expression.
 	}
 
 	argumentTypes := make([]Type, len(expression.Values))
@@ -84,13 +85,13 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) as
 		elementType = NeverType
 	}
 
-	checker.Elaboration.ArrayExpressionElementType[expression] = elementType
-
 	if inferType {
-		return &VariableSizedType{
+		resultType = &VariableSizedType{
 			Type: elementType,
 		}
 	}
 
-	return expectedType
+	checker.Elaboration.ArrayExpressionArrayTypes[expression] = resultType
+
+	return resultType
 }

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -91,7 +91,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) as
 		}
 	}
 
-	checker.Elaboration.ArrayExpressionArrayTypes[expression] = resultType
+	checker.Elaboration.ArrayExpressionArrayType[expression] = resultType
 
 	return resultType
 }

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -112,19 +112,13 @@ const HashAlgorithmTypeHashFunctionName = "hash"
 var HashAlgorithmTypeHashFunctionType = &FunctionType{
 	Parameters: []*Parameter{
 		{
-			Label:      ArgumentLabelNotRequired,
-			Identifier: "data",
-			TypeAnnotation: NewTypeAnnotation(
-				&VariableSizedType{
-					Type: UInt8Type,
-				},
-			),
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "data",
+			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&VariableSizedType{
-			Type: UInt8Type,
-		},
+		ByteArrayType,
 	),
 }
 
@@ -140,9 +134,7 @@ var HashAlgorithmTypeHashWithTagFunctionType = &FunctionType{
 			Label:      ArgumentLabelNotRequired,
 			Identifier: "data",
 			TypeAnnotation: NewTypeAnnotation(
-				&VariableSizedType{
-					Type: UInt8Type,
-				},
+				ByteArrayType,
 			),
 		},
 		{
@@ -151,9 +143,7 @@ var HashAlgorithmTypeHashWithTagFunctionType = &FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&VariableSizedType{
-			Type: UInt8Type,
-		},
+		ByteArrayType,
 	),
 }
 

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -65,9 +65,7 @@ var DeployedContractType = &SimpleType{
 					return NewPublicConstantFieldMember(
 						t,
 						identifier,
-						&VariableSizedType{
-							Type: UInt8Type,
-						},
+						ByteArrayType,
 						deployedContractTypeCodeFieldDocString,
 					)
 				},

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -56,7 +56,7 @@ type Elaboration struct {
 	MemberExpressionMemberInfos         map[*ast.MemberExpression]MemberInfo
 	MemberExpressionExpectedTypes       map[*ast.MemberExpression]Type
 	ArrayExpressionArgumentTypes        map[*ast.ArrayExpression][]Type
-	ArrayExpressionArrayTypes           map[*ast.ArrayExpression]ArrayType
+	ArrayExpressionArrayType            map[*ast.ArrayExpression]ArrayType
 	DictionaryExpressionType            map[*ast.DictionaryExpression]*DictionaryType
 	DictionaryExpressionEntryTypes      map[*ast.DictionaryExpression][]DictionaryEntryType
 	IntegerExpressionType               map[*ast.IntegerExpression]Type
@@ -111,7 +111,7 @@ func NewElaboration() *Elaboration {
 		MemberExpressionMemberInfos:         map[*ast.MemberExpression]MemberInfo{},
 		MemberExpressionExpectedTypes:       map[*ast.MemberExpression]Type{},
 		ArrayExpressionArgumentTypes:        map[*ast.ArrayExpression][]Type{},
-		ArrayExpressionArrayTypes:           map[*ast.ArrayExpression]ArrayType{},
+		ArrayExpressionArrayType:            map[*ast.ArrayExpression]ArrayType{},
 		DictionaryExpressionType:            map[*ast.DictionaryExpression]*DictionaryType{},
 		DictionaryExpressionEntryTypes:      map[*ast.DictionaryExpression][]DictionaryEntryType{},
 		IntegerExpressionType:               map[*ast.IntegerExpression]Type{},

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -56,7 +56,7 @@ type Elaboration struct {
 	MemberExpressionMemberInfos         map[*ast.MemberExpression]MemberInfo
 	MemberExpressionExpectedTypes       map[*ast.MemberExpression]Type
 	ArrayExpressionArgumentTypes        map[*ast.ArrayExpression][]Type
-	ArrayExpressionElementType          map[*ast.ArrayExpression]Type
+	ArrayExpressionArrayTypes           map[*ast.ArrayExpression]ArrayType
 	DictionaryExpressionType            map[*ast.DictionaryExpression]*DictionaryType
 	DictionaryExpressionEntryTypes      map[*ast.DictionaryExpression][]DictionaryEntryType
 	IntegerExpressionType               map[*ast.IntegerExpression]Type
@@ -111,7 +111,7 @@ func NewElaboration() *Elaboration {
 		MemberExpressionMemberInfos:         map[*ast.MemberExpression]MemberInfo{},
 		MemberExpressionExpectedTypes:       map[*ast.MemberExpression]Type{},
 		ArrayExpressionArgumentTypes:        map[*ast.ArrayExpression][]Type{},
-		ArrayExpressionElementType:          map[*ast.ArrayExpression]Type{},
+		ArrayExpressionArrayTypes:           map[*ast.ArrayExpression]ArrayType{},
 		DictionaryExpressionType:            map[*ast.DictionaryExpression]*DictionaryType{},
 		DictionaryExpressionEntryTypes:      map[*ast.DictionaryExpression][]DictionaryEntryType{},
 		IntegerExpressionType:               map[*ast.IntegerExpression]Type{},

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -92,9 +92,7 @@ func init() {
 					return NewPublicConstantFieldMember(
 						t,
 						identifier,
-						&VariableSizedType{
-							Type: UInt8Type,
-						},
+						ByteArrayType,
 						stringTypeUtf8FieldDocString,
 					)
 				},
@@ -155,12 +153,12 @@ It does not modify the original string.
 If either of the parameters are out of the bounds of the string, the function will fail
 `
 
+var ByteArrayType = &VariableSizedType{
+	Type: UInt8Type,
+}
+
 var stringTypeDecodeHexFunctionType = &FunctionType{
-	ReturnTypeAnnotation: NewTypeAnnotation(
-		&VariableSizedType{
-			Type: UInt8Type,
-		},
-	),
+	ReturnTypeAnnotation: NewTypeAnnotation(ByteArrayType),
 }
 
 const stringTypeDecodeHexFunctionDocString = `

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -360,9 +360,7 @@ const ToBigEndianBytesFunctionName = "toBigEndianBytes"
 
 var toBigEndianBytesFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&VariableSizedType{
-			Type: UInt8Type,
-		},
+		ByteArrayType,
 	),
 }
 
@@ -3033,9 +3031,7 @@ func init() {
 					Label:      ArgumentLabelNotRequired,
 					Identifier: "data",
 					TypeAnnotation: NewTypeAnnotation(
-						&VariableSizedType{
-							Type: UInt8Type,
-						},
+						ByteArrayType,
 					),
 				},
 			},
@@ -4448,9 +4444,7 @@ const AddressTypeToBytesFunctionName = `toBytes`
 
 var arrayTypeToBytesFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
-		&VariableSizedType{
-			Type: UInt8Type,
-		},
+		ByteArrayType,
 	),
 }
 
@@ -5883,17 +5877,13 @@ var publicKeyVerifyFunctionType = &FunctionType{
 		{
 			Identifier: "signature",
 			TypeAnnotation: NewTypeAnnotation(
-				&VariableSizedType{
-					Type: UInt8Type,
-				},
+				ByteArrayType,
 			),
 		},
 		{
 			Identifier: "signedData",
 			TypeAnnotation: NewTypeAnnotation(
-				&VariableSizedType{
-					Type: UInt8Type,
-				},
+				ByteArrayType,
 			),
 		},
 		{

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -347,9 +347,7 @@ var AccountEventCodeHashParameter = &sema.Parameter{
 var AccountEventPublicKeyParameter = &sema.Parameter{
 	Identifier: "publicKey",
 	TypeAnnotation: sema.NewTypeAnnotation(
-		&sema.VariableSizedType{
-			Type: sema.UInt8Type,
-		},
+		sema.ByteArrayType,
 	),
 }
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -35,14 +36,23 @@ import (
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
-func withWritesToStorage(arrayElementCount int, storageItemCount int, onWrite func(owner, key, value []byte), handler func(runtimeStorage *runtimeStorage)) {
+func withWritesToStorage(
+	arrayElementCount int,
+	storageItemCount int,
+	onWrite func(owner, key, value []byte),
+	handler func(runtimeStorage *runtimeStorage),
+) {
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestStorage(nil, onWrite),
 	}
 
 	runtimeStorage := newRuntimeStorage(runtimeInterface)
 
-	array := interpreter.NewArrayValueUnownedNonCopying()
+	array := interpreter.NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.IntType,
+		},
+	)
 
 	for i := 0; i < arrayElementCount; i++ {
 		array.Append(interpreter.NewIntValueFromInt64(int64(i)))

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -79,9 +79,7 @@ func TestCheckToBytes(t *testing.T) {
 		resType := RequireGlobalValue(t, checker.Elaboration, "res")
 
 		assert.Equal(t,
-			&sema.VariableSizedType{
-				Type: sema.UInt8Type,
-			},
+			sema.ByteArrayType,
 			resType,
 		)
 	})
@@ -105,9 +103,7 @@ func TestCheckToBigEndianBytes(t *testing.T) {
 			resType := RequireGlobalValue(t, checker.Elaboration, "res")
 
 			assert.Equal(t,
-				&sema.VariableSizedType{
-					Type: sema.UInt8Type,
-				},
+				sema.ByteArrayType,
 				resType,
 			)
 		})

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -271,9 +271,7 @@ func TestCheckStringDecodeHex(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&sema.VariableSizedType{
-			Type: sema.UInt8Type,
-		},
+		sema.ByteArrayType,
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }
@@ -306,9 +304,7 @@ func TestCheckStringUtf8Field(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&sema.VariableSizedType{
-			Type: sema.UInt8Type,
-		},
+		sema.ByteArrayType,
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -111,6 +111,7 @@ func TestInterpretToBytes(t *testing.T) {
 
 		assert.Equal(t,
 			interpreter.NewArrayValueUnownedNonCopying(
+				sema.ByteArrayType,
 				interpreter.UInt8Value(0x0),
 				interpreter.UInt8Value(0x0),
 				interpreter.UInt8Value(0x0),

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -1130,20 +1130,30 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							),
 						)
 
-						expectedValue := interpreter.NewArrayValueUnownedNonCopying(
+						expectedElements := []interpreter.Value{
 							interpreter.NewIntValueFromInt64(42),
-						)
+						}
+
+						xValue := inter.Globals["x"].GetValue()
+						require.IsType(t, xValue, &interpreter.ArrayValue{})
+						xArray := xValue.(*interpreter.ArrayValue)
 
 						assert.Equal(t,
-							expectedValue,
-							inter.Globals["x"].GetValue(),
+							expectedElements,
+							xArray.Elements(),
 						)
 
+						yValue := inter.Globals["y"].GetValue()
+						require.IsType(t, yValue, &interpreter.SomeValue{})
+						ySome := yValue.(*interpreter.SomeValue)
+
+						innerValue := ySome.Value
+						require.IsType(t, innerValue, &interpreter.ArrayValue{})
+						innerArray := innerValue.(*interpreter.ArrayValue)
+
 						assert.Equal(t,
-							interpreter.NewSomeValueOwningNonCopying(
-								expectedValue,
-							),
-							inter.Globals["y"].GetValue(),
+							expectedElements,
+							innerArray.Elements(),
 						)
 					})
 				}

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -1236,6 +1236,10 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 						)
 
 						expectedValue := interpreter.NewDictionaryValueUnownedNonCopying(
+							&sema.DictionaryType{
+								KeyType:   sema.StringType,
+								ValueType: sema.IntType,
+							},
 							interpreter.NewStringValue("test"), interpreter.NewIntValueFromInt64(42),
 						).Copy()
 

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -21,6 +21,7 @@ package interpreter_test
 import (
 	"testing"
 
+	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -118,6 +119,9 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 
 	require.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
@@ -144,6 +148,9 @@ func TestInterpretEnumConstructor(t *testing.T) {
 
 	require.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
@@ -169,6 +176,9 @@ func TestInterpretEnumInstance(t *testing.T) {
 
 	require.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
 		),

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -94,12 +94,15 @@ func TestInterpretForStatementWithContinue(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	require.IsType(t, value, &interpreter.ArrayValue{})
+	arrayValue := value.(*interpreter.ArrayValue)
+
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(4),
 			interpreter.NewIntValueFromInt64(5),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
 }
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -207,6 +207,9 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 		),
@@ -569,6 +572,9 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 	actualArray := inter.Globals["z"].GetValue()
 
 	expectedArray := interpreter.NewArrayValueUnownedNonCopying(
+		&sema.VariableSizedType{
+			Type: sema.IntType,
+		},
 		interpreter.NewIntValueFromInt64(0),
 		interpreter.NewIntValueFromInt64(3),
 	).Copy().(*interpreter.ArrayValue)
@@ -2098,6 +2104,9 @@ func TestInterpretStructCopyOnDeclaration(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(false),
 			interpreter.BoolValue(true),
 		),
@@ -2135,6 +2144,9 @@ func TestInterpretStructCopyOnDeclarationModifiedWithStructFunction(t *testing.T
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(false),
 			interpreter.BoolValue(true),
 		),
@@ -2169,6 +2181,9 @@ func TestInterpretStructCopyOnIdentifierAssignment(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(false),
 			interpreter.BoolValue(true),
 		),
@@ -2203,6 +2218,9 @@ func TestInterpretStructCopyOnIndexingAssignment(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(false),
 			interpreter.BoolValue(true),
 		),
@@ -2244,6 +2262,9 @@ func TestInterpretStructCopyOnMemberAssignment(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.BoolType,
+			},
 			interpreter.BoolValue(false),
 			interpreter.BoolValue(true),
 		),
@@ -2310,6 +2331,9 @@ func TestInterpretArrayCopy(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			interpreter.NewIntValueFromInt64(0),
 			interpreter.NewIntValueFromInt64(1),
 		),
@@ -2343,6 +2367,9 @@ func TestInterpretStructCopyInArray(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(1),
@@ -4307,22 +4334,11 @@ func TestInterpretArrayAppend(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	expectedArray := interpreter.NewArrayValueUnownedNonCopying(
-		interpreter.NewIntValueFromInt64(1),
-		interpreter.NewIntValueFromInt64(2),
-		interpreter.NewIntValueFromInt64(3),
-	).Copy().(*interpreter.ArrayValue)
-	expectedArray.Append(interpreter.NewIntValueFromInt64(4))
-
 	actualArray := inter.Globals["xs"].GetValue()
-
-	require.Equal(t,
-		expectedArray,
-		actualArray,
-	)
 
 	assert.True(t, actualArray.IsModified())
 
+	arrayValue := actualArray.(*interpreter.ArrayValue)
 	assert.Equal(t,
 		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
@@ -4330,8 +4346,9 @@ func TestInterpretArrayAppend(t *testing.T) {
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(4),
 		},
-		actualArray.(*interpreter.ArrayValue).Elements(),
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 }
 
 func TestInterpretArrayAppendBound(t *testing.T) {
@@ -4350,15 +4367,17 @@ func TestInterpretArrayAppendBound(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(4),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 }
 
 func TestInterpretArrayAppendAll(t *testing.T) {
@@ -4376,15 +4395,17 @@ func TestInterpretArrayAppendAll(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(4),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 }
 
 func TestInterpretArrayAppendAllBound(t *testing.T) {
@@ -4403,15 +4424,17 @@ func TestInterpretArrayAppendAllBound(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(4),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 }
 
 func TestInterpretArrayConcat(t *testing.T) {
@@ -4428,15 +4451,17 @@ func TestInterpretArrayConcat(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(4),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 }
 
 func TestInterpretArrayConcatBound(t *testing.T) {
@@ -4454,15 +4479,17 @@ func TestInterpretArrayConcatBound(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(4),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 }
 
 func TestInterpretArrayConcatDoesNotModifyOriginalArray(t *testing.T) {
@@ -4480,13 +4507,15 @@ func TestInterpretArrayConcatDoesNotModifyOriginalArray(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 }
 
 func TestInterpretArrayInsert(t *testing.T) {
@@ -4611,30 +4640,17 @@ func TestInterpretArrayRemove(t *testing.T) {
       let y = x.remove(at: 1)
     `)
 
-	expectedArray := interpreter.NewArrayValueUnownedNonCopying(
-		interpreter.NewIntValueFromInt64(1),
-		interpreter.NewIntValueFromInt64(2),
-		interpreter.NewIntValueFromInt64(3),
-	).Copy().(*interpreter.ArrayValue)
-	expectedArray.Remove(1, nil)
+	value := inter.Globals["x"].GetValue()
 
-	actualArray := inter.Globals["x"].GetValue()
-
-	require.Equal(t,
-		expectedArray,
-		actualArray,
-	)
-
-	assert.True(t, actualArray.IsModified())
-
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
 		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(3),
 		},
-		actualArray.(*interpreter.ArrayValue).Elements(),
+		arrayValue.Elements(),
 	)
-
+	assert.True(t, value.IsModified())
 	assert.Equal(t,
 		interpreter.NewIntValueFromInt64(2),
 		inter.Globals["y"].GetValue(),
@@ -4693,30 +4709,17 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
       let y = x.removeFirst()
     `)
 
-	expectedArray := interpreter.NewArrayValueUnownedNonCopying(
-		interpreter.NewIntValueFromInt64(1),
-		interpreter.NewIntValueFromInt64(2),
-		interpreter.NewIntValueFromInt64(3),
-	).Copy().(*interpreter.ArrayValue)
-	expectedArray.RemoveFirst(nil)
+	value := inter.Globals["x"].GetValue()
 
-	actualArray := inter.Globals["x"].GetValue()
-
-	require.Equal(t,
-		expectedArray,
-		actualArray,
-	)
-
-	assert.True(t, actualArray.IsModified())
-
+	arrayValue := value.(*interpreter.ArrayValue)
 	assert.Equal(t,
 		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(3),
 		},
-		actualArray.(*interpreter.ArrayValue).Elements(),
+		arrayValue.Elements(),
 	)
-
+	assert.True(t, value.IsModified())
 	assert.Equal(t,
 		interpreter.NewIntValueFromInt64(1),
 		inter.Globals["y"].GetValue(),
@@ -4765,29 +4768,18 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
           let y = x.removeLast()
     `)
 
-	expectedArray := interpreter.NewArrayValueUnownedNonCopying(
-		interpreter.NewIntValueFromInt64(1),
-		interpreter.NewIntValueFromInt64(2),
-		interpreter.NewIntValueFromInt64(3),
-	).Copy().(*interpreter.ArrayValue)
-	expectedArray.RemoveLast(nil)
+	value := inter.Globals["x"].GetValue()
 
-	actualArray := inter.Globals["x"].GetValue()
-
-	require.Equal(t,
-		expectedArray,
-		actualArray,
-	)
-
-	assert.True(t, actualArray.IsModified())
+	arrayValue := value.(*interpreter.ArrayValue)
 
 	assert.Equal(t,
 		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 		},
-		actualArray.(*interpreter.ArrayValue).Elements(),
+		arrayValue.Elements(),
 	)
+	assert.True(t, arrayValue.IsModified())
 
 	assert.Equal(t,
 		interpreter.NewIntValueFromInt64(3),
@@ -5057,13 +5049,15 @@ func TestInterpretDictionaryKeys(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
+
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewStringValue("def"),
 			interpreter.NewStringValue("abc"),
 			interpreter.NewStringValue("a"),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
 }
 
@@ -5082,13 +5076,15 @@ func TestInterpretDictionaryValues(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
+	arrayValue := value.(*interpreter.ArrayValue)
+
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(3),
-		),
-		value,
+		},
+		arrayValue.Elements(),
 	)
 }
 
@@ -5435,6 +5431,9 @@ func TestInterpretSwapVariables(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			interpreter.NewIntValueFromInt64(3),
 			interpreter.NewIntValueFromInt64(2),
 		),
@@ -5468,6 +5467,9 @@ func TestInterpretSwapArrayAndField(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(1),
 		),
@@ -5865,6 +5867,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 
 type testValue struct {
 	value              interpreter.Value
+	ty                 sema.Type
 	literal            string
 	notAsDictionaryKey bool
 }
@@ -5880,55 +5883,132 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 	t.Parallel()
 
+	sType := &sema.CompositeType{
+		Location:   TestLocation,
+		Identifier: "S",
+		Kind:       common.CompositeKindStructure,
+		Members:    sema.NewStringMemberOrderedMap(),
+	}
+
+	sValue := interpreter.NewCompositeValue(
+		TestLocation,
+		"S",
+		common.CompositeKindStructure,
+		interpreter.NewStringValueOrderedMap(),
+		nil,
+	)
+	sValue.Functions = map[string]interpreter.FunctionValue{}
+
 	validTypes := map[string]testValue{
-		"String":    {value: interpreter.NewStringValue("test")},
-		"Character": {value: interpreter.NewStringValue("X")},
-		"Bool":      {value: interpreter.BoolValue(true)},
+		"String": {
+			value: interpreter.NewStringValue("test"),
+			ty:    sema.StringType,
+		},
+		"Character": {
+			value: interpreter.NewStringValue("X"),
+			ty:    sema.CharacterType,
+		},
+		"Bool": {
+			value: interpreter.BoolValue(true),
+			ty:    sema.BoolType,
+		},
 		"Address": {
 			literal: `0x1`,
 			value:   interpreter.NewAddressValueFromBytes([]byte{0x1}),
+			ty:      &sema.AddressType{},
 		},
 		// Int*
-		"Int":    {value: interpreter.NewIntValueFromInt64(42)},
-		"Int8":   {value: interpreter.Int8Value(42)},
-		"Int16":  {value: interpreter.Int16Value(42)},
-		"Int32":  {value: interpreter.Int32Value(42)},
-		"Int64":  {value: interpreter.Int64Value(42)},
-		"Int128": {value: interpreter.NewInt128ValueFromInt64(42)},
-		"Int256": {value: interpreter.NewInt256ValueFromInt64(42)},
-		// UInt*
-		"UInt":    {value: interpreter.NewUIntValueFromUint64(42)},
-		"UInt8":   {value: interpreter.UInt8Value(42)},
-		"UInt16":  {value: interpreter.UInt16Value(42)},
-		"UInt32":  {value: interpreter.UInt32Value(42)},
-		"UInt64":  {value: interpreter.UInt64Value(42)},
-		"UInt128": {value: interpreter.NewUInt128ValueFromUint64(42)},
-		"UInt256": {value: interpreter.NewUInt256ValueFromUint64(42)},
-		// Word*
-		"Word8":  {value: interpreter.Word8Value(42)},
-		"Word16": {value: interpreter.Word16Value(42)},
-		"Word32": {value: interpreter.Word32Value(42)},
-		"Word64": {value: interpreter.Word64Value(42)},
-		// Fix*
-		"Fix64": {value: interpreter.Fix64Value(123000000)},
-		// UFix*
-		"UFix64": {value: interpreter.UFix64Value(123000000)},
-		// Struct
-		"S": {
-			literal: `S()`,
-			value: func() interpreter.Value {
-				v := interpreter.NewCompositeValue(
-					TestLocation,
-					"S",
-					common.CompositeKindStructure,
-					interpreter.NewStringValueOrderedMap(),
-					nil,
-				)
-				v.Functions = map[string]interpreter.FunctionValue{}
-				return v
-			}(),
-			notAsDictionaryKey: true,
+		"Int": {
+			value: interpreter.NewIntValueFromInt64(42),
+			ty:    sema.IntType,
 		},
+		"Int8": {
+			value: interpreter.Int8Value(42),
+			ty:    sema.Int8Type,
+		},
+		"Int16": {
+			value: interpreter.Int16Value(42),
+			ty:    sema.Int16Type,
+		},
+		"Int32": {
+			value: interpreter.Int32Value(42),
+			ty:    sema.Int32Type,
+		},
+		"Int64": {
+			value: interpreter.Int64Value(42),
+			ty:    sema.Int64Type,
+		},
+		"Int128": {
+			value: interpreter.NewInt128ValueFromInt64(42),
+			ty:    sema.Int128Type,
+		},
+		"Int256": {
+			value: interpreter.NewInt256ValueFromInt64(42),
+			ty:    sema.Int256Type,
+		},
+		// UInt*
+		"UInt": {
+			value: interpreter.NewUIntValueFromUint64(42),
+			ty:    sema.UIntType,
+		},
+		"UInt8": {
+			value: interpreter.UInt8Value(42),
+			ty:    sema.UInt8Type,
+		},
+		"UInt16": {
+			value: interpreter.UInt16Value(42),
+			ty:    sema.UInt16Type,
+		},
+		"UInt32": {
+			value: interpreter.UInt32Value(42),
+			ty:    sema.UInt32Type,
+		},
+		"UInt64": {
+			value: interpreter.UInt64Value(42),
+			ty:    sema.UInt64Type,
+		},
+		"UInt128": {
+			value: interpreter.NewUInt128ValueFromUint64(42),
+			ty:    sema.UInt128Type,
+		},
+		"UInt256": {
+			value: interpreter.NewUInt256ValueFromUint64(42),
+			ty:    sema.UInt256Type,
+		},
+		// Word*
+		"Word8": {
+			value: interpreter.Word8Value(42),
+			ty:    sema.Word8Type,
+		},
+		"Word16": {
+			value: interpreter.Word16Value(42),
+			ty:    sema.Word16Type,
+		},
+		"Word32": {
+			value: interpreter.Word32Value(42),
+			ty:    sema.Word32Type,
+		},
+		"Word64": {
+			value: interpreter.Word64Value(42),
+			ty:    sema.Word64Type,
+		},
+		// Fix*
+		"Fix64": {
+			value: interpreter.Fix64Value(123000000),
+			ty:    sema.Fix64Type,
+		},
+		// UFix*
+		"UFix64": {
+			value: interpreter.UFix64Value(123000000),
+			ty:    sema.UFix64Type,
+		},
+		// TODO:
+		//// Struct
+		//"S": {
+		//	literal:            `s`,
+		//	ty:                 sType,
+		//	notAsDictionaryKey: true,
+		//},
 	}
 
 	for _, integerType := range sema.AllIntegerTypes {
@@ -5968,13 +6048,24 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 		tests[fmt.Sprintf("[%s]", validType)] =
 			testValue{
-				value:   interpreter.NewArrayValueUnownedNonCopying(testCase.value),
+				value: interpreter.NewArrayValueUnownedNonCopying(
+					&sema.VariableSizedType{
+						Type: testCase.ty,
+					},
+					testCase.value,
+				),
 				literal: fmt.Sprintf("[%s as %s]", testCase, validType),
 			}
 
 		tests[fmt.Sprintf("[%s; 1]", validType)] =
 			testValue{
-				value:   interpreter.NewArrayValueUnownedNonCopying(testCase.value),
+				value: interpreter.NewArrayValueUnownedNonCopying(
+					&sema.ConstantSizedType{
+						Type: testCase.ty,
+						Size: 1,
+					},
+					testCase.value,
+				),
 				literal: fmt.Sprintf("[%s as %s]", testCase, validType),
 			}
 
@@ -5988,14 +6079,12 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		}
 	}
 
-	for ty, value := range tests {
+	for ty, testCase := range tests {
 
 		t.Run(ty, func(t *testing.T) {
 
 			code := fmt.Sprintf(
 				`
-                  struct S {}
-
                   event Test(_ value: %[1]s)
 
                   fun test() {
@@ -6003,10 +6092,32 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
                   }
                 `,
 				ty,
-				value,
+				testCase.String(),
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			valueDeclarations := stdlib.StandardLibraryValues{
+				{
+					Name:  "s",
+					Type:  sType,
+					Value: sValue,
+					Kind:  common.DeclarationKindConstant,
+				},
+			}
+
+			inter, err := parseCheckAndInterpretWithOptions(
+				t, code, ParseCheckAndInterpretOptions{
+					CheckerOptions: []sema.Option{
+						sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
+						sema.WithPredeclaredTypes([]sema.TypeDeclaration{
+							stdlib.StandardLibraryType{
+								Name: "S",
+								Type: sType,
+								Kind: common.DeclarationKindStructure,
+							},
+						}),
+					},
+				})
+			require.NoError(t, err)
 
 			var actualEvents []*interpreter.CompositeValue
 
@@ -6017,13 +6128,13 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 				},
 			)
 
-			_, err := inter.Invoke("test")
+			_, err = inter.Invoke("test")
 			require.NoError(t, err)
 
 			testType := checker.RequireGlobalType(t, inter.Program.Elaboration, "Test")
 
 			members := interpreter.NewStringValueOrderedMap()
-			members.Set("value", value.value)
+			members.Set("value", testCase.value)
 
 			expectedEvents := []*interpreter.CompositeValue{
 				interpreter.NewCompositeValue(
@@ -6204,6 +6315,9 @@ func TestInterpretReferenceUse(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
 			interpreter.NewIntValueFromInt64(2),
@@ -6248,6 +6362,9 @@ func TestInterpretReferenceUseAccess(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: sema.IntType,
+			},
 			interpreter.NewIntValueFromInt64(0),
 			interpreter.NewIntValueFromInt64(1),
 			interpreter.NewIntValueFromInt64(2),
@@ -6751,6 +6868,10 @@ func TestInterpretFungibleTokenContract(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.ConstantSizedType{
+				Type: sema.IntType,
+				Size: 2,
+			},
 			interpreter.NewIntValueFromInt64(40),
 			interpreter.NewIntValueFromInt64(60),
 		),
@@ -7135,7 +7256,7 @@ func TestInterpretHexDecode(t *testing.T) {
 
 	t.Parallel()
 
-	expected := interpreter.NewArrayValueUnownedNonCopying(
+	expected := []interpreter.Value{
 		interpreter.UInt8Value(71),
 		interpreter.UInt8Value(111),
 		interpreter.UInt8Value(32),
@@ -7152,7 +7273,7 @@ func TestInterpretHexDecode(t *testing.T) {
 		interpreter.UInt8Value(108),
 		interpreter.UInt8Value(111),
 		interpreter.UInt8Value(119),
-	)
+	}
 
 	t.Run("in Cadence", func(t *testing.T) {
 
@@ -7226,7 +7347,13 @@ func TestInterpretHexDecode(t *testing.T) {
 		result, err := inter.Invoke("test")
 		require.NoError(t, err)
 
-		assert.Equal(t, expected, result)
+		require.IsType(t, result, &interpreter.ArrayValue{})
+		arrayValue := result.(*interpreter.ArrayValue)
+
+		assert.Equal(t,
+			expected,
+			arrayValue.Elements(),
+		)
 	})
 
 	t.Run("native", func(t *testing.T) {
@@ -7242,7 +7369,13 @@ func TestInterpretHexDecode(t *testing.T) {
 		result, err := inter.Invoke("test")
 		require.NoError(t, err)
 
-		assert.Equal(t, expected, result)
+		require.IsType(t, result, &interpreter.ArrayValue{})
+		arrayValue := result.(*interpreter.ArrayValue)
+
+		assert.Equal(t,
+			expected,
+			arrayValue.Elements(),
+		)
 	})
 
 }
@@ -7389,11 +7522,11 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		interpreter.NewArrayValueUnownedNonCopying(
+		[]interpreter.Value{
 			interpreter.NilValue{},
 			interpreter.NewSomeValueOwningNonCopying(interpreter.AddressValue(address)),
-		),
-		result,
+		},
+		result.(*interpreter.ArrayValue).Elements(),
 	)
 }
 
@@ -8125,6 +8258,12 @@ func TestInterpretInternalAssignment(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			&sema.VariableSizedType{
+				Type: &sema.DictionaryType{
+					KeyType:   sema.StringType,
+					ValueType: sema.IntType,
+				},
+			},
 			interpreter.NewDictionaryValueUnownedNonCopying(
 				interpreter.NewStringValue("a"),
 				interpreter.NewIntValueFromInt64(1),

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -3598,6 +3598,10 @@ func TestInterpretDictionary(t *testing.T) {
     `)
 
 	expectedDict := interpreter.NewDictionaryValueUnownedNonCopying(
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.IntType,
+		},
 		interpreter.NewStringValue("a"), interpreter.NewIntValueFromInt64(1),
 		interpreter.NewStringValue("b"), interpreter.NewIntValueFromInt64(2),
 	).Copy()
@@ -3621,6 +3625,10 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
     `)
 
 	expectedDict := interpreter.NewDictionaryValueUnownedNonCopying(
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.IntType,
+		},
 		interpreter.NewStringValue("c"), interpreter.NewIntValueFromInt64(3),
 		interpreter.NewStringValue("a"), interpreter.NewIntValueFromInt64(1),
 		interpreter.NewStringValue("b"), interpreter.NewIntValueFromInt64(2),
@@ -3742,24 +3750,8 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 		value,
 	)
 
-	expectedDict := interpreter.NewDictionaryValueUnownedNonCopying(
-		interpreter.NewStringValue("abc"), interpreter.NewIntValueFromInt64(42),
-	).Copy().(*interpreter.DictionaryValue)
-	expectedDict.Set(
-		inter,
-		interpreter.ReturnEmptyLocationRange,
-		interpreter.NewStringValue("abc"),
-		interpreter.NewSomeValueOwningNonCopying(
-			interpreter.NewIntValueFromInt64(23),
-		),
-	)
-
-	actualDict := inter.Globals["x"].GetValue().(*interpreter.DictionaryValue)
-
-	require.Equal(t,
-		expectedDict,
-		actualDict,
-	)
+	actualValue := inter.Globals["x"].GetValue()
+	actualDict := actualValue.(*interpreter.DictionaryValue)
 
 	newValue := actualDict.
 		Get(inter, interpreter.ReturnEmptyLocationRange, interpreter.NewStringValue("abc"))
@@ -3807,6 +3799,10 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 	)
 
 	expectedDict := interpreter.NewDictionaryValueUnownedNonCopying(
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.IntType,
+		},
 		interpreter.NewStringValue("def"), interpreter.NewIntValueFromInt64(42),
 	).Copy().(*interpreter.DictionaryValue)
 	expectedDict.Set(
@@ -3873,6 +3869,10 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 	)
 
 	expectedDict := interpreter.NewDictionaryValueUnownedNonCopying(
+		&sema.DictionaryType{
+			KeyType:   sema.StringType,
+			ValueType: sema.IntType,
+		},
 		interpreter.NewStringValue("def"), interpreter.NewIntValueFromInt64(42),
 		interpreter.NewStringValue("abc"), interpreter.NewIntValueFromInt64(23),
 	).Copy().(*interpreter.DictionaryValue)
@@ -4942,18 +4942,10 @@ func TestInterpretDictionaryRemove(t *testing.T) {
       let removed = xs.remove(key: "abc")
     `)
 
-	expectedDict := interpreter.NewDictionaryValueUnownedNonCopying(
-		interpreter.NewStringValue("abc"), interpreter.NewIntValueFromInt64(1),
-		interpreter.NewStringValue("def"), interpreter.NewIntValueFromInt64(2),
-	).Copy().(*interpreter.DictionaryValue)
-	expectedDict.Remove(nil, interpreter.ReturnEmptyLocationRange, interpreter.NewStringValue("abc"))
+	actualValue := inter.Globals["xs"].GetValue()
 
-	actualDict := inter.Globals["xs"].GetValue().(*interpreter.DictionaryValue)
-
-	assert.Equal(t,
-		expectedDict,
-		actualDict,
-	)
+	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
+	actualDict := actualValue.(*interpreter.DictionaryValue)
 
 	expectedEntries := interpreter.NewStringValueOrderedMap()
 	expectedEntries.Set("def", interpreter.NewIntValueFromInt64(2))
@@ -4989,23 +4981,10 @@ func TestInterpretDictionaryInsert(t *testing.T) {
       let inserted = xs.insert(key: "abc", 3)
     `)
 
-	expectedDict := interpreter.NewDictionaryValueUnownedNonCopying(
-		interpreter.NewStringValue("abc"), interpreter.NewIntValueFromInt64(1),
-		interpreter.NewStringValue("def"), interpreter.NewIntValueFromInt64(2),
-	).Copy().(*interpreter.DictionaryValue)
-	expectedDict.Insert(
-		nil,
-		interpreter.ReturnEmptyLocationRange,
-		interpreter.NewStringValue("abc"),
-		interpreter.NewIntValueFromInt64(3),
-	)
+	actualValue := inter.Globals["xs"].GetValue()
 
-	actualDict := inter.Globals["xs"].GetValue().(*interpreter.DictionaryValue)
-
-	require.Equal(t,
-		expectedDict,
-		actualDict,
-	)
+	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
+	actualDict := actualValue.(*interpreter.DictionaryValue)
 
 	expectedEntries := interpreter.NewStringValueOrderedMap()
 	expectedEntries.Set("abc", interpreter.NewIntValueFromInt64(3))
@@ -6073,7 +6052,13 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 			tests[fmt.Sprintf("{%[1]s: %[1]s}", validType)] =
 				testValue{
-					value:   interpreter.NewDictionaryValueUnownedNonCopying(testCase.value, testCase.value).Copy(),
+					value: interpreter.NewDictionaryValueUnownedNonCopying(
+						&sema.DictionaryType{
+							KeyType:   testCase.ty,
+							ValueType: testCase.ty,
+						},
+						testCase.value, testCase.value,
+					).Copy(),
 					literal: fmt.Sprintf("{%[1]s as %[2]s: %[1]s as %[2]s}", testCase, validType),
 				}
 		}
@@ -8265,12 +8250,20 @@ func TestInterpretInternalAssignment(t *testing.T) {
 				},
 			},
 			interpreter.NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.StringType,
+					ValueType: sema.IntType,
+				},
 				interpreter.NewStringValue("a"),
 				interpreter.NewIntValueFromInt64(1),
 				interpreter.NewStringValue("b"),
 				interpreter.NewIntValueFromInt64(2),
 			),
 			interpreter.NewDictionaryValueUnownedNonCopying(
+				&sema.DictionaryType{
+					KeyType:   sema.StringType,
+					ValueType: sema.IntType,
+				},
 				interpreter.NewStringValue("a"),
 				interpreter.NewIntValueFromInt64(1),
 			),
@@ -8302,7 +8295,12 @@ func TestInterpretCopyOnReturn(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		interpreter.NewDictionaryValueUnownedNonCopying(),
+		interpreter.NewDictionaryValueUnownedNonCopying(
+			&sema.DictionaryType{
+				KeyType:   sema.StringType,
+				ValueType: sema.StringType,
+			},
+		),
 		value,
 	)
 }

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -478,8 +478,9 @@ func TestInterpretGetType(t *testing.T) {
               let result = [].getType()
             `,
 			result: interpreter.TypeValue{
-				// TODO: not yet supported
-				Type: nil,
+				Type: interpreter.VariableSizedStaticType{
+					Type: interpreter.PrimitiveStaticTypeNever,
+				},
 			},
 		},
 	}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,6 +90,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 
 	require.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			sema.ByteArrayType,
 			interpreter.UInt8Value(1),
 			interpreter.UInt8Value(0xCA),
 			interpreter.UInt8Value(0xDE),
@@ -131,6 +133,7 @@ func TestInterpretStringUtf8Field(t *testing.T) {
 
 	require.Equal(t,
 		interpreter.NewArrayValueUnownedNonCopying(
+			sema.ByteArrayType,
 			// Flowers
 			interpreter.UInt8Value(70),
 			interpreter.UInt8Value(108),

--- a/runtime/tests/interpreter/switch_test.go
+++ b/runtime/tests/interpreter/switch_test.go
@@ -169,25 +169,31 @@ func TestInterpretSwitchStatement(t *testing.T) {
           }
         `)
 
-		for argument, expected := range map[interpreter.Value]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1): interpreter.NewArrayValueUnownedNonCopying(
+		for argument, expectedValues := range map[interpreter.Value][]interpreter.Value{
+			interpreter.NewIntValueFromInt64(1): {
 				interpreter.NewStringValue("1"),
-			),
-			interpreter.NewIntValueFromInt64(2): interpreter.NewArrayValueUnownedNonCopying(
+			},
+			interpreter.NewIntValueFromInt64(2): {
 				interpreter.NewStringValue("2"),
-			),
-			interpreter.NewIntValueFromInt64(3): interpreter.NewArrayValueUnownedNonCopying(
+			},
+			interpreter.NewIntValueFromInt64(3): {
 				interpreter.NewStringValue("3"),
-			),
-			interpreter.NewIntValueFromInt64(4): interpreter.NewArrayValueUnownedNonCopying(
+			},
+			interpreter.NewIntValueFromInt64(4): {
 				interpreter.NewStringValue("3"),
-			),
+			},
 		} {
 
 			actual, err := inter.Invoke("test", argument)
 			require.NoError(t, err)
 
-			assert.Equal(t, expected, actual)
+			require.IsType(t, actual, &interpreter.ArrayValue{})
+			arrayValue := actual.(*interpreter.ArrayValue)
+
+			assert.Equal(t,
+				expectedValues,
+				arrayValue.Elements(),
+			)
 		}
 	})
 

--- a/types.go
+++ b/types.go
@@ -425,6 +425,7 @@ func (UFix64Type) ID() string {
 }
 
 type ArrayType interface {
+	Type
 	Element() Type
 }
 

--- a/values.go
+++ b/values.go
@@ -892,8 +892,8 @@ func (v UFix64) String() string {
 // Array
 
 type Array struct {
-	typ    Type
-	Values []Value
+	ArrayType ArrayType
+	Values    []Value
 }
 
 func NewArray(values []Value) Array {
@@ -903,7 +903,12 @@ func NewArray(values []Value) Array {
 func (Array) isValue() {}
 
 func (v Array) Type() Type {
-	return v.typ
+	return v.ArrayType
+}
+
+func (v Array) WithType(arrayType ArrayType) Array {
+	v.ArrayType = arrayType
+	return v
 }
 
 func (v Array) ToGoValue() interface{} {
@@ -927,8 +932,8 @@ func (v Array) String() string {
 // Dictionary
 
 type Dictionary struct {
-	typ   Type
-	Pairs []KeyValuePair
+	DictionaryType Type
+	Pairs          []KeyValuePair
 }
 
 func NewDictionary(pairs []KeyValuePair) Dictionary {
@@ -938,7 +943,12 @@ func NewDictionary(pairs []KeyValuePair) Dictionary {
 func (Dictionary) isValue() {}
 
 func (v Dictionary) Type() Type {
-	return v.typ
+	return v.DictionaryType
+}
+
+func (v Dictionary) WithType(dictionaryType DictionaryType) Dictionary {
+	v.DictionaryType = dictionaryType
+	return v
 }
 
 func (v Dictionary) ToGoValue() interface{} {


### PR DESCRIPTION
Work towards #870

## Description

- Record the static type for array expressions and dictionary expressions
- Add the static type to array values and dictionary values
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
