### PR TITLE
Typos

### DIFF
--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -711,7 +711,7 @@ The first argument to the `link` function is the path where you want to store th
 and the `target` argument is the path to the object in storage that is to be linked to.
 We always store links for capabilities in the `/private/` or `/public/` domains:
 - We choose `/private/` if we only want to allow one or a small number of users to access it
-- We choose `/public/` if we want any user in the network to be able to access it
+- We choose `/public/` if we want any user in the network to be able to access it.
 Capabilities always link to objects in the `/storage/` domain.
 
 To borrow a reference to an object from the capability, we use the capability's `borrow` method.
@@ -859,7 +859,7 @@ The contract corresponding to that account will be displayed in the editor where
 
 <Img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-accounts.png" />
 
-Upgrading contrats that are already deployed is very risky, so be careful!
+Upgrading contracts that are already deployed is very risky, so be careful!
 
 ## Transactions
 


### PR DESCRIPTION
Fixed a couple of typos in hello world tutorial

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
