### PR TITLE
Add benchstat GH action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,88 @@
+name: Benchmark
+on:
+  pull_request:
+    branches:
+      - master
+      - 'feature/**'
+      - 'v**'
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set benchmark repetitions
+        # reducing repetition will speed up execution,
+        # but will be more inaccurate at detecting change
+        run: echo "::set-output name=benchmark_repetitions::7"
+        id: settings
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install wabt
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.x'
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '15'
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: make build
+
+      - name: Run benchmark on current branch
+        run: |
+          go test ./... -run=XXX -bench=. -shuffle=on -count ${{ steps.settings.outputs.benchmark_repetitions }} | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' | tee new.txt
+      # the package replace line above is to make the results table more readable, since it is not fragmented by package
+      
+
+      - name: Checkout base branch
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Run benchmark on base branch
+        run: |
+          go test ./... -run=XXX -bench=. -shuffle=on -count ${{ steps.settings.outputs.benchmark_repetitions }} | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' | tee old.txt
+
+      # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
+      - name: Use benchstat for comparison
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          GO111MODULE=off go get golang.org/x/perf/cmd/benchstat
+          echo "BENCHSTAT<<EOF" >> $GITHUB_ENV
+          echo "$(benchstat -html -sort delta old.txt new.txt | sed  '/<title/,/<\/style>/d' | sed 's/<!doctype html>//g')" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Find existing comment on PR
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "## Cadence [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison"
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Cadence [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison
+            This branch with compared with the base branch ${{  github.event.pull_request.base.label }} commit ${{ github.event.pull_request.base.sha }}
+            The command `go test ./... -run=XXX -bench=. -shuffle=on -count N` was used.
+            Bench tests were run a total of ${{ steps.settings.outputs.benchmark_repetitions }} times on each branch.
+            ## Results
+            ${{ env.BENCHSTAT }}
+            
+          edit-mode: replace


### PR DESCRIPTION
## Description

Add a github action to output performance changes with the base branch of a PR using benchstat.


See https://github.com/janezpodhostnik/cadence/pull/1#issuecomment-964450162 for sample output.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
