### PR TITLE
[v0.20] Fix and simplify parser buffering

### DIFF
--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -50,15 +50,15 @@ type lexer struct {
 	// the offset in the token stream
 	cursor int
 	// the tokens of the stream
-	tokens []Token
+	tokens     []Token
+	tokenCount int
 }
 
 var _ TokenStream = &lexer{}
 
 func (l *lexer) Next() Token {
-	tokenCount := len(l.tokens)
-	if l.cursor >= tokenCount {
-		return l.tokens[tokenCount-1]
+	if l.cursor >= l.tokenCount {
+		return l.tokens[l.tokenCount-1]
 	}
 	token := l.tokens[l.cursor]
 	l.cursor++
@@ -197,6 +197,7 @@ func (l *lexer) emit(ty TokenType, val interface{}, rangeStart ast.Position, con
 	}
 
 	l.tokens = append(l.tokens, token)
+	l.tokenCount = len(l.tokens)
 
 	if consume {
 		l.startOffset = l.endOffset

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -19,33 +19,11 @@
 package lexer
 
 import (
-	"context"
 	"fmt"
 	"unicode/utf8"
 
 	"github.com/onflow/cadence/runtime/ast"
 )
-
-type Token struct {
-	Type  TokenType
-	Value interface{}
-	ast.Range
-}
-
-func (t Token) Is(ty TokenType) bool {
-	return t.Type == ty
-}
-
-func (t Token) IsString(ty TokenType, s string) bool {
-	if !t.Is(ty) {
-		return false
-	}
-	v, ok := t.Value.(string)
-	if !ok {
-		return false
-	}
-	return v == s
-}
 
 type position struct {
 	line   int
@@ -53,9 +31,6 @@ type position struct {
 }
 
 type lexer struct {
-	ctx context.Context
-	// the function that cancels the lexer
-	cancelLexer func()
 	// the entire input string
 	input string
 	// the start offset of the current word in the current line
@@ -68,82 +43,63 @@ type lexer struct {
 	current rune
 	// the previous rune was scanned, used for stepping back
 	prev rune
-	// the channel of tokens that has been scanned.
-	tokens chan Token
 	// signal whether stepping back is allowed
 	canBackup bool
 	// the start position of the current word
 	startPos position
+	// the offset in the token stream
+	cursor int
+	// the tokens of the stream
+	tokens []Token
 }
 
-type TokenStream interface {
-	// Next consumes and returns one Token. If there are no tokens remaining, it returns Token{TokenEOF}
-	Next() Token
-	// Close provides an opportunity for a TokenStream implementation to clean-up
-	Close()
-	// Input returns the whole input as source code
-	Input() string
-}
+var _ TokenStream = &lexer{}
 
 func (l *lexer) Next() Token {
-	token, ok := <-l.tokens
-	if !ok {
-		endPos := l.endPos()
-		pos := ast.Position{
-			Offset: l.endOffset - 1,
-			Line:   endPos.line,
-			Column: endPos.column - 1,
-		}
-		token = Token{
-			Type: TokenEOF,
-			Range: ast.Range{
-				StartPos: pos,
-				EndPos:   pos,
-			},
-		}
+	tokenCount := len(l.tokens)
+	if l.cursor >= tokenCount {
+		return l.tokens[tokenCount-1]
 	}
+	token := l.tokens[l.cursor]
+	l.cursor++
 	return token
-}
-
-func (l *lexer) Close() {
-	l.cancelLexer()
 }
 
 func (l *lexer) Input() string {
 	return l.input
 }
 
+func (l *lexer) Cursor() int {
+	return l.cursor
+}
+
+func (l *lexer) Revert(cursor int) {
+	l.cursor = cursor
+}
+
 func Lex(input string) TokenStream {
-	ctx, cancelLexer := context.WithCancel(context.Background())
 	l := &lexer{
-		ctx:           ctx,
-		cancelLexer:   cancelLexer,
 		input:         input,
 		startPos:      position{line: 1},
 		endOffset:     0,
 		prevEndOffset: 0,
 		current:       EOF,
 		prev:          EOF,
-		tokens:        make(chan Token),
 	}
-	go l.run(rootState)
+	l.run(rootState)
 	return l
 }
 
-type done struct{}
-
 // run executes the stateFn, which will scan the runes in the input
-// and emit tokens to the tokens channel.
+// and emit tokens.
 //
 // stateFn might return another stateFn to indicate further scanning work,
 // or nil if there is no scanning work left to be done,
 // i.e. run will keep running the returned stateFn until no more
 // stateFn is returned, which for example happens when reaching the end of the file.
 //
-// When all stateFn have been executed, the tokens channel will be closed.
+// When all stateFn have been executed, an EOF token is emitted.
 func (l *lexer) run(state stateFn) {
-	// Close token channel, no token remaining
-	defer close(l.tokens)
 
 	// catch panic exceptions, emit it to the tokens channel before
 	// closing it
@@ -151,8 +107,6 @@ func (l *lexer) run(state stateFn) {
 		if r := recover(); r != nil {
 			var err error
 			switch r := r.(type) {
-			case done:
-				return
 			case error:
 				err = r
 			default:
@@ -166,6 +120,8 @@ func (l *lexer) run(state stateFn) {
 	for state != nil {
 		state = state(l)
 	}
+
+	l.emitEOF()
 }
 
 // next decodes the next rune (UTF8 character) from the input string.
@@ -240,13 +196,7 @@ func (l *lexer) emit(ty TokenType, val interface{}, rangeStart ast.Position, con
 		},
 	}
 
-	select {
-	case <-l.ctx.Done():
-		panic(done{})
-
-	case l.tokens <- token:
-
-	}
+	l.tokens = append(l.tokens, token)
 
 	if consume {
 		l.startOffset = l.endOffset
@@ -422,6 +372,25 @@ func (l *lexer) scanFixedPointRemainder() {
 		return
 	}
 	l.acceptWhile(isDecimalDigitOrUnderscore)
+}
+
+func (l *lexer) emitEOF() {
+	endPos := l.endPos()
+	pos := ast.Position{
+		Offset: l.endOffset - 1,
+		Line:   endPos.line,
+		Column: endPos.column - 1,
+	}
+
+	token := Token{
+		Type: TokenEOF,
+		Range: ast.Range{
+			StartPos: pos,
+			EndPos:   pos,
+		},
+	}
+
+	l.tokens = append(l.tokens, token)
 }
 
 func isDecimalDigitOrUnderscore(r rune) bool {

--- a/runtime/parser2/lexer/token.go
+++ b/runtime/parser2/lexer/token.go
@@ -1,0 +1,44 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lexer
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+)
+
+type Token struct {
+	Type  TokenType
+	Value interface{}
+	ast.Range
+}
+
+func (t Token) Is(ty TokenType) bool {
+	return t.Type == ty
+}
+
+func (t Token) IsString(ty TokenType, s string) bool {
+	if !t.Is(ty) {
+		return false
+	}
+	v, ok := t.Value.(string)
+	if !ok {
+		return false
+	}
+	return v == s
+}

--- a/runtime/parser2/lexer/tokenstream.go
+++ b/runtime/parser2/lexer/tokenstream.go
@@ -1,0 +1,28 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lexer
+
+type TokenStream interface {
+	// Next consumes and returns one Token. If there are no tokens remaining, it returns Token{TokenEOF}
+	Next() Token
+	Cursor() int
+	Revert(cursor int)
+	// Input returns the whole input as source code
+	Input() string
+}

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -40,15 +40,10 @@ type parser struct {
 	current lexer.Token
 	// errors are the parsing errors encountered during parsing
 	errors []error
-	// buffering is a flag that indicates whether the next token
-	// will be read from buffered tokens or lexer
-	buffering bool
-	// bufferedTokens are the buffered tokens read from the lexer
-	bufferedTokens []lexer.Token
-	// bufferPos is the index of the next buffered token to read from (`bufferedTokens`)
-	bufferPos int
+	// backtrackingCursors
+	backtrackingCursors []int
 	// bufferedErrors are the parsing errors encountered during buffering
-	bufferedErrors []error
+	bufferedErrors [][]error
 }
 
 // Parse creates a lexer to scan the given input string,
@@ -66,8 +61,6 @@ func Parse(input string, parse func(*parser) interface{}) (result interface{}, e
 func ParseTokenStream(tokens lexer.TokenStream, parse func(*parser) interface{}) (result interface{}, errors []error) {
 	p := &parser{tokens: tokens}
 
-	defer tokens.Close()
-
 	defer func() {
 		if r := recover(); r != nil {
 			err, ok := r.(error)
@@ -81,8 +74,8 @@ func ParseTokenStream(tokens lexer.TokenStream, parse func(*parser) interface{})
 			errors = p.errors
 		}
 
-		if p.buffering {
-			errors = append(errors, p.bufferedErrors...)
+		for _, bufferedErrors := range p.bufferedErrors {
+			errors = append(errors, bufferedErrors...)
 		}
 	}()
 
@@ -122,25 +115,20 @@ func (p *parser) report(errs ...error) {
 			}
 		}
 
-		if p.buffering {
-			p.bufferedErrors = append(p.bufferedErrors, parseError)
+		// Add the errors to the buffered errors if buffering,
+		// or the final errors if not
+
+		bufferedErrorsDepth := len(p.bufferedErrors)
+		if bufferedErrorsDepth > 0 {
+			bufferedErrorsIndex := bufferedErrorsDepth - 1
+			p.bufferedErrors[bufferedErrorsIndex] = append(
+				p.bufferedErrors[bufferedErrorsIndex],
+				parseError,
+			)
 		} else {
 			p.errors = append(p.errors, parseError)
 		}
 	}
-}
-
-const bufferPosTrimThreshold = 128
-
-// maybeTrimBuffer checks whether the index of token we've read from buffered tokens
-// has reached a threshold, in which case the buffered tokens will be trimmed and bufferPos
-// will be reset.
-func (p *parser) maybeTrimBuffer() {
-	if p.bufferPos < bufferPosTrimThreshold {
-		return
-	}
-	p.bufferedTokens = p.bufferedTokens[p.bufferPos:]
-	p.bufferPos = 0
 }
 
 // next reads the next token and marks it as the "current" token.
@@ -148,50 +136,9 @@ func (p *parser) maybeTrimBuffer() {
 // the buffer.
 // Tokens are buffered when syntax ambiguity is involved.
 func (p *parser) next() {
-	// nextFromLexer reads the next token from the lexer.
-	nextFromLexer := func() lexer.Token {
-		return p.tokens.Next()
-	}
-
-	// nextFromLexer reads the next token from the buffer tokens, assuming there are buffered tokens.
-	nextFromBuffer := func() lexer.Token {
-		token := p.bufferedTokens[p.bufferPos]
-		p.bufferPos++
-		p.maybeTrimBuffer()
-		return token
-	}
 
 	for {
-		var token lexer.Token
-
-		// When the syntax has ambiguity, we need to process a series of tokens
-		// multiple times. However, a token can only be consumed once from the lexer's
-		// tokens channel. Therefore, in some circumstances, we need to buffer the tokens
-		// from the lexer.
-		//
-		// Buffering tokens allows us to potentially "replay" the buffered tokens later,
-		// for example to deal with syntax ambiguity
-
-		if p.buffering {
-
-			// If we need to buffer the next token
-			// then read the token from the lexer and buffer it.
-
-			token = nextFromLexer()
-			p.bufferedTokens = append(p.bufferedTokens, token)
-
-		} else if p.bufferPos < len(p.bufferedTokens) {
-
-			// If we don't need to buffer the next token and there are tokens buffered before,
-			// then read the token from the buffer.
-
-			token = nextFromBuffer()
-
-		} else {
-			// Otherwise no need to buffer, and there is no buffered token,
-			// then read the next token from the lexer.
-			token = nextFromLexer()
-		}
+		token := p.tokens.Next()
 
 		if token.Is(lexer.TokenError) {
 			// Report error token as error, skip.
@@ -231,17 +178,60 @@ func (p *parser) mustOneString(tokenType lexer.TokenType, string string) lexer.T
 	return t
 }
 
+func (p *parser) startBuffering() {
+	// Push the lexer's previous cursor to the stack.
+	// When start buffering is called, the lexer has already advanced to the next token
+	p.backtrackingCursors = append(p.backtrackingCursors, p.tokens.Cursor()-1)
+
+	// Push an empty slice of errors to the stack
+	p.bufferedErrors = append(p.bufferedErrors, nil)
+}
+
 func (p *parser) acceptBuffered() {
-	p.buffering = false
-	p.bufferPos = len(p.bufferedTokens)
-	p.report(p.bufferedErrors...)
-	p.maybeTrimBuffer()
+	// Pop the last backtracking cursor from the stack
+	// and ignore it
+
+	lastIndex := len(p.backtrackingCursors) - 1
+	p.backtrackingCursors = p.backtrackingCursors[:lastIndex]
+
+	// Pop the last buffered errors from the stack
+	// and apply them to the previous errors on the buffered errors stack,
+	// or the final errors, if we reached the bottom of the stack
+	// (i.e. this acceptance disables buffering)
+
+	lastIndex = len(p.bufferedErrors) - 1
+	bufferedErrors := p.bufferedErrors[lastIndex]
+	p.bufferedErrors[lastIndex] = nil
+	p.bufferedErrors = p.bufferedErrors[:lastIndex]
+	if len(bufferedErrors) > 0 {
+		p.bufferedErrors[lastIndex-1] = append(
+			p.bufferedErrors[lastIndex-1],
+			bufferedErrors...,
+		)
+	} else {
+		p.errors = append(
+			p.errors,
+			bufferedErrors...,
+		)
+	}
 }
 
 func (p *parser) replayBuffered() {
-	p.buffering = false
-	p.bufferedErrors = nil
+	// Pop the last backtracking cursor from the stack
+	// and revert the lexer back to it
+
+	lastIndex := len(p.backtrackingCursors) - 1
+	cursor := p.backtrackingCursors[lastIndex]
+	p.tokens.Revert(cursor)
 	p.next()
+	p.backtrackingCursors = p.backtrackingCursors[:lastIndex]
+
+	// Pop the last buffered errors from the stack
+	// and ignore them
+
+	lastIndex = len(p.bufferedErrors) - 1
+	p.bufferedErrors[lastIndex] = nil
+	p.bufferedErrors = p.bufferedErrors[:lastIndex]
 }
 
 type triviaOptions struct {
@@ -318,18 +308,6 @@ func (p *parser) parseTrivia(options triviaOptions) (containsNewline bool, docSt
 		}
 	}
 	return
-}
-
-func (p *parser) startBuffering() {
-	p.buffering = true
-
-	// Starting buffering should only buffer the current token
-	// if there's nothing to be read from the buffer.
-	// Otherwise, the current token would be buffered twice
-
-	if p.bufferPos >= len(p.bufferedTokens) {
-		p.bufferedTokens = append(p.bufferedTokens, p.current)
-	}
 }
 
 func mustIdentifier(p *parser) ast.Identifier {

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -234,24 +234,23 @@ func TestParseBuffering(t *testing.T) {
 
 		t.Parallel()
 
-		src := `
-        transaction { }
-        pub fun main() {
-            assert(isneg(x:-1.0))
-            assert(!isneg(x:-0.0/0.0))
-        }
-        pub fun isneg(x:SignedFixedPoint):Bool { /* I kinda forget what this is all about */
-            return x                             /* but we probably need to figure it out */
-                   <                             /* ************/((TODO?{/*))************ *//
-                  -x                             /* maybe it says NaNs are not negative?  */
-        }`
+		_, err := ParseProgram(`
+          fun main() {
+              assert(isneg(x:-1.0))
+              assert(!isneg(x:-0.0/0.0))
+          }
 
-		_, err := ParseProgram(src)
+          fun isneg(x: SignedFixedPoint): Bool {   /* I kinda forget what this is all about */
+              return x                             /* but we probably need to figure it out */
+                     <                             /* ************/((TODO?{/*))************ *//
+                    -x                             /* maybe it says NaNs are not negative?  */
+          }
+        `)
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: "expected token identifier",
-					Pos:     ast.Position{Offset: 371, Line: 10, Column: 12},
+					Pos:     ast.Position{Offset: 420, Line: 10, Column: 20},
 				},
 			},
 			err.(Error).Errors,
@@ -262,21 +261,20 @@ func TestParseBuffering(t *testing.T) {
 
 		t.Parallel()
 
-		src := `
-        transaction { }
-        pub fun main() {
-            fun abs(_:Int):Int { return _ > 0 ? _ : -_ }
-            let sanity = 0 <          /*****/((TODO?{/*****//
-                             abs(-1)
-            assert(sanity)
-        }`
+		_, err := ParseProgram(`
+          fun main() {
+              fun abs(_:Int):Int { return _ > 0 ? _ : -_ }
+              let sanity = 0 <          /*****/((TODO?{/*****//
+                               abs(-1)
+              assert(sanity)
+          }
+        `)
 
-		_, err := ParseProgram(src)
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: "expected token '/'",
-					Pos:     ast.Position{Offset: 159, Line: 6, Column: 20},
+					Pos:     ast.Position{Offset: 181, Line: 5, Column: 34},
 				},
 			},
 			err.(Error).Errors,

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -229,6 +229,102 @@ func TestParseBuffering(t *testing.T) {
 			errs,
 		)
 	})
+
+	t.Run("nested buffering, invalid", func(t *testing.T) {
+
+		t.Parallel()
+
+		src := `
+        transaction { }
+        pub fun main() {
+            assert(isneg(x:-1.0))
+            assert(!isneg(x:-0.0/0.0))
+        }
+        pub fun isneg(x:SignedFixedPoint):Bool { /* I kinda forget what this is all about */
+            return x                             /* but we probably need to figure it out */
+                   <                             /* ************/((TODO?{/*))************ *//
+                  -x                             /* maybe it says NaNs are not negative?  */
+        }`
+
+		_, err := ParseProgram(src)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected token identifier",
+					Pos:     ast.Position{Offset: 371, Line: 10, Column: 12},
+				},
+			},
+			err.(Error).Errors,
+		)
+	})
+
+	t.Run("nested buffering, invalid; apparent invocation elision", func(t *testing.T) {
+
+		t.Parallel()
+
+		src := `
+        transaction { }
+        pub fun main() {
+            fun abs(_:Int):Int { return _ > 0 ? _ : -_ }
+            let sanity = 0 <          /*****/((TODO?{/*****//
+                             abs(-1)
+            assert(sanity)
+        }`
+
+		_, err := ParseProgram(src)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected token '/'",
+					Pos:     ast.Position{Offset: 159, Line: 6, Column: 20},
+				},
+			},
+			err.(Error).Errors,
+		)
+	})
+
+	t.Run("nested buffering, valid; accept,accept,replay", func(t *testing.T) {
+
+		t.Parallel()
+
+		src := `
+            pub struct interface Y {}
+            pub struct X : Y {}
+            pub fun main():String {
+                fun f(a:Bool, _:String):String { return _; }
+                let S = 1
+                if false {
+                    let Type_X_Y__qp_identifier =
+                                    Type<X{Y}>().identifier; // parses fine
+                    return f(a:S<S, Type_X_Y__qp_identifier)
+                } else {
+                    return f(a:S<S, Type<X{Y}>().identifier) // should also parse fine
+                }
+            }`
+
+		_, err := ParseProgram(src)
+		assert.NoError(t, err)
+	})
+
+	t.Run("nested buffering, valid; overlapped", func(t *testing.T) {
+
+		t.Parallel()
+
+		src := `
+            transaction { }
+            pub fun main():String {
+                let A = 1
+                let B = 2
+                let C = 3
+                let D = 4
+                fun g(a:Bool, _:Bool):String { return _ ? "y" : "n" }
+                return g(a:A<B, C<(D>>(5)))
+            }`
+
+		_, err := ParseProgram(src)
+		assert.NoError(t, err)
+	})
+
 }
 
 func TestParseEOF(t *testing.T) {


### PR DESCRIPTION
## Description

Port of dapperlabs/cadence-internal#41 to v0.20 branch

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
