### PR TITLE
Report a hint when casting to a same type as the expected type

### DIFF
--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -154,6 +154,14 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 		return rightHandType
 
 	case ast.OperationCast:
+		if checker.expectedType == rightHandType {
+			checker.hint(
+				&UnnecessaryCastHint{
+					TargetType: rightHandType,
+					Range:      ast.NewRangeFromPositioned(expression.TypeAnnotation),
+				},
+			)
+		}
 		return rightHandType
 
 	default:

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -154,7 +154,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 		return rightHandType
 
 	case ast.OperationCast:
-		if checker.expectedType == rightHandType {
+		if checker.expectedType != nil && checker.expectedType.Equal(rightHandType) {
 			checker.hint(
 				&UnnecessaryCastHint{
 					TargetType: rightHandType,
@@ -162,6 +162,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 				},
 			)
 		}
+
 		return rightHandType
 
 	default:

--- a/runtime/sema/hints.go
+++ b/runtime/sema/hints.go
@@ -100,3 +100,19 @@ func (h *AlwaysSucceedingForceCastHint) Hint() string {
 }
 
 func (*AlwaysSucceedingForceCastHint) isHint() {}
+
+// UnnecessaryCastHint
+
+type UnnecessaryCastHint struct {
+	TargetType Type
+	ast.Range
+}
+
+func (h *UnnecessaryCastHint) Hint() string {
+	return fmt.Sprintf(
+		"cast to `%s` is redundant",
+		h.TargetType,
+	)
+}
+
+func (*UnnecessaryCastHint) isHint() {}

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -5896,3 +5896,115 @@ func TestCheckCastAuthorizedNonCompositeReferenceType(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestCheckUnnecessaryCasts(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("var decl", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheckWithAny(t, `
+            let x: Int8 = 1 as Int8
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+
+		require.IsType(t, &sema.UnnecessaryCastHint{}, hints[0])
+		castHint := hints[0].(*sema.UnnecessaryCastHint)
+
+		assert.Equal(t, sema.Int8Type, castHint.TargetType)
+	})
+
+	t.Run("binary exp", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheckWithAny(t, `
+            let x: Int8 = (1 as Int8) + (1 as Int8)
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 2)
+
+		require.IsType(t, &sema.UnnecessaryCastHint{}, hints[0])
+		castHint := hints[0].(*sema.UnnecessaryCastHint)
+		assert.Equal(t, sema.Int8Type, castHint.TargetType)
+
+		require.IsType(t, &sema.UnnecessaryCastHint{}, hints[1])
+		castHint = hints[1].(*sema.UnnecessaryCastHint)
+		assert.Equal(t, sema.Int8Type, castHint.TargetType)
+	})
+
+	t.Run("nested casts", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheckWithAny(t, `
+            let x = (1 as Int8) as Int8
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+
+		require.IsType(t, &sema.UnnecessaryCastHint{}, hints[0])
+		castHint := hints[0].(*sema.UnnecessaryCastHint)
+		assert.Equal(t, sema.Int8Type, castHint.TargetType)
+	})
+
+	t.Run("arrays", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheckWithAny(t, `
+            let x: [String] = ["foo" as String]
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+
+		require.IsType(t, &sema.UnnecessaryCastHint{}, hints[0])
+		castHint := hints[0].(*sema.UnnecessaryCastHint)
+		assert.Equal(t, sema.StringType, castHint.TargetType)
+	})
+
+	t.Run("dictionaries", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheckWithAny(t, `
+            let x: {String: UInt8} = {"foo": 4 as UInt8}
+        `)
+
+		require.NoError(t, err)
+
+		hints := checker.Hints()
+		require.Len(t, hints, 1)
+
+		require.IsType(t, &sema.UnnecessaryCastHint{}, hints[0])
+		castHint := hints[0].(*sema.UnnecessaryCastHint)
+		assert.Equal(t, sema.UInt8Type, castHint.TargetType)
+	})
+
+	t.Run("undefined types", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheckWithAny(t, `
+            let x: T = 5 as R
+        `)
+
+		require.Error(t, err)
+
+		errors := ExpectCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.NotDeclaredError{}, errors[0])
+		assert.IsType(t, &sema.NotDeclaredError{}, errors[1])
+
+		// Shouldn't log hints for undeclared types
+		require.Len(t, checker.Hints(), 0)
+	})
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -5999,7 +5999,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
                   event Test(_ value: %[1]s)
 
                   fun test() {
-                      emit Test(%[2]s as %[1]s)
+                      emit Test(%[2]s)
                   }
                 `,
 				ty,
@@ -7171,28 +7171,28 @@ func TestInterpretHexDecode(t *testing.T) {
                       panic("Input must have even number of characters")
                   }
                   let table: {String: UInt8} = {
-                          "0" : 0 as UInt8,
-                          "1" : 1 as UInt8,
-                          "2" : 2 as UInt8,
-                          "3" : 3 as UInt8,
-                          "4" : 4 as UInt8,
-                          "5" : 5 as UInt8,
-                          "6" : 6 as UInt8,
-                          "7" : 7 as UInt8,
-                          "8" : 8 as UInt8,
-                          "9" : 9 as UInt8,
-                          "a" : 10 as UInt8,
-                          "A" : 10 as UInt8,
-                          "b" : 11 as UInt8,
-                          "B" : 11 as UInt8,
-                          "c" : 12 as UInt8,
-                          "C" : 12 as UInt8,
-                          "d" : 13 as UInt8,
-                          "D" : 13 as UInt8,
-                          "e" : 14 as UInt8,
-                          "E" : 14 as UInt8,
-                          "f" : 15 as UInt8,
-                          "F" : 15 as UInt8
+                          "0" : 0,
+                          "1" : 1,
+                          "2" : 2,
+                          "3" : 3,
+                          "4" : 4,
+                          "5" : 5,
+                          "6" : 6,
+                          "7" : 7,
+                          "8" : 8,
+                          "9" : 9,
+                          "a" : 10,
+                          "A" : 10,
+                          "b" : 11,
+                          "B" : 11,
+                          "c" : 12,
+                          "C" : 12,
+                          "d" : 13,
+                          "D" : 13,
+                          "e" : 14,
+                          "E" : 14,
+                          "f" : 15,
+                          "F" : 15
                       }
                   let length = s.length / 2
                   var i = 0


### PR DESCRIPTION
Work towards #1047

## Description

Report a hint if the casted type `T` is the same as the contextually expected type `R`.
 i.e: if `T == R`

e.g:
```kotlin
var x = 5 as Int8         // this is ok

var x: Int8 = 5 as Int8   // Cast is redundant because '5' would be Int8 even without the cast.
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
