### PR TITLE
Fix resource field nesting check for enum raw value field

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -131,7 +131,7 @@ func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDecl
 	}
 
 	fieldPositionGetter := func(name string) ast.Position {
-		return declaration.Members.FieldPosition(name, declaration.CompositeKind)
+		return compositeType.FieldPosition(name, declaration)
 	}
 
 	checker.checkResourceFieldNesting(

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -87,7 +87,7 @@ func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDecl
 	)
 
 	fieldPositionGetter := func(name string) ast.Position {
-		return declaration.Members.FieldPosition(name, declaration.CompositeKind)
+		return interfaceType.FieldPosition(name, declaration)
 	}
 
 	checker.checkResourceFieldNesting(

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1733,14 +1733,24 @@ func (checker *Checker) checkResourceFieldNesting(
 		return
 	}
 
-	// The field is not a resource or contract, check if there are
-	// any fields that have a resource type  and report them
+	// The field is not a resource or contract.
+	// Check if there are any fields that have a resource type and report them
 
 	members.Foreach(func(name string, member *Member) {
 		// NOTE: check type, not resource annotation:
 		// the field could have a wrong annotation
 
 		if !member.TypeAnnotation.Type.IsResourceType() {
+			return
+		}
+
+		// Skip enums' implicit rawValue field.
+		// If a resource type is used as the enum raw type,
+		// it is already reported
+
+		if compositeKind == common.CompositeKindEnum &&
+			name == EnumRawValueFieldName {
+
 			return
 		}
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3854,6 +3854,20 @@ func (t *CompositeType) initializeMemberResolvers() {
 	})
 }
 
+func (t *CompositeType) FieldPosition(name string, declaration *ast.CompositeDeclaration) ast.Position {
+	var pos ast.Position
+	if t.Kind == common.CompositeKindEnum &&
+		name == EnumRawValueFieldName {
+
+		if len(declaration.Conformances) > 0 {
+			pos = declaration.Conformances[0].StartPosition()
+		}
+	} else {
+		pos = declaration.Members.FieldPosition(name, declaration.CompositeKind)
+	}
+	return pos
+}
+
 // Member
 
 type Member struct {
@@ -4215,6 +4229,10 @@ func (t *InterfaceType) IsContainerType() bool {
 
 func (t *InterfaceType) GetNestedTypes() *StringTypeOrderedMap {
 	return t.nestedTypes
+}
+
+func (t *InterfaceType) FieldPosition(name string, declaration *ast.InterfaceDeclaration) ast.Position {
+	return declaration.Members.FieldPosition(name, declaration.CompositeKind)
 }
 
 // DictionaryType consists of the key and value type

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -3063,6 +3063,55 @@ func TestCheckInvalidContractResourceFieldMove(t *testing.T) {
 	assert.IsType(t, &sema.InvalidNestedResourceMoveError{}, errs[0])
 }
 
+func TestCheckInvalidEnumResourceField(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("raw type given", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+	      resource R {}
+
+          enum E: R {}
+	    `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.InvalidEnumRawTypeError{}, errs[0])
+	})
+
+	t.Run("raw type given, nested", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+	      resource R {
+              enum E: R {}
+          }
+	    `)
+
+		errs := ExpectCheckerErrors(t, err, 2)
+
+		require.IsType(t, &sema.InvalidNestedDeclarationError{}, errs[0])
+		require.IsType(t, &sema.InvalidEnumRawTypeError{}, errs[1])
+	})
+
+	t.Run("raw type not given", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+	      enum E {}
+	    `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.MissingEnumRawTypeError{}, errs[0])
+	})
+}
+
 // TestCheckResourceInterfaceConformance tests the check
 // of conformance of resources to resource interfaces.
 //


### PR DESCRIPTION
Port of dapperlabs/cadence-internal#60

## Description

Fix a checker crasher.

Enums have an implicitly declared `rawValue` field. 

The checker validates that a resource-typed field only occurs in resources and contracts. When an invalid field is detected, its position is included in the error.

If the raw type of an enum declaration is a resource type, then an error is reported.
However, the `rawValue` field is not declared as a field, but through the raw type, i.e. the conformance list.

Fixes:
- Do not perform the resource-typed field check for enums' `rawValue` field. If the raw type of the enum is a resource, there is already a separate error reported for it (invalid enum raw type).
- Report the first conformance as the position of an enum's `rawValue` field
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
