### PR TITLE
Infer array and dictionary static types from expected type during import

### DIFF
--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -74,7 +74,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 		inter, err := interpreter.NewInterpreter(nil, utils.TestLocation)
 		require.NoError(t, err)
 
-		importedValue := importValue(inter, codeHashValue)
+		importedValue := importValue(inter, codeHashValue, sema.ByteArrayType)
 
 		actualCodeHash, err := interpreter.ByteArrayValueToByteSlice(importedValue)
 		require.NoError(t, err)

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -86,7 +86,7 @@ func ByteSliceToByteArrayValue(buf []byte) *ArrayValue {
 	}
 
 	return NewArrayValueUnownedNonCopying(
-		byteArrayStaticType,
+		ByteArrayStaticType,
 		values...,
 	)
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -328,9 +328,18 @@ func (d *DecoderV5) decodeArray(path []string, deferDecoding bool) (*ArrayValue,
 		}
 
 		// Decode type at array index encodedArrayValueStaticTypeFieldKeyV5
-		arrayStaticType, err := d.decodeStaticType()
+		staticType, err := d.decodeStaticType()
 		if err != nil {
 			return nil, err
+		}
+
+		arrayStaticType, ok := staticType.(ArrayStaticType)
+		if !ok {
+			return nil, fmt.Errorf(
+				"invalid decoded array static type (@ %s): %s",
+				strings.Join(path, "."),
+				staticType,
+			)
 		}
 
 		elements, err := d.decodeArrayElements(path)
@@ -1818,9 +1827,18 @@ func decodeArrayMetaInfo(array *ArrayValue, content []byte) error {
 	}
 
 	// Decode type at array index encodedArrayValueStaticTypeFieldKeyV5
-	arrayStaticType, err := d.decodeStaticType()
+	staticType, err := d.decodeStaticType()
 	if err != nil {
 		return err
+	}
+
+	arrayStaticType, ok := staticType.(ArrayStaticType)
+	if !ok {
+		return fmt.Errorf(
+			"invalid decoded array static type (@ %s): %s",
+			strings.Join(array.valuePath, "."),
+			staticType,
+		)
 	}
 
 	array.Type = arrayStaticType

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -167,7 +167,7 @@ const (
 	_
 )
 
-func (PrimitiveStaticType) IsStaticType() {}
+func (PrimitiveStaticType) isStaticType() {}
 
 func (i PrimitiveStaticType) SemaType() sema.Type {
 	switch i {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -535,7 +535,7 @@ func (v *StringValue) Get(_ *Interpreter, getLocationRange func() LocationRange,
 	return NewStringValue(char)
 }
 
-func (v *StringValue) Set(_ *Interpreter, _ func() LocationRange, key Value, value Value) {
+func (v *StringValue) Set(_ *Interpreter, _ func() LocationRange, _ Value, _ Value) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -594,7 +594,7 @@ func (*StringValue) IsStorable() bool {
 	return true
 }
 
-var byteArrayStaticType = ConvertSemaToStaticType(sema.ByteArrayType)
+var ByteArrayStaticType = ConvertSemaArrayTypeToStaticArrayType(sema.ByteArrayType)
 
 // DecodeHex hex-decodes this string and returns an array of UInt8 values
 //
@@ -611,7 +611,7 @@ func (v *StringValue) DecodeHex() *ArrayValue {
 		values[i] = UInt8Value(b)
 	}
 
-	return NewArrayValueUnownedNonCopying(byteArrayStaticType, values...)
+	return NewArrayValueUnownedNonCopying(ByteArrayStaticType, values...)
 }
 
 func (*StringValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
@@ -626,7 +626,7 @@ func (*StringValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicTyp
 // ArrayValue
 
 type ArrayValue struct {
-	Type     StaticType
+	Type     ArrayStaticType
 	values   []Value
 	Owner    *common.Address
 	modified bool
@@ -653,7 +653,7 @@ type ArrayValue struct {
 	encodingVersion uint16
 }
 
-func NewArrayValueUnownedNonCopying(arrayType StaticType, values ...Value) *ArrayValue {
+func NewArrayValueUnownedNonCopying(arrayType ArrayStaticType, values ...Value) *ArrayValue {
 	// NOTE: new value has no owner
 
 	for _, value := range values {

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -947,7 +947,7 @@ func TestBlockValue(t *testing.T) {
 	block := BlockValue{
 		Height:    4,
 		View:      5,
-		ID:        NewArrayValueUnownedNonCopying(byteArrayStaticType),
+		ID:        NewArrayValueUnownedNonCopying(ByteArrayStaticType),
 		Timestamp: 5.0,
 	}
 
@@ -1884,7 +1884,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 				NewStringValue("2"),
 			).Equal(
 				NewArrayValueUnownedNonCopying(
-					byteArrayStaticType,
+					ByteArrayStaticType,
 					UInt8Value(1),
 					UInt8Value(2),
 				),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -681,7 +681,7 @@ func validateArgumentParams(
 			}
 		}
 
-		arg := importValue(inter, value)
+		arg := importValue(inter, value, parameterType)
 
 		dynamicTypeResults := interpreter.DynamicTypeResults{}
 
@@ -2508,8 +2508,6 @@ func (r *interpreterRuntime) ReadLinked(address common.Address, path cadence.Pat
 	)
 }
 
-var byteArrayStaticType = interpreter.ConvertSemaToStaticType(sema.ByteArrayType)
-
 func NewBlockValue(block Block) interpreter.BlockValue {
 
 	// height
@@ -2524,7 +2522,7 @@ func NewBlockValue(block Block) interpreter.BlockValue {
 		values[i] = interpreter.UInt8Value(b)
 	}
 	idValue := interpreter.NewArrayValueUnownedNonCopying(
-		byteArrayStaticType,
+		interpreter.ByteArrayStaticType,
 		values...,
 	)
 


### PR DESCRIPTION
⚠️ Depends on #1042

Work towards #870 

## Description

When importing values, provide the expected type (e.g. the parameter type for a script argument) to the import function, and use it to determine the static type for array values and dictionary values.

______


- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
