### PR TITLE
Convert the maps in the type file to simple arrays

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -97,14 +97,14 @@ type postfixExpr struct {
 	leftDenotation postfixExprFunc
 }
 
-var exprNullDenotations = map[lexer.TokenType]exprNullDenotationFunc{}
+var exprNullDenotations = [lexer.TokenMax]exprNullDenotationFunc{}
 
 type exprLeftDenotationFunc func(parser *parser, token lexer.Token, left ast.Expression) ast.Expression
 
-var exprLeftBindingPowers = map[lexer.TokenType]int{}
+var exprLeftBindingPowers = [lexer.TokenMax]int{}
 var exprIdentifierLeftBindingPowers = map[string]int{}
-var exprLeftDenotations = map[lexer.TokenType]exprLeftDenotationFunc{}
-var exprMetaLeftDenotations = map[lexer.TokenType]exprMetaLeftDenotationFunc{}
+var exprLeftDenotations = [lexer.TokenMax]exprLeftDenotationFunc{}
+var exprMetaLeftDenotations = [lexer.TokenMax]exprMetaLeftDenotationFunc{}
 
 func defineExpr(def interface{}) {
 	switch def := def.(type) {
@@ -1242,8 +1242,8 @@ func applyExprMetaLeftDenotation(
 	// e.g. determining the left binding power based on parsing more tokens
 	// or performing look-ahead
 
-	metaLeftDenotation, ok := exprMetaLeftDenotations[p.current.Type]
-	if !ok {
+	metaLeftDenotation := exprMetaLeftDenotations[p.current.Type]
+	if metaLeftDenotation == nil {
 		metaLeftDenotation = defaultExprMetaLeftDenotation
 	}
 
@@ -1289,16 +1289,16 @@ func exprLeftBindingPower(token lexer.Token) int {
 
 func applyExprNullDenotation(p *parser, token lexer.Token) ast.Expression {
 	tokenType := token.Type
-	nullDenotation, ok := exprNullDenotations[tokenType]
-	if !ok {
-		panic(fmt.Errorf("unexpected token in expression: %s", token.Type))
+	nullDenotation := exprNullDenotations[tokenType]
+	if nullDenotation == nil {
+		panic(fmt.Errorf("unexpected token in expression: %s", tokenType))
 	}
 	return nullDenotation(p, token)
 }
 
 func applyExprLeftDenotation(p *parser, token lexer.Token, left ast.Expression) ast.Expression {
-	leftDenotation, ok := exprLeftDenotations[token.Type]
-	if !ok {
+	leftDenotation := exprLeftDenotations[token.Type]
+	if leftDenotation == nil {
 		panic(fmt.Errorf("unexpected token in expression: %s", token.Type))
 	}
 	return leftDenotation(p, token, left)

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -682,8 +682,7 @@ func applyTypeMetaLeftDenotation(
 	// e.g. determining the left binding power based on parsing more tokens,
 	// or performing look-ahead
 
-	var metaLeftDenotation typeMetaLeftDenotationFunc
-	metaLeftDenotation = typeMetaLeftDenotations[p.current.Type]
+	metaLeftDenotation := typeMetaLeftDenotations[p.current.Type]
 	if metaLeftDenotation == nil {
 		metaLeftDenotation = defaultTypeMetaLeftDenotation
 	}

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -743,7 +743,7 @@ func parseTypeAnnotation(p *parser) *ast.TypeAnnotation {
 
 func applyTypeNullDenotation(p *parser, token lexer.Token) ast.Type {
 	tokenType := token.Type
-	var nullDenotation typeNullDenotationFunc = typeNullDenotations[int(tokenType)]
+	nullDenotation := typeNullDenotations[tokenType]
 	if nullDenotation == nil {
 		panic(fmt.Errorf("unexpected token in type: %s", tokenType))
 	}

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -35,7 +35,7 @@ const (
 
 type typeNullDenotationFunc func(parser *parser, token lexer.Token) ast.Type
 
-var typeNullDenotations [256]typeNullDenotationFunc
+var typeNullDenotations [lexer.TokenMax]typeNullDenotationFunc
 
 type typeLeftDenotationFunc func(parser *parser, token lexer.Token, left ast.Type) ast.Type
 type typeMetaLeftDenotationFunc func(
@@ -47,9 +47,9 @@ type typeMetaLeftDenotationFunc func(
 	done bool,
 )
 
-var typeLeftBindingPowers [256]int
-var typeLeftDenotations [256]typeLeftDenotationFunc
-var typeMetaLeftDenotations [256]typeMetaLeftDenotationFunc
+var typeLeftBindingPowers [lexer.TokenMax]int
+var typeLeftDenotations [lexer.TokenMax]typeLeftDenotationFunc
+var typeMetaLeftDenotations [lexer.TokenMax]typeMetaLeftDenotationFunc
 
 func setTypeNullDenotation(tokenType lexer.TokenType, nullDenotation typeNullDenotationFunc) {
 	current := typeNullDenotations[int(tokenType)]
@@ -141,7 +141,8 @@ func defineType(def interface{}) {
 }
 
 func init() {
-	for i := 0; i < 256; i++ {
+	var i lexer.TokenType
+	for i = 0; i < lexer.TokenMax; i++ {
 		typeLeftBindingPowers[i] = 0
 		typeNullDenotations[i] = nil
 		typeLeftDenotations[i] = nil
@@ -742,17 +743,15 @@ func parseTypeAnnotation(p *parser) *ast.TypeAnnotation {
 
 func applyTypeNullDenotation(p *parser, token lexer.Token) ast.Type {
 	tokenType := token.Type
-	var nullDenotation typeNullDenotationFunc
-	nullDenotation = typeNullDenotations[int(tokenType)]
+	var nullDenotation typeNullDenotationFunc = typeNullDenotations[int(tokenType)]
 	if nullDenotation == nil {
-		panic(fmt.Errorf("unexpected token in type: %s", token.Type))
+		panic(fmt.Errorf("unexpected token in type: %s", tokenType))
 	}
 	return nullDenotation(p, token)
 }
 
 func applyTypeLeftDenotation(p *parser, token lexer.Token, left ast.Type) ast.Type {
-	var leftDenotation typeLeftDenotationFunc
-	leftDenotation = typeLeftDenotations[token.Type]
+	var leftDenotation typeLeftDenotationFunc = typeLeftDenotations[token.Type]
 	if leftDenotation == nil {
 		panic(fmt.Errorf("unexpected token in type: %s", token.Type))
 	}

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -52,7 +52,7 @@ var typeLeftDenotations [lexer.TokenMax]typeLeftDenotationFunc
 var typeMetaLeftDenotations [lexer.TokenMax]typeMetaLeftDenotationFunc
 
 func setTypeNullDenotation(tokenType lexer.TokenType, nullDenotation typeNullDenotationFunc) {
-	current := typeNullDenotations[int(tokenType)]
+	current := typeNullDenotations[tokenType]
 	if current != nil {
 		panic(fmt.Errorf(
 			"type null denotation for token %s already exists",
@@ -63,7 +63,7 @@ func setTypeNullDenotation(tokenType lexer.TokenType, nullDenotation typeNullDen
 }
 
 func setTypeLeftBindingPower(tokenType lexer.TokenType, power int) {
-	current := typeLeftBindingPowers[int(tokenType)]
+	current := typeLeftBindingPowers[tokenType]
 	if current > power {
 		return
 	}
@@ -71,25 +71,25 @@ func setTypeLeftBindingPower(tokenType lexer.TokenType, power int) {
 }
 
 func setTypeLeftDenotation(tokenType lexer.TokenType, leftDenotation typeLeftDenotationFunc) {
-	current := typeLeftDenotations[int(tokenType)]
+	current := typeLeftDenotations[tokenType]
 	if current != nil {
 		panic(fmt.Errorf(
 			"type left denotation for token %s already exists",
 			tokenType,
 		))
 	}
-	typeLeftDenotations[int(tokenType)] = leftDenotation
+	typeLeftDenotations[tokenType] = leftDenotation
 }
 
 func setTypeMetaLeftDenotation(tokenType lexer.TokenType, metaLeftDenotation typeMetaLeftDenotationFunc) {
-	current := typeMetaLeftDenotations[int(tokenType)]
+	current := typeMetaLeftDenotations[tokenType]
 	if current != nil {
 		panic(fmt.Errorf(
 			"type meta left denotation for token %s already exists",
 			tokenType,
 		))
 	}
-	typeMetaLeftDenotations[int(tokenType)] = metaLeftDenotation
+	typeMetaLeftDenotations[tokenType] = metaLeftDenotation
 }
 
 type prefixTypeFunc func(right ast.Type, tokenRange ast.Range) ast.Type
@@ -141,14 +141,6 @@ func defineType(def interface{}) {
 }
 
 func init() {
-	var i lexer.TokenType
-	for i = 0; i < lexer.TokenMax; i++ {
-		typeLeftBindingPowers[i] = 0
-		typeNullDenotations[i] = nil
-		typeLeftDenotations[i] = nil
-		typeMetaLeftDenotations[i] = nil
-	}
-
 	defineArrayType()
 	defineOptionalType()
 	defineReferenceType()
@@ -691,7 +683,7 @@ func applyTypeMetaLeftDenotation(
 	// or performing look-ahead
 
 	var metaLeftDenotation typeMetaLeftDenotationFunc
-	metaLeftDenotation = typeMetaLeftDenotations[int(p.current.Type)]
+	metaLeftDenotation = typeMetaLeftDenotations[p.current.Type]
 	if metaLeftDenotation == nil {
 		metaLeftDenotation = defaultTypeMetaLeftDenotation
 	}
@@ -710,7 +702,7 @@ func defaultTypeMetaLeftDenotation(
 	result ast.Type,
 	done bool,
 ) {
-	if rightBindingPower >= typeLeftBindingPowers[int(p.current.Type)] {
+	if rightBindingPower >= typeLeftBindingPowers[p.current.Type] {
 		return left, true
 	}
 

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -743,7 +743,7 @@ func applyTypeNullDenotation(p *parser, token lexer.Token) ast.Type {
 }
 
 func applyTypeLeftDenotation(p *parser, token lexer.Token, left ast.Type) ast.Type {
-	var leftDenotation typeLeftDenotationFunc = typeLeftDenotations[token.Type]
+	leftDenotation := typeLeftDenotations[token.Type]
 	if leftDenotation == nil {
 		panic(fmt.Errorf("unexpected token in type: %s", token.Type))
 	}


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/1079

## Description

This makes some changes to the 'map' objects in type.go, so that they are just simple arrays.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
