### PR TITLE
Support recursive supertype inferring for containers

### DIFF
--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -3242,7 +3242,10 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 				inter,
 				interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
-					ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
+					ValueType: interpreter.DictionaryStaticType{
+						KeyType:   interpreter.PrimitiveStaticTypeSignedInteger,
+						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
+					},
 				},
 
 				interpreter.NewStringValue("a"),

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -3241,7 +3241,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			interpreter.NewDictionaryValue(
 				inter,
 				interpreter.DictionaryStaticType{
-					KeyType:   interpreter.PrimitiveStaticTypeString,
+					KeyType: interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeSignedInteger,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -590,11 +590,11 @@ func findSuperTypeFromLowerMask(joinedTypeTag TypeTag, types []Type) Type {
 
 	// All derived types goes here.
 	case constantSizedTypeMask:
-		return getConstantSizedArraySuperType(types)
+		return commonSuperTypeOfConstantSizedArrays(types)
 	case variableSizedTypeMask:
-		return getVariableSizedSuperType(types)
+		return commonSuperTypeOfVariableSizedArrays(types)
 	case dictionaryTypeMask:
-		return getDictionarySuperType(types)
+		return commonSuperTypeOfDictionaries(types)
 	case referenceTypeMask,
 		genericTypeMask,
 		functionTypeMask,
@@ -653,10 +653,10 @@ func getSuperTypeOfDerivedTypes(types []Type) Type {
 	return prevType
 }
 
-func getVariableSizedSuperType(types []Type) Type {
+func commonSuperTypeOfVariableSizedArrays(types []Type) Type {
 	// We reach here if all types are variable-sized arrays.
-	// Therefore, check for member types, and decide the
-	// common supertype based on the element types.
+	// Therefore, decide the common supertype based on the element types.
+
 	elementTypes := make([]Type, 0)
 
 	for _, typ := range types {
@@ -668,7 +668,7 @@ func getVariableSizedSuperType(types []Type) Type {
 
 		arrayType, ok := typ.(*VariableSizedType)
 		if !ok {
-			panic(fmt.Errorf("expected variabled-sized array type, found %t", typ))
+			panic(fmt.Errorf("expected variabled-sized array type, found %s", typ))
 		}
 
 		elementTypes = append(elementTypes, arrayType.ElementType(false))
@@ -685,10 +685,10 @@ func getVariableSizedSuperType(types []Type) Type {
 	}
 }
 
-func getConstantSizedArraySuperType(types []Type) Type {
+func commonSuperTypeOfConstantSizedArrays(types []Type) Type {
 	// We reach here if all types are constant-sized arrays.
-	// Therefore, check for member types, and decide the
-	// common supertype based on the element types.
+	// Therefore, decide the common supertype based on the element types.
+
 	elementTypes := make([]Type, 0)
 	var prevType *ConstantSizedType
 
@@ -701,7 +701,7 @@ func getConstantSizedArraySuperType(types []Type) Type {
 
 		arrayType, ok := typ.(*ConstantSizedType)
 		if !ok {
-			panic(fmt.Errorf("expected constnant-sized array type, found %t", typ))
+			panic(fmt.Errorf("expected constnant-sized array type, found %s", typ))
 		}
 
 		elementTypes = append(elementTypes, arrayType.ElementType(false))
@@ -729,10 +729,9 @@ func getConstantSizedArraySuperType(types []Type) Type {
 	}
 }
 
-func getDictionarySuperType(types []Type) Type {
-	// We reach here if all types are constant-sized arrays.
-	// Therefore, check for member types, and decide the
-	// common supertype based on the element types.
+func commonSuperTypeOfDictionaries(types []Type) Type {
+	// We reach here if all types are dictionary types.
+	// Therefore, decide the common supertype based on the key types and value types.
 
 	keyTypes := make([]Type, 0)
 	valueTypes := make([]Type, 0)
@@ -746,7 +745,7 @@ func getDictionarySuperType(types []Type) Type {
 
 		dictionaryType, ok := typ.(*DictionaryType)
 		if !ok {
-			panic(fmt.Errorf("expected dictionary type, found %t", typ))
+			panic(fmt.Errorf("expected dictionary type, found %s", typ))
 		}
 
 		valueTypes = append(valueTypes, dictionaryType.ValueType)

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -668,7 +668,7 @@ func commonSuperTypeOfVariableSizedArrays(types []Type) Type {
 
 		arrayType, ok := typ.(*VariableSizedType)
 		if !ok {
-			panic(fmt.Errorf("expected variabled-sized array type, found %s", typ))
+			panic(fmt.Errorf("expected variable-sized array type, found %s", typ))
 		}
 
 		elementTypes = append(elementTypes, arrayType.ElementType(false))
@@ -701,7 +701,7 @@ func commonSuperTypeOfConstantSizedArrays(types []Type) Type {
 
 		arrayType, ok := typ.(*ConstantSizedType)
 		if !ok {
-			panic(fmt.Errorf("expected constnant-sized array type, found %s", typ))
+			panic(fmt.Errorf("expected constant-sized array type, found %s", typ))
 		}
 
 		elementTypes = append(elementTypes, arrayType.ElementType(false))

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -756,9 +756,12 @@ func commonSuperTypeOfDictionaries(types []Type) Type {
 	valueSuperType := LeastCommonSuperType(valueTypes...)
 
 	if keySuperType == InvalidType ||
-		valueSuperType == InvalidType ||
-		!IsValidDictionaryKeyType(keySuperType) {
+		valueSuperType == InvalidType {
 		return InvalidType
+	}
+
+	if !IsValidDictionaryKeyType(keySuperType) {
+		return commonSuperTypeOfHeterogeneousTypes(types)
 	}
 
 	return &DictionaryType{

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -1205,7 +1205,10 @@ func TestCommonSuperType(t *testing.T) {
 					stringStringDictionary,
 					stringBoolDictionary,
 				},
-				expectedSuperType: AnyStructType,
+				expectedSuperType: &DictionaryType{
+					KeyType:   StringType,
+					ValueType: AnyStructType,
+				},
 			},
 			{
 				name: "dictionary & non-dictionary",

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -1083,7 +1083,7 @@ func TestCommonSuperType(t *testing.T) {
 					stringArray,
 					&VariableSizedType{Type: BoolType},
 				},
-				expectedSuperType: AnyStructType,
+				expectedSuperType: &VariableSizedType{Type: AnyStructType},
 			},
 			{
 				name: "simple-typed array & resource array",
@@ -1143,7 +1143,9 @@ func TestCommonSuperType(t *testing.T) {
 						Type: Int8Type,
 					},
 				},
-				expectedSuperType: AnyStructType,
+				expectedSuperType: &VariableSizedType{
+					Type: SignedIntegerType,
+				},
 			},
 			{
 				name: "arrays with never",
@@ -1518,7 +1520,8 @@ func TestCommonSuperType(t *testing.T) {
 				unsignedIntegerTypeMask,
 				unsignedFixedPointTypeMask,
 
-				compositeTypeMask:
+				compositeTypeMask,
+				constantSizedTypeMask:
 				continue
 			}
 

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -1100,6 +1100,16 @@ func TestCheckDictionarySupertypeInference(t *testing.T) {
 				expectedKeyType:   sema.IntType,
 				expectedValueType: sema.AnyStructType,
 			},
+			{
+				name: "no supertype for inner keys with resource values",
+				code: `
+                    let x <- {0: <- {10: <- create Foo()}, 1: <- {"one": <- create Foo()}}
+
+                    pub resource Foo {}
+                `,
+				expectedKeyType:   sema.IntType,
+				expectedValueType: sema.AnyResourceType,
+			},
 		}
 
 		for _, test := range tests {

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -841,7 +841,7 @@ func TestCheckArraySupertypeInference(t *testing.T) {
 				},
 			},
 			{
-				name: "implicit covariant values",
+				name: "implicit covariant to interface",
 				code: `
                     let x = [[Bar()], [Baz()]]
 
@@ -851,11 +851,21 @@ func TestCheckArraySupertypeInference(t *testing.T) {
 
                     pub struct Baz: Foo {}
                 `,
-				// Covariance is not supported for now.
-				expectedElementType: sema.AnyStructType,
+				expectedElementType: &sema.VariableSizedType{
+					Type: &sema.RestrictedType{
+						Type: sema.AnyStructType,
+						Restrictions: []*sema.InterfaceType{
+							{
+								Location:      common.StringLocation("test"),
+								Identifier:    "Foo",
+								CompositeKind: common.CompositeKindStructure,
+							},
+						},
+					},
+				},
 			},
 			{
-				name: "explicit covariant values",
+				name: "explicit covariant to interface",
 				code: `
                     // Covariance is supported with explicit type annotation.
                     let x = [[Bar()], [Baz()]] as [[{Foo}]]
@@ -876,6 +886,25 @@ func TestCheckArraySupertypeInference(t *testing.T) {
 								CompositeKind: common.CompositeKindStructure,
 							},
 						},
+					},
+				},
+			},
+			{
+				name: "nested covariant var sized",
+				code: `let x = [[[1, 2]], [["foo", "bar"]], [[5.3, 6.4]]]`,
+				expectedElementType: &sema.VariableSizedType{
+					Type: &sema.VariableSizedType{
+						Type: sema.AnyStructType,
+					},
+				},
+			},
+			{
+				name: "nested covariant constant sized",
+				code: `let x = [[[1, 2] as [Int; 2]], [["foo", "bar"] as [String; 2]], [[5.3, 6.4] as [Fix64; 2]]]`,
+				expectedElementType: &sema.VariableSizedType{
+					Type: &sema.ConstantSizedType{
+						Type: sema.AnyStructType,
+						Size: 2,
 					},
 				},
 			},
@@ -1017,8 +1046,18 @@ func TestCheckDictionarySupertypeInference(t *testing.T) {
                     pub struct Baz: Foo {}
                 `,
 				expectedKeyType: sema.IntType,
-				// Covariance is not supported for now.
-				expectedValueType: sema.AnyStructType,
+				expectedValueType: &sema.VariableSizedType{
+					Type: &sema.RestrictedType{
+						Type: sema.AnyStructType,
+						Restrictions: []*sema.InterfaceType{
+							{
+								Location:      common.StringLocation("test"),
+								Identifier:    "Foo",
+								CompositeKind: common.CompositeKindStructure,
+							},
+						},
+					},
+				},
 			},
 			{
 				name: "explicit covariant values",

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -908,6 +908,13 @@ func TestCheckArraySupertypeInference(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "nested non-covariant constant sized",
+				code: `let x = [[[1, 2] as [Int; 2]], [["foo", "bar", "baz"] as [String; 3]], [[5.3, 6.4] as [Fix64; 2]]]`,
+				expectedElementType: &sema.VariableSizedType{
+					Type: sema.AnyStructType,
+				},
+			},
 		}
 
 		for _, test := range tests {

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -1087,6 +1087,12 @@ func TestCheckDictionarySupertypeInference(t *testing.T) {
 					},
 				},
 			},
+			{
+				name:              "no supertype for inner keys",
+				code:              `let x = {0: {10: 1, 20: 2}, 1: {"one": 1, "two": 2}}`,
+				expectedKeyType:   sema.IntType,
+				expectedValueType: sema.AnyStructType,
+			},
 		}
 
 		for _, test := range tests {
@@ -1131,18 +1137,6 @@ func TestCheckDictionarySupertypeInference(t *testing.T) {
 		checkerErr := ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidDictionaryKeyTypeError{}, checkerErr[0])
-	})
-
-	t.Run("no supertype for keys of inner dict", func(t *testing.T) {
-		t.Parallel()
-
-		code := `
-            let x = {0: {10: 1, 20: 2}, 1: {"one": 1, "two": 2}}
-        `
-		_, err := ParseAndCheck(t, code)
-		checkerErr := ExpectCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.TypeAnnotationRequiredError{}, checkerErr[0])
 	})
 
 	t.Run("unsupported supertype for keys", func(t *testing.T) {


### PR DESCRIPTION
Closes #1225

## Description

This PR add $subject for arrays and dictionaries.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
