### PR TITLE
Expand interpreter tracing for composite, array and dictionary types

### DIFF
--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -632,8 +632,12 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 	// tracing
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
+		invokedExpression := invocationExpression.InvokedExpression.String()
 		defer func() {
-			interpreter.reportFunctionTrace(invocationExpression.InvokedExpression.String(), time.Since(startTime))
+			interpreter.reportFunctionTrace(
+				invokedExpression,
+				time.Since(startTime),
+			)
 		}()
 	}
 

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -43,7 +43,10 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportImportTrace(resolvedLocation.Location.String(), time.Since(startTime))
+			interpreter.reportImportTrace(
+				resolvedLocation.Location.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2022 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,25 +35,25 @@ const (
 	tracingDictionaryPrefix = "dictionary."
 	tracingCompositePrefix  = "composite."
 
-	// Value operation prefixes
-	tracingConstructPrefix             = "construct."
-	tracingTransferPrefix              = "transfer."
-	tracingConformsToDynamicTypePrefix = "conformsToDynamicType."
-	tracingClonePrefix                 = "clone."
-	tracingDeepRemovePrefix            = "deepRemove."
-	tracingDestroyPrefix               = "distroy."
+	// Value operation postfixes
+	tracingConstructPostfix             = "construct"
+	tracingTransferPostfix              = "transfer"
+	tracingConformsToDynamicTypePostfix = "conformsToDynamicType"
+	tracingClonePostfix                 = "clone"
+	tracingDeepRemovePostfix            = "deepRemove"
+	tracingDestroyPostfix               = "distroy"
 
-	// ValueIndexable operation prefixes
+	// ValueIndexable operation postfixes
 	// TODO enable these
-	// tracingGetKeyPrefix    = "getKey."
-	// tracingSetKeyPrefix    = "setKey."
-	// tracingRemoveKeyPrefix = "removeKey."
-	// tracingInsertKeyPrefix = "insertKey."
+	// tracingGetKeyPostfix    = "getKey."
+	// tracingSetKeyPostfix    = "setKey."
+	// tracingRemoveKeyPostfix = "removeKey."
+	// tracingInsertKeyPostfix = "insertKey."
 
-	// MemberAccessible operation prefixes
-	tracingGetMemberPrefix    = "getMember."
-	tracingSetMemberPrefix    = "setMember."
-	tracingRemoveMemberPrefix = "removeMember."
+	// MemberAccessible operation postfixes
+	tracingGetMemberPostfix    = "getMember"
+	tracingSetMemberPostfix    = "setMember"
+	tracingRemoveMemberPostfix = "removeMember"
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
@@ -77,51 +77,51 @@ func prepareArrayAndMapValueTraceLogs(typeInfo string, count int) []opentracing.
 }
 
 func (interpreter *Interpreter) reportArrayValueConstructTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDestroyPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConformsToDynamicTypePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueConstructTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDeepRemovePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDestroyPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.LogRecord {
@@ -138,37 +138,37 @@ func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.Lo
 }
 
 func (interpreter *Interpreter) reportCompositeValueConstructTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueCloneTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueDeepRemoveTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDeepRemovePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDeepRemovePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueDestroyTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDestroyPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDestroyPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueTransferTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingTransferPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingTransferPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueConformsToDynamicTypeTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -39,7 +39,6 @@ const (
 	tracingConstructPostfix             = "construct"
 	tracingTransferPostfix              = "transfer"
 	tracingConformsToDynamicTypePostfix = "conformsToDynamicType"
-	tracingClonePostfix                 = "clone"
 	tracingDeepRemovePostfix            = "deepRemove"
 	tracingDestroyPostfix               = "destroy"
 
@@ -73,10 +72,6 @@ func (interpreter *Interpreter) reportArrayValueConstructTrace(typeInfo string, 
 	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
-func (interpreter *Interpreter) reportArrayValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
-}
-
 func (interpreter *Interpreter) reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
 	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
@@ -95,10 +90,6 @@ func (interpreter *Interpreter) reportArrayValueConformsToDynamicTypeTrace(typeI
 
 func (interpreter *Interpreter) reportDictionaryValueConstructTrace(typeInfo string, count int, duration time.Duration) {
 	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
-}
-
-func (interpreter *Interpreter) reportDictionaryValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
@@ -136,10 +127,6 @@ func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.Lo
 
 func (interpreter *Interpreter) reportCompositeValueConstructTrace(owner, typeID, kind string, duration time.Duration) {
 	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
-}
-
-func (interpreter *Interpreter) reportCompositeValueCloneTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueDeepRemoveTrace(owner, typeID, kind string, duration time.Duration) {

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -43,17 +43,10 @@ const (
 	tracingDeepRemovePostfix            = "deepRemove"
 	tracingDestroyPostfix               = "distroy"
 
-	// ValueIndexable operation postfixes
-	// TODO enable these
-	// tracingGetKeyPostfix    = "getKey."
-	// tracingSetKeyPostfix    = "setKey."
-	// tracingRemoveKeyPostfix = "removeKey."
-	// tracingInsertKeyPostfix = "insertKey."
-
-	// MemberAccessible operation postfixes
-	tracingGetMemberPostfix    = "getMember"
-	tracingSetMemberPostfix    = "setMember"
-	tracingRemoveMemberPostfix = "removeMember"
+	// MemberAccessible operation prefixes
+	tracingGetMemberPrefix    = "getMember."
+	tracingSetMemberPrefix    = "setMember."
+	tracingRemoveMemberPrefix = "removeMember."
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
@@ -124,6 +117,10 @@ func (interpreter *Interpreter) reportDictionaryValueConformsToDynamicTypeTrace(
 	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
+func (interpreter *Interpreter) reportDictionaryValueGetMemberTrace(typeInfo string, count int, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingGetMemberPrefix+name, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
 func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.LogRecord {
 	return []opentracing.LogRecord{
 		{
@@ -161,14 +158,14 @@ func (interpreter *Interpreter) reportCompositeValueConformsToDynamicTypeTrace(o
 	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
-func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPrefix+name, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
-func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPrefix+name, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
-func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPrefix+name, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -41,7 +41,7 @@ const (
 	tracingConformsToDynamicTypePostfix = "conformsToDynamicType"
 	tracingClonePostfix                 = "clone"
 	tracingDeepRemovePostfix            = "deepRemove"
-	tracingDestroyPostfix               = "distroy"
+	tracingDestroyPostfix               = "destroy"
 
 	// MemberAccessible operation prefixes
 	tracingGetMemberPrefix    = "getMember."

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -26,11 +26,34 @@ import (
 )
 
 const (
-	tracingFunctionPrefix   = "function."
-	tracingImportPrefix     = "import."
+	// common
+	tracingFunctionPrefix = "function."
+	tracingImportPrefix   = "import."
+
+	// type prefixes
 	tracingArrayPrefix      = "array."
 	tracingDictionaryPrefix = "dictionary."
-	tracingTransferPrefix   = "transfer."
+	tracingCompositePrefix  = "composite."
+
+	// Value operation prefixes
+	tracingConstructPrefix             = "construct."
+	tracingTransferPrefix              = "transfer."
+	tracingConformsToDynamicTypePrefix = "conformsToDynamicType."
+	tracingClonePrefix                 = "clone."
+	tracingDeepRemovePrefix            = "deepRemove."
+	tracingDestroyPrefix               = "distroy."
+
+	// ValueIndexable operation prefixes
+	// TODO enable these
+	// tracingGetKeyPrefix    = "getKey."
+	// tracingSetKeyPrefix    = "setKey."
+	// tracingRemoveKeyPrefix = "removeKey."
+	// tracingInsertKeyPrefix = "insertKey."
+
+	// MemberAccessible operation prefixes
+	tracingGetMemberPrefix    = "getMember."
+	tracingSetMemberPrefix    = "setMember."
+	tracingRemoveMemberPrefix = "removeMember."
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
@@ -41,8 +64,8 @@ func (interpreter *Interpreter) reportImportTrace(importPath string, duration ti
 	interpreter.onRecordTrace(interpreter, tracingImportPrefix+importPath, duration, nil)
 }
 
-func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	logs := []opentracing.LogRecord{
+func prepareArrayAndMapValueTraceLogs(typeInfo string, count int) []opentracing.LogRecord {
+	return []opentracing.LogRecord{
 		{
 			Timestamp: time.Now(),
 			Fields: []log.Field{
@@ -51,18 +74,101 @@ func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, c
 			},
 		},
 	}
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, logs)
+}
+
+func (interpreter *Interpreter) reportArrayValueConstructTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueCloneTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueConstructTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueCloneTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	logs := []opentracing.LogRecord{
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.LogRecord {
+	return []opentracing.LogRecord{
 		{
 			Timestamp: time.Now(),
 			Fields: []log.Field{
-				log.Int("count", count),
-				log.String("type", typeInfo),
+				log.String("owner", owner),
+				log.String("typeID", typeID),
+				log.String("kind", kind),
 			},
 		},
 	}
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, logs)
+}
+
+func (interpreter *Interpreter) reportCompositeValueConstructTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueCloneTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueDeepRemoveTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDeepRemovePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueDestroyTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDestroyPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueTransferTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingTransferPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueConformsToDynamicTypeTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -1,0 +1,91 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpreterTracing(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("composite tracing", func(t *testing.T) {
+		storage := interpreter.NewInMemoryStorage()
+
+		elaboration := sema.NewElaboration()
+		elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+
+		traceOps := make([]string, 0)
+		inter, err := interpreter.NewInterpreter(
+			&interpreter.Program{
+				Elaboration: elaboration,
+			},
+			utils.TestLocation,
+			interpreter.WithOnRecordTraceHandler(
+				func(inter *interpreter.Interpreter,
+					operationName string,
+					duration time.Duration,
+					logs []opentracing.LogRecord) {
+					traceOps = append(traceOps, operationName)
+				},
+			),
+			interpreter.WithStorage(storage),
+			interpreter.WithTracingEnabled(true),
+		)
+		require.NoError(t, err)
+
+		owner := common.Address{0x1}
+
+		value := newTestCompositeValue(inter, owner)
+
+		require.Equal(t, len(traceOps), 1)
+		require.Equal(t, traceOps[0], "composite.construct")
+
+		cloned := value.Clone(inter)
+		require.NotNil(t, cloned)
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "composite.clone")
+
+		cloned.DeepRemove(inter)
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "composite.deepRemove")
+
+		array := interpreter.NewArrayValue(
+			inter,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.PrimitiveStaticTypeAnyStruct,
+			},
+			common.Address{},
+			value,
+		)
+		require.NotNil(t, array)
+		require.Equal(t, len(traceOps), 5)
+		require.Equal(t, traceOps[3], "composite.transfer")
+		require.Equal(t, traceOps[4], "array.construct")
+	})
+}

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -76,17 +76,33 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 3)
 		require.Equal(t, traceOps[2], "composite.deepRemove")
 
+		value.SetMember(inter, nil, "abc", interpreter.NilValue{})
+		require.Equal(t, len(traceOps), 4)
+		require.Equal(t, traceOps[3], "composite.setMember.abc")
+
+		value.GetMember(inter, nil, "abc")
+		require.Equal(t, len(traceOps), 5)
+		require.Equal(t, traceOps[4], "composite.getMember.abc")
+
+		value.RemoveMember(inter, nil, "abc")
+		require.Equal(t, len(traceOps), 6)
+		require.Equal(t, traceOps[5], "composite.removeMember.abc")
+
+		value.Destroy(inter, nil)
+		require.Equal(t, len(traceOps), 7)
+		require.Equal(t, traceOps[6], "composite.destroy")
+
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			common.Address{},
-			value,
+			cloned,
 		)
 		require.NotNil(t, array)
-		require.Equal(t, len(traceOps), 5)
-		require.Equal(t, traceOps[3], "composite.transfer")
-		require.Equal(t, traceOps[4], "array.construct")
+		require.Equal(t, len(traceOps), 9)
+		require.Equal(t, traceOps[7], "composite.transfer")
+		require.Equal(t, traceOps[8], "array.construct")
 	})
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -22,12 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInterpreterTracing(t *testing.T) {

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -78,16 +78,13 @@ func TestInterpreterTracing(t *testing.T) {
 
 		cloned := array.Clone(inter)
 		require.NotNil(t, cloned)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "array.clone")
-
 		cloned.DeepRemove(inter)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "array.deepRemove")
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "array.deepRemove")
 
 		array.Destroy(inter, nil)
-		require.Equal(t, len(traceOps), 4)
-		require.Equal(t, traceOps[3], "array.destroy")
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "array.destroy")
 	})
 
 	t.Run("dictionary tracing", func(t *testing.T) {
@@ -110,16 +107,13 @@ func TestInterpreterTracing(t *testing.T) {
 
 		cloned := dict.Clone(inter)
 		require.NotNil(t, cloned)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "dictionary.clone")
-
 		cloned.DeepRemove(inter)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "dictionary.deepRemove")
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "dictionary.deepRemove")
 
 		dict.Destroy(inter, nil)
-		require.Equal(t, len(traceOps), 4)
-		require.Equal(t, traceOps[3], "dictionary.destroy")
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "dictionary.destroy")
 	})
 
 	t.Run("composite tracing", func(t *testing.T) {
@@ -136,28 +130,25 @@ func TestInterpreterTracing(t *testing.T) {
 
 		cloned := value.Clone(inter)
 		require.NotNil(t, cloned)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "composite.clone")
-
 		cloned.DeepRemove(inter)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "composite.deepRemove")
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "composite.deepRemove")
 
 		value.SetMember(inter, nil, "abc", interpreter.NilValue{})
-		require.Equal(t, len(traceOps), 4)
-		require.Equal(t, traceOps[3], "composite.setMember.abc")
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "composite.setMember.abc")
 
 		value.GetMember(inter, nil, "abc")
-		require.Equal(t, len(traceOps), 5)
-		require.Equal(t, traceOps[4], "composite.getMember.abc")
+		require.Equal(t, len(traceOps), 4)
+		require.Equal(t, traceOps[3], "composite.getMember.abc")
 
 		value.RemoveMember(inter, nil, "abc")
-		require.Equal(t, len(traceOps), 6)
-		require.Equal(t, traceOps[5], "composite.removeMember.abc")
+		require.Equal(t, len(traceOps), 5)
+		require.Equal(t, traceOps[4], "composite.removeMember.abc")
 
 		value.Destroy(inter, nil)
-		require.Equal(t, len(traceOps), 7)
-		require.Equal(t, traceOps[6], "composite.destroy")
+		require.Equal(t, len(traceOps), 6)
+		require.Equal(t, traceOps[5], "composite.destroy")
 
 		array := interpreter.NewArrayValue(
 			inter,
@@ -168,8 +159,8 @@ func TestInterpreterTracing(t *testing.T) {
 			cloned,
 		)
 		require.NotNil(t, array)
-		require.Equal(t, len(traceOps), 9)
-		require.Equal(t, traceOps[7], "composite.transfer")
-		require.Equal(t, traceOps[8], "array.construct")
+		require.Equal(t, len(traceOps), 8)
+		require.Equal(t, traceOps[6], "composite.transfer")
+		require.Equal(t, traceOps[7], "array.construct")
 	})
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -83,6 +83,53 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, traceOps[3], "array.destroy")
 	})
 
+	t.Run("dictionary tracing", func(t *testing.T) {
+		storage := interpreter.NewInMemoryStorage()
+
+		traceOps := make([]string, 0)
+		inter, err := interpreter.NewInterpreter(
+			&interpreter.Program{},
+			utils.TestLocation,
+			interpreter.WithOnRecordTraceHandler(
+				func(inter *interpreter.Interpreter,
+					operationName string,
+					duration time.Duration,
+					logs []opentracing.LogRecord) {
+					traceOps = append(traceOps, operationName)
+				},
+			),
+			interpreter.WithStorage(storage),
+			interpreter.WithTracingEnabled(true),
+		)
+		require.NoError(t, err)
+
+		dict := interpreter.NewDictionaryValue(
+			inter,
+			interpreter.DictionaryStaticType{
+				KeyType:   interpreter.PrimitiveStaticTypeString,
+				ValueType: interpreter.PrimitiveStaticTypeInt,
+			},
+			interpreter.NewStringValue("test"), interpreter.NewIntValueFromInt64(42),
+		)
+		require.NotNil(t, dict)
+		fmt.Println(traceOps)
+		require.Equal(t, len(traceOps), 1)
+		require.Equal(t, traceOps[0], "dictionary.construct")
+
+		cloned := dict.Clone(inter)
+		require.NotNil(t, cloned)
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "dictionary.clone")
+
+		cloned.DeepRemove(inter)
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "dictionary.deepRemove")
+
+		dict.Destroy(inter, nil)
+		require.Equal(t, len(traceOps), 4)
+		require.Equal(t, traceOps[3], "dictionary.destroy")
+	})
+
 	t.Run("composite tracing", func(t *testing.T) {
 		storage := interpreter.NewInMemoryStorage()
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1258,8 +1258,8 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 				time.Since(startTime),
 			)
 		}()
-  }
-  
+	}
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
@@ -11768,8 +11768,8 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 				time.Since(startTime),
 			)
 		}()
-  }
-  
+	}
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
@@ -11814,8 +11814,8 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 				time.Since(startTime),
 			)
 		}()
-  }
-  
+	}
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
@@ -12001,8 +12001,8 @@ func (v *CompositeValue) SetMember(
 				time.Since(startTime),
 			)
 		}()
-  }
-  
+	}
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
@@ -12329,8 +12329,8 @@ func (v *CompositeValue) Transfer(
 				time.Since(startTime),
 			)
 		}()
-  }
-  
+	}
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
@@ -12820,8 +12820,8 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 				time.Since(startTime),
 			)
 		}()
-  }
-  
+	}
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
@@ -12980,8 +12980,8 @@ func (v *DictionaryValue) GetMember(
 				time.Since(startTime),
 			)
 		}()
-  }
-  
+	}
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1152,7 +1152,11 @@ func NewArrayValueWithIterator(
 		startTime := time.Now()
 		defer func() {
 			// TODO figure out how to pass member counts here without iterating
-			interpreter.reportArrayValueConstructTrace(arrayType.String(), -1, time.Since(startTime))
+			interpreter.reportArrayValueConstructTrace(
+				arrayType.String(),
+				-1,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1240,7 +1244,11 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueDestroyTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueDestroyTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1780,7 +1788,11 @@ func (v *ArrayValue) ConformsToDynamicType(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueConformsToDynamicTypeTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueConformsToDynamicTypeTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1864,7 +1876,11 @@ func (v *ArrayValue) Transfer(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueTransferTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueTransferTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1956,7 +1972,11 @@ func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueCloneTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueCloneTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -2001,7 +2021,11 @@ func (v *ArrayValue) DeepRemove(interpreter *Interpreter) {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueDeepRemoveTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueDeepRemoveTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11556,7 +11580,12 @@ func NewCompositeValue(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueConstructTrace(address.String(), qualifiedIdentifier, kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueConstructTrace(
+				address.String(),
+				qualifiedIdentifier,
+				kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11663,7 +11692,12 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueDestroyTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueDestroyTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11696,7 +11730,13 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueGetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
+			interpreter.reportCompositeValueGetMemberTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11812,7 +11852,13 @@ func (v *CompositeValue) RemoveMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueRemoveMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
+			interpreter.reportCompositeValueRemoveMemberTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11858,7 +11904,13 @@ func (v *CompositeValue) SetMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueSetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
+			interpreter.reportCompositeValueSetMemberTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12054,7 +12106,12 @@ func (v *CompositeValue) ConformsToDynamicType(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueConformsToDynamicTypeTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueConformsToDynamicTypeTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12168,7 +12225,12 @@ func (v *CompositeValue) Transfer(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueTransferTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueTransferTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12302,7 +12364,12 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueCloneTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueCloneTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12362,7 +12429,12 @@ func (v *CompositeValue) DeepRemove(interpreter *Interpreter) {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueDeepRemoveTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueDeepRemoveTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12504,7 +12576,11 @@ func NewDictionaryValueWithAddress(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueConstructTrace(dictionaryType.String(), len(keysAndValues)/2, time.Since(startTime))
+			interpreter.reportDictionaryValueConstructTrace(
+				dictionaryType.String(),
+				len(keysAndValues)/2,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12617,7 +12693,11 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueDestroyTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueDestroyTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12754,7 +12834,12 @@ func (v *DictionaryValue) GetMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueGetMemberTrace(v.Type.String(), v.Count(), name, time.Since(startTime))
+			interpreter.reportDictionaryValueGetMemberTrace(
+				v.Type.String(),
+				v.Count(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -13020,7 +13105,11 @@ func (v *DictionaryValue) ConformsToDynamicType(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueConformsToDynamicTypeTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueConformsToDynamicTypeTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -13144,7 +13233,11 @@ func (v *DictionaryValue) Transfer(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueTransferTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueTransferTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -13249,7 +13342,11 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueCloneTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueCloneTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -13306,7 +13403,11 @@ func (v *DictionaryValue) DeepRemove(interpreter *Interpreter) {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueDeepRemoveTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueDeepRemoveTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -11696,7 +11696,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueGetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueGetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
 		}()
 	}
 
@@ -11812,7 +11812,7 @@ func (v *CompositeValue) RemoveMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueRemoveMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueRemoveMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
 		}()
 	}
 
@@ -11858,7 +11858,7 @@ func (v *CompositeValue) SetMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueSetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueSetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
 		}()
 	}
 
@@ -12750,6 +12750,13 @@ func (v *DictionaryValue) GetMember(
 	getLocationRange func() LocationRange,
 	name string,
 ) Value {
+
+	if interpreter.tracingEnabled {
+		startTime := time.Now()
+		defer func() {
+			interpreter.reportDictionaryValueGetMemberTrace(v.Type.String(), v.Count(), name, time.Since(startTime))
+		}()
+	}
 
 	switch name {
 	case "length":

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -12385,7 +12385,7 @@ func (v *CompositeValue) Transfer(
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
 
-	if interpreter.tracingEnabled && v.dictionary != nil {
+	if interpreter.tracingEnabled {
 		startTime := time.Now()
 
 		owner := v.GetOwner().String()

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -24,8 +24,10 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/onflow/atree"
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -95,6 +97,17 @@ func parseCheckAndInterpretWithOptions(
 			interpreter.WithStorage(interpreter.NewInMemoryStorage()),
 			interpreter.WithAtreeValueValidationEnabled(true),
 			interpreter.WithAtreeStorageValidationEnabled(true),
+			interpreter.WithOnRecordTraceHandler(
+				func(
+					_ *interpreter.Interpreter,
+					_ string,
+					_ time.Duration,
+					_ []opentracing.LogRecord,
+				) {
+					// NO-OP
+				},
+			),
+			interpreter.WithTracingEnabled(true),
 		},
 		options.Options...,
 	)


### PR DESCRIPTION

## Description
This PR expands tracing functionality inside cadence for composite, array and dictionary types. these open traces are disabled by default and upon enabling it, they would be passed to the interface's recordTrace method for further aggregation. These traces are great tools for analyzing the performance of the interpreter when handling these types.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
