### PR TITLE
Include and consider static types of arrays and dictionaries

### DIFF
--- a/runtime/interpreter/dynamictype.go
+++ b/runtime/interpreter/dynamictype.go
@@ -79,6 +79,7 @@ func (BoolDynamicType) IsImportable() bool {
 
 type ArrayDynamicType struct {
 	ElementTypes []DynamicType
+	StaticType   ArrayStaticType
 }
 
 func (ArrayDynamicType) IsDynamicType() {}
@@ -119,8 +120,14 @@ func (t CompositeDynamicType) IsImportable() bool {
 
 // DictionaryDynamicType
 
+type DictionaryStaticTypeEntry struct {
+	KeyType   DynamicType
+	ValueType DynamicType
+}
+
 type DictionaryDynamicType struct {
-	EntryTypes []struct{ KeyType, ValueType DynamicType }
+	EntryTypes []DictionaryStaticTypeEntry
+	StaticType DictionaryStaticType
 }
 
 func (DictionaryDynamicType) IsDynamicType() {}

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -636,7 +636,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 	case ast.OperationFailableCast, ast.OperationForceCast:
 		dynamicTypeResults := DynamicTypeResults{}
 		dynamicType := value.DynamicType(interpreter, dynamicTypeResults)
-		isSubType := IsSubType(dynamicType, expectedType)
+		isSubType := interpreter.IsSubType(dynamicType, expectedType)
 
 		switch expression.Operation {
 		case ast.OperationFailableCast:

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -720,6 +720,7 @@ func (v *ArrayValue) DynamicType(interpreter *Interpreter, results DynamicTypeRe
 
 	return ArrayDynamicType{
 		ElementTypes: elementTypes,
+		StaticType:   v.Type,
 	}
 }
 
@@ -7484,6 +7485,7 @@ func (v *DictionaryValue) DynamicType(interpreter *Interpreter, results DynamicT
 
 	return DictionaryDynamicType{
 		EntryTypes: entryTypes,
+		StaticType: v.Type,
 	}
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -7171,7 +7171,7 @@ func (v *CompositeValue) ConformsToDynamicType(
 		dynamicTypeResults := DynamicTypeResults{}
 		fieldDynamicType := field.DynamicType(interpreter, dynamicTypeResults)
 
-		if !IsSubType(fieldDynamicType, member.TypeAnnotation.Type) {
+		if !interpreter.IsSubType(fieldDynamicType, member.TypeAnnotation.Type) {
 			return false
 		}
 
@@ -8404,8 +8404,8 @@ func (v *StorageReferenceValue) ReferencedValue(interpreter *Interpreter) *Value
 		if v.BorrowedType != nil {
 			dynamicTypeResults := DynamicTypeResults{}
 			dynamicType := value.DynamicType(interpreter, dynamicTypeResults)
-			if !IsSubType(dynamicType, v.BorrowedType) {
-				IsSubType(dynamicType, v.BorrowedType)
+			if !interpreter.IsSubType(dynamicType, v.BorrowedType) {
+				interpreter.IsSubType(dynamicType, v.BorrowedType)
 				return nil
 			}
 		}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -1723,6 +1723,78 @@ func TestArrayValue_Equal(t *testing.T) {
 		)
 	})
 
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		uint16ArrayStaticType := VariableSizedStaticType{
+			Type: PrimitiveStaticTypeUInt16,
+		}
+
+		require.False(t,
+			NewArrayValueUnownedNonCopying(
+				uint8ArrayStaticType,
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					uint16ArrayStaticType,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("no type, type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewArrayValueUnownedNonCopying(
+				nil,
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					uint8ArrayStaticType,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("type, no type", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.False(t,
+			NewArrayValueUnownedNonCopying(
+				uint8ArrayStaticType,
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("no types", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			NewArrayValueUnownedNonCopying(
+				nil,
+			).Equal(
+				NewArrayValueUnownedNonCopying(
+					nil,
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
 	t.Run("different kind", func(t *testing.T) {
 
 		t.Parallel()
@@ -1864,6 +1936,28 @@ func TestDictionaryValue_Equal(t *testing.T) {
 					byteStringDictionaryType,
 					UInt8Value(1),
 					NewStringValue("1"),
+				),
+				nil,
+				true,
+			),
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+
+		t.Parallel()
+
+		stringByteDictionaryStaticType := DictionaryStaticType{
+			KeyType:   PrimitiveStaticTypeString,
+			ValueType: PrimitiveStaticTypeUInt8,
+		}
+
+		require.False(t,
+			NewDictionaryValueUnownedNonCopying(
+				byteStringDictionaryType,
+			).Equal(
+				NewDictionaryValueUnownedNonCopying(
+					stringByteDictionaryStaticType,
 				),
 				nil,
 				true,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -695,7 +695,7 @@ func validateArgumentParams(
 		}
 
 		// Check that decoded value is a subtype of static parameter type
-		if !interpreter.IsSubType(dynamicType, parameterType) {
+		if !inter.IsSubType(dynamicType, parameterType) {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: i,
 				Err: &InvalidValueTypeError{


### PR DESCRIPTION
⚠️ Depends on #1038

Work towards #870 

## Description

- Consider static types of arrays and dictionaries in equality tests
- Include static types in dynamic types for arrays and dictionaries
- Consider array / dictionary dynamic type's static type in dynamic type check
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
