### PR TITLE
update tutorial links for new playground format

### DIFF
--- a/docs/tutorial/03-fungible-tokens.mdx
+++ b/docs/tutorial/03-fungible-tokens.mdx
@@ -10,10 +10,10 @@ In this tutorial, we're going to deploy, store, and transfer fungible tokens.
   Open the starter code for this tutorial in the Flow Playground:
   <br />
   <a
-    href="https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1?type=script&id=eeb051a8-f2f2-4914-9f45-5e1f92fec5b5&storage=none"
+    href="https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1"
     target="_blank"
   >
-    https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1?type=script&id=eeb051a8-f2f2-4914-9f45-5e1f92fec5b5&storage=none
+    https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1
   </a>
   <br />
   The tutorial will ask you to take various actions to interact with this code.
@@ -88,10 +88,10 @@ and [Hello, World!](/cadence/tutorial/02-hello-world/) to learn the basics of th
   First, you'll need to follow this link to open a playground session with the
   Fungible Token contracts, transactions, and scripts pre-loaded:{" "}
   <a
-    href="https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1?type=script&id=eeb051a8-f2f2-4914-9f45-5e1f92fec5b5&storage=none"
+    href="https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1"
     target="_blank"
   >
-    https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1?type=script&id=eeb051a8-f2f2-4914-9f45-5e1f92fec5b5&storage=none
+    https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1
   </a>
 </Callout>
 <Callout type="info">

--- a/docs/tutorial/05-marketplace-setup.mdx
+++ b/docs/tutorial/05-marketplace-setup.mdx
@@ -4,8 +4,8 @@ title: 5. Marketplace Setup
 
 <Callout type="success">
 
-Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846"
-target="_blank">https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846</a><br/>
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/45ae690e-c527-409c-970e-57f03df92790"
+target="_blank">https://play.onflow.org/45ae690e-c527-409c-970e-57f03df92790</a><br/>
 The tutorial will be asking you to take various actions to interact with this code.
 
 </Callout>

--- a/docs/tutorial/06-marketplace-compose.mdx
+++ b/docs/tutorial/06-marketplace-compose.mdx
@@ -8,8 +8,8 @@ In this tutorial, we're going to create a marketplace that uses both the fungibl
 
 <Callout type="success">
 
-Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846"
-target="_blank">https://play.onflow.org/46ad1d6d-3ee2-40d4-adef-bfbad33f9846</a><br/>
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/45ae690e-c527-409c-970e-57f03df92790"
+target="_blank">https://play.onflow.org/45ae690e-c527-409c-970e-57f03df92790</a><br/>
 The tutorial will be asking you to take various actions to interact with this code.
 
 </Callout>

--- a/docs/tutorial/07-resources-compose.mdx
+++ b/docs/tutorial/07-resources-compose.mdx
@@ -8,7 +8,7 @@ In this tutorial, we're going to walk through how resources can own other resour
 
 <Callout type="info">
 
-Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/fb934880-ba3a-4d0d-8350-7bea017e6138" target="_blank">https://play.onflow.org/fb934880-ba3a-4d0d-8350-7bea017e6138</a><br/>
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/cda4d057-5898-4a7f-be34-fd47ec75085f" target="_blank">https://play.onflow.org/cda4d057-5898-4a7f-be34-fd47ec75085f</a><br/>
 The tutorial will be asking you do take various actions to interact with this code.
 
 </Callout>

--- a/docs/tutorial/08-voting.mdx
+++ b/docs/tutorial/08-voting.mdx
@@ -8,7 +8,7 @@ In this tutorial, we're going to deploy a contract that allows users to vote on 
 
 <Callout type="success">
 
-Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/a4db333e-0c7d-422f-b7bc-00fc3f341fd8" target="_blank">https://play.onflow.org/a4db333e-0c7d-422f-b7bc-00fc3f341fd8</a><br/>
+Open the starter code for this tutorial in the Flow Playground: <a href="https://play.onflow.org/75a6ce58-74bb-468f-b7bd-425716c93c3e" target="_blank">https://play.onflow.org/75a6ce58-74bb-468f-b7bd-425716c93c3e</a><br/>
 The tutorial will be asking you to take various actions to interact with this code.
 
 </Callout>


### PR DESCRIPTION
Closes https://github.com/onflow/flow/issues/780

## Description

Updates some of the links to new ones that have the playground README and title filled in.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
