### PR TITLE
Backport #1327 to `v0.21` branch

### DIFF
--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -27,7 +27,8 @@ pub enum HashAlgorithm: UInt8 {
     /// used in BLS signatures.
     pub case KMAC128_BLS_BLS12_381 = 5
 
-    /// KECCAK_256 is ethereum-compatible Keccak-256 hash
+    /// KECCAK_256 is the legacy Keccak algorithm with a 256-bits digest, as per the original submission to the NIST SHA3 competition.
+    /// KECCAK_256 is different than SHA3 and is used by Ethereum.  
     pub case KECCAK_256 = 6
 
     /// Returns the hash of the given data

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -27,8 +27,8 @@ pub enum HashAlgorithm: UInt8 {
     /// used in BLS signatures.
     pub case KMAC128_BLS_BLS12_381 = 5
 
-    /// Keccak256 is ethereum-compatible Keccak-256 hash
-    pub case Keccak256 = 6
+    /// KECCAK_256 is ethereum-compatible Keccak-256 hash
+    pub case KECCAK_256 = 6
 
     /// Returns the hash of the given data
     pub fun hash(_ data: [UInt8]): [UInt8]

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -27,6 +27,9 @@ pub enum HashAlgorithm: UInt8 {
     /// used in BLS signatures.
     pub case KMAC128_BLS_BLS12_381 = 5
 
+    /// Keccak256 is ethereum-compatible Keccak-256 hash
+    pub case Keccak256 = 6
+
     /// Returns the hash of the given data
     pub fun hash(_ data: [UInt8]): [UInt8]
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -941,17 +941,17 @@ func TestExportResourceDictionaryValue(t *testing.T) {
 	actual := exportValueFromScript(t, script)
 	expected := cadence.NewDictionary([]cadence.KeyValuePair{
 		{
-			Key: cadence.String("a"),
-			Value: cadence.NewResource([]cadence.Value{
-				cadence.NewUInt64(0),
-				cadence.NewInt(1),
-			}).WithType(fooResourceType),
-		},
-		{
 			Key: cadence.String("b"),
 			Value: cadence.NewResource([]cadence.Value{
 				cadence.NewUInt64(0),
 				cadence.NewInt(2),
+			}).WithType(fooResourceType),
+		},
+		{
+			Key: cadence.String("a"),
+			Value: cadence.NewResource([]cadence.Value{
+				cadence.NewUInt64(0),
+				cadence.NewInt(1),
 			}).WithType(fooResourceType),
 		},
 	})
@@ -1516,7 +1516,7 @@ func TestExportJsonDeterministic(t *testing.T) {
 	bytes, err := json.Encode(event)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "{\"type\":\"Event\",\"value\":{\"id\":\"S.test.Foo\",\"fields\":[{\"name\":\"bar\",\"value\":{\"type\":\"Int\",\"value\":\"2\"}},{\"name\":\"aaa\",\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"2\"},\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"String\",\"value\":\"c\"}},{\"key\":{\"type\":\"Int\",\"value\":\"7\"},\"value\":{\"type\":\"String\",\"value\":\"d\"}},{\"key\":{\"type\":\"Int\",\"value\":\"3\"},\"value\":{\"type\":\"String\",\"value\":\"b\"}}]}},{\"key\":{\"type\":\"Int\",\"value\":\"0\"},\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"0\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}},{\"key\":{\"type\":\"Int\",\"value\":\"2\"},\"value\":{\"type\":\"String\",\"value\":\"c\"}},{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}},{\"key\":{\"type\":\"Int\",\"value\":\"3\"},\"value\":{\"type\":\"String\",\"value\":\"c\"}}]}},{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"String\",\"value\":\"\"}},{\"key\":{\"type\":\"Int\",\"value\":\"2\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}},{\"key\":{\"type\":\"Int\",\"value\":\"3\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}},{\"key\":{\"type\":\"Int\",\"value\":\"7\"},\"value\":{\"type\":\"String\",\"value\":\"b\"}}]}}]}}]}}\n", string(bytes))
+	assert.Equal(t, "{\"type\":\"Event\",\"value\":{\"id\":\"S.test.Foo\",\"fields\":[{\"name\":\"bar\",\"value\":{\"type\":\"Int\",\"value\":\"2\"}},{\"name\":\"aaa\",\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"3\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}},{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"String\",\"value\":\"\"}},{\"key\":{\"type\":\"Int\",\"value\":\"7\"},\"value\":{\"type\":\"String\",\"value\":\"b\"}},{\"key\":{\"type\":\"Int\",\"value\":\"2\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}}]}},{\"key\":{\"type\":\"Int\",\"value\":\"2\"},\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"3\"},\"value\":{\"type\":\"String\",\"value\":\"b\"}},{\"key\":{\"type\":\"Int\",\"value\":\"7\"},\"value\":{\"type\":\"String\",\"value\":\"d\"}},{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"String\",\"value\":\"c\"}}]}},{\"key\":{\"type\":\"Int\",\"value\":\"0\"},\"value\":{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"Int\",\"value\":\"2\"},\"value\":{\"type\":\"String\",\"value\":\"c\"}},{\"key\":{\"type\":\"Int\",\"value\":\"3\"},\"value\":{\"type\":\"String\",\"value\":\"c\"}},{\"key\":{\"type\":\"Int\",\"value\":\"0\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}},{\"key\":{\"type\":\"Int\",\"value\":\"1\"},\"value\":{\"type\":\"String\",\"value\":\"a\"}}]}}]}}]}}\n", string(bytes))
 }
 
 var fooFields = []cadence.Field{

--- a/runtime/resourcedictionary_test.go
+++ b/runtime/resourcedictionary_test.go
@@ -967,9 +967,9 @@ func TestRuntimeSResourceDictionaryValues_Destruction(t *testing.T) {
 	assert.Equal(t,
 		[]string{
 			`"destroying R"`,
-			"2",
-			`"destroying R"`,
 			"1",
+			`"destroying R"`,
+			"2",
 		},
 		loggedMessages,
 	)

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -201,7 +201,7 @@ func (algo HashAlgorithm) Name() string {
 	case HashAlgorithmKMAC128_BLS_BLS12_381:
 		return "KMAC128_BLS_BLS12_381"
 	case HashAlgorithmKeccak256:
-		return "HashAlgorithmKeccak256"
+		return "Keccak256"
 	}
 
 	panic(errors.NewUnreachableError())

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -331,5 +331,6 @@ This is a customized version of KMAC128 that is compatible with the hashing to c
 used in BLS signatures.
 `
 const HashAlgorithmDocStringKECCAK_256 = `
-This is a specific function for calculating the Keccak256 hash of arbitrary data.
+KECCAK_256 is the legacy Keccak algorithm with a 256-bits digest, as per the original submission to the NIST SHA3 competition.
+KECCAK_256 is different than SHA3 and is used by Ethereum.
 `

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -38,6 +38,7 @@ var HashAlgorithms = []CryptoAlgorithm{
 	HashAlgorithmSHA3_256,
 	HashAlgorithmSHA3_384,
 	HashAlgorithmKMAC128_BLS_BLS12_381,
+	HashAlgorithmKeccak256,
 }
 
 var SignatureAlgorithmType = newNativeEnumType(
@@ -182,6 +183,7 @@ const (
 	HashAlgorithmSHA3_256
 	HashAlgorithmSHA3_384
 	HashAlgorithmKMAC128_BLS_BLS12_381
+	HashAlgorithmKeccak256
 )
 
 func (algo HashAlgorithm) Name() string {
@@ -198,6 +200,8 @@ func (algo HashAlgorithm) Name() string {
 		return "SHA3_384"
 	case HashAlgorithmKMAC128_BLS_BLS12_381:
 		return "KMAC128_BLS_BLS12_381"
+	case HashAlgorithmKeccak256:
+		return "HashAlgorithmKeccak256"
 	}
 
 	panic(errors.NewUnreachableError())
@@ -222,6 +226,8 @@ func (algo HashAlgorithm) RawValue() uint8 {
 		return 4
 	case HashAlgorithmKMAC128_BLS_BLS12_381:
 		return 5
+	case HashAlgorithmKeccak256:
+		return 6
 	}
 
 	panic(errors.NewUnreachableError())
@@ -241,6 +247,8 @@ func (algo HashAlgorithm) DocString() string {
 		return HashAlgorithmDocStringSHA3_384
 	case HashAlgorithmKMAC128_BLS_BLS12_381:
 		return HashAlgorithmDocStringKMAC128_BLS_BLS12_381
+	case HashAlgorithmKeccak256:
+		return Keccak256FunctionDocString
 	}
 
 	panic(errors.NewUnreachableError())
@@ -321,4 +329,7 @@ KMAC128_BLS_BLS12_381 is an instance of KECCAK Message Authentication Code (KMAC
 that can be used as the hashing algorithm for BLS signature scheme on the curve BLS12-381.
 This is a customized version of KMAC128 that is compatible with the hashing to curve 
 used in BLS signatures.
+`
+const Keccak256FunctionDocString = `
+This is a specific function for calculating the Keccak256 hash of arbitrary data.
 `

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -38,7 +38,7 @@ var HashAlgorithms = []CryptoAlgorithm{
 	HashAlgorithmSHA3_256,
 	HashAlgorithmSHA3_384,
 	HashAlgorithmKMAC128_BLS_BLS12_381,
-	HashAlgorithmKeccak256,
+	HashAlgorithmKECCAK_256,
 }
 
 var SignatureAlgorithmType = newNativeEnumType(
@@ -183,7 +183,7 @@ const (
 	HashAlgorithmSHA3_256
 	HashAlgorithmSHA3_384
 	HashAlgorithmKMAC128_BLS_BLS12_381
-	HashAlgorithmKeccak256
+	HashAlgorithmKECCAK_256
 )
 
 func (algo HashAlgorithm) Name() string {
@@ -200,8 +200,8 @@ func (algo HashAlgorithm) Name() string {
 		return "SHA3_384"
 	case HashAlgorithmKMAC128_BLS_BLS12_381:
 		return "KMAC128_BLS_BLS12_381"
-	case HashAlgorithmKeccak256:
-		return "Keccak256"
+	case HashAlgorithmKECCAK_256:
+		return "KECCAK_256"
 	}
 
 	panic(errors.NewUnreachableError())
@@ -226,7 +226,7 @@ func (algo HashAlgorithm) RawValue() uint8 {
 		return 4
 	case HashAlgorithmKMAC128_BLS_BLS12_381:
 		return 5
-	case HashAlgorithmKeccak256:
+	case HashAlgorithmKECCAK_256:
 		return 6
 	}
 
@@ -247,8 +247,8 @@ func (algo HashAlgorithm) DocString() string {
 		return HashAlgorithmDocStringSHA3_384
 	case HashAlgorithmKMAC128_BLS_BLS12_381:
 		return HashAlgorithmDocStringKMAC128_BLS_BLS12_381
-	case HashAlgorithmKeccak256:
-		return Keccak256FunctionDocString
+	case HashAlgorithmKECCAK_256:
+		return HashAlgorithmDocStringKECCAK_256
 	}
 
 	panic(errors.NewUnreachableError())
@@ -330,6 +330,6 @@ that can be used as the hashing algorithm for BLS signature scheme on the curve 
 This is a customized version of KMAC128 that is compatible with the hashing to curve 
 used in BLS signatures.
 `
-const Keccak256FunctionDocString = `
+const HashAlgorithmDocStringKECCAK_256 = `
 This is a specific function for calculating the Keccak256 hash of arbitrary data.
 `

--- a/runtime/sema/hashalgorithm_string.go
+++ b/runtime/sema/hashalgorithm_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[HashAlgorithmSHA3_256-3]
 	_ = x[HashAlgorithmSHA3_384-4]
 	_ = x[HashAlgorithmKMAC128_BLS_BLS12_381-5]
+	_ = x[HashAlgorithmKECCAK_256-6]
 }
 
-const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384HashAlgorithmKMAC128_BLS_BLS12_381"
+const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384HashAlgorithmKMAC128_BLS_BLS12_381HashAlgorithmKECCAK_256"
 
-var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104, 138}
+var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104, 138, 161}
 
 func (i HashAlgorithm) String() string {
 	if i >= HashAlgorithm(len(_HashAlgorithm_index)-1) {

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -65,7 +65,7 @@ const (
 	HashAlgorithmSHA3_256              = sema.HashAlgorithmSHA3_256
 	HashAlgorithmSHA3_384              = sema.HashAlgorithmSHA3_384
 	HashAlgorithmKMAC128_BLS_BLS12_381 = sema.HashAlgorithmKMAC128_BLS_BLS12_381
-	HashAlgorithmKeccak256             = sema.HashAlgorithmKeccak256
+	HashAlgorithmKECCAK_256            = sema.HashAlgorithmKECCAK_256
 )
 
 type AccountKey struct {

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -65,6 +65,7 @@ const (
 	HashAlgorithmSHA3_256              = sema.HashAlgorithmSHA3_256
 	HashAlgorithmSHA3_384              = sema.HashAlgorithmSHA3_384
 	HashAlgorithmKMAC128_BLS_BLS12_381 = sema.HashAlgorithmKMAC128_BLS_BLS12_381
+	HashAlgorithmKeccak256             = sema.HashAlgorithmKeccak256
 )
 
 type AccountKey struct {


### PR DESCRIPTION
## Description

As described in #1375, we would like to backport #1327 so that we can use it sooner than later. 

______

<!-- Complete: -->

- [X] Targeted PR against `v0.21` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
