### PR TITLE
fix bad link in Cadence tutorial page 01

### DIFF
--- a/docs/tutorial/01-first-steps.mdx
+++ b/docs/tutorial/01-first-steps.mdx
@@ -18,7 +18,7 @@ Cadence introduces new features to smart contract programming that help develope
 - The utilization of capability-based security, which enforces access control by requiring that access to objects
   is restricted to only the owner and those who have a valid reference to the object
 
-Please see the [Cadence introduction](/cadence/index) for more information about the high level design of the language.
+Please see the [Cadence introduction](/cadence/) for more information about the high level design of the language.
 
 ## What is the Flow Developer Playground?
 


### PR DESCRIPTION
## Description

Cadence introduction link should point to /cadence/ instead of /cadence/index. Will make redirect change in onflow/flow repo soon

______

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
