### PR TITLE
Add `names` field to auth account contracts

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -97,6 +97,9 @@ Every account can be accessed through two types:
       fun unlink(_ path: CapabilityPath)
 
       struct Contracts {
+
+          let names: [String]
+
           fun add(
               name: String,
               code: [UInt8],

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -1312,7 +1312,6 @@ func TestAuthAccountContracts(t *testing.T) {
 		assert.True(t, invoked)
 	})
 
-
 	t.Run("update names", func(t *testing.T) {
 		t.Parallel()
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -1268,7 +1268,7 @@ func TestAuthAccountContracts(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("names", func(t *testing.T) {
+	t.Run("get names", func(t *testing.T) {
 		t.Parallel()
 
 		rt := NewInterpreterRuntime()
@@ -1310,5 +1310,44 @@ func TestAuthAccountContracts(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.True(t, invoked)
+	})
+
+
+	t.Run("update names", func(t *testing.T) {
+		t.Parallel()
+
+		rt := NewInterpreterRuntime()
+
+		script := []byte(`
+            transaction {
+                prepare(signer: AuthAccount) {
+                    signer.contracts.names[0] = "baz"
+                    assert(signer.contracts.names[0] == "foo")
+                }
+            }
+        `)
+
+		runtimeInterface := &testRuntimeInterface{
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{{42}}, nil
+			},
+			getAccountContractNames: func(_ Address) ([]string, error) {
+				return []string{"foo", "bar"}, nil
+			},
+		}
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		err := rt.ExecuteTransaction(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.NoError(t, err)
 	})
 }

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -115,6 +115,8 @@ type Interface interface {
 	ImplementationDebugLog(message string) error
 	// ValidatePublicKey verifies the validity of a public key.
 	ValidatePublicKey(key *PublicKey) (bool, error)
+	// GetAccountContractNames returns the names of all contracts deployed in an account.
+	GetAccountContractNames(address Address) ([]string, error)
 }
 
 type Metrics interface {
@@ -290,4 +292,8 @@ func (i emptyRuntimeInterface) GetStorageCapacity(_ Address) (uint64, error) {
 
 func (i *emptyRuntimeInterface) ValidatePublicKey(_ *PublicKey) (bool, error) {
 	return false, nil
+}
+
+func (i *emptyRuntimeInterface) GetAccountContractNames(_ Address) ([]string, error) {
+	return nil, nil
 }

--- a/runtime/interpreter/authaccount_contracts.go
+++ b/runtime/interpreter/authaccount_contracts.go
@@ -32,12 +32,19 @@ func NewAuthAccountContractsValue(
 	updateFunction FunctionValue,
 	getFunction FunctionValue,
 	removeFunction FunctionValue,
+	namesGet func() *ArrayValue,
 ) *CompositeValue {
 	fields := NewStringValueOrderedMap()
 	fields.Set(sema.AuthAccountContractsTypeAddFunctionName, addFunction)
 	fields.Set(sema.AuthAccountContractsTypeGetFunctionName, getFunction)
 	fields.Set(sema.AuthAccountContractsTypeRemoveFunctionName, removeFunction)
 	fields.Set(sema.AuthAccountContractsTypeUpdateExperimentalFunctionName, updateFunction)
+
+	computedFields := NewStringComputedFieldOrderedMap()
+
+	computedFields.Set(sema.AuthAccountContractsTypeNamesField, func(*Interpreter) Value {
+		return namesGet()
+	})
 
 	stringer := func(_ SeenReferences) string {
 		return fmt.Sprintf("AuthAccount.Contracts(%s)", address)
@@ -47,6 +54,7 @@ func NewAuthAccountContractsValue(
 		qualifiedIdentifier: sema.AuthAccountContractsType.QualifiedIdentifier(),
 		kind:                sema.AuthAccountContractsType.Kind,
 		fields:              fields,
+		ComputedFields:      computedFields,
 		stringer:            stringer,
 	}
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1941,6 +1941,10 @@ func (r *interpreterRuntime) newAuthAccountContracts(
 			context.Interface,
 			runtimeStorage,
 		),
+		r.newAuthAccountContractsGetNamesFunction(
+			addressValue,
+			context.Interface,
+		),
 	)
 }
 
@@ -2460,6 +2464,31 @@ func (r *interpreterRuntime) newAuthAccountContractsRemoveFunction(
 			}
 		},
 	)
+}
+
+func (r *interpreterRuntime) newAuthAccountContractsGetNamesFunction(
+	addressValue interpreter.AddressValue,
+	runtimeInterface Interface,
+) func() *interpreter.ArrayValue {
+	address := addressValue.ToAddress()
+
+	return func() *interpreter.ArrayValue {
+		var names []string
+		var err error
+		wrapPanic(func() {
+			names, err = runtimeInterface.GetAccountContractNames(address)
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		values := make([]interpreter.Value, len(names))
+		for i, name := range names {
+			values[i] = interpreter.NewStringValue(name)
+		}
+
+		return interpreter.NewArrayValueUnownedNonCopying(values...)
+	}
 }
 
 func (r *interpreterRuntime) onStatementHandler() interpreter.OnStatementFunc {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -131,6 +131,7 @@ type testRuntimeInterface struct {
 	programs                   map[common.LocationID]*interpreter.Program
 	implementationDebugLog     func(message string) error
 	validatePublicKey          func(publicKey *PublicKey) (bool, error)
+	getAccountContractNames    func(address Address) ([]string, error)
 }
 
 // testRuntimeInterface should implement Interface
@@ -389,6 +390,14 @@ func (i *testRuntimeInterface) ValidatePublicKey(key *PublicKey) (bool, error) {
 	}
 
 	return i.validatePublicKey(key)
+}
+
+func (i *testRuntimeInterface) GetAccountContractNames(address Address) ([]string, error) {
+	if i.getAccountContractNames == nil {
+		return []string{}, nil
+	}
+
+	return i.getAccountContractNames(address)
 }
 
 func TestRuntimeImport(t *testing.T) {

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -27,6 +27,7 @@ const AuthAccountContractsTypeAddFunctionName = "add"
 const AuthAccountContractsTypeGetFunctionName = "get"
 const AuthAccountContractsTypeRemoveFunctionName = "remove"
 const AuthAccountContractsTypeUpdateExperimentalFunctionName = "update__experimental"
+const AuthAccountContractsTypeNamesField = "names"
 
 // AuthAccountContractsType represents the type `AuthAccount.Contracts`
 //
@@ -62,6 +63,14 @@ var AuthAccountContractsType = func() *CompositeType {
 			AuthAccountContractsTypeRemoveFunctionName,
 			authAccountContractsTypeRemoveFunctionType,
 			authAccountContractsTypeRemoveFunctionDocString,
+		),
+		NewPublicConstantFieldMember(
+			authAccountContractsType,
+			AuthAccountContractsTypeNamesField,
+			&VariableSizedType{
+				Type: StringType,
+			},
+			authAccountContractsTypeGetNamesDocString,
 		),
 	}
 
@@ -200,3 +209,7 @@ var authAccountContractsTypeRemoveFunctionType = &FunctionType{
 		},
 	),
 }
+
+const authAccountContractsTypeGetNamesDocString = `
+Names of all contracts deployed in the account.
+`

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1349,13 +1349,23 @@ func TestCheckAccount_StorageFields(t *testing.T) {
 	}
 }
 
-func TestAuthAccountContractsType(t *testing.T) {
+func TestAuthAccountContracts(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheckAccount(t, `
-      let contracts: AuthAccount.Contracts = authAccount.contracts
-	`)
+	t.Run("contracts type", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+          let contracts: AuthAccount.Contracts = authAccount.contracts
+	    `)
 
-	require.NoError(t, err)
+		require.NoError(t, err)
+	})
+
+	t.Run("contracts names", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+          let names: [String] = authAccount.contracts.names
+	    `)
+
+		require.NoError(t, err)
+	})
 }

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1368,4 +1368,18 @@ func TestAuthAccountContracts(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("update contracts names", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+            fun test() {
+                authAccount.contracts.names = ["foo"]
+            }
+	    `)
+
+		require.Error(t, err)
+		errors := ExpectCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errors[0])
+		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errors[1])
+	})
 }


### PR DESCRIPTION
Work towards #1075

## Description

Provides a way to get all deployed contracts of an auth account.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
