### PR TITLE
Add safety checks for go casts in the interpreter

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1268,11 +1268,11 @@ func (interpreter *Interpreter) visitCondition(condition *ast.Condition) {
 		Expression: condition.Test,
 	}
 
-	result := interpreter.evalStatement(statement).(ExpressionStatementResult)
+	result, ok := interpreter.evalStatement(statement).(ExpressionStatementResult)
 
-	value := result.Value.(BoolValue)
+	value, valueOk := result.Value.(BoolValue)
 
-	if value {
+	if ok && valueOk && bool(value) {
 		return
 	}
 
@@ -2871,7 +2871,10 @@ func init() {
 		"FunctionType",
 		NewHostFunctionValue(
 			func(invocation Invocation) Value {
-				parameters := invocation.Arguments[0].(*ArrayValue)
+				parameters, paramsOk := invocation.Arguments[0].(*ArrayValue)
+				if !paramsOk {
+					panic(errors.NewUnreachableError())
+				}
 				returnType := invocation.Interpreter.MustConvertStaticToSemaType(invocation.Arguments[1].(TypeValue).Type)
 				parameterTypes := make([]*sema.Parameter, 0, parameters.Count())
 				parameters.Iterate(func(param Value) bool {
@@ -2906,7 +2909,11 @@ func init() {
 }
 
 func RestrictedTypeFunction(invocation Invocation) Value {
-	restrictedIDs := invocation.Arguments[1].(*ArrayValue)
+	restrictedIDs, restrictedIDsOk := invocation.Arguments[1].(*ArrayValue)
+
+	if !restrictedIDsOk {
+		panic(errors.NewUnreachableError())
+	}
 
 	staticRestrictions := make([]InterfaceStaticType, 0, restrictedIDs.Count())
 	semaRestrictions := make([]*sema.InterfaceType, 0, restrictedIDs.Count())
@@ -3171,7 +3178,12 @@ var stringFunction = func() Value {
 		sema.StringTypeEncodeHexFunctionName,
 		NewHostFunctionValue(
 			func(invocation Invocation) Value {
-				argument := invocation.Arguments[0].(*ArrayValue)
+				argument, ok := invocation.Arguments[0].(*ArrayValue)
+
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
 				bytes, _ := ByteArrayValueToByteSlice(argument)
 				return NewStringValue(hex.EncodeToString(bytes))
 			},
@@ -3433,7 +3445,11 @@ func (interpreter *Interpreter) authAccountSaveFunction(addressValue AddressValu
 		func(invocation Invocation) Value {
 
 			value := invocation.Arguments[0]
-			path := invocation.Arguments[1].(PathValue)
+			path, pathOk := invocation.Arguments[1].(PathValue)
+
+			if !pathOk {
+				panic(errors.NewUnreachableError())
+			}
 
 			domain := path.Domain.Identifier()
 			identifier := path.Identifier
@@ -3482,7 +3498,11 @@ func (interpreter *Interpreter) authAccountTypeFunction(addressValue AddressValu
 	return NewHostFunctionValue(
 		func(invocation Invocation) Value {
 
-			path := invocation.Arguments[0].(PathValue)
+			path, pathOk := invocation.Arguments[0].(PathValue)
+
+			if !pathOk {
+				panic(errors.NewUnreachableError())
+			}
 
 			domain := path.Domain.Identifier()
 			identifier := path.Identifier
@@ -3520,7 +3540,11 @@ func (interpreter *Interpreter) authAccountReadFunction(addressValue AddressValu
 	return NewHostFunctionValue(
 		func(invocation Invocation) Value {
 
-			path := invocation.Arguments[0].(PathValue)
+			path, pathOk := invocation.Arguments[0].(PathValue)
+
+			if !pathOk {
+				panic(errors.NewUnreachableError())
+			}
 
 			domain := path.Domain.Identifier()
 			identifier := path.Identifier
@@ -3585,7 +3609,11 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 	return NewHostFunctionValue(
 		func(invocation Invocation) Value {
 
-			path := invocation.Arguments[0].(PathValue)
+			path, pathOk := invocation.Arguments[0].(PathValue)
+
+			if !pathOk {
+				panic(errors.NewUnreachableError())
+			}
 
 			typeParameterPair := invocation.TypeParameterTypes.Oldest()
 			if typeParameterPair == nil {
@@ -3594,7 +3622,10 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 
 			ty := typeParameterPair.Value
 
-			referenceType := ty.(*sema.ReferenceType)
+			referenceType, ok := ty.(*sema.ReferenceType)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
 
 			reference := &StorageReferenceValue{
 				Authorized:           referenceType.Authorized,
@@ -3634,10 +3665,23 @@ func (interpreter *Interpreter) authAccountLinkFunction(addressValue AddressValu
 				panic(errors.NewUnreachableError())
 			}
 
-			borrowType := typeParameterPair.Value.(*sema.ReferenceType)
+			borrowType, ok := typeParameterPair.Value.(*sema.ReferenceType)
 
-			newCapabilityPath := invocation.Arguments[0].(PathValue)
-			targetPath := invocation.Arguments[1].(PathValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			newCapabilityPath, capabilityPathOk := invocation.Arguments[0].(PathValue)
+
+			if !capabilityPathOk {
+				panic(errors.NewUnreachableError())
+			}
+
+			targetPath, pathOk := invocation.Arguments[1].(PathValue)
+
+			if !pathOk {
+				panic(errors.NewUnreachableError())
+			}
 
 			newCapabilityDomain := newCapabilityPath.Domain.Identifier()
 			newCapabilityIdentifier := newCapabilityPath.Identifier
@@ -3687,7 +3731,11 @@ func (interpreter *Interpreter) accountGetLinkTargetFunction(addressValue Addres
 	return NewHostFunctionValue(
 		func(invocation Invocation) Value {
 
-			capabilityPath := invocation.Arguments[0].(PathValue)
+			capabilityPath, pathOk := invocation.Arguments[0].(PathValue)
+
+			if !pathOk {
+				panic(errors.NewUnreachableError())
+			}
 
 			domain := capabilityPath.Domain.Identifier()
 			identifier := capabilityPath.Identifier
@@ -3717,7 +3765,11 @@ func (interpreter *Interpreter) authAccountUnlinkFunction(addressValue AddressVa
 	return NewHostFunctionValue(
 		func(invocation Invocation) Value {
 
-			capabilityPath := invocation.Arguments[0].(PathValue)
+			capabilityPath, pathOk := invocation.Arguments[0].(PathValue)
+
+			if !pathOk {
+				panic(errors.NewUnreachableError())
+			}
 
 			domain := capabilityPath.Domain.Identifier()
 			identifier := capabilityPath.Identifier
@@ -3748,7 +3800,12 @@ func (interpreter *Interpreter) capabilityBorrowFunction(
 				typeParameterPair := invocation.TypeParameterTypes.Oldest()
 				if typeParameterPair != nil {
 					ty := typeParameterPair.Value
-					borrowType = ty.(*sema.ReferenceType)
+					var ok bool
+					borrowType, ok = ty.(*sema.ReferenceType)
+					if !ok {
+						panic(errors.NewUnreachableError())
+					}
+
 				}
 			}
 
@@ -3813,7 +3870,12 @@ func (interpreter *Interpreter) capabilityCheckFunction(
 				typeParameterPair := invocation.TypeParameterTypes.Oldest()
 				if typeParameterPair != nil {
 					ty := typeParameterPair.Value
-					borrowType = ty.(*sema.ReferenceType)
+					var ok bool
+					borrowType, ok = ty.(*sema.ReferenceType)
+					if !ok {
+						panic(errors.NewUnreachableError())
+					}
+
 				}
 			}
 
@@ -4092,7 +4154,11 @@ func (interpreter *Interpreter) isInstanceFunction(self Value) *HostFunctionValu
 	return NewHostFunctionValue(
 		func(invocation Invocation) Value {
 			firstArgument := invocation.Arguments[0]
-			typeValue := firstArgument.(TypeValue)
+			typeValue, ok := firstArgument.(TypeValue)
+
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
 
 			staticType := typeValue.Type
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -170,9 +170,10 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 
 	leftValue := interpreter.evalExpression(expression.Left)
 
-	/* we make this a thunk so that we can skip computing it for certain short-circuiting
-	   operations */
-	rightValue := func() Value { return interpreter.evalExpression(expression.Right) }
+	// We make this a thunk so that we can skip computing it for certain short-circuiting operations
+	rightValue := func() Value {
+		return interpreter.evalExpression(expression.Right)
+	}
 
 	error := func(right Value) {
 		panic(InvalidOperandsError{

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -375,11 +375,17 @@ func (interpreter *Interpreter) VisitUnaryExpression(expression *ast.UnaryExpres
 
 	switch expression.Operation {
 	case ast.OperationNegate:
-		boolValue := value.(BoolValue)
+		boolValue, ok := value.(BoolValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
 		return boolValue.Negate()
 
 	case ast.OperationMinus:
-		integerValue := value.(NumberValue)
+		integerValue, ok := value.(NumberValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
 		return integerValue.Negate()
 
 	case ast.OperationMove:
@@ -573,14 +579,20 @@ func (interpreter *Interpreter) VisitMemberExpression(expression *ast.MemberExpr
 }
 
 func (interpreter *Interpreter) VisitIndexExpression(expression *ast.IndexExpression) ast.Repr {
-	typedResult := interpreter.evalExpression(expression.TargetExpression).(ValueIndexableValue)
+	typedResult, ok := interpreter.evalExpression(expression.TargetExpression).(ValueIndexableValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 	indexingValue := interpreter.evalExpression(expression.IndexingExpression)
 	getLocationRange := locationRangeGetter(interpreter.Location, expression)
 	return typedResult.GetKey(interpreter, getLocationRange, indexingValue)
 }
 
 func (interpreter *Interpreter) VisitConditionalExpression(expression *ast.ConditionalExpression) ast.Repr {
-	value := interpreter.evalExpression(expression.Test).(BoolValue)
+	value, ok := interpreter.evalExpression(expression.Test).(BoolValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 	if value {
 		return interpreter.evalExpression(expression.Then)
 	} else {
@@ -625,8 +637,10 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 		}
 	}
 
-	function := result.(FunctionValue)
-
+	function, ok := result.(FunctionValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 	// NOTE: evaluate all argument expressions in call-site scope, not in function body
 	argumentExpressions := make([]ast.Expression, len(invocationExpression.Arguments))
 	for i, argument := range invocationExpression.Arguments {

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -74,7 +74,10 @@ func (interpreter *Interpreter) identifierExpressionGetterSetter(identifierExpre
 // for the target index expression
 //
 func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast.IndexExpression) getterSetter {
-	target := interpreter.evalExpression(indexExpression.TargetExpression).(ValueIndexableValue)
+	target, ok := interpreter.evalExpression(indexExpression.TargetExpression).(ValueIndexableValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 	indexingValue := interpreter.evalExpression(indexExpression.IndexingExpression)
 	getLocationRange := locationRangeGetter(interpreter.Location, indexExpression)
 	_, isNestedResourceMove := interpreter.Program.Elaboration.IsNestedResourceMoveExpression[indexExpression]
@@ -164,90 +167,144 @@ func (interpreter *Interpreter) evalExpression(expression ast.Expression) Value 
 }
 
 func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpression) ast.Repr {
+
+	leftValue := interpreter.evalExpression(expression.Left)
+
+	/* we make this a thunk so that we can skip computing it for certain short-circuiting
+	   operations */
+	rightValue := func() Value { return interpreter.evalExpression(expression.Right) }
+
+	error := func() {
+		panic(InvalidOperandsError{
+			Operation:     expression.Operation,
+			LeftType:      leftValue.StaticType(),
+			RightType:     rightValue().StaticType(),
+			LocationRange: locationRangeGetter(interpreter.Location, expression)(),
+		})
+	}
+
 	switch expression.Operation {
 	case ast.OperationPlus:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.Plus(right)
 
 	case ast.OperationMinus:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.Minus(right)
 
 	case ast.OperationMod:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.Mod(right)
 
 	case ast.OperationMul:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.Mul(right)
 
 	case ast.OperationDiv:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.Div(right)
 
 	case ast.OperationBitwiseOr:
-		left := interpreter.evalExpression(expression.Left).(IntegerValue)
-		right := interpreter.evalExpression(expression.Right).(IntegerValue)
+		left, leftOk := leftValue.(IntegerValue)
+		right, rightOk := rightValue().(IntegerValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.BitwiseOr(right)
 
 	case ast.OperationBitwiseXor:
-		left := interpreter.evalExpression(expression.Left).(IntegerValue)
-		right := interpreter.evalExpression(expression.Right).(IntegerValue)
+		left, leftOk := leftValue.(IntegerValue)
+		right, rightOk := rightValue().(IntegerValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.BitwiseXor(right)
 
 	case ast.OperationBitwiseAnd:
-		left := interpreter.evalExpression(expression.Left).(IntegerValue)
-		right := interpreter.evalExpression(expression.Right).(IntegerValue)
+		left, leftOk := leftValue.(IntegerValue)
+		right, rightOk := rightValue().(IntegerValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.BitwiseAnd(right)
 
 	case ast.OperationBitwiseLeftShift:
-		left := interpreter.evalExpression(expression.Left).(IntegerValue)
-		right := interpreter.evalExpression(expression.Right).(IntegerValue)
+		left, leftOk := leftValue.(IntegerValue)
+		right, rightOk := rightValue().(IntegerValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.BitwiseLeftShift(right)
 
 	case ast.OperationBitwiseRightShift:
-		left := interpreter.evalExpression(expression.Left).(IntegerValue)
-		right := interpreter.evalExpression(expression.Right).(IntegerValue)
+		left, leftOk := leftValue.(IntegerValue)
+		right, rightOk := rightValue().(IntegerValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.BitwiseRightShift(right)
 
 	case ast.OperationLess:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.Less(right)
 
 	case ast.OperationLessEqual:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.LessEqual(right)
 
 	case ast.OperationGreater:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.Greater(right)
 
 	case ast.OperationGreaterEqual:
-		left := interpreter.evalExpression(expression.Left).(NumberValue)
-		right := interpreter.evalExpression(expression.Right).(NumberValue)
+		left, leftOk := leftValue.(NumberValue)
+		right, rightOk := rightValue().(NumberValue)
+		if !leftOk || !rightOk {
+			error()
+		}
 		return left.GreaterEqual(right)
 
 	case ast.OperationEqual:
-		left := interpreter.evalExpression(expression.Left)
-		right := interpreter.evalExpression(expression.Right)
-		return interpreter.testEqual(left, right, expression)
+		return interpreter.testEqual(leftValue, rightValue(), expression)
 
 	case ast.OperationNotEqual:
-		left := interpreter.evalExpression(expression.Left)
-		right := interpreter.evalExpression(expression.Right)
-		return !interpreter.testEqual(left, right, expression)
+		return !interpreter.testEqual(leftValue, rightValue(), expression)
 
 	case ast.OperationOr:
 		// interpret the left-hand side
-		left := interpreter.evalExpression(expression.Left).(BoolValue)
+		left, leftOk := leftValue.(BoolValue)
 		// only interpret right-hand side if left-hand side is false
 		if left {
 			return left
@@ -255,11 +312,15 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 
 		// after interpreting the left-hand side,
 		// interpret the right-hand side
-		return interpreter.evalExpression(expression.Right).(BoolValue)
+		right, rightOk := rightValue().(BoolValue)
+		if !leftOk || !rightOk {
+			error()
+		}
+		return right
 
 	case ast.OperationAnd:
 		// interpret the left-hand side
-		left := interpreter.evalExpression(expression.Left).(BoolValue)
+		left, leftOk := leftValue.(BoolValue)
 		// only interpret right-hand side if left-hand side is true
 		if !left {
 			return left
@@ -267,18 +328,19 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 
 		// after interpreting the left-hand side,
 		// interpret the right-hand side
-		return interpreter.evalExpression(expression.Right).(BoolValue)
+		right, rightOk := rightValue().(BoolValue)
+		if !leftOk || !rightOk {
+			error()
+		}
+		return right
 
 	case ast.OperationNilCoalesce:
-		// interpret the left-hand side
-		left := interpreter.evalExpression(expression.Left)
-
 		// only evaluate right-hand side if left-hand side is nil
-		if some, ok := left.(*SomeValue); ok {
+		if some, ok := leftValue.(*SomeValue); ok {
 			return some.Value
 		}
 
-		value := interpreter.evalExpression(expression.Right)
+		value := rightValue()
 
 		rightType := interpreter.Program.Elaboration.BinaryExpressionRightTypes[expression]
 		resultType := interpreter.Program.Elaboration.BinaryExpressionResultTypes[expression]

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -229,14 +229,15 @@ func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.Switch
 
 		caseValue, ok := result.(EquatableValue)
 
+		if !ok {
+			continue
+		}
+
 		// If the test value and case values are equal,
 		// evaluate the case's statements
 
 		getLocationRange := locationRangeGetter(interpreter.Location, switchCase.Expression)
 
-		if !ok {
-			continue
-		}
 		if testValue.Equal(interpreter, getLocationRange, caseValue) {
 			return runStatements()
 		}

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -234,7 +234,10 @@ func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.Switch
 
 		getLocationRange := locationRangeGetter(interpreter.Location, switchCase.Expression)
 
-		if ok && testValue.Equal(interpreter, getLocationRange, caseValue) {
+		if !ok {
+			continue
+		}
+		if testValue.Equal(interpreter, getLocationRange, caseValue) {
 			return runStatements()
 		}
 

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -104,7 +104,10 @@ func (interpreter *Interpreter) visitIfStatementWithTestExpression(
 	thenBlock, elseBlock *ast.Block,
 ) controlReturn {
 
-	value := interpreter.evalExpression(test).(BoolValue)
+	value, ok := interpreter.evalExpression(test).(BoolValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 	var result interface{}
 	if value {
 		result = thenBlock.Accept(interpreter)
@@ -189,7 +192,10 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 
 func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.SwitchStatement) ast.Repr {
 
-	testValue := interpreter.evalExpression(switchStatement.Expression).(EquatableValue)
+	testValue, ok := interpreter.evalExpression(switchStatement.Expression).(EquatableValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 
 	for _, switchCase := range switchStatement.Cases {
 
@@ -221,14 +227,14 @@ func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.Switch
 
 		result := interpreter.evalExpression(switchCase.Expression)
 
-		caseValue := result.(EquatableValue)
+		caseValue, ok := result.(EquatableValue)
 
 		// If the test value and case values are equal,
 		// evaluate the case's statements
 
 		getLocationRange := locationRangeGetter(interpreter.Location, switchCase.Expression)
 
-		if testValue.Equal(interpreter, getLocationRange, caseValue) {
+		if ok && testValue.Equal(interpreter, getLocationRange, caseValue) {
 			return runStatements()
 		}
 
@@ -243,8 +249,8 @@ func (interpreter *Interpreter) VisitWhileStatement(statement *ast.WhileStatemen
 
 	for {
 
-		value := interpreter.evalExpression(statement.Test).(BoolValue)
-		if !value {
+		value, ok := interpreter.evalExpression(statement.Test).(BoolValue)
+		if !ok || !bool(value) {
 			return nil
 		}
 
@@ -339,7 +345,10 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 }
 
 func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement) ast.Repr {
-	event := interpreter.evalExpression(statement.InvocationExpression).(*CompositeValue)
+	event, ok := interpreter.evalExpression(statement.InvocationExpression).(*CompositeValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
 
 	eventType := interpreter.Program.Elaboration.EmitStatementEventTypes[statement]
 


### PR DESCRIPTION
## Description

This adds more graceful go handling for some type assertions in the runtime/sema directory, which previously were unhandled. This should not result in any behavioral differences. Part of https://github.com/dapperlabs/cadence-private-issues/issues/4

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
