### PR TITLE
Add example of a script to add a key to existing account

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -228,6 +228,24 @@ transaction(publicKey: [UInt8]) {
 }
 ```
 
+To add a public key to the current auth account:
+```cadence
+transaction(publicKey: [UInt8]) {
+    prepare(signer: AuthAccount) {
+        let key = PublicKey(
+            publicKey: publicKey,
+            signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+        )
+
+        signer.keys.add(
+            publicKey: key,
+            hashAlgorithm: HashAlgorithm.SHA3_256,
+            weight: 10.0
+        )
+    }
+}
+```
+
 <Callout type="info">
 ⚠️  Note: Keys can also be added using the `addPublicKey` function.
 However, this method is currently deprecated and is available only for the backward compatibility.

--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -228,7 +228,7 @@ transaction(publicKey: [UInt8]) {
 }
 ```
 
-To add a public key to the current auth account:
+To add a public key to an existing account, which signed the transaction:
 ```cadence
 transaction(publicKey: [UInt8]) {
     prepare(signer: AuthAccount) {


### PR DESCRIPTION
## Description

When I was skimming the docs the call to `AuthAccount` in the middle of the of provided example really threw me off. An additional example would have made it clear.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
