### PR TITLE
Fix composite-typed argument passing

### DIFF
--- a/runtime/common/location.go
+++ b/runtime/common/location.go
@@ -96,6 +96,14 @@ func NewTypeID(parts ...string) TypeID {
 	return TypeID(strings.Join(parts, "."))
 }
 
+func NewTypeIDFromQualifiedName(location Location, qualifiedIdentifier string) TypeID {
+	if location == nil {
+		return TypeID(qualifiedIdentifier)
+	}
+
+	return location.TypeID(qualifiedIdentifier)
+}
+
 type TypeIDDecoder func(typeID string) (location Location, qualifiedIdentifier string, err error)
 
 var typeIDDecoders = map[string]TypeIDDecoder{}

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -792,11 +792,9 @@ func importCompositeValue(
 
 		var expectedFieldType sema.Type
 
-		if compositeType != nil {
-			member, ok := compositeType.Members.Get(fieldType.Identifier)
-			if ok {
-				expectedFieldType = member.TypeAnnotation.Type
-			}
+		member, ok := compositeType.Members.Get(fieldType.Identifier)
+		if ok {
+			expectedFieldType = member.TypeAnnotation.Type
 		}
 
 		importedFieldValue, err := importValue(inter, fieldValue, expectedFieldType)

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -505,7 +505,6 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 			v.StructType.QualifiedIdentifier,
 			v.StructType.Fields,
 			v.Fields,
-			expectedType,
 		)
 	case cadence.Resource:
 		return importCompositeValue(
@@ -515,7 +514,6 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 			v.ResourceType.QualifiedIdentifier,
 			v.ResourceType.Fields,
 			v.Fields,
-			expectedType,
 		)
 	case cadence.Event:
 		return importCompositeValue(
@@ -525,7 +523,6 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 			v.EventType.QualifiedIdentifier,
 			v.EventType.Fields,
 			v.Fields,
-			expectedType,
 		)
 	case cadence.Enum:
 		return importCompositeValue(
@@ -535,7 +532,6 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 			v.EnumType.QualifiedIdentifier,
 			v.EnumType.Fields,
 			v.Fields,
-			expectedType,
 		)
 	case cadence.TypeValue:
 		return importTypeValue(
@@ -778,14 +774,17 @@ func importCompositeValue(
 	qualifiedIdentifier string,
 	fieldTypes []cadence.Field,
 	fieldValues []cadence.Value,
-	expectedType sema.Type,
 ) (
 	*interpreter.CompositeValue,
 	error,
 ) {
 	var fields []interpreter.CompositeField
 
-	expectedCompositeType, ok := expectedType.(*sema.CompositeType)
+	typeID := common.NewTypeIDFromQualifiedName(location, qualifiedIdentifier)
+	compositeType, typeErr := inter.GetCompositeType(location, qualifiedIdentifier, typeID)
+	if typeErr != nil {
+		return nil, typeErr
+	}
 
 	for i := 0; i < len(fieldTypes) && i < len(fieldValues); i++ {
 		fieldType := fieldTypes[i]
@@ -793,8 +792,8 @@ func importCompositeValue(
 
 		var expectedFieldType sema.Type
 
-		if ok {
-			member, ok := expectedCompositeType.Members.Get(fieldType.Identifier)
+		if compositeType != nil {
+			member, ok := compositeType.Members.Get(fieldType.Identifier)
 			if ok {
 				expectedFieldType = member.TypeAnnotation.Type
 			}

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -4557,3 +4557,68 @@ func newTestInterpreter(tb testing.TB) *interpreter.Interpreter {
 
 	return inter
 }
+
+func TestInnerBytesArrayArgPassing(t *testing.T) {
+	script := `
+        pub fun main(v: AnyStruct): UInt8 {
+            return (v as! Foo).bytes[0]
+        }
+
+        pub struct Foo {
+            pub let bytes: [UInt8]
+            init(_ bytes: [UInt8]) {
+                self.bytes = bytes
+            }
+        }
+    `
+
+	jsonCdc := `
+      {
+        "value": {
+          "id": "S.test.Foo",
+          "fields": [
+            {
+              "name": "bytes",
+              "value": {
+                "value": [
+                  {
+                    "value": "32",
+                    "type": "UInt8"
+                  }
+                ],
+                "type": "Array"
+              }
+            }
+          ]
+        },
+        "type": "Struct"
+      }
+    `
+
+	rt := newTestInterpreterRuntime()
+
+	storage := newTestLedger(nil, nil)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: storage,
+		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(b)
+		},
+	}
+
+	value, err := rt.ExecuteScript(
+		Script{
+			Source: []byte(script),
+			Arguments: [][]byte{
+				[]byte(jsonCdc),
+			},
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  TestLocation,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, value, cadence.NewUInt8(32))
+}

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -4559,7 +4559,11 @@ func newTestInterpreter(tb testing.TB) *interpreter.Interpreter {
 }
 
 func TestNestedStructArgPassing(t *testing.T) {
+	t.Parallel()
+
 	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
 
 		script := `
             pub fun main(v: AnyStruct): UInt8 {
@@ -4627,6 +4631,8 @@ func TestNestedStructArgPassing(t *testing.T) {
 	})
 
 	t.Run("invalid interface", func(t *testing.T) {
+
+		t.Parallel()
 
 		script := `
             pub fun main(v: AnyStruct) {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -4558,7 +4558,7 @@ func newTestInterpreter(tb testing.TB) *interpreter.Interpreter {
 	return inter
 }
 
-func TestInnerBytesArrayArgPassing(t *testing.T) {
+func TestNestedStructArgPassing(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 
 		script := `
@@ -4626,7 +4626,7 @@ func TestInnerBytesArrayArgPassing(t *testing.T) {
 		assert.Equal(t, value, cadence.NewUInt8(32))
 	})
 
-	t.Run("valid interface", func(t *testing.T) {
+	t.Run("invalid interface", func(t *testing.T) {
 
 		script := `
             pub fun main(v: AnyStruct) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2649,7 +2649,7 @@ func lookupComposite(interpreter *Interpreter, typeID string) (*sema.CompositeTy
 		return nil, err
 	}
 
-	typ, err := interpreter.getCompositeType(location, qualifiedIdentifier, common.TypeID(typeID))
+	typ, err := interpreter.GetCompositeType(location, qualifiedIdentifier, common.TypeID(typeID))
 	if err != nil {
 		return nil, err
 	}
@@ -3765,7 +3765,7 @@ func (interpreter *Interpreter) ConvertStaticToSemaType(staticType StaticType) (
 			return interpreter.getInterfaceType(location, qualifiedIdentifier)
 		},
 		func(location common.Location, qualifiedIdentifier string, typeID common.TypeID) (*sema.CompositeType, error) {
-			return interpreter.getCompositeType(location, qualifiedIdentifier, typeID)
+			return interpreter.GetCompositeType(location, qualifiedIdentifier, typeID)
 		},
 	)
 }
@@ -3817,7 +3817,11 @@ func (interpreter *Interpreter) GetContractComposite(contractLocation common.Add
 	return contractValue, nil
 }
 
-func (interpreter *Interpreter) getCompositeType(location common.Location, qualifiedIdentifier string, typeID common.TypeID) (*sema.CompositeType, error) {
+func (interpreter *Interpreter) GetCompositeType(
+	location common.Location,
+	qualifiedIdentifier string,
+	typeID common.TypeID,
+) (*sema.CompositeType, error) {
 	if location == nil {
 		return interpreter.getNativeCompositeType(qualifiedIdentifier)
 	}

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -56,12 +56,7 @@ var _ StaticType = CompositeStaticType{}
 
 func NewCompositeStaticType(location common.Location, qualifiedIdentifier string) CompositeStaticType {
 
-	var typeID common.TypeID
-	if location == nil {
-		typeID = common.TypeID(qualifiedIdentifier)
-	} else {
-		typeID = location.TypeID(qualifiedIdentifier)
-	}
+	var typeID = common.NewTypeIDFromQualifiedName(location, qualifiedIdentifier)
 
 	return CompositeStaticType{
 		Location:            location,


### PR DESCRIPTION
Closes https://github.com/onflow/flow-emulator/issues/94

## Description

When composite typed values are passed in as arguments, always get the field type info from the type-definition.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
