### PR TITLE
Add CharacterValue type

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -1026,13 +1026,13 @@ func toBool(valueJSON interface{}) bool {
 }
 
 func toRune(valueJSON interface{}) rune {
-	v, toRune := valueJSON.(rune)
+	v, toRune := valueJSON.(float64)
 	if !toRune {
 		// TODO: improve error message
 		panic(ErrInvalidJSONCadence)
 	}
 
-	return v
+	return rune(v)
 }
 
 func toUInt(valueJSON interface{}) uint {

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -138,6 +138,8 @@ func decodeJSON(v interface{}) cadence.Value {
 		return decodeOptional(valueJSON)
 	case boolTypeStr:
 		return decodeBool(valueJSON)
+	case characterTypeStr:
+		return decodeCharacter(valueJSON)
 	case stringTypeStr:
 		return decodeString(valueJSON)
 	case addressTypeStr:
@@ -229,6 +231,10 @@ func decodeOptional(valueJSON interface{}) cadence.Optional {
 
 func decodeBool(valueJSON interface{}) cadence.Bool {
 	return cadence.NewBool(toBool(valueJSON))
+}
+
+func decodeCharacter(valueJSON interface{}) cadence.Character {
+	return cadence.NewCharacter(toByte(valueJSON))
 }
 
 func decodeString(valueJSON interface{}) cadence.String {
@@ -1012,6 +1018,16 @@ func (obj jsonObject) GetValue(key string) cadence.Value {
 func toBool(valueJSON interface{}) bool {
 	v, isBool := valueJSON.(bool)
 	if !isBool {
+		// TODO: improve error message
+		panic(ErrInvalidJSONCadence)
+	}
+
+	return v
+}
+
+func toByte(valueJSON interface{}) byte {
+	v, isByte := valueJSON.(byte)
+	if !isByte {
 		// TODO: improve error message
 		panic(ErrInvalidJSONCadence)
 	}

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -234,7 +234,7 @@ func decodeBool(valueJSON interface{}) cadence.Bool {
 }
 
 func decodeCharacter(valueJSON interface{}) cadence.Character {
-	return cadence.NewCharacter(toByte(valueJSON))
+	return cadence.NewCharacter(toRune(valueJSON))
 }
 
 func decodeString(valueJSON interface{}) cadence.String {
@@ -1025,9 +1025,9 @@ func toBool(valueJSON interface{}) bool {
 	return v
 }
 
-func toByte(valueJSON interface{}) byte {
-	v, isByte := valueJSON.(byte)
-	if !isByte {
+func toRune(valueJSON interface{}) rune {
+	v, toRune := valueJSON.(rune)
+	if !toRune {
 		// TODO: improve error message
 		panic(ErrInvalidJSONCadence)
 	}

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -209,6 +209,7 @@ const (
 	voidTypeStr       = "Void"
 	optionalTypeStr   = "Optional"
 	boolTypeStr       = "Bool"
+	characterTypeStr  = "Character"
 	stringTypeStr     = "String"
 	addressTypeStr    = "Address"
 	intTypeStr        = "Int"
@@ -254,6 +255,8 @@ func Prepare(v cadence.Value) jsonValue {
 		return prepareOptional(x)
 	case cadence.Bool:
 		return prepareBool(x)
+	case cadence.Character:
+		return prepareCharacter(x)
 	case cadence.String:
 		return prepareString(x)
 	case cadence.Address:
@@ -345,6 +348,13 @@ func prepareOptional(v cadence.Optional) jsonValue {
 func prepareBool(v cadence.Bool) jsonValue {
 	return jsonValueObject{
 		Type:  boolTypeStr,
+		Value: v,
+	}
+}
+
+func prepareCharacter(v cadence.Character) jsonValue {
+	return jsonValueObject{
+		Type:  characterTypeStr,
 		Value: v,
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -95,12 +95,12 @@ func TestEncodeCharacter(t *testing.T) {
 		{
 			"a",
 			cadence.NewCharacter('a'),
-			`{"type":"Bool","value":'a'}`,
+			`{"type":"Character","value":97}`,
 		},
 		{
 			"b",
-			cadence.NewCharacter('a'),
-			`{"type":"Bool","value":'b'}`,
+			cadence.NewCharacter('b'),
+			`{"type":"Character","value":98}`,
 		},
 	}...)
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -94,12 +94,12 @@ func TestEncodeCharacter(t *testing.T) {
 	testAllEncodeAndDecode(t, []encodeTest{
 		{
 			"a",
-			cadence.NewCharacter(byte('a')),
+			cadence.NewCharacter('a'),
 			`{"type":"Bool","value":'a'}`,
 		},
 		{
 			"b",
-			cadence.NewCharacter(byte('a')),
+			cadence.NewCharacter('a'),
 			`{"type":"Bool","value":'b'}`,
 		},
 	}...)

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -87,6 +87,24 @@ func TestEncodeBool(t *testing.T) {
 	}...)
 }
 
+func TestEncodeCharacter(t *testing.T) {
+
+	t.Parallel()
+
+	testAllEncodeAndDecode(t, []encodeTest{
+		{
+			"a",
+			cadence.NewCharacter(byte('a')),
+			`{"type":"Bool","value":'a'}`,
+		},
+		{
+			"b",
+			cadence.NewCharacter(byte('a')),
+			`{"type":"Bool","value":'b'}`,
+		},
+	}...)
+}
+
 func TestEncodeString(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -69,7 +69,7 @@ func exportValueWithInterpreter(
 	case *interpreter.StringValue:
 		return cadence.NewString(v.Str)
 	case interpreter.CharacterValue:
-		return cadence.NewCharacter(byte(v)), nil
+		return cadence.NewCharacter(rune(v)), nil
 	case *interpreter.ArrayValue:
 		return exportArrayValue(v, inter, seenReferences)
 	case interpreter.IntValue:
@@ -450,7 +450,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	case cadence.String:
 		return interpreter.NewStringValue(string(v)), nil
 	case cadence.Character:
-		return interpreter.NewCharacterValue(byte(v)), nil
+		return interpreter.NewCharacterValue(rune(v)), nil
 	case cadence.Bytes:
 		return interpreter.ByteSliceToByteArrayValue(inter, v), nil
 	case cadence.Address:

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -68,6 +68,8 @@ func exportValueWithInterpreter(
 		return cadence.NewBool(bool(v)), nil
 	case *interpreter.StringValue:
 		return cadence.NewString(v.Str)
+	case interpreter.CharacterValue:
+		return cadence.NewCharacter(byte(v)), nil
 	case *interpreter.ArrayValue:
 		return exportArrayValue(v, inter, seenReferences)
 	case interpreter.IntValue:
@@ -447,6 +449,8 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 		return interpreter.BoolValue(v), nil
 	case cadence.String:
 		return interpreter.NewStringValue(string(v)), nil
+	case cadence.Character:
+		return interpreter.NewCharacterValue(byte(v)), nil
 	case cadence.Bytes:
 		return interpreter.ByteSliceToByteArrayValue(inter, v), nil
 	case cadence.Address:

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -237,6 +237,11 @@ func TestExportValue(t *testing.T) {
 			expected: cadence.NewInt(42),
 		},
 		{
+			label:    "Character",
+			value:    interpreter.NewCharacterValue(byte('a')),
+			expected: cadence.NewCharacter(byte('a')),
+		},
+		{
 			label:    "Int8",
 			value:    interpreter.Int8Value(42),
 			expected: cadence.NewInt8(42),
@@ -612,6 +617,11 @@ func TestImportValue(t *testing.T) {
 			label:    "Int",
 			value:    cadence.NewInt(42),
 			expected: interpreter.NewIntValueFromInt64(42),
+		},
+		{
+			label:    "Character",
+			value:    cadence.NewCharacter(byte('a')),
+			expected: interpreter.NewCharacterValue(byte('a')),
 		},
 		{
 			label:    "Int8",

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -238,8 +238,8 @@ func TestExportValue(t *testing.T) {
 		},
 		{
 			label:    "Character",
-			value:    interpreter.NewCharacterValue(byte('a')),
-			expected: cadence.NewCharacter(byte('a')),
+			value:    interpreter.NewCharacterValue('a'),
+			expected: cadence.NewCharacter('a'),
 		},
 		{
 			label:    "Int8",
@@ -620,8 +620,8 @@ func TestImportValue(t *testing.T) {
 		},
 		{
 			label:    "Character",
-			value:    cadence.NewCharacter(byte('a')),
-			expected: interpreter.NewCharacterValue(byte('a')),
+			value:    cadence.NewCharacter('a'),
+			expected: interpreter.NewCharacterValue('a'),
 		},
 		{
 			label:    "Int8",

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -253,7 +253,7 @@ func (d Decoder) decodeString(v string) *StringValue {
 }
 
 func (d Decoder) decodeCharacter(v string) (CharacterValue, error) {
-	if len(v) > 0 {
+	if len(v) > 1 {
 		return '0', fmt.Errorf(
 			"invalid character encoding: %s",
 			v,

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -259,7 +259,7 @@ func (d Decoder) decodeCharacter(v string) (CharacterValue, error) {
 			v,
 		)
 	}
-	return NewCharacterValue(byte(v[0])), nil
+	return NewCharacterValue(rune(v[0])), nil
 }
 
 func decodeLocation(dec *cbor.StreamDecoder) (common.Location, error) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -128,6 +128,16 @@ func (d Decoder) decodeStorable() (atree.Storable, error) {
 			}
 			storable = d.decodeString(v)
 
+		case CBORTagCharacterValue:
+			v, err := d.decoder.DecodeString()
+			if err != nil {
+				return nil, err
+			}
+			storable, err = d.decodeCharacter(v)
+			if err != nil {
+				return nil, err
+			}
+
 		case CBORTagSomeValue:
 			storable, err = d.decodeSome()
 
@@ -240,6 +250,16 @@ func (d Decoder) decodeStorable() (atree.Storable, error) {
 
 func (d Decoder) decodeString(v string) *StringValue {
 	return NewStringValue(v)
+}
+
+func (d Decoder) decodeCharacter(v string) (CharacterValue, error) {
+	if len(v) > 0 {
+		return '0', fmt.Errorf(
+			"invalid character encoding: %s",
+			v,
+		)
+	}
+	return NewCharacterValue(byte(v[0])), nil
 }
 
 func decodeLocation(dec *cbor.StreamDecoder) (common.Location, error) {

--- a/runtime/interpreter/dynamictype.go
+++ b/runtime/interpreter/dynamictype.go
@@ -66,6 +66,16 @@ func (StringDynamicType) IsImportable() bool {
 	return sema.StringType.Importable
 }
 
+// StringDynamicType
+
+type CharacterDynamicType struct{}
+
+func (CharacterDynamicType) IsDynamicType() {}
+
+func (CharacterDynamicType) IsImportable() bool {
+	return sema.CharacterType.Importable
+}
+
 // BoolDynamicType
 
 type BoolDynamicType struct{}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -115,7 +115,7 @@ const (
 	CBORTagTypeValue
 	_ // DO *NOT* REPLACE. Previously used for array values
 	CBORTagStringValue
-	_
+	CBORTagCharacterValue
 	_
 	_
 	_
@@ -247,6 +247,19 @@ func (v NilValue) Encode(e *atree.Encoder) error {
 func (v BoolValue) Encode(e *atree.Encoder) error {
 	// NOTE: when updating, also update BoolValue.ByteSize
 	return e.CBOR.EncodeBool(bool(v))
+}
+
+// Encode encodes the value as a CBOR string
+//
+func (v CharacterValue) Encode(e *atree.Encoder) error {
+	err := e.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, CBORTagCharacterValue,
+	})
+	if err != nil {
+		return err
+	}
+	return e.CBOR.EncodeString(string(v))
 }
 
 // Encode encodes the value as a CBOR string

--- a/runtime/interpreter/hashablevalue.go
+++ b/runtime/interpreter/hashablevalue.go
@@ -61,7 +61,7 @@ const (
 	HashInputTypeAddress
 	HashInputTypePath
 	HashInputTypeType
-	_
+	HashInputTypeCharacter
 	_
 	_
 	_

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3237,9 +3237,15 @@ func (interpreter *Interpreter) IsSubType(subType DynamicType, superType sema.Ty
 			return true
 		}
 
+	case CharacterDynamicType:
+		switch superType {
+		case sema.AnyStructType, sema.CharacterType, sema.StringType:
+			return true
+		}
+
 	case StringDynamicType:
 		switch superType {
-		case sema.AnyStructType, sema.StringType, sema.CharacterType:
+		case sema.AnyStructType, sema.StringType:
 			return true
 		}
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -513,6 +513,13 @@ func (interpreter *Interpreter) VisitFixedPointExpression(expression *ast.FixedP
 }
 
 func (interpreter *Interpreter) VisitStringExpression(expression *ast.StringExpression) ast.Repr {
+	stringType := interpreter.Program.Elaboration.StringExpressionType[expression]
+
+	switch stringType {
+	case sema.CharacterType:
+		return NewCharacterValue(rune(expression.Value[0]))
+	}
+
 	return NewStringValue(expression.Value)
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -526,6 +526,7 @@ func (v BoolValue) String() string {
 func (v BoolValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
+
 func (v BoolValue) ConformsToDynamicType(
 	_ *Interpreter,
 	_ func() LocationRange,
@@ -578,6 +579,116 @@ func (v BoolValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 }
 
 func (BoolValue) ChildStorables() []atree.Storable {
+	return nil
+}
+
+// CharacterValue
+
+type CharacterValue byte
+
+func NewCharacterValue(r byte) CharacterValue {
+	return CharacterValue(r)
+}
+
+var _ Value = CharacterValue('a')
+var _ atree.Storable = CharacterValue('a')
+var _ EquatableValue = CharacterValue('a')
+var _ HashableValue = CharacterValue('a')
+
+func (CharacterValue) IsValue() {}
+
+func (v CharacterValue) Accept(interpreter *Interpreter, visitor Visitor) {
+	visitor.VisitCharacterValue(interpreter, v)
+}
+
+func (CharacterValue) Walk(_ func(Value)) {
+	// NO-OP
+}
+
+var charDyanmicType DynamicType = CharacterDynamicType{}
+
+func (CharacterValue) DynamicType(_ *Interpreter, _ SeenReferences) DynamicType {
+	return charDyanmicType
+}
+
+func (CharacterValue) StaticType() StaticType {
+	return PrimitiveStaticTypeCharacter
+}
+
+func (v CharacterValue) String() string {
+	return string(v)
+}
+
+func (v CharacterValue) RecursiveString(_ SeenReferences) string {
+	return v.String()
+}
+
+func (v CharacterValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+	otherChar, ok := other.(CharacterValue)
+	if !ok {
+		return false
+	}
+	return byte(v) == byte(otherChar)
+}
+
+func (v CharacterValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+	scratch[0] = byte(HashInputTypeCharacter)
+	scratch[1] = byte(v)
+	return scratch[:2]
+}
+
+func (v CharacterValue) ConformsToDynamicType(
+	_ *Interpreter,
+	_ func() LocationRange,
+	dynamicType DynamicType,
+	_ TypeConformanceResults,
+) bool {
+	_, ok := dynamicType.(BoolDynamicType)
+	return ok
+}
+
+func (v CharacterValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+	return v, nil
+}
+
+func (CharacterValue) NeedsStoreTo(_ atree.Address) bool {
+	return false
+}
+
+func (CharacterValue) IsResourceKinded(_ *Interpreter) bool {
+	return false
+}
+
+func (v CharacterValue) Transfer(
+	interpreter *Interpreter,
+	_ func() LocationRange,
+	_ atree.Address,
+	remove bool,
+	storable atree.Storable,
+) Value {
+	if remove {
+		interpreter.RemoveReferencedSlab(storable)
+	}
+	return v
+}
+
+func (v CharacterValue) Clone(_ *Interpreter) Value {
+	return v
+}
+
+func (CharacterValue) DeepRemove(_ *Interpreter) {
+	// NO-OP
+}
+
+func (v CharacterValue) ByteSize() uint32 {
+	return 1
+}
+
+func (v CharacterValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
+	return v, nil
+}
+
+func (CharacterValue) ChildStorables() []atree.Storable {
 	return nil
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -861,9 +861,12 @@ func (v *StringValue) GetKey(_ *Interpreter, getLocationRange func() LocationRan
 		v.graphemes.Next()
 	}
 
-	char := v.graphemes.Str()
+	chars := v.graphemes.Bytes()
+	if len(chars) != 1 {
+		panic(errors.NewUnreachableError())
+	}
 
-	return NewStringValue(char)
+	return NewCharacterValue(chars[0])
 }
 
 func (*StringValue) SetKey(_ *Interpreter, _ func() LocationRange, _ Value, _ Value) {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -616,7 +616,7 @@ func (CharacterValue) StaticType() StaticType {
 }
 
 func (v CharacterValue) String() string {
-	return string(v)
+	return format.String(string(v))
 }
 
 func (v CharacterValue) RecursiveString(_ SeenReferences) string {

--- a/runtime/interpreter/visitor.go
+++ b/runtime/interpreter/visitor.go
@@ -24,6 +24,7 @@ type Visitor interface {
 	VisitVoidValue(interpreter *Interpreter, value VoidValue)
 	VisitBoolValue(interpreter *Interpreter, value BoolValue)
 	VisitStringValue(interpreter *Interpreter, value *StringValue)
+	VisitCharacterValue(interpreter *Interpreter, value CharacterValue)
 	VisitArrayValue(interpreter *Interpreter, value *ArrayValue) bool
 	VisitIntValue(interpreter *Interpreter, value IntValue)
 	VisitInt8Value(interpreter *Interpreter, value Int8Value)
@@ -65,6 +66,7 @@ type EmptyVisitor struct {
 	TypeValueVisitor                func(interpreter *Interpreter, value TypeValue)
 	VoidValueVisitor                func(interpreter *Interpreter, value VoidValue)
 	BoolValueVisitor                func(interpreter *Interpreter, value BoolValue)
+	CharacterValueVisitor           func(interpreter *Interpreter, value CharacterValue)
 	StringValueVisitor              func(interpreter *Interpreter, value *StringValue)
 	ArrayValueVisitor               func(interpreter *Interpreter, value *ArrayValue) bool
 	IntValueVisitor                 func(interpreter *Interpreter, value IntValue)
@@ -137,6 +139,13 @@ func (v EmptyVisitor) VisitStringValue(interpreter *Interpreter, value *StringVa
 		return
 	}
 	v.StringValueVisitor(interpreter, value)
+}
+
+func (v EmptyVisitor) VisitCharacterValue(interpreter *Interpreter, value CharacterValue) {
+	if v.StringValueVisitor == nil {
+		return
+	}
+	v.CharacterValueVisitor(interpreter, value)
 }
 
 func (v EmptyVisitor) VisitArrayValue(interpreter *Interpreter, value *ArrayValue) bool {

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -218,12 +218,16 @@ func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpr
 func (checker *Checker) VisitStringExpression(expression *ast.StringExpression) ast.Repr {
 	expectedType := UnwrapOptionalType(checker.expectedType)
 
+	var actualType Type = StringType
+
 	if IsSameTypeKind(expectedType, CharacterType) {
 		checker.checkCharacterLiteral(expression)
-		return expectedType
+		actualType = expectedType
 	}
 
-	return StringType
+	checker.Elaboration.StringExpressionType[expression] = actualType
+
+	return actualType
 }
 
 func (checker *Checker) VisitIndexExpression(expression *ast.IndexExpression) ast.Repr {

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -61,6 +61,7 @@ type Elaboration struct {
 	DictionaryExpressionType            map[*ast.DictionaryExpression]*DictionaryType
 	DictionaryExpressionEntryTypes      map[*ast.DictionaryExpression][]DictionaryEntryType
 	IntegerExpressionType               map[*ast.IntegerExpression]Type
+	StringExpressionType                map[*ast.StringExpression]Type
 	FixedPointExpression                map[*ast.FixedPointExpression]Type
 	TransactionDeclarationTypes         map[*ast.TransactionDeclaration]*TransactionType
 	SwapStatementLeftTypes              map[*ast.SwapStatement]Type
@@ -117,6 +118,7 @@ func NewElaboration() *Elaboration {
 		DictionaryExpressionType:            map[*ast.DictionaryExpression]*DictionaryType{},
 		DictionaryExpressionEntryTypes:      map[*ast.DictionaryExpression][]DictionaryEntryType{},
 		IntegerExpressionType:               map[*ast.IntegerExpression]Type{},
+		StringExpressionType:                map[*ast.StringExpression]Type{},
 		FixedPointExpression:                map[*ast.FixedPointExpression]Type{},
 		TransactionDeclarationTypes:         map[*ast.TransactionDeclaration]*TransactionType{},
 		SwapStatementLeftTypes:              map[*ast.SwapStatement]Type{},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6617,7 +6617,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			ty:    sema.StringType,
 		},
 		"Character": {
-			value: interpreter.NewStringValue("X"),
+			value: interpreter.NewCharacterValue('X'),
 			ty:    sema.CharacterType,
 		},
 		"Bool": {

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -205,3 +205,23 @@ func TestInterpretStringToLower(t *testing.T) {
 		result,
 	)
 }
+
+func TestInterpretStringAccess(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+	fun test(): Type {
+		let c: Character = "x"[0]
+		return c.getType() 
+	}
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
+		result,
+	)
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -225,3 +225,86 @@ func TestInterpretStringAccess(t *testing.T) {
 		result,
 	)
 }
+
+func TestInterpretCharacterLiteralType(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+	fun test(): Type {
+		let c: Character = "x"
+		return c.getType() 
+	}
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
+		result,
+	)
+}
+
+func TestInterpretOneCharacterStringLiteralType(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+	fun test(): Type {
+		let c: String = "x"
+		return c.getType() 
+	}
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	// dynamic type is still a character, characater is a subtype of string
+	require.Equal(t,
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
+		result,
+	)
+}
+
+func TestInterpretCharacterLiteralTypeNoAnnotation(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+	fun test(): Type {
+		let c = "x"
+		return c.getType() 
+	}
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
+		result,
+	)
+}
+
+func TestInterpretCharacterConcatenation(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+	fun test(): Type {
+		let x: Character = "a"
+		let y: Character = "b"
+		let z: String = x.concat(y)
+		return z.getType() 
+	}
+	`)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeString},
+		result,
+	)
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -66,7 +66,7 @@ func TestInterpretStringFunction(t *testing.T) {
       fun test(): String {
           return String()
       }
-	`)
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
       fun test(): [UInt8] {
           return "01CADE".decodeHex()
       }
-	`)
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestInterpretStringEncodeHex(t *testing.T) {
       fun test(): String {
           return String.encodeHex([1, 2, 3, 0xCA, 0xDE])
       }
-	`)
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestInterpretStringUtf8Field(t *testing.T) {
       fun test(): [UInt8] {
           return "Flowers \u{1F490} are beautiful".utf8
       }
-	`)
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestInterpretStringToLower(t *testing.T) {
       fun test(): String {
           return "Flowers".toLower()
       }
-	`)
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
@@ -211,11 +211,11 @@ func TestInterpretStringAccess(t *testing.T) {
 	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
-	fun test(): Type {
-		let c: Character = "x"[0]
-		return c.getType() 
-	}
-	`)
+    fun test(): Type {
+        let c: Character = "x"[0]
+        return c.getType() 
+    }
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
@@ -231,11 +231,11 @@ func TestInterpretCharacterLiteralType(t *testing.T) {
 	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
-	fun test(): Type {
-		let c: Character = "x"
-		return c.getType() 
-	}
-	`)
+    fun test(): Type {
+        let c: Character = "x"
+        return c.getType() 
+    }
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
@@ -251,18 +251,17 @@ func TestInterpretOneCharacterStringLiteralType(t *testing.T) {
 	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
-	fun test(): Type {
-		let c: String = "x"
-		return c.getType() 
-	}
-	`)
+    fun test(): Type {
+        let c: String = "x"
+        return c.getType() 
+    }
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	// dynamic type is still a character, characater is a subtype of string
 	require.Equal(t,
-		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeString},
 		result,
 	)
 }
@@ -272,33 +271,31 @@ func TestInterpretCharacterLiteralTypeNoAnnotation(t *testing.T) {
 	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
-	fun test(): Type {
-		let c = "x"
-		return c.getType() 
-	}
-	`)
+    fun test(): Type {
+        let c = "x"
+        return c.getType() 
+    }
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)
 
 	require.Equal(t,
-		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeString},
 		result,
 	)
 }
 
-func TestInterpretCharacterConcatenation(t *testing.T) {
+func TestConvertCharacterToString(t *testing.T) {
 
 	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
-	fun test(): Type {
-		let x: Character = "a"
-		let y: Character = "b"
-		let z: String = x.concat(y)
-		return z.getType() 
-	}
-	`)
+    fun test(): String {
+        let c: Character = "x"
+        return c.toString()
+    }
+    `)
 
 	result, err := inter.Invoke("test")
 	require.NoError(t, err)

--- a/values.go
+++ b/values.go
@@ -181,6 +181,28 @@ func (v Bytes) String() string {
 	return format.Bytes(v)
 }
 
+// Character
+
+type Character byte
+
+func NewCharacter(b byte) Character {
+	return Character(b)
+}
+
+func (Character) isValue() {}
+
+func (Character) Type() Type {
+	return CharacterType{}
+}
+
+func (v Character) ToGoValue() interface{} {
+	return byte(v)
+}
+
+func (v Character) String() string {
+	return format.String(string(v))
+}
+
 // Address
 
 const AddressLength = 8

--- a/values.go
+++ b/values.go
@@ -183,9 +183,9 @@ func (v Bytes) String() string {
 
 // Character
 
-type Character byte
+type Character rune
 
-func NewCharacter(b byte) Character {
+func NewCharacter(b rune) Character {
 	return Character(b)
 }
 
@@ -196,7 +196,7 @@ func (Character) Type() Type {
 }
 
 func (v Character) ToGoValue() interface{} {
-	return byte(v)
+	return string(v)
 }
 
 func (v Character) String() string {


### PR DESCRIPTION
Closes #1373

## Description

Cadence previously lacked a runtime character value, causing some inconsistency between the static `Character` type and values with that type at runtime. This adds runtime `Character` values, which are produced by indexing into a string and by creating a character variable like so: `let x: Character = "a"`.

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
