### PR TITLE
Fix typo on marketplace design code sample

### DIFF
--- a/docs/tutorial/06-marketplace-compose.mdx
+++ b/docs/tutorial/06-marketplace-compose.mdx
@@ -91,7 +91,7 @@ pub fun main() {
   log(acct2ReceiverRef.balance)
 
   // verify that the balances are correct
-  if acct1ReceiverRef.balance != 40.0 || acct2ReceiverRef.balance != 40.0 {
+  if acct1ReceiverRef.balance != 40.0 || acct2ReceiverRef.balance != 20.0 {
       panic("Wrong balances!")
   }
 


### PR DESCRIPTION

## Description

There is a typo on marketplace sample documentation. Balance for the second account is not correct (it's working fine on the playground)
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
