### PR TITLE
[v0.20] Fix checking of `create before(...)` in post condition

### DIFF
--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -670,7 +670,21 @@ func (extractor *ExpressionExtractor) ExtractCreate(expression *CreateExpression
 
 	result := extractor.Extract(newExpression.InvocationExpression)
 
-	newExpression.InvocationExpression = result.RewrittenExpression.(*InvocationExpression)
+	invocationExpression, ok := result.RewrittenExpression.(*InvocationExpression)
+	if !ok {
+		// Edge-case:
+		// The rewritten expression returned from the extractor may not be an InvocationExpression,
+		// but an expression of another type.
+		//
+		// Wrap the rewritten expression in an InvocationExpression.
+
+		invocationExpression = &InvocationExpression{
+			InvokedExpression: result.RewrittenExpression,
+			EndPos:            result.RewrittenExpression.EndPosition(),
+		}
+	}
+
+	newExpression.InvocationExpression = invocationExpression
 
 	return ExpressionExtraction{
 		RewrittenExpression:  &newExpression,


### PR DESCRIPTION
## Description

Port of dapperlabs/cadence-internal#45 to v0.20 branch

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
