### PR TITLE
Require static types for all host function values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-20.04
     steps:
     - name: Install dependencies
@@ -46,6 +47,7 @@ jobs:
       run: make check-tidy
 
   lint:
+    name: Lint
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -64,3 +66,12 @@ jobs:
       run: make lint-github-actions
     - name: Check license headers
       run: make check-headers
+
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          config: semgrep.yaml

--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -143,7 +143,7 @@ func (s *slabStorage) SlabIterator() (atree.SlabIterator, error) {
 		storageKey
 	}
 
-	for key := range storage {
+	for key := range storage { //nolint:maprangecheck
 
 		var address atree.Address
 		copy(address[:], key[0])

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -171,6 +171,13 @@ func NewHostFunctionValue(
 	function HostFunction,
 	funcType *sema.FunctionType,
 ) *HostFunctionValue {
+	// Host functions can be passed by value,
+	// so for the interpreter value transfer check to work,
+	// they need a static type
+	if funcType == nil {
+		panic(errors.NewUnreachableError())
+	}
+
 	return &HostFunctionValue{
 		Function: function,
 		Type:     funcType,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -55,7 +55,7 @@ func (interpreter *Interpreter) assignmentGetterSetter(expression ast.Expression
 }
 
 // identifierExpressionGetterSetter returns a getter/setter function pair
-// for the target identifier expression, wrapped in a trampoline
+// for the target identifier expression
 //
 func (interpreter *Interpreter) identifierExpressionGetterSetter(identifierExpression *ast.IdentifierExpression) getterSetter {
 	variable := interpreter.findVariable(identifierExpression.Identifier.Identifier)

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -64,8 +64,15 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 		nil,
 	)
 
-	transactionFunction := NewHostFunctionValue(
-		func(invocation Invocation) Value {
+	// Construct a raw HostFunctionValue without a type,
+	// instead of using NewHostFunctionValue, which requires a type.
+	//
+	// This host function value is an internally created and used function,
+	// and can never be passed around as a value.
+	// Hence, the type is not required.
+
+	transactionFunction := &HostFunctionValue{
+		Function: func(invocation Invocation) Value {
 			interpreter.activations.PushNewWithParent(lexicalScope)
 
 			invocation.Self = self
@@ -131,11 +138,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 				sema.VoidType,
 			)
 		},
-
-		// This is an internally used function.
-		// So ideally wouldn't need to perform type checks.
-		nil,
-	)
+	}
 
 	interpreter.Transactions = append(
 		interpreter.Transactions,

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -31,12 +31,14 @@ const metaTypeSubtypeDocString = `
 Returns true if this type is a subtype of the given type at run-time
 `
 
+const MetaTypeName = "Type"
+
 // MetaType represents the type of a type.
 //
 var MetaType = &SimpleType{
-	Name:                 "Type",
-	QualifiedName:        "Type",
-	TypeID:               "Type",
+	Name:                 MetaTypeName,
+	QualifiedName:        MetaTypeName,
+	TypeID:               MetaTypeName,
 	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             true,

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -248,12 +248,14 @@ func (a *VariableActivations) Declare(declaration variableDeclaration) (variable
 
 	// Check if a variable with this name is already declared.
 	// Report an error if shadowing variables of outer scopes is not allowed,
-	// or the existing variable is declared in the current scope.
+	// or the existing variable is declared in the current scope,
+	// or the existing variable is a built-in.
 
 	existingVariable := a.Find(declaration.identifier)
 	if existingVariable != nil &&
 		(!declaration.allowOuterScopeShadowing ||
-			existingVariable.ActivationDepth == depth) {
+			existingVariable.ActivationDepth == depth ||
+			existingVariable.ActivationDepth == 0) {
 
 		err = &RedeclarationError{
 			Kind:        declaration.kind,

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -1067,23 +1067,24 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 	// in the post condition is in fact a reference (ephemeral reference value),
 	// and not a resource (composite value)
 
+	checkFunctionType := &sema.FunctionType{
+		Parameters: []*sema.Parameter{
+			{
+				Label:      sema.ArgumentLabelNotRequired,
+				Identifier: "value",
+				TypeAnnotation: sema.NewTypeAnnotation(
+					sema.AnyStructType,
+				),
+			},
+		},
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(
+			sema.VoidType,
+		),
+	}
 	valueDeclarations := stdlib.StandardLibraryValues{
 		{
 			Name: "check",
-			Type: &sema.FunctionType{
-				Parameters: []*sema.Parameter{
-					{
-						Label:      sema.ArgumentLabelNotRequired,
-						Identifier: "value",
-						TypeAnnotation: sema.NewTypeAnnotation(
-							sema.AnyStructType,
-						),
-					},
-				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					sema.VoidType,
-				),
-			},
+			Type: checkFunctionType,
 			ValueFactory: func(_ *interpreter.Interpreter) interpreter.Value {
 				return interpreter.NewHostFunctionValue(
 					func(invocation interpreter.Invocation) interpreter.Value {
@@ -1094,7 +1095,7 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 
 						return interpreter.VoidValue{}
 					},
-					nil,
+					checkFunctionType,
 				)
 			},
 			Kind: common.DeclarationKindConstant,

--- a/runtime/tests/interpreter/declaration_test.go
+++ b/runtime/tests/interpreter/declaration_test.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInterpretForwardReferenceCall(t *testing.T) {

--- a/runtime/tests/interpreter/declaration_test.go
+++ b/runtime/tests/interpreter/declaration_test.go
@@ -19,7 +19,12 @@
 package interpreter_test
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInterpretForwardReferenceCall(t *testing.T) {
@@ -72,4 +77,75 @@ func TestInterpretForwardReferenceCall(t *testing.T) {
 	    `)
 	})
 
+}
+
+func TestInterpretShadowingInFunction(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+	  fun foo(): Int {
+          var x = 1
+          fun bar() {
+              var x = x
+              x = 2
+          }
+          bar()
+          return x
+      }
+	`)
+
+	result, err := inter.Invoke("foo")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.NewIntValueFromInt64(1),
+		result,
+	)
+}
+
+func TestInterpretPassBuiltinByValue(t *testing.T) {
+
+	t.Parallel()
+
+	// Check built-ins have a static type, so value transfer check works
+
+	_ = sema.BaseValueActivation.ForEach(
+		func(name string, _ *sema.Variable) error {
+
+			t.Run(name, func(t *testing.T) {
+
+				t.Run("in function", func(t *testing.T) {
+
+					inter := parseCheckAndInterpret(t,
+						fmt.Sprintf(
+							`
+                                fun test() {
+                                    let x = %s
+                                }
+                            `,
+							name,
+						),
+					)
+
+					_, err := inter.Invoke("test")
+					require.NoError(t, err)
+				})
+
+				t.Run("global declaration", func(t *testing.T) {
+
+					_ = parseCheckAndInterpret(t,
+						fmt.Sprintf(
+							`
+                                let x = %s
+                            `,
+							name,
+						),
+					)
+				})
+			})
+
+			return nil
+		},
+	)
 }

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -97,7 +97,9 @@ func TestInterpretVirtualImport(t *testing.T) {
 								func(invocation interpreter.Invocation) interpreter.Value {
 									return interpreter.UInt64Value(42)
 								},
-								nil,
+								&sema.FunctionType{
+									ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UIntType),
+								},
 							),
 						}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4450,24 +4450,26 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 		storageAddress := common.MustBytesToAddress([]byte{0x42})
 		const storageKey = "test storage key"
 
+		getStorageReferenceFunctionType := &sema.FunctionType{
+			Parameters: []*sema.Parameter{
+				{
+					Label:      "authorized",
+					Identifier: "authorized",
+					TypeAnnotation: sema.NewTypeAnnotation(
+						sema.BoolType,
+					),
+				},
+			},
+			ReturnTypeAnnotation: sema.NewTypeAnnotation(
+				sema.AnyStructType,
+			),
+		}
+
 		standardLibraryFunctions :=
 			stdlib.StandardLibraryFunctions{
 				{
 					Name: "getStorageReference",
-					Type: &sema.FunctionType{
-						Parameters: []*sema.Parameter{
-							{
-								Label:      "authorized",
-								Identifier: "authorized",
-								TypeAnnotation: sema.NewTypeAnnotation(
-									sema.BoolType,
-								),
-							},
-						},
-						ReturnTypeAnnotation: sema.NewTypeAnnotation(
-							sema.AnyStructType,
-						),
-					},
+					Type: getStorageReferenceFunctionType,
 					Function: interpreter.NewHostFunctionValue(
 						func(invocation interpreter.Invocation) interpreter.Value {
 
@@ -4488,7 +4490,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 								},
 							}
 						},
-						nil,
+						getStorageReferenceFunctionType,
 					),
 				},
 			}

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -673,18 +673,20 @@ func TestInterpretGetType(t *testing.T) {
 			// Inject a function that returns a storage reference value,
 			// which is borrowed as: `auth &Int`
 
+			getStorageReferenceFunctionType := &sema.FunctionType{
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(
+					&sema.ReferenceType{
+						Authorized: true,
+						Type:       sema.IntType,
+					},
+				),
+			}
+
 			standardLibraryFunctions :=
 				stdlib.StandardLibraryFunctions{
 					{
 						Name: "getStorageReference",
-						Type: &sema.FunctionType{
-							ReturnTypeAnnotation: sema.NewTypeAnnotation(
-								&sema.ReferenceType{
-									Authorized: true,
-									Type:       sema.IntType,
-								},
-							),
-						},
+						Type: getStorageReferenceFunctionType,
 						Function: interpreter.NewHostFunctionValue(
 							func(invocation interpreter.Invocation) interpreter.Value {
 
@@ -695,7 +697,7 @@ func TestInterpretGetType(t *testing.T) {
 									BorrowedType:         sema.IntType,
 								}
 							},
-							nil,
+							getStorageReferenceFunctionType,
 						),
 					},
 				}

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,0 +1,9 @@
+rules:
+- id: host-function-value-without-type
+  languages:
+    - go
+  message: Host function values must have a static type
+  pattern-either:
+    - pattern: NewHostFunctionValue(..., nil)
+    - pattern: interpreter.NewHostFunctionValue(..., nil)
+  severity: ERROR


### PR DESCRIPTION
Port of https://github.com/dapperlabs/cadence-internal/pull/48

## Description

This PR fixes two bugs:
- dapperlabs/cadence-internal#47: 

    ## Global re-declarations of built-ins cause infinite loop / stack overflow

    ### Problem

    - Built-in functions, like the number conversion functions, are declared at depth 0
    - We allow shadowing of variables of outer depths (e.g. `let x = 1; fun test() { let x = 2 }` is valid)
    - Global variables are initialized lazily

    This means that currently a global variable declaration like `let UInt = UInt` is accepted by the checker, and then the interpreter runs into an infinite loop / stack overflow:
    - Statically this is valid, because the global declaration is at depth 1, the built-in is at depth 0, and like mentioned above, shadowing of a variable declared in an outer scope is valid
    - The interpreter then declares the lazy global variable. evaluating it means evaluating the variable value … which uses the deepest scope, so refers to itself, not to the built-in of the outer scope

    ### Steps to Reproduce

    Any global re-declaration of a built-in, e.g.

    `let UInt = UInt` 

   ### Solution

   Forbid redeclaring / shadowing builtins

- Passing built-in functions by value (e.g. assigning to a variable, passing to a function as an argument, etc.), causes a crasher. All Host function values need a static type, as the interpreter's value transfer check needs it, so add the missing types and also add a [semgrep](https://semgrep.dev/) rule as well as a run-time assertion to prevent regressions

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
