### PR TITLE
[v0.20] Fix type requirement checking

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1225,6 +1225,7 @@ func (checker *Checker) checkTypeRequirement(
 	// Find the composite declaration of the composite type
 
 	var compositeDeclaration *ast.CompositeDeclaration
+	var foundRedeclaration bool
 
 	for _, nestedCompositeDeclaration := range containerDeclaration.Members.Composites() {
 		nestedCompositeIdentifier := nestedCompositeDeclaration.Identifier.Identifier
@@ -1232,19 +1233,23 @@ func (checker *Checker) checkTypeRequirement(
 			// If we detected a second nested composite declaration with the same identifier,
 			// report an error and stop further type requirement checking
 			if compositeDeclaration != nil {
+				foundRedeclaration = true
 				checker.report(&RedeclarationError{
 					Kind:        nestedCompositeDeclaration.DeclarationKind(),
 					Name:        nestedCompositeDeclaration.Identifier.Identifier,
 					Pos:         nestedCompositeDeclaration.Identifier.Pos,
 					PreviousPos: &compositeDeclaration.Identifier.Pos,
 				})
-				return
 			}
 			compositeDeclaration = nestedCompositeDeclaration
 			// NOTE: Do not break / stop iteration, but keep looking for
 			// another (invalid) nested composite declaration with the same identifier,
 			// as the first found declaration is not necessarily the correct one
 		}
+	}
+
+	if foundRedeclaration {
+		return
 	}
 
 	if compositeDeclaration == nil {

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1229,8 +1229,21 @@ func (checker *Checker) checkTypeRequirement(
 	for _, nestedCompositeDeclaration := range containerDeclaration.Members.Composites() {
 		nestedCompositeIdentifier := nestedCompositeDeclaration.Identifier.Identifier
 		if nestedCompositeIdentifier == declaredCompositeType.Identifier {
+			// If we detected a second nested composite declaration with the same identifier,
+			// report an error and stop further type requirement checking
+			if compositeDeclaration != nil {
+				checker.report(&RedeclarationError{
+					Kind:        nestedCompositeDeclaration.DeclarationKind(),
+					Name:        nestedCompositeDeclaration.Identifier.Identifier,
+					Pos:         nestedCompositeDeclaration.Identifier.Pos,
+					PreviousPos: &compositeDeclaration.Identifier.Pos,
+				})
+				return
+			}
 			compositeDeclaration = nestedCompositeDeclaration
-			break
+			// NOTE: Do not break / stop iteration, but keep looking for
+			// another (invalid) nested composite declaration with the same identifier,
+			// as the first found declaration is not necessarily the correct one
 		}
 	}
 

--- a/runtime/tests/checker/conformance_test.go
+++ b/runtime/tests/checker/conformance_test.go
@@ -444,5 +444,19 @@ func TestCheckTypeRequirementDuplicateDeclaration(t *testing.T) {
 	  }
 	`)
 
-	require.Error(t, err)
+	errs := ExpectCheckerErrors(t, err, 13)
+
+	require.IsType(t, &sema.InvalidNestedDeclarationError{}, errs[0])
+	require.IsType(t, &sema.InvalidNestedDeclarationError{}, errs[1])
+	require.IsType(t, &sema.InvalidNestedDeclarationError{}, errs[2])
+	require.IsType(t, &sema.InvalidNestedDeclarationError{}, errs[3])
+	require.IsType(t, &sema.RedeclarationError{}, errs[4])
+	require.IsType(t, &sema.InvalidNestedDeclarationError{}, errs[5])
+	require.IsType(t, &sema.InvalidNestedDeclarationError{}, errs[6])
+	require.IsType(t, &sema.RedeclarationError{}, errs[7])
+	require.IsType(t, &sema.RedeclarationError{}, errs[8])
+	require.IsType(t, &sema.RedeclarationError{}, errs[9])
+	require.IsType(t, &sema.ConformanceError{}, errs[10])
+	require.IsType(t, &sema.ConformanceError{}, errs[11])
+	require.IsType(t, &sema.ConformanceError{}, errs[12])
 }


### PR DESCRIPTION
## Description

Port of dapperlabs/cadence-internal#42 to v0.20 branch

#1338 was accidentally against the `master` branch

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
