### PR TITLE
Ignore dead code

### DIFF
--- a/runtime/sema/check_block.go
+++ b/runtime/sema/check_block.go
@@ -39,8 +39,7 @@ func (checker *Checker) visitStatements(statements []ast.Statement) {
 		// Is this statement unreachable? Report it once for this statement,
 		// but avoid noise and don't report it for all remaining unreachable statements
 
-		if functionActivation.ReturnInfo.IsUnreachable() &&
-			!functionActivation.ReportedDeadCode {
+		if functionActivation.ReturnInfo.IsUnreachable() {
 
 			lastStatement := statements[len(statements)-1]
 
@@ -53,7 +52,7 @@ func (checker *Checker) visitStatements(statements []ast.Statement) {
 				},
 			)
 
-			functionActivation.ReportedDeadCode = true
+			break
 		}
 
 		if !checker.checkValidStatement(statement) {

--- a/runtime/sema/function_activations.go
+++ b/runtime/sema/function_activations.go
@@ -24,7 +24,6 @@ type FunctionActivation struct {
 	Switches             int
 	ValueActivationDepth int
 	ReturnInfo           *ReturnInfo
-	ReportedDeadCode     bool
 	InitializationInfo   *InitializationInfo
 }
 

--- a/runtime/tests/checker/switch_test.go
+++ b/runtime/tests/checker/switch_test.go
@@ -193,6 +193,29 @@ func TestCheckSwitchStatementDefaultDefinitiveReturn(t *testing.T) {
 
 		assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
 	})
+
+	t.Run("break before return", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          fun test(x: Int): String {
+              switch x {
+              case 1:
+                  return "one"
+              default:
+                  break
+                  return "two"
+              }
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
+		assert.IsType(t, &sema.MissingReturnStatementError{}, errs[1])
+	})
 }
 
 func TestCheckInvalidSwitchStatementCaseStatement(t *testing.T) {
@@ -373,6 +396,8 @@ func TestCheckSwitchStatementWithUnreachableReturn(t *testing.T) {
       }
     `)
 
-	errs := ExpectCheckerErrors(t, err, 1)
+	errs := ExpectCheckerErrors(t, err, 2)
+
 	assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
+	assert.IsType(t, &sema.MissingReturnStatementError{}, errs[1])
 }


### PR DESCRIPTION
## Description

Don't just report, but also ignore dead code. This reduces checking time, and actually has the side-effect of improving errors: Checking dead code was poisoning the data flow analysis (a function activation's return info tracks if the function definitely returned/jumped/halted), so e.g. a missing return statement error was not reported.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
