### PR TITLE
Optimize ByteSize functions for 7 Value types

### DIFF
--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/big"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/atree"
@@ -30,6 +31,19 @@ import (
 )
 
 const cborTagSize = 2
+
+var bigOne = big.NewInt(1)
+
+func getBigIntCBORSize(v *big.Int) uint32 {
+	sign := v.Sign()
+	if sign < 0 {
+		v = new(big.Int).Abs(v)
+		v.Sub(v, bigOne)
+	}
+
+	// tag number + bytes
+	return 1 + getBytesCBORSize(v.Bytes())
+}
 
 func getIntCBORSize(v int64) uint32 {
 	if v < 0 {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2051,8 +2051,7 @@ func (IntValue) DeepRemove(_ *Interpreter) {
 }
 
 func (v IntValue) ByteSize() uint32 {
-	// TODO: optimize
-	return mustStorableSize(v)
+	return cborTagSize + getBigIntCBORSize(v.BigInt)
 }
 
 func (v IntValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
@@ -3871,8 +3870,7 @@ func (Int128Value) DeepRemove(_ *Interpreter) {
 }
 
 func (v Int128Value) ByteSize() uint32 {
-	// TODO: optimize
-	return mustStorableSize(v)
+	return cborTagSize + getBigIntCBORSize(v.BigInt)
 }
 
 func (v Int128Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
@@ -4295,8 +4293,7 @@ func (Int256Value) DeepRemove(_ *Interpreter) {
 }
 
 func (v Int256Value) ByteSize() uint32 {
-	// TODO: optimize
-	return mustStorableSize(v)
+	return cborTagSize + getBigIntCBORSize(v.BigInt)
 }
 
 func (v Int256Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
@@ -4609,8 +4606,7 @@ func (UIntValue) DeepRemove(_ *Interpreter) {
 }
 
 func (v UIntValue) ByteSize() uint32 {
-	// TODO: optimize
-	return mustStorableSize(v)
+	return cborTagSize + getBigIntCBORSize(v.BigInt)
 }
 
 func (v UIntValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
@@ -6134,8 +6130,7 @@ func (UInt128Value) DeepRemove(_ *Interpreter) {
 }
 
 func (v UInt128Value) ByteSize() uint32 {
-	// TODO: optimize
-	return mustStorableSize(v)
+	return cborTagSize + getBigIntCBORSize(v.BigInt)
 }
 
 func (v UInt128Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
@@ -6504,8 +6499,7 @@ func (UInt256Value) DeepRemove(_ *Interpreter) {
 }
 
 func (v UInt256Value) ByteSize() uint32 {
-	// TODO: optimize
-	return mustStorableSize(v)
+	return cborTagSize + getBigIntCBORSize(v.BigInt)
 }
 
 func (v UInt256Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
@@ -11191,7 +11185,8 @@ func (PathValue) DeepRemove(_ *Interpreter) {
 }
 
 func (v PathValue) ByteSize() uint32 {
-	return mustStorableSize(v)
+	// tag number (2 bytes) + array head (1 byte) + domain (CBOR uint) + identifier (CBOR string)
+	return cborTagSize + 1 + getUintCBORSize(uint64(v.Domain)) + getBytesCBORSize([]byte(v.Identifier))
 }
 
 func (v PathValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {


### PR DESCRIPTION
Closes #1259 

## Description

ByteSize() of some types were obtained by encoding the values to CBOR and getting the resulting data size.

This optimization computes the data size without encoding.

Optimized ByteSize() for the following Value types:
- IntValue
- Int128Value
- Int256Value
- UIntValue
- UInt128Value
- UInt256Value
- PathValue

## Caveats

These were not optimized yet because it would increase code maintenance.
- TypeValue
- CapabilityValue
- LinkValue
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
