### PR TITLE
Remove trailing comma in JSON cadence spec

### DIFF
--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -243,7 +243,7 @@ Dictionaries are encoded as a list of key-value pairs to preserve the determinis
       "value": {
         "type": "String",
         "value": "test"
-      },
+      }
     }
   ],
   // ...


### PR DESCRIPTION
Closes None

## Description

Remove trailing comma in JSON cadence spec

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
