### PR TITLE
Update docs/design-patterns backquote paths

### DIFF
--- a/docs/design-patterns.mdx
+++ b/docs/design-patterns.mdx
@@ -46,7 +46,7 @@ A capability provided by one account to a second account must able to be revoked
 
 ### Solution
 
-The first account should create the capability as a link to a capability in /private/, which then links to a resource in /storage/ . That first link is then handed to the second account as the capability for them to use. This can be stored in their private storage or a Capability Receiver.
+The first account should create the capability as a link to a capability in `/private/`, which then links to a resource in `/storage/`. That first link is then handed to the second account as the capability for them to use. This can be stored in their private storage or a Capability Receiver.
 
 **Account 1:** `/private/capability` → `/storage/resource`
 


### PR DESCRIPTION
Closes none

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

I added missing backquotes in this doc

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
