### PR TITLE
Fix AST walking default-case in switch-statement

### DIFF
--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -597,7 +597,10 @@ func (s *SwitchStatement) Accept(visitor Visitor) Repr {
 func (s *SwitchStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Expression)
 	for _, switchCase := range s.Cases {
-		walkChild(switchCase.Expression)
+		// The default case has no expression
+		if switchCase.Expression != nil {
+			walkChild(switchCase.Expression)
+		}
 		walkStatements(walkChild, switchCase.Statements)
 	}
 }


### PR DESCRIPTION
## Description

Default-case's doesn't have an expression, skip it from visiting.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
