### PR TITLE
Use updated APIs for atree in tests 

### DIFF
--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -51,7 +51,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	}
 
 	dictValueKey := NewStringValue(
-		strings.Repeat("x", int(atree.MaxInlineElementSize+1)),
+		strings.Repeat("x", int(atree.MaxInlineMapKeyOrValueSize+1)),
 	)
 
 	dictValueValue := NewInt256ValueFromInt64(1)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strconv"
 	"testing"
 	"time"
@@ -76,7 +77,7 @@ func withWritesToStorage(
 		storable, err := array.Storable(
 			inter.Storage,
 			atree.Address(address),
-			atree.MaxInlineElementSize,
+			math.MaxUint64,
 		)
 		require.NoError(tb, err)
 


### PR DESCRIPTION
## Description

cherry-picking https://github.com/onflow/cadence/commit/efac7d5af428a26e6d711d26d547918757cb965b onto v0.20 branch

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
