### PR TITLE
Export `StringAtreeValue` from the interpreter

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -100,7 +100,7 @@ func (d Decoder) decodeStorable() (atree.Storable, error) {
 		if err != nil {
 			return nil, err
 		}
-		storable = stringAtreeValue(v)
+		storable = StringAtreeValue(v)
 
 	case cbor.TagType:
 		var num uint64

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -264,7 +264,7 @@ func (v *StringValue) Encode(e *atree.Encoder) error {
 
 // Encode encodes the value as a CBOR string
 //
-func (v stringAtreeValue) Encode(e *atree.Encoder) error {
+func (v StringAtreeValue) Encode(e *atree.Encoder) error {
 	return e.CBOR.EncodeString(string(v))
 }
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4299,8 +4299,8 @@ func (interpreter *Interpreter) ValidateAtreeValue(v atree.Value) {
 	defaultHIP := newHashInputProvider(interpreter, ReturnEmptyLocationRange)
 
 	hip := func(value atree.Value, buffer []byte) ([]byte, error) {
-		if _, ok := value.(stringAtreeValue); ok {
-			return stringAtreeHashInput(value, buffer)
+		if _, ok := value.(StringAtreeValue); ok {
+			return StringAtreeHashInput(value, buffer)
 		}
 
 		return defaultHIP(value, buffer)
@@ -4312,8 +4312,8 @@ func (interpreter *Interpreter) ValidateAtreeValue(v atree.Value) {
 			panic(err)
 		}
 
-		if _, ok := value.(stringAtreeValue); ok {
-			equal, err := stringAtreeComparator(interpreter.Storage, value, otherStorable)
+		if _, ok := value.(StringAtreeValue); ok {
+			equal, err := StringAtreeComparator(interpreter.Storage, value, otherStorable)
 			if err != nil {
 				panic(err)
 			}

--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -63,9 +63,9 @@ func NewStorageMapWithRootID(storage atree.SlabStorage, storageID atree.StorageI
 //
 func (s StorageMap) ValueExists(key string) bool {
 	_, err := s.orderedMap.Get(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(key),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(key),
 	)
 	if err != nil {
 		if _, ok := err.(*atree.KeyNotFoundError); ok {
@@ -82,9 +82,9 @@ func (s StorageMap) ValueExists(key string) bool {
 //
 func (s StorageMap) ReadValue(key string) Value {
 	storable, err := s.orderedMap.Get(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(key),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(key),
 	)
 	if err != nil {
 		if _, ok := err.(*atree.KeyNotFoundError); ok {
@@ -113,9 +113,9 @@ func (s StorageMap) WriteValue(interpreter *Interpreter, key string, value Value
 //
 func (s StorageMap) setValue(interpreter *Interpreter, key string, value Value) {
 	existingStorable, err := s.orderedMap.Set(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(key),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(key),
 		value,
 	)
 	if err != nil {
@@ -134,9 +134,9 @@ func (s StorageMap) setValue(interpreter *Interpreter, key string, value Value) 
 //
 func (s StorageMap) removeValue(interpreter *Interpreter, key string) {
 	existingKeyStorable, existingValueStorable, err := s.orderedMap.Remove(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(key),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(key),
 	)
 	if err != nil {
 		if _, ok := err.(*atree.KeyNotFoundError); ok {
@@ -200,7 +200,7 @@ func (i StorageMapIterator) Next() (string, Value) {
 		return "", nil
 	}
 
-	key := string(k.(stringAtreeValue))
+	key := string(k.(StringAtreeValue))
 	value := MustConvertStoredValue(v)
 
 	return key, value
@@ -219,7 +219,7 @@ func (i StorageMapIterator) NextKey() string {
 		return ""
 	}
 
-	return string(k.(stringAtreeValue))
+	return string(k.(StringAtreeValue))
 }
 
 // NextValue returns the next value in the storage map iterator.

--- a/runtime/interpreter/stringatreevalue.go
+++ b/runtime/interpreter/stringatreevalue.go
@@ -22,12 +22,12 @@ import (
 	"github.com/onflow/atree"
 )
 
-type stringAtreeValue string
+type StringAtreeValue string
 
-var _ atree.Value = stringAtreeValue("")
-var _ atree.Storable = stringAtreeValue("")
+var _ atree.Value = StringAtreeValue("")
+var _ atree.Storable = StringAtreeValue("")
 
-func (v stringAtreeValue) Storable(
+func (v StringAtreeValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
 	maxInlineSize uint64,
@@ -38,29 +38,29 @@ func (v stringAtreeValue) Storable(
 	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
-func (v stringAtreeValue) ByteSize() uint32 {
+func (v StringAtreeValue) ByteSize() uint32 {
 	return getBytesCBORSize([]byte(v))
 }
 
-func (v stringAtreeValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
+func (v StringAtreeValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
-func (stringAtreeValue) ChildStorables() []atree.Storable {
+func (StringAtreeValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func stringAtreeHashInput(v atree.Value, _ []byte) ([]byte, error) {
-	return []byte(v.(stringAtreeValue)), nil
+func StringAtreeHashInput(v atree.Value, _ []byte) ([]byte, error) {
+	return []byte(v.(StringAtreeValue)), nil
 }
 
-func stringAtreeComparator(storage atree.SlabStorage, value atree.Value, otherStorable atree.Storable) (bool, error) {
+func StringAtreeComparator(storage atree.SlabStorage, value atree.Value, otherStorable atree.Storable) (bool, error) {
 	otherValue, err := otherStorable.StoredValue(storage)
 	if err != nil {
 		return false, err
 	}
 
-	result := value.(stringAtreeValue) == otherValue.(stringAtreeValue)
+	result := value.(StringAtreeValue) == otherValue.(StringAtreeValue)
 
 	return result, nil
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -11427,9 +11427,9 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	}
 
 	storable, err := v.dictionary.Get(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(name),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(name),
 	)
 	if err != nil {
 		if _, ok := err.(*atree.KeyNotFoundError); !ok {
@@ -11533,9 +11533,9 @@ func (v *CompositeValue) RemoveMember(
 	// No need to clean up storable for passed-in key value,
 	// as atree never calls Storable()
 	existingKeyStorable, existingValueStorable, err := v.dictionary.Remove(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(name),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(name),
 	)
 	if err != nil {
 		if _, ok := err.(*atree.KeyNotFoundError); ok {
@@ -11580,9 +11580,9 @@ func (v *CompositeValue) SetMember(
 	)
 
 	existingStorable, err := v.dictionary.Set(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(name),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(name),
 		value,
 	)
 	if err != nil {
@@ -11652,9 +11652,9 @@ func formatComposite(typeId string, fields []CompositeField, seenReferences Seen
 func (v *CompositeValue) GetField(name string) Value {
 
 	storable, err := v.dictionary.Get(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(name),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(name),
 	)
 	if err != nil {
 		if _, ok := err.(*atree.KeyNotFoundError); ok {
@@ -11693,7 +11693,7 @@ func (v *CompositeValue) Equal(interpreter *Interpreter, getLocationRange func()
 			return true
 		}
 
-		fieldName := string(key.(stringAtreeValue))
+		fieldName := string(key.(StringAtreeValue))
 
 		// NOTE: Do NOT use an iterator, iteration order of fields may be different
 		// (if stored in different account, as storage ID is used as hash seed)
@@ -11883,8 +11883,8 @@ func (v *CompositeValue) Transfer(
 			address,
 			atree.NewDefaultDigesterBuilder(),
 			v.dictionary.Type(),
-			stringAtreeComparator,
-			stringAtreeHashInput,
+			StringAtreeComparator,
+			StringAtreeHashInput,
 			v.dictionary.Seed(),
 			func() (atree.Value, atree.Value, error) {
 
@@ -12001,8 +12001,8 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 		v.StorageID().Address,
 		atree.NewDefaultDigesterBuilder(),
 		v.dictionary.Type(),
-		stringAtreeComparator,
-		stringAtreeHashInput,
+		StringAtreeComparator,
+		StringAtreeHashInput,
 		v.dictionary.Seed(),
 		func() (atree.Value, atree.Value, error) {
 
@@ -12073,7 +12073,7 @@ func (v *CompositeValue) GetOwner() common.Address {
 func (v *CompositeValue) ForEachField(f func(fieldName string, fieldValue Value)) {
 	err := v.dictionary.Iterate(func(key atree.Value, value atree.Value) (resume bool, err error) {
 		f(
-			string(key.(stringAtreeValue)),
+			string(key.(StringAtreeValue)),
 			MustConvertStoredValue(value),
 		)
 		return true, nil
@@ -12094,9 +12094,9 @@ func (v *CompositeValue) RemoveField(
 ) {
 
 	existingKeyStorable, existingValueStorable, err := v.dictionary.Remove(
-		stringAtreeComparator,
-		stringAtreeHashInput,
-		stringAtreeValue(name),
+		StringAtreeComparator,
+		StringAtreeHashInput,
+		StringAtreeValue(name),
 	)
 	if err != nil {
 		if _, ok := err.(*atree.KeyNotFoundError); ok {


### PR DESCRIPTION
In order to write a migration for storage to the new ordered map format, this type needs to be accessible outside of the interpreter package. 
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
