### PR TITLE
Fix units on storageUsed and storageCapacity data members (bytes)

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -17,9 +17,9 @@ which represents the publicly available portion of an account.
       let balance: UFix64
       // The FLOW balance of the default vault of this account that is available to be moved
       let availableBalance: UFix64
-      // Amount of storage used by the account, in MB
+      // Amount of storage used by the account, in bytes
       let storageUsed: UInt64
-      // storage capacity of the account, in MB
+      // storage capacity of the account, in bytes
       let storageCapacity: UInt64
 
       // Contracts deployed to the account
@@ -75,9 +75,9 @@ to the `prepare` phase of the transaction.
       let balance: UFix64
       // The FLOW balance of the default vault of this account that is available to be moved
       let availableBalance: UFix64
-      // Amount of storage used by the account, in MB
+      // Amount of storage used by the account, in bytes
       let storageUsed: UInt64
-      // storage capacity of the account, in MB
+      // storage capacity of the account, in bytes
       let storageCapacity: UInt64
 
       // Contracts deployed to the account


### PR DESCRIPTION
Closes #1183 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR makes simple changes to some of the documentation around the `Accounts` language/API docs. It correctly fixes the units that are documented for the `storageUsed` and `storageCapacity` data members on the `PublicAccount` and `AuthAccount` struct.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
