### PR TITLE
Add PublicAccount conversion during InvokeContractFunction

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -421,6 +421,7 @@ func (r *interpreterRuntime) InvokeContractFunction(
 			arguments[i],
 			argumentType,
 			context,
+
 			runtimeStorage,
 			interpreterOptions,
 			checkerOptions,
@@ -489,6 +490,15 @@ func (r *interpreterRuntime) convertArgument(
 				runtimeStorage,
 				interpreterOptions,
 				checkerOptions,
+			)
+		}
+	case sema.PublicAccountType:
+		// convert addresses to public accounts so there is no need to construct a public account value for the caller
+		if addressValue, ok := argument.(interpreter.AddressValue); ok {
+			return r.getPublicAccount(
+				interpreter.NewAddressValue(addressValue.ToAddress()),
+				context.Interface,
+				runtimeStorage,
 			)
 		}
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2984,6 +2984,9 @@ func TestInvokeContractFunction(t *testing.T) {
 			pub fun helloAuthAcc(account: AuthAccount) {
 				log("Hello ".concat(account.address.toString()))
 			}
+			pub fun helloPublicAcc(account: PublicAccount) {
+				log("Hello pub ".concat(account.address.toString()))
+			}
         }
     `)
 
@@ -3185,6 +3188,28 @@ func TestInvokeContractFunction(t *testing.T) {
 		require.NoError(tt, err)
 
 		assert.Equal(tt, `"Hello 0x1"`, loggedMessage)
+	})
+	t.Run("function with public account works", func(tt *testing.T) {
+		_, err = runtime.InvokeContractFunction(
+			common.AddressLocation{
+				Address: addressValue,
+				Name:    "Test",
+			},
+			"helloPublicAcc",
+			[]interpreter.Value{
+				interpreter.AddressValue(addressValue),
+			},
+			[]sema.Type{
+				sema.PublicAccountType,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(tt, err)
+
+		assert.Equal(tt, `"Hello pub 0x1"`, loggedMessage)
 	})
 }
 


### PR DESCRIPTION
References https://github.com/dapperlabs/flow-internal/issues/1549

## Description

When using InvokeContractFunction from the FVM side it is Impossible to construct a PublicAccount value. This change allows  the FVM sending just the address of the PublicAccount and the type is constructed by the cadence runtime.

This is needed to change the meta-script calling [FlowServiceAccount.defaultTokenBalance](https://github.com/onflow/flow-core-contracts/blob/116ef281c548c817c847dd4048091ac1ff823c41/contracts/FlowServiceAccount.cdc#L48) to a InvokeContractFunction call.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
