### PR TITLE
Start refactor of interpreter options and shared state

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -736,17 +736,15 @@ func exportFromScript(t *testing.T, code string) cadence.Value {
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
-		interpreter.WithUUIDHandler(
-			func() (uint64, error) {
+		&interpreter.Options{
+			Storage: interpreter.NewInMemoryStorage(),
+			ResourceUUIDHandler: func() (uint64, error) {
 				uuid++
 				return uuid, nil
 			},
-		),
-		interpreter.WithAtreeStorageValidationEnabled(true),
-		interpreter.WithAtreeValueValidationEnabled(true),
-		interpreter.WithStorage(
-			interpreter.NewInMemoryStorage(),
-		),
+			AtreeStorageValidationEnabled: true,
+			AtreeValueValidationEnabled:   true,
+		},
 	)
 	require.NoError(t, err)
 

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -161,13 +161,15 @@ func PrepareInterpreter(filename string, debugger *interpreter.Debugger) (*inter
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
-		interpreter.WithStorage(storage),
-		interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
-		interpreter.WithUUIDHandler(func() (uint64, error) {
-			defer func() { uuid++ }()
-			return uuid, nil
-		}),
-		interpreter.WithDebugger(debugger),
+		&interpreter.Options{
+			Storage:           storage,
+			PredeclaredValues: valueDeclarations.ToInterpreterValueDeclarations(),
+			ResourceUUIDHandler: func() (uint64, error) {
+				defer func() { uuid++ }()
+				return uuid, nil
+			},
+			Debugger: debugger,
+		},
 	)
 	must(err)
 

--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -243,7 +243,9 @@ func load() {
 	inter, err := interpreter.NewInterpreter(
 		nil,
 		nil,
-		interpreter.WithStorage(interpreterStorage),
+		&interpreter.Options{
+			Storage: interpreterStorage,
+		},
 	)
 	if err != nil {
 		log.Fatalf("Failed to create interpreter: %s", err)

--- a/runtime/compiler/wasm/writer_test.go
+++ b/runtime/compiler/wasm/writer_test.go
@@ -498,6 +498,8 @@ func TestWASMWriter_writeNameSection(t *testing.T) {
 
 func TestWASMWriterReader(t *testing.T) {
 
+	t.Skip("WIP")
+
 	t.Parallel()
 
 	var b Buffer

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -923,7 +923,7 @@ func importPublicKey(
 		interpreter.ReturnEmptyLocationRange,
 		publicKeyValue,
 		signAlgoValue,
-		inter.PublicKeyValidationHandler,
+		inter.Options.PublicKeyValidationHandler,
 	), nil
 }
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -4598,9 +4598,11 @@ func newTestInterpreter(tb testing.TB) *interpreter.Interpreter {
 	inter, err := interpreter.NewInterpreter(
 		nil,
 		TestLocation,
-		interpreter.WithStorage(storage),
-		interpreter.WithAtreeValueValidationEnabled(true),
-		interpreter.WithAtreeStorageValidationEnabled(true),
+		&interpreter.Options{
+			Storage:                       storage,
+			AtreeValueValidationEnabled:   true,
+			AtreeStorageValidationEnabled: true,
+		},
 	)
 	require.NoError(tb, err)
 

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -41,7 +41,9 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	inter, err := NewInterpreter(
 		nil,
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -107,7 +107,13 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 		if test.deepEquality {
 			assert.Equal(t, expectedValue, decodedValue)
 		} else {
-			inter, err := NewInterpreter(nil, TestLocation, WithStorage(test.storage))
+			inter, err := NewInterpreter(
+				nil,
+				TestLocation,
+				&Options{
+					Storage: test.storage,
+				},
+			)
 			require.NoError(t, err)
 			AssertValuesEqual(t, inter, expectedValue, decodedValue)
 		}
@@ -274,7 +280,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				storage: inter.Storage,
+				storage: inter.Options.Storage,
 				value:   expected,
 				encoded: []byte{
 					// tag
@@ -306,7 +312,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				storage: inter.Storage,
+				storage: inter.Options.Storage,
 				value:   expected,
 				encoded: []byte{
 					// tag
@@ -341,7 +347,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				storage: inter.Storage,
+				storage: inter.Options.Storage,
 				value:   expected,
 				encoded: []byte{
 					// tag
@@ -378,7 +384,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				storage: inter.Storage,
+				storage: inter.Options.Storage,
 				value:   expected,
 				encoded: []byte{
 					// tag

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -619,7 +619,7 @@ func (interpreter *Interpreter) VisitConditionalExpression(expression *ast.Condi
 func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *ast.InvocationExpression) ast.Repr {
 
 	// tracing
-	if interpreter.tracingEnabled {
+	if interpreter.Options.TracingEnabled {
 		startTime := time.Now()
 		defer func() {
 			interpreter.reportFunctionTrace(invocationExpression.InvokedExpression.String(), time.Since(startTime))

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -40,7 +40,7 @@ func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDe
 func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.ResolvedLocation) {
 
 	// tracing
-	if interpreter.tracingEnabled {
+	if interpreter.Options.TracingEnabled {
 		startTime := time.Now()
 		defer func() {
 			interpreter.reportImportTrace(resolvedLocation.Location.String(), time.Since(startTime))

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -36,12 +36,12 @@ func (interpreter *Interpreter) evalStatement(statement ast.Statement) interface
 
 	interpreter.statement = statement
 
-	if interpreter.debugger != nil {
-		interpreter.debugger.onStatement(interpreter, statement)
+	if interpreter.Options.Debugger != nil {
+		interpreter.Options.Debugger.onStatement(interpreter, statement)
 	}
 
-	if interpreter.onStatement != nil {
-		interpreter.onStatement(interpreter, statement)
+	if interpreter.Options.OnStatement != nil {
+		interpreter.Options.OnStatement(interpreter, statement)
 	}
 
 	return statement.Accept(interpreter)
@@ -358,13 +358,13 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 
 	getLocationRange := locationRangeGetter(interpreter.Location, statement)
 
-	if interpreter.onEventEmitted == nil {
+	if interpreter.Options.OnEventEmitted == nil {
 		panic(EventEmissionUnavailableError{
 			LocationRange: getLocationRange(),
 		})
 	}
 
-	err := interpreter.onEventEmitted(interpreter, getLocationRange, event, eventType)
+	err := interpreter.Options.OnEventEmitted(interpreter, getLocationRange, event, eventType)
 	if err != nil {
 		panic(err)
 	}

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -34,11 +34,11 @@ const (
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingFunctionPrefix+functionName, duration, nil)
+	interpreter.Options.OnRecordTrace(interpreter, tracingFunctionPrefix+functionName, duration, nil)
 }
 
 func (interpreter *Interpreter) reportImportTrace(importPath string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingImportPrefix+importPath, duration, nil)
+	interpreter.Options.OnRecordTrace(interpreter, tracingImportPrefix+importPath, duration, nil)
 }
 
 func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, count int, duration time.Duration) {
@@ -51,7 +51,7 @@ func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, c
 			},
 		},
 	}
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, logs)
+	interpreter.Options.OnRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, logs)
 }
 
 func (interpreter *Interpreter) reportDictionaryValueTransferTrace(typeInfo string, count int, duration time.Duration) {
@@ -64,5 +64,5 @@ func (interpreter *Interpreter) reportDictionaryValueTransferTrace(typeInfo stri
 			},
 		},
 	}
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, logs)
+	interpreter.Options.OnRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, logs)
 }

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -41,7 +41,9 @@ func TestCompositeStorage(t *testing.T) {
 	inter, err := NewInterpreter(
 		nil,
 		common.AddressLocation{},
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -104,8 +106,10 @@ func TestArrayStorage(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			common.AddressLocation{},
-			WithStorage(storage),
-			WithImportLocationHandler(importLocationHandlerFunc),
+			&Options{
+				Storage:               storage,
+				ImportLocationHandler: importLocationHandlerFunc,
+			},
 		)
 		require.NoError(t, err)
 
@@ -167,8 +171,10 @@ func TestArrayStorage(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			common.AddressLocation{},
-			WithStorage(storage),
-			WithImportLocationHandler(importLocationHandlerFunc),
+			&Options{
+				Storage:               storage,
+				ImportLocationHandler: importLocationHandlerFunc,
+			},
 		)
 		require.NoError(t, err)
 
@@ -230,7 +236,9 @@ func TestDictionaryStorage(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			common.AddressLocation{},
-			WithStorage(storage),
+			&Options{
+				Storage: storage,
+			},
 		)
 		require.NoError(t, err)
 
@@ -286,7 +294,9 @@ func TestDictionaryStorage(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			common.AddressLocation{},
-			WithStorage(storage),
+			&Options{
+				Storage: storage,
+			},
 		)
 		require.NoError(t, err)
 
@@ -335,7 +345,9 @@ func TestDictionaryStorage(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			common.AddressLocation{},
-			WithStorage(storage),
+			&Options{
+				Storage: storage,
+			},
 		)
 		require.NoError(t, err)
 
@@ -383,7 +395,9 @@ func TestDictionaryStorage(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			common.AddressLocation{},
-			WithStorage(storage),
+			&Options{
+				Storage: storage,
+			},
 		)
 		require.NoError(t, err)
 
@@ -431,7 +445,9 @@ func TestStorageOverwriteAndRemove(t *testing.T) {
 	inter, err := NewInterpreter(
 		nil,
 		common.AddressLocation{},
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 

--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -124,7 +124,7 @@ func (s StorageMap) SetValue(interpreter *Interpreter, key string, value atree.V
 	interpreter.maybeValidateAtreeValue(s.orderedMap)
 
 	if existingStorable != nil {
-		existingValue := StoredValue(existingStorable, interpreter.Storage)
+		existingValue := StoredValue(existingStorable, interpreter.Options.Storage)
 		existingValue.DeepRemove(interpreter)
 		interpreter.RemoveReferencedSlab(existingStorable)
 	}
@@ -155,7 +155,7 @@ func (s StorageMap) removeValue(interpreter *Interpreter, key string) {
 	// Value
 
 	if existingValueStorable != nil {
-		existingValue := StoredValue(existingValueStorable, interpreter.Storage)
+		existingValue := StoredValue(existingValueStorable, interpreter.Options.Storage)
 		existingValue.DeepRemove(interpreter)
 		interpreter.RemoveReferencedSlab(existingValueStorable)
 	}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -72,7 +72,9 @@ func TestOwnerNewArray(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -111,7 +113,9 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -162,7 +166,9 @@ func TestOwnerArrayElement(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -200,7 +206,9 @@ func TestOwnerArraySetIndex(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -248,7 +256,9 @@ func TestOwnerArrayAppend(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -290,7 +300,9 @@ func TestOwnerArrayInsert(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -332,7 +344,9 @@ func TestOwnerArrayRemove(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -372,7 +386,9 @@ func TestOwnerNewDictionary(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -415,7 +431,9 @@ func TestOwnerDictionary(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -458,7 +476,9 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -513,7 +533,9 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -563,7 +585,9 @@ func TestOwnerDictionaryInsertNonExisting(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -614,7 +638,9 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -670,7 +696,9 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 			Elaboration: elaboration,
 		},
 		utils.TestLocation,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 	require.NoError(t, err)
 
@@ -1548,7 +1576,9 @@ func TestEphemeralReferenceTypeConformance(t *testing.T) {
 	inter, err := NewInterpreter(
 		ProgramFromChecker(checker),
 		checker.Location,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 
 	require.NoError(t, err)
@@ -3136,8 +3166,10 @@ func TestPublicKeyValue(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			utils.TestLocation,
-			WithStorage(storage),
-			WithPublicKeyValidationHandler(runtime.DoNotValidatePublicKey),
+			&Options{
+				Storage:                    storage,
+				PublicKeyValidationHandler: runtime.DoNotValidatePublicKey,
+			},
 		)
 		require.NoError(t, err)
 
@@ -3162,7 +3194,7 @@ func TestPublicKeyValue(t *testing.T) {
 			ReturnEmptyLocationRange,
 			publicKey,
 			sigAlgo,
-			inter.PublicKeyValidationHandler,
+			inter.Options.PublicKeyValidationHandler,
 		)
 
 		require.Equal(t,
@@ -3182,12 +3214,12 @@ func TestPublicKeyValue(t *testing.T) {
 		inter, err := NewInterpreter(
 			nil,
 			utils.TestLocation,
-			WithStorage(storage),
-			WithPublicKeyValidationHandler(
-				func(_ *Interpreter, _ func() LocationRange, _ *CompositeValue) error {
+			&Options{
+				Storage: storage,
+				PublicKeyValidationHandler: func(_ *Interpreter, _ func() LocationRange, _ *CompositeValue) error {
 					return fakeError
 				},
-			),
+			},
 		)
 		require.NoError(t, err)
 
@@ -3217,7 +3249,7 @@ func TestPublicKeyValue(t *testing.T) {
 					ReturnEmptyLocationRange,
 					publicKey,
 					sigAlgo,
-					inter.PublicKeyValidationHandler,
+					inter.Options.PublicKeyValidationHandler,
 				)
 			})
 	})
@@ -3337,9 +3369,11 @@ func newTestInterpreter(tb testing.TB) *Interpreter {
 	inter, err := NewInterpreter(
 		nil,
 		utils.TestLocation,
-		WithStorage(storage),
-		WithAtreeValueValidationEnabled(true),
-		WithAtreeStorageValidationEnabled(true),
+		&Options{
+			Storage:                       storage,
+			AtreeValueValidationEnabled:   true,
+			AtreeStorageValidationEnabled: true,
+		},
 	)
 	require.NoError(tb, err)
 
@@ -3377,7 +3411,9 @@ func TestNonStorable(t *testing.T) {
 	inter, err := NewInterpreter(
 		ProgramFromChecker(checker),
 		checker.Location,
-		WithStorage(storage),
+		&Options{
+			Storage: storage,
+		},
 	)
 
 	require.NoError(t, err)

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -130,7 +130,7 @@ var blsAggregatePublicKeysFunction = interpreter.NewHostFunctionValue(
 			getLocationRange,
 		)
 
-		return invocation.Interpreter.BLSAggregatePublicKeysHandler(
+		return invocation.Interpreter.Options.BLSAggregatePublicKeysHandler(
 			inter,
 			getLocationRange,
 			publicKeys,
@@ -155,7 +155,7 @@ var blsAggregateSignaturesFunction = interpreter.NewHostFunctionValue(
 			getLocationRange,
 		)
 
-		return inter.BLSAggregateSignaturesHandler(
+		return inter.Options.BLSAggregateSignaturesHandler(
 			inter,
 			getLocationRange,
 			signatures,

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -48,10 +48,10 @@ func TestAssert(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
-		interpreter.WithStorage(storage),
-		interpreter.WithPredeclaredValues(
-			BuiltinFunctions.ToInterpreterValueDeclarations(),
-		),
+		&interpreter.Options{
+			Storage:           storage,
+			PredeclaredValues: BuiltinFunctions.ToInterpreterValueDeclarations(),
+		},
 	)
 	require.Nil(t, err)
 
@@ -107,8 +107,10 @@ func TestPanic(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
-		interpreter.WithStorage(storage),
-		interpreter.WithPredeclaredValues(BuiltinFunctions.ToInterpreterValueDeclarations()),
+		&interpreter.Options{
+			Storage:           storage,
+			PredeclaredValues: BuiltinFunctions.ToInterpreterValueDeclarations(),
+		},
 	)
 	require.Nil(t, err)
 

--- a/runtime/stdlib/hashalgorithm.go
+++ b/runtime/stdlib/hashalgorithm.go
@@ -57,7 +57,7 @@ var hashAlgorithmHashFunction = interpreter.NewHostFunctionValue(
 			getLocationRange,
 		)
 
-		return inter.HashHandler(
+		return inter.Options.HashHandler(
 			inter,
 			getLocationRange,
 			dataValue,
@@ -92,7 +92,7 @@ var hashAlgorithmHashWithTagFunction = interpreter.NewHostFunctionValue(
 			getLocationRange,
 		)
 
-		return inter.HashHandler(
+		return inter.Options.HashHandler(
 			inter,
 			getLocationRange,
 			dataValue,

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -64,7 +64,7 @@ var publicKeyConstructor = NewStandardLibraryFunction(
 			invocation.GetLocationRange,
 			publicKey,
 			signAlgo,
-			inter.PublicKeyValidationHandler,
+			inter.Options.PublicKeyValidationHandler,
 		)
 	},
 )

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -95,8 +95,8 @@ func testAccount(
 			CheckerOptions: []sema.Option{
 				sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 			},
-			Options: []interpreter.Option{
-				interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
+			Options: &interpreter.Options{
+				PredeclaredValues: valueDeclarations.ToInterpreterValueDeclarations(),
 			},
 		},
 	)
@@ -105,7 +105,9 @@ func testAccount(
 	getAccountValues := func() map[storageKey]interpreter.Value {
 		accountValues := make(map[storageKey]interpreter.Value)
 
-		for storageMapKey, accountStorage := range inter.Storage.(interpreter.InMemoryStorage).StorageMaps {
+		storageMaps := inter.Options.Storage.(interpreter.InMemoryStorage).StorageMaps
+
+		for storageMapKey, accountStorage := range storageMaps {
 			iterator := accountStorage.Iterator()
 			for {
 				key, value := iterator.Next()

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -141,9 +141,9 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 				sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 				sema.WithPredeclaredTypes(typeDeclarations),
 			},
-			Options: []interpreter.Option{
-				interpreter.WithStorage(storage),
-				interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
+			Options: &interpreter.Options{
+				Storage:           storage,
+				PredeclaredValues: valueDeclarations.ToInterpreterValueDeclarations(),
 			},
 		},
 	)

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -420,8 +420,8 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 					tearDownCode,
 				),
 				ParseCheckAndInterpretOptions{
-					Options: []interpreter.Option{
-						makeContractValueHandler(nil, nil, nil),
+					Options: &interpreter.Options{
+						ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					},
 				},
 			)
@@ -541,9 +541,9 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 						}
 					}
 
-					uuidHandler := interpreter.WithUUIDHandler(func() (uint64, error) {
+					resourceUUIDHandler := func() (uint64, error) {
 						return 0, nil
-					})
+					}
 
 					if compositeKind == common.CompositeKindContract {
 
@@ -552,19 +552,21 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 						inter, err := interpreter.NewInterpreter(
 							interpreter.ProgramFromChecker(checker),
 							checker.Location,
-							interpreter.WithStorage(storage),
-							makeContractValueHandler(
-								[]interpreter.Value{
-									interpreter.NewIntValueFromInt64(value),
-								},
-								[]sema.Type{
-									sema.IntType,
-								},
-								[]sema.Type{
-									sema.IntType,
-								},
-							),
-							uuidHandler,
+							&interpreter.Options{
+								Storage: storage,
+								ContractValueHandler: makeContractValueHandler(
+									[]interpreter.Value{
+										interpreter.NewIntValueFromInt64(value),
+									},
+									[]sema.Type{
+										sema.IntType,
+									},
+									[]sema.Type{
+										sema.IntType,
+									},
+								),
+								ResourceUUIDHandler: resourceUUIDHandler,
+							},
 						)
 						require.NoError(t, err)
 
@@ -579,8 +581,10 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 						inter, err := interpreter.NewInterpreter(
 							interpreter.ProgramFromChecker(checker),
 							checker.Location,
-							interpreter.WithStorage(storage),
-							uuidHandler,
+							&interpreter.Options{
+								Storage:             storage,
+								ResourceUUIDHandler: resourceUUIDHandler,
+							},
 						)
 						require.NoError(t, err)
 
@@ -638,8 +642,8 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Options: []interpreter.Option{
-				makeContractValueHandler(nil, nil, nil),
+			Options: &interpreter.Options{
+				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
 	)
@@ -813,8 +817,8 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Options: []interpreter.Option{
-				makeContractValueHandler(nil, nil, nil),
+			Options: &interpreter.Options{
+				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
 	)
@@ -1034,8 +1038,8 @@ func TestInterpretIsInstanceCheckInPreCondition(t *testing.T) {
 				condition,
 			),
 			ParseCheckAndInterpretOptions{
-				Options: []interpreter.Option{
-					makeContractValueHandler(nil, nil, nil),
+				Options: &interpreter.Options{
+					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
 		)
@@ -1153,8 +1157,8 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 			CheckerOptions: []sema.Option{
 				sema.WithPredeclaredValues(semaValueDeclarations),
 			},
-			Options: []interpreter.Option{
-				interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+			Options: &interpreter.Options{
+				PredeclaredValues: interpreterValueDeclarations,
 			},
 		},
 	)

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -332,8 +332,8 @@ func TestArrayMutation(t *testing.T) {
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(valueDeclarations),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(values),
+				Options: &interpreter.Options{
+					PredeclaredValues: values,
 				},
 			},
 		)
@@ -462,8 +462,8 @@ func TestArrayMutation(t *testing.T) {
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(valueDeclarations),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(values),
+				Options: &interpreter.Options{
+					PredeclaredValues: values,
 				},
 			},
 		)
@@ -713,8 +713,8 @@ func TestDictionaryMutation(t *testing.T) {
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(valueDeclarations),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(values),
+				Options: &interpreter.Options{
+					PredeclaredValues: values,
 				},
 			},
 		)
@@ -843,8 +843,8 @@ func TestDictionaryMutation(t *testing.T) {
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(valueDeclarations),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(values),
+				Options: &interpreter.Options{
+					PredeclaredValues: values,
 				},
 			},
 		)

--- a/runtime/tests/interpreter/contract_test.go
+++ b/runtime/tests/interpreter/contract_test.go
@@ -53,8 +53,8 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Options: []interpreter.Option{
-					makeContractValueHandler(nil, nil, nil),
+				Options: &interpreter.Options{
+					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
 		)
@@ -84,8 +84,8 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Options: []interpreter.Option{
-					makeContractValueHandler(nil, nil, nil),
+				Options: &interpreter.Options{
+					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
 		)
@@ -115,8 +115,8 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Options: []interpreter.Option{
-					makeContractValueHandler(nil, nil, nil),
+				Options: &interpreter.Options{
+					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
 		)
@@ -148,8 +148,8 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Options: []interpreter.Option{
-					makeContractValueHandler(nil, nil, nil),
+				Options: &interpreter.Options{
+					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
 		)

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3486,10 +3486,10 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 				capabilityValueDeclaration,
 			}),
 		},
-		Options: []interpreter.Option{
-			interpreter.WithPredeclaredValues([]interpreter.ValueDeclaration{
+		Options: &interpreter.Options{
+			PredeclaredValues: []interpreter.ValueDeclaration{
 				capabilityValueDeclaration,
-			}),
+			},
 		},
 	}
 

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -235,8 +235,8 @@ func TestInterpretEnumInContract(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Options: []interpreter.Option{
-				makeContractValueHandler(nil, nil, nil),
+			Options: &interpreter.Options{
+				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
 	)

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -65,10 +65,10 @@ func TestInterpretEquality(t *testing.T) {
               let res2 = maybeCapNil == nil
 		    `,
 			ParseCheckAndInterpretOptions{
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues([]interpreter.ValueDeclaration{
+				Options: &interpreter.Options{
+					PredeclaredValues: []interpreter.ValueDeclaration{
 						capabilityValueDeclaration,
-					}),
+					},
 				},
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues([]sema.ValueDeclaration{

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -132,19 +132,16 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			},
 		}
 
-		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
-		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
-
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               let result = Type<Int>() == unknownType
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerOptions: []sema.Option{
-					sema.WithPredeclaredValues(semaValueDeclarations),
+					sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				Options: &interpreter.Options{
+					PredeclaredValues: valueDeclarations.ToInterpreterValueDeclarations(),
 				},
 			},
 		)
@@ -185,19 +182,16 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			},
 		}
 
-		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
-		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
-
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               let result = unknownType1 == unknownType2
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerOptions: []sema.Option{
-					sema.WithPredeclaredValues(semaValueDeclarations),
+					sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				Options: &interpreter.Options{
+					PredeclaredValues: valueDeclarations.ToInterpreterValueDeclarations(),
 				},
 			},
 		)
@@ -269,19 +263,16 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			},
 		}
 
-		semaValueDeclarations := valueDeclarations.ToSemaValueDeclarations()
-		interpreterValueDeclarations := valueDeclarations.ToInterpreterValueDeclarations()
-
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
               let identifier = unknownType.identifier
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerOptions: []sema.Option{
-					sema.WithPredeclaredValues(semaValueDeclarations),
+					sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				Options: &interpreter.Options{
+					PredeclaredValues: valueDeclarations.ToInterpreterValueDeclarations(),
 				},
 			},
 		)
@@ -407,8 +398,8 @@ func TestInterpretIsInstance(t *testing.T) {
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(semaValueDeclarations),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				Options: &interpreter.Options{
+					PredeclaredValues: interpreterValueDeclarations,
 				},
 			})
 			require.NoError(t, err)
@@ -548,8 +539,8 @@ func TestInterpretIsSubtype(t *testing.T) {
 				CheckerOptions: []sema.Option{
 					sema.WithPredeclaredValues(semaValueDeclarations),
 				},
-				Options: []interpreter.Option{
-					interpreter.WithPredeclaredValues(interpreterValueDeclarations),
+				Options: &interpreter.Options{
+					PredeclaredValues: interpreterValueDeclarations,
 				},
 			})
 			require.NoError(t, err)
@@ -719,9 +710,9 @@ func TestInterpretGetType(t *testing.T) {
 					CheckerOptions: []sema.Option{
 						sema.WithPredeclaredValues(valueDeclarations),
 					},
-					Options: []interpreter.Option{
-						interpreter.WithStorage(storage),
-						interpreter.WithPredeclaredValues(values),
+					Options: &interpreter.Options{
+						Storage:           storage,
+						PredeclaredValues: values,
 					},
 				},
 			)

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -101,9 +101,9 @@ func TestInterpretStatementHandler(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
 		importingChecker.Location,
-		interpreter.WithStorage(storage),
-		interpreter.WithOnStatementHandler(
-			func(interpreter *interpreter.Interpreter, statement ast.Statement) {
+		&interpreter.Options{
+			Storage: storage,
+			OnStatement: func(interpreter *interpreter.Interpreter, statement ast.Statement) {
 				id, ok := interpreterIDs[interpreter]
 				if !ok {
 					id = nextInterpreterID
@@ -116,9 +116,7 @@ func TestInterpretStatementHandler(t *testing.T) {
 					line:          statement.StartPosition().Line,
 				})
 			},
-		),
-		interpreter.WithImportLocationHandler(
-			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				assert.Equal(t,
 					utils.ImportedLocation,
 					location,
@@ -134,7 +132,7 @@ func TestInterpretStatementHandler(t *testing.T) {
 					Interpreter: subInterpreter,
 				}
 			},
-		),
+		},
 	)
 	require.NoError(t, err)
 
@@ -230,9 +228,9 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
 		importingChecker.Location,
-		interpreter.WithStorage(storage),
-		interpreter.WithOnLoopIterationHandler(
-			func(inter *interpreter.Interpreter, line int) {
+		&interpreter.Options{
+			Storage: storage,
+			OnLoopIteration: func(inter *interpreter.Interpreter, line int) {
 
 				id, ok := interpreterIDs[inter]
 				if !ok {
@@ -246,9 +244,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 					line:          line,
 				})
 			},
-		),
-		interpreter.WithImportLocationHandler(
-			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				assert.Equal(t,
 					utils.ImportedLocation,
 					location,
@@ -264,7 +260,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 					Interpreter: subInterpreter,
 				}
 			},
-		),
+		},
 	)
 	require.NoError(t, err)
 
@@ -369,9 +365,9 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
 		importingChecker.Location,
-		interpreter.WithStorage(storage),
-		interpreter.WithOnFunctionInvocationHandler(
-			func(inter *interpreter.Interpreter, line int) {
+		&interpreter.Options{
+			Storage: storage,
+			OnFunctionInvocation: func(inter *interpreter.Interpreter, line int) {
 
 				id, ok := interpreterIDs[inter]
 				if !ok {
@@ -385,9 +381,7 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 					line:          line,
 				})
 			},
-		),
-		interpreter.WithImportLocationHandler(
-			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				assert.Equal(t,
 					utils.ImportedLocation,
 					location,
@@ -403,7 +397,7 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 					Interpreter: subInterpreter,
 				}
 			},
-		),
+		},
 	)
 	require.NoError(t, err)
 

--- a/runtime/tests/interpreter/nesting_test.go
+++ b/runtime/tests/interpreter/nesting_test.go
@@ -42,8 +42,8 @@ func TestInterpretContractWithNestedDeclaration(t *testing.T) {
 	      }
 	    `,
 		ParseCheckAndInterpretOptions{
-			Options: []interpreter.Option{
-				makeContractValueHandler(nil, nil, nil),
+			Options: &interpreter.Options{
+				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
 	)

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -711,12 +711,10 @@ func TestInterpretReferenceUseAfterShiftStatementMove(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Options: []interpreter.Option{
-					interpreter.WithPublicAccountHandler(
-						func(_ *interpreter.Interpreter, address interpreter.AddressValue) interpreter.Value {
-							return newTestPublicAccountValue(address)
-						},
-					),
+				Options: &interpreter.Options{
+					PublicAccountHandler: func(_ *interpreter.Interpreter, address interpreter.AddressValue) interpreter.Value {
+						return newTestPublicAccountValue(address)
+					},
 				},
 			},
 		)

--- a/runtime/tests/interpreter/transfer_test.go
+++ b/runtime/tests/interpreter/transfer_test.go
@@ -71,8 +71,8 @@ func TestInterpretTransferCheck(t *testing.T) {
 				sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
 				sema.WithPredeclaredTypes(typeDeclarations.ToTypeDeclarations()),
 			},
-			Options: []interpreter.Option{
-				interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
+			Options: &interpreter.Options{
+				PredeclaredValues: valueDeclarations.ToInterpreterValueDeclarations(),
 			},
 		},
 	)

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -89,15 +89,13 @@ func TestInterpretResourceUUID(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
 		importingChecker.Location,
-		interpreter.WithStorage(storage),
-		interpreter.WithUUIDHandler(
-			func() (uint64, error) {
+		&interpreter.Options{
+			Storage: storage,
+			ResourceUUIDHandler: func() (uint64, error) {
 				defer func() { uuid++ }()
 				return uuid, nil
 			},
-		),
-		interpreter.WithImportLocationHandler(
-			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				assert.Equal(t,
 					ImportedLocation,
 					location,
@@ -113,7 +111,7 @@ func TestInterpretResourceUUID(t *testing.T) {
 					Interpreter: subInterpreter,
 				}
 			},
-		),
+		},
 	)
 	require.NoError(t, err)
 

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -65,16 +65,16 @@ func TestRandomMapOperations(t *testing.T) {
 			Elaboration: sema.NewElaboration(),
 		},
 		utils.TestLocation,
-		interpreter.WithStorage(storage),
-		interpreter.WithImportLocationHandler(
-			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+		&interpreter.Options{
+			Storage: storage,
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				return interpreter.VirtualImport{
 					Elaboration: inter.Program.Elaboration,
 				}
 			},
-		),
-		interpreter.WithAtreeStorageValidationEnabled(*validateAtree),
-		interpreter.WithAtreeValueValidationEnabled(*validateAtree),
+			AtreeStorageValidationEnabled: *validateAtree,
+			AtreeValueValidationEnabled:   *validateAtree,
+		},
 	)
 	require.NoError(t, err)
 
@@ -501,14 +501,14 @@ func TestRandomArrayOperations(t *testing.T) {
 			Elaboration: sema.NewElaboration(),
 		},
 		utils.TestLocation,
-		interpreter.WithStorage(storage),
-		interpreter.WithImportLocationHandler(
-			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+		&interpreter.Options{
+			Storage: storage,
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				return interpreter.VirtualImport{
 					Elaboration: inter.Program.Elaboration,
 				}
 			},
-		),
+		},
 	)
 	require.NoError(t, err)
 
@@ -859,14 +859,14 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 			Elaboration: sema.NewElaboration(),
 		},
 		utils.TestLocation,
-		interpreter.WithStorage(storage),
-		interpreter.WithImportLocationHandler(
-			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+		&interpreter.Options{
+			Storage: storage,
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				return interpreter.VirtualImport{
 					Elaboration: inter.Program.Elaboration,
 				}
 			},
-		),
+		},
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

When adding yet another interpreter option, I thought that the current implementation of options for the interpreter looks inefficient (many closures/allocations) and tried to refactor the options and state shared across interpreter options.

For whatever reason, this change is even less efficient, I see more allocations and fewer iterations for `BenchmarkRuntimeFungibleTokenTransfer` 🤔 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
