### PR TITLE
Add walker for values

### DIFF
--- a/runtime/interpreter/block.go
+++ b/runtime/interpreter/block.go
@@ -41,6 +41,13 @@ func (v BlockValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitValue(interpreter, v)
 }
 
+func (v BlockValue) Walk(walkChild func(Value)) {
+	walkChild(v.Height)
+	walkChild(v.View)
+	walkChild(v.ID)
+	walkChild(v.Timestamp)
+}
+
 var blockDynamicType DynamicType = BlockDynamicType{}
 
 func (BlockValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {

--- a/runtime/interpreter/deployed_contract.go
+++ b/runtime/interpreter/deployed_contract.go
@@ -40,6 +40,12 @@ func (v DeployedContractValue) Accept(interpreter *Interpreter, visitor Visitor)
 	visitor.VisitDeployedContractValue(interpreter, v)
 }
 
+func (v DeployedContractValue) Walk(walkChild func(Value)) {
+	walkChild(v.Address)
+	walkChild(v.Name)
+	walkChild(v.Code)
+}
+
 var deployedContractDynamicType DynamicType = DeployedContractDynamicType{}
 
 func (DeployedContractValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -73,6 +73,10 @@ func (f InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visit
 	visitor.VisitInterpretedFunctionValue(interpreter, f)
 }
 
+func (f InterpretedFunctionValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var functionDynamicType DynamicType = FunctionDynamicType{}
 
 func (InterpretedFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -168,6 +172,10 @@ func (f HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitHostFunctionValue(interpreter, f)
 }
 
+func (f HostFunctionValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var hostFunctionDynamicType DynamicType = FunctionDynamicType{}
 
 func (HostFunctionValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -250,6 +258,10 @@ func (BoundFunctionValue) IsValue() {}
 
 func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitBoundFunctionValue(interpreter, f)
+}
+
+func (f BoundFunctionValue) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var boundFunctionDynamicType DynamicType = FunctionDynamicType{}

--- a/runtime/interpreter/inspect.go
+++ b/runtime/interpreter/inspect.go
@@ -1,0 +1,33 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+type valueInspector func(Value) bool
+
+func (f valueInspector) WalkValue(value Value) ValueWalker {
+	if f(value) {
+		return f
+	}
+
+	return nil
+}
+
+func InspectValue(value Value, f func(Value) bool) {
+	WalkValue(valueInspector(f), value)
+}

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -1,0 +1,103 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInspectValue(t *testing.T) {
+
+	t.Parallel()
+
+	dictValue := NewDictionaryValueUnownedNonCopying()
+	dictValueKey := NewStringValue("hello world")
+	dictValueValue := NewInt256ValueFromInt64(1)
+	dictValue.Set(nil, ReturnEmptyLocationRange, dictValueKey, NewSomeValueOwningNonCopying(dictValueValue))
+
+	arrayValue := NewArrayValueUnownedNonCopying(dictValue)
+
+	optionalValue := NewSomeValueOwningNonCopying(arrayValue)
+
+	compositeValue := newTestCompositeValue(common.Address{})
+	compositeValue.Fields().Set("value", optionalValue)
+
+	t.Run("dict", func(t *testing.T) {
+
+		t.Parallel()
+
+		var inspectedValues []Value
+
+		InspectValue(
+			dictValue,
+			func(value Value) bool {
+				inspectedValues = append(inspectedValues, value)
+				return true
+			},
+		)
+
+		assert.Equal(t,
+			[]Value{
+				dictValue,
+				dictValueKey,
+				nil, // end key
+				dictValueValue,
+				nil, // end value
+				nil, // end dict
+			},
+			inspectedValues,
+		)
+	})
+
+	t.Run("composite", func(t *testing.T) {
+
+		t.Parallel()
+
+		var inspectedValues []Value
+
+		InspectValue(
+			compositeValue,
+			func(value Value) bool {
+				inspectedValues = append(inspectedValues, value)
+				return true
+			},
+		)
+
+		assert.Equal(t,
+			[]Value{
+				compositeValue,
+				optionalValue,
+				arrayValue,
+				dictValue,
+				dictValueKey,
+				nil, // end key
+				dictValueValue,
+				nil, // end value
+				nil, // end dict
+				nil, // end array
+				nil, // end optional
+				nil, // end composite
+			},
+			inspectedValues,
+		)
+	})
+}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -57,6 +57,7 @@ type Value interface {
 	fmt.Stringer
 	IsValue()
 	Accept(interpreter *Interpreter, visitor Visitor)
+	Walk(walkChild func(Value))
 	DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType
 	Copy() Value
 	GetOwner() *common.Address
@@ -124,6 +125,10 @@ func (TypeValue) IsValue() {}
 
 func (v TypeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitTypeValue(interpreter, v)
+}
+
+func (TypeValue) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var metaTypeDynamicType DynamicType = MetaTypeDynamicType{}
@@ -226,6 +231,10 @@ func (v VoidValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitVoidValue(interpreter, v)
 }
 
+func (VoidValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var voidDynamicType DynamicType = VoidDynamicType{}
 
 func (VoidValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -282,6 +291,10 @@ func (BoolValue) IsValue() {}
 
 func (v BoolValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitBoolValue(interpreter, v)
+}
+
+func (BoolValue) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var boolDynamicType DynamicType = BoolDynamicType{}
@@ -383,6 +396,10 @@ func (*StringValue) IsValue() {}
 
 func (v *StringValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitStringValue(interpreter, v)
+}
+
+func (*StringValue) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var stringDynamicType DynamicType = StringDynamicType{}
@@ -679,6 +696,12 @@ func (v *ArrayValue) Accept(interpreter *Interpreter, visitor Visitor) {
 
 	for _, value := range v.Elements() {
 		value.Accept(interpreter, visitor)
+	}
+}
+
+func (v *ArrayValue) Walk(walkChild func(Value)) {
+	for _, value := range v.Elements() {
+		walkChild(value)
 	}
 }
 
@@ -1234,6 +1257,10 @@ func (v IntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitIntValue(interpreter, v)
 }
 
+func (IntValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var intDynamicType DynamicType = NumberDynamicType{sema.IntType}
 
 func (IntValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -1454,6 +1481,10 @@ func (Int8Value) IsValue() {}
 
 func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt8Value(interpreter, v)
+}
+
+func (Int8Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var int8DynamicType DynamicType = NumberDynamicType{sema.Int8Type}
@@ -1757,6 +1788,10 @@ func (Int16Value) IsValue() {}
 
 func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt16Value(interpreter, v)
+}
+
+func (Int16Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var int16DynamicType DynamicType = NumberDynamicType{sema.Int16Type}
@@ -2064,6 +2099,10 @@ func (v Int32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt32Value(interpreter, v)
 }
 
+func (Int32Value) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var int32DynamicType DynamicType = NumberDynamicType{sema.Int32Type}
 
 func (Int32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -2367,6 +2406,10 @@ func (Int64Value) IsValue() {}
 
 func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt64Value(interpreter, v)
+}
+
+func (Int64Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var int64DynamicType DynamicType = NumberDynamicType{sema.Int64Type}
@@ -2680,6 +2723,10 @@ func (v Int128Value) IsValue() {}
 
 func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt128Value(interpreter, v)
+}
+
+func (Int128Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var int128DynamicType DynamicType = NumberDynamicType{sema.Int128Type}
@@ -3054,6 +3101,10 @@ func (v Int256Value) IsValue() {}
 
 func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitInt256Value(interpreter, v)
+}
+
+func (Int256Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var int256DynamicType DynamicType = NumberDynamicType{sema.Int256Type}
@@ -3451,6 +3502,10 @@ func (v UIntValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUIntValue(interpreter, v)
 }
 
+func (UIntValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var uintDynamicType DynamicType = NumberDynamicType{sema.UIntType}
 
 func (UIntValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -3682,6 +3737,10 @@ func (UInt8Value) IsValue() {}
 
 func (v UInt8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt8Value(interpreter, v)
+}
+
+func (UInt8Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var uint8DynamicType DynamicType = NumberDynamicType{sema.UInt8Type}
@@ -3918,6 +3977,10 @@ func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt16Value(interpreter, v)
 }
 
+func (UInt16Value) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var uint16DynamicType DynamicType = NumberDynamicType{sema.UInt16Type}
 
 func (UInt16Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -4150,6 +4213,10 @@ func (UInt32Value) IsValue() {}
 
 func (v UInt32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt32Value(interpreter, v)
+}
+
+func (UInt32Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var uint32DynamicType DynamicType = NumberDynamicType{sema.UInt32Type}
@@ -4385,6 +4452,10 @@ func (UInt64Value) IsValue() {}
 
 func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt64Value(interpreter, v)
+}
+
+func (UInt64Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var uint64DynamicType DynamicType = NumberDynamicType{sema.UInt64Type}
@@ -4633,6 +4704,10 @@ func (v UInt128Value) IsValue() {}
 
 func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt128Value(interpreter, v)
+}
+
+func (UInt128Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var uint128DynamicType DynamicType = NumberDynamicType{sema.UInt128Type}
@@ -4951,6 +5026,10 @@ func (v UInt256Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUInt256Value(interpreter, v)
 }
 
+func (UInt256Value) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var uint256DynamicType DynamicType = NumberDynamicType{sema.UInt256Type}
 
 func (UInt256Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -5257,6 +5336,10 @@ func (v Word8Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord8Value(interpreter, v)
 }
 
+func (Word8Value) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var word8DynamicType DynamicType = NumberDynamicType{sema.Word8Type}
 
 func (Word8Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -5434,6 +5517,10 @@ func (Word16Value) IsValue() {}
 
 func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord16Value(interpreter, v)
+}
+
+func (Word16Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var word16DynamicType DynamicType = NumberDynamicType{sema.Word16Type}
@@ -5615,6 +5702,10 @@ func (v Word32Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord32Value(interpreter, v)
 }
 
+func (Word32Value) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var word32DynamicType DynamicType = NumberDynamicType{sema.Word32Type}
 
 func (Word32Value) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -5794,6 +5885,10 @@ func (Word64Value) IsValue() {}
 
 func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitWord64Value(interpreter, v)
+}
+
+func (Word64Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var word64DynamicType DynamicType = NumberDynamicType{sema.Word64Type}
@@ -5990,6 +6085,10 @@ func (Fix64Value) IsValue() {}
 
 func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitFix64Value(interpreter, v)
+}
+
+func (Fix64Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var fix64DynamicType DynamicType = NumberDynamicType{sema.Fix64Type}
@@ -6268,6 +6367,10 @@ func (UFix64Value) IsValue() {}
 
 func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitUFix64Value(interpreter, v)
+}
+
+func (UFix64Value) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var ufix64DynamicType DynamicType = NumberDynamicType{sema.UFix64Type}
@@ -6617,6 +6720,12 @@ func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 
 	v.Fields().Foreach(func(_ string, value Value) {
 		value.Accept(interpreter, visitor)
+	})
+}
+
+func (v *CompositeValue) Walk(walkChild func(Value)) {
+	v.Fields().Foreach(func(_ string, value Value) {
+		walkChild(value)
 	})
 }
 
@@ -7295,6 +7404,15 @@ func (v *DictionaryValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	}
 }
 
+func (v *DictionaryValue) Walk(walkChild func(Value)) {
+	for _, value := range v.Keys().Elements() {
+		walkChild(value)
+	}
+	v.Entries().Foreach(func(_ string, value Value) {
+		walkChild(value)
+	})
+}
+
 func (v *DictionaryValue) DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType {
 	keys := v.Keys().Elements()
 	entryTypes := make([]struct{ KeyType, ValueType DynamicType }, len(keys))
@@ -7869,6 +7987,10 @@ func (v NilValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitNilValue(interpreter, v)
 }
 
+func (NilValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var nilDynamicType DynamicType = NilDynamicType{}
 
 func (NilValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -7971,6 +8093,10 @@ func (v *SomeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 		return
 	}
 	v.Value.Accept(interpreter, visitor)
+}
+
+func (v *SomeValue) Walk(walkChild func(Value)) {
+	walkChild(v.Value)
 }
 
 func (v *SomeValue) DynamicType(interpreter *Interpreter, results DynamicTypeResults) DynamicType {
@@ -8103,6 +8229,11 @@ func (*StorageReferenceValue) IsValue() {}
 
 func (v *StorageReferenceValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitStorageReferenceValue(interpreter, v)
+}
+
+func (*StorageReferenceValue) Walk(_ func(Value)) {
+	// NO-OP
+	// NOTE: *not* walking referenced value!
 }
 
 func (*StorageReferenceValue) String() string {
@@ -8324,6 +8455,11 @@ func (*EphemeralReferenceValue) IsValue() {}
 
 func (v *EphemeralReferenceValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitEphemeralReferenceValue(interpreter, v)
+}
+
+func (*EphemeralReferenceValue) Walk(_ func(Value)) {
+	// NO-OP
+	// NOTE: *not* walking referenced value!
 }
 
 func (v *EphemeralReferenceValue) String() string {
@@ -8562,6 +8698,10 @@ func (AddressValue) IsValue() {}
 
 func (v AddressValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitAddressValue(interpreter, v)
+}
+
+func (AddressValue) Walk(_ func(Value)) {
+	// NO-OP
 }
 
 var addressDynamicType DynamicType = AddressDynamicType{}
@@ -8836,6 +8976,10 @@ func (v PathValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitPathValue(interpreter, v)
 }
 
+func (PathValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
 var storagePathDynamicType DynamicType = StoragePathDynamicType{}
 var publicPathDynamicType DynamicType = PublicPathDynamicType{}
 var privatePathDynamicType DynamicType = PrivatePathDynamicType{}
@@ -8949,6 +9093,11 @@ func (CapabilityValue) IsValue() {}
 
 func (v CapabilityValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitCapabilityValue(interpreter, v)
+}
+
+func (v CapabilityValue) Walk(walkChild func(Value)) {
+	walkChild(v.Address)
+	walkChild(v.Path)
 }
 
 func (v CapabilityValue) DynamicType(inter *Interpreter, _ DynamicTypeResults) DynamicType {
@@ -9076,6 +9225,10 @@ func (LinkValue) IsValue() {}
 
 func (v LinkValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitLinkValue(interpreter, v)
+}
+
+func (v LinkValue) Walk(walkChild func(Value)) {
+	walkChild(v.TargetPath)
 }
 
 func (LinkValue) DynamicType(_ *Interpreter, _ DynamicTypeResults) DynamicType {

--- a/runtime/interpreter/walk.go
+++ b/runtime/interpreter/walk.go
@@ -1,0 +1,47 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+type ValueWalker interface {
+	WalkValue(value Value) ValueWalker
+}
+
+// WalkValue traverses a Value object graph in depth-first order:
+// It starts by calling valueWalker.WalkValue(value);
+// If the returned walker is nil,
+// child values are not walked.
+// If the returned walker is not-nil,
+// then WalkValue is invoked recursively on this returned walker
+// for each of the non-nil children of the value,
+// followed by a call of WalkValue(nil) on the returned walker.
+//
+// The initial walker may not be nil.
+//
+//
+func WalkValue(walker ValueWalker, value Value) {
+	if walker = walker.WalkValue(value); walker == nil {
+		return
+	}
+
+	value.Walk(func(child Value) {
+		WalkValue(walker, child)
+	})
+
+	walker.WalkValue(nil)
+}


### PR DESCRIPTION
Work towards #870 

## Description

Add a function to walk an `interpreter.Value`, `WalkValue`, similar to `ast.Walk`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
