### PR TITLE
Gracefully handle casts during comparison operators

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2042,12 +2042,30 @@ func (v IntValue) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v IntValue) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v IntValue) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -2528,11 +2546,29 @@ func (v Int8Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int8Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int8Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -3009,11 +3045,29 @@ func (v Int16Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int16Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int16Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -3492,11 +3546,29 @@ func (v Int32Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int32Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int32Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -3979,11 +4051,29 @@ func (v Int64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -4511,12 +4601,30 @@ func (v Int128Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int128Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v Int128Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -5075,12 +5183,30 @@ func (v Int256Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int256Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v Int256Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -5561,12 +5687,30 @@ func (v UIntValue) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UIntValue) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v UIntValue) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -5988,11 +6132,29 @@ func (v UInt8Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt8Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt8Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -6408,11 +6570,29 @@ func (v UInt16Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt16Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt16Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -6834,11 +7014,29 @@ func (v UInt32Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt32Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt32Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -7285,11 +7483,29 @@ func (v UInt64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -7772,12 +7988,30 @@ func (v UInt128Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt128Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v UInt128Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -8290,12 +8524,30 @@ func (v UInt256Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt256Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v UInt256Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -8675,11 +8927,29 @@ func (v Word8Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word8Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word8Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -9005,11 +9275,29 @@ func (v Word16Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word16Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word16Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -9338,11 +9626,29 @@ func (v Word32Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word32Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word32Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -9692,11 +9998,29 @@ func (v Word64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -10145,11 +10469,29 @@ func (v Fix64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Fix64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Fix64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Fix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -10532,11 +10874,29 @@ func (v UFix64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UFix64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UFix64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UFix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2014,12 +2014,30 @@ func (v IntValue) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v IntValue) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v IntValue) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -2484,11 +2502,29 @@ func (v Int8Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int8Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int8Value) Greater(other NumberValue) BoolValue {
@@ -2947,11 +2983,29 @@ func (v Int16Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int16Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int16Value) Greater(other NumberValue) BoolValue {
@@ -3412,11 +3466,29 @@ func (v Int32Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int32Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int32Value) Greater(other NumberValue) BoolValue {
@@ -3881,11 +3953,29 @@ func (v Int64Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int64Value) Greater(other NumberValue) BoolValue {
@@ -4393,12 +4483,30 @@ func (v Int128Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v Int128Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -4939,12 +5047,30 @@ func (v Int256Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v Int256Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -5407,12 +5533,30 @@ func (v UIntValue) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v UIntValue) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -5818,11 +5962,29 @@ func (v UInt8Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt8Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt8Value) Greater(other NumberValue) BoolValue {
@@ -6220,11 +6382,29 @@ func (v UInt16Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt16Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt16Value) Greater(other NumberValue) BoolValue {
@@ -6628,11 +6808,29 @@ func (v UInt32Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt32Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt32Value) Greater(other NumberValue) BoolValue {
@@ -7061,11 +7259,29 @@ func (v UInt64Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt64Value) Greater(other NumberValue) BoolValue {
@@ -7528,12 +7744,30 @@ func (v UInt128Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v UInt128Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -8028,12 +8262,30 @@ func (v UInt256Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v UInt256Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -8397,11 +8649,29 @@ func (v Word8Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word8Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word8Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word8Value) Greater(other NumberValue) BoolValue {
@@ -8709,11 +8979,29 @@ func (v Word16Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word16Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word16Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word16Value) Greater(other NumberValue) BoolValue {
@@ -9024,11 +9312,29 @@ func (v Word32Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word32Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word32Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word32Value) Greater(other NumberValue) BoolValue {
@@ -9360,11 +9666,29 @@ func (v Word64Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word64Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word64Value) Greater(other NumberValue) BoolValue {
@@ -9795,11 +10119,29 @@ func (v Fix64Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) Less(other NumberValue) BoolValue {
-	return v < other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Fix64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Fix64Value) Greater(other NumberValue) BoolValue {
@@ -10164,11 +10506,29 @@ func (v UFix64Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) Less(other NumberValue) BoolValue {
-	return v < other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UFix64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UFix64Value) Greater(other NumberValue) BoolValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5687,7 +5687,7 @@ func (v UIntValue) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UIntValue) Greater(other NumberValue) BoolValue {
-	o, ok := other.(IntValue)
+	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation: ast.OperationGreater,

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -145,8 +145,8 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 	t.Parallel()
 
 	operations := []ast.Operation{
-		//ast.OperationGreater,
-		//ast.OperationGreaterEqual,
+		ast.OperationGreater,
+		ast.OperationGreaterEqual,
 		ast.OperationLess,
 		ast.OperationLessEqual,
 		//ast.OperationEqual,

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -145,12 +145,12 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 	t.Parallel()
 
 	operations := []ast.Operation{
-		ast.OperationGreater,
-		ast.OperationGreaterEqual,
+		//ast.OperationGreater,
+		//ast.OperationGreaterEqual,
 		ast.OperationLess,
 		ast.OperationLessEqual,
-		ast.OperationEqual,
-		ast.OperationNotEqual,
+		//ast.OperationEqual,
+		//ast.OperationNotEqual,
 	}
 
 	t.Run("Integer subtypes", func(t *testing.T) {
@@ -185,6 +185,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 			for _, op := range operations {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+					t.Parallel()
 
 					code := fmt.Sprintf(`
                             fun test() {

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -206,6 +206,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(false), result)
 					case ast.OperationNotEqual:
+						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)
@@ -255,6 +256,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(false), result)
 					case ast.OperationNotEqual:
+						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)
@@ -304,6 +306,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(false), result)
 					case ast.OperationNotEqual:
+						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -149,8 +149,8 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 		ast.OperationGreaterEqual,
 		ast.OperationLess,
 		ast.OperationLessEqual,
-		//ast.OperationEqual,
-		//ast.OperationNotEqual,
+		ast.OperationEqual,
+		ast.OperationNotEqual,
 	}
 
 	t.Run("Integer subtypes", func(t *testing.T) {
@@ -188,11 +188,11 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 					t.Parallel()
 
 					code := fmt.Sprintf(`
-                            fun test() {
-                                let x: Integer = 5 as %s
-                                let y: Integer = 2 as %s
-                                let z = x %s y
-                            }`,
+                        fun test(): Bool {
+                            let x: Integer = 5 as %s
+                            let y: Integer = 2 as %s
+                            return x %s y
+                        }`,
 						subtype.String(),
 						rhsType.String(),
 						op.Symbol(),
@@ -200,15 +200,24 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 					inter := parseCheckAndInterpret(t, code)
 
-					_, err := inter.Invoke("test")
-					require.Error(t, err)
+					result, err := inter.Invoke("test")
 
-					operandError := &interpreter.InvalidOperandsError{}
-					require.ErrorAs(t, err, operandError)
+					switch op {
+					case ast.OperationEqual:
+						require.NoError(t, err)
+						assert.Equal(t, interpreter.BoolValue(false), result)
+					case ast.OperationNotEqual:
+						assert.Equal(t, interpreter.BoolValue(true), result)
+					default:
+						require.Error(t, err)
 
-					assert.Equal(t, op, operandError.Operation)
-					assert.Equal(t, subtype, operandError.LeftType)
-					assert.Equal(t, rhsType, operandError.RightType)
+						operandError := &interpreter.InvalidOperandsError{}
+						require.ErrorAs(t, err, operandError)
+
+						assert.Equal(t, op, operandError.Operation)
+						assert.Equal(t, subtype, operandError.LeftType)
+						assert.Equal(t, rhsType, operandError.RightType)
+					}
 				})
 			}
 		}
@@ -228,11 +237,11 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
 
 					code := fmt.Sprintf(`
-                            fun test() {
-                                let x: FixedPoint = 5.2 as %s
-                                let y: FixedPoint = 2.3 as %s
-                                let z = x %s y
-                            }`,
+                        fun test(): Bool {
+                            let x: FixedPoint = 5.2 as %s
+                            let y: FixedPoint = 2.3 as %s
+                            return x %s y
+                        }`,
 						subtype.String(),
 						rhsType.String(),
 						op.Symbol(),
@@ -240,15 +249,24 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 					inter := parseCheckAndInterpret(t, code)
 
-					_, err := inter.Invoke("test")
-					require.Error(t, err)
+					result, err := inter.Invoke("test")
 
-					operandError := &interpreter.InvalidOperandsError{}
-					require.ErrorAs(t, err, operandError)
+					switch op {
+					case ast.OperationEqual:
+						require.NoError(t, err)
+						assert.Equal(t, interpreter.BoolValue(false), result)
+					case ast.OperationNotEqual:
+						assert.Equal(t, interpreter.BoolValue(true), result)
+					default:
+						require.Error(t, err)
 
-					assert.Equal(t, op, operandError.Operation)
-					assert.Equal(t, subtype, operandError.LeftType)
-					assert.Equal(t, rhsType, operandError.RightType)
+						operandError := &interpreter.InvalidOperandsError{}
+						require.ErrorAs(t, err, operandError)
+
+						assert.Equal(t, op, operandError.Operation)
+						assert.Equal(t, subtype, operandError.LeftType)
+						assert.Equal(t, rhsType, operandError.RightType)
+					}
 				})
 			}
 		}
@@ -268,11 +286,11 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
 
 					code := fmt.Sprintf(`
-                            fun test() {
-                                let x: FixedPoint = 5.2 as %s
-                                let y: FixedPoint = 2.3 as %s
-                                let z = x %s y
-                            }`,
+                        fun test(): Bool {
+                            let x: FixedPoint = 5.2 as %s
+                            let y: FixedPoint = 2.3 as %s
+                            return x %s y
+                        }`,
 						subtype.String(),
 						rhsType.String(),
 						op.Symbol(),
@@ -280,15 +298,24 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 					inter := parseCheckAndInterpret(t, code)
 
-					_, err := inter.Invoke("test")
-					require.Error(t, err)
+					result, err := inter.Invoke("test")
 
-					operandError := &interpreter.InvalidOperandsError{}
-					require.ErrorAs(t, err, operandError)
+					switch op {
+					case ast.OperationEqual:
+						require.NoError(t, err)
+						assert.Equal(t, interpreter.BoolValue(false), result)
+					case ast.OperationNotEqual:
+						assert.Equal(t, interpreter.BoolValue(true), result)
+					default:
+						require.Error(t, err)
 
-					assert.Equal(t, op, operandError.Operation)
-					assert.Equal(t, subtype, operandError.LeftType)
-					assert.Equal(t, rhsType, operandError.RightType)
+						operandError := &interpreter.InvalidOperandsError{}
+						require.ErrorAs(t, err, operandError)
+
+						assert.Equal(t, op, operandError.Operation)
+						assert.Equal(t, subtype, operandError.LeftType)
+						assert.Equal(t, rhsType, operandError.RightType)
+					}
 				})
 			}
 		}

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -20,14 +20,14 @@ package interpreter_test
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	. "github.com/onflow/cadence/runtime/tests/utils"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -185,7 +185,6 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 			for _, op := range operations {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
-					t.Parallel()
 
 					code := fmt.Sprintf(`
                         fun test(): Bool {

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -19,6 +19,9 @@
 package interpreter_test
 
 import (
+	"fmt"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -134,5 +137,159 @@ func TestInterpretEquality(t *testing.T) {
 			interpreter.BoolValue(false),
 			inter.Globals["res"].GetValue(),
 		)
+	})
+}
+
+func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
+
+	t.Parallel()
+
+	operations := []ast.Operation{
+		ast.OperationGreater,
+		ast.OperationGreaterEqual,
+		ast.OperationLess,
+		ast.OperationLessEqual,
+		ast.OperationEqual,
+		ast.OperationNotEqual,
+	}
+
+	t.Run("Integer subtypes", func(t *testing.T) {
+		t.Parallel()
+
+		intSubtypes := []interpreter.StaticType{
+			interpreter.PrimitiveStaticTypeInt,
+			interpreter.PrimitiveStaticTypeInt8,
+			interpreter.PrimitiveStaticTypeInt16,
+			interpreter.PrimitiveStaticTypeInt32,
+			interpreter.PrimitiveStaticTypeInt64,
+			interpreter.PrimitiveStaticTypeInt128,
+			interpreter.PrimitiveStaticTypeInt256,
+			interpreter.PrimitiveStaticTypeUInt,
+			interpreter.PrimitiveStaticTypeUInt8,
+			interpreter.PrimitiveStaticTypeUInt16,
+			interpreter.PrimitiveStaticTypeUInt32,
+			interpreter.PrimitiveStaticTypeUInt64,
+			interpreter.PrimitiveStaticTypeUInt128,
+			interpreter.PrimitiveStaticTypeUInt256,
+			interpreter.PrimitiveStaticTypeWord8,
+			interpreter.PrimitiveStaticTypeWord16,
+			interpreter.PrimitiveStaticTypeWord32,
+			interpreter.PrimitiveStaticTypeWord64,
+		}
+
+		for _, subtype := range intSubtypes {
+			rhsType := interpreter.PrimitiveStaticTypeInt
+			if subtype == rhsType {
+				rhsType = interpreter.PrimitiveStaticTypeUInt
+			}
+
+			for _, op := range operations {
+				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+
+					code := fmt.Sprintf(`
+                            fun test() {
+                                let x: Integer = 5 as %s
+                                let y: Integer = 2 as %s
+                                let z = x %s y
+                            }`,
+						subtype.String(),
+						rhsType.String(),
+						op.Symbol(),
+					)
+
+					inter := parseCheckAndInterpret(t, code)
+
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+
+					operandError := &interpreter.InvalidOperandsError{}
+					require.ErrorAs(t, err, operandError)
+
+					assert.Equal(t, op, operandError.Operation)
+					assert.Equal(t, subtype, operandError.LeftType)
+					assert.Equal(t, rhsType, operandError.RightType)
+				})
+			}
+		}
+	})
+
+	t.Run("Fixed point subtypes", func(t *testing.T) {
+		t.Parallel()
+
+		fixedPointSubtypes := []interpreter.StaticType{
+			interpreter.PrimitiveStaticTypeFix64,
+		}
+
+		rhsType := interpreter.PrimitiveStaticTypeUFix64
+
+		for _, subtype := range fixedPointSubtypes {
+			for _, op := range operations {
+				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+
+					code := fmt.Sprintf(`
+                            fun test() {
+                                let x: FixedPoint = 5.2 as %s
+                                let y: FixedPoint = 2.3 as %s
+                                let z = x %s y
+                            }`,
+						subtype.String(),
+						rhsType.String(),
+						op.Symbol(),
+					)
+
+					inter := parseCheckAndInterpret(t, code)
+
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+
+					operandError := &interpreter.InvalidOperandsError{}
+					require.ErrorAs(t, err, operandError)
+
+					assert.Equal(t, op, operandError.Operation)
+					assert.Equal(t, subtype, operandError.LeftType)
+					assert.Equal(t, rhsType, operandError.RightType)
+				})
+			}
+		}
+	})
+
+	t.Run("Unsigned fixed point subtypes", func(t *testing.T) {
+		t.Parallel()
+
+		fixedPointSubtypes := []interpreter.StaticType{
+			interpreter.PrimitiveStaticTypeUFix64,
+		}
+
+		rhsType := interpreter.PrimitiveStaticTypeFix64
+
+		for _, subtype := range fixedPointSubtypes {
+			for _, op := range operations {
+				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+
+					code := fmt.Sprintf(`
+                            fun test() {
+                                let x: FixedPoint = 5.2 as %s
+                                let y: FixedPoint = 2.3 as %s
+                                let z = x %s y
+                            }`,
+						subtype.String(),
+						rhsType.String(),
+						op.Symbol(),
+					)
+
+					inter := parseCheckAndInterpret(t, code)
+
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+
+					operandError := &interpreter.InvalidOperandsError{}
+					require.ErrorAs(t, err, operandError)
+
+					assert.Equal(t, op, operandError.Operation)
+					assert.Equal(t, subtype, operandError.LeftType)
+					assert.Equal(t, rhsType, operandError.RightType)
+				})
+			}
+		}
 	})
 }


### PR DESCRIPTION
Port of https://github.com/dapperlabs/cadence-internal/pull/46

## Description

Handle Go casts during comparison operators (`<`, `<=`, `>`, `>=`).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
