### PR TITLE
Gracefully handle cadence crashes/panics

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -209,6 +209,19 @@ func NewInterpreterRuntime(options ...Option) Runtime {
 	return runtime
 }
 
+func (r *interpreterRuntime) Recover(onError func(error), context Context) {
+	var err error
+	switch recovered := recover().(type) {
+	case Error:
+		// avoid redundant wrapping
+		err = recovered
+	case error:
+		err = newError(recovered, context)
+	}
+
+	onError(err)
+}
+
 func (r *interpreterRuntime) SetCoverageReport(coverageReport *CoverageReport) {
 	r.coverageReport = coverageReport
 }
@@ -230,11 +243,12 @@ func (r *interpreterRuntime) SetResourceOwnerChangeHandlerEnabled(enabled bool) 
 }
 
 func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (val cadence.Value, err error) {
-	defer func() {
-		if recovered, ok := recover().(error); ok {
-			err = newError(recovered, context)
-		}
-	}()
+	defer r.Recover(
+		func(internalErr error) {
+			err = internalErr
+		},
+		context,
+	)
 
 	context.InitializeCodesAndPrograms()
 
@@ -473,11 +487,12 @@ func (r *interpreterRuntime) InvokeContractFunction(
 	argumentTypes []sema.Type,
 	context Context,
 ) (val cadence.Value, err error) {
-	defer func() {
-		if recovered, ok := recover().(error); ok {
-			err = newError(recovered, context)
-		}
-	}()
+	defer r.Recover(
+		func(internalErr error) {
+			err = internalErr
+		},
+		context,
+	)
 
 	context.InitializeCodesAndPrograms()
 
@@ -606,11 +621,12 @@ func (r *interpreterRuntime) convertArgument(
 }
 
 func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) (err error) {
-	defer func() {
-		if recovered, ok := recover().(error); ok {
-			err = newError(recovered, context)
-		}
-	}()
+	defer r.Recover(
+		func(internalErr error) {
+			err = internalErr
+		},
+		context,
+	)
 
 	context.InitializeCodesAndPrograms()
 
@@ -907,11 +923,12 @@ func (r *interpreterRuntime) ParseAndCheckProgram(
 	program *interpreter.Program,
 	err error,
 ) {
-	defer func() {
-		if recovered, ok := recover().(error); ok {
-			err = newError(recovered, context)
-		}
-	}()
+	defer r.Recover(
+		func(internalErr error) {
+			err = internalErr
+		},
+		context,
+	)
 
 	context.InitializeCodesAndPrograms()
 
@@ -2906,11 +2923,12 @@ func (r *interpreterRuntime) ReadStored(
 	val cadence.Value,
 	err error,
 ) {
-	defer func() {
-		if recovered, ok := recover().(error); ok {
-			err = newError(recovered, context)
-		}
-	}()
+	defer r.Recover(
+		func(internalErr error) {
+			err = internalErr
+		},
+		context,
+	)
 
 	return r.executeNonProgram(
 		func(inter *interpreter.Interpreter) (interpreter.Value, error) {
@@ -2935,11 +2953,12 @@ func (r *interpreterRuntime) ReadLinked(
 	val cadence.Value,
 	err error,
 ) {
-	defer func() {
-		if recovered, ok := recover().(error); ok {
-			err = newError(recovered, context)
-		}
-	}()
+	defer r.Recover(
+		func(internalErr error) {
+			err = internalErr
+		},
+		context,
+	)
 
 	return r.executeNonProgram(
 		func(inter *interpreter.Interpreter) (interpreter.Value, error) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -210,8 +210,13 @@ func NewInterpreterRuntime(options ...Option) Runtime {
 }
 
 func (r *interpreterRuntime) Recover(onError func(error), context Context) {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+
 	var err error
-	switch recovered := recover().(type) {
+	switch recovered := recovered.(type) {
 	case Error:
 		// avoid redundant wrapping
 		err = recovered

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2898,7 +2898,20 @@ func (r *interpreterRuntime) executeNonProgram(interpret interpretFunc, context 
 	return exportValue(value)
 }
 
-func (r *interpreterRuntime) ReadStored(address common.Address, path cadence.Path, context Context) (cadence.Value, error) {
+func (r *interpreterRuntime) ReadStored(
+	address common.Address,
+	path cadence.Path,
+	context Context,
+) (
+	val cadence.Value,
+	err error,
+) {
+	defer func() {
+		if recovered, ok := recover().(error); ok {
+			err = newError(recovered, context)
+		}
+	}()
+
 	return r.executeNonProgram(
 		func(inter *interpreter.Interpreter) (interpreter.Value, error) {
 			pathValue := importPathValue(path)
@@ -2914,7 +2927,20 @@ func (r *interpreterRuntime) ReadStored(address common.Address, path cadence.Pat
 	)
 }
 
-func (r *interpreterRuntime) ReadLinked(address common.Address, path cadence.Path, context Context) (cadence.Value, error) {
+func (r *interpreterRuntime) ReadLinked(
+	address common.Address,
+	path cadence.Path,
+	context Context,
+) (
+	val cadence.Value,
+	err error,
+) {
+	defer func() {
+		if recovered, ok := recover().(error); ok {
+			err = newError(recovered, context)
+		}
+	}()
+
 	return r.executeNonProgram(
 		func(inter *interpreter.Interpreter) (interpreter.Value, error) {
 			targetPath, _, err := inter.GetCapabilityFinalTargetPath(

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -472,7 +472,13 @@ func (r *interpreterRuntime) InvokeContractFunction(
 	arguments []interpreter.Value,
 	argumentTypes []sema.Type,
 	context Context,
-) (cadence.Value, error) {
+) (val cadence.Value, err error) {
+	defer func() {
+		if recovered, ok := recover().(error); ok {
+			err = newError(recovered, context)
+		}
+	}()
+
 	context.InitializeCodesAndPrograms()
 
 	storage := NewStorage(context.Interface)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -229,7 +229,13 @@ func (r *interpreterRuntime) SetResourceOwnerChangeHandlerEnabled(enabled bool) 
 	r.resourceOwnerChangeHandlerEnabled = enabled
 }
 
-func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (cadence.Value, error) {
+func (r *interpreterRuntime) ExecuteScript(script Script, context Context) (val cadence.Value, err error) {
+	defer func() {
+		if recovered, ok := recover().(error); ok {
+			err = newError(recovered, context)
+		}
+	}()
+
 	context.InitializeCodesAndPrograms()
 
 	storage := NewStorage(context.Interface)
@@ -593,7 +599,13 @@ func (r *interpreterRuntime) convertArgument(
 	return argument
 }
 
-func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) error {
+func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) (err error) {
+	defer func() {
+		if recovered, ok := recover().(error); ok {
+			err = newError(recovered, context)
+		}
+	}()
+
 	context.InitializeCodesAndPrograms()
 
 	storage := NewStorage(context.Interface)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -900,7 +900,19 @@ func hasValidStaticType(value interpreter.Value) bool {
 // ParseAndCheckProgram parses the given code and checks it.
 // Returns a program that can be interpreted (AST + elaboration).
 //
-func (r *interpreterRuntime) ParseAndCheckProgram(code []byte, context Context) (*interpreter.Program, error) {
+func (r *interpreterRuntime) ParseAndCheckProgram(
+	code []byte,
+	context Context,
+) (
+	program *interpreter.Program,
+	err error,
+) {
+	defer func() {
+		if recovered, ok := recover().(error); ok {
+			err = newError(recovered, context)
+		}
+	}()
+
 	context.InitializeCodesAndPrograms()
 
 	storage := NewStorage(context.Interface)
@@ -915,7 +927,7 @@ func (r *interpreterRuntime) ParseAndCheckProgram(code []byte, context Context) 
 		checkerOptions,
 	)
 
-	program, err := r.parseAndCheckProgram(
+	program, err = r.parseAndCheckProgram(
 		code,
 		context,
 		functions,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6946,6 +6946,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		)
 
+		require.Error(t, err)
 		require.ErrorAs(t, err, &Error{})
 	})
 
@@ -6978,6 +6979,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		)
 
+		require.Error(t, err)
 		require.ErrorAs(t, err, &Error{})
 	})
 
@@ -7014,13 +7016,13 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		)
 
+		require.Error(t, err)
 		require.ErrorAs(t, err, &Error{})
 	})
 
 	t.Run("contract function", func(t *testing.T) {
-		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		t.Parallel()
 
 		addressValue := Address{
 			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -7052,7 +7054,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 				return nil
 			},
 			emitEvent: func(_ cadence.Event) error {
-				return nil;
+				return nil
 			},
 			log: func(message string) {
 				// panic due to Cadence implementation error
@@ -7091,6 +7093,32 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		)
 
+		require.Error(t, err)
+		require.ErrorAs(t, err, &Error{})
+	})
+
+	t.Run("parse and check", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := []byte("pub fun test() {}")
+		runtimeInterface := &testRuntimeInterface{
+			setProgram: func(location Location, program *interpreter.Program) error {
+				panic(errors.New("crash while setting program"))
+			},
+		}
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		_, err := runtime.ParseAndCheckProgram(
+			script,
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.Error(t, err)
 		require.ErrorAs(t, err, &Error{})
 	})
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7127,7 +7127,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		t.Parallel()
 
 		runtimeInterface := &testRuntimeInterface{
-			storage:testLedger{
+			storage: testLedger{
 				getValue: func(owner, key []byte) (value []byte, err error) {
 					panic(errors.New("crasher"))
 				},
@@ -7154,7 +7154,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		t.Parallel()
 
 		runtimeInterface := &testRuntimeInterface{
-			storage:testLedger{
+			storage: testLedger{
 				getValue: func(owner, key []byte) (value []byte, err error) {
 					panic(errors.New("crasher"))
 				},

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7121,4 +7121,58 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorAs(t, err, &Error{})
 	})
+
+	t.Run("read stored", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtimeInterface := &testRuntimeInterface{
+			storage:testLedger{
+				getValue: func(owner, key []byte) (value []byte, err error) {
+					panic(errors.New("crasher"))
+				},
+			},
+		}
+
+		_, err := runtime.ReadStored(
+			common.BytesToAddress([]byte{0x42}),
+			cadence.Path{
+				Domain:     "storage",
+				Identifier: "test",
+			},
+			Context{
+				Interface: runtimeInterface,
+			},
+		)
+
+		require.Error(t, err)
+		require.ErrorAs(t, err, &Error{})
+	})
+
+	t.Run("read linked", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtimeInterface := &testRuntimeInterface{
+			storage:testLedger{
+				getValue: func(owner, key []byte) (value []byte, err error) {
+					panic(errors.New("crasher"))
+				},
+			},
+		}
+
+		_, err := runtime.ReadLinked(
+			common.BytesToAddress([]byte{0x42}),
+			cadence.Path{
+				Domain:     "storage",
+				Identifier: "test",
+			},
+			Context{
+				Interface: runtimeInterface,
+			},
+		)
+
+		require.Error(t, err)
+		require.ErrorAs(t, err, &Error{})
+	})
 }


### PR DESCRIPTION
Work towards :
- https://github.com/dapperlabs/cadence-private-issues/issues/4
- https://github.com/dapperlabs/cadence-private-issues/issues/9

## Description

This PR gracefully handles all the non-fatal panics in Cadence implementation, including Go runtime errors.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
