### PR TITLE
Add new syntax to bind for-in loop indices 

### DIFF
--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -306,9 +306,11 @@ for element in array {
 // "Bar"
 ```
 
-Optionally, developers may include an additional variable preceding the 
-element name, separated by a comma. When present, this variable contains the current
-index of the array being iterated through during each repeated execution (starting from 0).
+Optionally, developers may include an additional variable preceding the element name, 
+separated by a comma. 
+When present, this variable contains the current
+index of the array being iterated through 
+during each repeated execution (starting from 0).
 
 ```cadence
 let array = ["Hello", "World", "Foo", "Bar"]

--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -306,6 +306,24 @@ for element in array {
 // "Bar"
 ```
 
+Optionally, developers may include an additional variable preceding the 
+element name, separated by a comma. When present, this variable contains the current
+index of the array being iterated through during each repeated execution (starting from 0).
+
+```cadence
+let array = ["Hello", "World", "Foo", "Bar"]
+
+for index, element in array {
+    log(index)
+}
+
+// The loop would log:
+// 0
+// 1
+// 2
+// 3
+```
+
 To iterate over a dictionary's entries (keys and values), 
 use a for-in loop over the dictionary's keys and get the value for each key:
 

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -209,6 +209,7 @@ func (s *WhileStatement) MarshalJSON() ([]byte, error) {
 
 type ForStatement struct {
 	Identifier Identifier
+	Index      *Identifier
 	Value      Expression
 	Block      *Block
 	StartPos   Position `json:"-"`

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -301,6 +301,7 @@ func TestForStatement_MarshalJSON(t *testing.T) {
                 "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
                 "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
             },
+			"Index": null,
             "Value": {
                 "Type": "BoolExpression",
                 "Value": false,

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -288,11 +288,13 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 	}
 
 	var indexVariable *Variable
-	var one = NewIntValueFromInt64(1)
+	var index int64
+	var indexValue IntValue
 	if statement.Index != nil {
+		indexValue = NewIntValueFromInt64(0)
 		indexVariable = interpreter.declareVariable(
 			statement.Index.Identifier,
-			NewIntValueFromInt64(0),
+			indexValue,
 		)
 	}
 
@@ -329,7 +331,8 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 		}
 
 		if indexVariable != nil {
-			indexVariable.SetValue(indexVariable.GetValue().(IntValue).Plus(one))
+			index++
+			indexValue.BigInt.SetInt64(index)
 		}
 	}
 }

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -287,6 +287,15 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 		panic(ExternalError{err})
 	}
 
+	var indexVariable *Variable
+	var one = NewIntValueFromInt64(1)
+	if statement.Index != nil {
+		indexVariable = interpreter.declareVariable(
+			statement.Index.Identifier,
+			NewIntValueFromInt64(0),
+		)
+	}
+
 	for {
 		var atreeValue atree.Value
 		atreeValue, err = iterator.Next()
@@ -317,6 +326,10 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 
 		case functionReturn:
 			return result
+		}
+
+		if indexVariable != nil {
+			indexVariable.SetValue(indexVariable.GetValue().(IntValue).Plus(one))
 		}
 	}
 }

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -288,13 +288,11 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 	}
 
 	var indexVariable *Variable
-	var index int64
-	var indexValue IntValue
+	var one = NewIntValueFromInt64(1)
 	if statement.Index != nil {
-		indexValue = NewIntValueFromInt64(0)
 		indexVariable = interpreter.declareVariable(
 			statement.Index.Identifier,
-			indexValue,
+			NewIntValueFromInt64(0),
 		)
 	}
 
@@ -331,8 +329,7 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 		}
 
 		if indexVariable != nil {
-			index++
-			indexValue.BigInt.SetInt64(index)
+			indexVariable.SetValue(indexVariable.GetValue().(IntValue).Plus(one))
 		}
 	}
 }

--- a/runtime/parser2/statement.go
+++ b/runtime/parser2/statement.go
@@ -344,9 +344,22 @@ func parseForStatement(p *parser) *ast.ForStatement {
 
 	p.skipSpaceAndComments(true)
 
-	identifier := mustIdentifier(p)
+	firstValue := mustIdentifier(p)
 
 	p.skipSpaceAndComments(true)
+
+	var index *ast.Identifier
+	var identifier ast.Identifier
+
+	if p.current.Is(lexer.TokenComma) {
+		p.mustOne(lexer.TokenComma)
+		p.skipSpaceAndComments(true)
+		index = &firstValue
+		identifier = mustIdentifier(p)
+		p.skipSpaceAndComments(true)
+	} else {
+		identifier = firstValue
+	}
 
 	if !p.current.IsString(lexer.TokenIdentifier, keywordIn) {
 		p.report(fmt.Errorf(
@@ -364,6 +377,7 @@ func parseForStatement(p *parser) *ast.ForStatement {
 
 	return &ast.ForStatement{
 		Identifier: identifier,
+		Index:      index,
 		Block:      block,
 		Value:      expression,
 		StartPos:   startPos,

--- a/runtime/parser2/statement.go
+++ b/runtime/parser2/statement.go
@@ -344,6 +344,14 @@ func parseForStatement(p *parser) *ast.ForStatement {
 
 	p.skipSpaceAndComments(true)
 
+	if p.current.IsString(lexer.TokenIdentifier, keywordIn) {
+		p.report(fmt.Errorf(
+			"expected identifier, got keyword %q",
+			keywordIn,
+		))
+		p.next()
+	}
+
 	firstValue := mustIdentifier(p)
 
 	p.skipSpaceAndComments(true)
@@ -352,7 +360,7 @@ func parseForStatement(p *parser) *ast.ForStatement {
 	var identifier ast.Identifier
 
 	if p.current.Is(lexer.TokenComma) {
-		p.mustOne(lexer.TokenComma)
+		p.next()
 		p.skipSpaceAndComments(true)
 		index = &firstValue
 		identifier = mustIdentifier(p)

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -807,6 +807,49 @@ func TestParseForStatement(t *testing.T) {
 	})
 }
 
+func TestParseForStatementIndexBinding(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty block", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseStatements("for i, x in y { }")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Statement{
+				&ast.ForStatement{
+					Identifier: ast.Identifier{
+						Identifier: "x",
+						Pos:        ast.Position{Line: 1, Column: 7, Offset: 7},
+					},
+					Index: &ast.Identifier{
+						Identifier: "i",
+						Pos:        ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+					Value: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "y",
+							Pos:        ast.Position{Line: 1, Column: 12, Offset: 12},
+						},
+					},
+					Block: &ast.Block{
+						Statements: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
+							EndPos:   ast.Position{Line: 1, Column: 16, Offset: 16},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+				},
+			},
+			result,
+		)
+	})
+}
+
 func TestParseEmit(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/parser2/statement_test.go
+++ b/runtime/parser2/statement_test.go
@@ -848,6 +848,46 @@ func TestParseForStatementIndexBinding(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("no comma", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseStatements("for i x in y { }")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected keyword \"in\", got identifier",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
+				&SyntaxError{
+					Message: "expected token '{'",
+					Pos:     ast.Position{Offset: 11, Line: 1, Column: 11},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("no identifiers", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseStatements("for in y { }")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected identifier, got keyword \"in\"",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
+				&SyntaxError{
+					Message: "expected token identifier",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseEmit(t *testing.T) {

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -75,6 +75,23 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr 
 		checker.recordVariableDeclarationOccurrence(identifier, variable)
 	}
 
+	if statement.Index != nil {
+		index := statement.Index.Identifier
+		indexVariable, err := checker.valueActivations.Declare(variableDeclaration{
+			identifier:               index,
+			ty:                       IntType,
+			kind:                     common.DeclarationKindConstant,
+			pos:                      statement.Index.Pos,
+			isConstant:               true,
+			argumentLabels:           nil,
+			allowOuterScopeShadowing: false,
+		})
+		checker.report(err)
+		if checker.positionInfoEnabled {
+			checker.recordVariableDeclarationOccurrence(index, indexVariable)
+		}
+	}
+
 	// The body of the loop will maybe be evaluated.
 	// That means that resource invalidations and
 	// returns are not definite, but only potential.

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -162,7 +162,8 @@ func TestCheckForIndexBindingTypeErr(t *testing.T) {
        }
     `)
 
-	assert.Error(t, err)
+	errs := ExpectCheckerErrors(t, err, 1)
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 }
 
 func TestCheckForIndexBindingReferenceErr(t *testing.T) {
@@ -177,8 +178,8 @@ func TestCheckForIndexBindingReferenceErr(t *testing.T) {
            let y = index
        }
     `)
-
-	assert.Error(t, err)
+	errs := ExpectCheckerErrors(t, err, 1)
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 }
 
 func TestCheckInvalidForBreakStatement(t *testing.T) {

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -135,6 +135,25 @@ func TestCheckForBreakStatement(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+/*func TestCheckForIndexBinding(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+       fun test() {
+           for index, x in [1, 2, 3] {
+
+           }
+       }
+    `)
+
+	assert.NoError(t, err)
+	assert.Equal(t,
+		sema.IntType,
+		RequireGlobalValue(t, checker.Elaboration, "index"),
+	)
+}*/
+
 func TestCheckInvalidForBreakStatement(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -150,7 +150,7 @@ func TestCheckForIndexBinding(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCheckForIndexBindingErr(t *testing.T) {
+func TestCheckForIndexBindingTypeErr(t *testing.T) {
 
 	t.Parallel()
 
@@ -159,6 +159,22 @@ func TestCheckForIndexBindingErr(t *testing.T) {
            for index, x in ["", "", ""] {
                 let y: String = index
            }
+       }
+    `)
+
+	assert.Error(t, err)
+}
+
+func TestCheckForIndexBindingReferenceErr(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+       fun test() {
+           for index, x in ["", "", ""] {
+                
+           }
+           let y = index
        }
     `)
 

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -135,24 +135,35 @@ func TestCheckForBreakStatement(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-/*func TestCheckForIndexBinding(t *testing.T) {
+func TestCheckForIndexBinding(t *testing.T) {
 
 	t.Parallel()
 
-	checker, err := ParseAndCheck(t, `
+	_, err := ParseAndCheck(t, `
        fun test() {
-           for index, x in [1, 2, 3] {
-
+           for index, x in ["", "", ""] {
+                let y: Int = index
            }
        }
     `)
 
 	assert.NoError(t, err)
-	assert.Equal(t,
-		sema.IntType,
-		RequireGlobalValue(t, checker.Elaboration, "index"),
-	)
-}*/
+}
+
+func TestCheckForIndexBindingErr(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+       fun test() {
+           for index, x in ["", "", ""] {
+                let y: String = index
+           }
+       }
+    `)
+
+	assert.Error(t, err)
+}
 
 func TestCheckInvalidForBreakStatement(t *testing.T) {
 

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -78,6 +78,35 @@ func TestInterpretForStatementWithIndex(t *testing.T) {
 	)
 }
 
+func TestInterpretForStatementWithStoredIndex(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+       fun test(): Int {
+           let arr: [Int] = []
+           for x, y in [1, 2, 3, 4] {
+               arr.append(x)
+           }
+           var sum = 0
+           for z in arr {
+              sum = sum + z
+           }
+           return sum
+       }
+    `)
+
+	value, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	AssertValuesEqual(
+		t,
+		inter,
+		interpreter.NewIntValueFromInt64(6),
+		value,
+	)
+}
+
 func TestInterpretForStatementWithReturn(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -53,6 +53,31 @@ func TestInterpretForStatement(t *testing.T) {
 	)
 }
 
+func TestInterpretForStatementWithIndex(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+       fun test(): Int {
+           var sum = 0
+           for x, y in [1, 2, 3, 4] {
+               sum = sum + x
+           }
+           return sum
+       }
+    `)
+
+	value, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	AssertValuesEqual(
+		t,
+		inter,
+		interpreter.NewIntValueFromInt64(6),
+		value,
+	)
+}
+
 func TestInterpretForStatementWithReturn(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #402

## Description

This adds a new piece of syntax to for loops to the language to allow users to bind the index into the array being iterated over.

```
for x, y in array {
}
```

This introduces two variables `x` and `y` into the scope of the loop body; `y` is the element variable as in a normal for-in loop, while `x` is of type `int`, is initialized to 0 and is incremented by one at the end of each iteration of the loop, effectively tracking the index of the array being looped over. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
