### PR TITLE
Removed PublicKey.isValid and .Validated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,12 @@ suppressions
 
 languageserver/test/languageserver
 coverage.txt
+coverage.txt-e
 runtime/cmd/check/check
 runtime/cmd/main/main
 runtime/cmd/parse/parse
 runtime/cmd/parse/parse.wasm
 languageserver/cmd/languageserver/languageserver
 languageserver/cmd/languageserver/languageserver.wasm
+tools/golangci-lint/golangci-lint
+tools/maprangecheck/maprangecheck.so

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -96,7 +96,6 @@ pub enum SignatureAlgorithm: UInt8 {
 struct PublicKey {
     let publicKey: [UInt8]
     let signatureAlgorithm: SignatureAlgorithm
-    let isValid: Bool
 
     /// Verifies a signature under the given tag, data and public key.
     /// It uses the given hash algorithm to hash the tag and data.
@@ -146,8 +145,7 @@ publicKey.publicKey = []                                            // Not allow
 publicKey.publicKey[2] = 4      // No effect
 ```
 
-The validity of a public key can be checked using the `isValid` field.
-Verifications performed with an invalid public key (using `verify()` method) will always fail.
+Invalid public keys cannot be constructed so public keys are always valid.
 
 ### Signature verification
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onflow/cadence/runtime/interpreter"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -237,8 +239,6 @@ var accountKeyA = &AccountKey{
 	PublicKey: &PublicKey{
 		PublicKey: []byte{1, 2, 3},
 		SignAlgo:  sema.SignatureAlgorithmECDSA_P256,
-		IsValid:   false,
-		Validated: true,
 	},
 	HashAlgo:  sema.HashAlgorithmSHA3_256,
 	Weight:    100,
@@ -250,8 +250,6 @@ var accountKeyB = &AccountKey{
 	PublicKey: &PublicKey{
 		PublicKey: []byte{4, 5, 6},
 		SignAlgo:  sema.SignatureAlgorithmECDSA_secp256k1,
-		IsValid:   false,
-		Validated: false,
 	},
 	HashAlgo:  sema.HashAlgorithmSHA3_256,
 	Weight:    100,
@@ -275,7 +273,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		storage := newTestAccountKeyStorage()
 		rt := newTestInterpreterRuntime()
 		runtimeInterface := getAccountKeyTestRuntimeInterface(storage)
-
+		addPublicKeyValidation(runtimeInterface, nil)
 		addAuthAccountKey(t, rt, runtimeInterface)
 
 		assert.Equal(t, []*AccountKey{accountKeyA}, storage.keys)
@@ -289,6 +287,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		storage := newTestAccountKeyStorage()
 		rt := newTestInterpreterRuntime()
 		runtimeInterface := getAccountKeyTestRuntimeInterface(storage)
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		addAuthAccountKey(t, rt, runtimeInterface)
 
@@ -312,7 +311,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		assert.Equal(
 			t,
 			[]string{
-				"AccountKey(keyIndex: 0, publicKey: PublicKey(publicKey: [1, 2, 3], signatureAlgorithm: SignatureAlgorithm(rawValue: 1), isValid: false), hashAlgorithm: HashAlgorithm(rawValue: 3), weight: 100.00000000, isRevoked: false)",
+				"AccountKey(keyIndex: 0, publicKey: PublicKey(publicKey: [1, 2, 3], signatureAlgorithm: SignatureAlgorithm(rawValue: 1)), hashAlgorithm: HashAlgorithm(rawValue: 3), weight: 100.00000000, isRevoked: false)",
 			},
 			storage.logs,
 		)
@@ -325,6 +324,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		storage := newTestAccountKeyStorage()
 		rt := newTestInterpreterRuntime()
 		runtimeInterface := getAccountKeyTestRuntimeInterface(storage)
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		addAuthAccountKey(t, rt, runtimeInterface)
 
@@ -351,6 +351,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		storage := newTestAccountKeyStorage()
 		rt := newTestInterpreterRuntime()
 		runtimeInterface := getAccountKeyTestRuntimeInterface(storage)
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		addAuthAccountKey(t, rt, runtimeInterface)
 
@@ -379,6 +380,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		storage := newTestAccountKeyStorage()
 		rt := newTestInterpreterRuntime()
 		runtimeInterface := getAccountKeyTestRuntimeInterface(storage)
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		addAuthAccountKey(t, rt, runtimeInterface)
 
@@ -425,6 +427,7 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 
 	storage := newTestAccountKeyStorage()
 	runtimeInterface := getAccountKeyTestRuntimeInterface(storage)
+	addPublicKeyValidation(runtimeInterface, nil)
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
@@ -814,9 +817,6 @@ func accountKeyExportedValue(
 
 					// Signature Algo
 					newSignAlgoValue(signAlgo),
-
-					// valid
-					cadence.Bool(false),
 				},
 			},
 
@@ -919,6 +919,12 @@ func addAuthAccountKey(t *testing.T, runtime Runtime, runtimeInterface *testRunt
 	require.NoError(t, err)
 }
 
+func addPublicKeyValidation(runtimeInterface *testRuntimeInterface, returnError error) {
+	runtimeInterface.validatePublicKey = func(_ *PublicKey) error {
+		return returnError
+	}
+}
+
 func encodeArgs(argValues []cadence.Value) [][]byte {
 	args := make([][]byte, len(argValues))
 	for i, arg := range argValues {
@@ -1011,7 +1017,7 @@ func TestRuntimePublicKey(t *testing.T) {
 	t.Run("Constructor", func(t *testing.T) {
 		script := `
             pub fun main(): PublicKey {
-                let publicKey =  PublicKey(
+                let publicKey = PublicKey(
                     publicKey: "0102".decodeHex(),
                     signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
                 )
@@ -1025,6 +1031,7 @@ func TestRuntimePublicKey(t *testing.T) {
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
 		}
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		value, err := executeScript(script, runtimeInterface)
 		require.NoError(t, err)
@@ -1037,9 +1044,6 @@ func TestRuntimePublicKey(t *testing.T) {
 
 				// Signature Algo
 				newSignAlgoValue(sema.SignatureAlgorithmECDSA_P256),
-
-				// valid
-				cadence.Bool(false),
 			},
 		}
 
@@ -1058,92 +1062,84 @@ func TestRuntimePublicKey(t *testing.T) {
             }
         `
 
-		runtimeInterface := &testRuntimeInterface{
-			validatePublicKey: func(publicKey *PublicKey) (bool, error) {
-				return true, nil
-			},
-		}
+		runtimeInterface := &testRuntimeInterface{}
 
 		_, err := executeScript(script, runtimeInterface)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "value of type `PublicKey` has no member `validate`")
 	})
 
-	t.Run("IsValid", func(t *testing.T) {
-		for _, validity := range []bool{true, false} {
-			script := `
-              pub fun main(): Bool {
+	t.Run("Construct PublicKey in Cadence code", func(t *testing.T) {
+		script := `
+              pub fun main(): PublicKey {
                   let publicKey = PublicKey(
                       publicKey: "0102".decodeHex(),
                       signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
                   )
 
-                  return publicKey.isValid
+                  return publicKey
               }
             `
+
+		fakeError := &fakeError{}
+		for _, errorToReturn := range []error{fakeError, nil} {
 			invoked := false
-			validateMethodReturnValue := validity
 
 			storage := newTestLedger(nil, nil)
 
 			runtimeInterface := &testRuntimeInterface{
 				storage: storage,
-				validatePublicKey: func(publicKey *PublicKey) (bool, error) {
+				validatePublicKey: func(publicKey *PublicKey) error {
 					invoked = true
-					return validateMethodReturnValue, nil
+					return errorToReturn
 				},
 			}
 
 			value, err := executeScript(script, runtimeInterface)
-			require.NoError(t, err)
 
-			assert.True(t, invoked)
-			assert.Equal(t, cadence.Bool(validateMethodReturnValue), value)
+			assert.True(t, invoked, "validatePublicKey was not invoked")
 
+			if errorToReturn == nil {
+				assert.NotNil(t, value)
+				assert.NoError(t, err)
+			} else {
+				assert.Nil(t, value)
+				assert.ErrorAs(t, err, &errorToReturn)
+				assert.ErrorAs(t, err, &interpreter.InvalidPublicKeyError{})
+			}
 		}
 	})
 
-	t.Run("IsValid - publicKey from host env", func(t *testing.T) {
-
+	t.Run("PublicKey from host env", func(t *testing.T) {
 		storage := newTestAccountKeyStorage()
 		storage.keys = append(storage.keys, accountKeyA, accountKeyB)
 
-		for index, key := range storage.keys {
-			script := fmt.Sprintf(
-				`
-                  pub fun main(): Bool {
-                      // Get a public key from host env
-                      let acc = getAccount(0x02)
-                      let publicKey = acc.keys.get(keyIndex: %d)!.publicKey
-                      return publicKey.isValid
-                  }
-                `,
+		for index := range storage.keys {
+			script := fmt.Sprintf(`
+                          pub fun main(): PublicKey {
+                              // Get a public key from host env
+                              let acc = getAccount(0x02)
+                              let publicKey = acc.keys.get(keyIndex: %d)!.publicKey
+                              return publicKey
+                          }`,
 				index,
 			)
 
 			invoked := false
-			validateMethodReturnValue := true
 
 			runtimeInterface := getAccountKeyTestRuntimeInterface(storage)
-			runtimeInterface.validatePublicKey = func(publicKey *PublicKey) (bool, error) {
+			runtimeInterface.validatePublicKey = func(publicKey *PublicKey) error {
 				invoked = true
-				return validateMethodReturnValue, nil
+				return nil
 			}
 
 			value, err := executeScript(script, runtimeInterface)
-			require.NoError(t, err)
 
-			// If already validated, then the validation func shouldn't get re-invoked
-			assert.NotEqual(t, key.PublicKey.Validated, invoked)
+			// skip validation when key comes from host env aka FVM
+			assert.False(t, invoked, "validatePublicKey was not invoked")
 
-			// If validated, `isValid` should have the same value as `publicKey.IsValid`.
-			// Otherwise, it should give the value returned by the `validate()` func.
-			isValid := validateMethodReturnValue
-			if key.PublicKey.Validated {
-				isValid = key.PublicKey.IsValid
-			}
-
-			assert.Equal(t, cadence.Bool(isValid), value)
+			assert.IsType(t, cadence.Struct{}, value)
+			assert.Nil(t, err)
 		}
 	})
 
@@ -1181,6 +1177,7 @@ func TestRuntimePublicKey(t *testing.T) {
 				return true, nil
 			},
 		}
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		value, err := executeScript(script, runtimeInterface)
 		require.NoError(t, err)
@@ -1240,7 +1237,6 @@ func TestRuntimePublicKey(t *testing.T) {
 
                 publicKey.publicKey = []
                 publicKey.signatureAlgorithm = SignatureAlgorithm.ECDSA_secp256k1
-                publicKey.isValid = true
 
                 return publicKey
             }
@@ -1259,14 +1255,12 @@ func TestRuntimePublicKey(t *testing.T) {
 		require.ErrorAs(t, err, &checkerErr)
 
 		errs := checkerErr.Errors
-		require.Len(t, errs, 6)
+		require.Len(t, errs, 4)
 
 		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[0])
 		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errs[1])
 		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[2])
 		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errs[3])
-		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errs[4])
-		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errs[5])
 	})
 
 	t.Run("raw-key mutability", func(t *testing.T) {
@@ -1288,6 +1282,7 @@ func TestRuntimePublicKey(t *testing.T) {
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
 		}
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		_, err := executeScript(script, runtimeInterface)
 
@@ -1321,6 +1316,7 @@ func TestRuntimePublicKey(t *testing.T) {
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
 		}
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		value, err := executeScript(script, runtimeInterface)
 		require.NoError(t, err)
@@ -1332,8 +1328,6 @@ func TestRuntimePublicKey(t *testing.T) {
 				newBytesValue([]byte{1, 2}),
 				// Signature Algo
 				newSignAlgoValue(sema.SignatureAlgorithmECDSA_P256),
-				// valid
-				cadence.Bool(false),
 			},
 		}
 		assert.Equal(t, expected, value)
@@ -1882,4 +1876,10 @@ func TestGetAuthAccount(t *testing.T) {
 
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 	})
+}
+
+type fakeError struct{}
+
+func (fakeError) Error() string {
+	return "fake error for testing"
 }

--- a/runtime/cmd/parse/main_wasm.go
+++ b/runtime/cmd/parse/main_wasm.go
@@ -1,3 +1,4 @@
+//go:build wasm
 // +build wasm
 
 /*
@@ -52,8 +53,8 @@ func main() {
 }
 
 type result struct {
-	Program  *ast.Program `json:"program"`
-	Error    error        `json:"error,omitempty"`
+	Program *ast.Program `json:"program"`
+	Error   error        `json:"error,omitempty"`
 }
 
 func parse(code string) string {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -891,10 +891,6 @@ func importPublicKey(
 
 			signAlgoValue = compositeValue
 
-		case sema.PublicKeyIsValidField:
-			// 'isValid' field set by the user must be ignored.
-			// This is calculated when creating the public key.
-
 		default:
 			return nil, fmt.Errorf(
 				"cannot import value of type '%s'. invalid field '%s'",

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -98,10 +98,6 @@ func TestExportValue(t *testing.T) {
 				Identifier: "signatureAlgorithm",
 				Type:       signatureAlgorithmType,
 			},
-			{
-				Identifier: "isValid",
-				Type:       cadence.BoolType{},
-			},
 		},
 	}
 
@@ -375,15 +371,13 @@ func TestExportValue(t *testing.T) {
 						&PublicKey{
 							PublicKey: []byte{1, 2, 3},
 							SignAlgo:  2,
-							IsValid:   true,
-							Validated: true,
 						},
 						func(
 							_ *interpreter.Interpreter,
 							_ func() interpreter.LocationRange,
 							_ *interpreter.CompositeValue,
-						) interpreter.BoolValue {
-							return true
+						) error {
+							return nil
 						},
 					),
 					stdlib.NewHashAlgorithmCase(inter, 1),
@@ -433,7 +427,6 @@ func TestExportValue(t *testing.T) {
 									cadence.UInt8(2),
 								},
 							},
-							cadence.Bool(true),
 						},
 					},
 					cadence.Enum{
@@ -3792,19 +3785,18 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 		cadence.NewUInt8(2),
 	})
 
-	t.Run("Test IsValid", func(t *testing.T) {
+	t.Run("Test importing validates PublicKey", func(t *testing.T) {
 		t.Parallel()
 
-		testPublicKeyImport := func(userSetValidity, publicKeyActualValidity bool) {
+		testPublicKeyImport := func(publicKeyActualError error) {
 			t.Run(
-				fmt.Sprintf("UserSet(%v)|Actual(%v)", userSetValidity, publicKeyActualValidity),
+				fmt.Sprintf("Actual(%v)", publicKeyActualError),
 				func(t *testing.T) {
 
 					t.Parallel()
 
 					script := `
-                        pub fun main(key: PublicKey): Bool {
-                            return key.isValid
+                        pub fun main(key: PublicKey) {
                         }
                     `
 
@@ -3819,9 +3811,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 									cadence.NewUInt8(0),
 								},
 							).WithType(SignAlgoType),
-
-							// isValid
-							cadence.NewBool(userSetValidity),
 						},
 					).WithType(PublicKeyType)
 
@@ -3835,27 +3824,33 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 							return json.Decode(b)
 						},
 
-						validatePublicKey: func(publicKey *PublicKey) (bool, error) {
+						validatePublicKey: func(publicKey *PublicKey) error {
 							publicKeyValidated = true
-							return publicKeyActualValidity, nil
+							return publicKeyActualError
 						},
 					}
 
-					actual, err := executeScript(t, script, publicKey, runtimeInterface)
-					require.NoError(t, err)
+					_, err := executeScript(t, script, publicKey, runtimeInterface)
 
-					// Check whether 'isValid' field returns the actual validity of
-					// the public key, but not the one set by the user.
+					// runtimeInterface.validatePublicKey() should be called
 					assert.True(t, publicKeyValidated)
-					assert.Equal(t, actual, cadence.NewBool(publicKeyActualValidity))
+
+					// Invalid PublicKey errors but valid PublicKey does not.
+					if publicKeyActualError == nil {
+						require.NoError(t, err)
+					} else {
+						assert.Error(t, err)
+						var invalidEntryPointArgumentError *InvalidEntryPointArgumentError
+						assert.ErrorAs(t, err, &invalidEntryPointArgumentError)
+						assert.ErrorAs(t, err, &interpreter.InvalidPublicKeyError{})
+						assert.ErrorAs(t, err, &publicKeyActualError)
+					}
 				},
 			)
 		}
 
-		testPublicKeyImport(true, true)
-		testPublicKeyImport(true, false)
-		testPublicKeyImport(false, true)
-		testPublicKeyImport(false, false)
+		testPublicKeyImport(nil)
+		testPublicKeyImport(&fakeError{})
 	})
 
 	t.Run("Test Verify", func(t *testing.T) {
@@ -3883,9 +3878,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 						cadence.NewUInt8(0),
 					},
 				).WithType(SignAlgoType),
-
-				// isValid
-				cadence.NewBool(true),
 			},
 		).WithType(PublicKeyType)
 
@@ -3910,6 +3902,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 				return true, nil
 			},
 		}
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		actual, err := executeScript(t, script, publicKey, runtimeInterface)
 		require.NoError(t, err)
@@ -3934,8 +3927,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 						cadence.NewUInt8(0),
 					},
 				).WithType(SignAlgoType),
-
-				cadence.NewBool(true),
 			},
 		).WithType(PublicKeyType)
 
@@ -3974,8 +3965,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 						cadence.NewUInt8(0),
 					},
 				).WithType(SignAlgoType),
-
-				cadence.NewBool(true),
 			},
 		).WithType(PublicKeyType)
 
@@ -4006,8 +3995,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 				publicKeyBytes,
 
 				// Invalid value for 'signatureAlgorithm' field
-				cadence.NewBool(true),
-
 				cadence.NewBool(true),
 			},
 		).WithType(PublicKeyType)
@@ -4044,8 +4031,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 						cadence.String("hello"),
 					},
 				).WithType(SignAlgoType),
-
-				cadence.NewBool(true),
 			},
 		).WithType(PublicKeyType)
 
@@ -4112,13 +4097,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
                             }
                         },
                         {
-                            "name":"isValid",
-                            "value":{
-                            "type":"Bool",
-                            "value":true
-                            }
-                        },
-                        {
                             "name":"extraField",
                             "value":{
                             "type":"Bool",
@@ -4161,8 +4139,8 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 	t.Run("Missing raw public key", func(t *testing.T) {
 		script := `
-            pub fun main(key: PublicKey): Bool {
-                return key.isValid
+            pub fun main(key: PublicKey): PublicKey {
+                return key
             }
         `
 
@@ -4188,13 +4166,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
                                         }
                                     ]
                                 }
-                            }
-                        },
-                        {
-                            "name":"isValid",
-                            "value":{
-                            "type":"Bool",
-                            "value":true
                             }
                         }
                     ]
@@ -4230,10 +4201,10 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 		require.ErrorAs(t, err, &argErr)
 	})
 
-	t.Run("Missing isValid", func(t *testing.T) {
+	t.Run("Missing publicKey", func(t *testing.T) {
 		script := `
-            pub fun main(key: PublicKey): Bool {
-                return key.isValid
+            pub fun main(key: PublicKey): [UInt8] {
+                return key.publicKey
             }
         `
 
@@ -4243,22 +4214,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
                 "value":{
                     "id":"PublicKey",
                     "fields":[
-                        {
-                            "name":"publicKey",
-                            "value":{
-                                "type":"Array",
-                                "value":[
-                                    {
-                                        "type":"UInt8",
-                                        "value":"1"
-                                    },
-                                    {
-                                        "type":"UInt8",
-                                        "value":"2"
-                                    }
-                                ]
-                            }
-                        },
                         {
                             "name":"signatureAlgorithm",
                             "value":{
@@ -4293,9 +4248,9 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(b)
 			},
-			validatePublicKey: func(publicKey *PublicKey) (bool, error) {
+			validatePublicKey: func(publicKey *PublicKey) error {
 				publicKeyValidated = true
-				return true, nil
+				return nil
 			},
 		}
 
@@ -4312,10 +4267,82 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, err)
-		assert.True(t, publicKeyValidated)
-		assert.Equal(t, value, cadence.NewBool(true))
+		assert.Contains(t, err.Error(),
+			"invalid argument at index 0: cannot import value of type 'PublicKey'. missing field 'publicKey'")
+		assert.False(t, publicKeyValidated)
+		assert.Nil(t, value)
 	})
+
+	t.Run("Missing signatureAlgorithm", func(t *testing.T) {
+		script := `
+            pub fun main(key: PublicKey): SignatureAlgorithm {
+                return key.signatureAlgorithm
+            }
+        `
+
+		jsonCdc := `
+            {
+                "type":"Struct",
+                "value":{
+                    "id":"PublicKey",
+                    "fields":[
+                        {
+                            "name":"publicKey",
+                            "value":{
+                                "type":"Array",
+                                "value":[
+                                    {
+                                        "type":"UInt8",
+                                        "value":"1"
+                                    },
+                                    {
+                                        "type":"UInt8",
+                                        "value":"2"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        `
+
+		rt := newTestInterpreterRuntime()
+
+		publicKeyValidated := false
+
+		storage := newTestLedger(nil, nil)
+
+		runtimeInterface := &testRuntimeInterface{
+			storage: storage,
+			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(b)
+			},
+			validatePublicKey: func(publicKey *PublicKey) error {
+				publicKeyValidated = true
+				return nil
+			},
+		}
+
+		value, err := rt.ExecuteScript(
+			Script{
+				Source: []byte(script),
+				Arguments: [][]byte{
+					[]byte(jsonCdc),
+				},
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  TestLocation,
+			},
+		)
+
+		assert.Contains(t, err.Error(),
+			"invalid argument at index 0: cannot import value of type 'PublicKey'. missing field 'signatureAlgorithm'")
+		assert.False(t, publicKeyValidated)
+		assert.Nil(t, value)
+	})
+
 }
 
 func TestRuntimeImportExportComplex(t *testing.T) {

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -92,6 +92,7 @@ func TestRuntimeCrypto_verify(t *testing.T) {
 			return true, nil
 		},
 	}
+	addPublicKeyValidation(runtimeInterface, nil)
 
 	result, err := runtime.ExecuteScript(
 		Script{
@@ -489,6 +490,7 @@ func TestBLSVerifyPoP(t *testing.T) {
 			return true, nil
 		},
 	}
+	addPublicKeyValidation(runtimeInterface, nil)
 
 	result, err := runtime.ExecuteScript(
 		Script{
@@ -611,6 +613,7 @@ func TestAggregateBLSPublicKeys(t *testing.T) {
 			return &PublicKey{PublicKey: ret, SignAlgo: SignatureAlgorithmBLS_BLS12_381}, nil
 		},
 	}
+	addPublicKeyValidation(runtimeInterface, nil)
 
 	result, err := runtime.ExecuteScript(
 		Script{

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -120,7 +120,7 @@ type Interface interface {
 	// ImplementationDebugLog logs implementation log statements on a debug-level
 	ImplementationDebugLog(message string) error
 	// ValidatePublicKey verifies the validity of a public key.
-	ValidatePublicKey(key *PublicKey) (bool, error)
+	ValidatePublicKey(key *PublicKey) error
 	// GetAccountContractNames returns the names of all contracts deployed in an account.
 	GetAccountContractNames(address Address) ([]string, error)
 	// RecordTrace records a opentracing trace

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -559,7 +559,7 @@ type InterfaceMissingLocationError struct {
 	QualifiedIdentifier string
 }
 
-func (e *InterfaceMissingLocationError) Error() string {
+func (e InterfaceMissingLocationError) Error() string {
 	return fmt.Sprintf(
 		"tried to look up interface %s without a location",
 		e.QualifiedIdentifier,
@@ -590,4 +590,19 @@ func (e InvalidOperandsError) Error() string {
 		e.LeftType.String(),
 		e.RightType.String(),
 	)
+}
+
+// InvalidPublicKeyError is reported during PublicKey creation, if the PublicKey is invalid.
+type InvalidPublicKeyError struct {
+	PublicKey *ArrayValue
+	Err       error
+	LocationRange
+}
+
+func (e InvalidPublicKeyError) Error() string {
+	return fmt.Sprintf("invalid public key: %s", e.PublicKey)
+}
+
+func (e InvalidPublicKeyError) Unwrap() error {
+	return e.Err
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -173,7 +173,7 @@ type PublicKeyValidationHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
 	publicKey *CompositeValue,
-) BoolValue
+) error
 
 // VerifyBLSPoPHandlerFunc is a function that verifies a BLS proof of possession
 type VerifyBLSPoPHandlerFunc func(
@@ -4098,7 +4098,7 @@ func (interpreter *Interpreter) getNativeCompositeType(qualifiedIdentifier strin
 
 func (interpreter *Interpreter) getInterfaceType(location common.Location, qualifiedIdentifier string) (*sema.InterfaceType, error) {
 	if location == nil {
-		return nil, &InterfaceMissingLocationError{QualifiedIdentifier: qualifiedIdentifier}
+		return nil, InterfaceMissingLocationError{QualifiedIdentifier: qualifiedIdentifier}
 	}
 
 	typeID := location.TypeID(qualifiedIdentifier)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -15008,14 +15008,14 @@ func NewPublicKeyValue(
 		sema.PublicKeyVerifyPoPFunction: publicKeyVerifyPoPFunction,
 	}
 
-	// Validate the public key, and initialize 'isValid' field.
-
-	publicKeyValue.SetMember(
-		interpreter,
-		getLocationRange,
-		sema.PublicKeyIsValidField,
-		validatePublicKey(interpreter, getLocationRange, publicKeyValue),
-	)
+	err := validatePublicKey(interpreter, getLocationRange, publicKeyValue)
+	if err != nil {
+		panic(InvalidPublicKeyError{
+			PublicKey:     publicKey,
+			Err:           err,
+			LocationRange: getLocationRange(),
+		})
+	}
 
 	// Public key value to string should include the key even though it is a computed field
 	publicKeyValue.Stringer = func(publicKeyValue *CompositeValue, seenReferences SeenReferences) string {
@@ -15028,11 +15028,6 @@ func NewPublicKeyValue(
 				Name: sema.PublicKeySignAlgoField,
 				// TODO: provide proper location range
 				Value: publicKeyValue.GetField(sema.PublicKeySignAlgoField),
-			},
-			{
-				Name: sema.PublicKeyIsValidField,
-				// TODO: provide proper location range
-				Value: publicKeyValue.GetField(sema.PublicKeyIsValidField),
 			},
 		}
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -31,9 +31,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	. "github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
 	checkerUtils "github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -3135,11 +3137,7 @@ func TestPublicKeyValue(t *testing.T) {
 			nil,
 			utils.TestLocation,
 			WithStorage(storage),
-			WithPublicKeyValidationHandler(
-				func(_ *Interpreter, _ func() LocationRange, _ *CompositeValue) BoolValue {
-					return true
-				},
-			),
+			WithPublicKeyValidationHandler(runtime.DoNotValidatePublicKey),
 		)
 		require.NoError(t, err)
 
@@ -3154,18 +3152,9 @@ func TestPublicKeyValue(t *testing.T) {
 			NewIntValueFromInt64(3),
 		)
 
-		sigAlgo := NewCompositeValue(
+		sigAlgo := stdlib.NewSignatureAlgorithmCase(
 			inter,
-			nil,
-			sema.SignatureAlgorithmType.QualifiedIdentifier(),
-			sema.SignatureAlgorithmType.Kind,
-			[]CompositeField{
-				{
-					Name:  sema.EnumRawValueFieldName,
-					Value: UInt8Value(sema.SignatureAlgorithmECDSA_secp256k1.RawValue()),
-				},
-			},
-			common.Address{},
+			sema.SignatureAlgorithmECDSA_secp256k1.RawValue(),
 		)
 
 		key := NewPublicKeyValue(
@@ -3177,9 +3166,60 @@ func TestPublicKeyValue(t *testing.T) {
 		)
 
 		require.Equal(t,
-			"PublicKey(publicKey: [1, 7, 3], signatureAlgorithm: SignatureAlgorithm(rawValue: 2), isValid: true)",
+			"PublicKey(publicKey: [1, 7, 3], signatureAlgorithm: SignatureAlgorithm(rawValue: 2))",
 			key.String(),
 		)
+	})
+
+	t.Run("Panics when PublicKey is invalid", func(t *testing.T) {
+
+		t.Parallel()
+
+		storage := NewInMemoryStorage()
+
+		fakeError := fakeError{}
+
+		inter, err := NewInterpreter(
+			nil,
+			utils.TestLocation,
+			WithStorage(storage),
+			WithPublicKeyValidationHandler(
+				func(_ *Interpreter, _ func() LocationRange, _ *CompositeValue) error {
+					return fakeError
+				},
+			),
+		)
+		require.NoError(t, err)
+
+		publicKeyBytes := []byte{1, 7, 3}
+
+		publicKey := NewArrayValue(
+			inter,
+			VariableSizedStaticType{
+				Type: PrimitiveStaticTypeInt,
+			},
+			common.Address{},
+			NewIntValueFromInt64(int64(publicKeyBytes[0])),
+			NewIntValueFromInt64(int64(publicKeyBytes[1])),
+			NewIntValueFromInt64(int64(publicKeyBytes[2])),
+		)
+
+		sigAlgo := stdlib.NewSignatureAlgorithmCase(
+			inter,
+			sema.SignatureAlgorithmECDSA_secp256k1.RawValue(),
+		)
+
+		assert.PanicsWithError(t,
+			(InvalidPublicKeyError{PublicKey: publicKey, Err: fakeError}).Error(),
+			func() {
+				_ = NewPublicKeyValue(
+					inter,
+					ReturnEmptyLocationRange,
+					publicKey,
+					sigAlgo,
+					inter.PublicKeyValidationHandler,
+				)
+			})
 	})
 }
 
@@ -3348,4 +3388,10 @@ func TestNonStorable(t *testing.T) {
 	_, err = inter.Invoke("foo")
 	require.NoError(t, err)
 
+}
+
+type fakeError struct{}
+
+func (fakeError) Error() string {
+	return "fake error for testing"
 }

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -85,6 +85,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 				return json.Decode(b)
 			},
 		}
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		_, err = rt.ExecuteScript(
 			Script{
@@ -369,9 +370,6 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 								cadence.NewUInt8(0),
 							},
 						).WithType(SignAlgoType),
-
-						// isValid
-						cadence.NewBool(false),
 					},
 				).WithType(PublicKeyType)
 
@@ -552,6 +550,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 				return json.Decode(b)
 			},
 		}
+		addPublicKeyValidation(runtimeInterface, nil)
 
 		return rt.ExecuteTransaction(
 			Script{
@@ -848,9 +847,6 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 								cadence.NewUInt8(0),
 							},
 						).WithType(SignAlgoType),
-
-						// isValid
-						cadence.NewBool(false),
 					},
 				).WithType(PublicKeyType)
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -766,6 +766,37 @@ func wrapPanic(f func()) {
 	f()
 }
 
+// Executes `f`. On panic, the panic is returned as an error.
+// Wraps any non-`error` panics so panic is never propagated.
+func panicToError(f func()) (returnedError error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok := r.(error)
+			if ok {
+				returnedError = err
+			} else {
+				returnedError = fmt.Errorf("%s", r)
+			}
+		}
+	}()
+	f()
+	return nil
+}
+
+// Executes `f`. On panic, the panic is returned as an error.
+// Exception: panics when error is `goRuntime.Error` or `ExternalError`.
+func userPanicToError(f func()) error {
+	err := panicToError(f)
+
+	switch err := err.(type) {
+	case goRuntime.Error, interpreter.ExternalError:
+		panic(err)
+	default:
+		return err
+	}
+}
+
 func (r *interpreterRuntime) transactionExecutionFunction(
 	parameters []*sema.Parameter,
 	arguments [][]byte,
@@ -842,7 +873,19 @@ func validateArgumentParams(
 			}
 		}
 
-		arg, err := importValue(inter, value, parameterType)
+		var arg interpreter.Value
+		panicError := userPanicToError(func() {
+			// if importing an invalid public key, this call panics
+			arg, err = importValue(inter, value, parameterType)
+		})
+
+		if panicError != nil {
+			return nil, &InvalidEntryPointArgumentError{
+				Index: i,
+				Err:   panicError,
+			}
+		}
+
 		if err != nil {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: i,
@@ -1152,7 +1195,7 @@ func (r *interpreterRuntime) newInterpreter(
 		inter *interpreter.Interpreter,
 		getLocationRange func() interpreter.LocationRange,
 		publicKey *interpreter.CompositeValue,
-	) interpreter.BoolValue {
+	) error {
 		return validatePublicKey(
 			inter,
 			getLocationRange,
@@ -3119,7 +3162,7 @@ func (r *interpreterRuntime) newAccountKeysGetFunction(
 					inter,
 					invocation.GetLocationRange,
 					accountKey,
-					inter.PublicKeyValidationHandler,
+					DoNotValidatePublicKey, // key from FVM has already been validated
 				),
 			)
 		},
@@ -3172,7 +3215,7 @@ func (r *interpreterRuntime) newAccountKeysRevokeFunction(
 					inter,
 					invocation.GetLocationRange,
 					accountKey,
-					inter.PublicKeyValidationHandler,
+					DoNotValidatePublicKey, // key from FVM has already been validated
 				),
 			)
 		},
@@ -3274,19 +3317,9 @@ func NewPublicKeyFromValue(
 		)
 	}
 
-	// `valid` and `validated` fields
-	var valid, validated bool
-	validField := publicKey.GetMember(inter, getLocationRange, sema.PublicKeyIsValidField)
-	validated = validField != nil
-	if validated {
-		valid = bool(validField.(interpreter.BoolValue))
-	}
-
 	return &PublicKey{
 		PublicKey: byteArray,
 		SignAlgo:  SignatureAlgorithm(signAlgoRawValue.ToInt()),
-		IsValid:   valid,
-		Validated: validated,
 	}, nil
 }
 
@@ -3311,12 +3344,7 @@ func NewPublicKeyValue(
 			inter *interpreter.Interpreter,
 			getLocationRange func() interpreter.LocationRange,
 			publicKeyValue *interpreter.CompositeValue,
-		) interpreter.BoolValue {
-			// If the public key is already validated, avoid re-validating, and return the cached result.
-			if publicKey.Validated {
-				return interpreter.BoolValue(publicKey.IsValid)
-			}
-
+		) error {
 			return validatePublicKey(inter, getLocationRange, publicKeyValue)
 		},
 	)
@@ -3364,23 +3392,17 @@ func validatePublicKey(
 	getLocationRange func() interpreter.LocationRange,
 	publicKeyValue *interpreter.CompositeValue,
 	runtimeInterface Interface,
-) interpreter.BoolValue {
-
+) error {
 	publicKey, err := NewPublicKeyFromValue(inter, getLocationRange, publicKeyValue)
 	if err != nil {
-		return false
+		return err
 	}
 
-	var valid bool
 	wrapPanic(func() {
-		valid, err = runtimeInterface.ValidatePublicKey(publicKey)
+		err = runtimeInterface.ValidatePublicKey(publicKey)
 	})
 
-	if err != nil {
-		panic(err)
-	}
-
-	return interpreter.BoolValue(valid)
+	return err
 }
 
 func verifyBLSPOP(
@@ -3520,4 +3542,15 @@ func hash(
 	}
 
 	return interpreter.ByteSliceToByteArrayValue(inter, result)
+}
+
+// DoNotValidatePublicKey conforms to the method signature for PublicKeyValidationHandlerFunc.
+// It disregards its input and returns `nil` indicating that the public key is valid.
+// It's used when handling public keys from the FVM, where they're already validated.
+func DoNotValidatePublicKey(
+	_ *interpreter.Interpreter,
+	_ func() interpreter.LocationRange,
+	_ *interpreter.CompositeValue,
+) error {
+	return nil
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -177,7 +177,7 @@ type testRuntimeInterface struct {
 	getStorageCapacity         func(_ Address) (uint64, error)
 	programs                   map[common.LocationID]*interpreter.Program
 	implementationDebugLog     func(message string) error
-	validatePublicKey          func(publicKey *PublicKey) (bool, error)
+	validatePublicKey          func(publicKey *PublicKey) error
 	bLSVerifyPOP               func(pk *PublicKey, s []byte) (bool, error)
 	aggregateBLSSignatures     func(sigs [][]byte) ([]byte, error)
 	aggregateBLSPublicKeys     func(keys []*PublicKey) (*PublicKey, error)
@@ -435,9 +435,9 @@ func (i *testRuntimeInterface) ImplementationDebugLog(message string) error {
 	return i.implementationDebugLog(message)
 }
 
-func (i *testRuntimeInterface) ValidatePublicKey(key *PublicKey) (bool, error) {
+func (i *testRuntimeInterface) ValidatePublicKey(key *PublicKey) error {
 	if i.validatePublicKey == nil {
-		return false, nil
+		return errors.New("mock defaults to public key validation failure")
 	}
 
 	return i.validatePublicKey(key)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6159,7 +6159,6 @@ var AccountKeyType = func() *CompositeType {
 const PublicKeyTypeName = "PublicKey"
 const PublicKeyPublicKeyField = "publicKey"
 const PublicKeySignAlgoField = "signatureAlgorithm"
-const PublicKeyIsValidField = "isValid"
 const PublicKeyVerifyFunction = "verify"
 const PublicKeyVerifyPoPFunction = "verifyPoP"
 
@@ -6169,10 +6168,6 @@ The public key
 
 const publicKeySignAlgoFieldDocString = `
 The signature algorithm to be used with the key
-`
-
-const publicKeyIsValidFieldDocString = `
-Flag indicating whether the key is valid
 `
 
 const publicKeyVerifyFunctionDocString = `
@@ -6208,12 +6203,6 @@ var PublicKeyType = func() *CompositeType {
 			PublicKeySignAlgoField,
 			SignatureAlgorithmType,
 			publicKeySignAlgoFieldDocString,
-		),
-		NewPublicConstantFieldMember(
-			publicKeyType,
-			PublicKeyIsValidField,
-			BoolType,
-			publicKeyIsValidFieldDocString,
 		),
 		NewPublicFunctionMember(
 			publicKeyType,

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -79,6 +79,4 @@ type AccountKey struct {
 type PublicKey struct {
 	PublicKey []byte
 	SignAlgo  SignatureAlgorithm
-	IsValid   bool
-	Validated bool
 }


### PR DESCRIPTION
Closes #1268 

## Description

Panics when a public key isn't valid. This makes `PublicKey.isValid` and `PublicKey.Validated` unnecessary, so they're removed.

Changes Cadence:
1. `PublicKey` no longer has an `isValid` field. 
2. `PublicKey` can no longer be invalid.