### PR TITLE
[v0.20] Gracefully handle mismatching types during binary operations

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -509,7 +509,6 @@ func (e NonStorableValueError) Error() string {
 	)
 }
 
-// InvalidOperandsError
 // NonStorableStaticTypeError
 //
 type NonStorableStaticTypeError struct {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -509,6 +509,7 @@ func (e NonStorableValueError) Error() string {
 	)
 }
 
+// InvalidOperandsError
 // NonStorableStaticTypeError
 //
 type NonStorableStaticTypeError struct {
@@ -522,19 +523,27 @@ func (e NonStorableStaticTypeError) Error() string {
 	)
 }
 
-// InvalidBinaryOperandsError
+// InvalidOperandsError
 //
-type InvalidBinaryOperandsError struct {
-	Operation ast.Operation
-	LeftType  StaticType
-	RightType StaticType
+type InvalidOperandsError struct {
+	Operation    ast.Operation
+	FunctionName string
+	LeftType     StaticType
+	RightType    StaticType
 	LocationRange
 }
 
-func (e InvalidBinaryOperandsError) Error() string {
+func (e InvalidOperandsError) Error() string {
+	var op string
+	if e.Operation == ast.OperationUnknown {
+		op = e.FunctionName
+	} else {
+		op = e.Operation.Symbol()
+	}
+
 	return fmt.Sprintf(
-		"cannot apply binary operation %s to types: `%s`, `%s`",
-		e.Operation.Symbol(),
+		"cannot apply operation %s to types: `%s`, `%s`",
+		op,
 		e.LeftType.String(),
 		e.RightType.String(),
 	)

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -521,3 +521,21 @@ func (e NonStorableStaticTypeError) Error() string {
 		e.Type,
 	)
 }
+
+// InvalidBinaryOperandsError
+//
+type InvalidBinaryOperandsError struct {
+	Operation ast.Operation
+	LeftType  StaticType
+	RightType StaticType
+	LocationRange
+}
+
+func (e InvalidBinaryOperandsError) Error() string {
+	return fmt.Sprintf(
+		"cannot apply binary operation %s to types: `%s`, `%s`",
+		e.Operation.Symbol(),
+		e.LeftType.String(),
+		e.RightType.String(),
+	)
+}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1778,7 +1778,7 @@ func (v IntValue) Negate() NumberValue {
 func (v IntValue) Plus(other NumberValue) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1791,13 +1791,24 @@ func (v IntValue) Plus(other NumberValue) NumberValue {
 }
 
 func (v IntValue) SaturatingPlus(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Plus(other)
 }
 
 func (v IntValue) Minus(other NumberValue) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1810,13 +1821,24 @@ func (v IntValue) Minus(other NumberValue) NumberValue {
 }
 
 func (v IntValue) SaturatingMinus(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Minus(other)
 }
 
 func (v IntValue) Mod(other NumberValue) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1835,7 +1857,7 @@ func (v IntValue) Mod(other NumberValue) NumberValue {
 func (v IntValue) Mul(other NumberValue) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1848,13 +1870,24 @@ func (v IntValue) Mul(other NumberValue) NumberValue {
 }
 
 func (v IntValue) SaturatingMul(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Mul(other)
 }
 
 func (v IntValue) Div(other NumberValue) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1871,6 +1904,17 @@ func (v IntValue) Div(other NumberValue) NumberValue {
 }
 
 func (v IntValue) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -1914,7 +1958,7 @@ func (v IntValue) HashInput(_ *Interpreter, _ func() LocationRange, _ []byte) []
 func (v IntValue) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1929,7 +1973,7 @@ func (v IntValue) BitwiseOr(other IntegerValue) IntegerValue {
 func (v IntValue) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1944,7 +1988,7 @@ func (v IntValue) BitwiseXor(other IntegerValue) IntegerValue {
 func (v IntValue) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1959,7 +2003,7 @@ func (v IntValue) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v IntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -1980,7 +2024,7 @@ func (v IntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v IntValue) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2122,7 +2166,7 @@ func (v Int8Value) Negate() NumberValue {
 func (v Int8Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2141,10 +2185,10 @@ func (v Int8Value) Plus(other NumberValue) NumberValue {
 func (v Int8Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2160,7 +2204,7 @@ func (v Int8Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v Int8Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2179,10 +2223,10 @@ func (v Int8Value) Minus(other NumberValue) NumberValue {
 func (v Int8Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2198,7 +2242,7 @@ func (v Int8Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v Int8Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2215,7 +2259,7 @@ func (v Int8Value) Mod(other NumberValue) NumberValue {
 func (v Int8Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2254,10 +2298,10 @@ func (v Int8Value) Mul(other NumberValue) NumberValue {
 func (v Int8Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2293,7 +2337,7 @@ func (v Int8Value) SaturatingMul(other NumberValue) NumberValue {
 func (v Int8Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2313,10 +2357,10 @@ func (v Int8Value) Div(other NumberValue) NumberValue {
 func (v Int8Value) SaturatingDiv(other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2392,7 +2436,7 @@ func ConvertInt8(value Value) Int8Value {
 func (v Int8Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2405,7 +2449,7 @@ func (v Int8Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Int8Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2418,7 +2462,7 @@ func (v Int8Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Int8Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2431,7 +2475,7 @@ func (v Int8Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Int8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2444,7 +2488,7 @@ func (v Int8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2578,7 +2622,7 @@ func (v Int16Value) Negate() NumberValue {
 func (v Int16Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2597,10 +2641,10 @@ func (v Int16Value) Plus(other NumberValue) NumberValue {
 func (v Int16Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2616,7 +2660,7 @@ func (v Int16Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v Int16Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2635,10 +2679,10 @@ func (v Int16Value) Minus(other NumberValue) NumberValue {
 func (v Int16Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2654,7 +2698,7 @@ func (v Int16Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v Int16Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2671,7 +2715,7 @@ func (v Int16Value) Mod(other NumberValue) NumberValue {
 func (v Int16Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2710,10 +2754,10 @@ func (v Int16Value) Mul(other NumberValue) NumberValue {
 func (v Int16Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2749,7 +2793,7 @@ func (v Int16Value) SaturatingMul(other NumberValue) NumberValue {
 func (v Int16Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2769,10 +2813,10 @@ func (v Int16Value) Div(other NumberValue) NumberValue {
 func (v Int16Value) SaturatingDiv(other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -2848,7 +2892,7 @@ func ConvertInt16(value Value) Int16Value {
 func (v Int16Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2861,7 +2905,7 @@ func (v Int16Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Int16Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2874,7 +2918,7 @@ func (v Int16Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Int16Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2887,7 +2931,7 @@ func (v Int16Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Int16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -2900,7 +2944,7 @@ func (v Int16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3036,7 +3080,7 @@ func (v Int32Value) Negate() NumberValue {
 func (v Int32Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3055,10 +3099,10 @@ func (v Int32Value) Plus(other NumberValue) NumberValue {
 func (v Int32Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3074,7 +3118,7 @@ func (v Int32Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v Int32Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3093,10 +3137,10 @@ func (v Int32Value) Minus(other NumberValue) NumberValue {
 func (v Int32Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3112,7 +3156,7 @@ func (v Int32Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v Int32Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3129,7 +3173,7 @@ func (v Int32Value) Mod(other NumberValue) NumberValue {
 func (v Int32Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3168,10 +3212,10 @@ func (v Int32Value) Mul(other NumberValue) NumberValue {
 func (v Int32Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3207,7 +3251,7 @@ func (v Int32Value) SaturatingMul(other NumberValue) NumberValue {
 func (v Int32Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3227,10 +3271,10 @@ func (v Int32Value) Div(other NumberValue) NumberValue {
 func (v Int32Value) SaturatingDiv(other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3306,7 +3350,7 @@ func ConvertInt32(value Value) Int32Value {
 func (v Int32Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3319,7 +3363,7 @@ func (v Int32Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Int32Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3332,7 +3376,7 @@ func (v Int32Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Int32Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3345,7 +3389,7 @@ func (v Int32Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Int32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3358,7 +3402,7 @@ func (v Int32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3504,7 +3548,7 @@ func safeAddInt64(a, b int64) int64 {
 func (v Int64Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3517,10 +3561,10 @@ func (v Int64Value) Plus(other NumberValue) NumberValue {
 func (v Int64Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3536,7 +3580,7 @@ func (v Int64Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v Int64Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3555,10 +3599,10 @@ func (v Int64Value) Minus(other NumberValue) NumberValue {
 func (v Int64Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3574,7 +3618,7 @@ func (v Int64Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v Int64Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3591,7 +3635,7 @@ func (v Int64Value) Mod(other NumberValue) NumberValue {
 func (v Int64Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3630,10 +3674,10 @@ func (v Int64Value) Mul(other NumberValue) NumberValue {
 func (v Int64Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3669,7 +3713,7 @@ func (v Int64Value) SaturatingMul(other NumberValue) NumberValue {
 func (v Int64Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3689,10 +3733,10 @@ func (v Int64Value) Div(other NumberValue) NumberValue {
 func (v Int64Value) SaturatingDiv(other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -3763,7 +3807,7 @@ func ConvertInt64(value Value) Int64Value {
 func (v Int64Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3776,7 +3820,7 @@ func (v Int64Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Int64Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3789,7 +3833,7 @@ func (v Int64Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Int64Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3802,7 +3846,7 @@ func (v Int64Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Int64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3815,7 +3859,7 @@ func (v Int64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -3969,7 +4013,7 @@ func (v Int128Value) Negate() NumberValue {
 func (v Int128Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4001,10 +4045,10 @@ func (v Int128Value) Plus(other NumberValue) NumberValue {
 func (v Int128Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4033,7 +4077,7 @@ func (v Int128Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v Int128Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4065,10 +4109,10 @@ func (v Int128Value) Minus(other NumberValue) NumberValue {
 func (v Int128Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4097,7 +4141,7 @@ func (v Int128Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v Int128Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4116,7 +4160,7 @@ func (v Int128Value) Mod(other NumberValue) NumberValue {
 func (v Int128Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4136,10 +4180,10 @@ func (v Int128Value) Mul(other NumberValue) NumberValue {
 func (v Int128Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4156,7 +4200,7 @@ func (v Int128Value) SaturatingMul(other NumberValue) NumberValue {
 func (v Int128Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4184,10 +4228,10 @@ func (v Int128Value) Div(other NumberValue) NumberValue {
 func (v Int128Value) SaturatingDiv(other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4272,7 +4316,7 @@ func ConvertInt128(value Value) Int128Value {
 func (v Int128Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4287,7 +4331,7 @@ func (v Int128Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Int128Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4302,7 +4346,7 @@ func (v Int128Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Int128Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4317,7 +4361,7 @@ func (v Int128Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Int128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4338,7 +4382,7 @@ func (v Int128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int128Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4499,7 +4543,7 @@ func (v Int256Value) Negate() NumberValue {
 func (v Int256Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4531,10 +4575,10 @@ func (v Int256Value) Plus(other NumberValue) NumberValue {
 func (v Int256Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4563,7 +4607,7 @@ func (v Int256Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v Int256Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4595,10 +4639,10 @@ func (v Int256Value) Minus(other NumberValue) NumberValue {
 func (v Int256Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4627,7 +4671,7 @@ func (v Int256Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v Int256Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4646,7 +4690,7 @@ func (v Int256Value) Mod(other NumberValue) NumberValue {
 func (v Int256Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4666,10 +4710,10 @@ func (v Int256Value) Mul(other NumberValue) NumberValue {
 func (v Int256Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4686,7 +4730,7 @@ func (v Int256Value) SaturatingMul(other NumberValue) NumberValue {
 func (v Int256Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4714,10 +4758,10 @@ func (v Int256Value) Div(other NumberValue) NumberValue {
 func (v Int256Value) SaturatingDiv(other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -4802,7 +4846,7 @@ func ConvertInt256(value Value) Int256Value {
 func (v Int256Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4817,7 +4861,7 @@ func (v Int256Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Int256Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4832,7 +4876,7 @@ func (v Int256Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Int256Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4847,7 +4891,7 @@ func (v Int256Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Int256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -4868,7 +4912,7 @@ func (v Int256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Int256Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5043,7 +5087,7 @@ func (v UIntValue) Negate() NumberValue {
 func (v UIntValue) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5056,13 +5100,24 @@ func (v UIntValue) Plus(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) SaturatingPlus(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Plus(other)
 }
 
 func (v UIntValue) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5081,10 +5136,10 @@ func (v UIntValue) Minus(other NumberValue) NumberValue {
 func (v UIntValue) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5100,7 +5155,7 @@ func (v UIntValue) SaturatingMinus(other NumberValue) NumberValue {
 func (v UIntValue) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5119,7 +5174,7 @@ func (v UIntValue) Mod(other NumberValue) NumberValue {
 func (v UIntValue) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5132,16 +5187,27 @@ func (v UIntValue) Mul(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) SaturatingMul(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Mul(other)
 }
 
 func (v UIntValue) Div(other NumberValue) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5155,6 +5221,17 @@ func (v UIntValue) Div(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -5198,7 +5275,7 @@ func (v UIntValue) HashInput(_ *Interpreter, _ func() LocationRange, _ []byte) [
 func (v UIntValue) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5213,7 +5290,7 @@ func (v UIntValue) BitwiseOr(other IntegerValue) IntegerValue {
 func (v UIntValue) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5228,7 +5305,7 @@ func (v UIntValue) BitwiseXor(other IntegerValue) IntegerValue {
 func (v UIntValue) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5243,7 +5320,7 @@ func (v UIntValue) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v UIntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5264,7 +5341,7 @@ func (v UIntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UIntValue) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5403,7 +5480,7 @@ func (v UInt8Value) Negate() NumberValue {
 func (v UInt8Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5421,10 +5498,10 @@ func (v UInt8Value) Plus(other NumberValue) NumberValue {
 func (v UInt8Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5439,7 +5516,7 @@ func (v UInt8Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v UInt8Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5458,10 +5535,10 @@ func (v UInt8Value) Minus(other NumberValue) NumberValue {
 func (v UInt8Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5477,7 +5554,7 @@ func (v UInt8Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v UInt8Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5493,7 +5570,7 @@ func (v UInt8Value) Mod(other NumberValue) NumberValue {
 func (v UInt8Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5510,10 +5587,10 @@ func (v UInt8Value) Mul(other NumberValue) NumberValue {
 func (v UInt8Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5527,7 +5604,7 @@ func (v UInt8Value) SaturatingMul(other NumberValue) NumberValue {
 func (v UInt8Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5541,6 +5618,17 @@ func (v UInt8Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -5606,7 +5694,7 @@ func ConvertUInt8(value Value) UInt8Value {
 func (v UInt8Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5619,7 +5707,7 @@ func (v UInt8Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v UInt8Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5632,7 +5720,7 @@ func (v UInt8Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v UInt8Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5645,7 +5733,7 @@ func (v UInt8Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v UInt8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5658,7 +5746,7 @@ func (v UInt8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5787,7 +5875,7 @@ func (v UInt16Value) Negate() NumberValue {
 func (v UInt16Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5805,10 +5893,10 @@ func (v UInt16Value) Plus(other NumberValue) NumberValue {
 func (v UInt16Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5823,7 +5911,7 @@ func (v UInt16Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v UInt16Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5842,10 +5930,10 @@ func (v UInt16Value) Minus(other NumberValue) NumberValue {
 func (v UInt16Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5861,7 +5949,7 @@ func (v UInt16Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v UInt16Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5877,7 +5965,7 @@ func (v UInt16Value) Mod(other NumberValue) NumberValue {
 func (v UInt16Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5894,10 +5982,10 @@ func (v UInt16Value) Mul(other NumberValue) NumberValue {
 func (v UInt16Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -5911,7 +5999,7 @@ func (v UInt16Value) SaturatingMul(other NumberValue) NumberValue {
 func (v UInt16Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -5925,6 +6013,17 @@ func (v UInt16Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -5990,7 +6089,7 @@ func ConvertUInt16(value Value) UInt16Value {
 func (v UInt16Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6003,7 +6102,7 @@ func (v UInt16Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v UInt16Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6015,7 +6114,7 @@ func (v UInt16Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v UInt16Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6028,7 +6127,7 @@ func (v UInt16Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v UInt16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6041,7 +6140,7 @@ func (v UInt16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6177,7 +6276,7 @@ func (v UInt32Value) Negate() NumberValue {
 func (v UInt32Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6196,10 +6295,10 @@ func (v UInt32Value) Plus(other NumberValue) NumberValue {
 func (v UInt32Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -6214,7 +6313,7 @@ func (v UInt32Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v UInt32Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6233,10 +6332,10 @@ func (v UInt32Value) Minus(other NumberValue) NumberValue {
 func (v UInt32Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -6252,7 +6351,7 @@ func (v UInt32Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v UInt32Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6268,7 +6367,7 @@ func (v UInt32Value) Mod(other NumberValue) NumberValue {
 func (v UInt32Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6284,10 +6383,10 @@ func (v UInt32Value) Mul(other NumberValue) NumberValue {
 func (v UInt32Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -6301,7 +6400,7 @@ func (v UInt32Value) SaturatingMul(other NumberValue) NumberValue {
 func (v UInt32Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6315,6 +6414,17 @@ func (v UInt32Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -6380,7 +6490,7 @@ func ConvertUInt32(value Value) UInt32Value {
 func (v UInt32Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6393,7 +6503,7 @@ func (v UInt32Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v UInt32Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6405,7 +6515,7 @@ func (v UInt32Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v UInt32Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6418,7 +6528,7 @@ func (v UInt32Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v UInt32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6431,7 +6541,7 @@ func (v UInt32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6576,7 +6686,7 @@ func safeAddUint64(a, b uint64) uint64 {
 func (v UInt64Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6589,10 +6699,10 @@ func (v UInt64Value) Plus(other NumberValue) NumberValue {
 func (v UInt64Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -6608,7 +6718,7 @@ func (v UInt64Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v UInt64Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6627,10 +6737,10 @@ func (v UInt64Value) Minus(other NumberValue) NumberValue {
 func (v UInt64Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -6646,7 +6756,7 @@ func (v UInt64Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v UInt64Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6662,7 +6772,7 @@ func (v UInt64Value) Mod(other NumberValue) NumberValue {
 func (v UInt64Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6678,10 +6788,10 @@ func (v UInt64Value) Mul(other NumberValue) NumberValue {
 func (v UInt64Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -6695,7 +6805,7 @@ func (v UInt64Value) SaturatingMul(other NumberValue) NumberValue {
 func (v UInt64Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6709,6 +6819,17 @@ func (v UInt64Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -6772,7 +6893,7 @@ func ConvertUInt64(value Value) UInt64Value {
 func (v UInt64Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6785,7 +6906,7 @@ func (v UInt64Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v UInt64Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6797,7 +6918,7 @@ func (v UInt64Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v UInt64Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6810,7 +6931,7 @@ func (v UInt64Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v UInt64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6823,7 +6944,7 @@ func (v UInt64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -6974,7 +7095,7 @@ func (v UInt128Value) Negate() NumberValue {
 func (v UInt128Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7002,10 +7123,10 @@ func (v UInt128Value) Plus(other NumberValue) NumberValue {
 func (v UInt128Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -7030,7 +7151,7 @@ func (v UInt128Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v UInt128Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7058,10 +7179,10 @@ func (v UInt128Value) Minus(other NumberValue) NumberValue {
 func (v UInt128Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -7086,7 +7207,7 @@ func (v UInt128Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v UInt128Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7104,7 +7225,7 @@ func (v UInt128Value) Mod(other NumberValue) NumberValue {
 func (v UInt128Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7122,10 +7243,10 @@ func (v UInt128Value) Mul(other NumberValue) NumberValue {
 func (v UInt128Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -7140,7 +7261,7 @@ func (v UInt128Value) SaturatingMul(other NumberValue) NumberValue {
 func (v UInt128Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7156,6 +7277,17 @@ func (v UInt128Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -7222,7 +7354,7 @@ func ConvertUInt128(value Value) UInt128Value {
 func (v UInt128Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7237,7 +7369,7 @@ func (v UInt128Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v UInt128Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7252,7 +7384,7 @@ func (v UInt128Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v UInt128Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7267,7 +7399,7 @@ func (v UInt128Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v UInt128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7288,7 +7420,7 @@ func (v UInt128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt128Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7446,7 +7578,7 @@ func (v UInt256Value) Negate() NumberValue {
 func (v UInt256Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7474,10 +7606,10 @@ func (v UInt256Value) Plus(other NumberValue) NumberValue {
 func (v UInt256Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -7502,7 +7634,7 @@ func (v UInt256Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v UInt256Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7530,10 +7662,10 @@ func (v UInt256Value) Minus(other NumberValue) NumberValue {
 func (v UInt256Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -7558,7 +7690,7 @@ func (v UInt256Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v UInt256Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7576,7 +7708,7 @@ func (v UInt256Value) Mod(other NumberValue) NumberValue {
 func (v UInt256Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7594,10 +7726,10 @@ func (v UInt256Value) Mul(other NumberValue) NumberValue {
 func (v UInt256Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -7612,7 +7744,7 @@ func (v UInt256Value) SaturatingMul(other NumberValue) NumberValue {
 func (v UInt256Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7628,6 +7760,17 @@ func (v UInt256Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
@@ -7694,7 +7837,7 @@ func ConvertUInt256(value Value) UInt256Value {
 func (v UInt256Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7709,7 +7852,7 @@ func (v UInt256Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v UInt256Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7724,7 +7867,7 @@ func (v UInt256Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v UInt256Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7739,7 +7882,7 @@ func (v UInt256Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v UInt256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7760,7 +7903,7 @@ func (v UInt256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v UInt256Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7902,7 +8045,7 @@ func (v Word8Value) Negate() NumberValue {
 func (v Word8Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7919,7 +8062,7 @@ func (v Word8Value) SaturatingPlus(_ NumberValue) NumberValue {
 func (v Word8Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7936,7 +8079,7 @@ func (v Word8Value) SaturatingMinus(_ NumberValue) NumberValue {
 func (v Word8Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7952,7 +8095,7 @@ func (v Word8Value) Mod(other NumberValue) NumberValue {
 func (v Word8Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -7969,7 +8112,7 @@ func (v Word8Value) SaturatingMul(_ NumberValue) NumberValue {
 func (v Word8Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8023,7 +8166,7 @@ func ConvertWord8(value Value) Word8Value {
 func (v Word8Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8036,7 +8179,7 @@ func (v Word8Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Word8Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8048,7 +8191,7 @@ func (v Word8Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Word8Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8061,7 +8204,7 @@ func (v Word8Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Word8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8074,7 +8217,7 @@ func (v Word8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Word8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8207,7 +8350,7 @@ func (v Word16Value) Negate() NumberValue {
 func (v Word16Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8224,7 +8367,7 @@ func (v Word16Value) SaturatingPlus(_ NumberValue) NumberValue {
 func (v Word16Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8241,7 +8384,7 @@ func (v Word16Value) SaturatingMinus(_ NumberValue) NumberValue {
 func (v Word16Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8257,7 +8400,7 @@ func (v Word16Value) Mod(other NumberValue) NumberValue {
 func (v Word16Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8274,7 +8417,7 @@ func (v Word16Value) SaturatingMul(_ NumberValue) NumberValue {
 func (v Word16Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8328,7 +8471,7 @@ func ConvertWord16(value Value) Word16Value {
 func (v Word16Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8341,7 +8484,7 @@ func (v Word16Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Word16Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8353,7 +8496,7 @@ func (v Word16Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Word16Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8366,7 +8509,7 @@ func (v Word16Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Word16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8379,7 +8522,7 @@ func (v Word16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Word16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8515,7 +8658,7 @@ func (v Word32Value) Negate() NumberValue {
 func (v Word32Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8532,7 +8675,7 @@ func (v Word32Value) SaturatingPlus(_ NumberValue) NumberValue {
 func (v Word32Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8549,7 +8692,7 @@ func (v Word32Value) SaturatingMinus(_ NumberValue) NumberValue {
 func (v Word32Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8565,7 +8708,7 @@ func (v Word32Value) Mod(other NumberValue) NumberValue {
 func (v Word32Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8582,7 +8725,7 @@ func (v Word32Value) SaturatingMul(_ NumberValue) NumberValue {
 func (v Word32Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8636,7 +8779,7 @@ func ConvertWord32(value Value) Word32Value {
 func (v Word32Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8649,7 +8792,7 @@ func (v Word32Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Word32Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8661,7 +8804,7 @@ func (v Word32Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Word32Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8674,7 +8817,7 @@ func (v Word32Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Word32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8687,7 +8830,7 @@ func (v Word32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Word32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8823,7 +8966,7 @@ func (v Word64Value) Negate() NumberValue {
 func (v Word64Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8840,7 +8983,7 @@ func (v Word64Value) SaturatingPlus(_ NumberValue) NumberValue {
 func (v Word64Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8857,7 +9000,7 @@ func (v Word64Value) SaturatingMinus(_ NumberValue) NumberValue {
 func (v Word64Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8873,7 +9016,7 @@ func (v Word64Value) Mod(other NumberValue) NumberValue {
 func (v Word64Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8890,7 +9033,7 @@ func (v Word64Value) SaturatingMul(_ NumberValue) NumberValue {
 func (v Word64Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8944,7 +9087,7 @@ func ConvertWord64(value Value) Word64Value {
 func (v Word64Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8957,7 +9100,7 @@ func (v Word64Value) BitwiseOr(other IntegerValue) IntegerValue {
 func (v Word64Value) BitwiseXor(other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseXor,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8969,7 +9112,7 @@ func (v Word64Value) BitwiseXor(other IntegerValue) IntegerValue {
 func (v Word64Value) BitwiseAnd(other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseAnd,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8982,7 +9125,7 @@ func (v Word64Value) BitwiseAnd(other IntegerValue) IntegerValue {
 func (v Word64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -8995,7 +9138,7 @@ func (v Word64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 func (v Word64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9149,7 +9292,7 @@ func (v Fix64Value) Negate() NumberValue {
 func (v Fix64Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9162,10 +9305,10 @@ func (v Fix64Value) Plus(other NumberValue) NumberValue {
 func (v Fix64Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -9181,7 +9324,7 @@ func (v Fix64Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v Fix64Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9200,10 +9343,10 @@ func (v Fix64Value) Minus(other NumberValue) NumberValue {
 func (v Fix64Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -9222,7 +9365,7 @@ var maxInt64Big = big.NewInt(math.MaxInt64)
 func (v Fix64Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9247,10 +9390,10 @@ func (v Fix64Value) Mul(other NumberValue) NumberValue {
 func (v Fix64Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -9272,7 +9415,7 @@ func (v Fix64Value) SaturatingMul(other NumberValue) NumberValue {
 func (v Fix64Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9297,10 +9440,10 @@ func (v Fix64Value) Div(other NumberValue) NumberValue {
 func (v Fix64Value) SaturatingDiv(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationDiv,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -9322,7 +9465,7 @@ func (v Fix64Value) SaturatingDiv(other NumberValue) NumberValue {
 func (v Fix64Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9535,7 +9678,7 @@ func (v UFix64Value) Negate() NumberValue {
 func (v UFix64Value) Plus(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationPlus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9548,10 +9691,10 @@ func (v UFix64Value) Plus(other NumberValue) NumberValue {
 func (v UFix64Value) SaturatingPlus(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationPlus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -9566,7 +9709,7 @@ func (v UFix64Value) SaturatingPlus(other NumberValue) NumberValue {
 func (v UFix64Value) Minus(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMinus,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9585,10 +9728,10 @@ func (v UFix64Value) Minus(other NumberValue) NumberValue {
 func (v UFix64Value) SaturatingMinus(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMinus,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -9604,7 +9747,7 @@ func (v UFix64Value) SaturatingMinus(other NumberValue) NumberValue {
 func (v UFix64Value) Mul(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMul,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9627,10 +9770,10 @@ func (v UFix64Value) Mul(other NumberValue) NumberValue {
 func (v UFix64Value) SaturatingMul(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationMul,
-			LeftType:  v.StaticType(),
-			RightType: other.StaticType(),
+		panic(InvalidOperandsError{
+			FunctionName: sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:     v.StaticType(),
+			RightType:    other.StaticType(),
 		})
 	}
 
@@ -9650,7 +9793,7 @@ func (v UFix64Value) SaturatingMul(other NumberValue) NumberValue {
 func (v UFix64Value) Div(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationDiv,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
@@ -9667,13 +9810,24 @@ func (v UFix64Value) Div(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) SaturatingDiv(other NumberValue) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName: sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:     v.StaticType(),
+				RightType:    other.StaticType(),
+			})
+		}
+	}()
+
 	return v.Div(other)
 }
 
 func (v UFix64Value) Mod(other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidBinaryOperandsError{
+		panic(InvalidOperandsError{
 			Operation: ast.OperationMod,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"github.com/onflow/cadence/runtime/ast"
 	"math"
 	"math/big"
 	"strings"
@@ -31,6 +30,7 @@ import (
 	"github.com/rivo/uniseg"
 	"golang.org/x/text/unicode/norm"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/format"
@@ -3307,7 +3307,7 @@ func (v Int32Value) BitwiseOr(other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationBitwiseXor,
+			Operation: ast.OperationBitwiseOr,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
 		})
@@ -3346,13 +3346,13 @@ func (v Int32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidBinaryOperandsError{
-			Operation: ast.OperationBitwiseRightShift,
+			Operation: ast.OperationBitwiseLeftShift,
 			LeftType:  v.StaticType(),
 			RightType: other.StaticType(),
 		})
 	}
 
-	return v ^ o
+	return v << o
 }
 
 func (v Int32Value) BitwiseRightShift(other IntegerValue) IntegerValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"github.com/onflow/cadence/runtime/ast"
 	"math"
 	"math/big"
 	"strings"
@@ -1775,7 +1776,15 @@ func (v IntValue) Negate() NumberValue {
 }
 
 func (v IntValue) Plus(other NumberValue) NumberValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Add(v.BigInt, o.BigInt)
 	return IntValue{res}
@@ -1786,7 +1795,15 @@ func (v IntValue) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v IntValue) Minus(other NumberValue) NumberValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Sub(v.BigInt, o.BigInt)
 	return IntValue{res}
@@ -1797,7 +1814,15 @@ func (v IntValue) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v IntValue) Mod(other NumberValue) NumberValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C
 	if o.BigInt.Cmp(res) == 0 {
@@ -1808,7 +1833,15 @@ func (v IntValue) Mod(other NumberValue) NumberValue {
 }
 
 func (v IntValue) Mul(other NumberValue) NumberValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	return IntValue{res}
@@ -1819,7 +1852,15 @@ func (v IntValue) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v IntValue) Div(other NumberValue) NumberValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C
 	if o.BigInt.Cmp(res) == 0 {
@@ -1871,28 +1912,60 @@ func (v IntValue) HashInput(_ *Interpreter, _ func() LocationRange, _ []byte) []
 }
 
 func (v IntValue) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Or(v.BigInt, o.BigInt)
 	return IntValue{res}
 }
 
 func (v IntValue) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Xor(v.BigInt, o.BigInt)
 	return IntValue{res}
 }
 
 func (v IntValue) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.And(v.BigInt, o.BigInt)
 	return IntValue{res}
 }
 
 func (v IntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -1905,7 +1978,15 @@ func (v IntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
 }
 
 func (v IntValue) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(IntValue)
+	o, ok := other.(IntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -2039,7 +2120,15 @@ func (v Int8Value) Negate() NumberValue {
 }
 
 func (v Int8Value) Plus(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt8 - o)) {
 		panic(OverflowError{})
@@ -2050,7 +2139,15 @@ func (v Int8Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt8 - o)) {
 		return Int8Value(math.MaxInt8)
@@ -2061,7 +2158,15 @@ func (v Int8Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) Minus(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt8 + o)) {
 		panic(OverflowError{})
@@ -2072,7 +2177,15 @@ func (v Int8Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt8 + o)) {
 		return Int8Value(math.MinInt8)
@@ -2083,7 +2196,15 @@ func (v Int8Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) Mod(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	if o == 0 {
 		panic(DivisionByZeroError{})
@@ -2092,7 +2213,15 @@ func (v Int8Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) Mul(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -2123,7 +2252,15 @@ func (v Int8Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -2154,7 +2291,15 @@ func (v Int8Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) Div(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -2166,7 +2311,15 @@ func (v Int8Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Int8Value) SaturatingDiv(other NumberValue) NumberValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -2237,27 +2390,67 @@ func ConvertInt8(value Value) Int8Value {
 }
 
 func (v Int8Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Int8Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v ^ o
 }
 
 func (v Int8Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Int8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v Int8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Int8Value)
+	o, ok := other.(Int8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -2383,7 +2576,15 @@ func (v Int16Value) Negate() NumberValue {
 }
 
 func (v Int16Value) Plus(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt16 - o)) {
 		panic(OverflowError{})
@@ -2394,7 +2595,15 @@ func (v Int16Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt16 - o)) {
 		return Int16Value(math.MaxInt16)
@@ -2405,7 +2614,15 @@ func (v Int16Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) Minus(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt16 + o)) {
 		panic(OverflowError{})
@@ -2416,7 +2633,15 @@ func (v Int16Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt16 + o)) {
 		return Int16Value(math.MinInt16)
@@ -2427,7 +2652,15 @@ func (v Int16Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) Mod(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	if o == 0 {
 		panic(DivisionByZeroError{})
@@ -2436,7 +2669,15 @@ func (v Int16Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) Mul(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -2467,7 +2708,15 @@ func (v Int16Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -2498,7 +2747,15 @@ func (v Int16Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) Div(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -2510,7 +2767,15 @@ func (v Int16Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Int16Value) SaturatingDiv(other NumberValue) NumberValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -2581,27 +2846,67 @@ func ConvertInt16(value Value) Int16Value {
 }
 
 func (v Int16Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Int16Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v ^ o
 }
 
 func (v Int16Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Int16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v Int16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Int16Value)
+	o, ok := other.(Int16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -2729,7 +3034,15 @@ func (v Int32Value) Negate() NumberValue {
 }
 
 func (v Int32Value) Plus(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt32 - o)) {
 		panic(OverflowError{})
@@ -2740,7 +3053,15 @@ func (v Int32Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt32 - o)) {
 		return Int32Value(math.MaxInt32)
@@ -2751,7 +3072,15 @@ func (v Int32Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) Minus(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt32 + o)) {
 		panic(OverflowError{})
@@ -2762,7 +3091,15 @@ func (v Int32Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt32 + o)) {
 		return Int32Value(math.MinInt32)
@@ -2773,7 +3110,15 @@ func (v Int32Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) Mod(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	if o == 0 {
 		panic(DivisionByZeroError{})
@@ -2782,7 +3127,15 @@ func (v Int32Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) Mul(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -2813,7 +3166,15 @@ func (v Int32Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -2844,7 +3205,15 @@ func (v Int32Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) Div(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -2856,7 +3225,15 @@ func (v Int32Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Int32Value) SaturatingDiv(other NumberValue) NumberValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -2927,27 +3304,67 @@ func ConvertInt32(value Value) Int32Value {
 }
 
 func (v Int32Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Int32Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v ^ o
 }
 
 func (v Int32Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Int32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Int32Value)
-	return v << o
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v ^ o
 }
 
 func (v Int32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Int32Value)
+	o, ok := other.(Int32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -3085,12 +3502,28 @@ func safeAddInt64(a, b int64) int64 {
 }
 
 func (v Int64Value) Plus(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return Int64Value(safeAddInt64(int64(v), int64(o)))
 }
 
 func (v Int64Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt64 - o)) {
 		return Int64Value(math.MaxInt64)
@@ -3101,7 +3534,15 @@ func (v Int64Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) Minus(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
 		panic(OverflowError{})
@@ -3112,7 +3553,15 @@ func (v Int64Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
 		return Int64Value(math.MinInt64)
@@ -3123,7 +3572,15 @@ func (v Int64Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) Mod(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	if o == 0 {
 		panic(DivisionByZeroError{})
@@ -3132,7 +3589,15 @@ func (v Int64Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) Mul(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -3163,7 +3628,15 @@ func (v Int64Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if v > 0 {
 		if o > 0 {
@@ -3194,7 +3667,15 @@ func (v Int64Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) Div(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -3206,7 +3687,15 @@ func (v Int64Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Int64Value) SaturatingDiv(other NumberValue) NumberValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
@@ -3272,27 +3761,67 @@ func ConvertInt64(value Value) Int64Value {
 }
 
 func (v Int64Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Int64Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v ^ o
 }
 
 func (v Int64Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Int64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v Int64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Int64Value)
+	o, ok := other.(Int64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -3438,7 +3967,15 @@ func (v Int128Value) Negate() NumberValue {
 }
 
 func (v Int128Value) Plus(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -3462,7 +3999,15 @@ func (v Int128Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -3486,7 +4031,15 @@ func (v Int128Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) Minus(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -3510,7 +4063,15 @@ func (v Int128Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -3534,7 +4095,15 @@ func (v Int128Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) Mod(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C
 	if o.BigInt.Cmp(res) == 0 {
@@ -3545,7 +4114,15 @@ func (v Int128Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) Mul(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
@@ -3557,7 +4134,15 @@ func (v Int128Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
@@ -3569,7 +4154,15 @@ func (v Int128Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) Div(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C:
 	//   if o == 0 {
@@ -3589,7 +4182,15 @@ func (v Int128Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Int128Value) SaturatingDiv(other NumberValue) NumberValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C:
 	//   if o == 0 {
@@ -3669,28 +4270,60 @@ func ConvertInt128(value Value) Int128Value {
 }
 
 func (v Int128Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Or(v.BigInt, o.BigInt)
 	return Int128Value{res}
 }
 
 func (v Int128Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Xor(v.BigInt, o.BigInt)
 	return Int128Value{res}
 }
 
 func (v Int128Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.And(v.BigInt, o.BigInt)
 	return Int128Value{res}
 }
 
 func (v Int128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -3703,7 +4336,15 @@ func (v Int128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 }
 
 func (v Int128Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Int128Value)
+	o, ok := other.(Int128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -3856,7 +4497,15 @@ func (v Int256Value) Negate() NumberValue {
 }
 
 func (v Int256Value) Plus(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -3880,7 +4529,15 @@ func (v Int256Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -3904,7 +4561,15 @@ func (v Int256Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) Minus(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -3928,7 +4593,15 @@ func (v Int256Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -3952,7 +4625,15 @@ func (v Int256Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) Mod(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C
 	if o.BigInt.Cmp(res) == 0 {
@@ -3963,7 +4644,15 @@ func (v Int256Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) Mul(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
@@ -3975,7 +4664,15 @@ func (v Int256Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
@@ -3987,7 +4684,15 @@ func (v Int256Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) Div(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C:
 	//   if o == 0 {
@@ -4007,7 +4712,15 @@ func (v Int256Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Int256Value) SaturatingDiv(other NumberValue) NumberValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C:
 	//   if o == 0 {
@@ -4087,28 +4800,60 @@ func ConvertInt256(value Value) Int256Value {
 }
 
 func (v Int256Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Or(v.BigInt, o.BigInt)
 	return Int256Value{res}
 }
 
 func (v Int256Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Xor(v.BigInt, o.BigInt)
 	return Int256Value{res}
 }
 
 func (v Int256Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.And(v.BigInt, o.BigInt)
 	return Int256Value{res}
 }
 
 func (v Int256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -4121,7 +4866,15 @@ func (v Int256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 }
 
 func (v Int256Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Int256Value)
+	o, ok := other.(Int256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -4288,7 +5041,15 @@ func (v UIntValue) Negate() NumberValue {
 }
 
 func (v UIntValue) Plus(other NumberValue) NumberValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Add(v.BigInt, o.BigInt)
 	return UIntValue{res}
@@ -4299,7 +5060,15 @@ func (v UIntValue) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) Minus(other NumberValue) NumberValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Sub(v.BigInt, o.BigInt)
 	// INT30-C
@@ -4310,7 +5079,15 @@ func (v UIntValue) Minus(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Sub(v.BigInt, o.BigInt)
 	// INT30-C
@@ -4321,7 +5098,15 @@ func (v UIntValue) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) Mod(other NumberValue) NumberValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C
 	if o.BigInt.Cmp(res) == 0 {
@@ -4332,7 +5117,15 @@ func (v UIntValue) Mod(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) Mul(other NumberValue) NumberValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	return UIntValue{res}
@@ -4343,7 +5136,15 @@ func (v UIntValue) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UIntValue) Div(other NumberValue) NumberValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	// INT33-C
 	if o.BigInt.Cmp(res) == 0 {
@@ -4395,28 +5196,60 @@ func (v UIntValue) HashInput(_ *Interpreter, _ func() LocationRange, _ []byte) [
 }
 
 func (v UIntValue) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Or(v.BigInt, o.BigInt)
 	return UIntValue{res}
 }
 
 func (v UIntValue) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Xor(v.BigInt, o.BigInt)
 	return UIntValue{res}
 }
 
 func (v UIntValue) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.And(v.BigInt, o.BigInt)
 	return UIntValue{res}
 }
 
 func (v UIntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -4429,7 +5262,15 @@ func (v UIntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
 }
 
 func (v UIntValue) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(UIntValue)
+	o, ok := other.(UIntValue)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -4560,7 +5401,16 @@ func (v UInt8Value) Negate() NumberValue {
 }
 
 func (v UInt8Value) Plus(other NumberValue) NumberValue {
-	sum := v + other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	sum := v + o
 	// INT30-C
 	if sum < v {
 		panic(OverflowError{})
@@ -4569,7 +5419,16 @@ func (v UInt8Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) SaturatingPlus(other NumberValue) NumberValue {
-	sum := v + other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	sum := v + o
 	// INT30-C
 	if sum < v {
 		return UInt8Value(math.MaxUint8)
@@ -4578,7 +5437,17 @@ func (v UInt8Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) Minus(other NumberValue) NumberValue {
-	diff := v - other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
@@ -4587,7 +5456,17 @@ func (v UInt8Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) SaturatingMinus(other NumberValue) NumberValue {
-	diff := v - other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		return UInt8Value(0)
@@ -4596,7 +5475,15 @@ func (v UInt8Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) Mod(other NumberValue) NumberValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -4604,7 +5491,15 @@ func (v UInt8Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) Mul(other NumberValue) NumberValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint8 / o)) {
 		panic(OverflowError{})
@@ -4613,7 +5508,15 @@ func (v UInt8Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint8 / o)) {
 		return UInt8Value(math.MaxUint8)
@@ -4622,7 +5525,15 @@ func (v UInt8Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UInt8Value) Div(other NumberValue) NumberValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -4693,27 +5604,67 @@ func ConvertUInt8(value Value) UInt8Value {
 }
 
 func (v UInt8Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v UInt8Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v ^ o
 }
 
 func (v UInt8Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v UInt8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v UInt8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(UInt8Value)
+	o, ok := other.(UInt8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -4834,7 +5785,16 @@ func (v UInt16Value) Negate() NumberValue {
 }
 
 func (v UInt16Value) Plus(other NumberValue) NumberValue {
-	sum := v + other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	sum := v + o
 	// INT30-C
 	if sum < v {
 		panic(OverflowError{})
@@ -4843,7 +5803,16 @@ func (v UInt16Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) SaturatingPlus(other NumberValue) NumberValue {
-	sum := v + other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	sum := v + o
 	// INT30-C
 	if sum < v {
 		return UInt16Value(math.MaxUint16)
@@ -4852,7 +5821,17 @@ func (v UInt16Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) Minus(other NumberValue) NumberValue {
-	diff := v - other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
@@ -4861,7 +5840,17 @@ func (v UInt16Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) SaturatingMinus(other NumberValue) NumberValue {
-	diff := v - other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		return UInt16Value(0)
@@ -4870,7 +5859,15 @@ func (v UInt16Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) Mod(other NumberValue) NumberValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -4878,7 +5875,15 @@ func (v UInt16Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) Mul(other NumberValue) NumberValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint16 / o)) {
 		panic(OverflowError{})
@@ -4887,7 +5892,15 @@ func (v UInt16Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint16 / o)) {
 		return UInt16Value(math.MaxUint16)
@@ -4896,7 +5909,15 @@ func (v UInt16Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UInt16Value) Div(other NumberValue) NumberValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -4967,27 +5988,66 @@ func ConvertUInt16(value Value) UInt16Value {
 }
 
 func (v UInt16Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v UInt16Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 	return v ^ o
 }
 
 func (v UInt16Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v UInt16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v UInt16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(UInt16Value)
+	o, ok := other.(UInt16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -5115,7 +6175,17 @@ func (v UInt32Value) Negate() NumberValue {
 }
 
 func (v UInt32Value) Plus(other NumberValue) NumberValue {
-	sum := v + other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	sum := v + o
+
 	// INT30-C
 	if sum < v {
 		panic(OverflowError{})
@@ -5124,7 +6194,16 @@ func (v UInt32Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) SaturatingPlus(other NumberValue) NumberValue {
-	sum := v + other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	sum := v + o
 	// INT30-C
 	if sum < v {
 		return UInt32Value(math.MaxUint32)
@@ -5133,7 +6212,17 @@ func (v UInt32Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) Minus(other NumberValue) NumberValue {
-	diff := v - other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
@@ -5142,7 +6231,17 @@ func (v UInt32Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) SaturatingMinus(other NumberValue) NumberValue {
-	diff := v - other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		return UInt32Value(0)
@@ -5151,7 +6250,15 @@ func (v UInt32Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) Mod(other NumberValue) NumberValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -5159,7 +6266,15 @@ func (v UInt32Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) Mul(other NumberValue) NumberValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if (v > 0) && (o > 0) && (v > (math.MaxUint32 / o)) {
 		panic(OverflowError{})
 	}
@@ -5167,7 +6282,15 @@ func (v UInt32Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint32 / o)) {
 		return UInt32Value(math.MaxUint32)
@@ -5176,7 +6299,15 @@ func (v UInt32Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UInt32Value) Div(other NumberValue) NumberValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -5247,27 +6378,66 @@ func ConvertUInt32(value Value) UInt32Value {
 }
 
 func (v UInt32Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v UInt32Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 	return v ^ o
 }
 
 func (v UInt32Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v UInt32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v UInt32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(UInt32Value)
+	o, ok := other.(UInt32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -5404,12 +6574,30 @@ func safeAddUint64(a, b uint64) uint64 {
 }
 
 func (v UInt64Value) Plus(other NumberValue) NumberValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return UInt64Value(safeAddUint64(uint64(v), uint64(o)))
 }
 
 func (v UInt64Value) SaturatingPlus(other NumberValue) NumberValue {
-	sum := v + other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	sum := v + o
+
 	// INT30-C
 	if sum < v {
 		return UInt64Value(math.MaxUint64)
@@ -5418,7 +6606,17 @@ func (v UInt64Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) Minus(other NumberValue) NumberValue {
-	diff := v - other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
@@ -5427,7 +6625,17 @@ func (v UInt64Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) SaturatingMinus(other NumberValue) NumberValue {
-	diff := v - other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		return UInt64Value(0)
@@ -5436,7 +6644,15 @@ func (v UInt64Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) Mod(other NumberValue) NumberValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -5444,7 +6660,15 @@ func (v UInt64Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) Mul(other NumberValue) NumberValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if (v > 0) && (o > 0) && (v > (math.MaxUint64 / o)) {
 		panic(OverflowError{})
 	}
@@ -5452,7 +6676,15 @@ func (v UInt64Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT30-C
 	if (v > 0) && (o > 0) && (v > (math.MaxUint64 / o)) {
 		return UInt64Value(math.MaxUint64)
@@ -5461,7 +6693,15 @@ func (v UInt64Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UInt64Value) Div(other NumberValue) NumberValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -5530,27 +6770,66 @@ func ConvertUInt64(value Value) UInt64Value {
 }
 
 func (v UInt64Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v UInt64Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 	return v ^ o
 }
 
 func (v UInt64Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v UInt64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v UInt64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(UInt64Value)
+	o, ok := other.(UInt64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -5693,8 +6972,17 @@ func (v UInt128Value) Negate() NumberValue {
 }
 
 func (v UInt128Value) Plus(other NumberValue) NumberValue {
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	sum := new(big.Int)
-	sum.Add(v.BigInt, other.(UInt128Value).BigInt)
+	sum.Add(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -5712,8 +7000,17 @@ func (v UInt128Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) SaturatingPlus(other NumberValue) NumberValue {
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	sum := new(big.Int)
-	sum.Add(v.BigInt, other.(UInt128Value).BigInt)
+	sum.Add(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -5731,8 +7028,17 @@ func (v UInt128Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) Minus(other NumberValue) NumberValue {
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	diff := new(big.Int)
-	diff.Sub(v.BigInt, other.(UInt128Value).BigInt)
+	diff.Sub(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -5750,8 +7056,17 @@ func (v UInt128Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) SaturatingMinus(other NumberValue) NumberValue {
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	diff := new(big.Int)
-	diff.Sub(v.BigInt, other.(UInt128Value).BigInt)
+	diff.Sub(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -5769,7 +7084,15 @@ func (v UInt128Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) Mod(other NumberValue) NumberValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
@@ -5779,7 +7102,15 @@ func (v UInt128Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) Mul(other NumberValue) NumberValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
@@ -5789,7 +7120,15 @@ func (v UInt128Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
@@ -5799,7 +7138,15 @@ func (v UInt128Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UInt128Value) Div(other NumberValue) NumberValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
@@ -5873,28 +7220,60 @@ func ConvertUInt128(value Value) UInt128Value {
 }
 
 func (v UInt128Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Or(v.BigInt, o.BigInt)
 	return UInt128Value{res}
 }
 
 func (v UInt128Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Xor(v.BigInt, o.BigInt)
 	return UInt128Value{res}
 }
 
 func (v UInt128Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.And(v.BigInt, o.BigInt)
 	return UInt128Value{res}
 }
 
 func (v UInt128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -5907,7 +7286,15 @@ func (v UInt128Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 }
 
 func (v UInt128Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(UInt128Value)
+	o, ok := other.(UInt128Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -6057,8 +7444,17 @@ func (v UInt256Value) Negate() NumberValue {
 }
 
 func (v UInt256Value) Plus(other NumberValue) NumberValue {
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	sum := new(big.Int)
-	sum.Add(v.BigInt, other.(UInt256Value).BigInt)
+	sum.Add(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -6076,8 +7472,17 @@ func (v UInt256Value) Plus(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) SaturatingPlus(other NumberValue) NumberValue {
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	sum := new(big.Int)
-	sum.Add(v.BigInt, other.(UInt256Value).BigInt)
+	sum.Add(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just add and check the range of the result.
 	//
@@ -6095,8 +7500,17 @@ func (v UInt256Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) Minus(other NumberValue) NumberValue {
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	diff := new(big.Int)
-	diff.Sub(v.BigInt, other.(UInt256Value).BigInt)
+	diff.Sub(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -6114,8 +7528,17 @@ func (v UInt256Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) SaturatingMinus(other NumberValue) NumberValue {
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	diff := new(big.Int)
-	diff.Sub(v.BigInt, other.(UInt256Value).BigInt)
+	diff.Sub(v.BigInt, o.BigInt)
 	// Given that this value is backed by an arbitrary size integer,
 	// we can just subtract and check the range of the result.
 	//
@@ -6133,7 +7556,15 @@ func (v UInt256Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) Mod(other NumberValue) NumberValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
@@ -6143,7 +7574,15 @@ func (v UInt256Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) Mul(other NumberValue) NumberValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
@@ -6153,7 +7592,15 @@ func (v UInt256Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Mul(v.BigInt, o.BigInt)
 	if res.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
@@ -6163,7 +7610,15 @@ func (v UInt256Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UInt256Value) Div(other NumberValue) NumberValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Cmp(res) == 0 {
 		panic(DivisionByZeroError{})
@@ -6237,28 +7692,60 @@ func ConvertUInt256(value Value) UInt256Value {
 }
 
 func (v UInt256Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Or(v.BigInt, o.BigInt)
 	return UInt256Value{res}
 }
 
 func (v UInt256Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.Xor(v.BigInt, o.BigInt)
 	return UInt256Value{res}
 }
 
 func (v UInt256Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	res.And(v.BigInt, o.BigInt)
 	return UInt256Value{res}
 }
 
 func (v UInt256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -6271,7 +7758,15 @@ func (v UInt256Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
 }
 
 func (v UInt256Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(UInt256Value)
+	o, ok := other.(UInt256Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	res := new(big.Int)
 	if o.BigInt.Sign() < 0 {
 		panic(UnderflowError{})
@@ -6405,7 +7900,16 @@ func (v Word8Value) Negate() NumberValue {
 }
 
 func (v Word8Value) Plus(other NumberValue) NumberValue {
-	return v + other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v + o
 }
 
 func (v Word8Value) SaturatingPlus(_ NumberValue) NumberValue {
@@ -6413,7 +7917,16 @@ func (v Word8Value) SaturatingPlus(_ NumberValue) NumberValue {
 }
 
 func (v Word8Value) Minus(other NumberValue) NumberValue {
-	return v - other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v - o
 }
 
 func (v Word8Value) SaturatingMinus(_ NumberValue) NumberValue {
@@ -6421,7 +7934,15 @@ func (v Word8Value) SaturatingMinus(_ NumberValue) NumberValue {
 }
 
 func (v Word8Value) Mod(other NumberValue) NumberValue {
-	o := other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -6429,7 +7950,16 @@ func (v Word8Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Word8Value) Mul(other NumberValue) NumberValue {
-	return v * other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v * o
 }
 
 func (v Word8Value) SaturatingMul(_ NumberValue) NumberValue {
@@ -6437,7 +7967,15 @@ func (v Word8Value) SaturatingMul(_ NumberValue) NumberValue {
 }
 
 func (v Word8Value) Div(other NumberValue) NumberValue {
-	o := other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -6483,27 +8021,66 @@ func ConvertWord8(value Value) Word8Value {
 }
 
 func (v Word8Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Word8Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 	return v ^ o
 }
 
 func (v Word8Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Word8Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v Word8Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Word8Value)
+	o, ok := other.(Word8Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -6628,7 +8205,16 @@ func (v Word16Value) Negate() NumberValue {
 }
 
 func (v Word16Value) Plus(other NumberValue) NumberValue {
-	return v + other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v + o
 }
 
 func (v Word16Value) SaturatingPlus(_ NumberValue) NumberValue {
@@ -6636,7 +8222,16 @@ func (v Word16Value) SaturatingPlus(_ NumberValue) NumberValue {
 }
 
 func (v Word16Value) Minus(other NumberValue) NumberValue {
-	return v - other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v - o
 }
 
 func (v Word16Value) SaturatingMinus(_ NumberValue) NumberValue {
@@ -6644,7 +8239,15 @@ func (v Word16Value) SaturatingMinus(_ NumberValue) NumberValue {
 }
 
 func (v Word16Value) Mod(other NumberValue) NumberValue {
-	o := other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -6652,7 +8255,16 @@ func (v Word16Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Word16Value) Mul(other NumberValue) NumberValue {
-	return v * other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v * o
 }
 
 func (v Word16Value) SaturatingMul(_ NumberValue) NumberValue {
@@ -6660,7 +8272,15 @@ func (v Word16Value) SaturatingMul(_ NumberValue) NumberValue {
 }
 
 func (v Word16Value) Div(other NumberValue) NumberValue {
-	o := other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -6706,27 +8326,66 @@ func ConvertWord16(value Value) Word16Value {
 }
 
 func (v Word16Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Word16Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 	return v ^ o
 }
 
 func (v Word16Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Word16Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v Word16Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Word16Value)
+	o, ok := other.(Word16Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -6854,7 +8513,16 @@ func (v Word32Value) Negate() NumberValue {
 }
 
 func (v Word32Value) Plus(other NumberValue) NumberValue {
-	return v + other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v + o
 }
 
 func (v Word32Value) SaturatingPlus(_ NumberValue) NumberValue {
@@ -6862,7 +8530,16 @@ func (v Word32Value) SaturatingPlus(_ NumberValue) NumberValue {
 }
 
 func (v Word32Value) Minus(other NumberValue) NumberValue {
-	return v - other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v - o
 }
 
 func (v Word32Value) SaturatingMinus(_ NumberValue) NumberValue {
@@ -6870,7 +8547,15 @@ func (v Word32Value) SaturatingMinus(_ NumberValue) NumberValue {
 }
 
 func (v Word32Value) Mod(other NumberValue) NumberValue {
-	o := other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -6878,7 +8563,16 @@ func (v Word32Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Word32Value) Mul(other NumberValue) NumberValue {
-	return v * other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v * o
 }
 
 func (v Word32Value) SaturatingMul(_ NumberValue) NumberValue {
@@ -6886,7 +8580,15 @@ func (v Word32Value) SaturatingMul(_ NumberValue) NumberValue {
 }
 
 func (v Word32Value) Div(other NumberValue) NumberValue {
-	o := other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -6932,27 +8634,66 @@ func ConvertWord32(value Value) Word32Value {
 }
 
 func (v Word32Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Word32Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 	return v ^ o
 }
 
 func (v Word32Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Word32Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v Word32Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Word32Value)
+	o, ok := other.(Word32Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -7080,7 +8821,16 @@ func (v Word64Value) Negate() NumberValue {
 }
 
 func (v Word64Value) Plus(other NumberValue) NumberValue {
-	return v + other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v + o
 }
 
 func (v Word64Value) SaturatingPlus(_ NumberValue) NumberValue {
@@ -7088,7 +8838,16 @@ func (v Word64Value) SaturatingPlus(_ NumberValue) NumberValue {
 }
 
 func (v Word64Value) Minus(other NumberValue) NumberValue {
-	return v - other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v - o
 }
 
 func (v Word64Value) SaturatingMinus(_ NumberValue) NumberValue {
@@ -7096,7 +8855,15 @@ func (v Word64Value) SaturatingMinus(_ NumberValue) NumberValue {
 }
 
 func (v Word64Value) Mod(other NumberValue) NumberValue {
-	o := other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -7104,7 +8871,16 @@ func (v Word64Value) Mod(other NumberValue) NumberValue {
 }
 
 func (v Word64Value) Mul(other NumberValue) NumberValue {
-	return v * other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	return v * o
 }
 
 func (v Word64Value) SaturatingMul(_ NumberValue) NumberValue {
@@ -7112,7 +8888,15 @@ func (v Word64Value) SaturatingMul(_ NumberValue) NumberValue {
 }
 
 func (v Word64Value) Div(other NumberValue) NumberValue {
-	o := other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
@@ -7158,27 +8942,66 @@ func ConvertWord64(value Value) Word64Value {
 }
 
 func (v Word64Value) BitwiseOr(other IntegerValue) IntegerValue {
-	o := other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseOr,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v | o
 }
 
 func (v Word64Value) BitwiseXor(other IntegerValue) IntegerValue {
-	o := other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseXor,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 	return v ^ o
 }
 
 func (v Word64Value) BitwiseAnd(other IntegerValue) IntegerValue {
-	o := other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseAnd,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v & o
 }
 
 func (v Word64Value) BitwiseLeftShift(other IntegerValue) IntegerValue {
-	o := other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseLeftShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v << o
 }
 
 func (v Word64Value) BitwiseRightShift(other IntegerValue) IntegerValue {
-	o := other.(Word64Value)
+	o, ok := other.(Word64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationBitwiseRightShift,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return v >> o
 }
 
@@ -7324,12 +9147,28 @@ func (v Fix64Value) Negate() NumberValue {
 }
 
 func (v Fix64Value) Plus(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return Fix64Value(safeAddInt64(int64(v), int64(o)))
 }
 
 func (v Fix64Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt64 - o)) {
 		return Fix64Value(math.MaxInt64)
@@ -7340,7 +9179,15 @@ func (v Fix64Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) Minus(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
 		panic(OverflowError{})
@@ -7351,7 +9198,15 @@ func (v Fix64Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) SaturatingMinus(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
 		return Fix64Value(math.MinInt64)
@@ -7365,7 +9220,14 @@ var minInt64Big = big.NewInt(math.MinInt64)
 var maxInt64Big = big.NewInt(math.MaxInt64)
 
 func (v Fix64Value) Mul(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 
 	a := new(big.Int).SetInt64(int64(v))
 	b := new(big.Int).SetInt64(int64(o))
@@ -7383,7 +9245,14 @@ func (v Fix64Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 
 	a := new(big.Int).SetInt64(int64(v))
 	b := new(big.Int).SetInt64(int64(o))
@@ -7401,7 +9270,14 @@ func (v Fix64Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) Div(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 
 	a := new(big.Int).SetInt64(int64(v))
 	b := new(big.Int).SetInt64(int64(o))
@@ -7419,7 +9295,14 @@ func (v Fix64Value) Div(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) SaturatingDiv(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 
 	a := new(big.Int).SetInt64(int64(v))
 	b := new(big.Int).SetInt64(int64(o))
@@ -7437,7 +9320,15 @@ func (v Fix64Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v Fix64Value) Mod(other NumberValue) NumberValue {
-	o := other.(Fix64Value)
+	o, ok := other.(Fix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// v - int(v/o) * o
 	quotient := v.Div(o).(Fix64Value)
 	truncatedQuotient := (int64(quotient) / sema.Fix64Factor) * sema.Fix64Factor
@@ -7642,12 +9533,28 @@ func (v UFix64Value) Negate() NumberValue {
 }
 
 func (v UFix64Value) Plus(other NumberValue) NumberValue {
-	o := other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	return UFix64Value(safeAddUint64(uint64(v), uint64(o)))
 }
 
 func (v UFix64Value) SaturatingPlus(other NumberValue) NumberValue {
-	o := other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationPlus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	sum := v + o
 	// INT30-C
 	if sum < v {
@@ -7657,7 +9564,17 @@ func (v UFix64Value) SaturatingPlus(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) Minus(other NumberValue) NumberValue {
-	diff := v - other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		panic(UnderflowError{})
@@ -7666,7 +9583,17 @@ func (v UFix64Value) Minus(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) SaturatingMinus(other NumberValue) NumberValue {
-	diff := v - other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMinus,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
+	diff := v - o
+
 	// INT30-C
 	if diff > v {
 		return UFix64Value(0)
@@ -7675,7 +9602,14 @@ func (v UFix64Value) SaturatingMinus(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) Mul(other NumberValue) NumberValue {
-	o := other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 
 	a := new(big.Int).SetUint64(uint64(v))
 	b := new(big.Int).SetUint64(uint64(o))
@@ -7691,7 +9625,14 @@ func (v UFix64Value) Mul(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) SaturatingMul(other NumberValue) NumberValue {
-	o := other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMul,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 
 	a := new(big.Int).SetUint64(uint64(v))
 	b := new(big.Int).SetUint64(uint64(o))
@@ -7707,7 +9648,14 @@ func (v UFix64Value) SaturatingMul(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) Div(other NumberValue) NumberValue {
-	o := other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationDiv,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
 
 	a := new(big.Int).SetUint64(uint64(v))
 	b := new(big.Int).SetUint64(uint64(o))
@@ -7723,7 +9671,15 @@ func (v UFix64Value) SaturatingDiv(other NumberValue) NumberValue {
 }
 
 func (v UFix64Value) Mod(other NumberValue) NumberValue {
-	o := other.(UFix64Value)
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidBinaryOperandsError{
+			Operation: ast.OperationMod,
+			LeftType:  v.StaticType(),
+			RightType: other.StaticType(),
+		})
+	}
+
 	// v - int(v/o) * o
 	quotient := v.Div(o).(UFix64Value)
 	truncatedQuotient := (uint64(quotient) / sema.Fix64Factor) * sema.Fix64Factor

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -24,10 +24,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	. "github.com/onflow/cadence/runtime/tests/utils"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 )
@@ -835,4 +837,30 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 		test(ty, "Multiply", testCase.multiply)
 		test(ty, "Divide", testCase.divide)
 	}
+}
+
+func TestInterpretArithmeticOnSubTypes(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("param subtypes", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun test(): Integer {
+		        let x: Integer = 5 as Int8
+                return x * 2
+            }
+        `)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+
+		operandError := &interpreter.InvalidBinaryOperandsError{}
+		require.ErrorAs(t, err, operandError)
+
+		assert.Equal(t, ast.OperationMul, operandError.Operation)
+		assert.Equal(t, interpreter.PrimitiveStaticTypeInt8, operandError.LeftType)
+		assert.Equal(t, interpreter.PrimitiveStaticTypeInt, operandError.RightType)
+	})
 }


### PR DESCRIPTION
## Description

Port of https://github.com/dapperlabs/cadence-internal/pull/38

Seems this had not been ported to v0.20. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
