### PR TITLE
Fix resource loss analysis and definite initialization analysis

### DIFF
--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -270,13 +270,13 @@ func (checker *Checker) visitMemberExpressionAssignment(
 
 		if functionActivation.InitializationInfo != nil {
 
-			// If the function has already returned, the initialization
-			// is not definitive, and it must be ignored
+			// If the function potentially returned or jumped before,
+			// then the initialization is not definitive, and it must be ignored
 
-			// NOTE: assignment can still be considered definitive
-			//  if the function maybe halted
+			// NOTE: assignment can still be considered definitive if the function maybe halted
 
-			if !functionActivation.ReturnInfo.MaybeReturned {
+			if !functionActivation.ReturnInfo.MaybeReturned &&
+				!functionActivation.ReturnInfo.MaybeJumped {
 
 				// If the field is constant and it has already previously been
 				// initialized, report an error for the repeated assignment

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -275,8 +275,7 @@ func (checker *Checker) visitMemberExpressionAssignment(
 
 			// NOTE: assignment can still be considered definitive if the function maybe halted
 
-			if !functionActivation.ReturnInfo.MaybeReturned &&
-				!functionActivation.ReturnInfo.MaybeJumped {
+			if !functionActivation.ReturnInfo.MaybeJumpedOrReturned {
 
 				// If the field is constant and it has already previously been
 				// initialized, report an error for the repeated assignment

--- a/runtime/sema/check_block.go
+++ b/runtime/sema/check_block.go
@@ -39,11 +39,8 @@ func (checker *Checker) visitStatements(statements []ast.Statement) {
 		// Is this statement unreachable? Report it once for this statement,
 		// but avoid noise and don't report it for all remaining unreachable statements
 
-		definitelyReturnedOrHalted :=
-			functionActivation.ReturnInfo.DefinitelyReturned ||
-				functionActivation.ReturnInfo.DefinitelyHalted
-
-		if definitelyReturnedOrHalted && !functionActivation.ReportedDeadCode {
+		if functionActivation.ReturnInfo.IsUnreachable() &&
+			!functionActivation.ReportedDeadCode {
 
 			lastStatement := statements[len(statements)-1]
 

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -131,10 +131,10 @@ func (checker *Checker) checkFunction(
 
 	// Reset the returning state and restore it when leaving
 
-	returned := checker.resources.Returns
-	checker.resources.Returns = false
+	returned := checker.resources.JumpsOrReturns
+	checker.resources.JumpsOrReturns = false
 	defer func() {
-		checker.resources.Returns = returned
+		checker.resources.JumpsOrReturns = returned
 	}()
 
 	// NOTE: Always declare the function parameters, even if the function body is empty.

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -25,7 +25,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast
 
 	defer func() {
 		checker.checkResourceLossForFunction()
-		checker.resources.Returns = true
+		checker.resources.JumpsOrReturns = true
 		functionActivation.ReturnInfo.MaybeReturned = true
 		functionActivation.ReturnInfo.DefinitelyReturned = true
 	}()

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -26,7 +26,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast
 	defer func() {
 		checker.checkResourceLossForFunction()
 		checker.resources.JumpsOrReturns = true
-		functionActivation.ReturnInfo.MaybeReturned = true
+		functionActivation.ReturnInfo.MaybeJumpedOrReturned = true
 		functionActivation.ReturnInfo.DefinitelyReturned = true
 	}()
 

--- a/runtime/sema/check_switch.go
+++ b/runtime/sema/check_switch.go
@@ -138,11 +138,9 @@ func (checker *Checker) checkSwitchCasesStatements(cases []*ast.SwitchCase) {
 
 	switchCase := cases[0]
 
-	if caseCount == 1 {
-		if switchCase.Expression == nil {
-			checker.checkSwitchCaseStatements(switchCase)
-			return
-		}
+	if caseCount == 1 && switchCase.Expression == nil {
+		checker.checkSwitchCaseStatements(switchCase)
+		return
 	}
 
 	_, _ = checker.checkConditionalBranches(

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -115,7 +115,7 @@ func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.R
 
 	functionActivation := checker.functionActivations.Current()
 	checker.resources.JumpsOrReturns = true
-	functionActivation.ReturnInfo.MaybeJumped = true
+	functionActivation.ReturnInfo.MaybeJumpedOrReturned = true
 	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil
@@ -137,7 +137,7 @@ func (checker *Checker) VisitContinueStatement(statement *ast.ContinueStatement)
 
 	functionActivation := checker.functionActivations.Current()
 	checker.resources.JumpsOrReturns = true
-	functionActivation.ReturnInfo.MaybeJumped = true
+	functionActivation.ReturnInfo.MaybeJumpedOrReturned = true
 	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -115,6 +115,7 @@ func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.R
 
 	functionActivation := checker.functionActivations.Current()
 	checker.resources.JumpsOrReturns = true
+	functionActivation.ReturnInfo.MaybeJumped = true
 	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil
@@ -136,6 +137,7 @@ func (checker *Checker) VisitContinueStatement(statement *ast.ContinueStatement)
 
 	functionActivation := checker.functionActivations.Current()
 	checker.resources.JumpsOrReturns = true
+	functionActivation.ReturnInfo.MaybeJumped = true
 	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -110,7 +110,12 @@ func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.R
 				Range:            ast.NewRangeFromPositioned(statement),
 			},
 		)
+		return nil
 	}
+
+	functionActivation := checker.functionActivations.Current()
+	checker.resources.JumpsOrReturns = true
+	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil
 }
@@ -126,7 +131,12 @@ func (checker *Checker) VisitContinueStatement(statement *ast.ContinueStatement)
 				Range:            ast.NewRangeFromPositioned(statement),
 			},
 		)
+		return nil
 	}
+
+	functionActivation := checker.functionActivations.Current()
+	checker.resources.JumpsOrReturns = true
+	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1783,13 +1783,9 @@ func (checker *Checker) checkPotentiallyUnevaluated(check TypeCheckFunc) Type {
 		temporaryResources,
 	)
 
-	functionActivation.ReturnInfo.MaybeReturned =
-		functionActivation.ReturnInfo.MaybeReturned ||
-			temporaryReturnInfo.MaybeReturned
-
-	functionActivation.ReturnInfo.MaybeJumped =
-		functionActivation.ReturnInfo.MaybeJumped ||
-			temporaryReturnInfo.MaybeJumped
+	functionActivation.ReturnInfo.MaybeJumpedOrReturned =
+		functionActivation.ReturnInfo.MaybeJumpedOrReturned ||
+			temporaryReturnInfo.MaybeJumpedOrReturned
 
 	// NOTE: the definitive return state does not change
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1787,6 +1787,10 @@ func (checker *Checker) checkPotentiallyUnevaluated(check TypeCheckFunc) Type {
 		functionActivation.ReturnInfo.MaybeReturned ||
 			temporaryReturnInfo.MaybeReturned
 
+	functionActivation.ReturnInfo.MaybeJumped =
+		functionActivation.ReturnInfo.MaybeJumped ||
+			temporaryReturnInfo.MaybeJumped
+
 	// NOTE: the definitive return state does not change
 
 	checker.resources.MergeBranches(temporaryResources, nil)

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1584,7 +1584,7 @@ func (checker *Checker) recordResourceInvalidation(
 	}
 
 	if checker.allowSelfResourceFieldInvalidation && accessedSelfMember != nil {
-		checker.resources.AddInvalidation(accessedSelfMember, invalidation)
+		checker.maybeAddResourceInvalidation(accessedSelfMember, invalidation)
 
 		return &recordedResourceInvalidation{
 			resource:     accessedSelfMember,
@@ -1614,7 +1614,7 @@ func (checker *Checker) recordResourceInvalidation(
 		)
 	}
 
-	checker.resources.AddInvalidation(variable, invalidation)
+	checker.maybeAddResourceInvalidation(variable, invalidation)
 
 	return &recordedResourceInvalidation{
 		resource:     variable,
@@ -2478,6 +2478,16 @@ func (checker *Checker) declareGlobalRanges() {
 	checker.Elaboration.GlobalTypes.Foreach(addRange)
 
 	checker.Elaboration.GlobalValues.Foreach(addRange)
+}
+
+func (checker *Checker) maybeAddResourceInvalidation(resource interface{}, invalidation ResourceInvalidation) {
+	functionActivation := checker.functionActivations.Current()
+
+	if functionActivation.ReturnInfo.IsUnreachable() {
+		return
+	}
+
+	checker.resources.AddInvalidation(resource, invalidation)
 }
 
 func wrapWithOptionalIfNotNil(typ Type) Type {

--- a/runtime/sema/return_info.go
+++ b/runtime/sema/return_info.go
@@ -21,6 +21,7 @@ package sema
 type ReturnInfo struct {
 	MaybeReturned      bool
 	DefinitelyReturned bool
+	MaybeJumped        bool
 	DefinitelyHalted   bool
 	DefinitelyJumped   bool
 }
@@ -33,6 +34,10 @@ func (ri *ReturnInfo) MergeBranches(thenReturnInfo *ReturnInfo, elseReturnInfo *
 	ri.DefinitelyReturned = ri.DefinitelyReturned ||
 		(thenReturnInfo.DefinitelyReturned &&
 			elseReturnInfo.DefinitelyReturned)
+
+	ri.MaybeJumped = ri.MaybeJumped ||
+		thenReturnInfo.MaybeJumped ||
+		elseReturnInfo.MaybeJumped
 
 	ri.DefinitelyJumped = ri.DefinitelyJumped ||
 		(thenReturnInfo.DefinitelyJumped &&

--- a/runtime/sema/return_info.go
+++ b/runtime/sema/return_info.go
@@ -22,6 +22,7 @@ type ReturnInfo struct {
 	MaybeReturned      bool
 	DefinitelyReturned bool
 	DefinitelyHalted   bool
+	DefinitelyJumped   bool
 }
 
 func (ri *ReturnInfo) MergeBranches(thenReturnInfo *ReturnInfo, elseReturnInfo *ReturnInfo) {
@@ -33,6 +34,10 @@ func (ri *ReturnInfo) MergeBranches(thenReturnInfo *ReturnInfo, elseReturnInfo *
 		(thenReturnInfo.DefinitelyReturned &&
 			elseReturnInfo.DefinitelyReturned)
 
+	ri.DefinitelyJumped = ri.DefinitelyJumped ||
+		(thenReturnInfo.DefinitelyJumped &&
+			elseReturnInfo.DefinitelyJumped)
+
 	ri.DefinitelyHalted = ri.DefinitelyHalted ||
 		(thenReturnInfo.DefinitelyHalted &&
 			elseReturnInfo.DefinitelyHalted)
@@ -42,4 +47,10 @@ func (ri *ReturnInfo) Clone() *ReturnInfo {
 	result := &ReturnInfo{}
 	*result = *ri
 	return result
+}
+
+func (ri *ReturnInfo) IsUnreachable() bool {
+	return ri.DefinitelyReturned ||
+		ri.DefinitelyHalted ||
+		ri.DefinitelyJumped
 }

--- a/runtime/sema/return_info.go
+++ b/runtime/sema/return_info.go
@@ -19,25 +19,22 @@
 package sema
 
 type ReturnInfo struct {
-	MaybeReturned      bool
-	DefinitelyReturned bool
-	MaybeJumped        bool
-	DefinitelyHalted   bool
-	DefinitelyJumped   bool
+	// MaybeJumpedOrReturned indicates that the (branch of) the function
+	// contains a potentially taken return, break, or continue statement
+	MaybeJumpedOrReturned bool
+	DefinitelyReturned    bool
+	DefinitelyHalted      bool
+	DefinitelyJumped      bool
 }
 
 func (ri *ReturnInfo) MergeBranches(thenReturnInfo *ReturnInfo, elseReturnInfo *ReturnInfo) {
-	ri.MaybeReturned = ri.MaybeReturned ||
-		thenReturnInfo.MaybeReturned ||
-		elseReturnInfo.MaybeReturned
+	ri.MaybeJumpedOrReturned = ri.MaybeJumpedOrReturned ||
+		thenReturnInfo.MaybeJumpedOrReturned ||
+		elseReturnInfo.MaybeJumpedOrReturned
 
 	ri.DefinitelyReturned = ri.DefinitelyReturned ||
 		(thenReturnInfo.DefinitelyReturned &&
 			elseReturnInfo.DefinitelyReturned)
-
-	ri.MaybeJumped = ri.MaybeJumped ||
-		thenReturnInfo.MaybeJumped ||
-		elseReturnInfo.MaybeJumped
 
 	ri.DefinitelyJumped = ri.DefinitelyJumped ||
 		(thenReturnInfo.DefinitelyJumped &&

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -5402,7 +5402,7 @@ func TestCheckResourceInvalidationInBranchesAndLoops(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("switch-case: break in one case", func(t *testing.T) {
+	t.Run("switch-case: destroy missing in default case", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -2244,26 +2244,61 @@ func TestCheckResourceUseInNestedIfStatement(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheck(t, `
-      resource X {}
+	t.Run("resource loss", func(t *testing.T) {
+		t.Parallel()
 
-      fun test() {
-          let x <- create X()
-          if 1 > 2 {
-              if 2 > 1 {
+		_, err := ParseAndCheck(t, `
+          resource X {}
+
+          fun test() {
+              let x <- create X()
+              if 1 > 2 {
+                  if 2 > 1 {
+                      absorb(<-x)
+                  }
+                  // NOTE: resource is not destroyed in the else path
+              } else {
                   absorb(<-x)
               }
-          } else {
-              absorb(<-x)
           }
-      }
 
-      fun absorb(_ x: @X) {
-          destroy x
-      }
-    `)
+          fun absorb(_ x: @X) {
+              destroy x
+          }
+        `)
 
-	require.NoError(t, err)
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("no resource loss", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          resource X {}
+
+          fun test() {
+              let x <- create X()
+              if 1 > 2 {
+                  if 2 > 1 {
+                      absorb(<-x)
+                  } else {
+                      absorb(<-x)
+                  }
+              } else {
+                  absorb(<-x)
+              }
+          }
+
+          fun absorb(_ x: @X) {
+              destroy x
+          }
+        `)
+
+		require.NoError(t, err)
+	})
 }
 
 ////
@@ -2698,10 +2733,11 @@ func TestCheckInvalidResourceLossThroughReturn(t *testing.T) {
       }
     `)
 
-	errs := ExpectCheckerErrors(t, err, 2)
+	errs := ExpectCheckerErrors(t, err, 3)
 
 	assert.IsType(t, &sema.ResourceLossError{}, errs[0])
 	assert.IsType(t, &sema.UnreachableStatementError{}, errs[1])
+	assert.IsType(t, &sema.ResourceLossError{}, errs[2])
 }
 
 func TestCheckInvalidResourceLossThroughReturnInIfStatementThenBranch(t *testing.T) {
@@ -2748,10 +2784,11 @@ func TestCheckInvalidResourceLossThroughReturnInIfStatementBranches(t *testing.T
       }
     `)
 
-	errs := ExpectCheckerErrors(t, err, 2)
+	errs := ExpectCheckerErrors(t, err, 3)
 
 	assert.IsType(t, &sema.ResourceLossError{}, errs[0])
 	assert.IsType(t, &sema.UnreachableStatementError{}, errs[1])
+	assert.IsType(t, &sema.ResourceLossError{}, errs[2])
 }
 
 func TestCheckResourceWithMoveAndReturnInIfStatementThenAndDestroyInElse(t *testing.T) {
@@ -5047,5 +5084,386 @@ func TestCheckEmptyResourceCollectionMove(t *testing.T) {
         `)
 
 		require.NoError(t, err)
+	})
+}
+
+func TestCheckResourceInvalidationInBranchesAndLoops(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("if-else: missing else branch", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+            fun test(r: @R) {
+                if true {
+                    destroy r
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("if-else: missing else branches", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+            fun test(r: @R) {
+                if true {
+                    if true {
+                       destroy r
+                    }
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("if-else: missing else branches", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+            fun test(r: @R) {
+                if true {
+                    if true {
+                       destroy r
+                    }
+                } else {
+                    destroy r
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("switch-case: missing destruction in one case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        destroy r
+                    case 2:
+                        // Some random statement that has no effect
+                        let a = "do nothing"
+                    default:
+                        destroy r
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("switch-case: missing destruction in default case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        destroy r
+                    case 2:
+                        destroy r
+                    default:
+                        break
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("switch-case: resource destruction in all cases", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        destroy r
+                    case 2:
+                        destroy r
+                    default:
+                        destroy r
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("switch-case: no default", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        destroy r
+                    case 2:
+                        destroy r
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("switch-case: missing destruction of one resource in one case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r1: @R, r2: @R) {
+                switch n {
+                    case n:
+                        destroy r1
+                        destroy r2
+                    case 2:
+                        destroy r1
+                    default:
+                        destroy r1
+                        destroy r2
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("switch-case: missing destruction of one resource in default case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r1: @R, r2: @R) {
+                switch n {
+                    case n:
+                        destroy r1
+                        destroy r2
+                    case 2:
+                        destroy r1
+                        destroy r2
+                    default:
+                        destroy r1
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("switch-case: loss of all resources in one case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r1: @R, r2: @R) {
+                switch n {
+                    case 1:
+                        destroy r1
+                        destroy r2
+                    case 2:
+                        break
+                    default:
+                        destroy r1
+                        destroy r2
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+		assert.IsType(t, &sema.ResourceLossError{}, errs[1])
+	})
+
+	t.Run("switch-case: loss of all resources in default case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r1: @R, r2: @R) {
+                switch n {
+                    case 1:
+                        destroy r1
+                        destroy r2
+                    case 2:
+                        destroy r1
+                        destroy r2
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+		assert.IsType(t, &sema.ResourceLossError{}, errs[1])
+	})
+
+	t.Run("switch-case: unreachable destruction due to break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        break
+                        destroy r  // unreachable
+                    default:
+                        destroy r
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
+		assert.IsType(t, &sema.ResourceLossError{}, errs[1])
+	})
+
+	t.Run("switch-case: return in one case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        destroy r
+                        return
+                    default:
+                        destroy r
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("switch-case: break in one case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        destroy r
+                        break
+                    default:
+                        destroy r
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("switch-case: break in one case", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(n: Int, r: @R) {
+                switch n {
+                    case 1:
+                        destroy r
+                        return
+                    default:
+                        return
+                }
+                destroy r
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 3)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+		assert.IsType(t, &sema.UnreachableStatementError{}, errs[1])
+		assert.IsType(t, &sema.ResourceLossError{}, errs[2])
+	})
+
+	t.Run("while loop: unreachable destruction due to break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(r: @R) {
+                while true {
+                    break
+                    destroy r  // unreachable
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
+		assert.IsType(t, &sema.ResourceLossError{}, errs[1])
+	})
+
+	t.Run("while loop: unreachable destruction due to continue", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            fun test(r: @R) {
+                while true {
+                    continue
+                    destroy r  // unreachable
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
+		assert.IsType(t, &sema.ResourceLossError{}, errs[1])
 	})
 }

--- a/runtime/tests/checker/switch_test.go
+++ b/runtime/tests/checker/switch_test.go
@@ -356,3 +356,23 @@ func TestCheckInvalidSwitchStatementMissingStatements(t *testing.T) {
 
 	assert.IsType(t, &sema.MissingSwitchCaseStatementsError{}, errs[0])
 }
+
+func TestCheckSwitchStatementWithUnreachableReturn(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test(_ x: Int): Int {
+          switch x {
+          case 1:
+              break
+              return 1
+          default:
+              return 2
+          }
+      }
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+	assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
+}

--- a/runtime/tests/checker/while_test.go
+++ b/runtime/tests/checker/while_test.go
@@ -136,3 +136,31 @@ func TestCheckInvalidWhileContinueStatement(t *testing.T) {
 
 	assert.IsType(t, &sema.ControlStatementError{}, errs[0])
 }
+
+func TestCheckInvalidBreakStatement(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test() {
+          break
+      }
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+	assert.IsType(t, &sema.ControlStatementError{}, errs[0])
+}
+
+func TestCheckInvalidContinueStatement(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test() {
+          continue
+      }
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+	assert.IsType(t, &sema.ControlStatementError{}, errs[0])
+}


### PR DESCRIPTION
Closes #1325 

Based heavily on #1329, thank you @SupunS 🙏 

Investigating the issue I also discovered that the definite initialization analysis suffered from the same problem.

## Description

- Fix and simplify resource tracking / resource loss detection (82c260aab267981de61551782775294a2af569d2):
  -  Consider jumps (break and continue statements) when merging then/else branches' invalidations into the parent
  - Don't record resource invalidations if the code adding the invalidation is unreachable
- Consider jumps in definite initialization analysis and improve dead code reporting (88b9fbe6f850a5eb0a483961cdf53fc472776088)
  - In addition to when maybe a return statement occured, initializations should also be ignored when maybe a jump (break or continue statement) occured
  - In addition to when a definite return statement occurs, code is also unreachable if a definite jump (beak or continue statement) occurred before
- Add tests for resource loss analysis and definite initialization analysis fixes

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
