### PR TITLE
Change "Object" to plural (typo)

### DIFF
--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -158,7 +158,7 @@ Please refer to the [Access Control section of the language reference](/cadence/
 to learn more about the different levels of access control permitted in Cadence.
 
 The `init()` section is called the initializer. It is a special function that is only run when the contract is created and never again.
-Object similar to contracts, such as other [composite types like structs or resources](https://docs.onflow.org/cadence/language/composite-types/),
+Objects similar to contracts, such as other [composite types like structs or resources](https://docs.onflow.org/cadence/language/composite-types/),
 require that the `init()` function initialize any fields that are declared in a composite type.
 In this example, the initializer sets the `greeting` field to `"Hello, World!"`.
 


### PR DESCRIPTION
## Description
Typo in the docs.

Singular "Object" doesn't make sense here:
> Object similar to contracts, such as other composite types like structs or resources, require that the init() function initialize any fields that are declared in a composite type.

So I made it plural.
<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
