### PR TITLE
Infer RHS of nil-coalescing operator to have non-optional type of LHS

### DIFF
--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -147,7 +147,13 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 		// are not definite, but only potential.
 
 		rightType := checker.checkPotentiallyUnevaluated(func() Type {
-			return checker.VisitExpression(expression.Right, nil)
+			var expectedType Type
+			if !leftIsInvalid {
+				if optionalLeftType, ok := leftType.(*OptionalType); ok {
+					expectedType = optionalLeftType.Type
+				}
+			}
+			return checker.VisitExpressionWithForceType(expression.Right, expectedType, false)
 		})
 
 		rightIsInvalid := rightType.IsInvalidType()

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -521,3 +521,28 @@ func TestDictionaryMutation(t *testing.T) {
 		)
 	})
 }
+
+func TestInterpretContainerMutationAfterNilCoalescing(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      fun test(): String? {
+          let xs: {UInt32: String}? = nil
+          let ys: {UInt32: String} = xs ?? {}
+          ys[0] = "test"
+          return ys[0]
+      }
+    `)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		interpreter.NewSomeValueOwningNonCopying(
+			interpreter.NewStringValue("test"),
+		),
+		result,
+	)
+}


### PR DESCRIPTION
Closes #1153 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
