### PR TITLE
Fix array function member type creation

### DIFF
--- a/runtime/interpreter/deferred_decoding_test.go
+++ b/runtime/interpreter/deferred_decoding_test.go
@@ -737,6 +737,28 @@ func TestArrayDeferredDecoding(t *testing.T) {
 			assert.Equal(t, expected, decodeFieldValue)
 		}
 	})
+
+	t.Run("Get function member", func(t *testing.T) {
+		t.Parallel()
+
+		array := newTestArrayValue(10)
+
+		encoded, _, err := EncodeValue(array, nil, true, nil)
+		require.NoError(t, err)
+
+		decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+		require.NoError(t, err)
+
+		require.IsType(t, &ArrayValue{}, decoded)
+		decodedArray := decoded.(*ArrayValue)
+
+		inter := newTestInterpreter(t)
+
+		// Static types are not built at this point
+		member := decodedArray.GetMember(inter, nil, "append")
+		assert.IsType(t, &HostFunctionValue{}, member)
+		assert.IsType(t, FunctionStaticType{}, member.StaticType())
+	})
 }
 
 func BenchmarkArrayDeferredDecoding(b *testing.B) {
@@ -1072,6 +1094,28 @@ func TestDictionaryDeferredDecoding(t *testing.T) {
 			assert.Equal(t, NewStringValue(fmt.Sprintf("value%d", i)), value)
 			i++
 		})
+	})
+
+	t.Run("Get function member", func(t *testing.T) {
+		t.Parallel()
+
+		dictionary := newTestDictionaryValue(t, 2)
+
+		encoded, _, err := EncodeValue(dictionary, nil, true, nil)
+		require.NoError(t, err)
+
+		decoded, err := DecodeValue(encoded, &testOwner, nil, CurrentEncodingVersion, nil)
+		require.NoError(t, err)
+
+		require.IsType(t, &DictionaryValue{}, decoded)
+		decodedDictionary := decoded.(*DictionaryValue)
+
+		inter := newTestInterpreter(t)
+
+		// Static types are not built at this point
+		member := decodedDictionary.GetMember(inter, nil, "remove")
+		assert.IsType(t, &HostFunctionValue{}, member)
+		assert.IsType(t, FunctionStaticType{}, member.StaticType())
 	})
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1012,7 +1012,11 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 				v.Append(inter, getLocationRange, invocation.Arguments[0])
 				return VoidValue{}
 			},
-			sema.ArrayAppendFunctionType(inter.ConvertStaticToSemaType(v.Type.ElementType())),
+			sema.ArrayAppendFunctionType(
+				inter.ConvertStaticToSemaType(
+					v.StaticType().(ArrayStaticType).ElementType(),
+				),
+			),
 		)
 
 	case "appendAll":
@@ -1022,7 +1026,7 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 				v.AppendAll(inter, getLocationRange, otherArray)
 				return VoidValue{}
 			},
-			sema.ArrayAppendAllFunctionType(inter.ConvertStaticToSemaType(v.Type)),
+			sema.ArrayAppendAllFunctionType(inter.ConvertStaticToSemaType(v.StaticType())),
 		)
 
 	case "concat":
@@ -1031,7 +1035,9 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 				otherArray := invocation.Arguments[0].(ConcatenatableValue)
 				return v.Concat(otherArray)
 			},
-			sema.ArrayConcatFunctionType(inter.ConvertStaticToSemaType(v.Type)),
+			sema.ArrayConcatFunctionType(
+				inter.ConvertStaticToSemaType(v.StaticType()),
+			),
 		)
 
 	case "insert":
@@ -1042,7 +1048,11 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 				v.Insert(inter, invocation.GetLocationRange, index, element)
 				return VoidValue{}
 			},
-			sema.ArrayInsertFunctionType(inter.ConvertStaticToSemaType(v.Type.ElementType())),
+			sema.ArrayInsertFunctionType(
+				inter.ConvertStaticToSemaType(
+					v.StaticType().(ArrayStaticType).ElementType(),
+				),
+			),
 		)
 
 	case "remove":
@@ -1051,7 +1061,11 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 				i := invocation.Arguments[0].(NumberValue).ToInt()
 				return v.Remove(i, invocation.GetLocationRange)
 			},
-			sema.ArrayRemoveFunctionType(inter.ConvertStaticToSemaType(v.Type.ElementType())),
+			sema.ArrayRemoveFunctionType(
+				inter.ConvertStaticToSemaType(
+					v.StaticType().(ArrayStaticType).ElementType(),
+				),
+			),
 		)
 
 	case "removeFirst":
@@ -1059,7 +1073,11 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 			func(invocation Invocation) Value {
 				return v.RemoveFirst(invocation.GetLocationRange)
 			},
-			sema.ArrayRemoveFirstFunctionType(inter.ConvertStaticToSemaType(v.Type.ElementType())),
+			sema.ArrayRemoveFirstFunctionType(
+				inter.ConvertStaticToSemaType(
+					v.StaticType().(ArrayStaticType).ElementType(),
+				),
+			),
 		)
 
 	case "removeLast":
@@ -1067,7 +1085,11 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 			func(invocation Invocation) Value {
 				return v.RemoveLast(invocation.GetLocationRange)
 			},
-			sema.ArrayRemoveLastFunctionType(inter.ConvertStaticToSemaType(v.Type.ElementType())),
+			sema.ArrayRemoveLastFunctionType(
+				inter.ConvertStaticToSemaType(
+					v.StaticType().(ArrayStaticType).ElementType(),
+				),
+			),
 		)
 
 	case "contains":
@@ -1075,7 +1097,11 @@ func (v *ArrayValue) GetMember(inter *Interpreter, getLocationRange func() Locat
 			func(invocation Invocation) Value {
 				return v.Contains(invocation.Arguments[0])
 			},
-			sema.ArrayContainsFunctionType(inter.ConvertStaticToSemaType(v.Type.ElementType())),
+			sema.ArrayContainsFunctionType(
+				inter.ConvertStaticToSemaType(
+					v.StaticType().(ArrayStaticType).ElementType(),
+				),
+			),
 		)
 
 	}


### PR DESCRIPTION
## Description

For deferred values, the static type may not have been built by the time the members are accessed. So, use `v.StaticType()` function which ensures the meta info is built.

The same is already handled properly for dictionaries and composites.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
