### PR TITLE
Fix definite field initialization analysis 

### DIFF
--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -287,7 +287,7 @@ func (checker *Checker) visitMemberExpressionAssignment(
 
 		if functionActivation.InitializationInfo != nil {
 
-			// If the function potentially returned or jumped before,
+			// If the function potentially returned before,
 			// then the initialization is not definitive, and it must be ignored
 
 			// NOTE: assignment can still be considered definitive if the function maybe halted

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -292,7 +292,7 @@ func (checker *Checker) visitMemberExpressionAssignment(
 
 			// NOTE: assignment can still be considered definitive if the function maybe halted
 
-			if !functionActivation.ReturnInfo.MaybeJumpedOrReturned {
+			if !functionActivation.ReturnInfo.MaybeReturned {
 
 				// If the field is constant and it has already previously been
 				// initialized, report an error for the repeated assignment

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -26,7 +26,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast
 	defer func() {
 		checker.checkResourceLossForFunction()
 		checker.resources.JumpsOrReturns = true
-		functionActivation.ReturnInfo.MaybeJumpedOrReturned = true
+		functionActivation.ReturnInfo.MaybeReturned = true
 		functionActivation.ReturnInfo.DefinitelyReturned = true
 	}()
 

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -115,7 +115,6 @@ func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.R
 
 	functionActivation := checker.functionActivations.Current()
 	checker.resources.JumpsOrReturns = true
-	functionActivation.ReturnInfo.MaybeJumpedOrReturned = true
 	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil
@@ -137,7 +136,6 @@ func (checker *Checker) VisitContinueStatement(statement *ast.ContinueStatement)
 
 	functionActivation := checker.functionActivations.Current()
 	checker.resources.JumpsOrReturns = true
-	functionActivation.ReturnInfo.MaybeJumpedOrReturned = true
 	functionActivation.ReturnInfo.DefinitelyJumped = true
 
 	return nil

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1783,9 +1783,9 @@ func (checker *Checker) checkPotentiallyUnevaluated(check TypeCheckFunc) Type {
 		temporaryResources,
 	)
 
-	functionActivation.ReturnInfo.MaybeJumpedOrReturned =
-		functionActivation.ReturnInfo.MaybeJumpedOrReturned ||
-			temporaryReturnInfo.MaybeJumpedOrReturned
+	functionActivation.ReturnInfo.MaybeReturned =
+		functionActivation.ReturnInfo.MaybeReturned ||
+			temporaryReturnInfo.MaybeReturned
 
 	// NOTE: the definitive return state does not change
 

--- a/runtime/sema/return_info.go
+++ b/runtime/sema/return_info.go
@@ -19,18 +19,18 @@
 package sema
 
 type ReturnInfo struct {
-	// MaybeJumpedOrReturned indicates that the (branch of) the function
-	// contains a potentially taken return, break, or continue statement
-	MaybeJumpedOrReturned bool
-	DefinitelyReturned    bool
-	DefinitelyHalted      bool
-	DefinitelyJumped      bool
+	// MaybeReturned indicates that the (branch of) the function
+	// contains a potentially taken return statement
+	MaybeReturned      bool
+	DefinitelyReturned bool
+	DefinitelyHalted   bool
+	DefinitelyJumped   bool
 }
 
 func (ri *ReturnInfo) MergeBranches(thenReturnInfo *ReturnInfo, elseReturnInfo *ReturnInfo) {
-	ri.MaybeJumpedOrReturned = ri.MaybeJumpedOrReturned ||
-		thenReturnInfo.MaybeJumpedOrReturned ||
-		elseReturnInfo.MaybeJumpedOrReturned
+	ri.MaybeReturned = ri.MaybeReturned ||
+		thenReturnInfo.MaybeReturned ||
+		elseReturnInfo.MaybeReturned
 
 	ri.DefinitelyReturned = ri.DefinitelyReturned ||
 		(thenReturnInfo.DefinitelyReturned &&

--- a/runtime/sema/return_info.go
+++ b/runtime/sema/return_info.go
@@ -19,7 +19,7 @@
 package sema
 
 type ReturnInfo struct {
-	// MaybeReturned indicates that the (branch of) the function
+	// MaybeReturned indicates that (a branch of) the function
 	// contains a potentially taken return statement
 	MaybeReturned      bool
 	DefinitelyReturned bool

--- a/runtime/sema/return_info.go
+++ b/runtime/sema/return_info.go
@@ -19,7 +19,7 @@
 package sema
 
 type ReturnInfo struct {
-	// MaybeReturned indicates that (a branch of) the function
+	// MaybeReturned indicates that (the branch of) the function
 	// contains a potentially taken return statement
 	MaybeReturned      bool
 	DefinitelyReturned bool

--- a/runtime/tests/checker/initialization_test.go
+++ b/runtime/tests/checker/initialization_test.go
@@ -475,6 +475,49 @@ func TestCheckFieldInitializationWithReturn(t *testing.T) {
 
 		assert.IsType(t, &sema.FieldUninitializedError{}, errs[0])
 	})
+
+	t.Run("inside for", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var foo: Int
+
+                init(foo: Int) {
+                    for i in [] {
+                        return
+                    }
+                    self.foo = foo
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.FieldUninitializedError{}, errs[0])
+	})
+
+	t.Run("inside switch", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithPanic(t, `
+          struct Test {
+              let n: Int
+
+              init(n: Int) {
+                  switch n {
+                  case 1:
+                      return
+                  }
+                  self.n = n
+              }
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.FieldUninitializedError{}, errs[0])
+	})
 }
 
 func TestCheckFieldInitializationWithPotentialNeverCallInElse(t *testing.T) {

--- a/runtime/tests/checker/initialization_test.go
+++ b/runtime/tests/checker/initialization_test.go
@@ -642,3 +642,109 @@ func TestCheckFieldInitializationSwitchCase(t *testing.T) {
 		assert.IsType(t, &sema.FieldUninitializedError{}, errs[0])
 	})
 }
+
+func TestCheckFieldInitializationAfterJump(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("while, continue", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var foo: Int
+
+                init(foo: Int) {
+                    while true {
+                        continue
+                    }
+                    self.foo = foo
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("while, break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var foo: Int
+
+                init(foo: Int) {
+                    while true {
+                        break
+                    }
+                    self.foo = foo
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("for, continue", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var foo: Int
+
+                init(foo: Int) {
+                    for i in [] {
+                        continue
+                    }
+                    self.foo = foo
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("for, break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var foo: Int
+
+                init(foo: Int) {
+                    for i in [] {
+                        break
+                    }
+                    self.foo = foo
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("switch, break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithPanic(t, `
+          struct Test {
+              let n: Int
+
+              init(n: Int) {
+                  switch n {
+                  case 1:
+                      break
+                  }
+                  self.n = n
+              }
+          }
+        `)
+
+		require.NoError(t, err)
+	})
+}

--- a/runtime/tests/checker/initialization_test.go
+++ b/runtime/tests/checker/initialization_test.go
@@ -730,6 +730,30 @@ func TestCheckFieldInitializationAfterJump(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("while, conditional break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var foo: Int
+
+                init(foo: Int) {
+                    while true {
+                        if true {
+                           break
+                        }
+
+                        self.foo = foo
+                    }
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.FieldUninitializedError{}, errs[0])
+	})
+
 	t.Run("for, continue", func(t *testing.T) {
 
 		t.Parallel()
@@ -770,6 +794,30 @@ func TestCheckFieldInitializationAfterJump(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("for, conditional break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var foo: Int
+
+                init(foo: Int) {
+                    for i in [] {
+                        if true {
+                           break
+                        }
+
+                        self.foo = foo
+                    }
+                }
+            }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.FieldUninitializedError{}, errs[0])
+	})
+
 	t.Run("switch, break", func(t *testing.T) {
 
 		t.Parallel()
@@ -789,5 +837,29 @@ func TestCheckFieldInitializationAfterJump(t *testing.T) {
         `)
 
 		require.NoError(t, err)
+	})
+
+	t.Run("switch, conditional break", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithPanic(t, `
+          struct Test {
+              let n: Int
+
+              init(n: Int) {
+                  switch n {
+                  case 1:
+                      if true {
+                         break
+                      }
+                      self.n = n
+                  }
+              }
+          }
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.FieldUninitializedError{}, errs[0])
 	})
 }


### PR DESCRIPTION
Closes #1405

## Description

`MaybeJumpedOrReturned` (now `MaybeReturned`) was used only to determine whether a branch of the function has a 'return'. Marking it as `true` for jumps (`break` and `continue` statements) was going against the above assumption/usage.

Reverted the change of using that flag for both jumps and returns, and continue to use it for returns only.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
