### PR TITLE
Include dependencies in contributing doc, plus gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ suppressions
 
 languageserver/test/languageserver
 coverage.txt
+runtime/cmd/check/check
+runtime/cmd/main/main
+runtime/cmd/parse/parse
+runtime/cmd/parse/parse.wasm
+languageserver/cmd/languageserver/languageserver
+languageserver/cmd/languageserver/languageserver.wasm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Use your best judgment, and feel free to propose changes to this document in a p
 - [Reporting Bugs](#reporting-bugs)
 - [Suggesting Enhancements](#suggesting-enhancements)
 - [Your First Code Contribution](#your-first-code-contribution)
+  - [Dependencies](#dependencies)
 - [Pull Requests](#pull-requests)
 
 [Styleguides](#styleguides)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,13 @@ You can start by looking through these "Good first issue" and "Help wanted" issu
 Both issue lists are sorted by total number of comments.
 While not perfect, number of comments is a reasonable proxy for impact a given change will have.
 
+#### Dependencies
+
+You need some software installed to build and test Cadence:
+
+- [Go](https://golang.org/doc/install)
+- [wasm2wat](https://github.com/WebAssembly/wabt)
+
 ### Pull Requests
 
 The process described here has several goals:


### PR DESCRIPTION
## Description
I added a section describing the requirements to build and test cadence. Aside from `go`, `wabt` is also needed.

I also added some paths to .gitignore since they were generated when I ran `make build` or `make test`.

Notes:
- I didn't create an issue. Do I need to?
- Not sure which label(s) to use.
