### PR TITLE
Add github action to monitor performance regressions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,53 @@
+name: Benchmark
+
+on:
+  push:
+    branches:
+      - master
+      - 'feature/**'
+      - 'v**'
+  pull_request:
+    branches:
+      - master
+      - 'feature/**'
+      - 'v**'
+
+jobs:
+  benchmark:
+    name: perf regressions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+
+      # Run benchmark with `go test -bench` and stores the output to a file
+      - name: Run benchmark
+        run: go test -bench=. ./... | tee benchmark_results.txt
+
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          # What benchmark tool the benchmark_results.txt came from
+          tool: 'go'
+
+          # Where the output from the benchmark tool is stored
+          output-file-path: benchmark_results.txt
+
+          # Where the previous data file is stored
+          external-data-json-path: ./cache/benchmark-data.json
+          comment-always: true
+          alert-threshold: '120%'
+          fail-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Enable below to create a PR comment with a warning,
+          # if performance degrades over the given threshold
+          # comment-on-alert: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,13 +66,17 @@ jobs:
 
         # Where the previous data file is stored
         external-data-json-path: ./cache/benchmark-data.json
-        comment-always: true
+
         alert-threshold: '120%'
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-        # Enable below to create a PR comment with a warning,
-        # if performance degrades more than the given threshold.
-        # comment-on-alert: true
+        # Create comment with a warning, if performance degrades more than the given threshold.
+        comment-on-alert: true
 
-        # Enable below to fail the PR if performance degrades more than the given threshold.
+        # Fail the PR if performance degrades more than the given threshold.
         # fail-on-alert: true
+
+        # Add a comment with performance comparison for all benchmarks.
+        # Currently disabled, since it creates comments for each new commit
+        # on the PR, which adds noise to the PR.
+        # comment-always: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -62,9 +62,11 @@ jobs:
         external-data-json-path: ./cache/benchmark-data.json
         comment-always: true
         alert-threshold: '120%'
-        fail-on-alert: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
         # Enable below to create a PR comment with a warning,
-        # if performance degrades over the given threshold
+        # if performance degrades more than the given threshold.
         # comment-on-alert: true
+
+        # Enable below to fail the PR if performance degrades more than the given threshold.
+        # fail-on-alert: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,7 +39,13 @@ jobs:
 
     # Run benchmark with `go test -bench` and stores the output to a file
     - name: Run benchmark
-      run: make benchmark | tee benchmark_results.txt
+      run: make benchmark | tee benchmark_results_raw.txt
+
+    # A temp-workaround for https://github.com/benchmark-action/github-action-benchmark/issues/31
+    - name: Fix benchmark names
+      run: >-
+        perl -pe 's/^(Benchmark.+?)\/(\S+)(-\d+)(\s+)/\1__\2\4/' benchmark_results_raw.txt |
+        tr '=-' '_' | tee benchmark_results.txt
 
     # Download previous benchmark result from cache (if exists)
     - name: Download previous benchmark data

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,39 +15,56 @@ on:
 jobs:
   benchmark:
     name: perf regressions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install wabt
+    - uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.15.x'
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '15'
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Build
+      run: make build
 
-      # Run benchmark with `go test -bench` and stores the output to a file
-      - name: Run benchmark
-        run: go test -bench=. ./... | tee benchmark_results.txt
+    # Run benchmark with `go test -bench` and stores the output to a file
+    - name: Run benchmark
+      run: make benchmark | tee benchmark_results.txt
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
+    # Download previous benchmark result from cache (if exists)
+    - name: Download previous benchmark data
+      uses: actions/cache@v1
+      with:
+        path: ./cache
+        key: ${{ runner.os }}-benchmark
 
-      # Run `github-action-benchmark` action
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          # What benchmark tool the benchmark_results.txt came from
-          tool: 'go'
+    # Run `github-action-benchmark` action
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        # What benchmark tool the benchmark_results.txt came from
+        tool: 'go'
 
-          # Where the output from the benchmark tool is stored
-          output-file-path: benchmark_results.txt
+        # Where the output from the benchmark tool is stored
+        output-file-path: benchmark_results.txt
 
-          # Where the previous data file is stored
-          external-data-json-path: ./cache/benchmark-data.json
-          comment-always: true
-          alert-threshold: '120%'
-          fail-on-alert: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Where the previous data file is stored
+        external-data-json-path: ./cache/benchmark-data.json
+        comment-always: true
+        alert-threshold: '120%'
+        fail-on-alert: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
-          # Enable below to create a PR comment with a warning,
-          # if performance degrades over the given threshold
-          # comment-on-alert: true
+        # Enable below to create a PR comment with a warning,
+        # if performance degrades over the given threshold
+        # comment-on-alert: true

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ test:
 	sed -i -e 's/^.* 0 0$$//' coverage.txt
 	cd ./languageserver && make test
 
+.PHONY: benchmark
+benchmark:
+	# benchmark all packages
+	GO111MODULE=on go test -bench=. ./...
+
 .PHONY: build
 build:
 	go build -o ./runtime/cmd/parse/parse ./runtime/cmd/parse


### PR DESCRIPTION
## Description

Add a GitHub action to check the performance regressions using [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark).

With this, a comment will get added to a PR/commit, if the performance degrades by 20%. (We can tune this value. Initially started with 20% to avoid any false alarms, since I'm not sure how the benchmark results vary depending on the state of the CI environments)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
