### PR TITLE
flow-go sync tweaks

### DIFF
--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -90,4 +90,4 @@ jobs:
           # labels: A comma or newline-separated list of labels.
           # assignees: A comma or newline-separated list of assignees (GitHub usernames).
           # reviewers: A comma or newline-separated list of reviewers (GitHub usernames) to request a review from.
-          assignees: janezpodhostnik,ramtinms,turbolent
+          assignees: janezpodhostnik,ramtinms,turbolent,SupunS

--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -90,4 +90,4 @@ jobs:
           # labels: A comma or newline-separated list of labels.
           # assignees: A comma or newline-separated list of assignees (GitHub usernames).
           # reviewers: A comma or newline-separated list of reviewers (GitHub usernames) to request a review from.
-          assignees: janezpodhostnik,ramtinms,ba
+          assignees: janezpodhostnik,ramtinms,turbolent

--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - master
     types: [closed]
+    paths-ignore:
+      - '.github/**'
+      - 'compat/**'
+      - 'docs/**'
+      - 'npm-packages/**'
+      - 'rfcs/**'
+      - 'tools/**'
 
 jobs:
   sync-flow-go:
@@ -28,9 +35,15 @@ jobs:
       - name: Get onflow/flow-go base branch name
         run: |
           git fetch
-          BRANCH=$(git branch -r -l "*auto-cadence-upgrade/*" --format "%(refname:lstrip=3)" --sort=-committerdate | head -n 1)
+          BRANCH=$(git branch -r -l "*auto-cadence-upgrade/*" --format "%(refname:lstrip=3)" | sort -r | head -n 1)
           [ -z $BRANCH ] && BRANCH=master
           echo "BASE_BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      # create new branch name
+      - name: Create new branch name
+        run: |
+          NEW_BRANCH=auto-cadence-upgrade/$( date +%s )/${{ github.event.pull_request.head.ref }}
+          echo "NEW_BRANCH=$NEW_BRANCH" >> $GITHUB_ENV
 
       # checkout the correct branch of the remote repo
       - name: Checkout onflow/flow-go branch
@@ -70,11 +83,11 @@ jobs:
               Auto generated PR to update Cadence version.
 
               References: ${{ github.event.pull_request.html_url }}
-          branch: auto-cadence-upgrade/${{ github.event.pull_request.head.ref }}
+          branch: ${{ env.NEW_BRANCH }}
           delete-branch: true
 
           # we can tweak the following:
           # labels: A comma or newline-separated list of labels.
           # assignees: A comma or newline-separated list of assignees (GitHub usernames).
           # reviewers: A comma or newline-separated list of reviewers (GitHub usernames) to request a review from.
-          assignees: janezpodhostnik
+          assignees: janezpodhostnik,ramtinms,ba


### PR DESCRIPTION
References: https://github.com/dapperlabs/flow-internal/issues/1552

## Description

In order to improve the action that creates PRs in `flow-go` when a PR is merged in `cadence` I have made some changes:

- Add more reviewers to the auto created PRs
- Ignore changes in paths that do not affect flow-go integration
- add epoch seconds to the branch names, so they can be sorted alphabetically

It would be preferable to  merge all the open `auto cadence` PRs in flow go before merging this, otherwise the alphabetical ordering will cause new PRs to be based on the wrong PRs. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
