### PR TITLE
doc(06-marketplace-compose.mdx): update ownerVault access control keyword

### DIFF
--- a/docs/tutorial/06-marketplace-compose.mdx
+++ b/docs/tutorial/06-marketplace-compose.mdx
@@ -200,7 +200,7 @@ pub contract Marketplace {
     // The fungible token vault of the owner of this sale.
     // When someone buys a token, this resource can deposit
     // tokens into their account.
-    access(account) let ownerVault: Capability<&AnyResource{FungibleToken.Receiver}>
+    pub let ownerVault: Capability<&AnyResource{FungibleToken.Receiver}>
 
     init (vault: Capability<&AnyResource{FungibleToken.Receiver}>) {
         self.forSale <- {}


### PR DESCRIPTION
## Description

Hi there :wave:

This is the nitpicky one again.
I changed the access control keyword for the `ownerVault` from `access(account)` to `pub` in the `Marketplace.cdc` template.

Later in the documentation (L292), there is a reference to this same line but with the access keyword `pub`.

I chose to keep the `pub` keyword because I feel that the capability-based access control here is sufficient to safely expose the vault in the code (right?). On the other hand, I don't see the point of making the vault accessible at this level of access, we can just check the vault directly if needed (so `access(account)` is enought for the `purchase` function or further possible contracts to work with the vault ref).

What is the best practice? (sorry if it's not that important, but I think access control in smart contracts is something very important and I want to make sure I get everything correctly :sweat_smile: )

If we should to keep `access(account)`, I'll make the change on line 292.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
