### PR TITLE
Add public account contracts

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -18,6 +18,9 @@ Every account can be accessed through two types:
       let storageUsed: UInt64
       let storageCapacity: UInt64
 
+      // Contracts
+      let contracts: PublicAccount.Contracts
+
       // Keys
       let keys: PublicAccount.Keys
 
@@ -25,6 +28,13 @@ Every account can be accessed through two types:
 
       fun getCapability<T>(_ path: PublicPath): Capability<T>
       fun getLinkTarget(_ path: CapabilityPath): Path?
+
+      struct Contracts {
+
+          let names: [String]
+
+          fun get(name: String): DeployedContract?
+      }
 
       struct Keys {
           // Returns the key at the given index, if it exists.

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -164,7 +164,7 @@ const (
 	PrimitiveStaticTypePublicAccount
 	PrimitiveStaticTypeDeployedContract
 	PrimitiveStaticTypeAuthAccountContracts
-	_
+	PrimitiveStaticTypePublicAccountContracts
 )
 
 func (PrimitiveStaticType) IsStaticType() {}
@@ -296,6 +296,8 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return sema.DeployedContractType
 	case PrimitiveStaticTypeAuthAccountContracts:
 		return sema.AuthAccountContractsType
+	case PrimitiveStaticTypePublicAccountContracts:
+		return sema.PublicAccountContractsType
 	default:
 		panic(errors.NewUnreachableError())
 	}
@@ -413,6 +415,8 @@ func ConvertSemaToPrimitiveStaticType(t sema.Type) PrimitiveStaticType {
 		return PrimitiveStaticTypeDeployedContract
 	case sema.AuthAccountContractsType:
 		return PrimitiveStaticTypeAuthAccountContracts
+	case sema.PublicAccountContractsType:
+		return PrimitiveStaticTypePublicAccountContracts
 	case sema.StringType:
 		return PrimitiveStaticTypeString
 	}

--- a/runtime/interpreter/primitivestatictype_string.go
+++ b/runtime/interpreter/primitivestatictype_string.go
@@ -56,9 +56,10 @@ func _() {
 	_ = x[PrimitiveStaticTypePublicAccount-91]
 	_ = x[PrimitiveStaticTypeDeployedContract-92]
 	_ = x[PrimitiveStaticTypeAuthAccountContracts-93]
+	_ = x[PrimitiveStaticTypePublicAccountContracts-94]
 }
 
-const _PrimitiveStaticType_name = "UnknownVoidAnyNeverAnyStructAnyResourceBoolAddressStringCharacterMetaTypeBlockNumberSignedNumberIntegerSignedIntegerFixedPointSignedFixedPointIntInt8Int16Int32Int64Int128Int256UIntUInt8UInt16UInt32UInt64UInt128UInt256Word8Word16Word32Word64Fix64UFix64PathCapabilityStoragePathCapabilityPathPublicPathPrivatePathAuthAccountPublicAccountDeployedContractAuthAccountContracts"
+const _PrimitiveStaticType_name = "UnknownVoidAnyNeverAnyStructAnyResourceBoolAddressStringCharacterMetaTypeBlockNumberSignedNumberIntegerSignedIntegerFixedPointSignedFixedPointIntInt8Int16Int32Int64Int128Int256UIntUInt8UInt16UInt32UInt64UInt128UInt256Word8Word16Word32Word64Fix64UFix64PathCapabilityStoragePathCapabilityPathPublicPathPrivatePathAuthAccountPublicAccountDeployedContractAuthAccountContractsPublicAccountContracts"
 
 var _PrimitiveStaticType_map = map[PrimitiveStaticType]string{
 	0:  _PrimitiveStaticType_name[0:7],
@@ -109,6 +110,7 @@ var _PrimitiveStaticType_map = map[PrimitiveStaticType]string{
 	91: _PrimitiveStaticType_name[322:335],
 	92: _PrimitiveStaticType_name[335:351],
 	93: _PrimitiveStaticType_name[351:371],
+	94: _PrimitiveStaticType_name[371:393],
 }
 
 func (i PrimitiveStaticType) String() string {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -8887,12 +8887,14 @@ func NewPublicAccountValue(
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
 	storageCapacityGet func() UInt64Value,
 	keys *CompositeValue,
+	contracts *CompositeValue,
 ) *CompositeValue {
 
 	fields := NewStringValueOrderedMap()
 	fields.Set(sema.PublicAccountAddressField, address)
 	fields.Set(sema.PublicAccountGetCapabilityField, accountGetCapabilityFunction(address))
 	fields.Set(sema.PublicAccountKeysField, keys)
+	fields.Set(sema.PublicAccountContractsField, contracts)
 
 	// Computed fields
 	computedFields := NewStringComputedFieldOrderedMap()
@@ -9384,5 +9386,34 @@ func NewPublicAccountKeysValue(getFunction FunctionValue) *CompositeValue {
 		qualifiedIdentifier: sema.PublicAccountKeysType.QualifiedIdentifier(),
 		kind:                sema.PublicAccountKeysType.Kind,
 		fields:              fields,
+	}
+}
+
+// PublicAccountContractsValue
+
+func NewPublicAccountContractsValue(
+	address AddressValue,
+	getFunction FunctionValue,
+	namesGet func() *ArrayValue,
+) *CompositeValue {
+
+	fields := NewStringValueOrderedMap()
+	fields.Set(sema.PublicAccountContractsTypeGetFunctionName, getFunction)
+
+	computedFields := NewStringComputedFieldOrderedMap()
+	computedFields.Set(sema.PublicAccountContractsTypeNamesField, func(*Interpreter) Value {
+		return namesGet()
+	})
+
+	stringer := func(_ SeenReferences) string {
+		return fmt.Sprintf("PublicAccount.Contracts(%s)", address)
+	}
+
+	return &CompositeValue{
+		qualifiedIdentifier: sema.PublicAccountContractsType.QualifiedIdentifier(),
+		kind:                sema.PublicAccountContractsType.Kind,
+		fields:              fields,
+		ComputedFields:      computedFields,
+		stringer:            stringer,
 	}
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1813,6 +1813,7 @@ func (r *interpreterRuntime) getPublicAccount(
 		storageUsedGetFunction(accountAddress, runtimeInterface, runtimeStorage),
 		storageCapacityGetFunction(accountAddress, runtimeInterface),
 		r.newPublicAccountKeys(accountAddress, runtimeInterface),
+		r.newPublicAccountContracts(accountAddress, runtimeInterface),
 	)
 }
 
@@ -1932,7 +1933,7 @@ func (r *interpreterRuntime) newAuthAccountContracts(
 			checkerOptions,
 			true,
 		),
-		r.newAuthAccountContractsGetFunction(
+		r.newAccountContractsGetFunction(
 			addressValue,
 			context.Interface,
 		),
@@ -1941,7 +1942,7 @@ func (r *interpreterRuntime) newAuthAccountContracts(
 			context.Interface,
 			runtimeStorage,
 		),
-		r.newAuthAccountContractsGetNamesFunction(
+		r.newAccountContractsGetNamesFunction(
 			addressValue,
 			context.Interface,
 		),
@@ -2340,7 +2341,7 @@ func (r *interpreterRuntime) updateAccountContractCode(
 	return nil
 }
 
-func (r *interpreterRuntime) newAuthAccountContractsGetFunction(
+func (r *interpreterRuntime) newAccountContractsGetFunction(
 	addressValue interpreter.AddressValue,
 	runtimeInterface Interface,
 ) *interpreter.HostFunctionValue {
@@ -2466,7 +2467,7 @@ func (r *interpreterRuntime) newAuthAccountContractsRemoveFunction(
 	)
 }
 
-func (r *interpreterRuntime) newAuthAccountContractsGetNamesFunction(
+func (r *interpreterRuntime) newAccountContractsGetNamesFunction(
 	addressValue interpreter.AddressValue,
 	runtimeInterface Interface,
 ) func() *interpreter.ArrayValue {
@@ -2721,6 +2722,23 @@ func (r *interpreterRuntime) newPublicAccountKeys(addressValue interpreter.Addre
 		r.newAccountKeysGetFunction(
 			addressValue,
 			runtimeInterface,
+		),
+	)
+}
+
+func (r *interpreterRuntime) newPublicAccountContracts(
+	addressValue interpreter.AddressValue,
+	inter Interface,
+) *interpreter.CompositeValue {
+	return interpreter.NewPublicAccountContractsValue(
+		addressValue,
+		r.newAccountContractsGetFunction(
+			addressValue,
+			inter,
+		),
+		r.newAccountContractsGetNamesFunction(
+			addressValue,
+			inter,
 		),
 	)
 }

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -1,0 +1,90 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/common"
+)
+
+const PublicAccountContractsTypeName = "Contracts"
+const PublicAccountContractsTypeGetFunctionName = "get"
+const PublicAccountContractsTypeNamesField = "names"
+
+// PublicAccountContractsType represents the type `PublicAccount.Contracts`
+//
+var PublicAccountContractsType = func() *CompositeType {
+
+	publicAccountContractsType := &CompositeType{
+		Identifier: PublicAccountContractsTypeName,
+		Kind:       common.CompositeKindStructure,
+		importable: false,
+	}
+
+	var members = []*Member{
+		NewPublicFunctionMember(
+			publicAccountContractsType,
+			PublicAccountContractsTypeGetFunctionName,
+			publicAccountContractsTypeGetFunctionType,
+			publicAccountContractsTypeGetFunctionDocString,
+		),
+		NewPublicConstantFieldMember(
+			publicAccountContractsType,
+			PublicAccountContractsTypeNamesField,
+			&VariableSizedType{
+				Type: StringType,
+			},
+			publicAccountContractsTypeNamesDocString,
+		),
+	}
+
+	publicAccountContractsType.Members = GetMembersAsMap(members)
+	publicAccountContractsType.Fields = getFieldNames(members)
+	return publicAccountContractsType
+}()
+
+func init() {
+	// Set the container type after initializing the `PublicAccountContractsType`, to avoid initializing loop.
+	PublicAccountContractsType.SetContainerType(PublicAccountType)
+}
+
+const publicAccountContractsTypeGetFunctionDocString = `
+Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
+
+Returns nil if no contract/contract interface with the given name exists in the account.
+`
+
+var publicAccountContractsTypeGetFunctionType = &FunctionType{
+	Parameters: []*Parameter{
+		{
+			Identifier: "name",
+			TypeAnnotation: NewTypeAnnotation(
+				StringType,
+			),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: DeployedContractType,
+		},
+	),
+}
+
+const publicAccountContractsTypeNamesDocString = `
+Names of all contracts deployed in the account.
+`

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -31,6 +31,7 @@ const PublicAccountStorageCapacityField = "storageCapacity"
 const PublicAccountGetCapabilityField = "getCapability"
 const PublicAccountGetTargetLinkField = "getLinkTarget"
 const PublicAccountKeysField = "keys"
+const PublicAccountContractsField = "contracts"
 
 // PublicAccountType represents the publicly accessible portion of an account.
 //
@@ -45,6 +46,7 @@ var PublicAccountType = func() *CompositeType {
 		nestedTypes: func() *StringTypeOrderedMap {
 			nestedTypes := NewStringTypeOrderedMap()
 			nestedTypes.Set(AccountKeysTypeName, PublicAccountKeysType)
+			nestedTypes.Set(PublicAccountContractsTypeName, PublicAccountContractsType)
 			return nestedTypes
 		}(),
 	}
@@ -97,6 +99,12 @@ var PublicAccountType = func() *CompositeType {
 			PublicAccountKeysField,
 			PublicAccountKeysType,
 			accountTypeKeysFieldDocString,
+		),
+		NewPublicConstantFieldMember(
+			publicAccountType,
+			PublicAccountContractsField,
+			PublicAccountContractsType,
+			accountTypeContractsFieldDocString,
 		),
 	}
 

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1417,4 +1417,50 @@ func TestPublicAccountContracts(t *testing.T) {
 		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errors[0])
 		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errors[1])
 	})
+
+	t.Run("add contract", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+            fun test() {
+                publicAccount.contracts.add(name: "foo", code: "012".decodeHex())
+            }
+	    `)
+
+		require.Error(t, err)
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.NotDeclaredMemberError{}, errors[0])
+		notDeclaredError := errors[0].(*sema.NotDeclaredMemberError)
+		assert.Equal(t, "add", notDeclaredError.Name)
+	})
+
+	t.Run("update contract", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+            fun test() {
+                publicAccount.contracts.update__experimental(name: "foo", code: "012".decodeHex())
+            }
+	    `)
+
+		require.Error(t, err)
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.NotDeclaredMemberError{}, errors[0])
+		notDeclaredError := errors[0].(*sema.NotDeclaredMemberError)
+		assert.Equal(t, "update__experimental", notDeclaredError.Name)
+	})
+
+	t.Run("remove contract", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+            fun test() {
+                publicAccount.contracts.remove(name: "foo")
+            }
+	    `)
+
+		require.Error(t, err)
+		errors := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.NotDeclaredMemberError{}, errors[0])
+		notDeclaredError := errors[0].(*sema.NotDeclaredMemberError)
+		assert.Equal(t, "remove", notDeclaredError.Name)
+	})
+
 }

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1383,3 +1383,38 @@ func TestAuthAccountContracts(t *testing.T) {
 		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errors[1])
 	})
 }
+
+func TestPublicAccountContracts(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("contracts type", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+          let contracts: PublicAccount.Contracts = publicAccount.contracts
+	    `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("contracts names", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+          let names: [String] = publicAccount.contracts.names
+	    `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("update contracts names", func(t *testing.T) {
+		_, err := ParseAndCheckAccount(t, `
+            fun test() {
+                publicAccount.contracts.names = ["foo"]
+            }
+	    `)
+
+		require.Error(t, err)
+		errors := ExpectCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errors[0])
+		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errors[1])
+	})
+}

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1390,7 +1390,7 @@ func TestPublicAccountContracts(t *testing.T) {
 
 	t.Run("contracts type", func(t *testing.T) {
 		_, err := ParseAndCheckAccount(t, `
-          let contracts: PublicAccount.Contracts = publicAccount.contracts
+            let contracts: PublicAccount.Contracts = publicAccount.contracts
 	    `)
 
 		require.NoError(t, err)
@@ -1398,7 +1398,7 @@ func TestPublicAccountContracts(t *testing.T) {
 
 	t.Run("contracts names", func(t *testing.T) {
 		_, err := ParseAndCheckAccount(t, `
-          let names: [String] = publicAccount.contracts.names
+            let names: [String] = publicAccount.contracts.names
 	    `)
 
 		require.NoError(t, err)

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -87,6 +87,11 @@ func testAccount(
 			interpreter.NewPublicAccountKeysValue(
 				nil,
 			),
+			interpreter.NewPublicAccountContractsValue(
+				address,
+				nil,
+				nil,
+			),
 		),
 		Kind: common.DeclarationKindConstant,
 	}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7377,6 +7377,11 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 							interpreter.NewPublicAccountKeysValue(
 								panicFunction,
 							),
+							interpreter.NewPublicAccountContractsValue(
+								address,
+								nil,
+								nil,
+							),
 						)
 					},
 				),


### PR DESCRIPTION
Closes #1075

## Description

This PR:
- Adds a `contracts` field to public account to retrieve all contracts deployed under the account.
- Adds a `get()` method to get a deployed contract by name
- Add a `names` field to `PublicAccount.Contracts` to retrieve the names of all contracts deployed under the account.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
