### PR TITLE
Fix EOF emission in lexer

### DIFF
--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -777,7 +777,7 @@ func TestParseString(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid end of string literal: missing '\"'",
-					Pos:     ast.Position{Offset: 2, Line: 2, Column: 0},
+					Pos:     ast.Position{Line: 1, Column: 2, Offset: 2},
 				},
 			},
 			errs,
@@ -830,7 +830,7 @@ func TestParseString(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid end of string literal: missing '\"'",
-					Pos:     ast.Position{Offset: 3, Line: 2, Column: 0},
+					Pos:     ast.Position{Line: 1, Column: 3, Offset: 3},
 				},
 			},
 			errs,

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -777,7 +777,7 @@ func TestParseString(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid end of string literal: missing '\"'",
-					Pos:     ast.Position{Line: 1, Column: 2, Offset: 2},
+					Pos:     ast.Position{Line: 2, Column: 0, Offset: 2},
 				},
 			},
 			errs,
@@ -830,7 +830,7 @@ func TestParseString(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid end of string literal: missing '\"'",
-					Pos:     ast.Position{Line: 1, Column: 3, Offset: 3},
+					Pos:     ast.Position{Line: 2, Column: 0, Offset: 3},
 				},
 			},
 			errs,

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -61,28 +61,20 @@ func (l *lexer) Next() Token {
 
 		// At the end of the token stream,
 		// emit a synthetic EOF token
-		//
-		// Use the end position of the last token (if available)
 
-		var tokenRange ast.Range
-		if l.tokenCount > 0 {
-			lastToken := l.tokens[l.tokenCount-1]
-			endPos := lastToken.EndPos.Shifted(1)
-
-			tokenRange = ast.Range{
-				StartPos: endPos,
-				EndPos:   endPos,
-			}
-		} else {
-			tokenRange = ast.Range{
-				StartPos: ast.Position{Line: 1},
-				EndPos:   ast.Position{Line: 1},
-			}
+		endPos := l.endPos()
+		pos := ast.Position{
+			Offset: l.endOffset - 1,
+			Line:   endPos.line,
+			Column: endPos.column,
 		}
 
 		return Token{
-			Type:  TokenEOF,
-			Range: tokenRange,
+			Type: TokenEOF,
+			Range: ast.Range{
+				StartPos: pos,
+				EndPos:   pos,
+			},
 		}
 
 	}

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -382,8 +382,8 @@ func TestLexBasic(t *testing.T) {
 				{
 					Type: TokenEOF,
 					Range: ast.Range{
-						StartPos: ast.Position{Line: 2, Column: 4, Offset: 7},
-						EndPos:   ast.Position{Line: 2, Column: 4, Offset: 7},
+						StartPos: ast.Position{Line: 3, Column: 0, Offset: 7},
+						EndPos:   ast.Position{Line: 3, Column: 0, Offset: 7},
 					},
 				},
 			},
@@ -785,8 +785,8 @@ func TestLexString(t *testing.T) {
 				{
 					Type: TokenEOF,
 					Range: ast.Range{
-						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-						EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+						StartPos: ast.Position{Line: 2, Column: 0, Offset: 2},
+						EndPos:   ast.Position{Line: 2, Column: 0, Offset: 2},
 					},
 				},
 			},
@@ -816,8 +816,8 @@ func TestLexString(t *testing.T) {
 				{
 					Type: TokenEOF,
 					Range: ast.Range{
-						StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
-						EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						StartPos: ast.Position{Line: 2, Column: 0, Offset: 4},
+						EndPos:   ast.Position{Line: 2, Column: 0, Offset: 4},
 					},
 				},
 			},
@@ -893,8 +893,8 @@ func TestLexString(t *testing.T) {
 				{
 					Type: TokenEOF,
 					Range: ast.Range{
-						StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
-						EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+						StartPos: ast.Position{Line: 2, Column: 0, Offset: 3},
+						EndPos:   ast.Position{Line: 2, Column: 0, Offset: 3},
 					},
 				},
 			},
@@ -1568,8 +1568,8 @@ func TestLexIntegerLiterals(t *testing.T) {
 				{
 					Type: TokenEOF,
 					Range: ast.Range{
-						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-						EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+						StartPos: ast.Position{Line: 2, Column: 0, Offset: 2},
+						EndPos:   ast.Position{Line: 2, Column: 0, Offset: 2},
 					},
 				},
 			},
@@ -2063,8 +2063,8 @@ func TestEOFsAfterError(t *testing.T) {
 			Token{
 				Type: TokenEOF,
 				Range: ast.Range{
-					StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
-					EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+					StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+					EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
 				},
 			},
 			tokenStream.Next(),

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -37,7 +37,6 @@ func rootState(l *lexer) stateFn {
 		r := l.next()
 		switch r {
 		case EOF:
-			l.emitType(TokenEOF)
 			return nil
 		case '+':
 			l.emitType(TokenPlus)
@@ -310,7 +309,6 @@ func blockCommentState(nesting int) stateFn {
 		r := l.next()
 		switch r {
 		case EOF:
-			l.emitType(TokenEOF)
 			return nil
 		case '/':
 			beforeSlashOffset := l.prevEndOffset

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -530,5 +530,5 @@ func TestParseInvalidSingleQuoteImport(t *testing.T) {
 
 	_, err := ParseProgram(`import 'X'`)
 
-	require.EqualError(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:8\n  |\n1 | import 'X'\n  |         ^\n")
+	require.EqualError(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n")
 }

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -523,3 +523,12 @@ func TestParseArgumentList(t *testing.T) {
 	})
 
 }
+
+func TestParseInvalidSingleQuoteImport(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseProgram(`import 'X'`)
+
+	require.EqualError(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:8\n  |\n1 | import 'X'\n  |         ^\n")
+}


### PR DESCRIPTION
Port of dapperlabs/cadence-internal#52

## Description

Fix a bug in the lexer, where, after an error was reported, no following EOF token was produced afterwards. This caused an infinite loop in the parser, which kept on consuming from the lexer, looking for an EOF token.

Investigating the issue, there are several code paths in the lexer that emit an EOF token, and also fail to emit an EOF token. In addition, the position calculation for the EOF tokens was not consistent.

This PR ensures that the token stream will always report an EOF token, by replacing their explicit emission with an implicit emission in the `Lexer.Next()` function: When the end of the token stream is reached, an EOF token is emitted, which uses the position of the last token in the stream (if a token is available).

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
