### PR TITLE
Add more graceful handling for go type assertions in `runtime/sema`

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -753,7 +753,6 @@ func (s *Server) DocumentHighlight(
 
 	position := conversion.ProtocolToSemaPosition(params.Position)
 	occurrences := checker.Occurrences.FindAll(position)
-
 	// If there are no occurrences,
 	// then try the preceding position
 	if len(occurrences) == 0 && position.Column > 0 {
@@ -801,7 +800,6 @@ func (s *Server) Rename(
 
 	position := conversion.ProtocolToSemaPosition(params.Position)
 	occurrences := checker.Occurrences.FindAll(position)
-
 	// If there are no occurrences,
 	// then try the preceding position
 	if len(occurrences) == 0 && position.Column > 0 {

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -753,12 +753,18 @@ func (s *Server) DocumentHighlight(
 
 	position := conversion.ProtocolToSemaPosition(params.Position)
 	occurrences := checker.Occurrences.FindAll(position)
+	if occurrences == nil {
+		return nil, nil
+	}
 	// If there are no occurrences,
 	// then try the preceding position
 	if len(occurrences) == 0 && position.Column > 0 {
 		previousPosition := position
 		previousPosition.Column -= 1
 		occurrences = checker.Occurrences.FindAll(previousPosition)
+		if occurrences == nil {
+			return nil, nil
+		}
 	}
 
 	documentHighlights := make([]*protocol.DocumentHighlight, 0)
@@ -800,12 +806,18 @@ func (s *Server) Rename(
 
 	position := conversion.ProtocolToSemaPosition(params.Position)
 	occurrences := checker.Occurrences.FindAll(position)
+	if occurrences == nil {
+		return nil, nil
+	}
 	// If there are no occurrences,
 	// then try the preceding position
 	if len(occurrences) == 0 && position.Column > 0 {
 		previousPosition := position
 		previousPosition.Column -= 1
 		occurrences = checker.Occurrences.FindAll(previousPosition)
+		if occurrences == nil {
+			return nil, nil
+		}
 	}
 
 	textEdits := make([]protocol.TextEdit, 0)

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -753,18 +753,13 @@ func (s *Server) DocumentHighlight(
 
 	position := conversion.ProtocolToSemaPosition(params.Position)
 	occurrences := checker.Occurrences.FindAll(position)
-	if occurrences == nil {
-		return nil, nil
-	}
+
 	// If there are no occurrences,
 	// then try the preceding position
 	if len(occurrences) == 0 && position.Column > 0 {
 		previousPosition := position
 		previousPosition.Column -= 1
 		occurrences = checker.Occurrences.FindAll(previousPosition)
-		if occurrences == nil {
-			return nil, nil
-		}
 	}
 
 	documentHighlights := make([]*protocol.DocumentHighlight, 0)
@@ -806,18 +801,13 @@ func (s *Server) Rename(
 
 	position := conversion.ProtocolToSemaPosition(params.Position)
 	occurrences := checker.Occurrences.FindAll(position)
-	if occurrences == nil {
-		return nil, nil
-	}
+
 	// If there are no occurrences,
 	// then try the preceding position
 	if len(occurrences) == 0 && position.Column > 0 {
 		previousPosition := position
 		previousPosition.Column -= 1
 		occurrences = checker.Occurrences.FindAll(previousPosition)
-		if occurrences == nil {
-			return nil, nil
-		}
 	}
 
 	textEdits := make([]protocol.TextEdit, 0)

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -252,7 +252,11 @@ func (checker *Checker) declareCompositeNestedTypes(
 			if nestedCompositeDeclaration, isCompositeDeclaration :=
 				nestedDeclaration.(*ast.CompositeDeclaration); isCompositeDeclaration {
 
-				nestedCompositeType := nestedType.(*CompositeType)
+				nestedCompositeType, ok := nestedType.(*CompositeType)
+				if !ok {
+					// we just checked that this was a composite declaration
+					panic(errors.NewUnreachableError())
+				}
 
 				// Always determine composite constructor type
 
@@ -1743,7 +1747,11 @@ func (checker *Checker) checkSpecialFunction(
 	case ContainerKindComposite:
 		// Event declarations have an empty initializer as it is synthesized
 
-		compositeType := containerType.(*CompositeType)
+		compositeType, ok := containerType.(*CompositeType)
+		if !ok {
+			// we just checked that the container was a composite
+			panic(errors.NewUnreachableError())
+		}
 		if compositeType.Kind != common.CompositeKindEvent &&
 			specialFunction.FunctionDeclaration.FunctionBlock == nil {
 

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1118,8 +1118,12 @@ func (checker *Checker) memberSatisfied(compositeMember, interfaceMember *Member
 			// where argument labels are not considered,
 			// and parameters are contravariant.
 
-			interfaceMemberFunctionType := interfaceMemberType.(*FunctionType)
-			compositeMemberFunctionType := compositeMemberType.(*FunctionType)
+			interfaceMemberFunctionType, isInterfaceMemberFunctionType := interfaceMemberType.(*FunctionType)
+			compositeMemberFunctionType, isCompositeMemberFunctionType := compositeMemberType.(*FunctionType)
+
+			if !isInterfaceMemberFunctionType || !isCompositeMemberFunctionType {
+				return false
+			}
 
 			if !interfaceMemberFunctionType.HasSameArgumentLabels(compositeMemberFunctionType) {
 				return false

--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -107,22 +107,14 @@ func (checker *Checker) visitConditional(
 	return checker.checkConditionalBranches(
 		func() Type {
 			thenResult, ok := thenElement.Accept(checker).(Type)
-			if !ok {
-				// visiter must always return a Type
-				panic(errors.NewUnreachableError())
-			}
-			if thenResult == nil {
+			if !ok || thenResult == nil {
 				return nil
 			}
 			return thenResult
 		},
 		func() Type {
 			elseResult, ok := elseElement.Accept(checker).(Type)
-			if !ok {
-				// visiter must always return a Type
-				panic(errors.NewUnreachableError())
-			}
-			if elseResult == nil {
+			if !ok || elseResult == nil {
 				return nil
 			}
 			return elseResult

--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -106,18 +106,26 @@ func (checker *Checker) visitConditional(
 
 	return checker.checkConditionalBranches(
 		func() Type {
-			thenResult := thenElement.Accept(checker)
+			thenResult, ok := thenElement.Accept(checker).(Type)
+			if !ok {
+				// visiter must always return a Type
+				panic(errors.NewUnreachableError())
+			}
 			if thenResult == nil {
 				return nil
 			}
-			return thenResult.(Type)
+			return thenResult
 		},
 		func() Type {
-			elseResult := elseElement.Accept(checker)
+			elseResult, ok := elseElement.Accept(checker).(Type)
+			if !ok {
+				// visiter must always return a Type
+				panic(errors.NewUnreachableError())
+			}
 			if elseResult == nil {
 				return nil
 			}
-			return elseResult.(Type)
+			return elseResult
 		},
 	)
 }

--- a/runtime/sema/function_invocations.go
+++ b/runtime/sema/function_invocations.go
@@ -63,6 +63,9 @@ func (f *FunctionInvocations) Find(pos Position) *FunctionInvocation {
 	if interval == nil {
 		return nil
 	}
-	invocation := value.(FunctionInvocation)
+	invocation, ok := value.(FunctionInvocation)
+	if !ok {
+		return nil
+	}
 	return &invocation
 }

--- a/runtime/sema/member_accesses.go
+++ b/runtime/sema/member_accesses.go
@@ -57,7 +57,10 @@ func (m *MemberAccesses) Find(pos Position) *MemberAccess {
 	if interval == nil {
 		return nil
 	}
-	access := value.(MemberAccess)
+	access, ok := value.(MemberAccess)
+	if !ok {
+		return nil
+	}
 	return &access
 }
 
@@ -65,7 +68,11 @@ func (m *MemberAccesses) All() []MemberAccess {
 	values := m.tree.Values()
 	accesses := make([]MemberAccess, len(values))
 	for i, value := range values {
-		accesses[i] = value.(MemberAccess)
+		access, ok := value.(MemberAccess)
+		if !ok {
+			return nil
+		}
+		accesses[i] = access
 	}
 	return accesses
 }

--- a/runtime/sema/member_accesses.go
+++ b/runtime/sema/member_accesses.go
@@ -70,7 +70,7 @@ func (m *MemberAccesses) All() []MemberAccess {
 	for i, value := range values {
 		access, ok := value.(MemberAccess)
 		if !ok {
-			return nil
+			continue
 		}
 		accesses[i] = access
 	}

--- a/runtime/sema/occurrences.go
+++ b/runtime/sema/occurrences.go
@@ -119,7 +119,11 @@ func (o *Occurrences) All() []Occurrence {
 	values := o.tree.Values()
 	occurrences := make([]Occurrence, len(values))
 	for i, value := range values {
-		occurrences[i] = value.(Occurrence)
+		occurrence, ok := value.(Occurrence)
+		if !ok {
+			return nil
+		}
+		occurrences[i] = occurrence
 	}
 	return occurrences
 }
@@ -129,7 +133,10 @@ func (o *Occurrences) Find(pos Position) *Occurrence {
 	if interval == nil {
 		return nil
 	}
-	occurrence := value.(Occurrence)
+	occurrence, ok := value.(Occurrence)
+	if !ok {
+		return nil
+	}
 	return &occurrence
 }
 
@@ -137,7 +144,11 @@ func (o *Occurrences) FindAll(pos Position) []Occurrence {
 	entries := o.tree.SearchAll(pos)
 	occurrences := make([]Occurrence, len(entries))
 	for i, entry := range entries {
-		occurrences[i] = entry.Value.(Occurrence)
+		occurrence, ok := entry.Value.(Occurrence)
+		if !ok {
+			return nil
+		}
+		occurrences[i] = occurrence
 	}
 	return occurrences
 }

--- a/runtime/sema/ranges.go
+++ b/runtime/sema/ranges.go
@@ -53,7 +53,11 @@ func (r *Ranges) All() []Range {
 	values := r.tree.Values()
 	ranges := make([]Range, len(values))
 	for i, value := range values {
-		ranges[i] = value.(Range)
+		r, ok := value.(Range)
+		if !ok {
+			return nil
+		}
+		ranges[i] = r
 	}
 	return ranges
 }
@@ -62,7 +66,11 @@ func (r *Ranges) FindAll(pos Position) []Range {
 	entries := r.tree.SearchAll(pos)
 	ranges := make([]Range, len(entries))
 	for i, entry := range entries {
-		ranges[i] = entry.Value.(Range)
+		r, ok := entry.Value.(Range)
+		if !ok {
+			return nil
+		}
+		ranges[i] = r
 	}
 	return ranges
 }

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -20,6 +20,8 @@ package sema
 
 import (
 	"fmt"
+
+	"github.com/onflow/cadence/runtime/errors"
 )
 
 // TypeTag is a bitmask representation for types.
@@ -700,7 +702,11 @@ func commonSuperTypeOfComposites(types []Type) Type {
 			break
 		}
 
-		compositeType := typ.(*CompositeType)
+		compositeType, ok := typ.(*CompositeType)
+		// this function is only called when all types are composites, so this cannot fail
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
 
 		// NOTE: index 0 may not always be the first type, since there can be 'Never' types.
 		if firstType {

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
 )
 
 // An VariableActivation is a map of strings to variables.
@@ -132,7 +133,10 @@ var variableActivationPool = sync.Pool{
 }
 
 func getVariableActivation() *VariableActivation {
-	activation := variableActivationPool.Get().(*VariableActivation)
+	activation, ok := variableActivationPool.Get().(*VariableActivation)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 	activation.Clear()
 	return activation
 }


### PR DESCRIPTION
## Description

This adds more graceful go handling for some type assertions in the `runtime/sema` directory, which previously were unhandled. This should not result in any behavioral differences. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
