### PR TITLE
Pretty print statements

### DIFF
--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -53,17 +53,17 @@ func (b *Block) Doc() prettier.Doc {
 	return prettier.Concat{
 		blockStartDoc,
 		prettier.Indent{
-			Doc: b.statementsDoc(),
+			Doc: StatementsDoc(b.Statements),
 		},
 		prettier.HardLine{},
 		blockEndDoc,
 	}
 }
 
-func (b *Block) statementsDoc() prettier.Doc {
+func StatementsDoc(statements []Statement) prettier.Doc {
 	var statementsDoc prettier.Concat
 
-	for _, statement := range b.Statements {
+	for _, statement := range statements {
 		// TODO: replace once Statement implements Doc
 		hasDoc, ok := statement.(interface{ Doc() prettier.Doc })
 		if !ok {

--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -20,6 +20,8 @@ package ast
 
 import (
 	"encoding/json"
+
+	"github.com/turbolent/prettier"
 )
 
 type Block struct {
@@ -37,6 +39,45 @@ func (b *Block) Accept(visitor Visitor) Repr {
 
 func (b *Block) Walk(walkChild func(Element)) {
 	walkStatements(walkChild, b.Statements)
+}
+
+var blockStartDoc prettier.Doc = prettier.Text("{")
+var blockEndDoc prettier.Doc = prettier.Text("}")
+var blockEmptyDoc prettier.Doc = prettier.Text("{}")
+
+func (b *Block) Doc() prettier.Doc {
+	if b.IsEmpty() {
+		return blockEmptyDoc
+	}
+
+	return prettier.Concat{
+		blockStartDoc,
+		prettier.Indent{
+			Doc: b.statementsDoc(),
+		},
+		prettier.HardLine{},
+		blockEndDoc,
+	}
+}
+
+func (b *Block) statementsDoc() prettier.Doc {
+	var statementsDoc prettier.Concat
+
+	for _, statement := range b.Statements {
+		// TODO: replace once Statement implements Doc
+		hasDoc, ok := statement.(interface{ Doc() prettier.Doc })
+		if !ok {
+			continue
+		}
+
+		statementsDoc = append(
+			statementsDoc,
+			prettier.HardLine{},
+			hasDoc.Doc(),
+		)
+	}
+
+	return statementsDoc
 }
 
 func (b *Block) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1101,8 +1101,6 @@ var functionExpressionParameterSeparatorDoc prettier.Doc = prettier.Concat{
 }
 
 var typeSeparatorDoc prettier.Doc = prettier.Text(": ")
-var functionExpressionBlockStartDoc prettier.Doc = prettier.Text(" {")
-var functionExpressionBlockEndDoc prettier.Doc = prettier.Text("}")
 var functionExpressionEmptyBlockDoc prettier.Doc = prettier.Text(" {}")
 
 func (e *FunctionExpression) Doc() prettier.Doc {
@@ -1128,21 +1126,18 @@ func (e *FunctionExpression) Doc() prettier.Doc {
 
 	if e.FunctionBlock.IsEmpty() {
 		return append(doc, functionExpressionEmptyBlockDoc)
+	} else {
+		// TODO: pre-conditions
+		// TODO: post-conditions
+
+		blockDoc := e.FunctionBlock.Block.Doc()
+
+		return append(
+			doc,
+			prettier.Space,
+			blockDoc,
+		)
 	}
-
-	// TODO: pre-conditions
-	// TODO: post-conditions
-
-	statementsDoc := e.statementsDoc()
-
-	return append(doc,
-		functionExpressionBlockStartDoc,
-		prettier.Indent{
-			Doc: statementsDoc,
-		},
-		prettier.HardLine{},
-		functionExpressionBlockEndDoc,
-	)
 }
 
 func (e *FunctionExpression) parametersDoc() prettier.Doc {
@@ -1182,27 +1177,6 @@ func (e *FunctionExpression) parametersDoc() prettier.Doc {
 		),
 		prettier.SoftLine{},
 	)
-}
-
-func (e *FunctionExpression) statementsDoc() prettier.Doc {
-	var statementsDoc prettier.Concat
-
-	statements := e.FunctionBlock.Block.Statements
-
-	for _, statement := range statements {
-		// TODO: replace once Statement implements Doc
-		hasDoc, ok := statement.(interface{ Doc() prettier.Doc })
-		if !ok {
-			continue
-		}
-
-		statementsDoc = append(statementsDoc,
-			prettier.HardLine{},
-			hasDoc.Doc(),
-		)
-	}
-
-	return statementsDoc
 }
 
 func (e *FunctionExpression) StartPosition() Position {

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -45,6 +45,8 @@ type BoolExpression struct {
 	Range
 }
 
+var _ Expression = &BoolExpression{}
+
 func (*BoolExpression) isExpression() {}
 
 func (*BoolExpression) isIfStatementTest() {}
@@ -95,6 +97,8 @@ func (e *BoolExpression) MarshalJSON() ([]byte, error) {
 type NilExpression struct {
 	Pos Position `json:"-"`
 }
+
+var _ Expression = &NilExpression{}
 
 func (*NilExpression) isExpression() {}
 
@@ -150,6 +154,8 @@ type StringExpression struct {
 	Range
 }
 
+var _ Expression = &StringExpression{}
+
 func (*StringExpression) isExpression() {}
 
 func (*StringExpression) isIfStatementTest() {}
@@ -193,6 +199,8 @@ type IntegerExpression struct {
 	Base            int
 	Range
 }
+
+var _ Expression = &IntegerExpression{}
 
 func (*IntegerExpression) isExpression() {}
 
@@ -249,6 +257,8 @@ type FixedPointExpression struct {
 	Scale           uint
 	Range
 }
+
+var _ Expression = &FixedPointExpression{}
 
 func (*FixedPointExpression) isExpression() {}
 
@@ -319,6 +329,8 @@ type ArrayExpression struct {
 	Range
 }
 
+var _ Expression = &ArrayExpression{}
+
 func (*ArrayExpression) isExpression() {}
 
 func (*ArrayExpression) isIfStatementTest() {}
@@ -385,6 +397,8 @@ type DictionaryExpression struct {
 	Entries []DictionaryEntry
 	Range
 }
+
+var _ Expression = &DictionaryExpression{}
 
 func (*DictionaryExpression) isExpression() {}
 
@@ -492,6 +506,8 @@ type IdentifierExpression struct {
 	Identifier Identifier
 }
 
+var _ Expression = &IdentifierExpression{}
+
 func (*IdentifierExpression) isExpression() {}
 
 func (*IdentifierExpression) isIfStatementTest() {}
@@ -563,6 +579,8 @@ type InvocationExpression struct {
 	ArgumentsStartPos Position
 	EndPos            Position `json:"-"`
 }
+
+var _ Expression = &InvocationExpression{}
 
 func (*InvocationExpression) isExpression() {}
 
@@ -690,6 +708,8 @@ type MemberExpression struct {
 	Identifier Identifier
 }
 
+var _ Expression = &MemberExpression{}
+
 func (*MemberExpression) isExpression() {}
 
 func (*MemberExpression) isIfStatementTest() {}
@@ -781,6 +801,8 @@ type IndexExpression struct {
 	Range
 }
 
+var _ Expression = &IndexExpression{}
+
 func (*IndexExpression) isExpression() {}
 
 func (*IndexExpression) isIfStatementTest() {}
@@ -840,6 +862,8 @@ type ConditionalExpression struct {
 	Then Expression
 	Else Expression
 }
+
+var _ Expression = &ConditionalExpression{}
 
 func (*ConditionalExpression) isExpression() {}
 
@@ -934,6 +958,8 @@ type UnaryExpression struct {
 	StartPos   Position `json:"-"`
 }
 
+var _ Expression = &UnaryExpression{}
+
 func (*UnaryExpression) isExpression() {}
 
 func (*UnaryExpression) isIfStatementTest() {}
@@ -994,6 +1020,8 @@ type BinaryExpression struct {
 	Left      Expression
 	Right     Expression
 }
+
+var _ Expression = &BinaryExpression{}
 
 func (*BinaryExpression) isExpression() {}
 
@@ -1070,6 +1098,8 @@ type FunctionExpression struct {
 	FunctionBlock        *FunctionBlock
 	StartPos             Position `json:"-"`
 }
+
+var _ Expression = &FunctionExpression{}
 
 func (*FunctionExpression) isExpression() {}
 
@@ -1160,7 +1190,8 @@ func (e *FunctionExpression) parametersDoc() prettier.Doc {
 			)
 		}
 
-		parameterDoc = append(parameterDoc,
+		parameterDoc = append(
+			parameterDoc,
 			prettier.Text(parameter.Identifier.Identifier),
 			typeSeparatorDoc,
 		)
@@ -1208,6 +1239,8 @@ type CastingExpression struct {
 	TypeAnnotation            *TypeAnnotation
 	ParentVariableDeclaration *VariableDeclaration `json:"-"`
 }
+
+var _ Expression = &CastingExpression{}
 
 func (*CastingExpression) isExpression() {}
 
@@ -1277,6 +1310,8 @@ type CreateExpression struct {
 	StartPos             Position `json:"-"`
 }
 
+var _ Expression = &CreateExpression{}
+
 func (*CreateExpression) isExpression() {}
 
 func (*CreateExpression) isIfStatementTest() {}
@@ -1335,6 +1370,8 @@ type DestroyExpression struct {
 	Expression Expression
 	StartPos   Position `json:"-"`
 }
+
+var _ Expression = &DestroyExpression{}
 
 func (*DestroyExpression) isExpression() {}
 
@@ -1397,6 +1434,8 @@ type ReferenceExpression struct {
 	Type       Type     `json:"TargetType"`
 	StartPos   Position `json:"-"`
 }
+
+var _ Expression = &ReferenceExpression{}
 
 func (*ReferenceExpression) isExpression() {}
 
@@ -1472,6 +1511,8 @@ type ForceExpression struct {
 	EndPos     Position `json:"-"`
 }
 
+var _ Expression = &ForceExpression{}
+
 func (*ForceExpression) isExpression() {}
 
 func (*ForceExpression) isIfStatementTest() {}
@@ -1530,6 +1571,8 @@ type PathExpression struct {
 	Domain     Identifier
 	Identifier Identifier
 }
+
+var _ Expression = &PathExpression{}
 
 func (*PathExpression) isExpression() {}
 

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -2045,18 +2045,21 @@ func TestFunctionExpression_Doc(t *testing.T) {
 					// TODO: type
 				},
 			},
-			prettier.Text(" {"),
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.HardLine{},
-					prettier.Concat{
-						prettier.Text("return "),
-						prettier.Text("1"),
+			prettier.Text(" "),
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.HardLine{},
+						prettier.Concat{
+							prettier.Text("return "),
+							prettier.Text("1"),
+						},
 					},
 				},
+				prettier.HardLine{},
+				prettier.Text("}"),
 			},
-			prettier.HardLine{},
-			prettier.Text("}"),
 		}
 
 		assert.Equal(t, expected, expr.Doc())

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -403,6 +403,10 @@ type ExpressionStatement struct {
 	Expression Expression
 }
 
+var _ Statement = &ExpressionStatement{}
+
+func (*ExpressionStatement) isStatement() {}
+
 func (s *ExpressionStatement) StartPosition() Position {
 	return s.Expression.StartPosition()
 }
@@ -411,14 +415,16 @@ func (s *ExpressionStatement) EndPosition() Position {
 	return s.Expression.EndPosition()
 }
 
-func (*ExpressionStatement) isStatement() {}
-
 func (s *ExpressionStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitExpressionStatement(s)
 }
 
 func (s *ExpressionStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Expression)
+}
+
+func (s *ExpressionStatement) Doc() prettier.Doc {
+	return s.Expression.Doc()
 }
 
 func (s *ExpressionStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -251,6 +251,8 @@ type WhileStatement struct {
 	StartPos Position `json:"-"`
 }
 
+var _ Statement = &WhileStatement{}
+
 func (*WhileStatement) isStatement() {}
 
 func (s *WhileStatement) Accept(visitor Visitor) Repr {
@@ -268,6 +270,19 @@ func (s *WhileStatement) StartPosition() Position {
 
 func (s *WhileStatement) EndPosition() Position {
 	return s.Block.EndPosition()
+}
+
+const whileStatementKeywordSpaceDoc = prettier.Text("while ")
+
+func (s *WhileStatement) Doc() prettier.Doc {
+	return prettier.Group{
+		Doc: prettier.Concat{
+			whileStatementKeywordSpaceDoc,
+			s.Test.Doc(),
+			prettier.Space,
+			s.Block.Doc(),
+		},
+	}
 }
 
 func (s *WhileStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -80,6 +80,8 @@ type BreakStatement struct {
 	Range
 }
 
+var _ Statement = &BreakStatement{}
+
 func (*BreakStatement) isStatement() {}
 
 func (s *BreakStatement) Accept(visitor Visitor) Repr {
@@ -88,6 +90,12 @@ func (s *BreakStatement) Accept(visitor Visitor) Repr {
 
 func (*BreakStatement) Walk(_ func(Element)) {
 	// NO-OP
+}
+
+const breakStatementKeywordDoc = prettier.Text("break")
+
+func (*BreakStatement) Doc() prettier.Doc {
+	return breakStatementKeywordDoc
 }
 
 func (s *BreakStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -115,6 +115,8 @@ type ContinueStatement struct {
 	Range
 }
 
+var _ Statement = &ContinueStatement{}
+
 func (*ContinueStatement) isStatement() {}
 
 func (s *ContinueStatement) Accept(visitor Visitor) Repr {
@@ -123,6 +125,12 @@ func (s *ContinueStatement) Accept(visitor Visitor) Repr {
 
 func (*ContinueStatement) Walk(_ func(Element)) {
 	// NO-OP
+}
+
+const continueStatementKeywordDoc = prettier.Text("continue")
+
+func (*ContinueStatement) Doc() prettier.Doc {
+	return continueStatementKeywordDoc
 }
 
 func (s *ContinueStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -308,6 +308,8 @@ type ForStatement struct {
 	StartPos   Position `json:"-"`
 }
 
+var _ Statement = &ForStatement{}
+
 func (*ForStatement) isStatement() {}
 
 func (s *ForStatement) Accept(visitor Visitor) Repr {
@@ -325,6 +327,36 @@ func (s *ForStatement) StartPosition() Position {
 
 func (s *ForStatement) EndPosition() Position {
 	return s.Block.EndPosition()
+}
+
+const forStatementForKeywordSpaceDoc = prettier.Text("for ")
+const forStatementSpaceInKeywordSpaceDoc = prettier.Text(" in ")
+
+func (s *ForStatement) Doc() prettier.Doc {
+	doc := prettier.Concat{
+		forStatementForKeywordSpaceDoc,
+	}
+
+	if s.Index != nil {
+		doc = append(
+			doc,
+			prettier.Text(s.Index.Identifier),
+			prettier.Text(", "),
+		)
+	}
+
+	doc = append(
+		doc,
+		prettier.Text(s.Identifier.Identifier),
+		forStatementSpaceInKeywordSpaceDoc,
+		s.Value.Doc(),
+		prettier.Space,
+		s.Block.Doc(),
+	)
+
+	return prettier.Group{
+		Doc: doc,
+	}
 }
 
 func (s *ForStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -379,6 +379,10 @@ type EmitStatement struct {
 	StartPos             Position `json:"-"`
 }
 
+var _ Statement = &EmitStatement{}
+
+func (*EmitStatement) isStatement() {}
+
 func (s *EmitStatement) StartPosition() Position {
 	return s.StartPos
 }
@@ -387,14 +391,22 @@ func (s *EmitStatement) EndPosition() Position {
 	return s.InvocationExpression.EndPosition()
 }
 
-func (*EmitStatement) isStatement() {}
-
 func (s *EmitStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitEmitStatement(s)
 }
 
 func (s *EmitStatement) Walk(walkChild func(Element)) {
 	walkChild(s.InvocationExpression)
+}
+
+const emitStatementKeywordSpaceDoc = prettier.Text("emit ")
+
+func (s *EmitStatement) Doc() prettier.Doc {
+	return prettier.Concat{
+		emitStatementKeywordSpaceDoc,
+		// TODO: potentially parenthesize
+		s.InvocationExpression.Doc(),
+	}
 }
 
 func (s *EmitStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -430,6 +430,14 @@ type AssignmentStatement struct {
 	Value    Expression
 }
 
+var _ Statement = &AssignmentStatement{}
+
+func (*AssignmentStatement) isStatement() {}
+
+func (s *AssignmentStatement) Accept(visitor Visitor) Repr {
+	return visitor.VisitAssignmentStatement(s)
+}
+
 func (s *AssignmentStatement) StartPosition() Position {
 	return s.Target.StartPosition()
 }
@@ -438,15 +446,25 @@ func (s *AssignmentStatement) EndPosition() Position {
 	return s.Value.EndPosition()
 }
 
-func (*AssignmentStatement) isStatement() {}
-
-func (s *AssignmentStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitAssignmentStatement(s)
-}
-
 func (s *AssignmentStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Target)
 	walkChild(s.Value)
+}
+
+func (s *AssignmentStatement) Doc() prettier.Doc {
+	return prettier.Group{
+		Doc: prettier.Concat{
+			s.Target.Doc(),
+			prettier.Space,
+			s.Transfer.Doc(),
+			prettier.Space,
+			prettier.Group{
+				Doc: prettier.Indent{
+					Doc: s.Value.Doc(),
+				},
+			},
+		},
+	}
 }
 
 func (s *AssignmentStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -487,6 +487,10 @@ type SwapStatement struct {
 	Right Expression
 }
 
+var _ Statement = &SwapStatement{}
+
+func (*SwapStatement) isStatement() {}
+
 func (s *SwapStatement) StartPosition() Position {
 	return s.Left.StartPosition()
 }
@@ -495,8 +499,6 @@ func (s *SwapStatement) EndPosition() Position {
 	return s.Right.EndPosition()
 }
 
-func (*SwapStatement) isStatement() {}
-
 func (s *SwapStatement) Accept(visitor Visitor) Repr {
 	return visitor.VisitSwapStatement(s)
 }
@@ -504,6 +506,18 @@ func (s *SwapStatement) Accept(visitor Visitor) Repr {
 func (s *SwapStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Left)
 	walkChild(s.Right)
+}
+
+const swapStatementSpaceSymbolSpaceDoc = prettier.Text(" <-> ")
+
+func (s *SwapStatement) Doc() prettier.Doc {
+	return prettier.Group{
+		Doc: prettier.Concat{
+			s.Left.Doc(),
+			swapStatementSpaceSymbolSpaceDoc,
+			s.Right.Doc(),
+		},
+	}
 }
 
 func (s *SwapStatement) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -69,10 +69,6 @@ func TestExpressionStatement_Doc(t *testing.T) {
 	stmt := &ExpressionStatement{
 		Expression: &BoolExpression{
 			Value: false,
-			Range: Range{
-				StartPos: Position{Offset: 1, Line: 2, Column: 3},
-				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-			},
 		},
 	}
 
@@ -187,16 +183,9 @@ func TestBreakStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &BreakStatement{
-		Range: Range{
-			StartPos: Position{Offset: 1, Line: 2, Column: 3},
-			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-		},
-	}
-
 	assert.Equal(t,
 		prettier.Text("break"),
-		stmt.Doc(),
+		(&BreakStatement{}).Doc(),
 	)
 }
 
@@ -230,16 +219,9 @@ func TestContinueStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &ContinueStatement{
-		Range: Range{
-			StartPos: Position{Offset: 1, Line: 2, Column: 3},
-			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-		},
-	}
-
 	assert.Equal(t,
 		prettier.Text("continue"),
-		stmt.Doc(),
+		(&ContinueStatement{}).Doc(),
 	)
 }
 
@@ -316,26 +298,13 @@ func TestIfStatement_Doc(t *testing.T) {
 		stmt := &IfStatement{
 			Test: &BoolExpression{
 				Value: false,
-				Range: Range{
-					StartPos: Position{Offset: 1, Line: 2, Column: 3},
-					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-				},
 			},
 			Then: &Block{
 				Statements: []Statement{},
-				Range: Range{
-					StartPos: Position{Offset: 7, Line: 8, Column: 9},
-					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-				},
 			},
 			Else: &Block{
 				Statements: []Statement{},
-				Range: Range{
-					StartPos: Position{Offset: 13, Line: 14, Column: 15},
-					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
-				},
 			},
-			StartPos: Position{Offset: 19, Line: 20, Column: 21},
 		}
 
 		assert.Equal(t,
@@ -362,43 +331,22 @@ func TestIfStatement_Doc(t *testing.T) {
 		stmt := &IfStatement{
 			Test: &BoolExpression{
 				Value: false,
-				Range: Range{
-					StartPos: Position{Offset: 1, Line: 2, Column: 3},
-					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-				},
 			},
 			Then: &Block{
 				Statements: []Statement{},
-				Range: Range{
-					StartPos: Position{Offset: 7, Line: 8, Column: 9},
-					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-				},
 			},
 			Else: &Block{
 				Statements: []Statement{
 					&IfStatement{
 						Test: &BoolExpression{
 							Value: true,
-							Range: Range{
-								StartPos: Position{Offset: 22, Line: 23, Column: 24},
-								EndPos:   Position{Offset: 25, Line: 26, Column: 27},
-							},
 						},
 						Then: &Block{
 							Statements: []Statement{},
-							Range: Range{
-								StartPos: Position{Offset: 28, Line: 29, Column: 30},
-								EndPos:   Position{Offset: 31, Line: 32, Column: 33},
-							},
 						},
 					},
 				},
-				Range: Range{
-					StartPos: Position{Offset: 13, Line: 14, Column: 15},
-					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
-				},
 			},
-			StartPos: Position{Offset: 19, Line: 20, Column: 21},
 		}
 
 		assert.Equal(t,
@@ -482,19 +430,10 @@ func TestWhileStatement_Doc(t *testing.T) {
 	stmt := &WhileStatement{
 		Test: &BoolExpression{
 			Value: false,
-			Range: Range{
-				StartPos: Position{Offset: 1, Line: 2, Column: 3},
-				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-			},
 		},
 		Block: &Block{
 			Statements: []Statement{},
-			Range: Range{
-				StartPos: Position{Offset: 7, Line: 8, Column: 9},
-				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-			},
 		},
-		StartPos: Position{Offset: 13, Line: 14, Column: 15},
 	}
 
 	assert.Equal(t,
@@ -653,23 +592,13 @@ func TestForStatement_Doc(t *testing.T) {
 		stmt := &ForStatement{
 			Identifier: Identifier{
 				Identifier: "foobar",
-				Pos:        Position{Offset: 1, Line: 2, Column: 3},
 			},
 			Value: &BoolExpression{
 				Value: false,
-				Range: Range{
-					StartPos: Position{Offset: 4, Line: 5, Column: 6},
-					EndPos:   Position{Offset: 7, Line: 8, Column: 9},
-				},
 			},
 			Block: &Block{
 				Statements: []Statement{},
-				Range: Range{
-					StartPos: Position{Offset: 10, Line: 11, Column: 12},
-					EndPos:   Position{Offset: 13, Line: 14, Column: 15},
-				},
 			},
-			StartPos: Position{Offset: 16, Line: 17, Column: 18},
 		}
 
 		assert.Equal(t,
@@ -804,19 +733,13 @@ func TestAssignmentStatement_Doc(t *testing.T) {
 		Target: &IdentifierExpression{
 			Identifier: Identifier{
 				Identifier: "foobar",
-				Pos:        Position{Offset: 1, Line: 2, Column: 3},
 			},
 		},
 		Transfer: &Transfer{
 			Operation: TransferOperationCopy,
-			Pos:       Position{Offset: 4, Line: 5, Column: 6},
 		},
 		Value: &BoolExpression{
 			Value: false,
-			Range: Range{
-				StartPos: Position{Offset: 7, Line: 8, Column: 9},
-				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-			},
 		},
 	}
 
@@ -897,15 +820,10 @@ func TestSwapStatement_Doc(t *testing.T) {
 		Left: &IdentifierExpression{
 			Identifier: Identifier{
 				Identifier: "foobar",
-				Pos:        Position{Offset: 1, Line: 2, Column: 3},
 			},
 		},
 		Right: &BoolExpression{
 			Value: false,
-			Range: Range{
-				StartPos: Position{Offset: 4, Line: 5, Column: 6},
-				EndPos:   Position{Offset: 7, Line: 8, Column: 9},
-			},
 		},
 	}
 
@@ -1056,7 +974,7 @@ func TestEmitStatement_Doc(t *testing.T) {
 	)
 }
 
-func TestSwitchStatement_Doc(t *testing.T) {
+func TestSwitchStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()
 
@@ -1192,7 +1110,7 @@ func TestSwitchStatement_Doc(t *testing.T) {
 	)
 }
 
-func TestSwitchStatement_MarshalJSON(t *testing.T) {
+func TestSwitchStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
@@ -1200,31 +1118,21 @@ func TestSwitchStatement_MarshalJSON(t *testing.T) {
 		Expression: &IdentifierExpression{
 			Identifier: Identifier{
 				Identifier: "foo",
-				Pos:        Position{Offset: 1, Line: 2, Column: 3},
 			},
 		},
 		Cases: []*SwitchCase{
 			{
 				Expression: &BoolExpression{
 					Value: false,
-					Range: Range{
-						StartPos: Position{Offset: 4, Line: 5, Column: 6},
-						EndPos:   Position{Offset: 7, Line: 8, Column: 9},
-					},
 				},
 				Statements: []Statement{
 					&ExpressionStatement{
 						Expression: &IdentifierExpression{
 							Identifier: Identifier{
 								Identifier: "bar",
-								Pos:        Position{Offset: 10, Line: 11, Column: 12},
 							},
 						},
 					},
-				},
-				Range: Range{
-					StartPos: Position{Offset: 13, Line: 14, Column: 15},
-					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
 				},
 			},
 			{
@@ -1233,20 +1141,11 @@ func TestSwitchStatement_MarshalJSON(t *testing.T) {
 						Expression: &IdentifierExpression{
 							Identifier: Identifier{
 								Identifier: "baz",
-								Pos:        Position{Offset: 19, Line: 20, Column: 21},
 							},
 						},
 					},
 				},
-				Range: Range{
-					StartPos: Position{Offset: 22, Line: 23, Column: 24},
-					EndPos:   Position{Offset: 25, Line: 26, Column: 27},
-				},
 			},
-		},
-		Range: Range{
-			StartPos: Position{Offset: 28, Line: 29, Column: 30},
-			EndPos:   Position{Offset: 31, Line: 32, Column: 33},
 		},
 	}
 

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -1055,3 +1055,245 @@ func TestEmitStatement_Doc(t *testing.T) {
 		stmt.Doc(),
 	)
 }
+
+func TestSwitchStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &SwitchStatement{
+		Expression: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foo",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Cases: []*SwitchCase{
+			{
+				Expression: &BoolExpression{
+					Value: false,
+					Range: Range{
+						StartPos: Position{Offset: 4, Line: 5, Column: 6},
+						EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+					},
+				},
+				Statements: []Statement{
+					&ExpressionStatement{
+						Expression: &IdentifierExpression{
+							Identifier: Identifier{
+								Identifier: "bar",
+								Pos:        Position{Offset: 10, Line: 11, Column: 12},
+							},
+						},
+					},
+				},
+				Range: Range{
+					StartPos: Position{Offset: 13, Line: 14, Column: 15},
+					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+				},
+			},
+			{
+				Statements: []Statement{
+					&ExpressionStatement{
+						Expression: &IdentifierExpression{
+							Identifier: Identifier{
+								Identifier: "baz",
+								Pos:        Position{Offset: 19, Line: 20, Column: 21},
+							},
+						},
+					},
+				},
+				Range: Range{
+					StartPos: Position{Offset: 22, Line: 23, Column: 24},
+					EndPos:   Position{Offset: 25, Line: 26, Column: 27},
+				},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 28, Line: 29, Column: 30},
+			EndPos:   Position{Offset: 31, Line: 32, Column: 33},
+		},
+	}
+
+	actual, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`
+        {
+            "Type": "SwitchStatement",
+            "Expression": {
+                "Type": "IdentifierExpression",
+                "Identifier": {
+                    "Identifier": "foo",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 3, "Line": 2, "Column": 5}
+                },
+                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                "EndPos": {"Offset": 3, "Line": 2, "Column": 5}
+            },
+            "Cases": [
+                {
+                    "Type": "SwitchCase",
+                    "Expression": {
+                        "Type": "BoolExpression",
+                        "Value": false,
+                        "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                        "EndPos": {"Offset": 7, "Line": 8, "Column": 9}
+                    },
+                    "Statements": [
+                        {
+                            "Type": "ExpressionStatement",
+                            "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+                            "EndPos": {"Offset": 12, "Line": 11, "Column": 14},
+                            "Expression": {
+                                "Type": "IdentifierExpression",
+                                "Identifier": {
+                                    "Identifier": "bar",
+                                    "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+                                    "EndPos": {"Offset": 12, "Line": 11, "Column": 14}
+                                },
+                                "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+                                "EndPos": {"Offset": 12, "Line": 11, "Column": 14}
+                            }
+                        }
+                    ],
+                    "StartPos": {"Offset": 13, "Line": 14, "Column": 15},
+                    "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+                },
+                {
+                    "Type": "SwitchCase",
+                    "Expression": null,
+                    "Statements": [
+                        {
+                            "Type": "ExpressionStatement",
+                            "StartPos": {"Offset": 19, "Line": 20, "Column": 21},
+                            "EndPos": {"Offset": 21, "Line": 20, "Column": 23},
+                            "Expression": {
+                                "Type": "IdentifierExpression",
+                                "Identifier": {
+                                    "Identifier": "baz",
+                                    "StartPos": {"Offset": 19, "Line": 20, "Column": 21},
+                                    "EndPos": {"Offset": 21, "Line": 20, "Column": 23}
+                                },
+                                "StartPos": {"Offset": 19, "Line": 20, "Column": 21},
+                                "EndPos": {"Offset": 21, "Line": 20, "Column": 23}
+                            }
+                        }
+                    ],
+                    "StartPos": {"Offset": 22, "Line": 23, "Column": 24},
+                    "EndPos": {"Offset": 25, "Line": 26, "Column": 27}
+                }
+            ],
+            "StartPos": {"Offset": 28, "Line": 29, "Column": 30},
+            "EndPos": {"Offset": 31, "Line": 32, "Column": 33}
+        }
+        `,
+		string(actual),
+	)
+}
+
+func TestSwitchStatement_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &SwitchStatement{
+		Expression: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foo",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Cases: []*SwitchCase{
+			{
+				Expression: &BoolExpression{
+					Value: false,
+					Range: Range{
+						StartPos: Position{Offset: 4, Line: 5, Column: 6},
+						EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+					},
+				},
+				Statements: []Statement{
+					&ExpressionStatement{
+						Expression: &IdentifierExpression{
+							Identifier: Identifier{
+								Identifier: "bar",
+								Pos:        Position{Offset: 10, Line: 11, Column: 12},
+							},
+						},
+					},
+				},
+				Range: Range{
+					StartPos: Position{Offset: 13, Line: 14, Column: 15},
+					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+				},
+			},
+			{
+				Statements: []Statement{
+					&ExpressionStatement{
+						Expression: &IdentifierExpression{
+							Identifier: Identifier{
+								Identifier: "baz",
+								Pos:        Position{Offset: 19, Line: 20, Column: 21},
+							},
+						},
+					},
+				},
+				Range: Range{
+					StartPos: Position{Offset: 22, Line: 23, Column: 24},
+					EndPos:   Position{Offset: 25, Line: 26, Column: 27},
+				},
+			},
+		},
+		Range: Range{
+			StartPos: Position{Offset: 28, Line: 29, Column: 30},
+			EndPos:   Position{Offset: 31, Line: 32, Column: 33},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Group{
+				Doc: prettier.Concat{
+					switchStatementKeywordSpaceDoc,
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Text("foo"),
+						},
+					},
+					prettier.Line{},
+				},
+			},
+			prettier.Text("{"),
+			prettier.Indent{
+				Doc: prettier.Concat{
+					prettier.HardLine{},
+					prettier.Concat{
+						switchCaseKeywordSpaceDoc,
+						prettier.Text("false"),
+						switchCaseColonSymbolDoc,
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.HardLine{},
+								prettier.Text("bar"),
+							},
+						},
+					},
+					prettier.HardLine{},
+					prettier.Concat{
+						switchCaseDefaultKeywordSpaceDoc,
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.HardLine{},
+								prettier.Text("baz"),
+							},
+						},
+					},
+				},
+			},
+			prettier.HardLine{},
+			prettier.Text("}"),
+		},
+		stmt.Doc(),
+	)
+}

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -304,6 +304,127 @@ func TestIfStatement_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestIfStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty if-else", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &IfStatement{
+			Test: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+			Then: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 7, Line: 8, Column: 9},
+					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+				},
+			},
+			Else: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 13, Line: 14, Column: 15},
+					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+				},
+			},
+			StartPos: Position{Offset: 19, Line: 20, Column: 21},
+		}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("if "),
+					prettier.Text("false"),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+					prettier.Text(" else "),
+					prettier.Group{
+						Doc: prettier.Text("{}"),
+					},
+				},
+			},
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("if-else if", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &IfStatement{
+			Test: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+			Then: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 7, Line: 8, Column: 9},
+					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+				},
+			},
+			Else: &Block{
+				Statements: []Statement{
+					&IfStatement{
+						Test: &BoolExpression{
+							Value: true,
+							Range: Range{
+								StartPos: Position{Offset: 22, Line: 23, Column: 24},
+								EndPos:   Position{Offset: 25, Line: 26, Column: 27},
+							},
+						},
+						Then: &Block{
+							Statements: []Statement{},
+							Range: Range{
+								StartPos: Position{Offset: 28, Line: 29, Column: 30},
+								EndPos:   Position{Offset: 31, Line: 32, Column: 33},
+							},
+						},
+					},
+				},
+				Range: Range{
+					StartPos: Position{Offset: 13, Line: 14, Column: 15},
+					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+				},
+			},
+			StartPos: Position{Offset: 19, Line: 20, Column: 21},
+		}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("if "),
+					prettier.Text("false"),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+					prettier.Text(" else "),
+					prettier.Group{
+						Doc: prettier.Group{
+							Doc: prettier.Concat{
+								prettier.Text("if "),
+								prettier.Text("true"),
+								prettier.Text(" "),
+								prettier.Text("{}"),
+							},
+						},
+					},
+				},
+			},
+			stmt.Doc(),
+		)
+	})
+}
+
 func TestWhileStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -205,6 +205,23 @@ func TestContinueStatement_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestContinueStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &ContinueStatement{
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Text("continue"),
+		stmt.Doc(),
+	)
+}
+
 func TestIfStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -62,6 +62,26 @@ func TestExpressionStatement_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestExpressionStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &ExpressionStatement{
+		Expression: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Text("false"),
+		stmt.Doc(),
+	)
+}
+
 func TestReturnStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -889,6 +889,38 @@ func TestSwapStatement_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestSwapStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &SwapStatement{
+		Left: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Right: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 4, Line: 5, Column: 6},
+				EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Group{
+			Doc: prettier.Concat{
+				prettier.Text("foobar"),
+				swapStatementSpaceSymbolSpaceDoc,
+				prettier.Text("false"),
+			},
+		},
+		stmt.Doc(),
+	)
+}
+
 func TestEmitStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -796,6 +796,48 @@ func TestAssignmentStatement_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestAssignmentStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &AssignmentStatement{
+		Target: &IdentifierExpression{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+		},
+		Transfer: &Transfer{
+			Operation: TransferOperationCopy,
+			Pos:       Position{Offset: 4, Line: 5, Column: 6},
+		},
+		Value: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+		},
+	}
+
+	require.Equal(t,
+		prettier.Group{
+			Doc: prettier.Concat{
+				prettier.Text("foobar"),
+				prettier.Text(" "),
+				prettier.Text("="),
+				prettier.Text(" "),
+				prettier.Group{
+					Doc: prettier.Indent{
+						Doc: prettier.Text("false"),
+					},
+				},
+			},
+		},
+		stmt.Doc(),
+	)
+}
+
 func TestSwapStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -955,3 +955,29 @@ func TestEmitStatement_MarshalJSON(t *testing.T) {
 		string(actual),
 	)
 }
+
+func TestEmitStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &EmitStatement{
+		InvocationExpression: &InvocationExpression{
+			InvokedExpression: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foobar",
+				},
+			},
+		},
+	}
+
+	require.Equal(t,
+		prettier.Concat{
+			prettier.Text("emit "),
+			prettier.Concat{
+				prettier.Text("foobar"),
+				prettier.Text("()"),
+			},
+		},
+		stmt.Doc(),
+	)
+}

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -162,6 +162,23 @@ func TestBreakStatement_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestBreakStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &BreakStatement{
+		Range: Range{
+			StartPos: Position{Offset: 1, Line: 2, Column: 3},
+			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Text("break"),
+		stmt.Doc(),
+	)
+}
+
 func TestContinueStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -120,6 +120,7 @@ func TestReturnStatement_MarshalJSON(t *testing.T) {
 		string(actual),
 	)
 }
+
 func TestReturnStatement_Doc(t *testing.T) {
 
 	t.Parallel()
@@ -471,6 +472,41 @@ func TestWhileStatement_MarshalJSON(t *testing.T) {
         }
         `,
 		string(actual),
+	)
+}
+
+func TestWhileStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	stmt := &WhileStatement{
+		Test: &BoolExpression{
+			Value: false,
+			Range: Range{
+				StartPos: Position{Offset: 1, Line: 2, Column: 3},
+				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
+		Block: &Block{
+			Statements: []Statement{},
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+		},
+		StartPos: Position{Offset: 13, Line: 14, Column: 15},
+	}
+
+	assert.Equal(t,
+		prettier.Group{
+			Doc: prettier.Concat{
+				prettier.Text("while "),
+				prettier.Text("false"),
+				prettier.Text(" "),
+				prettier.Text("{}"),
+			},
+		},
+		stmt.Doc(),
 	)
 }
 

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -514,59 +514,225 @@ func TestForStatement_MarshalJSON(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &ForStatement{
-		Identifier: Identifier{
-			Identifier: "foobar",
-			Pos:        Position{Offset: 1, Line: 2, Column: 3},
-		},
-		Value: &BoolExpression{
-			Value: false,
-			Range: Range{
-				StartPos: Position{Offset: 4, Line: 5, Column: 6},
-				EndPos:   Position{Offset: 7, Line: 8, Column: 9},
-			},
-		},
-		Block: &Block{
-			Statements: []Statement{},
-			Range: Range{
-				StartPos: Position{Offset: 10, Line: 11, Column: 12},
-				EndPos:   Position{Offset: 13, Line: 14, Column: 15},
-			},
-		},
-		StartPos: Position{Offset: 16, Line: 17, Column: 18},
-	}
+	t.Run("without index", func(t *testing.T) {
 
-	actual, err := json.Marshal(stmt)
-	require.NoError(t, err)
+		t.Parallel()
 
-	assert.JSONEq(t,
-		`
-        {
-            "Type": "ForStatement",
-            "Identifier": {
-                "Identifier": "foobar",
-                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
-                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
-            },
-			"Index": null,
-            "Value": {
-                "Type": "BoolExpression",
-                "Value": false,
-                "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
-                "EndPos": {"Offset": 7, "Line": 8, "Column": 9}
-            },
-            "Block": {
-                "Type": "Block",
-                "Statements": [],
-                "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
-                "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
-            },
-            "StartPos": {"Offset": 16, "Line": 17, "Column": 18},
-            "EndPos":  {"Offset": 13, "Line": 14, "Column": 15}
-        }
-        `,
-		string(actual),
-	)
+		stmt := &ForStatement{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			Value: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 4, Line: 5, Column: 6},
+					EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+				},
+			},
+			Block: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 10, Line: 11, Column: 12},
+					EndPos:   Position{Offset: 13, Line: 14, Column: 15},
+				},
+			},
+			StartPos: Position{Offset: 16, Line: 17, Column: 18},
+		}
+
+		actual, err := json.Marshal(stmt)
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`
+            {
+                "Type": "ForStatement",
+                "Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+                },
+		    	"Index": null,
+                "Value": {
+                    "Type": "BoolExpression",
+                    "Value": false,
+                    "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                    "EndPos": {"Offset": 7, "Line": 8, "Column": 9}
+                },
+                "Block": {
+                    "Type": "Block",
+                    "Statements": [],
+                    "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
+                    "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+                },
+                "StartPos": {"Offset": 16, "Line": 17, "Column": 18},
+                "EndPos":  {"Offset": 13, "Line": 14, "Column": 15}
+            }
+            `,
+			string(actual),
+		)
+	})
+
+	t.Run("with index", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &ForStatement{
+			Index: &Identifier{
+				Identifier: "i",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 4, Line: 5, Column: 6},
+			},
+			Value: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 7, Line: 8, Column: 9},
+					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+				},
+			},
+			Block: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 13, Line: 14, Column: 15},
+					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+				},
+			},
+			StartPos: Position{Offset: 19, Line: 20, Column: 21},
+		}
+
+		actual, err := json.Marshal(stmt)
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`
+            {
+                "Type": "ForStatement",
+                "Index": {
+                    "Identifier": "i",
+                    "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+                    "EndPos": {"Offset": 1, "Line": 2, "Column": 3}
+                },
+		    	"Identifier": {
+                    "Identifier": "foobar",
+                    "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                    "EndPos": {"Offset": 9, "Line": 5, "Column": 11}
+                },
+                "Value": {
+                    "Type": "BoolExpression",
+                    "Value": false,
+                    "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+                    "EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+                },
+                "Block": {
+                    "Type": "Block",
+                    "Statements": [],
+                    "StartPos":{"Offset": 13, "Line": 14, "Column": 15},
+                    "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+                },
+                "StartPos": {"Offset": 19, "Line": 20, "Column": 21},
+                "EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+            }
+            `,
+			string(actual),
+		)
+	})
+
+}
+
+func TestForStatement_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("without index", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &ForStatement{
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			Value: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 4, Line: 5, Column: 6},
+					EndPos:   Position{Offset: 7, Line: 8, Column: 9},
+				},
+			},
+			Block: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 10, Line: 11, Column: 12},
+					EndPos:   Position{Offset: 13, Line: 14, Column: 15},
+				},
+			},
+			StartPos: Position{Offset: 16, Line: 17, Column: 18},
+		}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("for "),
+					prettier.Text("foobar"),
+					prettier.Text(" in "),
+					prettier.Text("false"),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("with index", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &ForStatement{
+			Index: &Identifier{
+				Identifier: "i",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			Identifier: Identifier{
+				Identifier: "foobar",
+				Pos:        Position{Offset: 4, Line: 5, Column: 6},
+			},
+			Value: &BoolExpression{
+				Value: false,
+				Range: Range{
+					StartPos: Position{Offset: 7, Line: 8, Column: 9},
+					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+				},
+			},
+			Block: &Block{
+				Statements: []Statement{},
+				Range: Range{
+					StartPos: Position{Offset: 13, Line: 14, Column: 15},
+					EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+				},
+			},
+			StartPos: Position{Offset: 19, Line: 20, Column: 21},
+		}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("for "),
+					prettier.Text("i"),
+					prettier.Text(", "),
+					prettier.Text("foobar"),
+					prettier.Text(" in "),
+					prettier.Text("false"),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
 }
 
 func TestAssignmentStatement_MarshalJSON(t *testing.T) {

--- a/tools/pretty/main.go
+++ b/tools/pretty/main.go
@@ -110,7 +110,7 @@ const page = `
     </style>
 </head>
 <body id="panels">
-<textarea id="editor"></textarea>
+<textarea id="editor" onkeydown="if(event.keyCode===9){var v=this.value,s=this.selectionStart,e=this.selectionEnd;this.value=v.substring(0, s)+'    '+v.substring(e);this.selectionStart=this.selectionEnd=s+4;return false;}"></textarea>
 <div id="pretty">
     <input id="stepper" type="number" min="1" step="1">
     <div id="output"></div>


### PR DESCRIPTION
Work towards #209

## Description

Implement pretty-printing functions for all statement AST nodes:

- `ReturnStatement`
- `BreakStatement`
- `ContinueStatement`
- `IfStatement`
- `WhileStatement`
- `ForStatement`
- `EmitStatement`
- `AssignmentStatement`
- `SwapStatement`
- `ExpressionStatement`

Also:
- Add missing JSON marshaling tests
- Allow inserting tabs (4 spaces) in the pretty printer tool's text area

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
