### PR TITLE
Fix race condition in hash and sign algorithm values

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -196,7 +196,7 @@ func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (cade
 		script.Source,
 		context,
 		functions,
-		stdlib.BuiltinValues,
+		stdlib.BuiltinValues(),
 		checkerOptions,
 		true,
 		importResolutionResults{},
@@ -241,7 +241,7 @@ func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (cade
 		context,
 		runtimeStorage,
 		functions,
-		stdlib.BuiltinValues,
+		stdlib.BuiltinValues(),
 		interpreterOptions,
 		checkerOptions,
 		interpret,
@@ -404,7 +404,7 @@ func (r *interpreterRuntime) InvokeContractFunction(
 		context,
 		runtimeStorage,
 		functions,
-		stdlib.BuiltinValues,
+		stdlib.BuiltinValues(),
 		interpreterOptions,
 		checkerOptions,
 		nil,
@@ -514,7 +514,7 @@ func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) 
 		script.Source,
 		context,
 		functions,
-		stdlib.BuiltinValues,
+		stdlib.BuiltinValues(),
 		checkerOptions,
 		true,
 		importResolutionResults{},
@@ -583,7 +583,7 @@ func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) 
 		context,
 		runtimeStorage,
 		functions,
-		stdlib.BuiltinValues,
+		stdlib.BuiltinValues(),
 		interpreterOptions,
 		checkerOptions,
 		r.transactionExecutionFunction(
@@ -766,7 +766,7 @@ func (r *interpreterRuntime) ParseAndCheckProgram(code []byte, context Context) 
 		code,
 		context,
 		functions,
-		stdlib.BuiltinValues,
+		stdlib.BuiltinValues(),
 		checkerOptions,
 		true,
 		importResolutionResults{},
@@ -2085,7 +2085,7 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 				code,
 				context,
 				functions,
-				stdlib.BuiltinValues,
+				stdlib.BuiltinValues(),
 				checkerOptions,
 				storeProgram,
 				importResolutionResults{},
@@ -2291,7 +2291,7 @@ func (r *interpreterRuntime) updateAccountContractCode(
 	if createContract {
 
 		functions := r.standardLibraryFunctions(context, runtimeStorage, interpreterOptions, checkerOptions)
-		values := stdlib.BuiltinValues
+		values := stdlib.BuiltinValues()
 
 		contractValue, err = r.instantiateContract(
 			program,

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -179,22 +179,37 @@ var CreatePublicKeyFunction = NewStandardLibraryFunction(
 
 // BuiltinValues
 
-var BuiltinValues = StandardLibraryValues{
-	SignatureAlgorithmValue,
-	HashAlgorithmValue,
-}
+func BuiltinValues() StandardLibraryValues {
+	signatureAlgorithmValue := StandardLibraryValue{
+		Name: sema.SignatureAlgorithmTypeName,
+		Type: cryptoAlgorithmEnumType(
+			sema.SignatureAlgorithmType,
+			sema.SignatureAlgorithms,
+		),
+		Value: cryptoAlgorithmEnumValue(
+			sema.SignatureAlgorithms,
+			NewSignatureAlgorithmCase,
+		),
+		Kind: common.DeclarationKindEnum,
+	}
 
-var SignatureAlgorithmValue = StandardLibraryValue{
-	Name: sema.SignatureAlgorithmTypeName,
-	Type: cryptoAlgorithmEnumType(
-		sema.SignatureAlgorithmType,
-		sema.SignatureAlgorithms,
-	),
-	Value: cryptoAlgorithmEnumValue(
-		sema.SignatureAlgorithms,
-		NewSignatureAlgorithmCase,
-	),
-	Kind: common.DeclarationKindEnum,
+	hashAlgorithmValue := StandardLibraryValue{
+		Name: sema.HashAlgorithmTypeName,
+		Type: cryptoAlgorithmEnumType(
+			sema.HashAlgorithmType,
+			sema.HashAlgorithms,
+		),
+		Value: cryptoAlgorithmEnumValue(
+			sema.HashAlgorithms,
+			NewHashAlgorithmCase,
+		),
+		Kind: common.DeclarationKindEnum,
+	}
+
+	return StandardLibraryValues{
+		signatureAlgorithmValue,
+		hashAlgorithmValue,
+	}
 }
 
 func NewSignatureAlgorithmCase(rawValue uint8) *interpreter.CompositeValue {
@@ -216,19 +231,6 @@ func NewHashAlgorithmCase(rawValue uint8) *interpreter.CompositeValue {
 		interpreter.UInt8Value(rawValue),
 		hashAlgorithmFunctions,
 	)
-}
-
-var HashAlgorithmValue = StandardLibraryValue{
-	Name: sema.HashAlgorithmTypeName,
-	Type: cryptoAlgorithmEnumType(
-		sema.HashAlgorithmType,
-		sema.HashAlgorithms,
-	),
-	Value: cryptoAlgorithmEnumValue(
-		sema.HashAlgorithms,
-		NewHashAlgorithmCase,
-	),
-	Kind: common.DeclarationKindEnum,
 }
 
 var hashAlgorithmHashFunction = interpreter.NewHostFunctionValue(

--- a/runtime/tests/checker/crypto_test.go
+++ b/runtime/tests/checker/crypto_test.go
@@ -43,7 +43,7 @@ func TestCheckHashAlgorithmCases(t *testing.T) {
 			ParseAndCheckOptions{
 				Options: []sema.Option{
 					sema.WithPredeclaredValues(
-						stdlib.BuiltinValues.ToSemaValueDeclarations(),
+						stdlib.BuiltinValues().ToSemaValueDeclarations(),
 					),
 				},
 			},
@@ -68,7 +68,7 @@ func TestCheckHashAlgorithmConstructor(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithPredeclaredValues(
-					stdlib.BuiltinValues.ToSemaValueDeclarations(),
+					stdlib.BuiltinValues().ToSemaValueDeclarations(),
 				),
 			},
 		},
@@ -90,7 +90,7 @@ func TestCheckHashAlgorithmHashFunctions(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithPredeclaredValues(
-					stdlib.BuiltinValues.ToSemaValueDeclarations(),
+					stdlib.BuiltinValues().ToSemaValueDeclarations(),
 				),
 			},
 		},
@@ -115,7 +115,7 @@ func TestCheckSignatureAlgorithmCases(t *testing.T) {
 			ParseAndCheckOptions{
 				Options: []sema.Option{
 					sema.WithPredeclaredValues(
-						stdlib.BuiltinValues.ToSemaValueDeclarations(),
+						stdlib.BuiltinValues().ToSemaValueDeclarations(),
 					),
 				},
 			},
@@ -140,7 +140,7 @@ func TestCheckSignatureAlgorithmConstructor(t *testing.T) {
 		ParseAndCheckOptions{
 			Options: []sema.Option{
 				sema.WithPredeclaredValues(
-					stdlib.BuiltinValues.ToSemaValueDeclarations(),
+					stdlib.BuiltinValues().ToSemaValueDeclarations(),
 				),
 			},
 		},


### PR DESCRIPTION
Closes #1088

## Description

Currently, the hash algorithm and sign algorithm values are singleton and are shared across all exectuions. This causes race-condition as some fields are loaded on-demand.

This PR fixes it by instantiating a new value of hash/sign algorithms for each execution.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
