### PR TITLE
Fix block ID static type

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2657,6 +2657,11 @@ func (r *interpreterRuntime) ReadLinked(address common.Address, path cadence.Pat
 	)
 }
 
+var BlockIDStaticType = interpreter.ConstantSizedStaticType{
+	Type: interpreter.PrimitiveStaticTypeUInt8,
+	Size: 32,
+}
+
 func NewBlockValue(block Block) interpreter.BlockValue {
 
 	// height
@@ -2671,7 +2676,7 @@ func NewBlockValue(block Block) interpreter.BlockValue {
 		values[i] = interpreter.UInt8Value(b)
 	}
 	idValue := interpreter.NewArrayValueUnownedNonCopying(
-		interpreter.ByteArrayStaticType,
+		BlockIDStaticType,
 		values...,
 	)
 


### PR DESCRIPTION
## Description

The static type for the array of the block ID was incorrect, leading to the run-time error:

```
error: invalid transfer of value: expected [UInt8; 32]
 --> 00:5:29
  |
5 |                     let id = block.id
  |                              ^^^^^^^^
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
