### PR TITLE
Catch potential panics produced by resource owner changed callback

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -3317,11 +3317,13 @@ func (r *interpreterRuntime) resourceOwnerChangedHandler(
 		oldOwner common.Address,
 		newOwner common.Address,
 	) {
-		runtimeInterface.ResourceOwnerChanged(
-			resource,
-			oldOwner,
-			newOwner,
-		)
+		wrapPanic(func() {
+			runtimeInterface.ResourceOwnerChanged(
+				resource,
+				oldOwner,
+				newOwner,
+			)
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Just noticed that the resource owner change callback was missing a `wrapPanic`, like all other runtime interface calls have.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
