### PR TITLE
[v0.20] Gracefully handle casts during comparison operators

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1834,12 +1834,30 @@ func (v IntValue) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v IntValue) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v IntValue) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -2178,11 +2196,29 @@ func (v Int8Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int8Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int8Value) Greater(other NumberValue) BoolValue {
@@ -2522,11 +2558,29 @@ func (v Int16Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int16Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int16Value) Greater(other NumberValue) BoolValue {
@@ -2868,11 +2922,29 @@ func (v Int32Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int32Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int32Value) Greater(other NumberValue) BoolValue {
@@ -3218,11 +3290,29 @@ func (v Int64Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) Less(other NumberValue) BoolValue {
-	return v < other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Int64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Int64Value) Greater(other NumberValue) BoolValue {
@@ -3609,12 +3699,30 @@ func (v Int128Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v Int128Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -4027,12 +4135,30 @@ func (v Int256Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v Int256Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -4358,12 +4484,30 @@ func (v UIntValue) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v UIntValue) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -4634,11 +4778,29 @@ func (v UInt8Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt8Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt8Value) Greater(other NumberValue) BoolValue {
@@ -4908,11 +5070,29 @@ func (v UInt16Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt16Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt16Value) Greater(other NumberValue) BoolValue {
@@ -5188,11 +5368,29 @@ func (v UInt32Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt32Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt32Value) Greater(other NumberValue) BoolValue {
@@ -5473,11 +5671,29 @@ func (v UInt64Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) Less(other NumberValue) BoolValue {
-	return v < other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UInt64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UInt64Value) Greater(other NumberValue) BoolValue {
@@ -5813,12 +6029,30 @@ func (v UInt128Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v UInt128Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -6177,12 +6411,30 @@ func (v UInt256Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) Less(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == -1
 }
 
 func (v UInt256Value) LessEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp <= 0
 }
 
@@ -6449,11 +6701,29 @@ func (v Word8Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word8Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word8Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word8Value) Greater(other NumberValue) BoolValue {
@@ -6672,11 +6942,29 @@ func (v Word16Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word16Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word16Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word16Value) Greater(other NumberValue) BoolValue {
@@ -6898,11 +7186,29 @@ func (v Word32Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word32Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word32Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word32Value) Greater(other NumberValue) BoolValue {
@@ -7124,11 +7430,29 @@ func (v Word64Value) SaturatingDiv(_ NumberValue) NumberValue {
 }
 
 func (v Word64Value) Less(other NumberValue) BoolValue {
-	return v < other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Word64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Word64Value) Greater(other NumberValue) BoolValue {
@@ -7445,11 +7769,29 @@ func (v Fix64Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) Less(other NumberValue) BoolValue {
-	return v < other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v Fix64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v Fix64Value) Greater(other NumberValue) BoolValue {
@@ -7731,11 +8073,29 @@ func (v UFix64Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) Less(other NumberValue) BoolValue {
-	return v < other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v < o
 }
 
 func (v UFix64Value) LessEqual(other NumberValue) BoolValue {
-	return v <= other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v <= o
 }
 
 func (v UFix64Value) Greater(other NumberValue) BoolValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1862,12 +1862,30 @@ func (v IntValue) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v IntValue) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v IntValue) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(IntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -2222,11 +2240,29 @@ func (v Int8Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int8Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int8Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -2584,11 +2620,29 @@ func (v Int16Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int16Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int16Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -2948,11 +3002,29 @@ func (v Int32Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int32Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int32Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -3316,11 +3388,29 @@ func (v Int64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Int64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Int64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -3727,12 +3817,30 @@ func (v Int128Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int128Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v Int128Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int128Value).BigInt)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -4163,12 +4271,30 @@ func (v Int256Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Int256Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v Int256Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(Int256Value).BigInt)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -4512,12 +4638,30 @@ func (v UIntValue) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UIntValue) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v UIntValue) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UIntValue).BigInt)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -4804,11 +4948,29 @@ func (v UInt8Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt8Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt8Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -5096,11 +5258,29 @@ func (v UInt16Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt16Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt16Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -5394,11 +5574,29 @@ func (v UInt32Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt32Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt32Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -5697,11 +5895,29 @@ func (v UInt64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UInt64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UInt64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -6057,12 +6273,30 @@ func (v UInt128Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt128Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v UInt128Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt128Value).BigInt)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -6439,12 +6673,30 @@ func (v UInt256Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UInt256Value) Greater(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp == 1
 }
 
 func (v UInt256Value) GreaterEqual(other NumberValue) BoolValue {
-	cmp := v.BigInt.Cmp(other.(UInt256Value).BigInt)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
 	return cmp >= 0
 }
 
@@ -6727,11 +6979,29 @@ func (v Word8Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word8Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word8Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -6968,11 +7238,29 @@ func (v Word16Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word16Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word16Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -7212,11 +7500,29 @@ func (v Word32Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word32Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word32Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -7456,11 +7762,29 @@ func (v Word64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Word64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Word64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Word64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -7795,11 +8119,29 @@ func (v Fix64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v Fix64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v Fix64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v Fix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -8099,11 +8441,29 @@ func (v UFix64Value) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UFix64Value) Greater(other NumberValue) BoolValue {
-	return v > other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v > o
 }
 
 func (v UFix64Value) GreaterEqual(other NumberValue) BoolValue {
-	return v >= other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v >= o
 }
 
 func (v UFix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4638,7 +4638,7 @@ func (v UIntValue) LessEqual(other NumberValue) BoolValue {
 }
 
 func (v UIntValue) Greater(other NumberValue) BoolValue {
-	o, ok := other.(IntValue)
+	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation: ast.OperationGreater,

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -145,8 +145,8 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 	t.Parallel()
 
 	operations := []ast.Operation{
-		//ast.OperationGreater,
-		//ast.OperationGreaterEqual,
+		ast.OperationGreater,
+		ast.OperationGreaterEqual,
 		ast.OperationLess,
 		ast.OperationLessEqual,
 		//ast.OperationEqual,

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -145,12 +145,12 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 	t.Parallel()
 
 	operations := []ast.Operation{
-		ast.OperationGreater,
-		ast.OperationGreaterEqual,
+		//ast.OperationGreater,
+		//ast.OperationGreaterEqual,
 		ast.OperationLess,
 		ast.OperationLessEqual,
-		ast.OperationEqual,
-		ast.OperationNotEqual,
+		//ast.OperationEqual,
+		//ast.OperationNotEqual,
 	}
 
 	t.Run("Integer subtypes", func(t *testing.T) {
@@ -185,6 +185,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 			for _, op := range operations {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+					t.Parallel()
 
 					code := fmt.Sprintf(`
                             fun test() {

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -206,6 +206,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(false), result)
 					case ast.OperationNotEqual:
+						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)
@@ -255,6 +256,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(false), result)
 					case ast.OperationNotEqual:
+						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)
@@ -304,6 +306,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(false), result)
 					case ast.OperationNotEqual:
+						require.NoError(t, err)
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -149,8 +149,8 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 		ast.OperationGreaterEqual,
 		ast.OperationLess,
 		ast.OperationLessEqual,
-		//ast.OperationEqual,
-		//ast.OperationNotEqual,
+		ast.OperationEqual,
+		ast.OperationNotEqual,
 	}
 
 	t.Run("Integer subtypes", func(t *testing.T) {
@@ -188,11 +188,11 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 					t.Parallel()
 
 					code := fmt.Sprintf(`
-                            fun test() {
-                                let x: Integer = 5 as %s
-                                let y: Integer = 2 as %s
-                                let z = x %s y
-                            }`,
+                        fun test(): Bool {
+                            let x: Integer = 5 as %s
+                            let y: Integer = 2 as %s
+                            return x %s y
+                        }`,
 						subtype.String(),
 						rhsType.String(),
 						op.Symbol(),
@@ -200,15 +200,24 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 					inter := parseCheckAndInterpret(t, code)
 
-					_, err := inter.Invoke("test")
-					require.Error(t, err)
+					result, err := inter.Invoke("test")
 
-					operandError := &interpreter.InvalidOperandsError{}
-					require.ErrorAs(t, err, operandError)
+					switch op {
+					case ast.OperationEqual:
+						require.NoError(t, err)
+						assert.Equal(t, interpreter.BoolValue(false), result)
+					case ast.OperationNotEqual:
+						assert.Equal(t, interpreter.BoolValue(true), result)
+					default:
+						require.Error(t, err)
 
-					assert.Equal(t, op, operandError.Operation)
-					assert.Equal(t, subtype, operandError.LeftType)
-					assert.Equal(t, rhsType, operandError.RightType)
+						operandError := &interpreter.InvalidOperandsError{}
+						require.ErrorAs(t, err, operandError)
+
+						assert.Equal(t, op, operandError.Operation)
+						assert.Equal(t, subtype, operandError.LeftType)
+						assert.Equal(t, rhsType, operandError.RightType)
+					}
 				})
 			}
 		}
@@ -228,11 +237,11 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
 
 					code := fmt.Sprintf(`
-                            fun test() {
-                                let x: FixedPoint = 5.2 as %s
-                                let y: FixedPoint = 2.3 as %s
-                                let z = x %s y
-                            }`,
+                        fun test(): Bool {
+                            let x: FixedPoint = 5.2 as %s
+                            let y: FixedPoint = 2.3 as %s
+                            return x %s y
+                        }`,
 						subtype.String(),
 						rhsType.String(),
 						op.Symbol(),
@@ -240,15 +249,24 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 					inter := parseCheckAndInterpret(t, code)
 
-					_, err := inter.Invoke("test")
-					require.Error(t, err)
+					result, err := inter.Invoke("test")
 
-					operandError := &interpreter.InvalidOperandsError{}
-					require.ErrorAs(t, err, operandError)
+					switch op {
+					case ast.OperationEqual:
+						require.NoError(t, err)
+						assert.Equal(t, interpreter.BoolValue(false), result)
+					case ast.OperationNotEqual:
+						assert.Equal(t, interpreter.BoolValue(true), result)
+					default:
+						require.Error(t, err)
 
-					assert.Equal(t, op, operandError.Operation)
-					assert.Equal(t, subtype, operandError.LeftType)
-					assert.Equal(t, rhsType, operandError.RightType)
+						operandError := &interpreter.InvalidOperandsError{}
+						require.ErrorAs(t, err, operandError)
+
+						assert.Equal(t, op, operandError.Operation)
+						assert.Equal(t, subtype, operandError.LeftType)
+						assert.Equal(t, rhsType, operandError.RightType)
+					}
 				})
 			}
 		}
@@ -268,11 +286,11 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
 
 					code := fmt.Sprintf(`
-                            fun test() {
-                                let x: FixedPoint = 5.2 as %s
-                                let y: FixedPoint = 2.3 as %s
-                                let z = x %s y
-                            }`,
+                        fun test(): Bool {
+                            let x: FixedPoint = 5.2 as %s
+                            let y: FixedPoint = 2.3 as %s
+                            return x %s y
+                        }`,
 						subtype.String(),
 						rhsType.String(),
 						op.Symbol(),
@@ -280,15 +298,24 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 					inter := parseCheckAndInterpret(t, code)
 
-					_, err := inter.Invoke("test")
-					require.Error(t, err)
+					result, err := inter.Invoke("test")
 
-					operandError := &interpreter.InvalidOperandsError{}
-					require.ErrorAs(t, err, operandError)
+					switch op {
+					case ast.OperationEqual:
+						require.NoError(t, err)
+						assert.Equal(t, interpreter.BoolValue(false), result)
+					case ast.OperationNotEqual:
+						assert.Equal(t, interpreter.BoolValue(true), result)
+					default:
+						require.Error(t, err)
 
-					assert.Equal(t, op, operandError.Operation)
-					assert.Equal(t, subtype, operandError.LeftType)
-					assert.Equal(t, rhsType, operandError.RightType)
+						operandError := &interpreter.InvalidOperandsError{}
+						require.ErrorAs(t, err, operandError)
+
+						assert.Equal(t, op, operandError.Operation)
+						assert.Equal(t, subtype, operandError.LeftType)
+						assert.Equal(t, rhsType, operandError.RightType)
+					}
 				})
 			}
 		}

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -20,14 +20,14 @@ package interpreter_test
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	. "github.com/onflow/cadence/runtime/tests/utils"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -185,7 +185,6 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 
 			for _, op := range operations {
 				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
-					t.Parallel()
 
 					code := fmt.Sprintf(`
                         fun test(): Bool {

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -19,6 +19,9 @@
 package interpreter_test
 
 import (
+	"fmt"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -134,5 +137,159 @@ func TestInterpretEquality(t *testing.T) {
 			interpreter.BoolValue(false),
 			inter.Globals["res"].GetValue(),
 		)
+	})
+}
+
+func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
+
+	t.Parallel()
+
+	operations := []ast.Operation{
+		ast.OperationGreater,
+		ast.OperationGreaterEqual,
+		ast.OperationLess,
+		ast.OperationLessEqual,
+		ast.OperationEqual,
+		ast.OperationNotEqual,
+	}
+
+	t.Run("Integer subtypes", func(t *testing.T) {
+		t.Parallel()
+
+		intSubtypes := []interpreter.StaticType{
+			interpreter.PrimitiveStaticTypeInt,
+			interpreter.PrimitiveStaticTypeInt8,
+			interpreter.PrimitiveStaticTypeInt16,
+			interpreter.PrimitiveStaticTypeInt32,
+			interpreter.PrimitiveStaticTypeInt64,
+			interpreter.PrimitiveStaticTypeInt128,
+			interpreter.PrimitiveStaticTypeInt256,
+			interpreter.PrimitiveStaticTypeUInt,
+			interpreter.PrimitiveStaticTypeUInt8,
+			interpreter.PrimitiveStaticTypeUInt16,
+			interpreter.PrimitiveStaticTypeUInt32,
+			interpreter.PrimitiveStaticTypeUInt64,
+			interpreter.PrimitiveStaticTypeUInt128,
+			interpreter.PrimitiveStaticTypeUInt256,
+			interpreter.PrimitiveStaticTypeWord8,
+			interpreter.PrimitiveStaticTypeWord16,
+			interpreter.PrimitiveStaticTypeWord32,
+			interpreter.PrimitiveStaticTypeWord64,
+		}
+
+		for _, subtype := range intSubtypes {
+			rhsType := interpreter.PrimitiveStaticTypeInt
+			if subtype == rhsType {
+				rhsType = interpreter.PrimitiveStaticTypeUInt
+			}
+
+			for _, op := range operations {
+				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+
+					code := fmt.Sprintf(`
+                            fun test() {
+                                let x: Integer = 5 as %s
+                                let y: Integer = 2 as %s
+                                let z = x %s y
+                            }`,
+						subtype.String(),
+						rhsType.String(),
+						op.Symbol(),
+					)
+
+					inter := parseCheckAndInterpret(t, code)
+
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+
+					operandError := &interpreter.InvalidOperandsError{}
+					require.ErrorAs(t, err, operandError)
+
+					assert.Equal(t, op, operandError.Operation)
+					assert.Equal(t, subtype, operandError.LeftType)
+					assert.Equal(t, rhsType, operandError.RightType)
+				})
+			}
+		}
+	})
+
+	t.Run("Fixed point subtypes", func(t *testing.T) {
+		t.Parallel()
+
+		fixedPointSubtypes := []interpreter.StaticType{
+			interpreter.PrimitiveStaticTypeFix64,
+		}
+
+		rhsType := interpreter.PrimitiveStaticTypeUFix64
+
+		for _, subtype := range fixedPointSubtypes {
+			for _, op := range operations {
+				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+
+					code := fmt.Sprintf(`
+                            fun test() {
+                                let x: FixedPoint = 5.2 as %s
+                                let y: FixedPoint = 2.3 as %s
+                                let z = x %s y
+                            }`,
+						subtype.String(),
+						rhsType.String(),
+						op.Symbol(),
+					)
+
+					inter := parseCheckAndInterpret(t, code)
+
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+
+					operandError := &interpreter.InvalidOperandsError{}
+					require.ErrorAs(t, err, operandError)
+
+					assert.Equal(t, op, operandError.Operation)
+					assert.Equal(t, subtype, operandError.LeftType)
+					assert.Equal(t, rhsType, operandError.RightType)
+				})
+			}
+		}
+	})
+
+	t.Run("Unsigned fixed point subtypes", func(t *testing.T) {
+		t.Parallel()
+
+		fixedPointSubtypes := []interpreter.StaticType{
+			interpreter.PrimitiveStaticTypeUFix64,
+		}
+
+		rhsType := interpreter.PrimitiveStaticTypeFix64
+
+		for _, subtype := range fixedPointSubtypes {
+			for _, op := range operations {
+				t.Run(fmt.Sprintf("%s,%s", op.String(), subtype.String()), func(t *testing.T) {
+
+					code := fmt.Sprintf(`
+                            fun test() {
+                                let x: FixedPoint = 5.2 as %s
+                                let y: FixedPoint = 2.3 as %s
+                                let z = x %s y
+                            }`,
+						subtype.String(),
+						rhsType.String(),
+						op.Symbol(),
+					)
+
+					inter := parseCheckAndInterpret(t, code)
+
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+
+					operandError := &interpreter.InvalidOperandsError{}
+					require.ErrorAs(t, err, operandError)
+
+					assert.Equal(t, op, operandError.Operation)
+					assert.Equal(t, subtype, operandError.LeftType)
+					assert.Equal(t, rhsType, operandError.RightType)
+				})
+			}
+		}
 	})
 }


### PR DESCRIPTION
## Description

Port of dapperlabs/cadence-internal#46 to v0.20 branch

Blocked by https://github.com/onflow/cadence/pull/1342

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
