### PR TITLE
Fix checking of `create before(...)` in post condition

### DIFF
--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -670,7 +670,21 @@ func (extractor *ExpressionExtractor) ExtractCreate(expression *CreateExpression
 
 	result := extractor.Extract(newExpression.InvocationExpression)
 
-	newExpression.InvocationExpression = result.RewrittenExpression.(*InvocationExpression)
+	invocationExpression, ok := result.RewrittenExpression.(*InvocationExpression)
+	if !ok {
+		// Edge-case:
+		// The rewritten expression returned from the extractor may not be an InvocationExpression,
+		// but an expression of another type.
+		//
+		// Wrap the rewritten expression in an InvocationExpression.
+
+		invocationExpression = &InvocationExpression{
+			InvokedExpression: result.RewrittenExpression,
+			EndPos:            result.RewrittenExpression.EndPosition(),
+		}
+	}
+
+	newExpression.InvocationExpression = invocationExpression
 
 	return ExpressionExtraction{
 		RewrittenExpression:  &newExpression,

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -497,3 +497,28 @@ func TestCheckFunctionWithPostConditionAndResourceResult(t *testing.T) {
 	require.IsType(t, &sema.InvalidMoveOperationError{}, errs[0])
 	require.IsType(t, &sema.TypeMismatchError{}, errs[1])
 }
+
+// TestCheckConditionCreateBefore tests if the AST expression extractor properly handles
+// that the rewritten expression of a create expression may not be an invocation expression.
+// For example, this is the case for the expression `create before(...)`,
+// where the sema.BeforeExtractor returns an IdentifierExpression.
+//
+func TestCheckConditionCreateBefore(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test(n: Int) {
+          post {
+              create before(n)
+          }
+      }
+    `)
+	require.Error(t, err)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	var notCallableErr *sema.NotCallableError
+	require.ErrorAs(t, errs[0], &notCallableErr)
+	require.Equal(t, sema.IntType, notCallableErr.Type)
+}


### PR DESCRIPTION
Port of https://github.com/dapperlabs/cadence-internal/pull/45 originally authored by Bastian.

## Description
Description from original PR:

> `sema.BeforeExtractor` returns an `ast.IdentifierExpression` `n` as the result of the `ast.InvocationExpression` `before(n)`.
> 
> Fix `ast.ExpressionExtractor` to handle the case where the rewritten expression of a `create` expression may not be an invocation expression.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
