### PR TITLE
doc(05-marketplace-setup.mdx): comment typo

### DIFF
--- a/docs/tutorial/05-marketplace-setup.mdx
+++ b/docs/tutorial/05-marketplace-setup.mdx
@@ -66,7 +66,7 @@ transaction {
   let minterRef: &NonFungibleToken.NFTMinter
 
   prepare(acct: AuthAccount) {
-    // create a new vault instance with an initial balance of 30
+    // create a new vault instance with an initial balance of 0
     let vaultA <- FungibleToken.createEmptyVault()
 
     // Store the vault in the account storage


### PR DESCRIPTION
## Description

I guess there is a typo in one of the comments of the setupAccount2Transaction.cdc code.

As we are calling createEmptyVault without any balance argument, I assume the comment should be: `creating a new vault instance with an initial value of 0`. Maybe I missed something...

I'm just nitpicking here, the cadence tutorial is awesome :heart_eyes: 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
