### PR TITLE
Add container mutation tests for inserting functions into dictionaries

### DIFF
--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -238,7 +238,7 @@ func TestArrayMutation(t *testing.T) {
 
 		inter := parseCheckAndInterpret(t, `
             let names: [AnyStruct] = ["foo", "bar"] as [String]
-            
+
             fun test(): [AnyStruct] {
                 return names.concat(["baz", 5] as [AnyStruct])
             }
@@ -291,7 +291,7 @@ func TestArrayMutation(t *testing.T) {
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 	})
 
-	t.Run("host function array mutation", func(t *testing.T) {
+	t.Run("host function mutation", func(t *testing.T) {
 		t.Parallel()
 
 		invoked := false
@@ -317,8 +317,7 @@ func TestArrayMutation(t *testing.T) {
             fun test() {
                 let array: [AnyStruct] = [nil] as [((AnyStruct):Void)?]
 
-                let x = 5
-                array[0] =  log
+                array[0] = log
 
                 let logger = array[0] as! ((AnyStruct):Void)
                 logger("hello")
@@ -341,15 +340,15 @@ func TestArrayMutation(t *testing.T) {
 		assert.True(t, invoked)
 	})
 
-	t.Run("function array mutation", func(t *testing.T) {
+	t.Run("function mutation", func(t *testing.T) {
 		t.Parallel()
 
 		inter := parseCheckAndInterpret(t, `
             fun test(): [String] {
                 let array: [AnyStruct] = [nil, nil] as [(():String)?]
 
-                array[0] =  foo
-                array[1] =  bar
+                array[0] = foo
+                array[1] = bar
 
                 let callFoo = array[0] as! (():String)
                 let callBar = array[1] as! (():String)
@@ -384,7 +383,7 @@ func TestArrayMutation(t *testing.T) {
 		)
 	})
 
-	t.Run("bound function array mutation", func(t *testing.T) {
+	t.Run("bound function mutation", func(t *testing.T) {
 		t.Parallel()
 
 		inter := parseCheckAndInterpret(t, `
@@ -406,8 +405,8 @@ func TestArrayMutation(t *testing.T) {
                 let a = Foo()
                 let b = Bar()
 
-                array[0] =  a.foo
-                array[1] =  b.bar
+                array[0] = a.foo
+                array[1] = b.bar
 
                 let callFoo = array[0] as! (():String)
                 let callBar = array[1] as! (():String)
@@ -435,7 +434,7 @@ func TestArrayMutation(t *testing.T) {
 		)
 	})
 
-	t.Run("invalid function array mutation", func(t *testing.T) {
+	t.Run("invalid function mutation", func(t *testing.T) {
 		t.Parallel()
 
 		standardLibraryFunctions :=
@@ -450,8 +449,7 @@ func TestArrayMutation(t *testing.T) {
                 fun test() {
                     let array: [AnyStruct] = [nil] as [(():Void)?]
 
-                    let x = 5
-                    array[0] =  log
+                    array[0] = log
                 }
             `,
 			ParseCheckAndInterpretOptions{
@@ -649,6 +647,221 @@ func TestDictionaryMutation(t *testing.T) {
 			},
 			mutationError.ExpectedType,
 		)
+	})
+
+	t.Run("host function mutation", func(t *testing.T) {
+
+		t.Parallel()
+
+		invoked := false
+
+		standardLibraryFunctions :=
+			stdlib.StandardLibraryFunctions{
+				stdlib.NewStandardLibraryFunction(
+					"log",
+					stdlib.LogFunctionType,
+					"",
+					func(invocation interpreter.Invocation) interpreter.Value {
+						invoked = true
+						assert.Equal(t, "\"hello\"", invocation.Arguments[0].String())
+						return interpreter.VoidValue{}
+					},
+				),
+			}
+
+		valueDeclarations := standardLibraryFunctions.ToSemaValueDeclarations()
+		values := standardLibraryFunctions.ToInterpreterValueDeclarations()
+
+		inter, err := parseCheckAndInterpretWithOptions(t, `
+            fun test() {
+                let dict: {String: AnyStruct} = {}
+
+                dict["test"] = log
+
+                let logger = dict["test"]! as! ((AnyStruct): Void)
+                logger("hello")
+            }`,
+			ParseCheckAndInterpretOptions{
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(valueDeclarations),
+				},
+				Options: []interpreter.Option{
+					interpreter.WithPredeclaredValues(values),
+				},
+			},
+		)
+
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+
+		assert.True(t, invoked)
+	})
+
+	t.Run("function mutation", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+	       fun test(): [String] {
+	           let dict: {String: AnyStruct} = {}
+
+	           dict["foo"] = foo
+	           dict["bar"] = bar
+
+	           let callFoo = dict["foo"]! as! (():String)
+	           let callBar = dict["bar"]! as! (():String)
+	           return [callFoo(), callBar()]
+	       }
+
+	       fun foo(): String {
+	           return "hello from foo"
+	       }
+
+	       fun bar(): String {
+	           return "hello from bar"
+	       }
+	   `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		require.IsType(t, &interpreter.ArrayValue{}, value)
+		array := value.(*interpreter.ArrayValue)
+
+		require.Equal(t, 2, array.Count())
+		assert.Equal(
+			t,
+			interpreter.NewStringValue("hello from foo"),
+			array.Get(inter, interpreter.ReturnEmptyLocationRange, 0),
+		)
+		assert.Equal(
+			t,
+			interpreter.NewStringValue("hello from bar"),
+			array.Get(inter, interpreter.ReturnEmptyLocationRange, 1),
+		)
+	})
+
+	t.Run("bound function mutation", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+	       struct Foo {
+	           fun foo(): String {
+	               return "hello from foo"
+	           }
+	       }
+
+	       struct Bar {
+	           fun bar(): String {
+	               return "hello from bar"
+	           }
+	       }
+
+	       fun test(): [String] {
+	           let dict: {String: AnyStruct} = {}
+
+	           let a = Foo()
+	           let b = Bar()
+
+	           dict["foo"] = a.foo
+	           dict["bar"] = b.bar
+
+	           let callFoo = dict["foo"]! as! (():String)
+	           let callBar = dict["bar"]! as! (():String)
+
+	           return [callFoo(), callBar()]
+	       }
+	   `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		require.IsType(t, &interpreter.ArrayValue{}, value)
+		array := value.(*interpreter.ArrayValue)
+
+		require.Equal(t, 2, array.Count())
+		assert.Equal(
+			t,
+			interpreter.NewStringValue("hello from foo"),
+			array.Get(inter, interpreter.ReturnEmptyLocationRange, 0),
+		)
+		assert.Equal(
+			t,
+			interpreter.NewStringValue("hello from bar"),
+			array.Get(inter, interpreter.ReturnEmptyLocationRange, 1),
+		)
+	})
+
+	t.Run("invalid function mutation", func(t *testing.T) {
+		t.Parallel()
+
+		standardLibraryFunctions :=
+			stdlib.StandardLibraryFunctions{
+				stdlib.LogFunction,
+			}
+
+		valueDeclarations := standardLibraryFunctions.ToSemaValueDeclarations()
+		values := standardLibraryFunctions.ToInterpreterValueDeclarations()
+
+		inter, err := parseCheckAndInterpretWithOptions(t, `
+	           fun test() {
+	               let dict: {String: AnyStruct} = {} as {String: (():Void)}
+
+	               dict["log"] = log
+	           }
+	       `,
+			ParseCheckAndInterpretOptions{
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(valueDeclarations),
+				},
+				Options: []interpreter.Option{
+					interpreter.WithPredeclaredValues(values),
+				},
+			},
+		)
+
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+
+		mutationError := &interpreter.ContainerMutationError{}
+		require.ErrorAs(t, err, mutationError)
+
+		require.IsType(t, &sema.OptionalType{}, mutationError.ExpectedType)
+		optionalType := mutationError.ExpectedType.(*sema.OptionalType)
+
+		require.IsType(t, &sema.FunctionType{}, optionalType.Type)
+		funcType := optionalType.Type.(*sema.FunctionType)
+
+		assert.Equal(t, sema.VoidType, funcType.ReturnTypeAnnotation.Type)
+		assert.Nil(t, funcType.ReceiverType)
+		assert.Empty(t, funcType.Parameters)
+	})
+
+	t.Run("valid function mutation", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            struct S {}
+
+	        fun test(owner: PublicAccount) {
+	            let funcs: {String: ((PublicAccount, [UInt64]): [S])} = {}
+
+                funcs["test"] = fun (owner: PublicAccount, ids: [UInt64]): [S] { return [] }
+
+	            funcs["test"]!(owner: owner, ids: [1])
+	        }
+	    `)
+
+		owner := newTestPublicAccountValue(
+			interpreter.NewAddressValue(common.Address{0x1}),
+		)
+
+		_, err := inter.Invoke("test", owner)
+		require.NoError(t, err)
+
 	})
 }
 

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -703,25 +703,25 @@ func TestDictionaryMutation(t *testing.T) {
 		t.Parallel()
 
 		inter := parseCheckAndInterpret(t, `
-	       fun test(): [String] {
-	           let dict: {String: AnyStruct} = {}
+           fun test(): [String] {
+               let dict: {String: AnyStruct} = {}
 
-	           dict["foo"] = foo
-	           dict["bar"] = bar
+               dict["foo"] = foo
+               dict["bar"] = bar
 
-	           let callFoo = dict["foo"]! as! (():String)
-	           let callBar = dict["bar"]! as! (():String)
-	           return [callFoo(), callBar()]
-	       }
+               let callFoo = dict["foo"]! as! (():String)
+               let callBar = dict["bar"]! as! (():String)
+               return [callFoo(), callBar()]
+           }
 
-	       fun foo(): String {
-	           return "hello from foo"
-	       }
+           fun foo(): String {
+               return "hello from foo"
+           }
 
-	       fun bar(): String {
-	           return "hello from bar"
-	       }
-	   `)
+           fun bar(): String {
+               return "hello from bar"
+           }
+       `)
 
 		value, err := inter.Invoke("test")
 		require.NoError(t, err)
@@ -746,33 +746,33 @@ func TestDictionaryMutation(t *testing.T) {
 		t.Parallel()
 
 		inter := parseCheckAndInterpret(t, `
-	       struct Foo {
-	           fun foo(): String {
-	               return "hello from foo"
-	           }
-	       }
+           struct Foo {
+               fun foo(): String {
+                   return "hello from foo"
+               }
+           }
 
-	       struct Bar {
-	           fun bar(): String {
-	               return "hello from bar"
-	           }
-	       }
+           struct Bar {
+               fun bar(): String {
+                   return "hello from bar"
+               }
+           }
 
-	       fun test(): [String] {
-	           let dict: {String: AnyStruct} = {}
+           fun test(): [String] {
+               let dict: {String: AnyStruct} = {}
 
-	           let a = Foo()
-	           let b = Bar()
+               let a = Foo()
+               let b = Bar()
 
-	           dict["foo"] = a.foo
-	           dict["bar"] = b.bar
+               dict["foo"] = a.foo
+               dict["bar"] = b.bar
 
-	           let callFoo = dict["foo"]! as! (():String)
-	           let callBar = dict["bar"]! as! (():String)
+               let callFoo = dict["foo"]! as! (():String)
+               let callBar = dict["bar"]! as! (():String)
 
-	           return [callFoo(), callBar()]
-	       }
-	   `)
+               return [callFoo(), callBar()]
+           }
+       `)
 
 		value, err := inter.Invoke("test")
 		require.NoError(t, err)
@@ -805,12 +805,12 @@ func TestDictionaryMutation(t *testing.T) {
 		values := standardLibraryFunctions.ToInterpreterValueDeclarations()
 
 		inter, err := parseCheckAndInterpretWithOptions(t, `
-	           fun test() {
-	               let dict: {String: AnyStruct} = {} as {String: (():Void)}
+               fun test() {
+                   let dict: {String: AnyStruct} = {} as {String: (():Void)}
 
-	               dict["log"] = log
-	           }
-	       `,
+                   dict["log"] = log
+               }
+           `,
 			ParseCheckAndInterpretOptions{
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(valueDeclarations),
@@ -846,14 +846,14 @@ func TestDictionaryMutation(t *testing.T) {
 		inter := parseCheckAndInterpret(t, `
             struct S {}
 
-	        fun test(owner: PublicAccount) {
-	            let funcs: {String: ((PublicAccount, [UInt64]): [S])} = {}
+            fun test(owner: PublicAccount) {
+                let funcs: {String: ((PublicAccount, [UInt64]): [S])} = {}
 
                 funcs["test"] = fun (owner: PublicAccount, ids: [UInt64]): [S] { return [] }
 
-	            funcs["test"]!(owner: owner, ids: [1])
-	        }
-	    `)
+                funcs["test"]!(owner: owner, ids: [1])
+            }
+        `)
 
 		owner := newTestPublicAccountValue(
 			interpreter.NewAddressValue(common.Address{0x1}),


### PR DESCRIPTION


## Description

Just like for arrays, check the insertion of various kinds of functions into dictionaries.

This was triggered by a report from @sideninja that insertion of functions into dictionaries is not working on Mainnet.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
