### PR TITLE
Add Path.toString() with tests and documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# XXXXXXX
-
-## ⭐ Features
-
-- The function `fun toString(): String` was added to all path types. It returns the textual representation of the type.
-
 # v0.16.0 (2021-04-21)
 
 ## 💥 Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# XXXXXXX
+
+## ⭐ Features
+
+- The function `fun toString(): String` was added to all path types. It returns the textual representation of the type.
+
 # v0.16.0 (2021-04-21)
 
 ## 💥 Breaking Changes

--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -305,6 +305,18 @@ Both `StoragePath` and `CapabilityPath` are subtypes of `Path`.
   </tr>
 </table>
 
+#### Path Functions
+
+- `cadence•fun toString(): String`
+
+  Returns the string representation of the path.
+
+  ```cadence
+  let storagePath = /storage/path
+
+  storagePath.toString()  // is "/storage/path"
+  ```
+
 ### Account Storage API
 
 Account storage is accessed through the following functions of `AuthAccount`.

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -1472,8 +1472,3 @@ and [`Equatable`](../interfaces#equatable-interface) [interfaces](../interfaces)
 Most of the built-in types, like booleans and integers,
 are hashable and equatable, so can be used as keys in dictionaries.
 
-## Paths
-
-Paths represent locations in account storage that objects can be stored and accessed at.
-
-They consist of a domain (`storage`, `private`, or `public`) and an identifier separated by forward slashes. e.g. `/storage/MyProjectCollectionResource` .

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -1477,15 +1477,3 @@ are hashable and equatable, so can be used as keys in dictionaries.
 Paths represent locations in account storage that objects can be stored and accessed at.
 
 They consist of a domain (`storage`, `private`, or `public`) and an identifier separated by forward slashes. e.g. `/storage/MyProjectCollectionResource` .
-
-### Path functions
-
-- `cadence•fun toString(): String`
-
-  Returns the string representation of the path.
-
-  ```cadence
-  let storagePath = /storage/path
-
-  storagePath.toString()  // is "/storage/path"
-  ```

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -1471,3 +1471,21 @@ and [`Equatable`](../interfaces#equatable-interface) [interfaces](../interfaces)
 
 Most of the built-in types, like booleans and integers,
 are hashable and equatable, so can be used as keys in dictionaries.
+
+## Paths
+
+Paths represent locations in account storage that objects can be stored and accessed at.
+
+They consist of a domain (`storage`, `private`, or `public`) and an identifier separated by forward slashes. e.g. `/storage/MyProjectCollectionResource` .
+
+### Path functions
+
+- `cadence•fun toString(): String`
+
+  Returns the string representation of the path.
+
+  ```cadence
+  let storagePath = /storage/path
+
+  storagePath.toString()  // is "/storage/path"
+  ```

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -9161,6 +9161,24 @@ func (v PathValue) KeyString() string {
 	)
 }
 
+func (v PathValue) GetMember(_ *Interpreter, _ func() LocationRange, name string) Value {
+	switch name {
+
+	case sema.ToStringFunctionName:
+		return NewHostFunctionValue(
+			func(invocation Invocation) Value {
+				return NewStringValue(v.String())
+			},
+		)
+	}
+
+	return nil
+}
+
+func (PathValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+	panic(errors.NewUnreachableError())
+}
+
 func (v PathValue) ConformsToDynamicType(_ *Interpreter, dynamicType DynamicType, _ TypeConformanceResults) bool {
 	switch dynamicType.(type) {
 	case PublicPathDynamicType:

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -401,9 +401,9 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 		},
 	}
 
-	// All number types and addresses have a `toString` function
+	// All number types, addresses, and path types have a `toString` function
 
-	if IsSubType(ty, NumberType) || IsSubType(ty, &AddressType{}) {
+	if IsSubType(ty, NumberType) || IsSubType(ty, &AddressType{}) || IsSubType(ty, PathType) {
 
 		members[ToStringFunctionName] = MemberResolver{
 			Kind: common.DeclarationKindFunction,

--- a/runtime/tests/checker/path_test.go
+++ b/runtime/tests/checker/path_test.go
@@ -64,8 +64,34 @@ func TestCheckPath(t *testing.T) {
 		})
 	}
 
+	testPathToString := func(domain common.PathDomain) {
+
+		t.Run(fmt.Sprintf("toString: %s", domain.Identifier()), func(t *testing.T) {
+
+			t.Parallel()
+
+			checker, err := ParseAndCheck(t,
+				fmt.Sprintf(
+					`
+                      let x = /%[1]s/foo
+                      let y = x.toString()
+                    `,
+					domain.Identifier(),
+				),
+			)
+
+			require.NoError(t, err)
+
+			assert.IsType(t,
+				sema.StringType,
+				RequireGlobalValue(t, checker.Elaboration, "y"),
+			)
+		})
+	}
+
 	for _, domain := range common.AllPathDomainsByIdentifier {
 		test(domain)
+		testPathToString(domain)
 	}
 
 	t.Run("invalid: unsupported domain", func(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -5146,6 +5146,38 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 	}
 }
 
+func TestPathToString(t *testing.T) {
+
+	t.Parallel()
+
+	tests := map[string]string{
+		"Path":           `/storage/a`,
+		"StoragePath":    `/storage/a`,
+		"PublicPath":     `/public/a`,
+		"PrivatePath":    `/private/a`,
+		"CapabilityPath": `/private/a`,
+	}
+
+	for ty, val := range tests {
+		t.Run(ty, func(t *testing.T) {
+			inter := parseCheckAndInterpret(t,
+				fmt.Sprintf(
+					`
+					  let x: %s = %s
+					  let y: String = x.toString()
+					`,
+					ty,
+					val,
+				))
+
+			assert.Equal(t,
+				interpreter.NewStringValue(val),
+				inter.Globals["y"].GetValue(),
+			)
+		})
+	}
+}
+
 func TestInterpretIndirectDestroy(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -5146,7 +5146,7 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 	}
 }
 
-func TestPathToString(t *testing.T) {
+func TestInterpretPathToString(t *testing.T) {
 
 	t.Parallel()
 


### PR DESCRIPTION
## Description

This PR adds a `toString()` function to Cadence `Path` types, and a golang test for that functionality.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
