### PR TITLE
Added test to partially ensure HashableValue does not regress

### DIFF
--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -218,6 +218,11 @@ const (
 	CBORTagReferenceStaticType
 	CBORTagRestrictedStaticType
 	CBORTagCapabilityStaticType
+
+	// !!! *WARNING* !!!
+	// ADD NEW TYPES *BEFORE* THIS WARNING.
+	// DO *NOT* ADD NEW TYPES AFTER THIS LINE!
+	CBORTag_Count
 )
 
 // CBOREncMode

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3824,3 +3824,11 @@ func TestEncodeDecodeStaticType(t *testing.T) {
 		require.Equal(t, ty, actualType)
 	})
 }
+
+func TestCBORTagValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("No new types added in between", func(t *testing.T) {
+		require.Equal(t, byte(222), byte(CBORTag_Count))
+	})
+}

--- a/runtime/interpreter/hashablevalue.go
+++ b/runtime/interpreter/hashablevalue.go
@@ -45,6 +45,7 @@ func newHashInputProvider(interpreter *Interpreter, getLocationRange func() Loca
 //
 // Only remove types by:
 // - replace existing types with a placeholder `_`
+//   and a comment indicating that this placeholder cannot be used for a new type
 //
 // DO *NOT* REPLACE EXISTING TYPES!
 // DO *NOT* ADD NEW TYPES IN BETWEEN!

--- a/runtime/interpreter/hashablevalue.go
+++ b/runtime/interpreter/hashablevalue.go
@@ -115,4 +115,9 @@ const (
 	_ // future: UFix128
 	_ // future: UFix256
 	_
+
+	// !!! *WARNING* !!!
+	// ADD NEW TYPES *BEFORE* THIS WARNING.
+	// DO *NOT* ADD NEW TYPES AFTER THIS LINE!
+	HashInputType_Count
 )

--- a/runtime/interpreter/hashablevalue_test.go
+++ b/runtime/interpreter/hashablevalue_test.go
@@ -19,8 +19,9 @@
 package interpreter
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHashableValue(t *testing.T) {

--- a/runtime/interpreter/hashablevalue_test.go
+++ b/runtime/interpreter/hashablevalue_test.go
@@ -1,0 +1,32 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestHashableValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("No new types added in between", func(t *testing.T) {
+		require.Equal(t, byte(HashInputTypeUFix64), byte(46))
+	})
+}

--- a/runtime/interpreter/hashablevalue_test.go
+++ b/runtime/interpreter/hashablevalue_test.go
@@ -28,6 +28,6 @@ func TestHashableValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("No new types added in between", func(t *testing.T) {
-		require.Equal(t, byte(HashInputTypeUFix64), byte(46))
+		require.Equal(t, byte(50), byte(HashInputType_Count))
 	})
 }

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -168,6 +168,11 @@ const (
 	PrimitiveStaticTypeAuthAccountKeys
 	PrimitiveStaticTypePublicAccountKeys
 	PrimitiveStaticTypeAccountKey
+
+	// !!! *WARNING* !!!
+	// ADD NEW TYPES *BEFORE* THIS WARNING.
+	// DO *NOT* ADD NEW TYPES AFTER THIS LINE!
+	PrimitiveStaticType_Count
 )
 
 func (PrimitiveStaticType) isStaticType() {}

--- a/runtime/interpreter/primitivestatictype_string.go
+++ b/runtime/interpreter/primitivestatictype_string.go
@@ -60,9 +60,10 @@ func _() {
 	_ = x[PrimitiveStaticTypeAuthAccountKeys-95]
 	_ = x[PrimitiveStaticTypePublicAccountKeys-96]
 	_ = x[PrimitiveStaticTypeAccountKey-97]
+	_ = x[PrimitiveStaticType_Count-98]
 }
 
-const _PrimitiveStaticType_name = "UnknownVoidAnyNeverAnyStructAnyResourceBoolAddressStringCharacterMetaTypeBlockNumberSignedNumberIntegerSignedIntegerFixedPointSignedFixedPointIntInt8Int16Int32Int64Int128Int256UIntUInt8UInt16UInt32UInt64UInt128UInt256Word8Word16Word32Word64Fix64UFix64PathCapabilityStoragePathCapabilityPathPublicPathPrivatePathAuthAccountPublicAccountDeployedContractAuthAccountContractsPublicAccountContractsAuthAccountKeysPublicAccountKeysAccountKey"
+const _PrimitiveStaticType_name = "UnknownVoidAnyNeverAnyStructAnyResourceBoolAddressStringCharacterMetaTypeBlockNumberSignedNumberIntegerSignedIntegerFixedPointSignedFixedPointIntInt8Int16Int32Int64Int128Int256UIntUInt8UInt16UInt32UInt64UInt128UInt256Word8Word16Word32Word64Fix64UFix64PathCapabilityStoragePathCapabilityPathPublicPathPrivatePathAuthAccountPublicAccountDeployedContractAuthAccountContractsPublicAccountContractsAuthAccountKeysPublicAccountKeysAccountKey_Count"
 
 var _PrimitiveStaticType_map = map[PrimitiveStaticType]string{
 	0:  _PrimitiveStaticType_name[0:7],
@@ -117,6 +118,7 @@ var _PrimitiveStaticType_map = map[PrimitiveStaticType]string{
 	95: _PrimitiveStaticType_name[393:408],
 	96: _PrimitiveStaticType_name[408:425],
 	97: _PrimitiveStaticType_name[425:435],
+	98: _PrimitiveStaticType_name[435:441],
 }
 
 func (i PrimitiveStaticType) String() string {

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -942,3 +942,11 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 		)
 	})
 }
+
+func TestPrimitiveStaticTypeCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("No new types added in between", func(t *testing.T) {
+		require.Equal(t, byte(98), byte(PrimitiveStaticType_Count))
+	})
+}


### PR DESCRIPTION
Closes nothing (just ran into this)

## Description

While looking into another issue, I came across the warning in `hashablevalue.go` and figured it could use a quick test to catch a possible regression.

I also added some language to the warning because it had a loophole.


______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
