### PR TITLE
add `forceSave` function to save and overwrite stored data

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -104,6 +104,7 @@ to the `prepare` phase of the transaction.
       // Account storage API (see the section below for documentation)
 
       fun save<T>(_ value: T, to: StoragePath)
+      fun forceSave<T>(_ value: T, to: StoragePath): Bool
       fun load<T>(from: StoragePath): T?
       fun copy<T: AnyStruct>(from: StoragePath): T?
 
@@ -358,6 +359,20 @@ to all its stored objects.
   If there is already an object stored under the given path, the program aborts.
 
   The path must be a storage path, i.e., only the domain `storage` is allowed.
+
+- `cadence•fun forceSave<T>(_ value: T, to: StoragePath): Bool`
+  
+  Saves the given object into the account's storage at the given path.
+  Resources are moved into storage, and structures are copied.
+
+  If there is already an object stored under the given path, the stored
+  object will be overwritten. If the stored object was a resource, it will
+  be destroyed.  
+
+  The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed.
+
+  This function returns true if a previously stored object was overwritten, and
+  false if the given path had no stored object. 
 
 - `cadence•fun load<T>(from: StoragePath): T?`
 

--- a/runtime/interpreter/account.go
+++ b/runtime/interpreter/account.go
@@ -98,6 +98,9 @@ func NewAuthAccountValue(
 		sema.AuthAccountSaveField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return inter.authAccountSaveFunction(address)
 		},
+		sema.AuthAccountForceSaveField: func(inter *Interpreter, _ func() LocationRange) Value {
+			return inter.authAccountForceSaveFunction(address)
+		},
 		sema.AuthAccountBorrowField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return inter.authAccountBorrowFunction(address)
 		},

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -31,6 +31,7 @@ const AuthAccountStorageCapacityField = "storageCapacity"
 const AuthAccountAddPublicKeyField = "addPublicKey"
 const AuthAccountRemovePublicKeyField = "removePublicKey"
 const AuthAccountSaveField = "save"
+const AuthAccountForceSaveField = "forceSave"
 const AuthAccountLoadField = "load"
 const AuthAccountCopyField = "copy"
 const AuthAccountBorrowField = "borrow"
@@ -109,6 +110,12 @@ var AuthAccountType = func() *CompositeType {
 			AuthAccountSaveField,
 			AuthAccountTypeSaveFunctionType,
 			authAccountTypeSaveFunctionDocString,
+		),
+		NewPublicFunctionMember(
+			authAccountType,
+			AuthAccountForceSaveField,
+			AuthAccountTypeForceSaveFunctionType,
+			authAccountTypeForceSaveFunctionDocString,
 		),
 		NewPublicFunctionMember(
 			authAccountType,
@@ -247,6 +254,51 @@ Resources are moved into storage, and structures are copied.
 If there is already an object stored under the given path, the program aborts.
 
 The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed
+`
+
+var AuthAccountTypeForceSaveFunctionType = func() *FunctionType {
+
+	typeParameter := &TypeParameter{
+		Name:      "T",
+		TypeBound: StorableType,
+	}
+
+	return &FunctionType{
+		TypeParameters: []*TypeParameter{
+			typeParameter,
+		},
+		Parameters: []*Parameter{
+			{
+				Label:      ArgumentLabelNotRequired,
+				Identifier: "value",
+				TypeAnnotation: NewTypeAnnotation(
+					&GenericType{
+						TypeParameter: typeParameter,
+					},
+				),
+			},
+			{
+				Label:          "to",
+				Identifier:     "path",
+				TypeAnnotation: NewTypeAnnotation(StoragePathType),
+			},
+		},
+		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
+	}
+}()
+
+const authAccountTypeForceSaveFunctionDocString = `
+Saves the given object into the account's storage at the given path.
+Resources are moved into storage, and structures are copied.
+
+If there is already an object stored under the given path, the stored
+object will be overwritten. If the stored object was a resource, it will
+be destroyed.  
+
+The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed.
+
+This function returns true if a previously stored object was overwritten, and
+false if the given path had no stored object. 
 `
 
 var AuthAccountTypeLoadFunctionType = func() *FunctionType {


### PR DESCRIPTION
Closes #1244 

## Description

Adds the following method to `AuthAccount` objects:
```
fun forceSave<T>(_ value: T, to path: Path): Bool
```

This will save a value to the specified path, overwriting any data present (and destroying it if it is a resource). Returns whether or not any data was overwritten. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
