### PR TITLE
Reintroduce and fix stringAtreeValue

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -96,11 +96,11 @@ func (d Decoder) decodeStorable() (atree.Storable, error) {
 		storable = NilValue{}
 
 	case cbor.TextStringType:
-		str, err := d.decoder.DecodeString()
+		v, err := d.decoder.DecodeString()
 		if err != nil {
 			return nil, err
 		}
-		storable = NewStringValue(str)
+		storable = stringAtreeValue(v)
 
 	case cbor.TagType:
 		var num uint64

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -249,6 +249,12 @@ func (v *StringValue) Encode(e *atree.Encoder) error {
 	return e.CBOR.EncodeString(v.Str)
 }
 
+// Encode encodes the value as a CBOR string
+//
+func (v stringAtreeValue) Encode(e *atree.Encoder) error {
+	return e.CBOR.EncodeString(string(v))
+}
+
 // cborVoidValue represents the CBOR value:
 //
 // 	cbor.Tag{

--- a/runtime/interpreter/stringatreevalue.go
+++ b/runtime/interpreter/stringatreevalue.go
@@ -1,0 +1,62 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"github.com/onflow/atree"
+)
+
+type stringAtreeValue string
+
+var _ atree.Value = stringAtreeValue("")
+var _ atree.Storable = stringAtreeValue("")
+
+func (v stringAtreeValue) Storable(
+	storage atree.SlabStorage,
+	address atree.Address,
+	maxInlineSize uint64,
+) (
+	atree.Storable,
+	error,
+) {
+	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+}
+
+func (v stringAtreeValue) ByteSize() uint32 {
+	return getBytesCBORSize([]byte(v))
+}
+
+func (v stringAtreeValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
+	return v, nil
+}
+
+func stringAtreeHashInput(v atree.Value, _ []byte) ([]byte, error) {
+	return []byte(v.(stringAtreeValue)), nil
+}
+
+func stringAtreeComparator(storage atree.SlabStorage, value atree.Value, otherStorable atree.Storable) (bool, error) {
+	otherValue, err := otherStorable.StoredValue(storage)
+	if err != nil {
+		return false, err
+	}
+
+	result := value.(stringAtreeValue) == otherValue.(stringAtreeValue)
+
+	return result, nil
+}


### PR DESCRIPTION
Reverts and fixes 17eec97826e60b4d16b418d5e564346795cb3d0d, i.e. reintroduce `stringAtreeValue` as the `atree.Value` used for composite value field names (atree ordered map keys).

This restores the behaviour, so we do not need a migration for Testnet, and the PR also fixes the problem identified by @fxamacker earlier that the old `stringAtreeValue` code was not handling the case properly where the value's size exceeds the max inline limit, and storables where casted to `stringAtreeValue`, but may be `StorageIDStorable` in that case