### PR TITLE
Tweak Cadence bench to be more stable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run benchmark on current branch
         run: |
-          go test ./... -run=XXX -bench=. -shuffle=on -count ${{ steps.settings.outputs.benchmark_repetitions }} | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' | tee new.txt
+          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' ) | tee new.txt
       # the package replace line above is to make the results table more readable, since it is not fragmented by package
       
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run benchmark on base branch
         run: |
-          go test ./... -run=XXX -bench=. -shuffle=on -count ${{ steps.settings.outputs.benchmark_repetitions }} | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' | tee old.txt
+          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' ) | tee old.txt
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison
@@ -80,7 +80,7 @@ jobs:
           body: |
             ## Cadence [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison
             This branch with compared with the base branch ${{  github.event.pull_request.base.label }} commit ${{ github.event.pull_request.base.sha }}
-            The command `go test ./... -run=XXX -bench=. -shuffle=on -count N` was used.
+            The command `for i in {1..N}; do go test ./... -run=XXX -bench=. -shuffle=on; done` was used.
             Bench tests were run a total of ${{ steps.settings.outputs.benchmark_repetitions }} times on each branch.
             ## Results
             ${{ env.BENCHSTAT }}


### PR DESCRIPTION
## Description

Related to https://github.com/onflow/flow-go/pull/1722

Bench tests were being run grouped. Given test A and B with shuffle on and count 3 they would either run like this AAA BBB or like this BBB AAA.

This fix changes the use of the -count flag into a for loop. Which means all test are ran once in a shuffled order, and then this repeats N times.

This tweak causes the uncertainty in the results to go up, which in turn causes the prediction of how much the performance changes to be more conservative.

Example:

```
name                                              old time/op    new time/op    delta
RuntimeResourceDictionaryValues-8                   17.8ms ±34%    14.5ms ± 7%   ~     (p=1.000 n=3+3)
RuntimeFungibleTokenTransfer-8                      1.11ms ±21%    1.03ms ±11%   ~     (p=0.700 n=3+3)
ParseFungibleToken-8                                 578µs ±14%     534µs ±14%   ~     (p=0.400 n=3+3)
ParseDeploy/byte_array-8                            42.7ms ± 9%    40.2ms ±19%   ~     (p=0.700 n=3+3)
ParseDeploy/decode_hex-8                            1.28ms ±21%    1.09ms ±12%   ~     (p=0.400 n=3+3)
ParseArray-8                                        26.5ms ±11%    25.0ms ± 7%   ~     (p=1.000 n=3+3)
ParseInfix-8                                        28.6µs ± 4%    25.8µs ± 9%   ~     (p=0.100 n=3+3)
QualifiedIdentifierCreation/One_level-8             2.91ns ±18%    2.56ns ± 3%   ~     (p=0.400 n=3+3)
QualifiedIdentifierCreation/Three_levels-8           121ns ± 8%     114ns ± 8%   ~     (p=0.400 n=3+3)
CheckContractInterfaceFungibleTokenConformance-8     176µs ±13%     145µs ±12%   ~     (p=0.100 n=3+3)
ContractInterfaceFungibleToken-8                    51.3µs ±14%    44.4µs ± 6%   ~     (p=0.200 n=3+3)
NewInterpreter/new_interpreter-8                    1.22µs ±16%    1.07µs ± 6%   ~     (p=0.400 n=3+3)
NewInterpreter/new_sub-interpreter-8                2.19µs ±15%    1.94µs ± 1%   ~     (p=0.200 n=3+3)
InterpretRecursionFib-8                             2.82ms ±12%    2.55ms ± 3%   ~     (p=0.700 n=3+3)

name                                              old alloc/op   new alloc/op   delta
RuntimeResourceDictionaryValues-8                   4.34MB ± 0%    4.34MB ± 0%   ~     (p=0.400 n=3+3)
RuntimeFungibleTokenTransfer-8                       239kB ± 0%     239kB ± 0%   ~     (p=0.700 n=3+3)
QualifiedIdentifierCreation/One_level-8              0.00B          0.00B        ~     (all equal)
QualifiedIdentifierCreation/Three_levels-8           64.0B ± 0%     64.0B ± 0%   ~     (all equal)
CheckContractInterfaceFungibleTokenConformance-8    65.7kB ± 0%    65.7kB ± 0%   ~     (p=1.000 n=3+3)
ContractInterfaceFungibleToken-8                    26.5kB ± 0%    26.5kB ± 0%   ~     (all equal)
NewInterpreter/new_interpreter-8                      720B ± 0%      720B ± 0%   ~     (all equal)
NewInterpreter/new_sub-interpreter-8                1.11kB ± 0%    1.11kB ± 0%   ~     (all equal)
InterpretRecursionFib-8                             1.24MB ± 0%    1.24MB ± 0%   ~     (p=1.000 n=3+3)

name                                              old allocs/op  new allocs/op  delta
RuntimeResourceDictionaryValues-8                     108k ± 0%      108k ± 0%   ~     (p=1.000 n=3+3)
RuntimeFungibleTokenTransfer-8                       4.54k ± 0%     4.54k ± 0%   ~     (p=1.000 n=3+3)
QualifiedIdentifierCreation/One_level-8               0.00           0.00        ~     (all equal)
QualifiedIdentifierCreation/Three_levels-8            2.00 ± 0%      2.00 ± 0%   ~     (all equal)
CheckContractInterfaceFungibleTokenConformance-8     1.07k ± 0%     1.07k ± 0%   ~     (all equal)
ContractInterfaceFungibleToken-8                       457 ± 0%       457 ± 0%   ~     (all equal)
NewInterpreter/new_interpreter-8                      11.0 ± 0%      11.0 ± 0%   ~     (all equal)
NewInterpreter/new_sub-interpreter-8                  32.0 ± 0%      32.0 ± 0%   ~     (all equal)
InterpretRecursionFib-8                              25.0k ± 0%     25.0k ± 0%   ~     (all equal)
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
