### PR TITLE
Fix integer conversion

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1717,7 +1717,6 @@ func ConvertInt(value Value) IntValue {
 		return NewIntValueFromBigInt(value.ToBigInt())
 
 	case NumberValue:
-		// NOTE: safe, UInt64Value is handled by BigNumberValue above
 		return NewIntValueFromInt64(int64(value.ToInt()))
 
 	default:
@@ -1754,7 +1753,9 @@ func (IntValue) StaticType() StaticType {
 }
 
 func (v IntValue) ToInt() int {
-	// TODO: handle overflow
+	if !v.BigInt.IsInt64() {
+		panic(OverflowError{})
+	}
 	return int(v.BigInt.Int64())
 }
 
@@ -3410,7 +3411,9 @@ func (Int128Value) StaticType() StaticType {
 }
 
 func (v Int128Value) ToInt() int {
-	// TODO: handle overflow
+	if !v.BigInt.IsInt64() {
+		panic(OverflowError{})
+	}
 	return int(v.BigInt.Int64())
 }
 
@@ -3828,7 +3831,9 @@ func (Int256Value) StaticType() StaticType {
 }
 
 func (v Int256Value) ToInt() int {
-	// TODO: handle overflow
+	if !v.BigInt.IsInt64() {
+		panic(OverflowError{})
+	}
 	return int(v.BigInt.Int64())
 }
 
@@ -4267,7 +4272,9 @@ func (UIntValue) StaticType() StaticType {
 }
 
 func (v UIntValue) ToInt() int {
-	// TODO: handle overflow
+	if v.BigInt.IsInt64() {
+		panic(OverflowError{})
+	}
 	return int(v.BigInt.Int64())
 }
 
@@ -5358,6 +5365,13 @@ var _ EquatableValue = UInt64Value(0)
 var _ HashableValue = UInt64Value(0)
 var _ MemberAccessibleValue = UInt64Value(0)
 
+// NOTE: important, do *NOT* remove:
+// UInt64 values > math.MaxInt64 overflow int.
+// Implementing BigNumberValue ensures conversion functions
+// call ToBigInt instead of ToInt.
+//
+var _ BigNumberValue = UInt64Value(0)
+
 func (UInt64Value) IsValue() {}
 
 func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor) {
@@ -5387,7 +5401,21 @@ func (v UInt64Value) RecursiveString(_ SeenReferences) string {
 }
 
 func (v UInt64Value) ToInt() int {
+	if v > math.MaxInt64 {
+		panic(OverflowError{})
+	}
 	return int(v)
+}
+
+// ToBigInt
+//
+// NOTE: important, do *NOT* remove:
+// UInt64 values > math.MaxInt64 overflow int.
+// Implementing BigNumberValue ensures conversion functions
+// call ToBigInt instead of ToInt.
+//
+func (v UInt64Value) ToBigInt() *big.Int {
+	return new(big.Int).SetUint64(uint64(v))
 }
 
 func (v UInt64Value) Negate() NumberValue {
@@ -5672,7 +5700,9 @@ func (UInt128Value) StaticType() StaticType {
 }
 
 func (v UInt128Value) ToInt() int {
-	// TODO: handle overflow
+	if !v.BigInt.IsInt64() {
+		panic(OverflowError{})
+	}
 	return int(v.BigInt.Int64())
 }
 
@@ -6036,7 +6066,10 @@ func (UInt256Value) StaticType() StaticType {
 }
 
 func (v UInt256Value) ToInt() int {
-	// TODO: handle overflow
+	if !v.BigInt.IsInt64() {
+		panic(OverflowError{})
+	}
+
 	return int(v.BigInt.Int64())
 }
 
@@ -7043,6 +7076,13 @@ var _ EquatableValue = Word64Value(0)
 var _ HashableValue = Word64Value(0)
 var _ MemberAccessibleValue = Word64Value(0)
 
+// NOTE: important, do *NOT* remove:
+// Word64 values > math.MaxInt64 overflow int.
+// Implementing BigNumberValue ensures conversion functions
+// call ToBigInt instead of ToInt.
+//
+var _ BigNumberValue = Word64Value(0)
+
 func (Word64Value) IsValue() {}
 
 func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor) {
@@ -7072,7 +7112,21 @@ func (v Word64Value) RecursiveString(_ SeenReferences) string {
 }
 
 func (v Word64Value) ToInt() int {
+	if v > math.MaxInt64 {
+		panic(OverflowError{})
+	}
 	return int(v)
+}
+
+// ToBigInt
+//
+// NOTE: important, do *NOT* remove:
+// Word64 values > math.MaxInt64 overflow int.
+// Implementing BigNumberValue ensures conversion functions
+// call ToBigInt instead of ToInt.
+//
+func (v Word64Value) ToBigInt() *big.Int {
+	return new(big.Int).SetUint64(uint64(v))
 }
 
 func (v Word64Value) Negate() NumberValue {

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -471,7 +471,7 @@ func TestInterpretIntegerConversion(t *testing.T) {
 		inter := parseCheckAndInterpret(t,
 			fmt.Sprintf(
 				`
-				  fun test(value: %[1]s): %[2]s {
+                  fun test(value: %[1]s): %[2]s {
                       return %[2]s(value)
                   }
 				`,

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -21,8 +21,10 @@ package interpreter_test
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	. "github.com/onflow/cadence/runtime/tests/utils"
@@ -450,6 +452,224 @@ func TestInterpretIntegerLiteralTypeConversionInReturnOptional(t *testing.T) {
 				result,
 			)
 		})
+	}
+}
+
+func TestInterpretIntegerConversion(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(
+		t *testing.T,
+		sourceType sema.Type,
+		targetType sema.Type,
+		value interpreter.Value,
+		expectedValue interpreter.Value,
+		expectedError error,
+	) {
+
+		inter := parseCheckAndInterpret(t,
+			fmt.Sprintf(
+				`
+				  fun test(value: %[1]s): %[2]s {
+                      return %[2]s(value)
+                  }
+				`,
+				sourceType,
+				targetType,
+			),
+		)
+
+		result, err := inter.Invoke("test", value)
+
+		if expectedError != nil {
+			require.Error(t, err)
+			require.ErrorAs(t, err, &expectedError)
+		} else {
+			require.NoError(t, err)
+
+			if expectedValue != nil {
+				assert.Equal(t, expectedValue, result)
+			} else {
+				// Fall back to string comparison,
+				// as it is too much work to construct the expected value
+				assert.Equal(t, value.String(), result.String())
+			}
+		}
+	}
+
+	type values struct {
+		fortyTwo interpreter.Value
+		min      interpreter.Value
+		max      interpreter.Value
+	}
+
+	testValues := map[*sema.NumericType]values{
+		sema.IntType: {
+			fortyTwo: interpreter.NewIntValueFromInt64(42),
+			// Int does not actually have a minimum, but create a "large" value,
+			// which can be used for testing against other types
+			min: func() interpreter.Value {
+				i := big.NewInt(-1)
+				i.Lsh(i, 1000)
+				return interpreter.NewIntValueFromBigInt(i)
+			}(),
+			// Int does not actually have a maximum, but create a "large" value,
+			// which can be used for testing against other types
+			max: func() interpreter.Value {
+				i := big.NewInt(1)
+				i.Lsh(i, 1000)
+				return interpreter.NewIntValueFromBigInt(i)
+			}(),
+		},
+		sema.UIntType: {
+			fortyTwo: interpreter.NewUIntValueFromUint64(42),
+			min:      interpreter.NewUIntValueFromUint64(0),
+			// UInt does not actually have a maximum, but create a "large" value,
+			// which can be used for testing against other types
+			max: func() interpreter.Value {
+				i := big.NewInt(1)
+				i.Lsh(i, 1000)
+				return interpreter.NewUIntValueFromBigInt(i)
+			}(),
+		},
+		sema.UInt8Type: {
+			fortyTwo: interpreter.UInt8Value(42),
+			min:      interpreter.UInt8Value(0),
+			max:      interpreter.UInt8Value(math.MaxUint8),
+		},
+		sema.UInt16Type: {
+			fortyTwo: interpreter.UInt16Value(42),
+			min:      interpreter.UInt16Value(0),
+			max:      interpreter.UInt16Value(math.MaxUint16),
+		},
+		sema.UInt32Type: {
+			fortyTwo: interpreter.UInt32Value(42),
+			min:      interpreter.UInt32Value(0),
+			max:      interpreter.UInt32Value(math.MaxUint32),
+		},
+		sema.UInt64Type: {
+			fortyTwo: interpreter.UInt64Value(42),
+			min:      interpreter.UInt64Value(0),
+			max:      interpreter.UInt64Value(math.MaxUint64),
+		},
+		sema.UInt128Type: {
+			fortyTwo: interpreter.NewUInt128ValueFromUint64(42),
+			min:      interpreter.NewUInt128ValueFromUint64(0),
+			max:      interpreter.NewUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+		},
+		sema.UInt256Type: {
+			fortyTwo: interpreter.NewUInt256ValueFromUint64(42),
+			min:      interpreter.NewUInt256ValueFromUint64(0),
+			max:      interpreter.NewUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+		},
+		sema.Word8Type: {
+			fortyTwo: interpreter.Word8Value(42),
+			min:      interpreter.Word8Value(0),
+			max:      interpreter.Word8Value(math.MaxUint8),
+		},
+		sema.Word16Type: {
+			fortyTwo: interpreter.Word16Value(42),
+			min:      interpreter.Word16Value(0),
+			max:      interpreter.Word16Value(math.MaxUint16),
+		},
+		sema.Word32Type: {
+			fortyTwo: interpreter.Word32Value(42),
+			min:      interpreter.Word32Value(0),
+			max:      interpreter.Word32Value(math.MaxUint32),
+		},
+		sema.Word64Type: {
+			fortyTwo: interpreter.Word64Value(42),
+			min:      interpreter.Word64Value(0),
+			max:      interpreter.Word64Value(math.MaxUint64),
+		},
+		sema.Int8Type: {
+			fortyTwo: interpreter.Int8Value(42),
+			min:      interpreter.Int8Value(math.MinInt8),
+			max:      interpreter.Int8Value(math.MaxInt8),
+		},
+		sema.Int16Type: {
+			fortyTwo: interpreter.Int16Value(42),
+			min:      interpreter.Int16Value(math.MinInt16),
+			max:      interpreter.Int16Value(math.MaxInt16),
+		},
+		sema.Int32Type: {
+			fortyTwo: interpreter.Int32Value(42),
+			min:      interpreter.Int32Value(math.MinInt32),
+			max:      interpreter.Int32Value(math.MaxInt32),
+		},
+		sema.Int64Type: {
+			fortyTwo: interpreter.Int64Value(42),
+			min:      interpreter.Int64Value(math.MinInt64),
+			max:      interpreter.Int64Value(math.MaxInt64),
+		},
+		sema.Int128Type: {
+			fortyTwo: interpreter.NewInt128ValueFromInt64(42),
+			min:      interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+			max:      interpreter.NewInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+		},
+		sema.Int256Type: {
+			fortyTwo: interpreter.NewInt256ValueFromInt64(42),
+			min:      interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+			max:      interpreter.NewInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+		},
+	}
+
+	for _, ty := range sema.AllIntegerTypes {
+		// Only test leaf types
+		switch ty {
+		case sema.IntegerType, sema.SignedIntegerType:
+			continue
+		}
+
+		_, ok := testValues[ty.(*sema.NumericType)]
+		require.True(t, ok, "missing expected value for type %s", ty.String())
+	}
+
+	for sourceType, sourceValues := range testValues {
+		for targetType, targetValues := range testValues {
+
+			t.Run(fmt.Sprintf("%s to %s", sourceType, targetType), func(t *testing.T) {
+
+				// Check underflow is handled correctly
+
+				targetMinInt := targetType.MinInt()
+				sourceMinInt := sourceType.MinInt()
+
+				if targetMinInt != nil && (sourceMinInt == nil || sourceMinInt.Cmp(targetMinInt) < 0) {
+					t.Run("underflow", func(t *testing.T) {
+						test(t, sourceType, targetType, sourceValues.min, nil, interpreter.UnderflowError{})
+					})
+				}
+
+				// Check a "typical" value can be converted
+
+				t.Run("valid", func(t *testing.T) {
+					test(t, sourceType, targetType, sourceValues.fortyTwo, targetValues.fortyTwo, nil)
+				})
+
+				// Check overflow is handled correctly
+
+				targetMaxInt := targetType.MaxInt()
+				sourceMaxInt := sourceType.MaxInt()
+
+				if targetMaxInt != nil && (sourceMaxInt == nil || sourceMaxInt.Cmp(targetMaxInt) > 0) {
+					t.Run("overflow", func(t *testing.T) {
+						test(t, sourceType, targetType, sourceValues.max, nil, interpreter.OverflowError{})
+					})
+				}
+
+				// Check the maximum value can be converted.
+				// For example, this tests that BigNumberValue.ToBigInt() is used / correctly implemented,
+				// instead of NumberValue.ToInt(), for example in the case Int(UInt64.max)
+
+				if sourceMaxInt != nil && (targetMaxInt == nil || sourceMaxInt.Cmp(targetMaxInt) < 0) {
+					t.Run("max", func(t *testing.T) {
+						test(t, sourceType, targetType, sourceValues.max, nil, nil)
+					})
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1126 

## Description

- Fix conversion of integers > `math.MaxInt64`: 
  Implement `BigNumberValue` for `UInt64` and `Word64`
- Handle overflow/underflow when converting number values to `int` (in `ToInt()`)
- Add an extensive test case which performs number conversions between all integer types, for various values ("typical" value, overflowing, underflowing, and max value)

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
