### PR TITLE
Remove obsolete script/transaction parameter check

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -793,13 +793,6 @@ func (interpreter *Interpreter) prepareInvoke(
 	preparedArguments := make([]Value, len(arguments))
 	for i, argument := range arguments {
 		parameterType := parameters[i].TypeAnnotation.Type
-		// TODO: value type is not known, reject for now
-		switch parameterType {
-		case sema.AnyStructType, sema.AnyResourceType:
-			return nil, NotInvokableError{
-				Value: functionValue,
-			}
-		}
 
 		// converts the argument into the parameter type declared by the function
 		preparedArguments[i] = interpreter.convertAndBox(argument, nil, parameterType)


### PR DESCRIPTION
Closes #1099

## Description

This check is now obsolete as we do check for importability of types at: 
https://github.com/onflow/cadence/blob/fa0c3f625056cbaf001acc8567658c8aaabdbffb/runtime/runtime.go#L214-L223


There are already tests available to cover the different cases:
https://github.com/onflow/cadence/blob/fa0c3f625056cbaf001acc8567658c8aaabdbffb/runtime/program_params_validation_test.go#L180-L194
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
