### PR TITLE
Add test for CharacterValue.HashInput

### DIFF
--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -1377,6 +1377,13 @@ func TestGetHashInput(t *testing.T) {
 				[]byte(strings.Repeat("a", 32))...,
 			),
 		},
+		"Character": {
+			value: NewCharacterValue("ᄀᄀᄀ각ᆨᆨ"),
+			expected: []byte{
+				byte(HashInputTypeCharacter),
+				0xe1, 0x84, 0x80, 0xe1, 0x84, 0x80, 0xe1, 0x84, 0x80, 0xea, 0xb0, 0x81, 0xe1, 0x86, 0xa8, 0xe1, 0x86, 0xa8,
+			},
+		},
 		"Address": {
 			value:    NewAddressValue(common.Address{0, 0, 0, 0, 0, 0, 0, 1}),
 			expected: []byte{byte(HashInputTypeAddress), 0, 0, 0, 0, 0, 0, 0, 1},


### PR DESCRIPTION
Closes nothing

## Description

For some reason we don't have a test for `CharacterValue` hashing so I added one.

I used the example of a large grapheme cluster from the spec according to [this blog post](https://manishearth.github.io/blog/2017/01/14/stop-ascribing-meaning-to-unicode-code-points/).

I didn't verify that the output value is correct because my intent here is just to add test coverage in case of regressions. But I can if desired.

______

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
