### PR TITLE
Fix boxing in casts

### DIFF
--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -143,7 +143,7 @@ func (s *slabStorage) SlabIterator() (atree.SlabIterator, error) {
 		storageKey
 	}
 
-	for key := range storage {
+	for key := range storage { //nolint:maprangecheck
 
 		var address atree.Address
 		copy(address[:], key[0])

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -829,7 +829,7 @@ func (interpreter *Interpreter) prepareInvoke(
 		parameterType := parameters[i].TypeAnnotation.Type
 
 		// converts the argument into the parameter type declared by the function
-		preparedArguments[i] = interpreter.ConvertAndBox(argument, nil, parameterType)
+		preparedArguments[i] = ConvertAndBox(argument, nil, parameterType)
 	}
 
 	// NOTE: can't fill argument types, as they are unknown
@@ -1571,7 +1571,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 	for i, enumCase := range enumCases {
 
-		rawValue := interpreter.convert(
+		rawValue := convert(
 			NewIntValueFromInt64(int64(i)),
 			intType,
 			compositeType.EnumRawType,
@@ -1888,7 +1888,7 @@ func (interpreter *Interpreter) transferAndConvert(
 		nil,
 	)
 
-	result := interpreter.ConvertAndBox(
+	result := ConvertAndBox(
 		transferredValue,
 		valueType,
 		targetType,
@@ -1905,12 +1905,12 @@ func (interpreter *Interpreter) transferAndConvert(
 }
 
 // ConvertAndBox converts a value to a target type, and boxes in optionals and any value, if necessary
-func (interpreter *Interpreter) ConvertAndBox(value Value, valueType, targetType sema.Type) Value {
-	value = interpreter.convert(value, valueType, targetType)
-	return interpreter.BoxOptional(value, valueType, targetType)
+func ConvertAndBox(value Value, valueType, targetType sema.Type) Value {
+	value = convert(value, valueType, targetType)
+	return BoxOptional(value, targetType)
 }
 
-func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.Type) Value {
+func convert(value Value, valueType, targetType sema.Type) Value {
 	if valueType == nil {
 		return value
 	}
@@ -2039,7 +2039,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 }
 
 // BoxOptional boxes a value in optionals, if necessary
-func (interpreter *Interpreter) BoxOptional(value Value, valueType, targetType sema.Type) Value {
+func BoxOptional(value Value, targetType sema.Type) Value {
 	inner := value
 	for {
 		optionalType, ok := targetType.(*sema.OptionalType)
@@ -2057,9 +2057,6 @@ func (interpreter *Interpreter) BoxOptional(value Value, valueType, targetType s
 
 		default:
 			value = NewSomeValueNonCopying(value)
-			valueType = &sema.OptionalType{
-				Type: valueType,
-			}
 		}
 
 		targetType = optionalType.Type
@@ -2067,7 +2064,7 @@ func (interpreter *Interpreter) BoxOptional(value Value, valueType, targetType s
 	return value
 }
 
-func (interpreter *Interpreter) unbox(value Value) Value {
+func Unbox(value Value) Value {
 	for {
 		some, ok := value.(*SomeValue)
 		if !ok {

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -22,30 +22,18 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	. "github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-	"github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInterpreterOptionalBoxing(t *testing.T) {
 
 	t.Parallel()
 
-	checker, err := sema.NewChecker(nil, utils.TestLocation)
-	require.NoError(t, err)
-
-	program := ProgramFromChecker(checker)
-
-	inter, err := NewInterpreter(program, checker.Location)
-	require.NoError(t, err)
-
 	t.Run("Bool to Bool?", func(t *testing.T) {
-		value := inter.BoxOptional(
+		value := BoxOptional(
 			BoolValue(true),
-			sema.BoolType,
 			&sema.OptionalType{Type: sema.BoolType},
 		)
 		assert.Equal(t,
@@ -55,9 +43,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	})
 
 	t.Run("Bool? to Bool?", func(t *testing.T) {
-		value := inter.BoxOptional(
+		value := BoxOptional(
 			NewSomeValueNonCopying(BoolValue(true)),
-			&sema.OptionalType{Type: sema.BoolType},
 			&sema.OptionalType{Type: sema.BoolType},
 		)
 		assert.Equal(t,
@@ -67,9 +54,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	})
 
 	t.Run("Bool? to Bool??", func(t *testing.T) {
-		value := inter.BoxOptional(
+		value := BoxOptional(
 			NewSomeValueNonCopying(BoolValue(true)),
-			&sema.OptionalType{Type: sema.BoolType},
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
@@ -82,9 +68,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 
 	t.Run("nil (Never?) to Bool??", func(t *testing.T) {
 		// NOTE:
-		value := inter.BoxOptional(
+		value := BoxOptional(
 			NilValue{},
-			&sema.OptionalType{Type: sema.NeverType},
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
@@ -95,9 +80,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 
 	t.Run("nil (Some(nil): Never??) to Bool??", func(t *testing.T) {
 		// NOTE:
-		value := inter.BoxOptional(
+		value := BoxOptional(
 			NewSomeValueNonCopying(NilValue{}),
-			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.NeverType}},
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
@@ -110,14 +94,6 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 func TestInterpreterBoxing(t *testing.T) {
 
 	t.Parallel()
-
-	checker, err := sema.NewChecker(nil, utils.TestLocation)
-	require.NoError(t, err)
-
-	program := ProgramFromChecker(checker)
-
-	inter, err := NewInterpreter(program, checker.Location)
-	require.NoError(t, err)
 
 	for _, anyType := range []sema.Type{
 		sema.AnyStructType,
@@ -132,7 +108,7 @@ func TestInterpreterBoxing(t *testing.T) {
 					NewSomeValueNonCopying(
 						BoolValue(true),
 					),
-					inter.ConvertAndBox(
+					ConvertAndBox(
 						BoolValue(true),
 						sema.BoolType,
 						&sema.OptionalType{Type: anyType},
@@ -147,7 +123,7 @@ func TestInterpreterBoxing(t *testing.T) {
 					NewSomeValueNonCopying(
 						BoolValue(true),
 					),
-					inter.ConvertAndBox(
+					ConvertAndBox(
 						NewSomeValueNonCopying(BoolValue(true)),
 						&sema.OptionalType{Type: sema.BoolType},
 						&sema.OptionalType{Type: anyType},

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	. "github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestInterpreterOptionalBoxing(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -9372,3 +9372,74 @@ func TestHostFunctionStaticType(t *testing.T) {
 		assert.Equal(t, xValue.StaticType(), yValue.StaticType())
 	})
 }
+
+func TestInterpretCastingBoxing(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("failable cast", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          let a = (1 as? Int?!)?.getType()
+        `)
+
+		variable, ok := inter.Globals.Get("a")
+		require.True(t, ok)
+
+		require.Equal(
+			t,
+			interpreter.NewSomeValueNonCopying(
+				interpreter.TypeValue{
+					Type: interpreter.PrimitiveStaticTypeInt,
+				},
+			),
+			variable.GetValue(),
+		)
+	})
+
+	t.Run("force cast", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          let a = (1 as! Int?)?.getType()
+        `)
+
+		variable, ok := inter.Globals.Get("a")
+		require.True(t, ok)
+
+		require.Equal(
+			t,
+			interpreter.NewSomeValueNonCopying(
+				interpreter.TypeValue{
+					Type: interpreter.PrimitiveStaticTypeInt,
+				},
+			),
+			variable.GetValue(),
+		)
+	})
+
+	t.Run("cast", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          let a = (1 as Int?)?.getType()
+        `)
+
+		variable, ok := inter.Globals.Get("a")
+		require.True(t, ok)
+
+		require.Equal(
+			t,
+			interpreter.NewSomeValueNonCopying(
+				interpreter.TypeValue{
+					Type: interpreter.PrimitiveStaticTypeInt,
+				},
+			),
+			variable.GetValue(),
+		)
+	})
+}


### PR DESCRIPTION
Port of https://github.com/dapperlabs/cadence-internal/pull/49


## Description

Fix a crasher:

- Add missing boxing for failable and force casts
- Remove unnecessary code in `BoxOptional`

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
