### PR TITLE
Add BLS-specific crypto functions to cadence 

### DIFF
--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -102,6 +102,12 @@ struct PublicKey {
         domainSeparationTag: String,
         hashAlgorithm: HashAlgorithm
     ): Bool
+
+    /// Verifies the proof of possession of the private key.
+    /// This function is only implemented if the signature algorithm of the public key is BLS, it errors if called with any other signature algorithm. 
+    pub fun verifyPoP(
+        proof: [UInt8],
+    ): Bool
 }
 ```
 
@@ -184,6 +190,31 @@ The inputs to `verify()` depend on the signature scheme used:
      Only `KMAC128_BLS_BLS12_381` is accepted.
 
 BLS verification performs the necessary membership check of the signature while the membership check of the public key is performed at the creation of the `PublicKey` object.
+
+The BLS signature scheme also supports two additional operations on keys and signatures:
+
+```cadence
+/// This is a specific function for the BLS signature scheme. It aggregate multiple BLS signatures into one, 
+/// considering the proof of possession as a defence against the rogue attacks.
+///
+/// Signatures could be generated from the same or distinct messages, they
+/// could also be the aggregation of other signatures.
+/// The order of the signatures in the slice does not matter since the aggregation is commutative. 
+/// No subgroup membership check is performed on the input signatures.
+/// The function errors if the array is empty or if decoding one of the signature fails. 
+BLSAggregateSignatures(
+     signatures: [[UInt8]],
+    ): [UInt8]
+
+/// This is a specific function for the BLS signature scheme. It aggregates multiple BLS public keys into one.
+///
+/// The order of the public keys in the slice does not matter since the aggregation is commutative. 
+/// No subgroup membership check is performed on the input keys.
+/// The function errors if the array is empty or any of the input keys is not a BLS key.
+BLSAggregatePublicKeys(
+     signatures: [PublicKey],
+    ): PublicKey
+```
 
 ## Crypto Contract
 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -105,9 +105,7 @@ struct PublicKey {
 
     /// Verifies the proof of possession of the private key.
     /// This function is only implemented if the signature algorithm of the public key is BLS, it errors if called with any other signature algorithm. 
-    pub fun verifyPoP(
-        proof: [UInt8],
-    ): Bool
+    pub fun verifyPoP(_ proof: [UInt8]): Bool
 }
 ```
 
@@ -202,18 +200,14 @@ The BLS signature scheme also supports two additional operations on keys and sig
 /// The order of the signatures in the slice does not matter since the aggregation is commutative. 
 /// No subgroup membership check is performed on the input signatures.
 /// The function errors if the array is empty or if decoding one of the signature fails. 
-BLSAggregateSignatures(
-     signatures: [[UInt8]],
-    ): [UInt8]
+AggregateBLSSignatures(_ signatures: [[UInt8]]): [UInt8]
 
 /// This is a specific function for the BLS signature scheme. It aggregates multiple BLS public keys into one.
 ///
 /// The order of the public keys in the slice does not matter since the aggregation is commutative. 
 /// No subgroup membership check is performed on the input keys.
 /// The function errors if the array is empty or any of the input keys is not a BLS key.
-BLSAggregatePublicKeys(
-     signatures: [PublicKey],
-    ): PublicKey
+AggregateBLSPublicKeys(_ signatures: [PublicKey]): PublicKey
 ```
 
 ## Crypto Contract

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -463,7 +463,6 @@ func TestBLSVerifyPoP(t *testing.T) {
 	runtime := newTestInterpreterRuntime()
 
 	script := []byte(`
-      import Crypto
 
       pub fun main(): Bool {
           let publicKey = PublicKey(
@@ -517,7 +516,6 @@ func TestBLSAggregateSignatures(t *testing.T) {
 	runtime := newTestInterpreterRuntime()
 
 	script := []byte(`
-      import Crypto
 
       pub fun main(): [UInt8] {
 		return AggregateBLSSignatures([
@@ -581,7 +579,6 @@ func TestAggregateBLSPublicKeys(t *testing.T) {
 	runtime := newTestInterpreterRuntime()
 
 	script := []byte(`
-      import Crypto
 
       pub fun main(): PublicKey {
 		let k1 = PublicKey(

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -455,3 +455,186 @@ func TestRuntimeHashAlgorithmImport(t *testing.T) {
 		testHashAlgorithm(algo)
 	}
 }
+
+func TestBLSVerifyPoP(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	script := []byte(`
+      import Crypto
+
+      pub fun main(): Bool {
+          let publicKey = PublicKey(
+              publicKey: "0102".decodeHex(),
+              signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381
+          )
+
+          return publicKey.verifyPoP([1, 2, 3, 4, 5])
+      }
+    `)
+
+	called := false
+
+	storage := newTestLedger(nil, nil)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: storage,
+		bLSVerifyPOP: func(
+			pk *PublicKey,
+			proof []byte,
+		) (bool, error) {
+			assert.Equal(t, pk.PublicKey, []byte{1, 2})
+			called = true
+			return true, nil
+		},
+	}
+
+	result, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  utils.TestLocation,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		cadence.NewBool(true),
+		result,
+	)
+
+	assert.True(t, called)
+}
+
+func TestBLSAggregateSignatures(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	script := []byte(`
+      import Crypto
+
+      pub fun main(): [UInt8] {
+		return AggregateBLSSignatures([
+			  [1, 1, 1, 1, 1], 
+			  [2, 2, 2, 2, 2],
+			  [3, 3, 3, 3, 3],
+			  [4, 4, 4, 4, 4],
+			  [5, 5, 5, 5, 5]
+			])
+      }
+    `)
+
+	called := false
+
+	storage := newTestLedger(nil, nil)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: storage,
+		aggregateBLSSignatures: func(
+			sigs [][]byte,
+		) ([]byte, error) {
+			assert.Equal(t, len(sigs), 5)
+			ret := make([]byte, 0, len(sigs[0]))
+			for i, sig := range sigs {
+				ret = append(ret, sig[i])
+			}
+			called = true
+			return ret, nil
+		},
+	}
+
+	result, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  utils.TestLocation,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		cadence.NewArray([]cadence.Value{
+			cadence.UInt8(1),
+			cadence.UInt8(2),
+			cadence.UInt8(3),
+			cadence.UInt8(4),
+			cadence.UInt8(5),
+		}),
+		result,
+	)
+
+	assert.True(t, called)
+}
+
+func TestAggregateBLSPublicKeys(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	script := []byte(`
+      import Crypto
+
+      pub fun main(): PublicKey {
+		let k1 = PublicKey(
+			publicKey: "0102".decodeHex(),
+			signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381
+		)
+		let k2 = PublicKey(
+			publicKey: "0102".decodeHex(),
+			signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381
+		)
+		return AggregateBLSPublicKeys([k1, k2])
+      }
+    `)
+
+	called := false
+
+	storage := newTestLedger(nil, nil)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: storage,
+		aggregateBLSPublicKeys: func(
+			keys []*PublicKey,
+		) (*PublicKey, error) {
+			assert.Equal(t, len(keys), 2)
+			ret := make([]byte, 0, len(keys))
+			for _, key := range keys {
+				ret = append(ret, key.PublicKey...)
+			}
+			called = true
+			return &PublicKey{PublicKey: ret, SignAlgo: SignatureAlgorithmBLS_BLS12_381}, nil
+		},
+	}
+
+	result, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  utils.TestLocation,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		cadence.NewArray([]cadence.Value{
+			cadence.UInt8(1),
+			cadence.UInt8(2),
+			cadence.UInt8(1),
+			cadence.UInt8(2),
+		}),
+		result.(cadence.Struct).Fields[0],
+	)
+
+	assert.True(t, called)
+}

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -125,6 +125,12 @@ type Interface interface {
 	GetAccountContractNames(address Address) ([]string, error)
 	// RecordTrace records a opentracing trace
 	RecordTrace(operation string, location common.Location, duration time.Duration, logs []opentracing.LogRecord)
+	// BLSVerifyPOP verifies a proof of possession (PoP) for the receiver public key.
+	BLSVerifyPOP(pk PublicKey, s []byte) (bool, error)
+	// AggregateBLSSignatures aggregate multiple BLS signatures into one.
+	AggregateBLSSignatures(sigs [][]byte) ([]byte, error)
+	// AggregateBLSPublicKeys aggregate multiple BLS public keys into one.
+	AggregateBLSPublicKeys(keys []PublicKey) (PublicKey, error)
 }
 
 type Metrics interface {

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -126,11 +126,11 @@ type Interface interface {
 	// RecordTrace records a opentracing trace
 	RecordTrace(operation string, location common.Location, duration time.Duration, logs []opentracing.LogRecord)
 	// BLSVerifyPOP verifies a proof of possession (PoP) for the receiver public key.
-	BLSVerifyPOP(pk PublicKey, s []byte) (bool, error)
+	BLSVerifyPOP(pk *PublicKey, s []byte) (bool, error)
 	// AggregateBLSSignatures aggregate multiple BLS signatures into one.
 	AggregateBLSSignatures(sigs [][]byte) ([]byte, error)
 	// AggregateBLSPublicKeys aggregate multiple BLS public keys into one.
-	AggregateBLSPublicKeys(keys []PublicKey) (PublicKey, error)
+	AggregateBLSPublicKeys(keys []*PublicKey) (*PublicKey, error)
 }
 
 type Metrics interface {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2471,6 +2471,7 @@ func (interpreter *Interpreter) NewSubInterpreter(
 		WithPublicKeyValidationHandler(interpreter.PublicKeyValidationHandler),
 		WithSignatureVerificationHandler(interpreter.SignatureVerificationHandler),
 		WithHashHandler(interpreter.HashHandler),
+		WithBLSCryptoFunctions(interpreter.BLSVerifyPoPHandler, interpreter.AggregateBLSSignaturesHandler, interpreter.AggregateBLSPublicKeysHandler),
 	}
 
 	return NewInterpreter(

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -186,8 +186,8 @@ type AggregateBLSSignaturesHandlerFunc func(
 type AggregateBLSPublicKeysHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
-	publicKeys []*CompositeValue,
-) (*CompositeValue, error)
+	publicKeys []MemberAccessibleValue,
+) (MemberAccessibleValue, error)
 
 // SignatureVerificationHandlerFunc is a function that validates a signature.
 type SignatureVerificationHandlerFunc func(

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -167,7 +167,7 @@ type PublicKeyValidationHandlerFunc func(
 	publicKey *CompositeValue,
 ) BoolValue
 
-// VerifyBLSPoPHandlerFunc is a function that verifies a BLS proof of posession
+// VerifyBLSPoPHandlerFunc is a function that verifies a BLS proof of possession
 type VerifyBLSPoPHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -171,7 +171,7 @@ type PublicKeyValidationHandlerFunc func(
 type VerifyBLSPoPHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
-	publicKey *CompositeValue,
+	publicKey MemberAccessibleValue,
 	signature []byte,
 ) (BoolValue, error)
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -11251,7 +11251,8 @@ func NewPublicKeyValue(
 		},
 	}
 	publicKeyValue.Functions = map[string]FunctionValue{
-		sema.PublicKeyVerifyFunction: publicKeyVerifyFunction,
+		sema.PublicKeyVerifyFunction:    publicKeyVerifyFunction,
+		sema.PublicKeyVerifyPoPFunction: publicKeyVerifyPoPFunction,
 	}
 
 	// Validate the public key, and initialize 'isValid' field.
@@ -11321,4 +11322,40 @@ var publicKeyVerifyFunction = NewHostFunctionValue(
 		)
 	},
 	sema.PublicKeyVerifyFunctionType,
+)
+
+var publicKeyVerifyPoPFunction = NewHostFunctionValue(
+	func(invocation Invocation) (v Value) {
+		signatureValue := invocation.Arguments[0].(*ArrayValue)
+		publicKey := invocation.Self
+
+		interpreter := invocation.Interpreter
+
+		getLocationRange := invocation.GetLocationRange
+
+		interpreter.ExpectType(
+			publicKey,
+			sema.PublicKeyType,
+			getLocationRange,
+		)
+
+		bytesArray := make([]byte, 0, signatureValue.Count())
+		signatureValue.Iterate(func(element Value) (resume bool) {
+			b := element.(UInt8Value)
+			bytesArray = append(bytesArray, byte(b))
+			return true
+		})
+
+		v, err := interpreter.BLSVerifyPoPHandler(
+			interpreter,
+			getLocationRange,
+			publicKey,
+			bytesArray,
+		)
+		if err != nil {
+			panic(err)
+		}
+		return
+	},
+	sema.PublicKeyVerifyPoPFunctionType,
 )

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -11346,7 +11346,8 @@ var publicKeyVerifyPoPFunction = NewHostFunctionValue(
 			return true
 		})
 
-		v, err := interpreter.BLSVerifyPoPHandler(
+		var err error
+		v, err = interpreter.BLSVerifyPoPHandler(
 			interpreter,
 			getLocationRange,
 			publicKey,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1176,8 +1176,8 @@ func (r *interpreterRuntime) newInterpreter(
 			func(
 				inter *interpreter.Interpreter,
 				getLocationRange func() interpreter.LocationRange,
-				publicKeys []*interpreter.CompositeValue,
-			) (*interpreter.CompositeValue, error) {
+				publicKeys []interpreter.MemberAccessibleValue,
+			) (interpreter.MemberAccessibleValue, error) {
 				return aggregateBLSPublicKeys(
 					inter,
 					getLocationRange,
@@ -3219,12 +3219,13 @@ func verifyBLSPOP(
 func aggregateBLSPublicKeys(
 	inter *interpreter.Interpreter,
 	getLocationRange func() interpreter.LocationRange,
-	publicKeyValues []*interpreter.CompositeValue,
+	publicKeyValues []interpreter.MemberAccessibleValue,
 	runtimeInterface Interface,
 	validator interpreter.PublicKeyValidationHandlerFunc,
-) (*interpreter.CompositeValue, error) {
+) (interpreter.MemberAccessibleValue, error) {
 	publicKeys := make([]*PublicKey, 0, len(publicKeyValues))
 	for _, value := range publicKeyValues {
+		fmt.Printf("at runtime: %T\n", value)
 		publicKey, err := NewPublicKeyFromValue(inter, getLocationRange, value)
 		if err != nil {
 			return nil, err

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1157,7 +1157,7 @@ func (r *interpreterRuntime) newInterpreter(
 			func(
 				inter *interpreter.Interpreter,
 				getLocationRange func() interpreter.LocationRange,
-				publicKeyValue *interpreter.CompositeValue,
+				publicKeyValue interpreter.MemberAccessibleValue,
 				signature []byte,
 			) (interpreter.BoolValue, error) {
 				return verifyBLSPOP(
@@ -3195,7 +3195,7 @@ func validatePublicKey(
 func verifyBLSPOP(
 	inter *interpreter.Interpreter,
 	getLocationRange func() interpreter.LocationRange,
-	publicKeyValue *interpreter.CompositeValue,
+	publicKeyValue interpreter.MemberAccessibleValue,
 	signature []byte,
 	runtimeInterface Interface,
 ) (interpreter.BoolValue, error) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -445,7 +445,7 @@ func (i *testRuntimeInterface) ValidatePublicKey(key *PublicKey) (bool, error) {
 }
 
 func (i *testRuntimeInterface) BLSVerifyPOP(key *PublicKey, s []byte) (bool, error) {
-	if i.validatePublicKey == nil {
+	if i.bLSVerifyPOP == nil {
 		return false, nil
 	}
 
@@ -461,7 +461,7 @@ func (i *testRuntimeInterface) AggregateBLSSignatures(sigs [][]byte) ([]byte, er
 }
 
 func (i *testRuntimeInterface) AggregateBLSPublicKeys(keys []*PublicKey) (*PublicKey, error) {
-	if i.aggregateBLSSignatures == nil {
+	if i.aggregateBLSPublicKeys == nil {
 		return nil, nil
 	}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -175,6 +175,9 @@ type testRuntimeInterface struct {
 	programs                   map[common.LocationID]*interpreter.Program
 	implementationDebugLog     func(message string) error
 	validatePublicKey          func(publicKey *PublicKey) (bool, error)
+	bLSVerifyPOP               func(pk *PublicKey, s []byte) (bool, error)
+	aggregateBLSSignatures     func(sigs [][]byte) ([]byte, error)
+	aggregateBLSPublicKeys     func(keys []*PublicKey) (*PublicKey, error)
 	getAccountContractNames    func(address Address) ([]string, error)
 	recordTrace                func(operation string, location common.Location, duration time.Duration, logs []opentracing.LogRecord)
 }
@@ -439,6 +442,30 @@ func (i *testRuntimeInterface) ValidatePublicKey(key *PublicKey) (bool, error) {
 	}
 
 	return i.validatePublicKey(key)
+}
+
+func (i *testRuntimeInterface) BLSVerifyPOP(key *PublicKey, s []byte) (bool, error) {
+	if i.validatePublicKey == nil {
+		return false, nil
+	}
+
+	return i.bLSVerifyPOP(key, s)
+}
+
+func (i *testRuntimeInterface) AggregateBLSSignatures(sigs [][]byte) ([]byte, error) {
+	if i.aggregateBLSSignatures == nil {
+		return []byte{}, nil
+	}
+
+	return i.aggregateBLSSignatures(sigs)
+}
+
+func (i *testRuntimeInterface) AggregateBLSPublicKeys(keys []*PublicKey) (*PublicKey, error) {
+	if i.aggregateBLSSignatures == nil {
+		return nil, nil
+	}
+
+	return i.aggregateBLSPublicKeys(keys)
 }
 
 func (i *testRuntimeInterface) GetAccountContractNames(address Address) ([]string, error) {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5970,6 +5970,7 @@ const PublicKeyPublicKeyField = "publicKey"
 const PublicKeySignAlgoField = "signatureAlgorithm"
 const PublicKeyIsValidField = "isValid"
 const PublicKeyVerifyFunction = "verify"
+const PublicKeyVerifyPoPFunction = "verifyPoP"
 
 const publicKeyKeyFieldDocString = `
 The public key
@@ -5986,6 +5987,12 @@ Flag indicating whether the key is valid
 const publicKeyVerifyFunctionDocString = `
 Verifies a signature. Checks whether the signature was produced by signing
 the given tag and data, using this public key and the given hash algorithm
+`
+
+const publicKeyVerifyPoPFunctionDocString = `
+Verifies the proof of possession of the private key. This function is 
+currently only implemented if the signature algorithm of the public 
+key is BLS, it errors if called with any other signature algorithm.
 `
 
 // PublicKeyType represents the public key associated with an account key.
@@ -6023,6 +6030,12 @@ var PublicKeyType = func() *CompositeType {
 			PublicKeyVerifyFunctionType,
 			publicKeyVerifyFunctionDocString,
 		),
+		NewPublicFunctionMember(
+			publicKeyType,
+			PublicKeyVerifyPoPFunction,
+			PublicKeyVerifyPoPFunctionType,
+			publicKeyVerifyPoPFunctionDocString,
+		),
 	}
 
 	publicKeyType.Members = GetMembersAsMap(members)
@@ -6053,6 +6066,20 @@ var PublicKeyVerifyFunctionType = &FunctionType{
 		{
 			Identifier:     "hashAlgorithm",
 			TypeAnnotation: NewTypeAnnotation(HashAlgorithmType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
+}
+
+var PublicKeyVerifyPoPFunctionType = &FunctionType{
+	TypeParameters: []*TypeParameter{},
+	Parameters: []*Parameter{
+		{
+			Label:      ArgumentLabelNotRequired,
+			Identifier: "proof",
+			TypeAnnotation: NewTypeAnnotation(
+				ByteArrayType,
+			),
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(BoolType),

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -119,6 +119,7 @@ var BuiltinFunctions = StandardLibraryFunctions{
 	AssertFunction,
 	PanicFunction,
 	CreatePublicKeyFunction,
+	AggregateBLSSignaturesFunction,
 }
 
 // LogFunction
@@ -176,6 +177,36 @@ var CreatePublicKeyFunction = NewStandardLibraryFunction(
 			signAlgo,
 			inter.PublicKeyValidationHandler,
 		)
+	},
+)
+
+const aggregateBLSSignaturesFunctionDocString = `
+This is a specific function for the BLS signature scheme. 
+It aggregates multiple BLS signatures into one, 
+considering the proof of possession as a defense against rogue attacks.
+
+Signatures could be generated from the same or distinct messages, 
+they could also be the aggregation of other signatures.
+The order of the signatures in the slice does not matter since the aggregation is commutative. 
+No subgroup membership check is performed on the input signatures.
+The function errors if the array is empty or if decoding one of the signature fails. 
+`
+
+var AggregateBLSSignaturesFunction = NewStandardLibraryFunction(
+	"AggregateBLSSignatures",
+	&sema.FunctionType{
+		Parameters: []*sema.Parameter{
+			{
+				Label:          sema.ArgumentLabelNotRequired,
+				Identifier:     "signatures",
+				TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{Type: sema.ByteArrayType}),
+			},
+		},
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
+	},
+	aggregateBLSSignaturesFunctionDocString,
+	func(invocation interpreter.Invocation) interpreter.Value {
+		panic("unimplemented")
 	},
 )
 

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -236,15 +236,36 @@ var AggregateBLSPublicKeysFunction = NewStandardLibraryFunction(
 	aggregateBLSPublicKeysFunctionDocString,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		publicKeys := invocation.Arguments[0].(*interpreter.ArrayValue)
-		return AggregateBLSPublicKeys(invocation.Interpreter, publicKeys)
+		return AggregateBLSPublicKeys(
+			invocation.Interpreter,
+			invocation.GetLocationRange,
+			publicKeys,
+		)
 	},
 )
 
 func AggregateBLSPublicKeys(
 	inter *interpreter.Interpreter,
+	getLocationRange func() interpreter.LocationRange,
 	publicKeys *interpreter.ArrayValue,
 ) interpreter.Value {
-	panic("unimplemented")
+	publicKeyArray := make([]interpreter.MemberAccessibleValue, 0, publicKeys.Count())
+	publicKeys.Iterate(func(element interpreter.Value) (resume bool) {
+		publicKey := element.(*interpreter.CompositeValue)
+		publicKeyArray = append(publicKeyArray, publicKey)
+		return true
+	})
+
+	aggregatedKey, err := inter.AggregateBLSPublicKeysHandler(
+		inter,
+		getLocationRange,
+		publicKeyArray,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return aggregatedKey
 }
 
 func AggregateBLSSignatures(

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -120,6 +120,7 @@ var BuiltinFunctions = StandardLibraryFunctions{
 	PanicFunction,
 	CreatePublicKeyFunction,
 	AggregateBLSSignaturesFunction,
+	AggregateBLSPublicKeysFunction,
 }
 
 // LogFunction
@@ -205,6 +206,33 @@ var AggregateBLSSignaturesFunction = NewStandardLibraryFunction(
 		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
 	},
 	aggregateBLSSignaturesFunctionDocString,
+	func(invocation interpreter.Invocation) interpreter.Value {
+		panic("unimplemented")
+	},
+)
+
+const aggregateBLSPublicKeysFunctionDocString = `
+This is a specific function for the BLS signature scheme. 
+It aggregates multiple BLS public keys into one.
+
+The order of the public keys in the slice does not matter since the aggregation is commutative. 
+No subgroup membership check is performed on the input keys.
+The function errors if the array is empty or any of the input keys is not a BLS key.
+`
+
+var AggregateBLSPublicKeysFunction = NewStandardLibraryFunction(
+	"AggregateBLSPublicKeys",
+	&sema.FunctionType{
+		Parameters: []*sema.Parameter{
+			{
+				Label:          sema.ArgumentLabelNotRequired,
+				Identifier:     "keys",
+				TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{Type: sema.PublicKeyType}),
+			},
+		},
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.PublicKeyType),
+	},
+	aggregateBLSPublicKeysFunctionDocString,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		panic("unimplemented")
 	},

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -235,11 +235,22 @@ var AggregateBLSPublicKeysFunction = NewStandardLibraryFunction(
 	},
 	aggregateBLSPublicKeysFunctionDocString,
 	func(invocation interpreter.Invocation) interpreter.Value {
-		panic("unimplemented")
+		publicKeys := invocation.Arguments[0].(*interpreter.ArrayValue)
+		return AggregateBLSPublicKeys(invocation.Interpreter, publicKeys)
 	},
 )
 
-func AggregateBLSSignatures(inter *interpreter.Interpreter, signatures *interpreter.ArrayValue) interpreter.Value {
+func AggregateBLSPublicKeys(
+	inter *interpreter.Interpreter,
+	publicKeys *interpreter.ArrayValue,
+) interpreter.Value {
+	panic("unimplemented")
+}
+
+func AggregateBLSSignatures(
+	inter *interpreter.Interpreter,
+	signatures *interpreter.ArrayValue,
+) interpreter.Value {
 	bytesArray := make([][]byte, 0, signatures.Count())
 	signatures.Iterate(func(element interpreter.Value) (resume bool) {
 		sig := element.(*interpreter.ArrayValue)

--- a/runtime/tests/checker/crypto_test.go
+++ b/runtime/tests/checker/crypto_test.go
@@ -239,3 +239,44 @@ func TestCheckAggregateBLSSignaturesError(t *testing.T) {
 	require.IsType(t, mismatch, errs[0])
 	require.IsType(t, mismatch, errs[1])
 }
+
+func TestCheckAggregateBLSPublicKeys(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+           let r : PublicKey = AggregateBLSPublicKeys([PublicKey(publicKey: [], signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381)])  
+        `,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithPredeclaredValues(stdlib.BuiltinFunctions.ToSemaValueDeclarations()),
+				sema.WithPredeclaredValues(stdlib.BuiltinValues().ToSemaValueDeclarations()),
+			},
+		},
+	)
+
+	require.NoError(t, err)
+}
+
+func TestCheckAggregateBLSPublicKeysError(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+           let r : [PublicKey] = AggregateBLSPublicKeys([1])  
+        `,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithPredeclaredValues(stdlib.BuiltinFunctions.ToSemaValueDeclarations()),
+				sema.WithPredeclaredValues(stdlib.BuiltinValues().ToSemaValueDeclarations()),
+			},
+		},
+	)
+
+	errs := ExpectCheckerErrors(t, err, 2)
+	var mismatch *sema.TypeMismatchError
+	require.IsType(t, mismatch, errs[0])
+	require.IsType(t, mismatch, errs[1])
+}

--- a/runtime/tests/checker/crypto_test.go
+++ b/runtime/tests/checker/crypto_test.go
@@ -149,3 +149,59 @@ func TestCheckSignatureAlgorithmConstructor(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestCheckVerifyPoP(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+           let key = PublicKey(
+              publicKey: "".decodeHex(), 
+              signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381)
+
+           let x = key.verifyPoP([1 as UInt8, 2, 3])  
+        `,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithPredeclaredValues(
+					append(
+						stdlib.BuiltinFunctions.ToSemaValueDeclarations(),
+						stdlib.BuiltinValues().ToSemaValueDeclarations()...,
+					),
+				),
+			},
+		},
+	)
+
+	require.NoError(t, err)
+}
+
+func TestCheckVerifyPoPInvalidArgument(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+           let key = PublicKey(
+              publicKey: "".decodeHex(), 
+              signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381)
+
+           let x = key.verifyPoP([1 as Int32, 2, 3])  
+        `,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithPredeclaredValues(
+					append(
+						stdlib.BuiltinFunctions.ToSemaValueDeclarations(),
+						stdlib.BuiltinValues().ToSemaValueDeclarations()...,
+					),
+				),
+			},
+		},
+	)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+	var mismatch *sema.TypeMismatchError
+	require.IsType(t, mismatch, errs[0])
+}


### PR DESCRIPTION
Closes #1127 
Closes #1128 
Closes #1129 

## Description

* Adds support for the three linked BLS crypto functions to the runtime interface
* Implements typechecking for these functions
* Interpreter delegates calls to these functions to the FVM

This is the Cadence side of the overall Flow changes. The FVM side is in https://github.com/onflow/flow-go/pull/1605

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
