### PR TITLE
Reject invalid access modifiers

### DIFF
--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -67,6 +67,9 @@ func parseDeclaration(p *parser, docString string) ast.Declaration {
 
 		switch p.current.Type {
 		case lexer.TokenPragma:
+			if access != ast.AccessNotSpecified {
+				panic(fmt.Errorf("invalid access modifier for pragma"))
+			}
 			return parsePragmaDeclaration(p)
 		case lexer.TokenIdentifier:
 			switch p.current.Value {
@@ -93,7 +96,7 @@ func parseDeclaration(p *parser, docString string) ast.Declaration {
 
 			case keywordPriv, keywordPub, keywordAccess:
 				if access != ast.AccessNotSpecified {
-					panic(fmt.Errorf("unexpected access modifier"))
+					panic(fmt.Errorf("invalid second access modifier"))
 				}
 				pos := p.current.StartPos
 				accessPos = &pos

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -4898,3 +4898,56 @@ func TestParsePreconditionWithUnaryNegation(t *testing.T) {
 		result.Declarations(),
 	)
 }
+
+func TestParseInvalidAccessModifiers(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("pragma", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations("pub #test")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid access modifier for pragma",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("transaction", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations("pub transaction {}")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid access modifier for transaction",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("transaction", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations("pub priv let x = 1")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid second access modifier",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
+			},
+			errs,
+		)
+	})
+}


### PR DESCRIPTION
Closes dapperlabs/cadence-private-issues#16

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
