### PR TITLE
Fix IsContainerType for CompositeType and InterfaceType

### DIFF
--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -1,3 +1,4 @@
+//go:build !wasm
 // +build !wasm
 
 /*

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1317,7 +1317,7 @@ func (checker *Checker) convertNominalType(t *ast.NominalType) Type {
 	var resolvedIdentifiers []ast.Identifier
 
 	for _, identifier := range t.NestedIdentifiers {
-		if containerType, ok := ty.(ContainerType); ok && containerType.isContainerType() {
+		if containerType, ok := ty.(ContainerType); ok && containerType.IsContainerType() {
 			ty, _ = containerType.GetNestedTypes().Get(identifier.Identifier)
 		} else {
 			if !ty.IsInvalidType() {

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -129,7 +129,7 @@ func (t *SimpleType) initializeMembers() {
 	})
 }
 
-func (t *SimpleType) isContainerType() bool {
+func (t *SimpleType) IsContainerType() bool {
 	return t.NestedTypes != nil
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -198,7 +198,7 @@ type ContainedType interface {
 //
 type ContainerType interface {
 	Type
-	isContainerType() bool
+	IsContainerType() bool
 	GetNestedTypes() *StringTypeOrderedMap
 }
 
@@ -206,7 +206,7 @@ func VisitThisAndNested(t Type, visit func(ty Type)) {
 	visit(t)
 
 	containerType, ok := t.(ContainerType)
-	if !ok || !containerType.isContainerType() {
+	if !ok || !containerType.IsContainerType() {
 		return
 	}
 
@@ -3664,8 +3664,8 @@ func (t *CompositeType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
 	return t
 }
 
-func (*CompositeType) isContainerType() bool {
-	return true
+func (t *CompositeType) IsContainerType() bool {
+	return t.nestedTypes != nil
 }
 
 func (t *CompositeType) GetNestedTypes() *StringTypeOrderedMap {
@@ -4061,8 +4061,8 @@ func (t *InterfaceType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
 	return t
 }
 
-func (*InterfaceType) isContainerType() bool {
-	return true
+func (t *InterfaceType) IsContainerType() bool {
+	return t.nestedTypes != nil
 }
 
 func (t *InterfaceType) GetNestedTypes() *StringTypeOrderedMap {

--- a/runtime/tests/checker/nesting_test.go
+++ b/runtime/tests/checker/nesting_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -278,4 +279,46 @@ func TestCheckInvalidNestedType(t *testing.T) {
 	errs := ExpectCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.InvalidNestedTypeError{}, errs[0])
+}
+
+func TestCheckNestedTypeInvalidChildType(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(t *testing.T, ty sema.Type) {
+		_, err := ParseAndCheckWithOptions(t,
+			`let u: T.U = nil`,
+			ParseAndCheckOptions{
+				Options: []sema.Option{
+					sema.WithPredeclaredTypes([]sema.TypeDeclaration{
+						stdlib.StandardLibraryType{
+							Name: "T",
+							Type: ty,
+							Kind: common.DeclarationKindType,
+						},
+					}),
+				},
+			},
+		)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.InvalidNestedTypeError{}, errs[0])
+	}
+
+	testCases := map[string]sema.Type{
+		"CompositeType": &sema.CompositeType{Identifier: "T"},
+		"InterfaceType": &sema.InterfaceType{Identifier: "T"},
+		"SimpleType":    &sema.SimpleType{Name: "T"},
+	}
+
+	for name, ty := range testCases {
+
+		t.Run(name, func(t *testing.T) {
+
+			t.Parallel()
+
+			test(t, ty)
+		})
+	}
 }

--- a/runtime/tests/checker/nesting_test.go
+++ b/runtime/tests/checker/nesting_test.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/stdlib"
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"


### PR DESCRIPTION
Port of https://github.com/dapperlabs/cadence-internal/pull/43 originally authored by Bastian.

## Description
Description from original PR:

> Some internal types, like HashAlgorithm, do not have any nested types.
> Fix a crasher when a nested type of such types is accessed.
> 
> This is also an opportunity for a future optimization: user-defined composite types are always instantiated with an empty nested type map. We could lazily create it if needed and save an allocation in the common case where a type has no nested types.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
