### PR TITLE
add a `clear` method to delete saved data in storage

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -377,6 +377,20 @@ to all its stored objects.
 
   The path must be a storage path, i.e., only the domain `storage` is allowed.
 
+- `cadence•fun clear(_ path: StoragePath): Bool`
+
+  Clears an object from the account's storage which is stored under the given path
+
+  If there is an object stored, the stored resource or structure is removed from storage, and 
+  destroyed if it is a resource.
+
+  When the function returns, the storage no longer contains an object under the given path.
+
+  The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed.
+
+  The function returns true if a stored object was cleared, and false if no object
+  was stored under the given path.
+
 - `cadence•fun copy<T: AnyStruct>(from: StoragePath): T?`
 
   Returns a copy of a structure stored in account storage, without removing it from storage.

--- a/runtime/interpreter/account.go
+++ b/runtime/interpreter/account.go
@@ -92,6 +92,9 @@ func NewAuthAccountValue(
 		sema.AuthAccountLoadField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return inter.authAccountLoadFunction(address)
 		},
+		sema.AuthAccountClearField: func(inter *Interpreter, _ func() LocationRange) Value {
+			return inter.authAccountClearFunction(address)
+		},
 		sema.AuthAccountCopyField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return inter.authAccountCopyFunction(address)
 		},

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -32,6 +32,7 @@ const AuthAccountAddPublicKeyField = "addPublicKey"
 const AuthAccountRemovePublicKeyField = "removePublicKey"
 const AuthAccountSaveField = "save"
 const AuthAccountLoadField = "load"
+const AuthAccountClearField = "clear"
 const AuthAccountCopyField = "copy"
 const AuthAccountBorrowField = "borrow"
 const AuthAccountLinkField = "link"
@@ -115,6 +116,12 @@ var AuthAccountType = func() *CompositeType {
 			AuthAccountLoadField,
 			AuthAccountTypeLoadFunctionType,
 			authAccountTypeLoadFunctionDocString,
+		),
+		NewPublicFunctionMember(
+			authAccountType,
+			AuthAccountClearField,
+			AuthAccountTypeClearFunctionType,
+			authAccountTypeClearFunctionDocString,
 		),
 		NewPublicFunctionMember(
 			authAccountType,
@@ -289,6 +296,33 @@ If it is not, the function returns nil.
 The given type must not necessarily be exactly the same as the type of the loaded object.
 
 The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed
+`
+
+var AuthAccountTypeClearFunctionType = func() *FunctionType {
+	return &FunctionType{
+		Parameters: []*Parameter{
+			{
+				Label:          ArgumentLabelNotRequired,
+				Identifier:     "path",
+				TypeAnnotation: NewTypeAnnotation(StoragePathType),
+			},
+		},
+		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
+	}
+}()
+
+const authAccountTypeClearFunctionDocString = `
+Clears an object from the account's storage which is stored under the given path
+
+If there is an object stored, the stored resource or structure is removed from storage, and 
+destroyed if it is a resource.
+
+When the function returns, the storage no longer contains an object under the given path.
+
+The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed.
+
+The function returns true if a stored object was cleared, and false if no object
+was stored under the given path.
 `
 
 var AuthAccountTypeCopyFunctionType = func() *FunctionType {

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -489,6 +489,46 @@ func TestCheckAccount_load(t *testing.T) {
 	}
 }
 
+func TestCheckAccount_clear(t *testing.T) {
+
+	t.Parallel()
+
+	testClear := func(domain common.PathDomain) {
+
+		testName := fmt.Sprintf(
+			"clear, %s",
+			domain.Identifier(),
+		)
+
+		t.Run(testName, func(t *testing.T) {
+
+			t.Parallel()
+
+			checker, err := ParseAndCheckAccount(t,
+				fmt.Sprintf(
+					`
+						let r = authAccount.clear(/%s/r)
+					`,
+					domain.Identifier(),
+				),
+			)
+
+			if domain == common.PathDomainStorage {
+				require.NoError(t, err)
+				rValueType := RequireGlobalValue(t, checker.Elaboration, "r")
+				require.Equal(t, sema.BoolType, rValueType)
+			} else {
+				errs := ExpectCheckerErrors(t, err, 1)
+				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			}
+		})
+	}
+
+	for _, domain := range common.AllPathDomainsByIdentifier {
+		testClear(domain)
+	}
+}
+
 func TestCheckAccount_copy(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #1245

Adds a new method to the `AuthAccount` object:

```
fun clear(_ path: Path): Bool
```

This function deletes whatever is present at the specified path, destroying any resources, and returns whether anything was present originally. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
