### PR TITLE
Clean up types in `cadence` package

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -695,7 +695,7 @@ func decodeFunctionType(returnValue, parametersValue, id interface{}) cadence.Ty
 	parameters := decodeParamTypes(toSlice(parametersValue))
 	returnType := decodeType(returnValue)
 
-	return cadence.Function{
+	return cadence.FunctionType{
 		Parameters: parameters,
 		ReturnType: returnType,
 	}.WithID(toString(id))

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -654,7 +654,6 @@ func prepareType(typ cadence.Type) jsonValue {
 	case cadence.AnyType,
 		cadence.AnyStructType,
 		cadence.AnyResourceType,
-		cadence.Variable,
 		cadence.MetaType,
 		cadence.VoidType,
 		cadence.NeverType,
@@ -775,7 +774,7 @@ func prepareType(typ cadence.Type) jsonValue {
 			Fields:       prepareFields(typ.Fields),
 			Initializers: prepareInitializers(typ.Initializers),
 		}
-	case cadence.Function:
+	case cadence.FunctionType:
 		return jsonFunctionType{
 			Kind:       "Function",
 			TypeID:     typ.ID(),

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -556,7 +556,7 @@ func prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cade
 	nonFunctionFieldTypes := make([]cadence.Field, 0)
 
 	for _, field := range fieldTypes {
-		if _, ok := field.Type.(cadence.Function); !ok {
+		if _, ok := field.Type.(cadence.FunctionType); !ok {
 			nonFunctionFieldTypes = append(nonFunctionFieldTypes, field)
 		}
 	}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1419,7 +1419,7 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.Function{
+				StaticType: cadence.FunctionType{
 					Parameters: []cadence.Parameter{
 						{Label: "qux", Identifier: "baz", Type: cadence.StringType{}},
 					},

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -350,7 +350,7 @@ func exportFunctionType(t *sema.FunctionType, results map[sema.TypeID]cadence.Ty
 
 	convertedReturnType := ExportType(t.ReturnTypeAnnotation.Type, results)
 
-	return cadence.Function{
+	return cadence.FunctionType{
 		Parameters: convertedParameters,
 		ReturnType: convertedReturnType,
 	}.WithID(string(t.ID()))

--- a/types.go
+++ b/types.go
@@ -781,18 +781,6 @@ func (t FunctionType) WithID(id string) FunctionType {
 	return t
 }
 
-// ResourcePointer
-
-type ResourcePointer struct {
-	TypeName string
-}
-
-func (ResourcePointer) isType() {}
-
-func (t ResourcePointer) ID() string {
-	return t.TypeName
-}
-
 // ReferenceType
 
 type ReferenceType struct {

--- a/types.go
+++ b/types.go
@@ -777,19 +777,19 @@ func (t *ContractInterfaceType) InterfaceInitializers() [][]Parameter {
 
 // Function
 
-type Function struct {
+type FunctionType struct {
 	typeID     string
 	Parameters []Parameter
 	ReturnType Type
 }
 
-func (t Function) isType() {}
+func (FunctionType) isType() {}
 
-func (t Function) ID() string {
+func (t FunctionType) ID() string {
 	return t.typeID
 }
 
-func (t Function) WithID(id string) Function {
+func (t FunctionType) WithID(id string) FunctionType {
 	t.typeID = id
 	return t
 }

--- a/types.go
+++ b/types.go
@@ -428,8 +428,8 @@ func (t VariableSizedArrayType) ID() string {
 	return fmt.Sprintf("[%s]", t.ElementType.ID())
 }
 
-func (v VariableSizedArrayType) Element() Type {
-	return v.ElementType
+func (t VariableSizedArrayType) Element() Type {
+	return t.ElementType
 }
 
 // ConstantSizedArrayType
@@ -445,8 +445,8 @@ func (t ConstantSizedArrayType) ID() string {
 	return fmt.Sprintf("[%s;%d]", t.ElementType.ID(), t.Size)
 }
 
-func (v ConstantSizedArrayType) Element() Type {
-	return v.ElementType
+func (t ConstantSizedArrayType) Element() Type {
+	return t.ElementType
 }
 
 // DictionaryType
@@ -901,7 +901,7 @@ type EnumType struct {
 	Initializers        [][]Parameter
 }
 
-func (t *EnumType) isType() {}
+func (*EnumType) isType() {}
 
 func (t *EnumType) ID() string {
 	if t.Location == nil {

--- a/types.go
+++ b/types.go
@@ -71,19 +71,6 @@ func (t OptionalType) ID() string {
 	return fmt.Sprintf("%s?", t.Type.ID())
 }
 
-// Variable
-
-type Variable struct {
-	Type Type
-}
-
-func (Variable) isType() {}
-
-// TODO:
-func (Variable) ID() string {
-	panic("not implemented")
-}
-
 // MetaType
 
 type MetaType struct{}


### PR DESCRIPTION
## Description

While reviewing #1202 I noticed some tech debt


- Fix naming: Rename `cadence.Function` to `cadence.FunctionType` to be consistent with the naming for other types in the package
- Remove unused `cadence.Variable` and `cadence.ResourcePointer`. I don't know why they were there
- Fix method receiver names 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
