### PR TITLE
Always check address overflow

### DIFF
--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -523,7 +523,7 @@ payloadLoop:
 		}
 
 		if filter {
-			owner := common.BytesToAddress([]byte(storageKey[0]))
+			owner := common.MustBytesToAddress([]byte(storageKey[0]))
 			var found bool
 			for _, address := range addresses {
 				if owner == address {

--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -20,21 +20,40 @@ package common
 
 import (
 	"encoding/hex"
+	goErrors "errors"
 	"fmt"
 	"strings"
 )
+
+var addressOverflowError = goErrors.New("address too large")
 
 const AddressLength = 8
 
 type Address [AddressLength]byte
 
+// MustBytesToAddress returns Address with value b.
+//
+// If the address is too large, then the function panics.
+//
+func MustBytesToAddress(b []byte) Address {
+	address, err := BytesToAddress(b)
+	if err != nil {
+		panic(err)
+	}
+	return address
+}
+
 // BytesToAddress returns Address with value b.
 //
-// If b is larger than len(h), b will be cropped from the left.
-func BytesToAddress(b []byte) Address {
+// If the address is too large, then the function returns an error.
+//
+func BytesToAddress(b []byte) (Address, error) {
+	if len(b) > AddressLength {
+		return Address{}, addressOverflowError
+	}
 	var a Address
 	a.SetBytes(b)
-	return a
+	return a, nil
 }
 
 // Hex returns the hex string representation of the address.
@@ -101,5 +120,5 @@ func HexToAddress(h string) (Address, error) {
 	if err != nil {
 		return Address{}, err
 	}
-	return BytesToAddress(b), nil
+	return BytesToAddress(b)
 }

--- a/runtime/common/address_test.go
+++ b/runtime/common/address_test.go
@@ -22,26 +22,89 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestMustBytesToAddress(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("short", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.NotPanics(t, func() {
+			assert.Equal(t,
+				Address{0, 0, 0, 0, 0, 0, 0, 0x1},
+				MustBytesToAddress([]byte{0x1}),
+			)
+		})
+	})
+
+	t.Run("full", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.NotPanics(t, func() {
+			assert.Equal(t,
+				Address{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+				MustBytesToAddress([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}),
+			)
+		})
+	})
+
+	t.Run("too long", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.Panics(t, func() {
+			MustBytesToAddress([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9})
+		})
+	})
+}
 
 func TestBytesToAddress(t *testing.T) {
 
 	t.Parallel()
 
-	assert.Equal(t,
-		Address{0, 0, 0, 0, 0, 0, 0, 0x1},
-		BytesToAddress([]byte{0x1}),
-	)
+	t.Run("short", func(t *testing.T) {
 
-	assert.Equal(t,
-		Address{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
-		BytesToAddress([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}),
-	)
+		t.Parallel()
 
-	assert.Equal(t,
-		Address{0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9},
-		BytesToAddress([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}),
-	)
+		address, err := BytesToAddress([]byte{0x1})
+
+		require.NoError(t, err)
+		assert.Equal(t,
+			Address{0, 0, 0, 0, 0, 0, 0, 0x1},
+			address,
+		)
+	})
+
+	t.Run("full", func(t *testing.T) {
+
+		t.Parallel()
+
+		address, err := BytesToAddress([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8})
+
+		require.NoError(t, err)
+		assert.Equal(t,
+			Address{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+			address,
+		)
+	})
+
+	t.Run("too long", func(t *testing.T) {
+
+		t.Parallel()
+
+		address, err := BytesToAddress([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9})
+
+		require.Error(t, err)
+		assert.Equal(t,
+			Address{},
+			address,
+		)
+	})
 }
 
 func TestAddress_Hex(t *testing.T) {
@@ -180,7 +243,7 @@ func TestAddress_HexToAddress(t *testing.T) {
 		{"01", []byte{0x1}},
 	} {
 
-		expected := BytesToAddress(test.value)
+		expected := MustBytesToAddress(test.value)
 
 		address, err := HexToAddress(test.literal)
 		assert.NoError(t, err)

--- a/runtime/common/addresslocation.go
+++ b/runtime/common/addresslocation.go
@@ -160,7 +160,7 @@ func decodeAddressLocationTypeID(typeID string) (AddressLocation, string, error)
 
 	// `<location>`, the second part, must be a hex string.
 
-	address, err := hex.DecodeString(parts[1])
+	rawAddress, err := hex.DecodeString(parts[1])
 	if err != nil {
 		return AddressLocation{}, "", fmt.Errorf(
 			"%s: invalid address: %w",
@@ -193,8 +193,13 @@ func decodeAddressLocationTypeID(typeID string) (AddressLocation, string, error)
 		panic(errors.NewUnreachableError())
 	}
 
+	address, err := BytesToAddress(rawAddress)
+	if err != nil {
+		return AddressLocation{}, "", err
+	}
+
 	location := AddressLocation{
-		Address: BytesToAddress(address),
+		Address: address,
 		Name:    name,
 	}
 

--- a/runtime/common/addresslocation_test.go
+++ b/runtime/common/addresslocation_test.go
@@ -31,7 +31,7 @@ func TestAddressLocation_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	loc := AddressLocation{
-		Address: BytesToAddress([]byte{1}),
+		Address: MustBytesToAddress([]byte{1}),
 		Name:    "A",
 	}
 
@@ -95,7 +95,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		assert.Equal(t,
 			AddressLocation{
-				Address: BytesToAddress([]byte{1}),
+				Address: MustBytesToAddress([]byte{1}),
 				Name:    "T",
 			},
 			location,
@@ -112,7 +112,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		assert.Equal(t,
 			AddressLocation{
-				Address: BytesToAddress([]byte{1}),
+				Address: MustBytesToAddress([]byte{1}),
 				Name:    "T",
 			},
 			location,

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -654,7 +654,7 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestLedger(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
-			return []Address{common.BytesToAddress([]byte{0x1})}, nil
+			return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
 			location := common.AddressLocation{

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -1874,7 +1874,7 @@ func getMockedRuntimeInterfaceForTxUpdate(
 		},
 		storage: newTestLedger(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
-			return []Address{common.BytesToAddress([]byte{0x42})}, nil
+			return []Address{common.MustBytesToAddress([]byte{0x42})}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
 		getAccountContractCode: func(address Address, name string) (code []byte, err error) {

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -297,7 +297,7 @@ func TestRuntimeError(t *testing.T) {
               import A from 0x1
             `,
 			common.AddressLocation{
-				Address: common.BytesToAddress([]byte{0x1}),
+				Address: common.MustBytesToAddress([]byte{0x1}),
 				Name:    "A",
 			}.ID(): `
               // import program that has errors
@@ -312,7 +312,7 @@ func TestRuntimeError(t *testing.T) {
               }
             `,
 			common.AddressLocation{
-				Address: common.BytesToAddress([]byte{0x2}),
+				Address: common.MustBytesToAddress([]byte{0x2}),
 				Name:    "B",
 			}.ID(): `
               // invalid top-level declaration

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -505,9 +505,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
 	runtime := newTestInterpreterRuntime()
 
-	contractsAddress := common.BytesToAddress([]byte{0x1})
-	senderAddress := common.BytesToAddress([]byte{0x2})
-	receiverAddress := common.BytesToAddress([]byte{0x3})
+	contractsAddress := common.MustBytesToAddress([]byte{0x1})
+	senderAddress := common.MustBytesToAddress([]byte{0x2})
+	receiverAddress := common.MustBytesToAddress([]byte{0x3})
 
 	accountCodes := map[common.LocationID][]byte{}
 

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -373,8 +373,13 @@ func decodeAddressLocation(dec *cbor.StreamDecoder) (common.Location, error) {
 		return nil, err
 	}
 
+	address, err := common.BytesToAddress(encodedAddress)
+	if err != nil {
+		return nil, err
+	}
+
 	return common.AddressLocation{
-		Address: common.BytesToAddress(encodedAddress),
+		Address: address,
 		Name:    name,
 	}, nil
 }

--- a/runtime/interpreter/encoding_benchmark_test.go
+++ b/runtime/interpreter/encoding_benchmark_test.go
@@ -149,7 +149,7 @@ package interpreter_test
 //		name += fmt.Sprintf("_%dbytes", fileSize)
 //
 //		// Decode test data to value
-//		owner := common.BytesToAddress([]byte{})
+//		owner := common.MustBytesToAddress([]byte{})
 //
 //		value, err := DecodeValue(buf.Bytes(), &owner, nil, version, nil)
 //		if err != nil {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -51,7 +51,7 @@ type encodeDecodeTest struct {
 	maxInlineElementSize uint64
 }
 
-var testOwner = common.BytesToAddress([]byte{0x42})
+var testOwner = common.MustBytesToAddress([]byte{0x42})
 
 func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 
@@ -2703,7 +2703,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: AddressValue(common.BytesToAddress([]byte{0x42})),
+				value: AddressValue(common.MustBytesToAddress([]byte{0x42})),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagAddressValue,
@@ -2721,7 +2721,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: AddressValue(common.BytesToAddress([]byte{0x0, 0x42})),
+				value: AddressValue(common.MustBytesToAddress([]byte{0x0, 0x42})),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagAddressValue,
@@ -2739,7 +2739,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: AddressValue(common.BytesToAddress([]byte{0x0, 0x42, 0x0, 0x43, 0x0})),
+				value: AddressValue(common.MustBytesToAddress([]byte{0x0, 0x42, 0x0, 0x43, 0x0})),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagAddressValue,

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -596,15 +596,20 @@ func parseHexadecimalLocation(literal string) common.AddressLocation {
 		length++
 	}
 
-	address := make([]byte, hex.DecodedLen(length))
-	_, err := hex.Decode(address, bytes)
+	rawAddress := make([]byte, hex.DecodedLen(length))
+	_, err := hex.Decode(rawAddress, bytes)
 	if err != nil {
 		// unreachable, hex literal should always be valid
 		panic(err)
 	}
 
+	address, err := common.BytesToAddress(rawAddress)
+	if err != nil {
+		panic(err)
+	}
+
 	return common.AddressLocation{
-		Address: common.BytesToAddress(address),
+		Address: address,
 	}
 }
 

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -1251,7 +1251,7 @@ func TestParseImportDeclaration(t *testing.T) {
 				&ast.ImportDeclaration{
 					Identifiers: nil,
 					Location: common.AddressLocation{
-						Address: common.BytesToAddress([]byte{0x42}),
+						Address: common.MustBytesToAddress([]byte{0x42}),
 					},
 					LocationPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 					Range: ast.Range{
@@ -1260,6 +1260,29 @@ func TestParseImportDeclaration(t *testing.T) {
 					},
 				},
 			},
+			result,
+		)
+	})
+
+	t.Run("no identifiers, address location, address too long", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations(` import 0x10000000000000001`)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "address too large",
+					Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
+				},
+			},
+			errs,
+		)
+
+		var expected []ast.Declaration
+
+		utils.AssertEqualWithDiff(t,
+			expected,
 			result,
 		)
 	})
@@ -1366,7 +1389,7 @@ func TestParseImportDeclaration(t *testing.T) {
 						},
 					},
 					Location: common.AddressLocation{
-						Address: common.BytesToAddress([]byte{0x42}),
+						Address: common.MustBytesToAddress([]byte{0x42}),
 					},
 					LocationPos: ast.Position{Line: 1, Column: 29, Offset: 29},
 					Range: ast.Range{
@@ -1449,7 +1472,7 @@ func TestParseImportDeclaration(t *testing.T) {
 						},
 					},
 					Location: common.AddressLocation{
-						Address: common.BytesToAddress([]byte{0x42}),
+						Address: common.MustBytesToAddress([]byte{0x42}),
 					},
 					LocationPos: ast.Position{Line: 2, Column: 25, Offset: 26},
 					Range: ast.Range{
@@ -1473,7 +1496,7 @@ func TestParseImportDeclaration(t *testing.T) {
 						},
 					},
 					Location: common.AddressLocation{
-						Address: common.BytesToAddress([]byte{0x42}),
+						Address: common.MustBytesToAddress([]byte{0x42}),
 					},
 					LocationPos: ast.Position{Line: 3, Column: 30, Offset: 61},
 					Range: ast.Range{
@@ -3933,7 +3956,7 @@ func TestParseImportWithAddress(t *testing.T) {
 			&ast.ImportDeclaration{
 				Identifiers: nil,
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress([]byte{0x12, 0x34}),
+					Address: common.MustBytesToAddress([]byte{0x12, 0x34}),
 				},
 				Range: ast.Range{
 					StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},
@@ -3969,7 +3992,7 @@ func TestParseImportWithIdentifiers(t *testing.T) {
 					},
 				},
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress([]byte{0x1}),
+					Address: common.MustBytesToAddress([]byte{0x1}),
 				},
 				Range: ast.Range{
 					StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},
@@ -4066,7 +4089,7 @@ func TestParseImportWithFromIdentifier(t *testing.T) {
 					},
 				},
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress([]byte{0x1}),
+					Address: common.MustBytesToAddress([]byte{0x1}),
 				},
 				Range: ast.Range{
 					StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -39,9 +39,9 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 	// Only predeclare a function 'foo' for 0x2 and 0x4.
 	// Both functions have the same name, but different types.
 
-	address2 := common.BytesToAddress([]byte{0x2})
-	address3 := common.BytesToAddress([]byte{0x3})
-	address4 := common.BytesToAddress([]byte{0x4})
+	address2 := common.MustBytesToAddress([]byte{0x2})
+	address3 := common.MustBytesToAddress([]byte{0x3})
+	address4 := common.MustBytesToAddress([]byte{0x4})
 
 	valueDeclaration1 := ValueDeclaration{
 		Name: "foo",

--- a/runtime/resourcedictionary_test.go
+++ b/runtime/resourcedictionary_test.go
@@ -575,8 +575,8 @@ func TestRuntimeResourceDictionaryValues_DictionaryTransfer(t *testing.T) {
 
 	t.Parallel()
 
-	signer1 := common.BytesToAddress([]byte{0x1})
-	signer2 := common.BytesToAddress([]byte{0x2})
+	signer1 := common.MustBytesToAddress([]byte{0x1})
+	signer2 := common.MustBytesToAddress([]byte{0x2})
 
 	runtime := newTestInterpreterRuntime()
 
@@ -787,7 +787,7 @@ func TestRuntimeResourceDictionaryValues_Removal(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	signer := common.BytesToAddress([]byte{0x1})
+	signer := common.MustBytesToAddress([]byte{0x1})
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
@@ -901,7 +901,7 @@ func TestRuntimeSResourceDictionaryValues_Destruction(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	signer := common.BytesToAddress([]byte{0x1})
+	signer := common.MustBytesToAddress([]byte{0x1})
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
@@ -1042,7 +1042,7 @@ func TestRuntimeResourceDictionaryValues_Insertion(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	signer := common.BytesToAddress([]byte{0x1})
+	signer := common.MustBytesToAddress([]byte{0x1})
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(_ Location) (bytes []byte, err error) {
@@ -1189,9 +1189,9 @@ func TestRuntimeResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	signer1 := common.BytesToAddress([]byte{0x1})
-	signer2 := common.BytesToAddress([]byte{0x2})
-	signer3 := common.BytesToAddress([]byte{0x3})
+	signer1 := common.MustBytesToAddress([]byte{0x1})
+	signer2 := common.MustBytesToAddress([]byte{0x2})
+	signer3 := common.MustBytesToAddress([]byte{0x3})
 
 	var signers []Address
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -823,7 +823,7 @@ func TestRuntimeTransactionWithAccount(t *testing.T) {
 	runtimeInterface := &testRuntimeInterface{
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{
-				common.BytesToAddress([]byte{42}),
+				common.MustBytesToAddress([]byte{42}),
 			}, nil
 		},
 		log: func(message string) {
@@ -891,7 +891,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			args: [][]byte{
 				jsoncdc.MustEncode(cadence.NewInt(42)),
 			},
-			authorizers:  []Address{common.BytesToAddress([]byte{42})},
+			authorizers:  []Address{common.MustBytesToAddress([]byte{42})},
 			expectedLogs: []string{"0x000000000000002a", "42"},
 		},
 		{
@@ -2762,7 +2762,7 @@ func TestRuntimeAccountAddress(t *testing.T) {
 
 	var loggedMessages []string
 
-	address := common.BytesToAddress([]byte{42})
+	address := common.MustBytesToAddress([]byte{42})
 
 	runtimeInterface := &testRuntimeInterface{
 		getSigningAccounts: func() ([]Address, error) {
@@ -2866,7 +2866,7 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
       }
     `)
 
-	address := common.BytesToAddress([]byte{42})
+	address := common.MustBytesToAddress([]byte{42})
 
 	script2 := []byte(
 		fmt.Sprintf(
@@ -6402,7 +6402,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 	var codeChanged bool
 
-	signerAddress := common.BytesToAddress([]byte{0x42})
+	signerAddress := common.MustBytesToAddress([]byte{0x42})
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestLedger(nil, nil),

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1040,7 +1040,7 @@ type UnresolvedImportError struct {
 }
 
 func (e *UnresolvedImportError) Error() string {
-	return "import could not be resolved"
+	return fmt.Sprintf("import could not be resolved: %s", e.ImportLocation)
 }
 
 func (*UnresolvedImportError) isSemanticError() {}

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -50,7 +50,7 @@ func withWritesToStorage(
 
 	inter := newTestInterpreter(tb)
 
-	address := common.BytesToAddress([]byte{0x1})
+	address := common.MustBytesToAddress([]byte{0x1})
 
 	for i := 0; i < count; i++ {
 
@@ -150,7 +150,7 @@ func TestRuntimeStorageWrite(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	address := common.BytesToAddress([]byte{0x1})
+	address := common.MustBytesToAddress([]byte{0x1})
 
 	tx := []byte(`
       transaction {
@@ -274,7 +274,7 @@ func TestRuntimePublicCapabilityBorrowTypeConfusion(t *testing.T) {
 	addressString, err := hex.DecodeString("aad3e26e406987c2")
 	require.NoError(t, err)
 
-	signingAddress := common.BytesToAddress(addressString)
+	signingAddress := common.MustBytesToAddress(addressString)
 
 	deployFTContractTx := utils.DeploymentTransaction("FungibleToken", []byte(realFungibleTokenContractInterface))
 
@@ -629,7 +629,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 
 	storage := newTestLedger(nil, nil)
 
-	signer := common.BytesToAddress([]byte{0x42})
+	signer := common.MustBytesToAddress([]byte{0x42})
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: storage,
@@ -948,7 +948,7 @@ func TestRuntimeTopShotBatchTransfer(t *testing.T) {
       }
     `
 
-	signerAddress = common.BytesToAddress([]byte{0x42})
+	signerAddress = common.MustBytesToAddress([]byte{0x42})
 
 	err = runtime.ExecuteTransaction(
 		Script{
@@ -1113,7 +1113,7 @@ func TestRuntimeBatchMintAndTransfer(t *testing.T) {
 
 	deployTx := utils.DeploymentTransaction("Test", []byte(contract))
 
-	contractAddress := common.BytesToAddress([]byte{0x1})
+	contractAddress := common.MustBytesToAddress([]byte{0x1})
 
 	var events []cadence.Event
 	var loggedMessages []string
@@ -1226,7 +1226,7 @@ func TestRuntimeBatchMintAndTransfer(t *testing.T) {
       }
     `
 
-	signerAddress = common.BytesToAddress([]byte{0x2})
+	signerAddress = common.MustBytesToAddress([]byte{0x2})
 
 	err = runtime.ExecuteTransaction(
 		Script{
@@ -1297,7 +1297,7 @@ func TestRuntimeStorageUnlink(t *testing.T) {
 
 	storage := newTestLedger(nil, nil)
 
-	signer := common.BytesToAddress([]byte{0x42})
+	signer := common.MustBytesToAddress([]byte{0x42})
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: storage,
@@ -1383,7 +1383,7 @@ func TestRuntimeStorageSaveCapability(t *testing.T) {
 
 	storage := newTestLedger(nil, nil)
 
-	signer := common.BytesToAddress([]byte{0x42})
+	signer := common.MustBytesToAddress([]byte{0x42})
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: storage,
@@ -1472,7 +1472,7 @@ func TestRuntimeStorageReferenceCast(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	signerAddress := common.BytesToAddress([]byte{0x42})
+	signerAddress := common.MustBytesToAddress([]byte{0x42})
 
 	deployTx := utils.DeploymentTransaction("Test", []byte(`
       pub contract Test {
@@ -1579,7 +1579,7 @@ func TestRuntimeStorageNonStorable(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	address := common.BytesToAddress([]byte{0x1})
+	address := common.MustBytesToAddress([]byte{0x1})
 
 	for name, code := range map[string]string{
 		"ephemeral reference": `
@@ -1641,7 +1641,7 @@ func TestRuntimeStorageRecursiveReference(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	address := common.BytesToAddress([]byte{0x1})
+	address := common.MustBytesToAddress([]byte{0x1})
 
 	const code = `
       transaction {
@@ -1682,8 +1682,8 @@ func TestRuntimeStorageTransfer(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	address1 := common.BytesToAddress([]byte{0x1})
-	address2 := common.BytesToAddress([]byte{0x2})
+	address1 := common.MustBytesToAddress([]byte{0x1})
+	address2 := common.MustBytesToAddress([]byte{0x2})
 
 	ledger := newTestLedger(nil, nil)
 
@@ -1765,8 +1765,8 @@ func TestRuntimeResourceOwnerChange(t *testing.T) {
 	runtime := newTestInterpreterRuntime()
 	runtime.SetResourceOwnerChangeHandlerEnabled(true)
 
-	address1 := common.BytesToAddress([]byte{0x1})
-	address2 := common.BytesToAddress([]byte{0x2})
+	address1 := common.MustBytesToAddress([]byte{0x1})
+	address2 := common.MustBytesToAddress([]byte{0x2})
 
 	ledger := newTestLedger(nil, nil)
 
@@ -2196,7 +2196,7 @@ transaction {
 
 	runtime := newTestInterpreterRuntime()
 
-	testAddress := common.BytesToAddress([]byte{0x1})
+	testAddress := common.MustBytesToAddress([]byte{0x1})
 
 	accountCodes := map[common.LocationID][]byte{}
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -2331,7 +2331,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 		var loggedMessages []string
 
 		signers := []Address{
-			common.BytesToAddress([]byte{0x1}),
+			common.MustBytesToAddress([]byte{0x1}),
 		}
 
 		runtimeInterface := &testRuntimeInterface{
@@ -2391,8 +2391,8 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 		// Run transaction
 
 		signers = []Address{
-			common.BytesToAddress([]byte{0x1}),
-			common.BytesToAddress([]byte{0x2}),
+			common.MustBytesToAddress([]byte{0x1}),
+			common.MustBytesToAddress([]byte{0x2}),
 		}
 
 		err = runtime.ExecuteTransaction(
@@ -2456,7 +2456,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
 		runtime := newTestInterpreterRuntime()
 
-		testAddress := common.BytesToAddress([]byte{0x1})
+		testAddress := common.MustBytesToAddress([]byte{0x1})
 
 		accountCodes := map[common.LocationID][]byte{}
 
@@ -2594,7 +2594,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
 		runtime := newTestInterpreterRuntime()
 
-		testAddress := common.BytesToAddress([]byte{0x1})
+		testAddress := common.MustBytesToAddress([]byte{0x1})
 
 		accountCodes := map[common.LocationID][]byte{}
 
@@ -2719,7 +2719,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
 		runtime := newTestInterpreterRuntime()
 
-		testAddress := common.BytesToAddress([]byte{0x1})
+		testAddress := common.MustBytesToAddress([]byte{0x1})
 
 		accountCodes := map[common.LocationID][]byte{}
 
@@ -2842,7 +2842,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
 		runtime := newTestInterpreterRuntime()
 
-		testAddress := common.BytesToAddress([]byte{0x1})
+		testAddress := common.MustBytesToAddress([]byte{0x1})
 
 		accountCodes := map[common.LocationID][]byte{}
 

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -2290,19 +2290,19 @@ func TestCheckAccountAccess(t *testing.T) {
 	t.Parallel()
 
 	location1A := common.AddressLocation{
-		Address: common.BytesToAddress([]byte{0x1}),
+		Address: common.MustBytesToAddress([]byte{0x1}),
 		Name:    "A",
 	}
 
 	location1B := common.AddressLocation{
 		// NOTE: same address as A
-		Address: common.BytesToAddress([]byte{0x1}),
+		Address: common.MustBytesToAddress([]byte{0x1}),
 		Name:    "B",
 	}
 
 	location2B := common.AddressLocation{
 		// NOTE: different address from A
-		Address: common.BytesToAddress([]byte{0x2}),
+		Address: common.MustBytesToAddress([]byte{0x2}),
 		Name:    "B",
 	}
 

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -85,7 +85,7 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddress := common.BytesToAddress([]byte{0x1})
+	importedAddress := common.MustBytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`
@@ -208,7 +208,7 @@ func TestCheckImportResolutionSplit(t *testing.T) {
 
 	t.Parallel()
 
-	importedAddress := common.BytesToAddress([]byte{0x1})
+	importedAddress := common.MustBytesToAddress([]byte{0x1})
 
 	importedCheckerX, err := ParseAndCheckWithOptions(t,
 		`

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -388,6 +388,21 @@ func TestCheckInvalidAddressDecimal(t *testing.T) {
 	assert.IsType(t, &sema.InvalidAddressLiteralError{}, errs[1])
 }
 
+func TestCheckInvalidTooLongAddress(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+        let a: Address = 0x10000000000000001
+        let b = Address(0x10000000000000001)
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 2)
+
+	assert.IsType(t, &sema.InvalidAddressLiteralError{}, errs[0])
+	assert.IsType(t, &sema.InvalidAddressLiteralError{}, errs[1])
+}
+
 func TestCheckSignedIntegerNegate(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/nft_test.go
+++ b/runtime/tests/checker/nft_test.go
@@ -980,7 +980,7 @@ func TestCheckTopShotContract(t *testing.T) {
 		realNonFungibleTokenContractInterface,
 		ParseAndCheckOptions{
 			Location: common.AddressLocation{
-				Address: common.BytesToAddress([]byte{0x1}),
+				Address: common.MustBytesToAddress([]byte{0x1}),
 				Name:    "NonFungibleToken",
 			},
 		},
@@ -991,7 +991,7 @@ func TestCheckTopShotContract(t *testing.T) {
 		topShotContract,
 		ParseAndCheckOptions{
 			Location: common.AddressLocation{
-				Address: common.BytesToAddress([]byte{0x2}),
+				Address: common.MustBytesToAddress([]byte{0x2}),
 				Name:    "TopShot",
 			},
 			Options: []sema.Option{

--- a/runtime/tests/checker/predeclaredvalues_test.go
+++ b/runtime/tests/checker/predeclaredvalues_test.go
@@ -73,19 +73,19 @@ func TestCheckPredeclaredValues(t *testing.T) {
 		// Both functions have the same name, but different types.
 
 		location1 := common.AddressLocation{
-			Address: common.BytesToAddress([]byte{0x1}),
+			Address: common.MustBytesToAddress([]byte{0x1}),
 		}
 
 		location2 := common.AddressLocation{
-			Address: common.BytesToAddress([]byte{0x2}),
+			Address: common.MustBytesToAddress([]byte{0x2}),
 		}
 
 		location3 := common.AddressLocation{
-			Address: common.BytesToAddress([]byte{0x3}),
+			Address: common.MustBytesToAddress([]byte{0x3}),
 		}
 
 		location4 := common.AddressLocation{
-			Address: common.BytesToAddress([]byte{0x4}),
+			Address: common.MustBytesToAddress([]byte{0x4}),
 		}
 
 		valueDeclaration1 := stdlib.StandardLibraryFunction{

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -47,7 +47,7 @@ func TestInterpretEquality(t *testing.T) {
 			Type: &sema.CapabilityType{},
 			ValueFactory: func(_ *interpreter.Interpreter) interpreter.Value {
 				return &interpreter.CapabilityValue{
-					Address: interpreter.NewAddressValue(common.BytesToAddress([]byte{0x1})),
+					Address: interpreter.NewAddressValue(common.MustBytesToAddress([]byte{0x1})),
 					Path: interpreter.PathValue{
 						Domain:     common.PathDomainStorage,
 						Identifier: "something",

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -153,7 +153,7 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 
 	t.Parallel()
 
-	address := common.BytesToAddress([]byte{0x1})
+	address := common.MustBytesToAddress([]byte{0x1})
 
 	importedCheckerA, err := checker.ParseAndCheckWithOptions(t,
 		`
@@ -319,7 +319,7 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
 
 	t.Parallel()
 
-	address := common.BytesToAddress([]byte{0x1})
+	address := common.MustBytesToAddress([]byte{0x1})
 
 	importedChecker, err := checker.ParseAndCheckWithOptions(t,
 		`

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4526,7 +4526,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 		// - `&R{RI}` (unauthorized, if argument for parameter `authorized` == false)
 		// - `auth &R{RI}` (authorized, if argument for parameter `authorized` == true)
 
-		storageAddress := common.BytesToAddress([]byte{0x42})
+		storageAddress := common.MustBytesToAddress([]byte{0x42})
 		storagePath := interpreter.PathValue{
 			Domain:     common.PathDomainStorage,
 			Identifier: "test",

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -566,7 +566,7 @@ func TestInterpretGetType(t *testing.T) {
 
 	t.Parallel()
 
-	storageAddress := common.BytesToAddress([]byte{0x42})
+	storageAddress := common.MustBytesToAddress([]byte{0x42})
 	storagePath := interpreter.PathValue{
 		Domain:     common.PathDomainStorage,
 		Identifier: "test",

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1353,7 +1353,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 		rand.Read(address)
 
 		location := common.AddressLocation{
-			Address: common.BytesToAddress(address),
+			Address: common.MustBytesToAddress(address),
 			Name:    identifier,
 		}
 
@@ -1476,7 +1476,7 @@ func randomCompositeValue(
 	rand.Read(address)
 
 	location := common.AddressLocation{
-		Address: common.BytesToAddress(address),
+		Address: common.MustBytesToAddress(address),
 		Name:    identifier,
 	}
 

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -57,7 +57,7 @@ func TestRuntimeTypeStorage(t *testing.T) {
 		storage: newTestLedger(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{
-				common.BytesToAddress([]byte{42}),
+				common.MustBytesToAddress([]byte{42}),
 			}, nil
 		},
 		log: func(message string) {


### PR DESCRIPTION
Closes dapperlabs/cadence-private-issues#15

## Description

Instead of silently truncating addresses, always report an error when addresses are too large.

This already was the case for address literals and in address conversion, but e.g. not address locations (i.e. in import declarations).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
