### PR TITLE
Fix parsing of 0_ integer literals

### DIFF
--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -3034,6 +3034,48 @@ func TestParseIntegerLiterals(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("leading zero and underscore", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression(`0_100`)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.IntegerExpression{
+				PositiveLiteral: "0_100",
+				Value:           big.NewInt(100),
+				Base:            10,
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("leading one and underscore", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseExpression(`1_100`)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.IntegerExpression{
+				PositiveLiteral: "1_100",
+				Value:           big.NewInt(1100),
+				Base:            10,
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+				},
+			},
+			result,
+		)
+	})
 }
 
 func TestParseFixedPoint(t *testing.T) {

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -3076,6 +3076,26 @@ func TestParseIntegerLiterals(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("leading underscore", func(t *testing.T) {
+
+		t.Parallel()
+
+		// NOTE: a leading underscore introduces an identifier
+
+		result, errs := ParseExpression(`_100`)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.IdentifierExpression{
+				Identifier: ast.Identifier{
+					Identifier: "_100",
+					Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			result,
+		)
+	})
 }
 
 func TestParseFixedPoint(t *testing.T) {

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -1628,6 +1628,54 @@ func TestLexIntegerLiterals(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("leading zero and underscore", func(t *testing.T) {
+
+		testLex(t,
+			"0_100",
+			[]Token{
+				{
+					Type:  TokenDecimalIntegerLiteral,
+					Value: "0_100",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+				},
+				{
+					Type: TokenEOF,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
+						EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
+					},
+				},
+			},
+		)
+	})
+
+	t.Run("leading one and underscore", func(t *testing.T) {
+
+		testLex(t,
+			"1_100",
+			[]Token{
+				{
+					Type:  TokenDecimalIntegerLiteral,
+					Value: "1_100",
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+						EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+					},
+				},
+				{
+					Type: TokenEOF,
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
+						EndPos:   ast.Position{Line: 1, Column: 5, Offset: 5},
+					},
+				},
+			},
+		)
+	})
 }
 
 func TestLexFixedPoint(t *testing.T) {

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -210,7 +210,7 @@ func numberState(l *lexer) stateFn {
 			}
 			l.emitValue(TokenHexadecimalIntegerLiteral)
 
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_':
 			tokenType := l.scanDecimalOrFixedPointRemainder()
 			l.emitValue(tokenType)
 

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -2760,18 +2760,22 @@ func TestParseConstantSizedSizedArrayWithTrailingUnderscoreSize(t *testing.T) {
 
 	t.Parallel()
 
-	actual, err := ParseProgram(`
+	_, errs := ParseDeclarations(`
 	  let T:[d;0_]=0
 	`)
 
-	assert.Nil(t, actual)
-
-	require.Error(t, err)
-
-	require.IsType(t, Error{}, err)
-
-	errors := err.(Error).Errors
-	assert.Len(t, errors, 1)
-
-	require.IsType(t, &SyntaxError{}, errors[0])
+	utils.AssertEqualWithDiff(t,
+		[]error{
+			&InvalidIntegerLiteralError{
+				Literal:                   "0_",
+				IntegerLiteralKind:        IntegerLiteralKindDecimal,
+				InvalidIntegerLiteralKind: InvalidNumberLiteralKindTrailingUnderscore,
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 2, Column: 12, Offset: 13},
+					EndPos:   ast.Position{Line: 2, Column: 13, Offset: 14},
+				},
+			},
+		},
+		errs,
+	)
 }


### PR DESCRIPTION
Closes dapperlabs/cadence-private-issues#14
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
