### PR TITLE
Return a dedicated error when decoding fails due to an unsupported CBOR tag

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -49,6 +49,19 @@ type DecoderV5 struct {
 // maxInt is math.MaxInt32 or math.MaxInt64 depending on arch.
 const maxInt = 1<<(bits.UintSize-1) - 1
 
+type UnsupportedTagDecodingError struct {
+	Path []string
+	Tag  uint64
+}
+
+func (e UnsupportedTagDecodingError) Error() string {
+	return fmt.Sprintf(
+		"unsupported decoded tag (@ %s): %d",
+		strings.Join(e.Path, "."),
+		e.Tag,
+	)
+}
+
 // DecodeValue returns a value decoded from its CBOR-encoded representation,
 // for the given owner (can be `nil`).  It can decode storage format
 // version 4 and later.
@@ -290,11 +303,10 @@ func (d *DecoderV5) decodeValue(path []string) (Value, error) {
 			value, err = d.decodeType()
 
 		default:
-			return nil, fmt.Errorf(
-				"unsupported decoded tag (@ %s): %d",
-				strings.Join(path, "."),
-				num,
-			)
+			return nil, UnsupportedTagDecodingError{
+				Path: path[:],
+				Tag:  num,
+			}
 		}
 
 	default:

--- a/runtime/interpreter/decode_v4.go
+++ b/runtime/interpreter/decode_v4.go
@@ -271,11 +271,10 @@ func (d *DecoderV4) decodeValue(path []string) (Value, error) {
 			value, err = d.decodeType()
 
 		default:
-			return nil, fmt.Errorf(
-				"unsupported decoded tag (@ %s): %d",
-				strings.Join(path, "."),
-				num,
-			)
+			return nil, UnsupportedTagDecodingError{
+				Path: path[:],
+				Tag:  num,
+			}
 		}
 
 	default:


### PR DESCRIPTION
Work towards #870 

## Description

Returning a dedicated error allows the storage migration due handle this decoding error in particular.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
