### PR TITLE
add missing types and conversion functions to cadence package

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -929,13 +929,13 @@ func decodeType(valueJSON interface{}) cadence.Type {
 		return cadence.AuthAccountType{}
 	case "PublicAccount":
 		return cadence.PublicAccountType{}
-	case "AuthAccountKeys":
+	case "AuthAccount.Keys":
 		return cadence.AuthAccountKeysType{}
-	case "PublicAccountKeys":
+	case "PublicAccount.Keys":
 		return cadence.PublicAccountKeysType{}
-	case "AuthAccountContracts":
+	case "AuthAccount.Contracts":
 		return cadence.AuthAccountContractsType{}
-	case "PublicAccountContracts":
+	case "PublicAccount.Contracts":
 		return cadence.PublicAccountContractsType{}
 	case "DeployedContract":
 		return cadence.DeployedContractType{}

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -777,7 +777,7 @@ func decodeNominalType(obj jsonObject, kind, typeID string, fs, initializers []i
 	panic(ErrInvalidJSONCadence)
 }
 
-func decodeRestricedType(
+func decodeRestrictedType(
 	typeValue interface{},
 	restrictionsValue []interface{},
 	typeIDValue string,
@@ -811,7 +811,7 @@ func decodeType(valueJSON interface{}) cadence.Type {
 		restrictionsValue := obj.Get(restrictionsKey)
 		typeIDValue := toString(obj.Get(typeIDKey))
 		typeValue := obj.Get(typeKey)
-		return decodeRestricedType(typeValue, toSlice(restrictionsValue), typeIDValue)
+		return decodeRestrictedType(typeValue, toSlice(restrictionsValue), typeIDValue)
 	case "Optional":
 		return cadence.OptionalType{
 			Type: decodeType(obj.Get(typeKey)),
@@ -925,6 +925,22 @@ func decodeType(valueJSON interface{}) cadence.Type {
 		return cadence.PublicPathType{}
 	case "PrivatePath":
 		return cadence.PrivatePathType{}
+	case "AuthAccount":
+		return cadence.AuthAccountType{}
+	case "PublicAccount":
+		return cadence.PublicAccountType{}
+	case "AuthAccountKeys":
+		return cadence.AuthAccountKeysType{}
+	case "PublicAccountKeys":
+		return cadence.PublicAccountKeysType{}
+	case "AuthAccountContracts":
+		return cadence.AuthAccountContractsType{}
+	case "PublicAccountContracts":
+		return cadence.PublicAccountContractsType{}
+	case "DeployedContract":
+		return cadence.DeployedContractType{}
+	case "AccountKey":
+		return cadence.AccountKeyType{}
 	default:
 		fieldsValue := obj.Get(fieldsKey)
 		typeIDValue := toString(obj.Get(typeIDKey))

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -692,7 +692,15 @@ func prepareType(typ cadence.Type) jsonValue {
 		cadence.CapabilityPathType,
 		cadence.StoragePathType,
 		cadence.PublicPathType,
-		cadence.PrivatePathType:
+		cadence.PrivatePathType,
+		cadence.AccountKeyType,
+		cadence.AuthAccountContractsType,
+		cadence.AuthAccountKeysType,
+		cadence.AuthAccountType,
+		cadence.PublicAccountContractsType,
+		cadence.PublicAccountKeysType,
+		cadence.PublicAccountType,
+		cadence.DeployedContractType:
 		return jsonSimpleType{
 			Kind: typ.ID(),
 		}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1047,6 +1047,14 @@ func TestEncodeSimpleTypes(t *testing.T) {
 		cadence.StoragePathType{},
 		cadence.PublicPathType{},
 		cadence.PrivatePathType{},
+		cadence.AccountKeyType{},
+		cadence.AuthAccountContractsType{},
+		cadence.AuthAccountKeysType{},
+		cadence.AuthAccountType{},
+		cadence.PublicAccountContractsType{},
+		cadence.PublicAccountKeysType{},
+		cadence.PublicAccountType{},
+		cadence.DeployedContractType{},
 	}
 
 	for _, test := range tests {

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -150,6 +150,22 @@ func ExportType(t sema.Type, results map[sema.TypeID]cadence.Type) cadence.Type 
 			return cadence.BlockType{}
 		case sema.StringType:
 			return cadence.StringType{}
+		case sema.AccountKeyType:
+			return cadence.AccountKeyType{}
+		case sema.PublicAccountContractsType:
+			return cadence.PublicAccountContractsType{}
+		case sema.AuthAccountContractsType:
+			return cadence.AuthAccountContractsType{}
+		case sema.PublicAccountKeysType:
+			return cadence.PublicAccountKeysType{}
+		case sema.AuthAccountKeysType:
+			return cadence.AuthAccountKeysType{}
+		case sema.PublicAccountType:
+			return cadence.PublicAccountType{}
+		case sema.AuthAccountType:
+			return cadence.AuthAccountType{}
+		case sema.DeployedContractType:
+			return cadence.DeployedContractType{}
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))
@@ -541,6 +557,23 @@ func ImportType(t cadence.Type) interpreter.StaticType {
 		return interpreter.CapabilityStaticType{
 			BorrowType: ImportType(t.BorrowType),
 		}
+	case cadence.AccountKeyType:
+		return interpreter.PrimitiveStaticTypeAccountKey
+	case cadence.AuthAccountContractsType:
+		return interpreter.PrimitiveStaticTypeAuthAccountContracts
+	case cadence.AuthAccountKeysType:
+		return interpreter.PrimitiveStaticTypeAuthAccountKeys
+	case cadence.AuthAccountType:
+		return interpreter.PrimitiveStaticTypeAuthAccount
+	case cadence.PublicAccountContractsType:
+		return interpreter.PrimitiveStaticTypePublicAccountContracts
+	case cadence.PublicAccountKeysType:
+		return interpreter.PrimitiveStaticTypePublicAccountKeys
+	case cadence.PublicAccountType:
+		return interpreter.PrimitiveStaticTypePublicAccount
+	case cadence.DeployedContractType:
+		return interpreter.PrimitiveStaticTypeDeployedContract
+	default:
+		panic(fmt.Sprintf("cannot export type of type %T", t))
 	}
-	panic(fmt.Sprintf("cannot export type of type %T", t))
 }

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -975,6 +975,46 @@ func TestImportRuntimeType(t *testing.T) {
 			expected: interpreter.PrimitiveStaticTypePrivatePath,
 		},
 		{
+			label:    "AuthAccount",
+			actual:   cadence.AuthAccountType{},
+			expected: interpreter.PrimitiveStaticTypeAuthAccount,
+		},
+		{
+			label:    "PublicAccount",
+			actual:   cadence.PublicAccountType{},
+			expected: interpreter.PrimitiveStaticTypePublicAccount,
+		},
+		{
+			label:    "DeployedContract",
+			actual:   cadence.DeployedContractType{},
+			expected: interpreter.PrimitiveStaticTypeDeployedContract,
+		},
+		{
+			label:    "AuthAccountKeys",
+			actual:   cadence.AuthAccountKeysType{},
+			expected: interpreter.PrimitiveStaticTypeAuthAccountKeys,
+		},
+		{
+			label:    "PublicAccountKeys",
+			actual:   cadence.PublicAccountKeysType{},
+			expected: interpreter.PrimitiveStaticTypePublicAccountKeys,
+		},
+		{
+			label:    "AuthAccountContracts",
+			actual:   cadence.AuthAccountContractsType{},
+			expected: interpreter.PrimitiveStaticTypeAuthAccountContracts,
+		},
+		{
+			label:    "PublicAccountContracts",
+			actual:   cadence.PublicAccountContractsType{},
+			expected: interpreter.PrimitiveStaticTypePublicAccountContracts,
+		},
+		{
+			label:    "AccountKey",
+			actual:   cadence.AccountKeyType{},
+			expected: interpreter.PrimitiveStaticTypeAccountKey,
+		},
+		{
 			label: "Optional",
 			actual: cadence.OptionalType{
 				Type: cadence.IntType{},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -990,22 +990,22 @@ func TestImportRuntimeType(t *testing.T) {
 			expected: interpreter.PrimitiveStaticTypeDeployedContract,
 		},
 		{
-			label:    "AuthAccountKeys",
+			label:    "AuthAccount.Keys",
 			actual:   cadence.AuthAccountKeysType{},
 			expected: interpreter.PrimitiveStaticTypeAuthAccountKeys,
 		},
 		{
-			label:    "PublicAccountKeys",
+			label:    "PublicAccount.Keys",
 			actual:   cadence.PublicAccountKeysType{},
 			expected: interpreter.PrimitiveStaticTypePublicAccountKeys,
 		},
 		{
-			label:    "AuthAccountContracts",
+			label:    "AuthAccount.Contracts",
 			actual:   cadence.AuthAccountContractsType{},
 			expected: interpreter.PrimitiveStaticTypeAuthAccountContracts,
 		},
 		{
-			label:    "PublicAccountContracts",
+			label:    "PublicAccount.Contracts",
 			actual:   cadence.PublicAccountContractsType{},
 			expected: interpreter.PrimitiveStaticTypePublicAccountContracts,
 		},

--- a/types.go
+++ b/types.go
@@ -928,3 +928,75 @@ func (t *EnumType) CompositeFields() []Field {
 func (t *EnumType) CompositeInitializers() [][]Parameter {
 	return t.Initializers
 }
+
+// AuthAccountType
+type AuthAccountType struct{}
+
+func (AuthAccountType) isType() {}
+
+func (AuthAccountType) ID() string {
+	return "AuthAccount"
+}
+
+// PublicAccountType
+type PublicAccountType struct{}
+
+func (PublicAccountType) isType() {}
+
+func (PublicAccountType) ID() string {
+	return "PublicAccount"
+}
+
+// DeployedContractType
+type DeployedContractType struct{}
+
+func (DeployedContractType) isType() {}
+
+func (DeployedContractType) ID() string {
+	return "DeployedContract"
+}
+
+// AuthAccountContractsType
+type AuthAccountContractsType struct{}
+
+func (AuthAccountContractsType) isType() {}
+
+func (AuthAccountContractsType) ID() string {
+	return "AuthAccountContracts"
+}
+
+// PublicAccountContractsType
+type PublicAccountContractsType struct{}
+
+func (PublicAccountContractsType) isType() {}
+
+func (PublicAccountContractsType) ID() string {
+	return "PublicAccountContracts"
+}
+
+// AuthAccountKeysType
+type AuthAccountKeysType struct{}
+
+func (AuthAccountKeysType) isType() {}
+
+func (AuthAccountKeysType) ID() string {
+	return "AuthAccountKeys"
+}
+
+// PublicAccountContractsType
+type PublicAccountKeysType struct{}
+
+func (PublicAccountKeysType) isType() {}
+
+func (PublicAccountKeysType) ID() string {
+	return "PublicAccountKeys"
+}
+
+// AccountKeyType
+type AccountKeyType struct{}
+
+func (AccountKeyType) isType() {}
+
+func (AccountKeyType) ID() string {
+	return "AccountKey"
+}

--- a/types.go
+++ b/types.go
@@ -962,7 +962,7 @@ type AuthAccountContractsType struct{}
 func (AuthAccountContractsType) isType() {}
 
 func (AuthAccountContractsType) ID() string {
-	return "AuthAccountContracts"
+	return "AuthAccount.Contracts"
 }
 
 // PublicAccountContractsType
@@ -971,7 +971,7 @@ type PublicAccountContractsType struct{}
 func (PublicAccountContractsType) isType() {}
 
 func (PublicAccountContractsType) ID() string {
-	return "PublicAccountContracts"
+	return "PublicAccount.Contracts"
 }
 
 // AuthAccountKeysType
@@ -980,7 +980,7 @@ type AuthAccountKeysType struct{}
 func (AuthAccountKeysType) isType() {}
 
 func (AuthAccountKeysType) ID() string {
-	return "AuthAccountKeys"
+	return "AuthAccount.Keys"
 }
 
 // PublicAccountContractsType
@@ -989,7 +989,7 @@ type PublicAccountKeysType struct{}
 func (PublicAccountKeysType) isType() {}
 
 func (PublicAccountKeysType) ID() string {
-	return "PublicAccountKeys"
+	return "PublicAccount.Keys"
 }
 
 // AccountKeyType


### PR DESCRIPTION
Closes #1219 

## Description

These types were previously missing from the `cadence` package, but had equivalents in `sema` and `interpreter`. This fills in the missing types and adds encoding, decoding, import and export converters for them. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
