### PR TITLE
Update Resource Doucmantation link in 02-hello-world.mdx 

### DIFF
--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -272,7 +272,7 @@ Congratulations, you just executed your first Cadence transaction! :100:
 
 ---
 
-Next, we are going to get some practice with an example that uses **[resources](/cadence/language/composite-types/#resources)**,
+Next, we are going to get some practice with an example that uses **[resources](/cadence/language/resources/)**,
 one of the defining features in Cadence. A resource is a composite type like a struct or a class, but with some special rules.
 
 <Callout type="info">


### PR DESCRIPTION
## Description

as real documentation of resources is located in /cadence/language/resources/, so I updated the path of the link.

previous path is linked to  https://docs.onflow.org/cadence/language/composite-types/#resources
![image](https://user-images.githubusercontent.com/10865414/144868746-79ab3c37-0543-4319-b0bf-27ed86bfd3c0.png)

I suggest modifying the 1 depth link as it is more comfortable than the 2 depth link.


<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
