### PR TITLE
Add encoder/decoder v5

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1571,7 +1571,7 @@ func (d *DecoderV5) decodeCapabilityStaticType() (StaticType, error) {
 // This also extracts out the fields raw content and cache it separately inside the value.
 //
 func decodeCompositeMetaInfo(v *CompositeValue, content []byte) error {
-	if v.encodingVersion == 4 {
+	if v.encodingVersion < 5 {
 		return decodeCompositeMetaInfoV4(v, content)
 	}
 
@@ -1685,7 +1685,7 @@ func decodeCompositeMetaInfo(v *CompositeValue, content []byte) error {
 // decodeCompositeFields decodes fields from the byte content and updates the composite value.
 //
 func decodeCompositeFields(v *CompositeValue, content []byte) error {
-	if v.encodingVersion == 4 {
+	if v.encodingVersion < 5 {
 		return decodeCompositeFieldsV4(v, content)
 	}
 
@@ -1762,7 +1762,7 @@ func decodeCompositeFields(v *CompositeValue, content []byte) error {
 }
 
 func decodeArrayElements(array *ArrayValue, elementContent []byte) error {
-	if array.encodingVersion == 4 {
+	if array.encodingVersion < 5 {
 		return decodeArrayElementsV4(array, elementContent)
 	}
 
@@ -1781,7 +1781,7 @@ func decodeArrayElements(array *ArrayValue, elementContent []byte) error {
 }
 
 func decodeDictionaryEntries(v *DictionaryValue, content []byte) error {
-	if v.encodingVersion == 4 {
+	if v.encodingVersion < 5 {
 		return decodeDictionaryEntriesV4(v, content)
 	}
 

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 	"math/bits"
 	"strconv"
 	"strings"
@@ -565,6 +566,8 @@ func (d *DecoderV5) decodeComposite(path []string) (*CompositeValue, error) {
 
 	return NewDeferredCompositeValue(valuePath, content, d.owner, d.decodeCallback, d.version), nil
 }
+
+var bigOne = big.NewInt(1)
 
 func (d *DecoderV5) decodeInt() (IntValue, error) {
 	bigInt, err := d.decoder.DecodeBigInt()

--- a/runtime/interpreter/decode_v4.go
+++ b/runtime/interpreter/decode_v4.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/big"
 	"strconv"
 	"strings"
 
@@ -546,8 +545,6 @@ func (d *DecoderV4) decodeComposite(path []string) (*CompositeValue, error) {
 
 	return NewDeferredCompositeValue(valuePath, content, d.owner, d.decodeCallback, d.version), nil
 }
-
-var bigOne = big.NewInt(1)
 
 func (d *DecoderV4) decodeInt() (IntValue, error) {
 	bigInt, err := d.decoder.DecodeBigInt()

--- a/runtime/interpreter/magic.go
+++ b/runtime/interpreter/magic.go
@@ -28,7 +28,7 @@ import (
 var Magic = []byte{0x0, 0xCA, 0xDE}
 var MagicLength = len(Magic)
 
-const CurrentEncodingVersion uint16 = 4
+const CurrentEncodingVersion uint16 = 5
 const VersionEncodingLength = 2
 
 var fullPrefixLength = MagicLength + VersionEncodingLength


### PR DESCRIPTION
Work towards #870 

## Description

Add a new encoder/decoder v5, with **no functionality change**.
- Backup the current encoder/decoder as v4
- Duplicate the same encoder/decoder as v5
- Update the lazy decoding functions to use the correct decoder based on the version.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
