### PR TITLE
Test and implement json.Unmarshal() support code

### DIFF
--- a/runtime/ast/access_test.go
+++ b/runtime/ast/access_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestAccess_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	for access := Access(0); access < Access(AccessCount()); access++ {
-		actual, err := json.Marshal(access)
+		actual, err := jsonMarshalAndVerify(access)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, fmt.Sprintf(`"%s"`, access), string(actual))

--- a/runtime/ast/argument_test.go
+++ b/runtime/ast/argument_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +44,7 @@ func TestArgument_MarshalJSON(t *testing.T) {
 			TrailingSeparatorPos: Position{Offset: 7, Line: 8, Column: 9},
 		}
 
-		actual, err := json.Marshal(argument)
+		actual, err := jsonMarshalAndVerify(argument)
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
@@ -84,7 +83,7 @@ func TestArgument_MarshalJSON(t *testing.T) {
 			TrailingSeparatorPos: Position{Offset: 13, Line: 14, Column: 15},
 		}
 
-		actual, err := json.Marshal(argument)
+		actual, err := jsonMarshalAndVerify(argument)
 		require.NoError(t, err)
 
 		assert.JSONEq(t,

--- a/runtime/ast/block_test.go
+++ b/runtime/ast/block_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +47,7 @@ func TestBlock_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(block)
+	actual, err := jsonMarshalAndVerify(block)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -104,7 +103,7 @@ func TestFunctionBlock_MarshalJSON(t *testing.T) {
 			},
 		}
 
-		actual, err := json.Marshal(block)
+		actual, err := jsonMarshalAndVerify(block)
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
@@ -189,7 +188,7 @@ func TestFunctionBlock_MarshalJSON(t *testing.T) {
 			},
 		}
 
-		actual, err := json.Marshal(block)
+		actual, err := jsonMarshalAndVerify(block)
 		require.NoError(t, err)
 
 		assert.JSONEq(t,

--- a/runtime/ast/composite_test.go
+++ b/runtime/ast/composite_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,7 +55,7 @@ func TestFieldDeclaration_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -121,7 +120,7 @@ func TestCompositeDeclaration_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/conditionkind_test.go
+++ b/runtime/ast/conditionkind_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestConditionKind_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	for conditionKind := ConditionKind(0); conditionKind < ConditionKind(ConditionKindCount()); conditionKind++ {
-		actual, err := json.Marshal(conditionKind)
+		actual, err := jsonMarshalAndVerify(conditionKind)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, fmt.Sprintf(`"%s"`, conditionKind), string(actual))

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -39,7 +38,7 @@ func TestBoolExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -63,7 +62,7 @@ func TestNilExpression_MarshalJSON(t *testing.T) {
 		Pos: Position{Offset: 1, Line: 2, Column: 3},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -90,7 +89,7 @@ func TestStringExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -119,7 +118,7 @@ func TestIntegerExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -151,7 +150,7 @@ func TestFixedPointExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -193,7 +192,7 @@ func TestArrayExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -246,7 +245,7 @@ func TestDictionaryExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -288,7 +287,7 @@ func TestIdentifierExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -324,7 +323,7 @@ func TestPathExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -369,7 +368,7 @@ func TestMemberExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -418,7 +417,7 @@ func TestIndexExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -461,7 +460,7 @@ func TestUnaryExpression_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 7, Line: 8, Column: 9},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -508,7 +507,7 @@ func TestBinaryExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -552,7 +551,7 @@ func TestDestroyExpression_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 4, Line: 5, Column: 6},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -591,7 +590,7 @@ func TestForceExpression_MarshalJSON(t *testing.T) {
 		EndPos: Position{Offset: 4, Line: 5, Column: 6},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -646,7 +645,7 @@ func TestConditionalExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -723,7 +722,7 @@ func TestInvocationExpression_MarshalJSON(t *testing.T) {
 		EndPos:            Position{Offset: 22, Line: 23, Column: 24},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -806,7 +805,7 @@ func TestCastingExpression_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -892,7 +891,7 @@ func TestCreateExpression_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 25, Line: 26, Column: 27},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -974,7 +973,7 @@ func TestReferenceExpression_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 7, Line: 8, Column: 9},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -1064,7 +1063,7 @@ func TestFunctionExpression_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 34, Line: 35, Column: 36},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/function_declaration_test.go
+++ b/runtime/ast/function_declaration_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,7 +88,7 @@ func TestFunctionDeclaration_MarshalJSON(t *testing.T) {
 		StartPos:  Position{Offset: 34, Line: 35, Column: 36},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -232,7 +231,7 @@ func TestSpecialFunctionDeclaration_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +46,7 @@ func TestImportDeclaration_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/interface_test.go
+++ b/runtime/ast/interface_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +46,7 @@ func TestInterfaceDeclaration_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/members_test.go
+++ b/runtime/ast/members_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +31,7 @@ func TestMembers_MarshalJSON(t *testing.T) {
 
 	members := NewMembers([]Declaration{})
 
-	actual, err := json.Marshal(members)
+	actual, err := jsonMarshalAndVerify(members)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/operation_test.go
+++ b/runtime/ast/operation_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestOperation_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	for operation := Operation(0); operation < Operation(OperationCount()); operation++ {
-		actual, err := json.Marshal(operation)
+		actual, err := jsonMarshalAndVerify(operation)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, fmt.Sprintf(`"%s"`, operation), string(actual))

--- a/runtime/ast/pragma_test.go
+++ b/runtime/ast/pragma_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,7 @@ func TestPragmaDeclaration_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(members)
+	actual, err := jsonMarshalAndVerify(members)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/program_test.go
+++ b/runtime/ast/program_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +31,7 @@ func TestProgram_MarshalJSON(t *testing.T) {
 
 	program := NewProgram([]Declaration{})
 
-	actual, err := json.Marshal(program)
+	actual, err := jsonMarshalAndVerify(program)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +39,7 @@ func TestExpressionStatement_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -79,7 +78,7 @@ func TestReturnStatement_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -111,7 +110,7 @@ func TestBreakStatement_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -137,7 +136,7 @@ func TestContinueStatement_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -181,7 +180,7 @@ func TestIfStatement_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 19, Line: 20, Column: 21},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -236,7 +235,7 @@ func TestWhileStatement_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 13, Line: 14, Column: 15},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -289,7 +288,7 @@ func TestForStatement_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 16, Line: 17, Column: 18},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -345,7 +344,7 @@ func TestAssignmentStatement_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -402,7 +401,7 @@ func TestSwapStatement_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -478,7 +477,7 @@ func TestEmitStatement_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 25, Line: 26, Column: 27},
 	}
 
-	actual, err := json.Marshal(stmt)
+	actual, err := jsonMarshalAndVerify(stmt)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/transaction_declaration_test.go
+++ b/runtime/ast/transaction_declaration_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,7 +49,7 @@ func TestTransactionDeclaration_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/transfer_test.go
+++ b/runtime/ast/transfer_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,7 +34,7 @@ func TestTransfer_MarshalJSON(t *testing.T) {
 		Pos:       Position{Offset: 1, Line: 2, Column: 3},
 	}
 
-	actual, err := json.Marshal(expr)
+	actual, err := jsonMarshalAndVerify(expr)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/transferoperation_test.go
+++ b/runtime/ast/transferoperation_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestTransferOperation_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	for transferOperation := TransferOperation(0); transferOperation < TransferOperation(TransferOperationCount()); transferOperation++ {
-		actual, err := json.Marshal(transferOperation)
+		actual, err := jsonMarshalAndVerify(transferOperation)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, fmt.Sprintf(`"%s"`, transferOperation), string(actual))

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestTypeAnnotation_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 4, Line: 5, Column: 6},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -84,7 +83,7 @@ func TestNominalType_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -125,7 +124,7 @@ func TestOptionalType_MarshalJSON(t *testing.T) {
 		EndPos: Position{Offset: 4, Line: 5, Column: 6},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -167,7 +166,7 @@ func TestVariableSizedType_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -217,7 +216,7 @@ func TestConstantSizedType_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -272,7 +271,7 @@ func TestDictionaryType_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -340,7 +339,7 @@ func TestFunctionType_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -402,7 +401,7 @@ func TestReferenceType_MarshalJSON(t *testing.T) {
 		StartPos: Position{Offset: 4, Line: 5, Column: 6},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -459,7 +458,7 @@ func TestRestrictedType_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -543,7 +542,7 @@ func TestInstantiationType_MarshalJSON(t *testing.T) {
 		EndPos:                Position{Offset: 19, Line: 20, Column: 21},
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/unmarshal.go
+++ b/runtime/ast/unmarshal.go
@@ -1,0 +1,9 @@
+package ast
+
+import (
+	"encoding/json"
+)
+
+func jsonMarshalAndVerify(i interface{}) ([]byte, error) {
+	return json.Marshal(i)
+}

--- a/runtime/ast/unmarshal.go
+++ b/runtime/ast/unmarshal.go
@@ -2,8 +2,28 @@ package ast
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 )
 
 func jsonMarshalAndVerify(i interface{}) ([]byte, error) {
-	return json.Marshal(i)
+	b, err := json.Marshal(i)
+	if err != nil { return b, err }
+
+	expected := string(b)
+
+	unmarshalled := reflect.New(reflect.TypeOf(i)).Interface()
+	err = json.Unmarshal(b, &unmarshalled)
+	if err != nil { return b, err }
+
+	b2, err2 := json.Marshal(unmarshalled)
+	if err2 != nil { return b2, err2 }
+
+	actual := string(b2)
+
+	if expected != actual {
+		return nil, fmt.Errorf("un/marshal failed:\n%s\n%s\n", expected, actual)
+	}
+
+	return b, err
 }

--- a/runtime/ast/unmarshal.go
+++ b/runtime/ast/unmarshal.go
@@ -3,27 +3,899 @@ package ast
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/onflow/cadence/runtime/common"
 )
 
-func jsonMarshalAndVerify(i interface{}) ([]byte, error) {
-	b, err := json.Marshal(i)
-	if err != nil { return b, err }
-
-	expected := string(b)
-
-	unmarshalled := reflect.New(reflect.TypeOf(i)).Interface()
-	err = json.Unmarshal(b, &unmarshalled)
-	if err != nil { return b, err }
-
-	b2, err2 := json.Marshal(unmarshalled)
-	if err2 != nil { return b2, err2 }
-
-	actual := string(b2)
-
-	if expected != actual {
-		return nil, fmt.Errorf("un/marshal failed:\n%s\n%s\n", expected, actual)
+func jsonMarshalAndVerify(i interface{}) (b []byte, err error) {
+	if b, err = json.Marshal(i); err == nil {
+		expected := string(b)
+		roundtripped := reflect.New(reflect.TypeOf(i)).Interface()
+		if err = json.Unmarshal(b, &roundtripped); err == nil {
+			if b, err = json.Marshal(roundtripped); err == nil {
+				actual := string(b)
+				if expected != actual {
+					return nil, fmt.Errorf("un/marshal failed:\n%s\n%s\n", expected, actual)
+				}
+			}
+		}
 	}
+	return
+}
 
-	return b, err
+//////////////////////////////////////////////////////////////////////////////
+
+var accessKindMap = map[string]Access{
+	"AccessNotSpecified":   AccessNotSpecified,
+	"AccessPrivate":        AccessPrivate,
+	"AccessContract":       AccessContract,
+	"AccessAccount":        AccessAccount,
+	"AccessPublic":         AccessPublic,
+	"AccessPublicSettable": AccessPublicSettable,
+}
+
+var conditionKindMap = map[string]ConditionKind{
+	"ConditionKindUnknown": ConditionKindUnknown,
+	"ConditionKindPre":     ConditionKindPre,
+	"ConditionKindPost":    ConditionKindPost,
+}
+
+var expressionTypeMap = map[string]func() Expression{
+	"ArrayExpression":       func() Expression { return &ArrayExpression{} },
+	"BinaryExpression":      func() Expression { return &BinaryExpression{} },
+	"BoolExpression":        func() Expression { return &BoolExpression{} },
+	"CastingExpression":     func() Expression { return &CastingExpression{} },
+	"ConditionalExpression": func() Expression { return &ConditionalExpression{} },
+	"CreateExpression":      func() Expression { return &CreateExpression{} },
+	"DestroyExpression":     func() Expression { return &DestroyExpression{} },
+	"DictionaryExpression":  func() Expression { return &DictionaryExpression{} },
+	"FixedPointExpression":  func() Expression { return &FixedPointExpression{} },
+	"ForceExpression":       func() Expression { return &ForceExpression{} },
+	"FunctionExpression":    func() Expression { return &FunctionExpression{} },
+	"IdentifierExpression":  func() Expression { return &IdentifierExpression{} },
+	"IndexExpression":       func() Expression { return &IndexExpression{} },
+	"IntegerExpression":     func() Expression { return &IntegerExpression{} },
+	"InvocationExpression":  func() Expression { return &InvocationExpression{} },
+	"MemberExpression":      func() Expression { return &MemberExpression{} },
+	"NilExpression":         func() Expression { return &NilExpression{} },
+	"PathExpression":        func() Expression { return &PathExpression{} },
+	"ReferenceExpression":   func() Expression { return &ReferenceExpression{} },
+	"StringExpression":      func() Expression { return &StringExpression{} },
+	"UnaryExpression":       func() Expression { return &UnaryExpression{} },
+}
+
+var locationKindMap = map[string]func() common.Location{
+	"AddressLocation":     func() common.Location { return &common.AddressLocation{} },
+	"REPLLocation":        func() common.Location { return &common.REPLLocation{} },
+	"ScriptLocation":      func() common.Location { return &common.ScriptLocation{} },
+	"TransactionLocation": func() common.Location { return &common.TransactionLocation{} },
+	"StringLocation":      func() common.Location { return nil },
+	"FlowLocation":        func() common.Location { return nil },
+	"IdentifierLocation":  func() common.Location { return nil },
+}
+
+var operationMap = map[string]Operation{
+	"OperationUnknown":           OperationUnknown,
+	"OperationOr":                OperationOr,
+	"OperationAnd":               OperationAnd,
+	"OperationEqual":             OperationEqual,
+	"OperationNotEqual":          OperationNotEqual,
+	"OperationLess":              OperationLess,
+	"OperationGreater":           OperationGreater,
+	"OperationLessEqual":         OperationLessEqual,
+	"OperationGreaterEqual":      OperationGreaterEqual,
+	"OperationPlus":              OperationPlus,
+	"OperationMinus":             OperationMinus,
+	"OperationMul":               OperationMul,
+	"OperationDiv":               OperationDiv,
+	"OperationMod":               OperationMod,
+	"OperationNegate":            OperationNegate,
+	"OperationNilCoalesce":       OperationNilCoalesce,
+	"OperationMove":              OperationMove,
+	"OperationCast":              OperationCast,
+	"OperationFailableCast":      OperationFailableCast,
+	"OperationForceCast":         OperationForceCast,
+	"OperationBitwiseOr":         OperationBitwiseOr,
+	"OperationBitwiseXor":        OperationBitwiseXor,
+	"OperationBitwiseAnd":        OperationBitwiseAnd,
+	"OperationBitwiseLeftShift":  OperationBitwiseLeftShift,
+	"OperationBitwiseRightShift": OperationBitwiseRightShift,
+}
+
+var statementKindMap = map[string]func() Statement{
+	"AssignmentStatement":        func() Statement { return &AssignmentStatement{} },
+	"BreakStatement":             func() Statement { return &BreakStatement{} },
+	"CompositeDeclaration":       func() Statement { return &CompositeDeclaration{} },
+	"ContinueStatement":          func() Statement { return &ContinueStatement{} },
+	"EmitStatement":              func() Statement { return &EmitStatement{} },
+	"ExpressionStatement":        func() Statement { return &ExpressionStatement{} },
+	"ForStatement":               func() Statement { return &ForStatement{} },
+	"FunctionDeclaration":        func() Statement { return &FunctionDeclaration{} },
+	"IfStatement":                func() Statement { return &IfStatement{} },
+	"ImportDeclaration":          func() Statement { return &ImportDeclaration{} },
+	"InterfaceDeclaration":       func() Statement { return &InterfaceDeclaration{} },
+	"PragmaDeclaration":          func() Statement { return &PragmaDeclaration{} },
+	"ReturnStatement":            func() Statement { return &ReturnStatement{} },
+	"SpecialFunctionDeclaration": func() Statement { return &SpecialFunctionDeclaration{} },
+	"SwapStatement":              func() Statement { return &SwapStatement{} },
+	"SwitchStatement":            func() Statement { return &SwitchStatement{} },
+	"TransactionDeclaration":     func() Statement { return &TransactionDeclaration{} },
+	"VariableDeclaration":        func() Statement { return &VariableDeclaration{} },
+	"WhileStatement":             func() Statement { return &WhileStatement{} },
+}
+
+var transferOperationMap = map[string]TransferOperation{
+	"TransferOperationUnknown":    TransferOperationUnknown,
+	"TransferOperationCopy":       TransferOperationCopy,
+	"TransferOperationMove":       TransferOperationMove,
+	"TransferOperationMoveForced": TransferOperationMoveForced,
+}
+
+var typeNameMap = map[string]func() Type{
+	"ConstantSizedType": func() Type { return &ConstantSizedType{} },
+	"DictionaryType":    func() Type { return &DictionaryType{} },
+	"FunctionType":      func() Type { return &FunctionType{} },
+	"InstantiationType": func() Type { return &InstantiationType{} },
+	"NominalType":       func() Type { return &NominalType{} },
+	"OptionalType":      func() Type { return &OptionalType{} },
+	"ReferenceType":     func() Type { return &ReferenceType{} },
+	"RestrictedType":    func() Type { return &RestrictedType{} },
+	"VariableSizedType": func() Type { return &VariableSizedType{} },
+}
+
+var variableKindMap = map[string]VariableKind{
+	"VariableKindNotSpecified": VariableKindNotSpecified,
+	"VariableKindVariable":     VariableKindVariable,
+	"VariableKindConstant":     VariableKindConstant,
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+type BigIntUnmarshaler struct{ Int **big.Int }
+type ExpressionUnmarshaler struct{ Expression *Expression }
+type ExpressionsUnmarshaler struct{ Expressions *[]Expression }
+type LocationUnmarshaler struct{ Location *common.Location }
+type StatementUnmarshaler struct{ Statement *Statement }
+type StatementsUnmarshaler struct{ Statements *[]Statement }
+type TypeUnmarshaler struct{ Type *Type }
+
+func (a *BigIntUnmarshaler) UnmarshalJSON(b []byte) (err error) {
+	s := string(b)
+	if s, err = strconv.Unquote(s); err != nil {
+		return err
+	} else if s == "null" {
+		*a.Int = nil
+		return nil
+	}
+	if z, ok := (&big.Int{}).SetString(s, 10); !ok {
+		return fmt.Errorf("invalid BigInt %s", s)
+	} else {
+		*a.Int = z
+		return nil
+	}
+}
+
+func (a *ExpressionUnmarshaler) UnmarshalJSON(b []byte) error {
+	var expressionTypeName string
+	err := json.Unmarshal(b, &struct{ Type *string }{&expressionTypeName})
+	if err != nil {
+		return err
+	}
+	if et, ok := expressionTypeMap[expressionTypeName]; ok {
+		*a.Expression = et()
+		return json.Unmarshal(b, &a.Expression)
+	}
+	return fmt.Errorf("unknown Expression type")
+}
+
+func (a *ExpressionsUnmarshaler) UnmarshalJSON(b []byte) error {
+	var rms []json.RawMessage
+	err := json.Unmarshal(b, &rms)
+	if err != nil {
+		return err
+	}
+	*a.Expressions = make([]Expression, len(rms))
+	for i, v := range rms {
+		err := json.Unmarshal(v, &ExpressionUnmarshaler{&(*a.Expressions)[i]})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *LocationUnmarshaler) UnmarshalJSON(b []byte) error {
+	var locationKind string
+	var stringLocation common.StringLocation = ""
+	err := json.Unmarshal(b, &struct {
+		Type   *string
+		String *common.StringLocation
+	}{Type: &locationKind, String: &stringLocation})
+	if err != nil {
+		return err
+	}
+	if stringLocation != "" {
+		*a.Location = stringLocation
+		return nil
+	}
+	if f, ok := locationKindMap[locationKind]; ok {
+		*a.Location = f()
+		return nil
+	}
+	return fmt.Errorf("unknown Location")
+}
+
+func (a *StatementUnmarshaler) UnmarshalJSON(b []byte) error {
+	var statementKindName string
+	if err := json.Unmarshal(b, &struct{ Type *string }{&statementKindName}); err != nil {
+		return err
+	}
+	if sk, ok := statementKindMap[statementKindName]; ok {
+		*a.Statement = sk()
+		return json.Unmarshal(b, &a.Statement)
+	}
+	return fmt.Errorf("unknown Statement Kind")
+}
+
+func (a *StatementsUnmarshaler) UnmarshalJSON(b []byte) error {
+	var rms []json.RawMessage
+	err := json.Unmarshal(b, &rms)
+	if err != nil {
+		return err
+	}
+	*a.Statements = make([]Statement, len(rms))
+	for i, v := range rms {
+		err := json.Unmarshal(v, &StatementUnmarshaler{&(*a.Statements)[i]})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *TypeUnmarshaler) UnmarshalJSON(b []byte) error {
+	var typeName string
+	err := json.Unmarshal(b, &struct{ Type *string }{&typeName})
+	if err != nil {
+		return err
+	}
+	if f, ok := typeNameMap[typeName]; ok {
+		*a.Type = f()
+		return json.Unmarshal(b, &a.Type)
+	}
+	return fmt.Errorf("unknown Type")
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+func (a *Access) UnmarshalJSON(b []byte) error {
+	if c, ok := accessKindMap[strings.Trim(string(b), `"`)]; ok {
+		*a = c
+		return nil
+	}
+	return fmt.Errorf("unknown Access kind")
+}
+
+func (a *Argument) UnmarshalJSON(b []byte) error {
+	type Alias Argument
+	err := json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+	})
+	return err
+}
+
+func (a *AssignmentStatement) UnmarshalJSON(b []byte) error {
+	type Alias AssignmentStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Target   ExpressionUnmarshaler
+		Value    ExpressionUnmarshaler
+		StartPos *Position
+		EndPos   *Position
+	}{
+		Alias:  (*Alias)(a),
+		Target: ExpressionUnmarshaler{&a.Target},
+		Value:  ExpressionUnmarshaler{&a.Value},
+	})
+}
+
+func (a *Block) UnmarshalJSON(bs []byte) error {
+	type Alias Block
+	err := json.Unmarshal(bs, &struct {
+		*Alias
+		Statements StatementsUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Statements: StatementsUnmarshaler{&a.Statements},
+	})
+	return err
+}
+
+func (a *BreakStatement) UnmarshalJSON(b []byte) error {
+	type Alias BreakStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(a)})
+}
+
+func (a *CompositeDeclaration) UnmarshalJSON(b []byte) error {
+	type Alias CompositeDeclaration
+	return json.Unmarshal(b, &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(a)})
+}
+
+func (a *Condition) UnmarshalJSON(b []byte) error {
+	type Alias Condition
+	err := json.Unmarshal(b, &struct {
+		*Alias
+		Test    ExpressionUnmarshaler
+		Message ExpressionUnmarshaler
+	}{
+		Alias:   (*Alias)(a),
+		Test:    ExpressionUnmarshaler{&a.Test},
+		Message: ExpressionUnmarshaler{&a.Message},
+	})
+	return err
+}
+
+func (a *ConditionKind) UnmarshalJSON(b []byte) error {
+	if c, ok := conditionKindMap[strings.Trim(string(b), `"`)]; ok {
+		*a = c
+		return nil
+	}
+	return fmt.Errorf("unknown ConditionKind")
+}
+
+func (a *ConstantSizedType) UnmarshalJSON(b []byte) error {
+	type Alias ConstantSizedType
+	return json.Unmarshal(b, &struct {
+		*Alias
+		ElementType TypeUnmarshaler
+	}{
+		Alias:       (*Alias)(a),
+		ElementType: TypeUnmarshaler{Type: &a.Type},
+	})
+}
+
+func (a *DictionaryType) UnmarshalJSON(b []byte) error {
+	type Alias DictionaryType
+	return json.Unmarshal(b, &struct {
+		*Alias
+		KeyType   TypeUnmarshaler
+		ValueType TypeUnmarshaler
+	}{
+		Alias:     (*Alias)(a),
+		KeyType:   TypeUnmarshaler{&a.KeyType},
+		ValueType: TypeUnmarshaler{&a.ValueType},
+	})
+}
+
+func (a *DictionaryEntry) UnmarshalJSON(b []byte) error {
+	type Alias DictionaryEntry
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Key   ExpressionUnmarshaler
+		Value ExpressionUnmarshaler
+	}{
+		Alias: (*Alias)(a),
+		Key:   ExpressionUnmarshaler{&a.Key},
+		Value: ExpressionUnmarshaler{&a.Value},
+	})
+}
+
+func (a *EmitStatement) UnmarshalJSON(b []byte) error {
+	type Alias EmitStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.StartPos,
+	})
+}
+
+func (a *ExpressionStatement) UnmarshalJSON(b []byte) error {
+	type Alias ExpressionStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+	})
+}
+
+func (a *ForStatement) UnmarshalJSON(b []byte) error {
+	type Alias ForStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Value    ExpressionUnmarshaler
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		Value:    ExpressionUnmarshaler{&a.Value},
+		StartPos: &a.StartPos,
+	})
+}
+
+func (a *FunctionDeclaration) UnmarshalJSON(b []byte) error {
+	type Alias FunctionDeclaration
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.StartPos,
+	})
+}
+
+func (a *IfStatement) UnmarshalJSON(b []byte) error {
+	type Alias IfStatement
+	a.Test = &BoolExpression{}
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.StartPos,
+	})
+}
+
+func (a *ImportDeclaration) UnmarshalJSON(b []byte) error {
+	type Alias ImportDeclaration
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Location LocationUnmarshaler
+	}{
+		Alias:    (*Alias)(a),
+		Location: LocationUnmarshaler{&a.Location},
+	})
+}
+
+func (a *InstantiationType) UnmarshalJSON(b []byte) error {
+	type Alias InstantiationType
+	return json.Unmarshal(b, &struct {
+		*Alias
+		InstantiatedType TypeUnmarshaler
+		EndPos           *Position
+	}{
+		Alias:            (*Alias)(a),
+		InstantiatedType: TypeUnmarshaler{&a.Type},
+		EndPos:           &a.EndPos,
+	})
+}
+
+func (a *Members) UnmarshalJSON(b []byte) error {
+	type Alias Members
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Declarations *[]Declaration
+	}{
+		Alias:        (*Alias)(a),
+		Declarations: &a.declarations,
+	})
+}
+
+func (a *NominalType) UnmarshalJSON(b []byte) error {
+	type Alias NominalType
+	return json.Unmarshal(b, &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(a)})
+}
+
+func (a *Operation) UnmarshalJSON(b []byte) error {
+	if op, ok := operationMap[strings.Trim(string(b), `"`)]; ok {
+		*a = op
+		return nil
+	}
+	return fmt.Errorf("unknown Operation %s", string(b))
+}
+
+func (a *OptionalType) UnmarshalJSON(b []byte) error {
+	type Alias OptionalType
+	return json.Unmarshal(b, &struct {
+		*Alias
+		ElementType TypeUnmarshaler
+		EndPos      *Position
+	}{
+		Alias:       (*Alias)(a),
+		ElementType: TypeUnmarshaler{&a.Type},
+		EndPos:      &a.EndPos,
+	})
+}
+
+func (a *PragmaDeclaration) UnmarshalJSON(b []byte) error {
+	type Alias PragmaDeclaration
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+	})
+}
+
+func (a *Program) UnmarshalJSON(b []byte) error {
+	type Alias Program
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Declarations *[]Declaration
+	}{
+		Alias:        (*Alias)(a),
+		Declarations: &a.declarations,
+	})
+}
+
+func (a *ReferenceType) UnmarshalJSON(b []byte) error {
+	type Alias ReferenceType
+	return json.Unmarshal(b, &struct {
+		*Alias
+		ReferencedType TypeUnmarshaler
+		StartPos       *Position
+	}{
+		Alias:          (*Alias)(a),
+		ReferencedType: TypeUnmarshaler{&a.Type},
+		StartPos:       &a.StartPos,
+	})
+}
+
+func (a *RestrictedType) UnmarshalJSON(b []byte) error {
+	type Alias RestrictedType
+	return json.Unmarshal(b, &struct {
+		*Alias
+		RestrictedType TypeUnmarshaler
+	}{
+		Alias:          (*Alias)(a),
+		RestrictedType: TypeUnmarshaler{&a.Type},
+	})
+}
+
+func (a *ReturnStatement) UnmarshalJSON(b []byte) error {
+	type Alias ReturnStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+	})
+}
+
+func (a *SwapStatement) UnmarshalJSON(b []byte) error {
+	type Alias SwapStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Left  ExpressionUnmarshaler
+		Right ExpressionUnmarshaler
+	}{
+		Alias: (*Alias)(a),
+		Left:  ExpressionUnmarshaler{&a.Left},
+		Right: ExpressionUnmarshaler{&a.Right},
+	})
+}
+
+func (a *SwitchStatement) UnmarshalJSON(b []byte) error {
+	type Alias SwitchStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+	})
+}
+
+func (a *Transfer) UnmarshalJSON(b []byte) error {
+	type Alias Transfer
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.Pos,
+	})
+}
+
+func (a *TransferOperation) UnmarshalJSON(b []byte) error {
+	if op, ok := transferOperationMap[strings.Trim(string(b), `"`)]; ok {
+		*a = op
+		return nil
+	}
+	return fmt.Errorf("unknown TransferOperation")
+}
+
+func (a *TypeAnnotation) UnmarshalJSON(b []byte) error {
+	type Alias TypeAnnotation
+	return json.Unmarshal(b, &struct {
+		*Alias
+		AnnotatedType TypeUnmarshaler
+		StartPos      *Position
+	}{
+		Alias:         (*Alias)(a),
+		AnnotatedType: TypeUnmarshaler{&a.Type},
+		StartPos:      &a.StartPos,
+	})
+}
+
+func (a *VariableDeclaration) UnmarshalJSON(b []byte) error {
+	type Alias VariableDeclaration
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Value       ExpressionUnmarshaler
+		SecondValue ExpressionUnmarshaler
+		StartPos    *Position
+	}{
+		Alias:       (*Alias)(a),
+		Value:       ExpressionUnmarshaler{&a.Value},
+		SecondValue: ExpressionUnmarshaler{&a.SecondValue},
+		StartPos:    &a.StartPos,
+	})
+}
+
+func (a *VariableKind) UnmarshalJSON(b []byte) error {
+	if vk, ok := variableKindMap[strings.Trim(string(b), `"`)]; ok {
+		*a = vk
+		return nil
+	}
+	return fmt.Errorf("unknown VariableKind")
+}
+
+func (a *VariableSizedType) UnmarshalJSON(b []byte) error {
+	type Alias VariableSizedType
+	return json.Unmarshal(b, &struct {
+		*Alias
+		ElementType TypeUnmarshaler
+	}{
+		Alias:       (*Alias)(a),
+		ElementType: TypeUnmarshaler{&a.Type},
+	})
+}
+
+func (a *WhileStatement) UnmarshalJSON(b []byte) error {
+	type Alias WhileStatement
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Test     ExpressionUnmarshaler
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		Test:     ExpressionUnmarshaler{&a.Test},
+		StartPos: &a.StartPos,
+	})
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+func (a *ArrayExpression) UnmarshalJSON(b []byte) error {
+	type Alias ArrayExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Values ExpressionsUnmarshaler
+	}{
+		Alias:  (*Alias)(a),
+		Values: ExpressionsUnmarshaler{&a.Values},
+	})
+}
+
+func (a *BinaryExpression) UnmarshalJSON(b []byte) error {
+	type Alias BinaryExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Left  ExpressionUnmarshaler
+		Right ExpressionUnmarshaler
+	}{
+		Alias: (*Alias)(a),
+		Left:  ExpressionUnmarshaler{&a.Left},
+		Right: ExpressionUnmarshaler{&a.Right},
+	})
+}
+
+func (a *CastingExpression) UnmarshalJSON(b []byte) error {
+	type Alias CastingExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+	})
+}
+
+func (a *ConditionalExpression) UnmarshalJSON(b []byte) error {
+	type Alias ConditionalExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Test ExpressionUnmarshaler
+		Then ExpressionUnmarshaler
+		Else ExpressionUnmarshaler
+	}{
+		Alias: (*Alias)(a),
+		Test:  ExpressionUnmarshaler{&a.Test},
+		Then:  ExpressionUnmarshaler{&a.Then},
+		Else:  ExpressionUnmarshaler{&a.Else},
+	})
+}
+
+func (a *CreateExpression) UnmarshalJSON(b []byte) error {
+	type Alias CreateExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		InvocationExpression **InvocationExpression
+		StartPos             *Position
+	}{
+		Alias:                (*Alias)(a),
+		InvocationExpression: &a.InvocationExpression,
+		StartPos:             &a.StartPos,
+	})
+}
+
+func (a *DestroyExpression) UnmarshalJSON(b []byte) error {
+	type Alias DestroyExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+		StartPos   *Position
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+		StartPos:   &a.StartPos,
+	})
+}
+
+func (a *FixedPointExpression) UnmarshalJSON(b []byte) error {
+	type Alias FixedPointExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		UnsignedInteger BigIntUnmarshaler
+		Fractional      BigIntUnmarshaler
+	}{
+		Alias:           (*Alias)(a),
+		UnsignedInteger: BigIntUnmarshaler{&a.UnsignedInteger},
+		Fractional:      BigIntUnmarshaler{&a.Fractional},
+	})
+}
+
+func (a *ForceExpression) UnmarshalJSON(b []byte) error {
+	type Alias ForceExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+		EndPos     *Position
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+		EndPos:     &a.EndPos,
+	})
+}
+
+func (a *FunctionExpression) UnmarshalJSON(b []byte) error {
+	type Alias FunctionExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.StartPos,
+	})
+}
+
+func (a *Identifier) UnmarshalJSON(b []byte) error {
+	type Alias Identifier
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.Pos,
+	})
+}
+
+func (a *IndexExpression) UnmarshalJSON(b []byte) error {
+	type Alias IndexExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		TargetExpression   ExpressionUnmarshaler
+		IndexingExpression ExpressionUnmarshaler
+	}{
+		Alias:              (*Alias)(a),
+		TargetExpression:   ExpressionUnmarshaler{&a.TargetExpression},
+		IndexingExpression: ExpressionUnmarshaler{&a.IndexingExpression},
+	})
+}
+
+func (a *IntegerExpression) UnmarshalJSON(b []byte) error {
+	type Alias IntegerExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Value BigIntUnmarshaler
+	}{
+		Alias: (*Alias)(a),
+		Value: BigIntUnmarshaler{Int: &a.Value},
+	})
+}
+
+func (a *InvocationExpression) UnmarshalJSON(b []byte) error {
+	type Alias InvocationExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		InvokedExpression ExpressionUnmarshaler
+		EndPos            *Position
+	}{
+		Alias:             (*Alias)(a),
+		InvokedExpression: ExpressionUnmarshaler{&a.InvokedExpression},
+		EndPos:            &a.EndPos,
+	})
+}
+
+func (a *MemberExpression) UnmarshalJSON(b []byte) error {
+	type Alias MemberExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+	})
+}
+
+func (a *NilExpression) UnmarshalJSON(b []byte) error {
+	type Alias NilExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.Pos,
+	})
+}
+
+func (a *PathExpression) UnmarshalJSON(b []byte) error {
+	type Alias PathExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		StartPos *Position
+	}{
+		Alias:    (*Alias)(a),
+		StartPos: &a.StartPos,
+	})
+}
+
+func (a *ReferenceExpression) UnmarshalJSON(b []byte) error {
+	type Alias ReferenceExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+		TargetType TypeUnmarshaler
+		StartPos   *Position
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+		TargetType: TypeUnmarshaler{&a.Type},
+		StartPos:   &a.StartPos,
+	})
+}
+
+func (a *UnaryExpression) UnmarshalJSON(b []byte) error {
+	type Alias UnaryExpression
+	return json.Unmarshal(b, &struct {
+		*Alias
+		Expression ExpressionUnmarshaler
+		StartPos   *Position
+	}{
+		Alias:      (*Alias)(a),
+		Expression: ExpressionUnmarshaler{&a.Expression},
+		StartPos:   &a.StartPos,
+	})
 }

--- a/runtime/ast/variable_declaration_test.go
+++ b/runtime/ast/variable_declaration_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,7 +72,7 @@ func TestVariableDeclaration_MarshalJSON(t *testing.T) {
 		DocString: "test",
 	}
 
-	actual, err := json.Marshal(ty)
+	actual, err := jsonMarshalAndVerify(ty)
 	require.NoError(t, err)
 
 	assert.JSONEq(t,

--- a/runtime/ast/variablekind_test.go
+++ b/runtime/ast/variablekind_test.go
@@ -19,7 +19,6 @@
 package ast
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestVariableKind_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	for variableKind := VariableKind(0); variableKind < VariableKind(VariableKindCount()); variableKind++ {
-		actual, err := json.Marshal(variableKind)
+		actual, err := jsonMarshalAndVerify(variableKind)
 		require.NoError(t, err)
 
 		assert.JSONEq(t, fmt.Sprintf(`"%s"`, variableKind), string(actual))

--- a/runtime/common/compositekind.go
+++ b/runtime/common/compositekind.go
@@ -20,6 +20,8 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/errors"
 )
@@ -179,4 +181,21 @@ func (k CompositeKind) SupportsInterfaces() bool {
 
 func (k CompositeKind) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.String())
+}
+
+var compositeKindMap = map[string]CompositeKind{
+	"CompositeKindUnknown":   CompositeKindUnknown,
+	"CompositeKindStructure": CompositeKindStructure,
+	"CompositeKindResource":  CompositeKindResource,
+	"CompositeKindContract":  CompositeKindContract,
+	"CompositeKindEvent":     CompositeKindEvent,
+	"CompositeKindEnum":      CompositeKindEnum,
+}
+
+func (a *CompositeKind) UnmarshalJSON(b []byte) error {
+	if c, ok := compositeKindMap[strings.Trim(string(b), `"`)]; ok {
+		*a = c
+		return nil
+	}
+	return fmt.Errorf("unknown CompositeKind")
 }

--- a/runtime/common/declarationkind.go
+++ b/runtime/common/declarationkind.go
@@ -20,6 +20,8 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/onflow/cadence/runtime/errors"
 )
@@ -189,4 +191,42 @@ func (k DeclarationKind) Keywords() string {
 
 func (k DeclarationKind) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.String())
+}
+
+var declarationKindMap = map[string]DeclarationKind{
+	"DeclarationKindUnknown":            DeclarationKindUnknown,
+	"DeclarationKindValue":              DeclarationKindValue,
+	"DeclarationKindFunction":           DeclarationKindFunction,
+	"DeclarationKindVariable":           DeclarationKindVariable,
+	"DeclarationKindConstant":           DeclarationKindConstant,
+	"DeclarationKindType":               DeclarationKindType,
+	"DeclarationKindParameter":          DeclarationKindParameter,
+	"DeclarationKindArgumentLabel":      DeclarationKindArgumentLabel,
+	"DeclarationKindStructure":          DeclarationKindStructure,
+	"DeclarationKindResource":           DeclarationKindResource,
+	"DeclarationKindContract":           DeclarationKindContract,
+	"DeclarationKindEvent":              DeclarationKindEvent,
+	"DeclarationKindField":              DeclarationKindField,
+	"DeclarationKindInitializer":        DeclarationKindInitializer,
+	"DeclarationKindDestructor":         DeclarationKindDestructor,
+	"DeclarationKindStructureInterface": DeclarationKindStructureInterface,
+	"DeclarationKindResourceInterface":  DeclarationKindResourceInterface,
+	"DeclarationKindContractInterface":  DeclarationKindContractInterface,
+	"DeclarationKindImport":             DeclarationKindImport,
+	"DeclarationKindSelf":               DeclarationKindSelf,
+	"DeclarationKindTransaction":        DeclarationKindTransaction,
+	"DeclarationKindPrepare":            DeclarationKindPrepare,
+	"DeclarationKindExecute":            DeclarationKindExecute,
+	"DeclarationKindTypeParameter":      DeclarationKindTypeParameter,
+	"DeclarationKindPragma":             DeclarationKindPragma,
+	"DeclarationKindEnum":               DeclarationKindEnum,
+	"DeclarationKindEnumCase":           DeclarationKindEnumCase,
+}
+
+func (a *DeclarationKind) UnmarshalJSON(b []byte) error {
+	if c, ok := declarationKindMap[strings.Trim(string(b), `"`)]; ok {
+		*a = c
+		return nil
+	}
+	return fmt.Errorf("unknown DeclarationKind")
 }


### PR DESCRIPTION
## Description

In attempt to prove that the existing JSON marshaling is complete, we refactor AST tests to "roundtrip" the marshaling process. Where we normally call `json.Marshal(x)` in an AST test, we now call `json.Marshal(json.Unmarshal(json.Marshal(x))`

See `runtime/ast/unmarshal.go`
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- `n/a` Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- `n/a` Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [?] Added appropriate labels 
