### PR TITLE
Make error reporting in contract update validation deterministic

### DIFF
--- a/runtime/contract_update_validation.go
+++ b/runtime/contract_update_validation.go
@@ -19,6 +19,8 @@
 package runtime
 
 import (
+	"sort"
+
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
@@ -151,9 +153,9 @@ func (validator *ContractUpdateValidator) checkFields(oldDeclaration ast.Declara
 	newFields := newDeclaration.DeclarationMembers().Fields()
 
 	// Updated contract has to have at-most the same number of field as the old contract.
-	// Any additional field may cause crashes/garbage-values when deserializing the
-	// already-stored data. However, having less number of fields is fine for now. It will
-	// only leave some unused-data, and will not do any harm to the programs that are running.
+	// Any additional field may cause crashes/garbage-values when deserializing the already-stored data.
+	// However, having fewer fields is fine for now. It will only leave some unused data,
+	// and will not do any harm to the programs that are running.
 
 	for _, newField := range newFields {
 		oldField := oldFields[newField.Identifier.Identifier]
@@ -195,13 +197,13 @@ func (validator *ContractUpdateValidator) checkNestedDeclarations(
 	for _, newNestedDecl := range newNestedCompositeDecls {
 		oldNestedDecl, found := oldCompositeAndInterfaceDecls[newNestedDecl.Identifier.Identifier]
 		if !found {
-			// Then its a new declaration
+			// Then it's a new declaration
 			continue
 		}
 
 		validator.checkDeclarationUpdatability(oldNestedDecl, newNestedDecl)
 
-		// If theres a matching new decl, then remove the old one from the map.
+		// If there's a matching new decl, then remove the old one from the map.
 		delete(oldCompositeAndInterfaceDecls, newNestedDecl.Identifier.Identifier)
 	}
 
@@ -216,7 +218,7 @@ func (validator *ContractUpdateValidator) checkNestedDeclarations(
 
 		validator.checkDeclarationUpdatability(oldNestedDecl, newNestedDecl)
 
-		// If theres a matching new decl, then remove the old one from the map.
+		// If there's a matching new decl, then remove the old one from the map.
 		delete(oldCompositeAndInterfaceDecls, newNestedDecl.Identifier.Identifier)
 	}
 
@@ -245,7 +247,7 @@ func (validator *ContractUpdateValidator) checkNestedDeclarations(
 		})
 	}
 
-	// Check enum-cases, if theres any.
+	// Check enum-cases, if there are any.
 	validator.checkEnumCases(oldDeclaration, newDeclaration)
 }
 
@@ -284,7 +286,8 @@ func (validator *ContractUpdateValidator) checkEnumCases(oldDeclaration ast.Decl
 		})
 
 		// If some enum cases are removed, trying to match each enum case
-		// may result in too many regression errors. hence return.
+		// may result in too many regression errors.
+		// Hence, return.
 		return
 	}
 

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2021 Dapper Labs, Inc.
+ * Copyright 2019-2022 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,1840 +27,63 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
-	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-func TestRuntimeContractUpdateValidation(t *testing.T) {
+func newContractDeployTransaction(function, name, code string) string {
+	return fmt.Sprintf(
+		`
+                transaction {
+                    prepare(signer: AuthAccount) {
+                        signer.contracts.%s(name: "%s", code: "%s".decodeHex())
+                    }
+                }
+            `,
+		function,
+		name,
+		hex.EncodeToString([]byte(code)),
+	)
+}
 
-	t.Parallel()
+func newContractAddTransaction(name string, code string) string {
+	return newContractDeployTransaction(
+		sema.AuthAccountContractsTypeAddFunctionName,
+		name,
+		code,
+	)
+}
 
-	runtime := newTestInterpreterRuntime(
-		WithContractUpdateValidationEnabled(true),
+func newContractUpdateTransaction(name string, code string) string {
+	return newContractDeployTransaction(
+		sema.AuthAccountContractsTypeUpdateExperimentalFunctionName,
+		name,
+		code,
+	)
+}
+
+func newContractRemovalTransaction(contractName string) string {
+	return fmt.Sprintf(
+		`
+           transaction {
+               prepare(signer: AuthAccount) {
+                   signer.contracts.%s(name: "%s")
+               }
+           }
+       `,
+		sema.AuthAccountContractsTypeRemoveFunctionName,
+		contractName,
+	)
+}
+
+func newContractDeploymentTransactor(t *testing.T, updateValidationEnabled bool) func(code string) error {
+	rt := newTestInterpreterRuntime(
+		WithContractUpdateValidationEnabled(updateValidationEnabled),
 	)
 
-	newDeployTransaction := func(function, name, code string) []byte {
-		return []byte(fmt.Sprintf(`
-            transaction {
-                prepare(signer: AuthAccount) {
-                    signer.contracts.%s(name: "%s", code: "%s".decodeHex())
-                }
-            }`,
-			function,
-			name,
-			hex.EncodeToString([]byte(code)),
-		))
-	}
-
-	newContractRemovalTransaction := func(contractName string) []byte {
-		return []byte(fmt.Sprintf(`
-            transaction {
-                prepare(signer: AuthAccount) {
-                    signer.contracts.%s(name: "%s")
-                }
-            }`,
-			sema.AuthAccountContractsTypeRemoveFunctionName,
-			contractName,
-		))
-	}
-
-	accountCode := map[common.LocationID][]byte{}
+	accountCodes := map[common.LocationID][]byte{}
 	var events []cadence.Event
-	runtimeInterface := getMockedRuntimeInterfaceForTxUpdate(t, accountCode, events)
-	nextTransactionLocation := newTransactionLocationGenerator()
-
-	deployAndUpdate := func(t *testing.T, name string, oldCode string, newCode string) error {
-		deployTx1 := newDeployTransaction(sema.AuthAccountContractsTypeAddFunctionName, name, oldCode)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-		require.NoError(t, err)
-
-		deployTx2 := newDeployTransaction(sema.AuthAccountContractsTypeUpdateExperimentalFunctionName, name, newCode)
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx2,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-		return err
-	}
-
-	t.Run("change field type", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test1 {
-                pub var a: String
-                init() {
-                    self.a = "hello"
-                }
-              }`
-
-		const newCode = `
-            pub contract Test1 {
-                pub var a: Int
-                init() {
-                    self.a = 0
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test1", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test1")
-		assertFieldTypeMismatchError(t, cause, "Test1", "a", "String", "Int")
-	})
-
-	t.Run("add field", func(t *testing.T) {
-		const oldCode = `
-              pub contract Test2 {
-                  pub var a: String
-                init() {
-                    self.a = "hello"
-                }
-              }`
-
-		const newCode = `
-            pub contract Test2 {
-                pub var a: String
-                pub var b: Int
-                init() {
-                    self.a = "hello"
-                    self.b = 0
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test2", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test2")
-		assertExtraneousFieldError(t, cause, "Test2", "b")
-	})
-
-	t.Run("remove field", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test3 {
-                pub var a: String
-                pub var b: Int
-                init() {
-                    self.a = "hello"
-                    self.b = 0
-                }
-            }`
-
-		const newCode = `
-            pub contract Test3 {
-                pub var a: String
-
-                init() {
-                    self.a = "hello"
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test3", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("change nested decl field type", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test4 {
-
-                pub var a: @TestResource
-
-                init() {
-                    self.a <- create Test4.TestResource()
-                }
-
-                pub resource TestResource {
-
-                    pub let b: Int
-
-                    init() {
-                        self.b = 1234
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test4 {
-
-                pub var a: @Test4.TestResource
-
-                init() {
-                    self.a <- create Test4.TestResource()
-                }
-
-                pub resource TestResource {
-
-                    pub let b: String
-
-                    init() {
-                        self.b = "string_1234"
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test4", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test4")
-		assertFieldTypeMismatchError(t, cause, "TestResource", "b", "Int", "String")
-	})
-
-	t.Run("add field to nested decl", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test5 {
-
-                pub var a: @TestResource
-
-                init() {
-                    self.a <- create Test5.TestResource()
-                }
-
-                pub resource TestResource {
-
-                    pub var b: String
-
-                    init() {
-                        self.b = "hello"
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test5 {
-
-                pub var a: @Test5.TestResource
-
-                init() {
-                    self.a <- create Test5.TestResource()
-                }
-
-                pub resource TestResource {
-
-                    pub var b: String
-                    pub var c: Int
-
-                    init() {
-                        self.b = "hello"
-                        self.c = 0
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test5", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test5")
-		assertExtraneousFieldError(t, cause, "TestResource", "c")
-	})
-
-	t.Run("change indirect field type", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test6 {
-
-                pub var x: [TestStruct; 1]
-
-                init() {
-                    self.x = [TestStruct()]
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-                    pub var b: Int
-
-                    init() {
-                        self.a = 123
-                        self.b = 456
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test6 {
-
-                pub var x: [TestStruct; 1]
-
-                init() {
-                    self.x = [TestStruct()]
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-                    pub var b: String
-
-                    init() {
-                        self.a = 123
-                        self.b = "string_456"
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test6", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test6")
-		assertFieldTypeMismatchError(t, cause, "TestStruct", "b", "Int", "String")
-	})
-
-	t.Run("circular types refs", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test7{
-
-                pub var x: {String: Foo}
-
-                init() {
-                    self.x = { "foo" : Foo() }
-                }
-
-                pub struct Foo {
-
-                    pub let a: Foo?
-                    pub let b: Bar
-
-                    init() {
-                        self.a = nil
-                        self.b = Bar()
-                    }
-                }
-
-                pub struct Bar {
-
-                    pub let c: Foo?
-                    pub let d: Bar?
-
-                    init() {
-                        self.c = nil
-                        self.d = nil
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test7 {
-
-                pub var x: {String: Foo}
-
-                init() {
-                    self.x = { "foo" : Foo() }
-                }
-
-                pub struct Foo {
-
-                    pub let a: Foo?
-                    pub let b: Bar
-
-                    init() {
-                        self.a = nil
-                        self.b = Bar()
-                    }
-                }
-
-                pub struct Bar {
-
-                    pub let c: Foo?
-                    pub let d: String
-
-                    init() {
-                        self.c = nil
-                        self.d = "string_d"
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test7", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test7")
-		assertFieldTypeMismatchError(t, cause, "Bar", "d", "Bar?", "String")
-	})
-
-	t.Run("qualified vs unqualified nominal type", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test8 {
-
-                pub var x: Test8.TestStruct
-                pub var y: TestStruct
-
-                init() {
-                    self.x = Test8.TestStruct()
-                    self.y = TestStruct()
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test8 {
-
-                pub var x: TestStruct
-                pub var y: Test8.TestStruct
-
-                init() {
-                    self.x = TestStruct()
-                    self.y = Test8.TestStruct()
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test8", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("change imported nominal type to local", func(t *testing.T) {
-		const importCode = `
-            pub contract Test9Import {
-
-                pub struct TestStruct {
-                    pub let a: Int
-                    pub var b: Int
-
-                    init() {
-                        self.a = 123
-                        self.b = 456
-                    }
-                }
-            }`
-
-		deployTx1 := newDeployTransaction(
-			sema.AuthAccountContractsTypeAddFunctionName,
-			"Test9Import",
-			importCode,
-		)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-		require.NoError(t, err)
-
-		const oldCode = `
-            import Test9Import from 0x42
-
-            pub contract Test9 {
-
-                pub var x: Test9Import.TestStruct
-
-                init() {
-                    self.x = Test9Import.TestStruct()
-                }
-            }`
-
-		const newCode = `
-            pub contract Test9 {
-
-                pub var x: TestStruct
-
-                init() {
-                    self.x = TestStruct()
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-                    pub var b: Int
-
-                    init() {
-                        self.a = 123
-                        self.b = 456
-                    }
-                }
-            }`
-
-		err = deployAndUpdate(t, "Test9", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test9")
-		assertFieldTypeMismatchError(t, cause, "Test9", "x", "Test9Import.TestStruct", "TestStruct")
-	})
-
-	t.Run("contract interface update", func(t *testing.T) {
-		const oldCode = `
-            pub contract interface Test10 {
-                pub var a: String
-                pub fun getA() : String
-            }`
-
-		const newCode = `
-            pub contract interface Test10 {
-                pub var a: Int
-                pub fun getA() : Int
-            }`
-
-		err := deployAndUpdate(t, "Test10", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test10")
-		assertFieldTypeMismatchError(t, cause, "Test10", "a", "String", "Int")
-	})
-
-	t.Run("convert interface to contract", func(t *testing.T) {
-		const oldCode = `
-            pub contract interface Test11 {
-                pub var a: String
-                pub fun getA() : String
-            }`
-
-		const newCode = `
-            pub contract Test11 {
-
-                pub var a: String
-
-                init() {
-                    self.a = "hello"
-                }
-
-                pub fun getA() : String {
-                    return self.a
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test11", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test11")
-		assertDeclTypeChangeError(
-			t,
-			cause,
-			"Test11",
-			common.DeclarationKindContractInterface,
-			common.DeclarationKindContract,
-		)
-	})
-
-	t.Run("convert contract to interface", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test12 {
-
-                pub var a: String
-
-                init() {
-                    self.a = "hello"
-                }
-
-                pub fun getA() : String {
-                    return self.a
-                }
-            }`
-
-		const newCode = `
-            pub contract interface Test12 {
-                pub var a: String
-                pub fun getA() : String
-            }`
-
-		err := deployAndUpdate(t, "Test12", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test12")
-		assertDeclTypeChangeError(
-			t,
-			cause,
-			"Test12",
-			common.DeclarationKindContract,
-			common.DeclarationKindContractInterface,
-		)
-	})
-
-	t.Run("change non stored", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test13 {
-
-                pub var x: UsedStruct
-
-                init() {
-                    self.x = UsedStruct()
-                }
-
-                pub struct UsedStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-
-                    pub fun getA() : Int {
-                        return self.a
-                    }
-                }
-
-                pub struct UnusedStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-
-                    pub fun getA() : Int {
-                        return self.a
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test13 {
-
-                pub var x: UsedStruct
-
-                init() {
-                    self.x = UsedStruct()
-                }
-
-                pub struct UsedStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-
-                    pub fun getA() : String {
-                        return "hello_123"
-                    }
-
-                    pub fun getA_new() : Int {
-                        return self.a
-                    }
-                }
-
-                pub struct UnusedStruct {
-                    pub let a: String
-
-                    init() {
-                        self.a = "string_456"
-                    }
-
-                    pub fun getA() : String {
-                        return self.a
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test13", oldCode, newCode)
-
-		// Changing unused public composite types should also fail, since those could be
-		// referred by anyone in the chain, and may cause data inconsistency.
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test13")
-		assertFieldTypeMismatchError(t, cause, "UnusedStruct", "a", "Int", "String")
-	})
-
-	t.Run("change enum type", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test14 {
-
-                pub var x: Foo
-
-                init() {
-                    self.x = Foo.up
-                }
-
-                pub enum Foo: UInt8 {
-                    pub case up
-                    pub case down
-                }
-            }`
-
-		const newCode = `
-            pub contract Test14 {
-
-                pub var x: Foo
-
-                init() {
-                    self.x = Foo.up
-                }
-
-                pub enum Foo: UInt128 {
-                    pub case up
-                    pub case down
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test14", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test14")
-		assertConformanceMismatchError(t, cause, "Foo")
-	})
-
-	t.Run("change nested interface", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test15 {
-
-                pub var x: AnyStruct{TestStruct}?
-
-                init() {
-                    self.x = nil
-                }
-
-                pub struct interface TestStruct {
-                    pub let a: String
-                    pub var b: Int
-                }
-            }`
-
-		const newCode = `
-            pub contract Test15 {
-
-                pub var x: AnyStruct{TestStruct}?
-
-                init() {
-                    self.x = nil
-                }
-
-                pub struct interface TestStruct {
-                    pub let a: Int
-                    pub var b: Int
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test15", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test15")
-		assertFieldTypeMismatchError(t, cause, "TestStruct", "a", "String", "Int")
-	})
-
-	t.Run("change nested interface to struct", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test16 {
-                pub struct interface TestStruct {
-                    pub var a: Int
-                }
-            }`
-
-		const newCode = `
-            pub contract Test16 {
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test16", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test16")
-		assertDeclTypeChangeError(
-			t,
-			cause,
-			"TestStruct",
-			common.DeclarationKindStructureInterface,
-			common.DeclarationKindStructure,
-		)
-	})
-
-	t.Run("adding a nested struct", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test17 {
-            }`
-
-		const newCode = `
-            pub contract Test17 {
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test17", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("removing a nested struct", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test18 {
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test18 {
-            }`
-
-		err := deployAndUpdate(t, "Test18", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test18")
-		assertMissingCompositeDeclarationError(t, cause, "TestStruct")
-	})
-
-	t.Run("add and remove field", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test19 {
-                pub var a: String
-                init() {
-                    self.a = "hello"
-                }
-            }`
-
-		const newCode = `
-            pub contract Test19 {
-                pub var b: Int
-                init() {
-                    self.b = 0
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test19", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test19")
-		assertExtraneousFieldError(t, cause, "Test19", "b")
-	})
-
-	t.Run("multiple errors", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test20 {
-                pub var a: String
-
-                init() {
-                    self.a = "hello"
-                }
-
-                pub struct interface TestStruct {
-                    pub var a: Int
-                }
-            }`
-
-		const newCode = `
-            pub contract Test20 {
-                pub var a: Int
-                pub var b: String
-
-                init() {
-                    self.a = 0
-                    self.b = "hello"
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test20", oldCode, newCode)
-		require.Error(t, err)
-
-		updateErr := getContractUpdateError(t, err)
-		require.NotNil(t, updateErr)
-		assert.Equal(t, fmt.Sprintf("cannot update contract `%s`", "Test20"), updateErr.Error())
-
-		childErrors := updateErr.ChildErrors()
-		require.Equal(t, 3, len(childErrors))
-
-		assertFieldTypeMismatchError(t, childErrors[0], "Test20", "a", "String", "Int")
-
-		assertExtraneousFieldError(t, childErrors[1], "Test20", "b")
-
-		assertDeclTypeChangeError(
-			t,
-			childErrors[2],
-			"TestStruct",
-			common.DeclarationKindStructureInterface,
-			common.DeclarationKindStructure,
-		)
-	})
-
-	t.Run("check error messages", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test21 {
-                pub var a: String
-
-                init() {
-                    self.a = "hello"
-                }
-
-                pub struct interface TestStruct {
-                    pub var a: Int
-                }
-            }`
-
-		const newCode = `
-            pub contract Test21 {
-                pub var a: Int
-                pub var b: String
-
-                init() {
-                    self.a = 0
-                    self.b = "hello"
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test21", oldCode, newCode)
-		require.Error(t, err)
-
-		const expectedError = "error: mismatching field `a` in `Test21`\n" +
-			" --> 0000000000000042.Test21:3:27\n" +
-			"  |\n" +
-			"3 |                 pub var a: Int\n" +
-			"  |                            ^^^ incompatible type annotations. expected `String`, found `Int`\n" +
-			"\n" +
-			"error: found new field `b` in `Test21`\n" +
-			" --> 0000000000000042.Test21:4:24\n" +
-			"  |\n" +
-			"4 |                 pub var b: String\n" +
-			"  |                         ^\n" +
-			"\n" +
-			"error: trying to convert structure interface `TestStruct` to a structure\n" +
-			"  --> 0000000000000042.Test21:11:27\n" +
-			"   |\n" +
-			"11 |                 pub struct TestStruct {\n" +
-			"   |                            ^^^^^^^^^^"
-
-		require.Contains(t, err.Error(), expectedError)
-	})
-
-	t.Run("Test reference types", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test22 {
-
-                pub var vault: Capability<&TestStruct>?
-
-                init() {
-                    self.vault = nil
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test22 {
-
-                pub var vault: Capability<&TestStruct>?
-
-                init() {
-                    self.vault = nil
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test22", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("Test function type", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test23 {
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		const newCode = `
-            pub contract Test23 {
-
-                pub var add: ((Int, Int): Int)
-
-                init() {
-                    self.add = fun (a: Int, b: Int): Int {
-                        return a + b
-                    }
-                }
-
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test23", oldCode, newCode)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "error: field add has non-storable type: ((Int, Int): Int)")
-	})
-
-	t.Run("Test conformance", func(t *testing.T) {
-		const importCode = `
-            pub contract Test24Import {
-                pub struct interface AnInterface {
-                    pub a: Int
-                }
-            }`
-
-		deployTx1 := newDeployTransaction("add", "Test24Import", importCode)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-		require.NoError(t, err)
-
-		const oldCode = `
-            import Test24Import from 0x42
-
-            pub contract Test24 {
-                pub struct TestStruct1 {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct TestStruct2: Test24Import.AnInterface {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		const newCode = `
-            import Test24Import from 0x42
-
-            pub contract Test24 {
-
-                pub struct TestStruct2: Test24Import.AnInterface {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct TestStruct1 {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err = deployAndUpdate(t, "Test24", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("Test all types", func(t *testing.T) {
-
-		const oldCode = `
-            pub contract Test25 {
-                // simple nominal type
-                pub var a: TestStruct
-
-                // qualified nominal type
-                pub var b: Test25.TestStruct
-
-                // optional type
-                pub var c: Int?
-
-                // variable sized type
-                pub var d: [Int]
-
-                // constant sized type
-                pub var e: [Int; 2]
-
-                // dictionary type
-                pub var f: {Int: String}
-
-                // restricted type
-                pub var g: {TestInterface}
-
-                // instantiation and reference types
-                pub var h:  Capability<&TestStruct>?
-
-                // function type
-                pub var i: Capability<&((Int, Int): Int)>?
-
-                init() {
-                    var count: Int = 567
-                    self.a = TestStruct()
-                    self.b = Test25.TestStruct()
-                    self.c = 123
-                    self.d = [123]
-                    self.e = [123, 456]
-                    self.f = {1: "Hello"}
-                    self.g = TestStruct()
-                    self.h = nil
-                    self.i = nil
-                }
-
-                pub struct TestStruct:TestInterface {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct interface TestInterface {
-                    pub let a: Int
-                }
-            }`
-
-		const newCode = `
-            pub contract Test25 {
-
-
-                // function type
-                pub var i: Capability<&((Int, Int): Int)>?
-
-                // instantiation and reference types
-                pub var h:  Capability<&TestStruct>?
-
-                // restricted type
-                pub var g: {TestInterface}
-
-                // dictionary type
-                pub var f: {Int: String}
-
-                // constant sized type
-                pub var e: [Int; 2]
-
-                // variable sized type
-                pub var d: [Int]
-
-                // optional type
-                pub var c: Int?
-
-                // qualified nominal type
-                pub var b: Test25.TestStruct
-
-                // simple nominal type
-                pub var a: TestStruct
-
-                init() {
-                    var count: Int = 567
-                    self.a = TestStruct()
-                    self.b = Test25.TestStruct()
-                    self.c = 123
-                    self.d = [123]
-                    self.e = [123, 456]
-                    self.f = {1: "Hello"}
-                    self.g = TestStruct()
-                    self.h = nil
-                    self.i = nil
-                }
-
-                pub struct TestStruct:TestInterface {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct interface TestInterface {
-                    pub let a: Int
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test25", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("Test restricted types", func(t *testing.T) {
-
-		const oldCode = `
-            pub contract Test26 {
-
-                // restricted type
-                pub var a: {TestInterface}
-                pub var b: {TestInterface}
-                pub var c: AnyStruct{TestInterface}
-                pub var d: AnyStruct{TestInterface}
-
-                init() {
-                    var count: Int = 567
-                    self.a = TestStruct()
-                    self.b = TestStruct()
-                    self.c = TestStruct()
-                    self.d = TestStruct()
-                }
-
-                pub struct TestStruct:TestInterface {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct interface TestInterface {
-                    pub let a: Int
-                }
-            }`
-
-		const newCode = `
-            pub contract Test26 {
-                pub var a: {TestInterface}
-                pub var b: AnyStruct{TestInterface}
-                pub var c: {TestInterface}
-                pub var d: AnyStruct{TestInterface}
-
-                init() {
-                    var count: Int = 567
-                    self.a = TestStruct()
-                    self.b = TestStruct()
-                    self.c = TestStruct()
-                    self.d = TestStruct()
-                }
-
-                pub struct TestStruct:TestInterface {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct interface TestInterface {
-                    pub let a: Int
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test26", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("Test invalid restricted types change", func(t *testing.T) {
-
-		const oldCode = `
-            pub contract Test27 {
-
-                // restricted type
-                pub var a: TestStruct{TestInterface}
-                pub var b: {TestInterface}
-
-                init() {
-                    var count: Int = 567
-                    self.a = TestStruct()
-                    self.b = TestStruct()
-                }
-
-                pub struct TestStruct:TestInterface {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct interface TestInterface {
-                    pub let a: Int
-                }
-            }`
-
-		const newCode = `
-            pub contract Test27 {
-                pub var a: {TestInterface}
-                pub var b: TestStruct{TestInterface}
-
-                init() {
-                    var count: Int = 567
-                    self.a = TestStruct()
-                    self.b = TestStruct()
-                }
-
-                pub struct TestStruct:TestInterface {
-                    pub let a: Int
-                    init() {
-                        self.a = 123
-                    }
-                }
-
-                pub struct interface TestInterface {
-                    pub let a: Int
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test27", oldCode, newCode)
-		require.Error(t, err)
-
-		assert.Contains(t, err.Error(), "pub var a: {TestInterface}"+
-			"\n  |                            ^^^^^^^^^^^^^^^ "+
-			"incompatible type annotations. expected `TestStruct{TestInterface}`, found `{TestInterface}`")
-
-		assert.Contains(t, err.Error(), "pub var b: TestStruct{TestInterface}"+
-			"\n  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ "+
-			"incompatible type annotations. expected `{TestInterface}`, found `TestStruct{TestInterface}`")
-	})
-
-	t.Run("enum valid", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test28 {
-                pub enum Foo: UInt8 {
-                    pub case up
-                    pub case down
-                }
-            }`
-
-		const newCode = `
-            pub contract Test28 {
-                pub enum Foo: UInt8 {
-                    pub case up
-                    pub case down
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test28", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("enum remove case", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test29 {
-                pub enum Foo: UInt8 {
-                    pub case up
-                    pub case down
-                }
-            }`
-
-		const newCode = `
-            pub contract Test29 {
-                pub enum Foo: UInt8 {
-                    pub case up
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test29", oldCode, newCode)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test29")
-		assertMissingEnumCasesError(t, cause, "Foo", 2, 1)
-	})
-
-	t.Run("enum add case", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test30 {
-                pub enum Foo: UInt8 {
-                    pub case up
-                    pub case down
-                }
-            }`
-
-		const newCode = `
-            pub contract Test30 {
-                pub enum Foo: UInt8 {
-                    pub case up
-                    pub case down
-                    pub case left
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test30", oldCode, newCode)
-		require.NoError(t, err)
-	})
-
-	t.Run("enum swap cases", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test31 {
-                pub enum Foo: UInt8 {
-                    pub case up
-                    pub case down
-                    pub case left
-                }
-            }`
-
-		const newCode = `
-            pub contract Test31 {
-                pub enum Foo: UInt8 {
-                    pub case down
-                    pub case left
-                    pub case up
-                }
-            }`
-
-		err := deployAndUpdate(t, "Test31", oldCode, newCode)
-		require.Error(t, err)
-
-		updateErr := getContractUpdateError(t, err)
-		require.NotNil(t, updateErr)
-		assert.Equal(t, fmt.Sprintf("cannot update contract `%s`", "Test31"), updateErr.Error())
-
-		childErrors := updateErr.ChildErrors()
-		require.Equal(t, 3, len(childErrors))
-
-		assertEnumCaseMismatchError(t, childErrors[0], "up", "down")
-		assertEnumCaseMismatchError(t, childErrors[1], "down", "left")
-		assertEnumCaseMismatchError(t, childErrors[2], "left", "up")
-	})
-
-	t.Run("Remove and add struct", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test32 {
-
-                pub struct TestStruct {
-                    pub let a: Int
-                    pub var b: Int
-
-                    init() {
-                        self.a = 123
-                        self.b = 456
-                    }
-                }
-            }`
-
-		const updateCode1 = `
-            pub contract Test32 {
-            }`
-
-		err := deployAndUpdate(t, "Test32", oldCode, updateCode1)
-		require.Error(t, err)
-
-		cause := getErrorCause(t, err, "Test32")
-		assertMissingCompositeDeclarationError(t, cause, "TestStruct")
-
-		const updateCode2 = `
-            pub contract Test32 {
-
-                pub struct TestStruct {
-                    pub let a: String
-
-                    init() {
-                        self.a = "hello123"
-                    }
-                }
-            }`
-
-		updateTx := newDeployTransaction(
-			sema.AuthAccountContractsTypeUpdateExperimentalFunctionName,
-			"Test32",
-			updateCode2,
-		)
-
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: updateTx,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.Error(t, err)
-		cause = getErrorCause(t, err, "Test32")
-
-		assertFieldTypeMismatchError(t, cause, "TestStruct", "a", "Int", "String")
-	})
-
-	t.Run("Rename struct", func(t *testing.T) {
-		const oldCode = `
-            pub contract Test33 {
-
-                pub struct TestStruct {
-                    pub let a: Int
-                    pub var b: Int
-
-                    init() {
-                        self.a = 123
-                        self.b = 456
-                    }
-                }
-            }`
-
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: newDeployTransaction(
-					sema.AuthAccountContractsTypeAddFunctionName,
-					"Test33",
-					oldCode),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
-
-		// Rename the struct
-
-		const newCode = `
-            pub contract Test33 {
-
-                pub struct TestStructRenamed {
-                    pub let a: Int
-                    pub var b: Int
-
-                    init() {
-                        self.a = 123
-                        self.b = 456
-                    }
-                }
-            }`
-
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: newDeployTransaction(
-					sema.AuthAccountContractsTypeUpdateExperimentalFunctionName,
-					"Test33",
-					newCode,
-				),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.Error(t, err)
-		cause := getErrorCause(t, err, "Test33")
-		assertMissingCompositeDeclarationError(t, cause, "TestStruct")
-	})
-
-	t.Run("Remove contract with enum", func(t *testing.T) {
-		// Add contract
-		const oldCode = `
-            pub contract Test34 {
-                pub enum TestEnum: Int {
-                }
-            }`
-
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: newDeployTransaction(
-					sema.AuthAccountContractsTypeAddFunctionName,
-					"Test34",
-					oldCode,
-				),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
-
-		// Remove the added contract.
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: newContractRemovalTransaction("Test34"),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.Error(t, err)
-		require.IsType(t, Error{}, err)
-		runtimeError := err.(Error)
-
-		require.IsType(t, interpreter.Error{}, runtimeError.Err)
-		interpreterError := runtimeError.Err.(interpreter.Error)
-		cause := interpreterError.Err
-
-		require.IsType(t, &ContractRemovalError{}, cause)
-		contractRemovalError := cause.(*ContractRemovalError)
-
-		assert.Equal(
-			t,
-			fmt.Sprintf("cannot remove contract `%s`", "Test34"),
-			contractRemovalError.Error(),
-		)
-	})
-
-	t.Run("Remove contract interface with enum", func(t *testing.T) {
-		// Add contract
-		const oldCode = `
-            pub contract interface Test35 {
-                pub enum TestEnum: Int {
-                }
-            }`
-
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: newDeployTransaction(
-					sema.AuthAccountContractsTypeAddFunctionName,
-					"Test35",
-					oldCode,
-				),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
-
-		// Remove the added contract.
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: newContractRemovalTransaction("Test35"),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.Error(t, err)
-		require.IsType(t, Error{}, err)
-		runtimeError := err.(Error)
-
-		require.IsType(t, interpreter.Error{}, runtimeError.Err)
-		interpreterError := runtimeError.Err.(interpreter.Error)
-		cause := interpreterError.Err
-
-		require.IsType(t, &ContractRemovalError{}, cause)
-		contractRemovalError := cause.(*ContractRemovalError)
-
-		assert.Equal(
-			t,
-			fmt.Sprintf("cannot remove contract `%s`", "Test35"),
-			contractRemovalError.Error(),
-		)
-	})
-
-	t.Run("Remove contract without enum", func(t *testing.T) {
-		// Add contract
-		const oldCode = `
-            pub contract Test36 {
-                pub struct TestStruct {
-                    pub let a: Int
-
-                    init() {
-                        self.a = 123
-                    }
-                }
-            }`
-
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: newDeployTransaction(
-					sema.AuthAccountContractsTypeAddFunctionName,
-					"Test36",
-					oldCode,
-				),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
-
-		// Remove the added contract.
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: newContractRemovalTransaction("Test36"),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		assert.NoError(t, err)
-	})
-}
-
-func assertDeclTypeChangeError(
-	t *testing.T,
-	err error,
-	erroneousDeclName string,
-	oldKind common.DeclarationKind,
-	newKind common.DeclarationKind,
-) {
-
-	require.Error(t, err)
-	require.IsType(t, &InvalidDeclarationKindChangeError{}, err)
-	declTypeChangeError := err.(*InvalidDeclarationKindChangeError)
-	assert.Equal(
-		t,
-		fmt.Sprintf("trying to convert %s `%s` to a %s", oldKind.Name(), erroneousDeclName, newKind.Name()),
-		declTypeChangeError.Error(),
-	)
-}
-
-func assertExtraneousFieldError(t *testing.T, err error, erroneousDeclName string, fieldName string) {
-	require.Error(t, err)
-	require.IsType(t, &ExtraneousFieldError{}, err)
-	extraFieldError := err.(*ExtraneousFieldError)
-	assert.Equal(t, fmt.Sprintf("found new field `%s` in `%s`", fieldName, erroneousDeclName), extraFieldError.Error())
-}
-
-func assertFieldTypeMismatchError(
-	t *testing.T,
-	err error,
-	erroneousDeclName string,
-	fieldName string,
-	expectedType string,
-	foundType string,
-) {
-
-	require.Error(t, err)
-	require.IsType(t, &FieldMismatchError{}, err)
-	fieldMismatchError := err.(*FieldMismatchError)
-	assert.Equal(
-		t,
-		fmt.Sprintf("mismatching field `%s` in `%s`", fieldName, erroneousDeclName),
-		fieldMismatchError.Error(),
-	)
-
-	assert.IsType(t, &TypeMismatchError{}, fieldMismatchError.Err)
-	assert.Equal(
-		t,
-		fmt.Sprintf("incompatible type annotations. expected `%s`, found `%s`", expectedType, foundType),
-		fieldMismatchError.Err.Error(),
-	)
-}
-
-func assertConformanceMismatchError(
-	t *testing.T,
-	err error,
-	erroneousDeclName string,
-) {
-
-	require.Error(t, err)
-	require.IsType(t, &ConformanceMismatchError{}, err)
-	conformanceMismatchError := err.(*ConformanceMismatchError)
-	assert.Equal(
-		t,
-		fmt.Sprintf("conformances does not match in `%s`", erroneousDeclName),
-		conformanceMismatchError.Error(),
-	)
-}
-
-func assertEnumCaseMismatchError(t *testing.T, err error, expectedEnumCase string, foundEnumCase string) {
-	require.Error(t, err)
-	require.IsType(t, &EnumCaseMismatchError{}, err)
-	enumMismatchError := err.(*EnumCaseMismatchError)
-
-	assert.Equal(
-		t,
-		fmt.Sprintf(
-			"mismatching enum case: expected `%s`, found `%s`",
-			expectedEnumCase,
-			foundEnumCase,
-		),
-		enumMismatchError.Error(),
-	)
-}
-
-func assertMissingEnumCasesError(t *testing.T, err error, declName string, expectedCases int, foundCases int) {
-	require.Error(t, err)
-	require.IsType(t, &MissingEnumCasesError{}, err)
-	missingEnumCasesError := err.(*MissingEnumCasesError)
-	assert.Equal(
-		t,
-		fmt.Sprintf(
-			"missing cases in enum `%s`: expected %d or more, found %d",
-			declName,
-			expectedCases,
-			foundCases,
-		),
-		missingEnumCasesError.Error(),
-	)
-}
-
-func assertMissingCompositeDeclarationError(t *testing.T, err error, declName string) {
-	require.Error(t, err)
-
-	require.IsType(t, &MissingCompositeDeclarationError{}, err)
-	missingDeclError := err.(*MissingCompositeDeclarationError)
-
-	assert.Equal(
-		t,
-		fmt.Sprintf("missing composite declaration `%s`", declName),
-		missingDeclError.Error(),
-	)
-}
-
-func getErrorCause(t *testing.T, err error, contractName string) error {
-	updateErr := getContractUpdateError(t, err)
-	assert.Equal(t, fmt.Sprintf("cannot update contract `%s`", contractName), updateErr.Error())
-
-	require.Equal(t, 1, len(updateErr.ChildErrors()))
-	childError := updateErr.ChildErrors()[0]
-
-	return childError
-}
-
-func getContractUpdateError(t *testing.T, err error) *ContractUpdateError {
-	require.Error(t, err)
-	require.IsType(t, Error{}, err)
-	runtimeError := err.(Error)
-
-	require.IsType(t, interpreter.Error{}, runtimeError.Err)
-	interpreterError := runtimeError.Err.(interpreter.Error)
-
-	require.IsType(t, &InvalidContractDeploymentError{}, interpreterError.Err)
-	deploymentError := interpreterError.Err.(*InvalidContractDeploymentError)
-
-	require.IsType(t, &ContractUpdateError{}, deploymentError.Err)
-	return deploymentError.Err.(*ContractUpdateError)
-}
-
-func getMockedRuntimeInterfaceForTxUpdate(
-	t *testing.T,
-	accountCodes map[common.LocationID][]byte,
-	events []cadence.Event,
-) *testRuntimeInterface {
-
-	return &testRuntimeInterface{
+	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location.ID()], nil
 		},
@@ -1897,78 +120,1854 @@ func getMockedRuntimeInterfaceForTxUpdate(
 			return nil
 		},
 	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	return func(code string) error {
+		return rt.ExecuteTransaction(
+			Script{
+				Source: []byte(code),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+	}
+}
+
+// testDeployAndUpdate deploys a contract in one transaction,
+// then updates the contract in another transaction
+func testDeployAndUpdate(t *testing.T, updateValidationEnabled bool, name string, oldCode string, newCode string) error {
+	executeTransaction := newContractDeploymentTransactor(t, updateValidationEnabled)
+	err := executeTransaction(newContractAddTransaction(name, oldCode))
+	require.NoError(t, err)
+
+	return executeTransaction(newContractUpdateTransaction(name, newCode))
+}
+
+// testDeployAndRemove deploys a contract in one transaction,
+// then removes the contract in another transaction
+func testDeployAndRemove(t *testing.T, updateValidationEnabled bool, name string, code string) error {
+	executeTransaction := newContractDeploymentTransactor(t, updateValidationEnabled)
+	err := executeTransaction(newContractAddTransaction(name, code))
+	require.NoError(t, err)
+
+	return executeTransaction(newContractRemovalTransaction(name))
+}
+
+func TestRuntimeContractUpdateValidation(t *testing.T) {
+
+	t.Parallel()
+
+	const contractValidationEnabled = true
+
+	t.Run("change field type", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub var a: String
+                init() {
+                    self.a = "hello"
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub var a: Int
+                init() {
+                    self.a = 0
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "Test", "a", "String", "Int")
+	})
+
+	t.Run("add field", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub var a: String
+
+                init() {
+                    self.a = "hello"
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub var a: String
+                pub var b: Int
+
+                init() {
+                    self.a = "hello"
+                    self.b = 0
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertExtraneousFieldError(t, cause, "Test", "b")
+	})
+
+	t.Run("remove field", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub var a: String
+                pub var b: Int
+
+                init() {
+                    self.a = "hello"
+                    self.b = 0
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub var a: String
+
+                init() {
+                    self.a = "hello"
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("change nested decl field type", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var a: @TestResource
+
+                init() {
+                    self.a <- create Test.TestResource()
+                }
+
+                pub resource TestResource {
+
+                    pub let b: Int
+
+                    init() {
+                        self.b = 1234
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var a: @Test.TestResource
+
+                init() {
+                    self.a <- create Test.TestResource()
+                }
+
+                pub resource TestResource {
+
+                    pub let b: String
+
+                    init() {
+                        self.b = "string_1234"
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "TestResource", "b", "Int", "String")
+	})
+
+	t.Run("add field to nested decl", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var a: @TestResource
+
+                init() {
+                    self.a <- create Test.TestResource()
+                }
+
+                pub resource TestResource {
+
+                    pub var b: String
+
+                    init() {
+                        self.b = "hello"
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var a: @Test.TestResource
+
+                init() {
+                    self.a <- create Test.TestResource()
+                }
+
+                pub resource TestResource {
+
+                    pub var b: String
+                    pub var c: Int
+
+                    init() {
+                        self.b = "hello"
+                        self.c = 0
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertExtraneousFieldError(t, cause, "TestResource", "c")
+	})
+
+	t.Run("change indirect field type", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var x: [TestStruct; 1]
+
+                init() {
+                    self.x = [TestStruct()]
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+                    pub var b: Int
+
+                    init() {
+                        self.a = 123
+                        self.b = 456
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var x: [TestStruct; 1]
+
+                init() {
+                    self.x = [TestStruct()]
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+                    pub var b: String
+
+                    init() {
+                        self.a = 123
+                        self.b = "string_456"
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "TestStruct", "b", "Int", "String")
+	})
+
+	t.Run("circular types refs", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var x: {String: Foo}
+
+                init() {
+                    self.x = { "foo" : Foo() }
+                }
+
+                pub struct Foo {
+
+                    pub let a: Foo?
+                    pub let b: Bar
+
+                    init() {
+                        self.a = nil
+                        self.b = Bar()
+                    }
+                }
+
+                pub struct Bar {
+
+                    pub let c: Foo?
+                    pub let d: Bar?
+
+                    init() {
+                        self.c = nil
+                        self.d = nil
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var x: {String: Foo}
+
+                init() {
+                    self.x = { "foo" : Foo() }
+                }
+
+                pub struct Foo {
+
+                    pub let a: Foo?
+                    pub let b: Bar
+
+                    init() {
+                        self.a = nil
+                        self.b = Bar()
+                    }
+                }
+
+                pub struct Bar {
+
+                    pub let c: Foo?
+                    pub let d: String
+
+                    init() {
+                        self.c = nil
+                        self.d = "string_d"
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "Bar", "d", "Bar?", "String")
+	})
+
+	t.Run("qualified vs unqualified nominal type", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var x: Test.TestStruct
+                pub var y: TestStruct
+
+                init() {
+                    self.x = Test.TestStruct()
+                    self.y = TestStruct()
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var x: TestStruct
+                pub var y: Test.TestStruct
+
+                init() {
+                    self.x = TestStruct()
+                    self.y = Test.TestStruct()
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("change imported nominal type to local", func(t *testing.T) {
+
+		t.Parallel()
+
+		const importCode = `
+		    pub contract TestImport {
+
+		        pub struct TestStruct {
+		            pub let a: Int
+		            pub var b: Int
+
+		            init() {
+		                self.a = 123
+		                self.b = 456
+		            }
+		        }
+		    }
+		`
+
+		executeTransaction := newContractDeploymentTransactor(t, contractValidationEnabled)
+
+		err := executeTransaction(newContractAddTransaction("TestImport", importCode))
+		require.NoError(t, err)
+
+		const oldCode = `
+		    import TestImport from 0x42
+
+		    pub contract Test {
+
+		        pub var x: TestImport.TestStruct
+
+		        init() {
+		            self.x = TestImport.TestStruct()
+		        }
+		    }
+		`
+
+		const newCode = `
+		    pub contract Test {
+
+		        pub var x: TestStruct
+
+		        init() {
+		            self.x = TestStruct()
+		        }
+
+		        pub struct TestStruct {
+		            pub let a: Int
+		            pub var b: Int
+
+		            init() {
+		                self.a = 123
+		                self.b = 456
+		            }
+		        }
+		    }
+		`
+
+		err = executeTransaction(newContractAddTransaction("Test", oldCode))
+		require.NoError(t, err)
+
+		err = executeTransaction(newContractUpdateTransaction("Test", newCode))
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "Test", "x", "TestImport.TestStruct", "TestStruct")
+	})
+
+	t.Run("contract interface update", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract interface Test {
+                pub var a: String
+                pub fun getA() : String
+            }
+        `
+
+		const newCode = `
+            pub contract interface Test {
+                pub var a: Int
+                pub fun getA() : Int
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "Test", "a", "String", "Int")
+	})
+
+	t.Run("convert interface to contract", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract interface Test {
+                pub var a: String
+                pub fun getA() : String
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var a: String
+
+                init() {
+                    self.a = "hello"
+                }
+
+                pub fun getA() : String {
+                    return self.a
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertDeclTypeChangeError(
+			t,
+			cause,
+			"Test",
+			common.DeclarationKindContractInterface,
+			common.DeclarationKindContract,
+		)
+	})
+
+	t.Run("convert contract to interface", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var a: String
+
+                init() {
+                    self.a = "hello"
+                }
+
+                pub fun getA() : String {
+                    return self.a
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract interface Test {
+                pub var a: String
+                pub fun getA() : String
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertDeclTypeChangeError(
+			t,
+			cause,
+			"Test",
+			common.DeclarationKindContract,
+			common.DeclarationKindContractInterface,
+		)
+	})
+
+	t.Run("change non stored", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var x: UsedStruct
+
+                init() {
+                    self.x = UsedStruct()
+                }
+
+                pub struct UsedStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+
+                    pub fun getA() : Int {
+                        return self.a
+                    }
+                }
+
+                pub struct UnusedStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+
+                    pub fun getA() : Int {
+                        return self.a
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var x: UsedStruct
+
+                init() {
+                    self.x = UsedStruct()
+                }
+
+                pub struct UsedStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+
+                    pub fun getA() : String {
+                        return "hello_123"
+                    }
+
+                    pub fun getA_new() : Int {
+                        return self.a
+                    }
+                }
+
+                pub struct UnusedStruct {
+                    pub let a: String
+
+                    init() {
+                        self.a = "string_456"
+                    }
+
+                    pub fun getA() : String {
+                        return self.a
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+
+		// Changing unused public composite types should also fail, since those could be
+		// referred by anyone in the chain, and may cause data inconsistency.
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "UnusedStruct", "a", "Int", "String")
+	})
+
+	t.Run("change enum type", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var x: Foo
+
+                init() {
+                    self.x = Foo.up
+                }
+
+                pub enum Foo: UInt8 {
+                    pub case up
+                    pub case down
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var x: Foo
+
+                init() {
+                    self.x = Foo.up
+                }
+
+                pub enum Foo: UInt128 {
+                    pub case up
+                    pub case down
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertConformanceMismatchError(t, cause, "Foo")
+	})
+
+	t.Run("change nested interface", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var x: AnyStruct{TestStruct}?
+
+                init() {
+                    self.x = nil
+                }
+
+                pub struct interface TestStruct {
+                    pub let a: String
+                    pub var b: Int
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var x: AnyStruct{TestStruct}?
+
+                init() {
+                    self.x = nil
+                }
+
+                pub struct interface TestStruct {
+                    pub let a: Int
+                    pub var b: Int
+                }
+            }
+       `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "TestStruct", "a", "String", "Int")
+	})
+
+	t.Run("change nested interface to struct", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub struct interface TestStruct {
+                    pub var a: Int
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertDeclTypeChangeError(
+			t,
+			cause,
+			"TestStruct",
+			common.DeclarationKindStructureInterface,
+			common.DeclarationKindStructure,
+		)
+	})
+
+	t.Run("adding a nested struct", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+       `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("removing a nested struct", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertMissingDeclarationError(t, cause, "TestStruct")
+	})
+
+	t.Run("add and remove field", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub var a: String
+                init() {
+                    self.a = "hello"
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub var b: Int
+                init() {
+                    self.b = 0
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertExtraneousFieldError(t, cause, "Test", "b")
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub var a: String
+
+                init() {
+                    self.a = "hello"
+                }
+
+                pub struct interface TestStruct {
+                    pub var a: Int
+                }
+            }
+       `
+
+		const newCode = `
+            pub contract Test {
+                pub var a: Int
+                pub var b: String
+
+                init() {
+                    self.a = 0
+                    self.b = "hello"
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		updateErr := getContractUpdateError(t, err, "Test")
+		require.NotNil(t, updateErr)
+
+		childErrors := updateErr.Errors
+		require.Len(t, childErrors, 3)
+
+		assertFieldTypeMismatchError(t, childErrors[0], "Test", "a", "String", "Int")
+		assertExtraneousFieldError(t, childErrors[1], "Test", "b")
+		assertDeclTypeChangeError(
+			t,
+			childErrors[2],
+			"TestStruct",
+			common.DeclarationKindStructureInterface,
+			common.DeclarationKindStructure,
+		)
+	})
+
+	t.Run("check error messages", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub var a: String
+
+                init() {
+                    self.a = "hello"
+                }
+
+                pub struct interface TestStruct {
+                    pub var a: Int
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub var a: Int
+                pub var b: String
+
+                init() {
+                    self.a = 0
+                    self.b = "hello"
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		const expectedError = "error: mismatching field `a` in `Test`\n" +
+			" --> 0000000000000042.Test:3:27\n" +
+			"  |\n" +
+			"3 |                 pub var a: Int\n" +
+			"  |                            ^^^ incompatible type annotations. expected `String`, found `Int`\n" +
+			"\n" +
+			"error: found new field `b` in `Test`\n" +
+			" --> 0000000000000042.Test:4:24\n" +
+			"  |\n" +
+			"4 |                 pub var b: String\n" +
+			"  |                         ^\n" +
+			"\n" +
+			"error: trying to convert structure interface `TestStruct` to a structure\n" +
+			"  --> 0000000000000042.Test:11:27\n" +
+			"   |\n" +
+			"11 |                 pub struct TestStruct {\n" +
+			"   |                            ^^^^^^^^^^"
+
+		require.Contains(t, err.Error(), expectedError)
+	})
+
+	t.Run("Test reference types", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub var vault: Capability<&TestStruct>?
+
+                init() {
+                    self.vault = nil
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var vault: Capability<&TestStruct>?
+
+                init() {
+                    self.vault = nil
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("Test function type", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+                pub var add: ((Int, Int): Int)
+
+                init() {
+                    self.add = fun (a: Int, b: Int): Int {
+                        return a + b
+                    }
+                }
+
+                pub struct TestStruct {
+                    pub let a: Int
+
+                    init() {
+                        self.a = 123
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error: field add has non-storable type: ((Int, Int): Int)")
+	})
+
+	t.Run("Test conformance", func(t *testing.T) {
+
+		t.Parallel()
+
+		const importCode = `
+		    pub contract TestImport {
+		        pub struct interface AnInterface {
+		            pub a: Int
+		        }
+		    }
+		`
+
+		executeTransaction := newContractDeploymentTransactor(t, contractValidationEnabled)
+		err := executeTransaction(newContractAddTransaction("TestImport", importCode))
+		require.NoError(t, err)
+
+		const oldCode = `
+		    import TestImport from 0x42
+
+		    pub contract Test {
+		        pub struct TestStruct1 {
+		            pub let a: Int
+		            init() {
+		                self.a = 123
+		            }
+		        }
+
+		        pub struct TestStruct2: TestImport.AnInterface {
+		            pub let a: Int
+
+		            init() {
+		                self.a = 123
+		            }
+		        }
+		    }
+	    `
+
+		const newCode = `
+		    import TestImport from 0x42
+
+		    pub contract Test {
+
+		        pub struct TestStruct2: TestImport.AnInterface {
+		            pub let a: Int
+
+		            init() {
+		                self.a = 123
+		            }
+		        }
+
+		        pub struct TestStruct1 {
+		            pub let a: Int
+		            init() {
+		                self.a = 123
+		            }
+		        }
+		    }
+		`
+
+		err = executeTransaction(newContractAddTransaction("Test", oldCode))
+		require.NoError(t, err)
+
+		err = executeTransaction(newContractUpdateTransaction("Test", newCode))
+		require.NoError(t, err)
+	})
+
+	t.Run("Test all types", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                // simple nominal type
+                pub var a: TestStruct
+
+                // qualified nominal type
+                pub var b: Test.TestStruct
+
+                // optional type
+                pub var c: Int?
+
+                // variable sized type
+                pub var d: [Int]
+
+                // constant sized type
+                pub var e: [Int; 2]
+
+                // dictionary type
+                pub var f: {Int: String}
+
+                // restricted type
+                pub var g: {TestInterface}
+
+                // instantiation and reference types
+                pub var h:  Capability<&TestStruct>?
+
+                // function type
+                pub var i: Capability<&((Int, Int): Int)>?
+
+                init() {
+                    var count: Int = 567
+                    self.a = TestStruct()
+                    self.b = Test.TestStruct()
+                    self.c = 123
+                    self.d = [123]
+                    self.e = [123, 456]
+                    self.f = {1: "Hello"}
+                    self.g = TestStruct()
+                    self.h = nil
+                    self.i = nil
+                }
+
+                pub struct TestStruct:TestInterface {
+                    pub let a: Int
+                    init() {
+                        self.a = 123
+                    }
+                }
+
+                pub struct interface TestInterface {
+                    pub let a: Int
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+
+
+                // function type
+                pub var i: Capability<&((Int, Int): Int)>?
+
+                // instantiation and reference types
+                pub var h:  Capability<&TestStruct>?
+
+                // restricted type
+                pub var g: {TestInterface}
+
+                // dictionary type
+                pub var f: {Int: String}
+
+                // constant sized type
+                pub var e: [Int; 2]
+
+                // variable sized type
+                pub var d: [Int]
+
+                // optional type
+                pub var c: Int?
+
+                // qualified nominal type
+                pub var b: Test.TestStruct
+
+                // simple nominal type
+                pub var a: TestStruct
+
+                init() {
+                    var count: Int = 567
+                    self.a = TestStruct()
+                    self.b = Test.TestStruct()
+                    self.c = 123
+                    self.d = [123]
+                    self.e = [123, 456]
+                    self.f = {1: "Hello"}
+                    self.g = TestStruct()
+                    self.h = nil
+                    self.i = nil
+                }
+
+                pub struct TestStruct:TestInterface {
+                    pub let a: Int
+                    init() {
+                        self.a = 123
+                    }
+                }
+
+                pub struct interface TestInterface {
+                    pub let a: Int
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("Test restricted types", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                // restricted type
+                pub var a: {TestInterface}
+                pub var b: {TestInterface}
+                pub var c: AnyStruct{TestInterface}
+                pub var d: AnyStruct{TestInterface}
+
+                init() {
+                    var count: Int = 567
+                    self.a = TestStruct()
+                    self.b = TestStruct()
+                    self.c = TestStruct()
+                    self.d = TestStruct()
+                }
+
+                pub struct TestStruct:TestInterface {
+                    pub let a: Int
+                    init() {
+                        self.a = 123
+                    }
+                }
+
+                pub struct interface TestInterface {
+                    pub let a: Int
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub var a: {TestInterface}
+                pub var b: AnyStruct{TestInterface}
+                pub var c: {TestInterface}
+                pub var d: AnyStruct{TestInterface}
+
+                init() {
+                    var count: Int = 567
+                    self.a = TestStruct()
+                    self.b = TestStruct()
+                    self.c = TestStruct()
+                    self.d = TestStruct()
+                }
+
+                pub struct TestStruct:TestInterface {
+                    pub let a: Int
+                    init() {
+                        self.a = 123
+                    }
+                }
+
+                pub struct interface TestInterface {
+                    pub let a: Int
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("Test invalid restricted types change", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+
+                // restricted type
+                pub var a: TestStruct{TestInterface}
+                pub var b: {TestInterface}
+
+                init() {
+                    var count: Int = 567
+                    self.a = TestStruct()
+                    self.b = TestStruct()
+                }
+
+                pub struct TestStruct:TestInterface {
+                    pub let a: Int
+                    init() {
+                        self.a = 123
+                    }
+                }
+
+                pub struct interface TestInterface {
+                    pub let a: Int
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub var a: {TestInterface}
+                pub var b: TestStruct{TestInterface}
+
+                init() {
+                    var count: Int = 567
+                    self.a = TestStruct()
+                    self.b = TestStruct()
+                }
+
+                pub struct TestStruct:TestInterface {
+                    pub let a: Int
+                    init() {
+                        self.a = 123
+                    }
+                }
+
+                pub struct interface TestInterface {
+                    pub let a: Int
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		assert.Contains(t, err.Error(), "pub var a: {TestInterface}"+
+			"\n  |                            ^^^^^^^^^^^^^^^ "+
+			"incompatible type annotations. expected `TestStruct{TestInterface}`, found `{TestInterface}`")
+
+		assert.Contains(t, err.Error(), "pub var b: TestStruct{TestInterface}"+
+			"\n  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ "+
+			"incompatible type annotations. expected `{TestInterface}`, found `TestStruct{TestInterface}`")
+	})
+
+	t.Run("enum valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case up
+                    pub case down
+                }
+            }
+       `
+
+		const newCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case up
+                    pub case down
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("enum remove case", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case up
+                    pub case down
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case up
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertMissingEnumCasesError(t, cause, "Foo", 2, 1)
+	})
+
+	t.Run("enum add case", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case up
+                    pub case down
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case up
+                    pub case down
+                    pub case left
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.NoError(t, err)
+	})
+
+	t.Run("enum swap cases", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case up
+                    pub case down
+                    pub case left
+                }
+            }
+        `
+
+		const newCode = `
+            pub contract Test {
+                pub enum Foo: UInt8 {
+                    pub case down
+                    pub case left
+                    pub case up
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		updateErr := getContractUpdateError(t, err, "Test")
+		require.NotNil(t, updateErr)
+
+		childErrors := updateErr.Errors
+		require.Len(t, childErrors, 3)
+
+		assertEnumCaseMismatchError(t, childErrors[0], "up", "down")
+		assertEnumCaseMismatchError(t, childErrors[1], "down", "left")
+		assertEnumCaseMismatchError(t, childErrors[2], "left", "up")
+	})
+
+	t.Run("Remove and add struct", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+		    pub contract Test {
+
+		        pub struct TestStruct {
+		            pub let a: Int
+		            pub var b: Int
+
+		            init() {
+		                self.a = 123
+		                self.b = 456
+		            }
+		        }
+		    }
+		`
+
+		const updateCode1 = `
+		    pub contract Test {
+		    }
+		`
+
+		executeTransaction := newContractDeploymentTransactor(t, contractValidationEnabled)
+
+		err := executeTransaction(newContractAddTransaction("Test", oldCode))
+		require.NoError(t, err)
+
+		err = executeTransaction(newContractUpdateTransaction("Test", updateCode1))
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertMissingDeclarationError(t, cause, "TestStruct")
+
+		const updateCode2 = `
+		    pub contract Test {
+
+		        pub struct TestStruct {
+		            pub let a: String
+
+		            init() {
+		                self.a = "hello123"
+		            }
+		        }
+		    }
+		`
+
+		err = executeTransaction(newContractUpdateTransaction("Test", updateCode2))
+		require.Error(t, err)
+
+		cause = getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldTypeMismatchError(t, cause, "TestStruct", "a", "Int", "String")
+	})
+
+	t.Run("Rename struct", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+		    pub contract Test {
+
+		        pub struct TestStruct {
+		            pub let a: Int
+		            pub var b: Int
+
+		            init() {
+		                self.a = 123
+		                self.b = 456
+		            }
+		        }
+		    }
+		`
+
+		const newCode = `
+		    pub contract Test {
+
+		        pub struct TestStructRenamed {
+		            pub let a: Int
+		            pub var b: Int
+
+		            init() {
+		                self.a = 123
+		                self.b = 456
+		            }
+		        }
+		    }
+		`
+
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+		require.Error(t, err)
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertMissingDeclarationError(t, cause, "TestStruct")
+	})
+
+	t.Run("Remove contract with enum", func(t *testing.T) {
+
+		t.Parallel()
+
+		const code = `
+		    pub contract Test {
+		        pub enum TestEnum: Int {
+		        }
+		    }
+		`
+
+		err := testDeployAndRemove(t, contractValidationEnabled, "Test", code)
+		require.Error(t, err)
+
+		assertContractRemovalError(t, err, "Test")
+	})
+
+	t.Run("Remove contract interface with enum", func(t *testing.T) {
+
+		const code = `
+		    pub contract interface Test {
+		        pub enum TestEnum: Int {
+		        }
+		    }
+		`
+
+		err := testDeployAndRemove(t, contractValidationEnabled, "Test", code)
+		require.Error(t, err)
+
+		assertContractRemovalError(t, err, "Test")
+	})
+
+	t.Run("Remove contract without enum", func(t *testing.T) {
+
+		t.Parallel()
+
+		const code = `
+		    pub contract Test {
+		        pub struct TestStruct {
+		            pub let a: Int
+
+		            init() {
+		                self.a = 123
+		            }
+		        }
+		    }
+		`
+
+		err := testDeployAndRemove(t, contractValidationEnabled, "Test", code)
+		require.NoError(t, err)
+	})
+
+	t.Run("removing multiple nested structs", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+		    pub contract Test {
+		        pub struct A {}
+		        pub struct B {}
+		    }
+		`
+
+		const newCode = `
+		    pub contract Test {}
+		`
+
+		// Errors reporting was previously non-deterministic,
+		// assert that reports are deterministic
+
+		for i := 0; i < 1000; i++ {
+
+			err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
+			require.Error(t, err)
+
+			updateErr := getContractUpdateError(t, err, "Test")
+
+			childErrors := updateErr.Errors
+			require.Len(t, childErrors, 2)
+
+			if !assertMissingDeclarationError(t, childErrors[0], "A") {
+				t.FailNow()
+			}
+			assertMissingDeclarationError(t, childErrors[1], "B")
+		}
+	})
+}
+
+func assertContractRemovalError(t *testing.T, err error, name string) {
+	var contractRemovalError *ContractRemovalError
+	require.ErrorAs(t, err, &contractRemovalError)
+
+	assert.Equal(t, name, contractRemovalError.Name)
+}
+
+func assertDeclTypeChangeError(
+	t *testing.T,
+	err error,
+	erroneousDeclName string,
+	oldKind common.DeclarationKind,
+	newKind common.DeclarationKind,
+) {
+	var declTypeChangeError *InvalidDeclarationKindChangeError
+	require.ErrorAs(t, err, &declTypeChangeError)
+
+	assert.Equal(t, oldKind, declTypeChangeError.OldKind)
+	assert.Equal(t, erroneousDeclName, declTypeChangeError.Name)
+	assert.Equal(t, newKind, declTypeChangeError.NewKind)
+}
+
+func assertExtraneousFieldError(t *testing.T, err error, erroneousDeclName string, fieldName string) {
+	var extraFieldError *ExtraneousFieldError
+	require.ErrorAs(t, err, &extraFieldError)
+
+	assert.Equal(t, fieldName, extraFieldError.FieldName)
+	assert.Equal(t, erroneousDeclName, extraFieldError.DeclName)
+}
+
+func assertFieldTypeMismatchError(
+	t *testing.T,
+	err error,
+	erroneousDeclName string,
+	fieldName string,
+	expectedType string,
+	foundType string,
+) {
+	var fieldMismatchError *FieldMismatchError
+	require.ErrorAs(t, err, &fieldMismatchError)
+
+	assert.Equal(t, fieldName, fieldMismatchError.FieldName)
+	assert.Equal(t, erroneousDeclName, fieldMismatchError.DeclName)
+
+	var typeMismatchError *TypeMismatchError
+	assert.ErrorAs(t, fieldMismatchError.Err, &typeMismatchError)
+
+	assert.Equal(t, expectedType, typeMismatchError.ExpectedType.String())
+	assert.Equal(t, foundType, typeMismatchError.FoundType.String())
+}
+
+func assertConformanceMismatchError(
+	t *testing.T,
+	err error,
+	erroneousDeclName string,
+) {
+	var conformanceMismatchError *ConformanceMismatchError
+	require.ErrorAs(t, err, &conformanceMismatchError)
+
+	assert.Equal(t, erroneousDeclName, conformanceMismatchError.DeclName)
+}
+
+func assertEnumCaseMismatchError(t *testing.T, err error, expectedEnumCase string, foundEnumCase string) {
+	var enumMismatchError *EnumCaseMismatchError
+	require.ErrorAs(t, err, &enumMismatchError)
+
+	assert.Equal(t, expectedEnumCase, enumMismatchError.ExpectedName)
+	assert.Equal(t, foundEnumCase, enumMismatchError.FoundName)
+}
+
+func assertMissingEnumCasesError(t *testing.T, err error, declName string, expectedCases int, foundCases int) {
+	var missingEnumCasesError *MissingEnumCasesError
+	require.ErrorAs(t, err, &missingEnumCasesError)
+
+	assert.Equal(t, declName, missingEnumCasesError.DeclName)
+	assert.Equal(t, expectedCases, missingEnumCasesError.Expected)
+	assert.Equal(t, foundCases, missingEnumCasesError.Found)
+}
+
+func assertMissingDeclarationError(t *testing.T, err error, declName string) bool {
+	var missingDeclError *MissingDeclarationError
+	require.ErrorAs(t, err, &missingDeclError)
+
+	return assert.Equal(t, declName, missingDeclError.Name)
+}
+
+func getSingleContractUpdateErrorCause(t *testing.T, err error, contractName string) error {
+	updateErr := getContractUpdateError(t, err, contractName)
+
+	require.Len(t, updateErr.Errors, 1)
+	return updateErr.Errors[0]
+}
+
+func getContractUpdateError(t *testing.T, err error, contractName string) *ContractUpdateError {
+	require.Error(t, err)
+
+	var invalidContractDeploymentErr *InvalidContractDeploymentError
+	require.ErrorAs(t, err, &invalidContractDeploymentErr)
+
+	var contractUpdateErr *ContractUpdateError
+	require.ErrorAs(t, err, &contractUpdateErr)
+
+	assert.Equal(t, contractName, contractUpdateErr.ContractName)
+
+	return contractUpdateErr
 }
 
 func TestContractUpdateValidationDisabled(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime(
-		WithContractUpdateValidationEnabled(false),
-	)
-
-	newDeployTransaction := func(function, name, code string) []byte {
-		return []byte(fmt.Sprintf(`
-            transaction {
-                prepare(signer: AuthAccount) {
-                    signer.contracts.%s(name: "%s", code: "%s".decodeHex())
-                }
-            }`,
-			function,
-			name,
-			hex.EncodeToString([]byte(code)),
-		))
-	}
-
-	accountCode := map[common.LocationID][]byte{}
-	var events []cadence.Event
-	runtimeInterface := getMockedRuntimeInterfaceForTxUpdate(t, accountCode, events)
-	nextTransactionLocation := newTransactionLocationGenerator()
-
-	deployAndUpdate := func(t *testing.T, name string, oldCode string, newCode string) error {
-		deployTx1 := newDeployTransaction(sema.AuthAccountContractsTypeAddFunctionName, name, oldCode)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-		require.NoError(t, err)
-
-		deployTx2 := newDeployTransaction(sema.AuthAccountContractsTypeUpdateExperimentalFunctionName, name, newCode)
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx2,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-		return err
-	}
+	const contractValidationEnabled = false
 
 	t.Run("change field type", func(t *testing.T) {
+
+		t.Parallel()
+
 		const oldCode = `
-            pub contract Test1 {
+            pub contract Test {
                 pub var a: String
                 init() {
                     self.a = "hello"
                 }
-              }`
+              }
+        `
 
 		const newCode = `
-            pub contract Test1 {
+            pub contract Test {
                 pub var a: Int
                 init() {
                     self.a = 0
                 }
-            }`
+            }
+        `
 
-		err := deployAndUpdate(t, "Test1", oldCode, newCode)
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
 		require.NoError(t, err)
 	})
 }
@@ -1977,68 +1976,14 @@ func TestConformanceChanges(t *testing.T) {
 
 	t.Parallel()
 
-	contractAddress := common.MustBytesToAddress([]byte{0x1})
-
-	runtime := newTestInterpreterRuntime(
-		WithContractUpdateValidationEnabled(true),
-	)
-
-	newDeployTransaction := func(function, name, code string) []byte {
-		return []byte(fmt.Sprintf(`
-            transaction {
-                prepare(signer: AuthAccount) {
-                    signer.contracts.%s(name: "%s", code: "%s".decodeHex())
-                }
-            }`,
-			function,
-			name,
-			hex.EncodeToString([]byte(code)),
-		))
-	}
-
-	accountCodes := map[common.LocationID][]byte{}
-	var events []cadence.Event
-
-	signerAccount := contractAddress
-
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
-			return accountCodes[location.ID()], nil
-		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
-			return []Address{signerAccount}, nil
-		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
-			return accountCodes[location.ID()], nil
-		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
-			accountCodes[location.ID()] = code
-			return nil
-		},
-		emitEvent: func(event cadence.Event) error {
-			events = append(events, event)
-			return nil
-		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
-		},
-	}
-
-	nextTransactionLocation := newTransactionLocationGenerator()
+	const contractValidationEnabled = true
 
 	t.Run("Adding conformance", func(t *testing.T) {
+
+		t.Parallel()
+
 		const oldCode = `
-            pub contract Test1 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2047,22 +1992,11 @@ func TestConformanceChanges(t *testing.T) {
                 pub struct Foo {
                     init() {}
                 }
-            }`
-		deployTx1 := newDeployTransaction(sema.AuthAccountContractsTypeAddFunctionName, "Test1", oldCode)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
+            }
+        `
 
 		const newCode = `
-            pub contract Test1 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2080,47 +2014,19 @@ func TestConformanceChanges(t *testing.T) {
                 pub struct interface Bar {
                     pub fun getName(): String
                 }
-            }`
+            }
+        `
 
-		deployTx2 := newDeployTransaction(sema.AuthAccountContractsTypeUpdateExperimentalFunctionName, "Test1", newCode)
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx2,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
 		require.NoError(t, err)
-
-		const scriptCode = `
-        import Test1 from 0x01
-
-        pub fun main(): String {
-            var x: {Test1.Bar} = Test1.a
-            return x.getName()
-        }
-`
-
-		result, err := runtime.ExecuteScript(
-			Script{
-				Source: []byte(scriptCode),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
-		assert.Equal(t, cadence.String("John"), result)
 	})
 
 	t.Run("Adding conformance with new fields", func(t *testing.T) {
+
+		t.Parallel()
+
 		const oldCode = `
-            pub contract Test2 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2129,22 +2035,11 @@ func TestConformanceChanges(t *testing.T) {
                 pub struct Foo {
                     init() {}
                 }
-            }`
-		deployTx1 := newDeployTransaction(sema.AuthAccountContractsTypeAddFunctionName, "Test2", oldCode)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
+            }
+        `
 
 		const newCode = `
-            pub contract Test2 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2161,27 +2056,23 @@ func TestConformanceChanges(t *testing.T) {
                 pub struct interface Bar {
                     pub var name: String
                 }
-            }`
+            }
+        `
 
-		deployTx2 := newDeployTransaction(sema.AuthAccountContractsTypeUpdateExperimentalFunctionName, "Test2", newCode)
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx2,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
 		require.Error(t, err)
-		cause := getErrorCause(t, err, "Test2")
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+
 		assertExtraneousFieldError(t, cause, "Foo", "name")
 	})
 
 	t.Run("Removing conformance", func(t *testing.T) {
+
+		t.Parallel()
+
 		const oldCode = `
-            pub contract Test3 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2193,22 +2084,11 @@ func TestConformanceChanges(t *testing.T) {
 
                 pub struct interface Bar {
                 }
-            }`
-		deployTx1 := newDeployTransaction(sema.AuthAccountContractsTypeAddFunctionName, "Test3", oldCode)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
+            }
+        `
 
 		const newCode = `
-            pub contract Test3 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2220,27 +2100,23 @@ func TestConformanceChanges(t *testing.T) {
 
                 pub struct interface Bar {
                 }
-            }`
+            }
+        `
 
-		deployTx2 := newDeployTransaction(sema.AuthAccountContractsTypeUpdateExperimentalFunctionName, "Test3", newCode)
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx2,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
 		require.Error(t, err)
-		cause := getErrorCause(t, err, "Test3")
+
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+
 		assertConformanceMismatchError(t, cause, "Foo")
 	})
 
 	t.Run("Change conformance order", func(t *testing.T) {
+
+		t.Parallel()
+
 		const oldCode = `
-            pub contract Test4 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2255,22 +2131,11 @@ func TestConformanceChanges(t *testing.T) {
 
                 pub struct interface Second {
                 }
-            }`
-		deployTx1 := newDeployTransaction(sema.AuthAccountContractsTypeAddFunctionName, "Test4", oldCode)
-		err := runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx1,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		require.NoError(t, err)
+            }
+        `
 
 		const newCode = `
-            pub contract Test4 {
+            pub contract Test {
                 pub var a: Foo
                 init() {
                     self.a = Foo()
@@ -2285,19 +2150,10 @@ func TestConformanceChanges(t *testing.T) {
 
                 pub struct interface Second {
                 }
-            }`
+            }
+        `
 
-		deployTx2 := newDeployTransaction(sema.AuthAccountContractsTypeUpdateExperimentalFunctionName, "Test4", newCode)
-		err = runtime.ExecuteTransaction(
-			Script{
-				Source: deployTx2,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
+		err := testDeployAndUpdate(t, contractValidationEnabled, "Test", oldCode, newCode)
 		require.NoError(t, err)
 	})
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -453,16 +453,18 @@ func (e *MissingEnumCasesError) Error() string {
 	)
 }
 
-// MissingCompositeDeclarationError is reported during an contract update, if an existing
-// composite declaration (struct or struct interface) is removed.
-type MissingCompositeDeclarationError struct {
+// MissingDeclarationError is reported during a contract update,
+// if an existing declaration is removed.
+type MissingDeclarationError struct {
 	Name string
+	Kind common.DeclarationKind
 	ast.Range
 }
 
-func (e *MissingCompositeDeclarationError) Error() string {
+func (e *MissingDeclarationError) Error() string {
 	return fmt.Sprintf(
-		"missing composite declaration `%s`",
+		"missing %s declaration `%s`",
+		e.Kind,
 		e.Name,
 	)
 }


### PR DESCRIPTION
Closes #1419 

## Description

- Make error reporting in contract update validation deterministic, by sorting declarations
- Improve contract update validation tests: Avoid global state across multiple tests, parallelize, and improve helpers

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
