### PR TITLE
Change WriteValue and SetValue to take an atree.Value input

### DIFF
--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -100,18 +100,18 @@ func (s StorageMap) ReadValue(key string) Value {
 // If the given value is a SomeValue, the key is updated.
 // If the given value is NilValue, the key is removed.
 //
-func (s StorageMap) WriteValue(interpreter *Interpreter, key string, value Value) {
+func (s StorageMap) WriteValue(interpreter *Interpreter, key string, value atree.Value) {
 	if value == nil {
 		s.removeValue(interpreter, key)
 	} else {
-		s.setValue(interpreter, key, value)
+		s.SetValue(interpreter, key, value)
 	}
 }
 
-// setValue sets a value in the storage map.
+// SetValue sets a value in the storage map.
 // If the given key already stores a value, it is overwritten.
 //
-func (s StorageMap) setValue(interpreter *Interpreter, key string, value Value) {
+func (s StorageMap) SetValue(interpreter *Interpreter, key string, value atree.Value) {
 	existingStorable, err := s.orderedMap.Set(
 		StringAtreeComparator,
 		StringAtreeHashInput,


### PR DESCRIPTION
For https://github.com/onflow/flow-go/pull/1839 we would like to be able to call these functions from outside the interpreter package without having to create an entire interpreter value. This should make them usable by the storage migration. 
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
