### PR TITLE
Pretty print types

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -627,10 +627,9 @@ func (e *InvocationExpression) Doc() prettier.Doc {
 
 	if len(e.TypeArguments) > 0 {
 		typeArgumentDocs := make([]prettier.Doc, len(e.TypeArguments))
-		// TODO: type arguments
-		//for i, typeArgument := range e.TypeArguments {
-		//	typeArgumentDocs[i] = typeArgument.Doc()
-		//}
+		for i, typeArgument := range e.TypeArguments {
+			typeArgumentDocs[i] = typeArgument.Doc()
+		}
 
 		result = append(result,
 			prettier.Wrap(
@@ -1143,7 +1142,7 @@ func (e *FunctionExpression) Doc() prettier.Doc {
 		signatureDoc = prettier.Concat{
 			signatureDoc,
 			typeSeparatorDoc,
-			// TODO: type
+			e.ReturnTypeAnnotation.Doc(),
 		}
 	}
 
@@ -1194,9 +1193,8 @@ func (e *FunctionExpression) parametersDoc() prettier.Doc {
 			parameterDoc,
 			prettier.Text(parameter.Identifier.Identifier),
 			typeSeparatorDoc,
+			parameter.TypeAnnotation.Doc(),
 		)
-
-		// TODO: type
 
 		parameterDocs = append(parameterDocs, parameterDoc)
 	}
@@ -1276,8 +1274,8 @@ func (e *CastingExpression) Doc() prettier.Doc {
 			},
 			prettier.Line{},
 			prettier.Text(e.Operation.Symbol()),
-			prettier.Space,
-			// TODO: type
+			prettier.Line{},
+			e.TypeAnnotation.Doc(),
 		},
 	}
 }
@@ -1477,8 +1475,8 @@ func (e *ReferenceExpression) Doc() prettier.Doc {
 			},
 			prettier.Line{},
 			referenceExpressionAsOperatorDoc,
-			prettier.Space,
-			// TODO: type
+			prettier.Line{},
+			e.Type.Doc(),
 		},
 	}
 }

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -1440,7 +1440,10 @@ func TestInvocationExpression_Doc(t *testing.T) {
 						prettier.Indent{
 							Doc: prettier.Concat{
 								prettier.SoftLine{},
-								nil,
+								prettier.Concat{
+									prettier.Text("@"),
+									prettier.Text("AB"),
+								},
 							},
 						},
 						prettier.SoftLine{},
@@ -1549,7 +1552,7 @@ func TestCastingExpression_Doc(t *testing.T) {
 			IsResource: true,
 			Type: &NominalType{
 				Identifier: Identifier{
-					Identifier: "Int",
+					Identifier: "R",
 				},
 			},
 		},
@@ -1563,8 +1566,11 @@ func TestCastingExpression_Doc(t *testing.T) {
 				},
 				prettier.Line{},
 				prettier.Text("as?"),
-				prettier.Space,
-				// TODO: type
+				prettier.Line{},
+				prettier.Concat{
+					prettier.Text("@"),
+					prettier.Text("R"),
+				},
 			},
 		},
 		expr.Doc(),
@@ -1788,8 +1794,12 @@ func TestReferenceExpression_Doc(t *testing.T) {
 				},
 				prettier.Line{},
 				prettier.Text("as"),
-				prettier.Space,
-				// TODO: type
+				prettier.Line{},
+				prettier.Concat{
+					prettier.Text("auth "),
+					prettier.Text("&"),
+					prettier.Text("Int"),
+				},
 			},
 		},
 		expr.Doc(),
@@ -1990,7 +2000,7 @@ func TestFunctionExpression_Doc(t *testing.T) {
 				IsResource: true,
 				Type: &NominalType{
 					Identifier: Identifier{
-						Identifier: "Int",
+						Identifier: "R",
 					},
 				},
 			},
@@ -2025,6 +2035,7 @@ func TestFunctionExpression_Doc(t *testing.T) {
 											prettier.Space,
 											prettier.Text("b"),
 											prettier.Text(": "),
+											prettier.Text("C"),
 										},
 										prettier.Concat{
 											prettier.Text(","),
@@ -2033,6 +2044,7 @@ func TestFunctionExpression_Doc(t *testing.T) {
 										prettier.Concat{
 											prettier.Text("d"),
 											prettier.Text(": "),
+											prettier.Text("E"),
 										},
 									},
 								},
@@ -2042,7 +2054,10 @@ func TestFunctionExpression_Doc(t *testing.T) {
 						},
 					},
 					prettier.Text(": "),
-					// TODO: type
+					prettier.Concat{
+						prettier.Text("@"),
+						prettier.Text("R"),
+					},
 				},
 			},
 			prettier.Text(" "),

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -140,6 +140,8 @@ type OptionalType struct {
 	EndPos Position `json:"-"`
 }
 
+var _ Type = &OptionalType{}
+
 func (*OptionalType) isType() {}
 
 func (t *OptionalType) String() string {
@@ -152,6 +154,15 @@ func (t *OptionalType) StartPosition() Position {
 
 func (t *OptionalType) EndPosition() Position {
 	return t.EndPos
+}
+
+const optionalTypeSymbolDoc = prettier.Text("?")
+
+func (t *OptionalType) Doc() prettier.Doc {
+	return prettier.Concat{
+		t.Type.Doc(),
+		optionalTypeSymbolDoc,
+	}
 }
 
 func (t *OptionalType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -49,6 +49,19 @@ func (t *TypeAnnotation) EndPosition() Position {
 	return t.Type.EndPosition()
 }
 
+const typeAnnotationResourceSymbolDoc = prettier.Text("@")
+
+func (t *TypeAnnotation) Doc() prettier.Doc {
+	if !t.IsResource {
+		return t.Type.Doc()
+	}
+
+	return prettier.Concat{
+		typeAnnotationResourceSymbolDoc,
+		t.Type.Doc(),
+	}
+}
+
 func (t *TypeAnnotation) MarshalJSON() ([]byte, error) {
 	type Alias TypeAnnotation
 	return json.Marshal(&struct {
@@ -66,6 +79,7 @@ type Type interface {
 	HasPosition
 	fmt.Stringer
 	isType()
+	Doc() prettier.Doc
 	CheckEqual(other Type, checker TypeEqualityChecker) error
 }
 

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -286,10 +286,32 @@ type DictionaryType struct {
 	Range
 }
 
+var _ Type = &DictionaryType{}
+
 func (*DictionaryType) isType() {}
 
 func (t *DictionaryType) String() string {
 	return fmt.Sprintf("{%s: %s}", t.KeyType, t.ValueType)
+}
+
+const dictionaryTypeStartDoc = prettier.Text("{")
+const dictionaryTypeEndDoc = prettier.Text("}")
+const dictionaryTypeSeparatorSpaceDoc = prettier.Text(": ")
+
+func (t *DictionaryType) Doc() prettier.Doc {
+	return prettier.Concat{
+		dictionaryTypeStartDoc,
+		prettier.Indent{
+			Doc: prettier.Concat{
+				prettier.SoftLine{},
+				t.KeyType.Doc(),
+				dictionaryTypeSeparatorSpaceDoc,
+				t.ValueType.Doc(),
+			},
+		},
+		prettier.SoftLine{},
+		dictionaryTypeEndDoc,
+	}
 }
 
 func (t *DictionaryType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -568,6 +568,8 @@ type InstantiationType struct {
 	EndPos                Position `json:"-"`
 }
 
+var _ Type = &InstantiationType{}
+
 func (*InstantiationType) isType() {}
 
 func (t *InstantiationType) String() string {
@@ -590,6 +592,44 @@ func (t *InstantiationType) StartPosition() Position {
 
 func (t *InstantiationType) EndPosition() Position {
 	return t.EndPos
+}
+
+const instantiationTypeStartDoc = prettier.Text("<")
+const instantiationTypeEndDoc = prettier.Text(">")
+const instantiationTypeSeparatorDoc = prettier.Text(",")
+
+func (t *InstantiationType) Doc() prettier.Doc {
+	typeArgumentsDoc := prettier.Concat{
+		prettier.SoftLine{},
+	}
+
+	for i, typeArgument := range t.TypeArguments {
+		if i > 0 {
+			typeArgumentsDoc = append(
+				typeArgumentsDoc,
+				instantiationTypeSeparatorDoc,
+				prettier.Line{},
+			)
+		}
+		typeArgumentsDoc = append(
+			typeArgumentsDoc,
+			typeArgument.Doc(),
+		)
+	}
+
+	return prettier.Concat{
+		t.Type.Doc(),
+		prettier.Group{
+			Doc: prettier.Concat{
+				instantiationTypeStartDoc,
+				prettier.Indent{
+					Doc: typeArgumentsDoc,
+				},
+				prettier.SoftLine{},
+				instantiationTypeEndDoc,
+			},
+		},
+	}
 }
 
 func (t *InstantiationType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -229,7 +229,7 @@ func (t *VariableSizedType) CheckEqual(other Type, checker TypeEqualityChecker) 
 	return checker.CheckVariableSizedTypeEquality(t, other)
 }
 
-// ConstantSizedType is a constant sized array type
+// ConstantSizedType is a constant-sized array type
 
 type ConstantSizedType struct {
 	Type Type `json:"ElementType"`
@@ -237,10 +237,30 @@ type ConstantSizedType struct {
 	Range
 }
 
+var _ Type = &ConstantSizedType{}
+
 func (*ConstantSizedType) isType() {}
 
 func (t *ConstantSizedType) String() string {
 	return fmt.Sprintf("[%s; %s]", t.Type, t.Size)
+}
+
+const constantSizedTypeSeparatorSpaceDoc = prettier.Text("; ")
+
+func (t *ConstantSizedType) Doc() prettier.Doc {
+	return prettier.Concat{
+		arrayTypeStartDoc,
+		prettier.Indent{
+			Doc: prettier.Concat{
+				prettier.SoftLine{},
+				t.Type.Doc(),
+				constantSizedTypeSeparatorSpaceDoc,
+				t.Size.Doc(),
+			},
+		},
+		prettier.SoftLine{},
+		arrayTypeEndDoc,
+	}
 }
 
 func (t *ConstantSizedType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -418,6 +418,8 @@ type ReferenceType struct {
 	StartPos   Position `json:"-"`
 }
 
+var _ Type = &ReferenceType{}
+
 func (*ReferenceType) isType() {}
 
 func (t *ReferenceType) String() string {
@@ -436,6 +438,22 @@ func (t *ReferenceType) StartPosition() Position {
 
 func (t *ReferenceType) EndPosition() Position {
 	return t.Type.EndPosition()
+}
+
+const referenceTypeAuthKeywordSpaceDoc = prettier.Text("auth ")
+const referenceTypeSymbolDoc = prettier.Text("&")
+
+func (t *ReferenceType) Doc() prettier.Doc {
+	var doc prettier.Concat
+	if t.Authorized {
+		doc = append(doc, referenceTypeAuthKeywordSpaceDoc)
+	}
+
+	return append(
+		doc,
+		referenceTypeSymbolDoc,
+		t.Type.Doc(),
+	)
 }
 
 func (t *ReferenceType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -337,6 +337,8 @@ type FunctionType struct {
 	Range
 }
 
+var _ Type = &FunctionType{}
+
 func (*FunctionType) isType() {}
 
 func (t *FunctionType) String() string {
@@ -349,6 +351,48 @@ func (t *FunctionType) String() string {
 	}
 
 	return fmt.Sprintf("((%s): %s)", parameters.String(), t.ReturnTypeAnnotation.String())
+}
+
+const functionTypeStartDoc = prettier.Text("(")
+const functionTypeEndDoc = prettier.Text(")")
+const functionTypeTypeSeparatorSpaceDoc = prettier.Text(": ")
+const functionTypeParameterSeparatorDoc = prettier.Text(",")
+
+func (t *FunctionType) Doc() prettier.Doc {
+	parametersDoc := prettier.Concat{
+		prettier.SoftLine{},
+	}
+
+	for i, parameterTypeAnnotation := range t.ParameterTypeAnnotations {
+		if i > 0 {
+			parametersDoc = append(
+				parametersDoc,
+				functionTypeParameterSeparatorDoc,
+				prettier.Line{},
+			)
+		}
+		parametersDoc = append(
+			parametersDoc,
+			parameterTypeAnnotation.Doc(),
+		)
+	}
+
+	return prettier.Concat{
+		functionTypeStartDoc,
+		prettier.Group{
+			Doc: prettier.Concat{
+				functionTypeStartDoc,
+				prettier.Indent{
+					Doc: parametersDoc,
+				},
+				prettier.SoftLine{},
+				functionTypeEndDoc,
+			},
+		},
+		functionTypeTypeSeparatorSpaceDoc,
+		t.ReturnTypeAnnotation.Doc(),
+		functionTypeEndDoc,
+	}
 }
 
 func (t *FunctionType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -481,6 +481,8 @@ type RestrictedType struct {
 	Range
 }
 
+var _ Type = &RestrictedType{}
+
 func (*RestrictedType) isType() {}
 
 func (t *RestrictedType) String() string {
@@ -497,6 +499,49 @@ func (t *RestrictedType) String() string {
 	}
 	builder.WriteRune('}')
 	return builder.String()
+}
+
+const restrictedTypeStartDoc = prettier.Text("{")
+const restrictedTypeEndDoc = prettier.Text("}")
+const restrictedTypeSeparatorDoc = prettier.Text(",")
+
+func (t *RestrictedType) Doc() prettier.Doc {
+	restrictionsDoc := prettier.Concat{
+		prettier.SoftLine{},
+	}
+
+	for i, restriction := range t.Restrictions {
+		if i > 0 {
+			restrictionsDoc = append(
+				restrictionsDoc,
+				restrictedTypeSeparatorDoc,
+				prettier.Line{},
+			)
+		}
+		restrictionsDoc = append(
+			restrictionsDoc,
+			restriction.Doc(),
+		)
+	}
+
+	var doc prettier.Concat
+	if t.Type != nil {
+		doc = append(doc, t.Type.Doc())
+	}
+
+	return append(doc,
+		prettier.Group{
+			Doc: prettier.Concat{
+				restrictedTypeStartDoc,
+				prettier.Indent{
+					Doc: restrictionsDoc,
+				},
+				prettier.SoftLine{},
+				restrictedTypeEndDoc,
+			},
+		},
+	)
+
 }
 
 func (t *RestrictedType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -189,10 +189,29 @@ type VariableSizedType struct {
 	Range
 }
 
+var _ Type = &VariableSizedType{}
+
 func (*VariableSizedType) isType() {}
 
 func (t *VariableSizedType) String() string {
 	return fmt.Sprintf("[%s]", t.Type)
+}
+
+const arrayTypeStartDoc = prettier.Text("[")
+const arrayTypeEndDoc = prettier.Text("]")
+
+func (t *VariableSizedType) Doc() prettier.Doc {
+	return prettier.Concat{
+		arrayTypeStartDoc,
+		prettier.Indent{
+			Doc: prettier.Concat{
+				prettier.SoftLine{},
+				t.Type.Doc(),
+			},
+		},
+		prettier.SoftLine{},
+		arrayTypeEndDoc,
+	}
 }
 
 func (t *VariableSizedType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/turbolent/prettier"
 )
 
 // TypeAnnotation
@@ -79,6 +81,8 @@ type NominalType struct {
 	NestedIdentifiers []Identifier `json:",omitempty"`
 }
 
+var _ Type = &NominalType{}
+
 func (*NominalType) isType() {}
 
 func (t *NominalType) String() string {
@@ -102,6 +106,10 @@ func (t *NominalType) EndPosition() Position {
 	}
 	lastIdentifier := t.NestedIdentifiers[nestedCount-1]
 	return lastIdentifier.EndPosition()
+}
+
+func (t *NominalType) Doc() prettier.Doc {
+	return prettier.Text(t.String())
 }
 
 func (t *NominalType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -128,6 +128,27 @@ func TestNominalType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestOptionalType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &OptionalType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "R",
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("R"),
+			prettier.Text("?"),
+		},
+		ty.Doc(),
+	)
+}
+
 func TestOptionalType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -188,6 +188,34 @@ func TestOptionalType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestVariableSizedType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &VariableSizedType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "T",
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("["),
+			prettier.Indent{
+				Doc: prettier.Concat{
+					prettier.SoftLine{},
+					prettier.Text("T"),
+				},
+			},
+			prettier.SoftLine{},
+			prettier.Text("]"),
+		},
+		ty.Doc(),
+	)
+}
+
 func TestVariableSizedType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -807,6 +807,63 @@ func TestRestrictedType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestInstantiationType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &InstantiationType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "AB",
+			},
+		},
+		TypeArguments: []*TypeAnnotation{
+			{
+				IsResource: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "CD",
+					},
+				},
+			},
+			{
+				IsResource: false,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "EF",
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("AB"),
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("<"),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Concat{
+								prettier.Text("@"),
+								prettier.Text("CD"),
+							},
+							prettier.Text(","),
+							prettier.Line{},
+							prettier.Text("EF"),
+						},
+					},
+					prettier.SoftLine{},
+					prettier.Text(">"),
+				},
+			},
+		},
+		ty.Doc(),
+	)
+}
+
 func TestInstantiationType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -590,6 +590,56 @@ func TestFunctionType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestReferenceType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("auth", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{
+			Authorized: true,
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("auth "),
+				prettier.Text("&"),
+				prettier.Text("T"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("un-auth", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("&"),
+				prettier.Text("T"),
+			},
+			ty.Doc(),
+		)
+	})
+
+}
+
 func TestReferenceType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/turbolent/prettier"
 )
 
 func TestTypeAnnotation_MarshalJSON(t *testing.T) {
@@ -64,6 +65,22 @@ func TestTypeAnnotation_MarshalJSON(t *testing.T) {
         }
         `,
 		string(actual),
+	)
+}
+
+func TestNominalType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &NominalType{
+		Identifier: Identifier{
+			Identifier: "R",
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Text("R"),
+		ty.Doc(),
 	)
 }
 

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -681,6 +681,54 @@ func TestReferenceType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestRestrictedType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &RestrictedType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "AB",
+			},
+		},
+		Restrictions: []*NominalType{
+			{
+				Identifier: Identifier{
+					Identifier: "CD",
+				},
+			},
+			{
+				Identifier: Identifier{
+					Identifier: "EF",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("AB"),
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("{"),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Text("CD"),
+							prettier.Text(","),
+							prettier.Line{},
+							prettier.Text("EF"),
+						},
+					},
+					prettier.SoftLine{},
+					prettier.Text("}"),
+				},
+			},
+		},
+		ty.Doc(),
+	)
+}
+
 func TestRestrictedType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -258,6 +258,41 @@ func TestVariableSizedType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestConstantSizedType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &ConstantSizedType{
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "T",
+			},
+		},
+		Size: &IntegerExpression{
+			PositiveLiteral: "42",
+			Value:           big.NewInt(42),
+			Base:            10,
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("["),
+			prettier.Indent{
+				Doc: prettier.Concat{
+					prettier.SoftLine{},
+					prettier.Text("T"),
+					prettier.Text("; "),
+					prettier.Text("42"),
+				},
+			},
+			prettier.SoftLine{},
+			prettier.Text("]"),
+		},
+		ty.Doc(),
+	)
+}
+
 func TestConstantSizedType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -352,6 +352,41 @@ func TestConstantSizedType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestDictionaryType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &DictionaryType{
+		KeyType: &NominalType{
+			Identifier: Identifier{
+				Identifier: "AB",
+			},
+		},
+		ValueType: &NominalType{
+			Identifier: Identifier{
+				Identifier: "CD",
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("{"),
+			prettier.Indent{
+				Doc: prettier.Concat{
+					prettier.SoftLine{},
+					prettier.Text("AB"),
+					prettier.Text(": "),
+					prettier.Text("CD"),
+				},
+			},
+			prettier.SoftLine{},
+			prettier.Text("}"),
+		},
+		ty.Doc(),
+	)
+}
+
 func TestDictionaryType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -445,6 +445,71 @@ func TestDictionaryType_MarshalJSON(t *testing.T) {
 	)
 }
 
+func TestFunctionType_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &FunctionType{
+		ParameterTypeAnnotations: []*TypeAnnotation{
+			{
+				IsResource: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "AB",
+					},
+				},
+			},
+			{
+				IsResource: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "CD",
+					},
+				},
+			},
+		},
+		ReturnTypeAnnotation: &TypeAnnotation{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "EF",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("("),
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("("),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Concat{
+								prettier.Text("@"),
+								prettier.Text("AB"),
+							},
+							prettier.Text(","),
+							prettier.Line{},
+							prettier.Concat{
+								prettier.Text("@"),
+								prettier.Text("CD"),
+							},
+						},
+					},
+					prettier.SoftLine{},
+					prettier.Text(")"),
+				},
+			},
+			prettier.Text(": "),
+			prettier.Text("EF"),
+			prettier.Text(")"),
+		},
+		ty.Doc(),
+	)
+}
+
 func TestFunctionType_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -28,6 +28,28 @@ import (
 	"github.com/turbolent/prettier"
 )
 
+func TestTypeAnnotation_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &TypeAnnotation{
+		IsResource: true,
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "R",
+			},
+		},
+	}
+
+	assert.Equal(t,
+		prettier.Concat{
+			prettier.Text("@"),
+			prettier.Text("R"),
+		},
+		ty.Doc(),
+	)
+}
+
 func TestTypeAnnotation_MarshalJSON(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/variable_declaration.go
+++ b/runtime/ast/variable_declaration.go
@@ -114,6 +114,7 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 				Doc: prettier.Concat{
 					prettier.Text(d.Identifier.Identifier),
 					prettier.Space,
+					// TODO: type annotation, if any
 					d.Transfer.Doc(),
 					prettier.Space,
 					prettier.Group{


### PR DESCRIPTION
Work towards #209

## Description

Implement pretty-printing functions for all type AST nodes:

- `TypeAnnotation`
- `NominalType`
- `OptionalType`
- `VariableSizedType`
- `ConstantSizedType`
- `DictionaryType`
- `FunctionType`
- `ReferenceType`
- `RestrictedType`
- `InstantiationType`

Also, include type annotations in expressions.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
