### PR TITLE
Consider halting when determining definite invalidation

### DIFF
--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -131,10 +131,13 @@ func (checker *Checker) checkFunction(
 
 	// Reset the returning state and restore it when leaving
 
-	returned := checker.resources.JumpsOrReturns
+	jumpedOrReturned := checker.resources.JumpsOrReturns
+	halted := checker.resources.Halts
 	checker.resources.JumpsOrReturns = false
+	checker.resources.Halts = false
 	defer func() {
-		checker.resources.JumpsOrReturns = returned
+		checker.resources.JumpsOrReturns = jumpedOrReturned
+		checker.resources.Halts = halted
 	}()
 
 	// NOTE: Always declare the function parameters, even if the function body is empty.

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -182,6 +182,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	// Update the return info for invocations that do not return (i.e. have a `Never` return type)
 
 	if returnType == NeverType {
+		checker.resources.Halts = true
 		functionActivation := checker.functionActivations.Current()
 		functionActivation.ReturnInfo.DefinitelyHalted = true
 	}


### PR DESCRIPTION
Port of dapperlabs/cadence-internal#58

## Description

When determining if a resource was definitely invalidated, also take into account the halting of the program.
This was previously already supported, but due to a bug (!), which was fixed in #1332. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
