### PR TITLE
Fix move operator on empty resource collections

### DIFF
--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -25,7 +25,12 @@ import (
 
 func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) ast.Repr {
 
-	valueType := checker.VisitExpression(expression.Expression, nil)
+	var expectedType Type
+	if expression.Operation == ast.OperationMove {
+		expectedType = checker.expectedType
+	}
+
+	valueType := checker.VisitExpressionWithForceType(expression.Expression, expectedType, false)
 
 	reportInvalidUnaryOperator := func(expectedType Type) {
 		checker.report(

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -5002,3 +5002,50 @@ func TestCheckOptionalResourceBindingWithSecondValue(t *testing.T) {
     `)
 	require.NoError(t, err)
 }
+
+func TestCheckEmptyResourceCollectionMove(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("Dictionary", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {
+                init() {
+                }
+            }
+
+            fun foo() {
+               bar(a: <-{})
+            }
+
+            fun bar(a: @{String: R}) {
+                destroy a
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Array", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {
+                init() {
+                }
+            }
+
+            fun foo() {
+               bar(a: <-[])
+            }
+
+            fun bar(a: @[R]) {
+                destroy a
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description
```kotlin
resource R {
    init() {
    }
}

fun foo() {
    bar(a: <-{})  // error: invalid move operation for non-resource
}

fun bar(a: @{String: R}) {
    destroy a
}
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
