### PR TITLE
Disable existing hints if linting is disabled

### DIFF
--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -124,7 +124,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 						Range:        ast.NewRangeFromPositioned(leftHandExpression),
 					},
 				)
-			} else if IsSubType(leftHandType, rightHandType) {
+			} else if checker.lintEnabled && IsSubType(leftHandType, rightHandType) {
 
 				switch expression.Operation {
 				case ast.OperationFailableCast:

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -42,18 +42,19 @@ func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) as
 
 	optionalType, ok := valueType.(*OptionalType)
 	if !ok {
-
 		// A non-optional type is forced. Suggest removing it
 
-		checker.hint(
-			&RemovalHint{
-				Description: "unnecessary force operator",
-				Range: ast.Range{
-					StartPos: expression.EndPos,
-					EndPos:   expression.EndPos,
+		if checker.lintEnabled {
+			checker.hint(
+				&RemovalHint{
+					Description: "unnecessary force operator",
+					Range: ast.Range{
+						StartPos: expression.EndPos,
+						EndPos:   expression.EndPos,
+					},
 				},
-			},
-		)
+			)
+		}
 
 		return valueType
 	}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3126,14 +3126,16 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 		switch argument := argument.(type) {
 		case *ast.IntegerExpression:
 			if CheckIntegerLiteral(argument, targetType, checker.report) {
-
-				suggestIntegerLiteralConversionReplacement(checker, argument, targetType, invocationRange)
+				if checker.lintEnabled {
+					suggestIntegerLiteralConversionReplacement(checker, argument, targetType, invocationRange)
+				}
 			}
 
 		case *ast.FixedPointExpression:
 			if CheckFixedPointLiteral(argument, targetType, checker.report) {
-
-				suggestFixedPointLiteralConversionReplacement(checker, targetType, argument, invocationRange)
+				if checker.lintEnabled {
+					suggestFixedPointLiteralConversionReplacement(checker, targetType, argument, invocationRange)
+				}
 			}
 		}
 	}

--- a/runtime/tests/checker/conversion_test.go
+++ b/runtime/tests/checker/conversion_test.go
@@ -38,7 +38,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = Fix64(1)
         `)
 
@@ -58,7 +58,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = UFix64(1)
         `)
 
@@ -78,7 +78,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = Fix64(-1)
         `)
 
@@ -100,7 +100,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = UFix64(1.2)
         `)
 
@@ -120,7 +120,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = Fix64(-1.2)
         `)
 
@@ -144,7 +144,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = UInt8(1)
         `)
 
@@ -164,7 +164,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = Int8(1)
         `)
 
@@ -184,7 +184,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = Int8(-1)
         `)
 
@@ -204,7 +204,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = Int(1)
         `)
 
@@ -224,7 +224,7 @@ func TestCheckNumberConversionReplacementHint(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
            let x = Int(-1)
         `)
 

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -1295,6 +1295,8 @@ func TestCheckDynamicCastingCapability(t *testing.T) {
 
 func TestCheckAlwaysSucceedingDynamicCast(t *testing.T) {
 
+	t.Parallel()
+
 	const types = `
           struct interface I {}
 
@@ -1305,6 +1307,8 @@ func TestCheckAlwaysSucceedingDynamicCast(t *testing.T) {
 
 	test := func(t *testing.T, operation ast.Operation, hintType sema.Hint) {
 
+		t.Parallel()
+
 		usage := fmt.Sprintf(
 			`
               let s1 = S1()
@@ -1314,7 +1318,8 @@ func TestCheckAlwaysSucceedingDynamicCast(t *testing.T) {
             `,
 			operation.Symbol(),
 		)
-		checker, err := ParseAndCheck(t, types+usage)
+
+		checker, err := ParseAndCheckWithLinting(t, types+usage)
 
 		errs := ExpectCheckerErrors(t, err, 1)
 

--- a/runtime/tests/checker/force_test.go
+++ b/runtime/tests/checker/force_test.go
@@ -54,7 +54,7 @@ func TestCheckForce(t *testing.T) {
 
 	t.Run("non-optional", func(t *testing.T) {
 
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithLinting(t, `
           let x: Int = 1
           let y = x!
         `)

--- a/runtime/tests/checker/utils_test.go
+++ b/runtime/tests/checker/utils_test.go
@@ -40,6 +40,7 @@ func ParseAndCheckWithPanic(t *testing.T, code string) (*sema.Checker, error) {
 		},
 	)
 }
+
 func ParseAndCheckWithAny(t *testing.T, code string) (*sema.Checker, error) {
 	return ParseAndCheckWithOptions(t,
 		code,
@@ -52,6 +53,17 @@ func ParseAndCheckWithAny(t *testing.T, code string) (*sema.Checker, error) {
 						Kind: common.DeclarationKindType,
 					},
 				}),
+				sema.WithLintingEnabled(true),
+			},
+		},
+	)
+}
+
+func ParseAndCheckWithLinting(t *testing.T, code string) (*sema.Checker, error) {
+	return ParseAndCheckWithOptions(t,
+		code,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
 				sema.WithLintingEnabled(true),
 			},
 		},


### PR DESCRIPTION
Depends on #1072 

### Description

Just like disabling the new hint in #1072, also disable the existing hints when linting is disabled (the default).

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
