### PR TITLE
Report an error when the parameter list is missing commas

### DIFF
--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -449,6 +449,22 @@ func TestParseParameterList(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("two, with and without argument label, missing comma", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := parse("( a b : Int   c : Int )")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "parser: expected comma, got start of parameter",
+					Pos:     ast.Position{Offset: 14, Line: 1, Column: 14},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseFunctionDeclaration(t *testing.T) {

--- a/runtime/parser2/function.go
+++ b/runtime/parser2/function.go
@@ -51,6 +51,9 @@ func parseParameterList(p *parser) (parameterList *ast.ParameterList) {
 		p.skipSpaceAndComments(true)
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
+			if !expectParameter {
+				panic("expected comma, got start of parameter")
+			}
 			parameter := parseParameter(p)
 			parameters = append(parameters, parameter)
 			expectParameter = false


### PR DESCRIPTION

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
