### PR TITLE
use feature branch for cadence->flow-go sync PRs

### DIFF
--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -1,5 +1,6 @@
 # Open a PR in flow-go when a PR in cadence is merged
-# The PR in flow-go is based on the last opened `auto-cadence-upgrade/*` if it exists, otherwise on the master branch
+# The PR in flow-go is based on the last opened `auto-cadence-upgrade/*` if it exists.
+# Otherwise, it's based on the feature-secure-cadence branch.
 name: Sync flow-go
 
 # Only run on pull requests merged to master
@@ -19,7 +20,7 @@ on:
 jobs:
   sync-flow-go:
     runs-on: ubuntu-latest
-    # the PR could have been closed otherwise. Only run if it has actually ben merged
+    # the PR could have been closed otherwise. Only run if it has actually been merged
     if: github.event.pull_request.merged == true
     steps:
     
@@ -32,11 +33,12 @@ jobs:
           repository: onflow/flow-go
       
       # get the latest update branch name to base the PR on that branch
+      # else, use the "feature-secure-cadence" branch
       - name: Get onflow/flow-go base branch name
         run: |
           git fetch
           BRANCH=$(git branch -r -l "*auto-cadence-upgrade/*" --format "%(refname:lstrip=3)" | sort -r | head -n 1)
-          [ -z $BRANCH ] && BRANCH=master
+          [ -z $BRANCH ] && BRANCH=feature-secure-cadence
           echo "BASE_BRANCH=$BRANCH" >> $GITHUB_ENV
 
       # create new branch name
@@ -44,6 +46,16 @@ jobs:
         run: |
           NEW_BRANCH=auto-cadence-upgrade/$( date +%s )/${{ github.event.pull_request.head.ref }}
           echo "NEW_BRANCH=$NEW_BRANCH" >> $GITHUB_ENV
+
+      # create feature branch if needed
+      - name: Create feature-secure-cadence branch
+        uses: peterjgrainger/action-create-branch@v2.0.1
+        if: ${{ env.BASE_BRANCH == "feature-secure-cadence" }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: feature-secure-cadence
+          ref: master
 
       # checkout the correct branch of the remote repo
       - name: Checkout onflow/flow-go branch

--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git fetch
           BRANCH=$(git branch -r -l "*auto-cadence-upgrade/*" --format "%(refname:lstrip=3)" | sort -r | head -n 1)
-          [ -z $BRANCH ] && BRANCH=feature-secure-cadence
+          [ -z $BRANCH ] && BRANCH=feature/secure-cadence
           echo "BASE_BRANCH=$BRANCH" >> $GITHUB_ENV
 
       # create new branch name


### PR DESCRIPTION
Creates feature-secure-cadence branch off of master, if needed.

Closes #1415 

## Description

We want to keep the flow-go and cadence repos synchronized. But that does not always extend to their master branches.

To this end every cadence PR that makes it into master creates a PR in the flow-go repo. They use a version of cadence that corresponds to the cadence PR that made it into master.

Currently we base off of the flow-go master branch. This is a problem because our cadence and flow-go releases are disjoint while cadence is undergoing major breaking changes in preparation for the secure cadence release. We don't want to add such breaking changes to flow-go releases in the meantime.

The solution here is to branch off of master into a new branch `feature-secure-cadence`. This branch needs to be periodically (manually) synchronized with the flow-go master branch.

When it's time to release secure cadence, the feature branch will be merged into master.

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
