### PR TITLE
Gracefully handle invalid restrictions

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1141,6 +1141,10 @@ func (checker *Checker) convertRestrictedType(t *ast.RestrictedType) Type {
 					Range: ast.NewRangeFromPositioned(restriction),
 				})
 			}
+
+			// NOTE: ignore this invalid type
+			// and do not add it to the restrictions result
+			continue
 		}
 
 		restrictions = append(restrictions, restrictionInterfaceType)

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -1124,3 +1124,17 @@ func TestCheckRestrictedConformance(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestCheckInvalidRestriction(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      let x: {h} = nil
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 2)
+
+	require.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	require.IsType(t, &sema.AmbiguousRestrictedTypeError{}, errs[1])
+}


### PR DESCRIPTION
## Description

Fix regression introduced in a250336. Bring back [the `continue` statement which ignores invalid restrictions](https://github.com/onflow/cadence/commit/a250336#diff-74d0954852bf407e9259a7c9bb55e8af093f080f00f5e35689c250886c29860aL980)
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
