### PR TITLE
Add test for casting storage ref to an invalid type

### DIFF
--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -660,6 +660,13 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
                  return ref.foo
               }
+
+              fun invalidBorrowS(): &S2? {
+                  let s = S()
+                  account.save(s, to: /storage/another_s)
+                  let borrowedS = account.borrow<auth &AnyStruct>(from: /storage/another_s)
+                  return borrowedS as! auth &S2?
+              }
             `,
 		)
 
@@ -734,6 +741,12 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 			_, err := inter.Invoke("changeAfterBorrow")
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
+		})
+
+		t.Run("borrow as invalid type", func(t *testing.T) {
+			_, err = inter.Invoke("invalidBorrowS")
+			require.Error(t, err)
+			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 		})
 	})
 }


### PR DESCRIPTION
## Description

There were no tests for the following scenario:
 - Saving struct value of type `T` in an account
 - Borrowing it as a super-type `auth AnyStruct`
 - Downcast it to a different type `auth R`

This was the only scenario that doesn't work if we do https://github.com/onflow/cadence/issues/1217 (_there's a solution for it, I'll update the original git-issue with more context/info_), but realized there were no test cases for this particular case (all tests were passing!)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
