### PR TITLE
`load`, `copy` and `borrow` cause a force cast 

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3567,7 +3567,11 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 			// which reads the stored value
 			// and performs a dynamic type check
 
-			if reference.ReferencedValue(interpreter) == nil {
+			value, errFunc := reference.dereference(interpreter)
+			if errFunc != nil {
+				panic(errFunc(invocation.GetLocationRange()))
+			}
+			if value == nil {
 				return NilValue{}
 			}
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3500,7 +3500,10 @@ func (interpreter *Interpreter) authAccountReadFunction(addressValue AddressValu
 
 				dynamicType := value.Value.DynamicType(interpreter, SeenReferences{})
 				if !interpreter.IsSubType(dynamicType, ty) {
-					return NilValue{}
+					panic(ForceCastTypeMismatchError{
+						ExpectedType:  ty,
+						LocationRange: invocation.GetLocationRange(),
+					})
 				}
 
 				inter := invocation.Interpreter

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -367,10 +367,9 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			// load
 
-			value, err := inter.Invoke("loadR2")
-			require.NoError(t, err)
+			_, err = inter.Invoke("loadR2")
 
-			require.IsType(t, interpreter.NilValue{}, value)
+			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, accountStorables, 1)
@@ -449,10 +448,8 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			// load
 
-			value, err := inter.Invoke("loadS2")
-			require.NoError(t, err)
-
-			require.IsType(t, interpreter.NilValue{}, value)
+			_, err = inter.Invoke("loadS2")
+			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, accountStorables, 1)
@@ -545,10 +542,8 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 
 		// load
 
-		value, err := inter.Invoke("copyS2")
-		require.NoError(t, err)
-
-		require.IsType(t, interpreter.NilValue{}, value)
+		_, err = inter.Invoke("copyS2")
+		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 		// NOTE: check loaded value was *not* removed from storage
 		require.Len(t, accountStorables, 1)
@@ -674,10 +669,8 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 		t.Run("borrow R2", func(t *testing.T) {
 
-			value, err := inter.Invoke("borrowR2")
-			require.NoError(t, err)
-
-			require.IsType(t, interpreter.NilValue{}, value)
+			_, err := inter.Invoke("borrowR2")
+			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, accountStorables, 1)
@@ -813,10 +806,8 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 		t.Run("borrow S2", func(t *testing.T) {
 
-			value, err := inter.Invoke("borrowS2")
-			require.NoError(t, err)
-
-			require.IsType(t, interpreter.NilValue{}, value)
+			_, err = inter.Invoke("borrowS2")
+			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, accountStorables, 1)


### PR DESCRIPTION
Closes #1247

## Description

This changes the storage API to cause `load`, `copy` and `borrow` to produce a runtime error if the supplied type argument does not match the stored value. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
