### PR TITLE
Check transfer and use of transfered or destroyed resources at runtime

### DIFF
--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -361,7 +361,7 @@ func loadStorageKey(
 
 					if composite, ok := v.(*interpreter.CompositeValue); ok &&
 						composite.Kind == common.CompositeKindResource &&
-						composite.ResourceUUID(interpreter.ReturnEmptyLocationRange) == nil {
+						composite.ResourceUUID(inter, interpreter.ReturnEmptyLocationRange) == nil {
 
 						log.Printf(
 							"Failed to get UUID for resource @ 0x%x %s",

--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -361,7 +361,7 @@ func loadStorageKey(
 
 					if composite, ok := v.(*interpreter.CompositeValue); ok &&
 						composite.Kind == common.CompositeKindResource &&
-						composite.ResourceUUID() == nil {
+						composite.ResourceUUID(interpreter.ReturnEmptyLocationRange) == nil {
 
 						log.Printf(
 							"Failed to get UUID for resource @ 0x%x %s",

--- a/runtime/compiler/wasm/writer_test.go
+++ b/runtime/compiler/wasm/writer_test.go
@@ -498,6 +498,8 @@ func TestWASMWriter_writeNameSection(t *testing.T) {
 
 func TestWASMWriterReader(t *testing.T) {
 
+	t.Skip("WIP")
+
 	t.Parallel()
 
 	var b Buffer

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -156,11 +156,14 @@ func exportSomeValue(
 	cadence.Optional,
 	error,
 ) {
-	if v.Value == nil {
+	// TODO: provide proper location range
+	innerValue := v.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+
+	if innerValue == nil {
 		return cadence.NewOptional(nil), nil
 	}
 
-	value, err := exportValueWithInterpreter(v.Value, inter, seenReferences)
+	value, err := exportValueWithInterpreter(innerValue, inter, seenReferences)
 	if err != nil {
 		return cadence.Optional{}, err
 	}

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -222,7 +222,7 @@ func exportCompositeValue(
 		fieldName := field.Identifier
 
 		// TODO: provide proper location range
-		fieldValue := v.GetField(interpreter.ReturnEmptyLocationRange, fieldName)
+		fieldValue := v.GetField(inter, interpreter.ReturnEmptyLocationRange, fieldName)
 		if fieldValue == nil && v.ComputedFields != nil {
 			if computedField, ok := v.ComputedFields[fieldName]; ok {
 				// TODO: provide proper location range

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -222,7 +222,7 @@ func exportCompositeValue(
 		fieldName := field.Identifier
 
 		// TODO: provide proper location range
-		fieldValue := v.GetField(fieldName)
+		fieldValue := v.GetField(interpreter.ReturnEmptyLocationRange, fieldName)
 		if fieldValue == nil && v.ComputedFields != nil {
 			if computedField, ok := v.ComputedFields[fieldName]; ok {
 				// TODO: provide proper location range

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -132,7 +132,12 @@ type Interface interface {
 	// BLSAggregatePublicKeys aggregate multiple BLS public keys into one.
 	BLSAggregatePublicKeys(keys []*PublicKey) (*PublicKey, error)
 	// ResourceOwnerChanged gets called when a resource's owner changed (if enabled)
-	ResourceOwnerChanged(resource *interpreter.CompositeValue, oldOwner common.Address, newOwner common.Address)
+	ResourceOwnerChanged(
+		interpreter *interpreter.Interpreter,
+		resource *interpreter.CompositeValue,
+		oldOwner common.Address,
+		newOwner common.Address,
+	)
 }
 
 type Metrics interface {

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -71,7 +71,7 @@ func TestInspectValue(t *testing.T) {
 	// Get actually stored values.
 	// The values above were removed when they were inserted into the containers.
 
-	optionalValue := compositeValue.GetField(ReturnEmptyLocationRange, "value").(*SomeValue)
+	optionalValue := compositeValue.GetField(inter, ReturnEmptyLocationRange, "value").(*SomeValue)
 	arrayValue := optionalValue.Value.(*ArrayValue)
 	dictValue := arrayValue.Get(inter, ReturnEmptyLocationRange, 0).(*DictionaryValue)
 	dictValueKey := NewStringValue("hello world")

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -71,7 +71,7 @@ func TestInspectValue(t *testing.T) {
 	// Get actually stored values.
 	// The values above were removed when they were inserted into the containers.
 
-	optionalValue := compositeValue.GetField("value").(*SomeValue)
+	optionalValue := compositeValue.GetField(ReturnEmptyLocationRange, "value").(*SomeValue)
 	arrayValue := optionalValue.Value.(*ArrayValue)
 	dictValue := arrayValue.Get(inter, ReturnEmptyLocationRange, 0).(*DictionaryValue)
 	dictValueKey := NewStringValue("hello world")

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -72,7 +72,7 @@ func TestInspectValue(t *testing.T) {
 	// The values above were removed when they were inserted into the containers.
 
 	optionalValue := compositeValue.GetField(inter, ReturnEmptyLocationRange, "value").(*SomeValue)
-	arrayValue := optionalValue.Value.(*ArrayValue)
+	arrayValue := optionalValue.InnerValue(inter, ReturnEmptyLocationRange).(*ArrayValue)
 	dictValue := arrayValue.Get(inter, ReturnEmptyLocationRange, 0).(*DictionaryValue)
 	dictValueKey := NewStringValue("hello world")
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -348,7 +348,8 @@ type Interpreter struct {
 	atreeStorageValidationEnabled  bool
 	tracingEnabled                 bool
 	// TODO: ideally this would be a weak map, but Go has no weak references
-	referencedResourceKindedValues ReferencedResourceKindedValues
+	referencedResourceKindedValues       ReferencedResourceKindedValues
+	invalidatedResourceValidationEnabled bool
 }
 
 type Option func(*Interpreter) error
@@ -602,6 +603,16 @@ func WithTracingEnabled(enabled bool) Option {
 	}
 }
 
+// WithInvalidatedResourceValidationEnabled returns an interpreter option which sets
+// the resource validation option.
+//
+func WithInvalidatedResourceValidationEnabled(enabled bool) Option {
+	return func(interpreter *Interpreter) error {
+		interpreter.SetInvalidatedResourceValidationEnabled(enabled)
+		return nil
+	}
+}
+
 // withTypeCodes returns an interpreter option which sets the type codes.
 //
 func withTypeCodes(typeCodes TypeCodes) Option {
@@ -820,6 +831,12 @@ func (interpreter *Interpreter) SetAtreeStorageValidationEnabled(enabled bool) {
 //
 func (interpreter *Interpreter) SetTracingEnabled(enabled bool) {
 	interpreter.tracingEnabled = enabled
+}
+
+// SetInvalidatedResourceValidationEnabled sets the invalidated resource validation option.
+//
+func (interpreter *Interpreter) SetInvalidatedResourceValidationEnabled(enabled bool) {
+	interpreter.invalidatedResourceValidationEnabled = enabled
 }
 
 // setTypeCodes sets the type codes.

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -670,6 +670,7 @@ func NewInterpreter(program *Program, location common.Location, options ...Optio
 			TypeRequirementCodes: map[sema.TypeID]WrapperCode{},
 		}),
 		withReferencedResourceKindedValues(map[atree.StorageID]map[ReferenceTrackedResourceKindedValue]struct{}{}),
+		WithInvalidatedResourceValidationEnabled(true),
 	}
 
 	for _, option := range defaultOptions {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1810,7 +1810,7 @@ func EnumConstructorFunction(
 	lookupTable := make(map[string]*CompositeValue)
 
 	for _, caseValue := range caseValues {
-		rawValue := caseValue.GetField(getLocationRange, sema.EnumRawValueFieldName)
+		rawValue := caseValue.GetField(inter, getLocationRange, sema.EnumRawValueFieldName)
 		rawValueBigEndianBytes := rawValue.(IntegerValue).ToBigEndianBytes()
 		lookupTable[string(rawValueBigEndianBytes)] = caseValue
 	}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1810,7 +1810,7 @@ func EnumConstructorFunction(
 	lookupTable := make(map[string]*CompositeValue)
 
 	for _, caseValue := range caseValues {
-		rawValue := caseValue.GetField(sema.EnumRawValueFieldName)
+		rawValue := caseValue.GetField(getLocationRange, sema.EnumRawValueFieldName)
 		rawValueBigEndianBytes := rawValue.(IntegerValue).ToBigEndianBytes()
 		lookupTable[string(rawValueBigEndianBytes)] = caseValue
 	}

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -164,8 +164,9 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 
 		targetType := interpreter.Program.Elaboration.VariableDeclarationTargetTypes[declaration]
 		getLocationRange := locationRangeGetter(interpreter.Location, declaration.Value)
+		innerValue := someValue.InnerValue(interpreter, getLocationRange)
 		transferredUnwrappedValue := interpreter.transferAndConvert(
-			someValue.Value,
+			innerValue,
 			valueType,
 			targetType,
 			getLocationRange,

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -33,7 +33,10 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Bool to Bool?", func(t *testing.T) {
-		value := BoxOptional(
+		inter := newTestInterpreter(t)
+
+		value := inter.BoxOptional(
+			ReturnEmptyLocationRange,
 			BoolValue(true),
 			&sema.OptionalType{Type: sema.BoolType},
 		)
@@ -44,7 +47,10 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	})
 
 	t.Run("Bool? to Bool?", func(t *testing.T) {
-		value := BoxOptional(
+		inter := newTestInterpreter(t)
+
+		value := inter.BoxOptional(
+			ReturnEmptyLocationRange,
 			NewSomeValueNonCopying(BoolValue(true)),
 			&sema.OptionalType{Type: sema.BoolType},
 		)
@@ -55,7 +61,10 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	})
 
 	t.Run("Bool? to Bool??", func(t *testing.T) {
-		value := BoxOptional(
+		inter := newTestInterpreter(t)
+
+		value := inter.BoxOptional(
+			ReturnEmptyLocationRange,
 			NewSomeValueNonCopying(BoolValue(true)),
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
@@ -68,8 +77,11 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	})
 
 	t.Run("nil (Never?) to Bool??", func(t *testing.T) {
+		inter := newTestInterpreter(t)
+
 		// NOTE:
-		value := BoxOptional(
+		value := inter.BoxOptional(
+			ReturnEmptyLocationRange,
 			NilValue{},
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
@@ -80,8 +92,11 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	})
 
 	t.Run("nil (Some(nil): Never??) to Bool??", func(t *testing.T) {
+		inter := newTestInterpreter(t)
+
 		// NOTE:
-		value := BoxOptional(
+		value := inter.BoxOptional(
+			ReturnEmptyLocationRange,
 			NewSomeValueNonCopying(NilValue{}),
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
@@ -104,12 +119,14 @@ func TestInterpreterBoxing(t *testing.T) {
 		t.Run(anyType.String(), func(t *testing.T) {
 
 			t.Run(fmt.Sprintf("Bool to %s?", anyType), func(t *testing.T) {
+				inter := newTestInterpreter(t)
 
 				assert.Equal(t,
 					NewSomeValueNonCopying(
 						BoolValue(true),
 					),
-					ConvertAndBox(
+					inter.ConvertAndBox(
+						ReturnEmptyLocationRange,
 						BoolValue(true),
 						sema.BoolType,
 						&sema.OptionalType{Type: anyType},
@@ -119,12 +136,14 @@ func TestInterpreterBoxing(t *testing.T) {
 			})
 
 			t.Run(fmt.Sprintf("Bool? to %s?", anyType), func(t *testing.T) {
+				inter := newTestInterpreter(t)
 
 				assert.Equal(t,
 					NewSomeValueNonCopying(
 						BoolValue(true),
 					),
-					ConvertAndBox(
+					inter.ConvertAndBox(
+						ReturnEmptyLocationRange,
 						NewSomeValueNonCopying(BoolValue(true)),
 						&sema.OptionalType{Type: sema.BoolType},
 						&sema.OptionalType{Type: anyType},

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -81,7 +81,7 @@ func TestCompositeStorage(t *testing.T) {
 		t,
 		inter,
 		BoolValue(true),
-		storedComposite.GetField(ReturnEmptyLocationRange, fieldName),
+		storedComposite.GetField(inter, ReturnEmptyLocationRange, fieldName),
 	)
 }
 

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -81,7 +81,7 @@ func TestCompositeStorage(t *testing.T) {
 		t,
 		inter,
 		BoolValue(true),
-		storedComposite.GetField(fieldName),
+		storedComposite.GetField(ReturnEmptyLocationRange, fieldName),
 	)
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1734,7 +1734,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 				)
 			},
 			sema.ArrayFirstIndexFunctionType(
-				v.SemaType(inter).ElementType(false),
+				v.SemaType(interpreter).ElementType(false),
 			),
 		)
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -646,7 +646,8 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 		value2,
 	)
 	require.IsType(t, &SomeValue{}, existingValue)
-	value1 = existingValue.(*SomeValue).Value.(*CompositeValue)
+	innerValue := existingValue.(*SomeValue).InnerValue(inter, ReturnEmptyLocationRange)
+	value1 = innerValue.(*CompositeValue)
 
 	queriedValue, _ := dictionary.Get(inter, ReturnEmptyLocationRange, keyValue)
 	value2 = queriedValue.(*CompositeValue)
@@ -699,7 +700,8 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 		keyValue,
 	)
 	require.IsType(t, &SomeValue{}, existingValue)
-	value = existingValue.(*SomeValue).Value.(*CompositeValue)
+	innerValue := existingValue.(*SomeValue).InnerValue(inter, ReturnEmptyLocationRange)
+	value = innerValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
 	assert.Equal(t, common.Address{}, value.GetOwner())

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1681,7 +1681,7 @@ func (r *interpreterRuntime) emitEvent(
 	fields := make([]exportableValue, len(eventType.ConstructorParameters))
 
 	for i, parameter := range eventType.ConstructorParameters {
-		value := event.GetField(parameter.Identifier)
+		value := event.GetField(getLocationRange, parameter.Identifier)
 		fields[i] = newExportableValue(value, inter)
 	}
 
@@ -3377,7 +3377,7 @@ func NewPublicKeyFromValue(
 		)
 	}
 
-	rawValue := signAlgoValue.GetField(sema.EnumRawValueFieldName)
+	rawValue := signAlgoValue.GetField(getLocationRange, sema.EnumRawValueFieldName)
 	if rawValue == nil {
 		return nil, errors.New("sign algorithm raw value is not set")
 	}
@@ -3450,7 +3450,7 @@ func NewHashAlgorithmFromValue(
 ) HashAlgorithm {
 	hashAlgoValue := value.(*interpreter.CompositeValue)
 
-	rawValue := hashAlgoValue.GetField(sema.EnumRawValueFieldName)
+	rawValue := hashAlgoValue.GetField(getLocationRange, sema.EnumRawValueFieldName)
 	if rawValue == nil {
 		panic("cannot find hash algorithm raw value")
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1681,7 +1681,7 @@ func (r *interpreterRuntime) emitEvent(
 	fields := make([]exportableValue, len(eventType.ConstructorParameters))
 
 	for i, parameter := range eventType.ConstructorParameters {
-		value := event.GetField(getLocationRange, parameter.Identifier)
+		value := event.GetField(inter, getLocationRange, parameter.Identifier)
 		fields[i] = newExportableValue(value, inter)
 	}
 
@@ -3331,13 +3331,14 @@ func (r *interpreterRuntime) resourceOwnerChangedHandler(
 		return nil
 	}
 	return func(
-		_ *interpreter.Interpreter,
+		interpreter *interpreter.Interpreter,
 		resource *interpreter.CompositeValue,
 		oldOwner common.Address,
 		newOwner common.Address,
 	) {
 		wrapPanic(func() {
 			runtimeInterface.ResourceOwnerChanged(
+				interpreter,
 				resource,
 				oldOwner,
 				newOwner,
@@ -3377,7 +3378,7 @@ func NewPublicKeyFromValue(
 		)
 	}
 
-	rawValue := signAlgoValue.GetField(getLocationRange, sema.EnumRawValueFieldName)
+	rawValue := signAlgoValue.GetField(inter, getLocationRange, sema.EnumRawValueFieldName)
 	if rawValue == nil {
 		return nil, errors.New("sign algorithm raw value is not set")
 	}
@@ -3450,7 +3451,7 @@ func NewHashAlgorithmFromValue(
 ) HashAlgorithm {
 	hashAlgoValue := value.(*interpreter.CompositeValue)
 
-	rawValue := hashAlgoValue.GetField(getLocationRange, sema.EnumRawValueFieldName)
+	rawValue := hashAlgoValue.GetField(inter, getLocationRange, sema.EnumRawValueFieldName)
 	if rawValue == nil {
 		panic("cannot find hash algorithm raw value")
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -150,6 +150,7 @@ type testRuntimeInterface struct {
 	log                       func(string)
 	emitEvent                 func(cadence.Event) error
 	resourceOwnerChanged      func(
+		interpreter *interpreter.Interpreter,
 		resource *interpreter.CompositeValue,
 		oldAddress common.Address,
 		newAddress common.Address,
@@ -338,12 +339,18 @@ func (i *testRuntimeInterface) EmitEvent(event cadence.Event) error {
 }
 
 func (i *testRuntimeInterface) ResourceOwnerChanged(
+	interpreter *interpreter.Interpreter,
 	resource *interpreter.CompositeValue,
 	oldOwner common.Address,
 	newOwner common.Address,
 ) {
 	if i.resourceOwnerChanged != nil {
-		i.resourceOwnerChanged(resource, oldOwner, newOwner)
+		i.resourceOwnerChanged(
+			interpreter,
+			resource,
+			oldOwner,
+			newOwner,
+		)
 	}
 }
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1825,6 +1825,7 @@ func TestRuntimeResourceOwnerChange(t *testing.T) {
 			loggedMessages = append(loggedMessages, message)
 		},
 		resourceOwnerChanged: func(
+			inter *interpreter.Interpreter,
 			resource *interpreter.CompositeValue,
 			oldAddress common.Address,
 			newAddress common.Address,
@@ -1834,7 +1835,7 @@ func TestRuntimeResourceOwnerChange(t *testing.T) {
 				resourceOwnerChange{
 					typeID: resource.TypeID(),
 					// TODO: provide proper location range
-					uuid:       resource.ResourceUUID(interpreter.ReturnEmptyLocationRange),
+					uuid:       resource.ResourceUUID(inter, interpreter.ReturnEmptyLocationRange),
 					oldAddress: oldAddress,
 					newAddress: newAddress,
 				},

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1832,8 +1832,9 @@ func TestRuntimeResourceOwnerChange(t *testing.T) {
 			resourceOwnerChanges = append(
 				resourceOwnerChanges,
 				resourceOwnerChange{
-					typeID:     resource.TypeID(),
-					uuid:       resource.ResourceUUID(),
+					typeID: resource.TypeID(),
+					// TODO: provide proper location range
+					uuid:       resource.ResourceUUID(interpreter.ReturnEmptyLocationRange),
 					oldAddress: oldAddress,
 					newAddress: newAddress,
 				},

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -285,15 +285,18 @@ func TestInterpretAuthAccount_type(t *testing.T) {
 
 		value, err = inter.Invoke("typeAt")
 		require.NoError(t, err)
-		require.Equal(t, &interpreter.SomeValue{
-			Value: interpreter.TypeValue{
-				Type: interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "R",
-					TypeID:              "S.test.R",
+		require.Equal(t,
+			interpreter.NewSomeValueNonCopying(
+				interpreter.TypeValue{
+					Type: interpreter.CompositeStaticType{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "R",
+						TypeID:              "S.test.R",
+					},
 				},
-			},
-		}, value)
+			),
+			value,
+		)
 
 		// save S
 
@@ -305,15 +308,18 @@ func TestInterpretAuthAccount_type(t *testing.T) {
 
 		value, err = inter.Invoke("typeAt")
 		require.NoError(t, err)
-		require.Equal(t, &interpreter.SomeValue{
-			Value: interpreter.TypeValue{
-				Type: interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "S",
-					TypeID:              "S.test.S",
+		require.Equal(t,
+			interpreter.NewSomeValueNonCopying(
+				interpreter.TypeValue{
+					Type: interpreter.CompositeStaticType{
+						Location:            utils.TestLocation,
+						QualifiedIdentifier: "S",
+						TypeID:              "S.test.S",
+					},
 				},
-			},
-		}, value)
+			),
+			value,
+		)
 	})
 }
 
@@ -367,7 +373,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).Value
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 			assert.IsType(t, &interpreter.CompositeValue{}, innerValue)
 
@@ -448,7 +454,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).Value
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 			assert.IsType(t, &interpreter.CompositeValue{}, innerValue)
 
@@ -533,7 +539,7 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).Value
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 			assert.IsType(t, &interpreter.CompositeValue{}, innerValue)
 
@@ -654,7 +660,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).Value
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -685,7 +691,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue = value.(*interpreter.SomeValue).Value
+			innerValue = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -791,7 +797,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).Value
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -822,7 +828,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue = value.(*interpreter.SomeValue).Value
+			innerValue = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -911,7 +917,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).Value
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 					rType := checker.RequireGlobalType(t, inter.Program.Elaboration, "R")
 
@@ -959,7 +965,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).Value
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 					r2Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R2")
 
@@ -1061,7 +1067,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).Value
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 					sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 
@@ -1109,7 +1115,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).Value
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 					require.IsType(t, &interpreter.CapabilityValue{}, capability)
 
 					s2Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "S2")
@@ -1215,7 +1221,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 				require.NoError(t, err)
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				capability := value.(*interpreter.SomeValue).Value
+				capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S1")
 				expectedBorrowType := interpreter.ConvertSemaToStaticType(
@@ -1294,7 +1300,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 				// 1 value + 2 links
 				require.Len(t, getAccountValues(), 3)
 
-				capability := value.(*interpreter.SomeValue).Value
+				capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 				expectedBorrowType := interpreter.ConvertSemaToStaticType(
@@ -1322,7 +1328,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 				require.NoError(t, err)
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				capability = value.(*interpreter.SomeValue).Value
+				capability = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 				sType = checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 				expectedBorrowType = interpreter.ConvertSemaToStaticType(
@@ -1554,7 +1560,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				innerValue := value.(*interpreter.SomeValue).Value
+				innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 				AssertValuesEqual(
 					t,
@@ -1632,7 +1638,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				innerValue := value.(*interpreter.SomeValue).Value
+				innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 				AssertValuesEqual(
 					t,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -593,7 +593,8 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 
 						require.IsType(t,
 							&interpreter.CompositeValue{},
-							inter.Globals["y"].GetValue().(*interpreter.SomeValue).Value,
+							inter.Globals["y"].GetValue().(*interpreter.SomeValue).
+								InnerValue(inter, interpreter.ReturnEmptyLocationRange),
 						)
 					})
 				}
@@ -739,7 +740,8 @@ func testResourceCastValid(t *testing.T, types, fromType string, targetType stri
 
 		require.IsType(t,
 			&interpreter.CompositeValue{},
-			value.(*interpreter.SomeValue).Value,
+			value.(*interpreter.SomeValue).
+				InnerValue(inter, interpreter.ReturnEmptyLocationRange),
 		)
 
 	case ast.OperationForceCast:
@@ -885,7 +887,8 @@ func testStructCastValid(t *testing.T, types, fromType string, targetType string
 
 		require.IsType(t,
 			&interpreter.CompositeValue{},
-			value.(*interpreter.SomeValue).Value,
+			value.(*interpreter.SomeValue).
+				InnerValue(inter, interpreter.ReturnEmptyLocationRange),
 		)
 
 	case ast.OperationForceCast:
@@ -1194,7 +1197,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 						require.IsType(t, zValue, &interpreter.SomeValue{})
 						zSome := zValue.(*interpreter.SomeValue)
 
-						innerValue := zSome.Value
+						innerValue := zSome.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 						require.IsType(t, innerValue, &interpreter.ArrayValue{})
 						innerArray := innerValue.(*interpreter.ArrayValue)
 
@@ -2281,7 +2284,8 @@ func testReferenceCastValid(t *testing.T, types, fromType, targetType string, op
 
 		require.IsType(t,
 			&interpreter.EphemeralReferenceValue{},
-			value.(*interpreter.SomeValue).Value,
+			value.(*interpreter.SomeValue).
+				InnerValue(inter, interpreter.ReturnEmptyLocationRange),
 		)
 
 	case ast.OperationForceCast:

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -246,7 +246,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 
-	eValue := contract.GetField(interpreter.ReturnEmptyLocationRange, "e")
+	eValue := contract.GetField(inter, interpreter.ReturnEmptyLocationRange, "e")
 	require.NotNil(t, eValue)
 
 	require.IsType(t, &interpreter.CompositeValue{}, eValue)

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -246,7 +246,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 
-	eValue := contract.GetField("e")
+	eValue := contract.GetField(interpreter.ReturnEmptyLocationRange, "e")
 	require.NotNil(t, eValue)
 
 	require.IsType(t, &interpreter.CompositeValue{}, eValue)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -2193,7 +2193,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(1),
-		test.GetField("foo"),
+		test.GetField(interpreter.ReturnEmptyLocationRange, "foo"),
 	)
 
 	value, err := inter.Invoke("callTest")
@@ -2210,7 +2210,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(3),
-		test.GetField("foo"),
+		test.GetField(interpreter.ReturnEmptyLocationRange, "foo"),
 	)
 }
 
@@ -7206,7 +7206,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(2),
-		firstResource.GetField("id"),
+		firstResource.GetField(interpreter.ReturnEmptyLocationRange, "id"),
 	)
 
 	require.IsType(t,
@@ -7227,7 +7227,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(1),
-		secondResource.GetField("id"),
+		secondResource.GetField(interpreter.ReturnEmptyLocationRange, "id"),
 	)
 }
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6964,7 +6964,8 @@ func TestInterpretSwapResourceDictionaryElementReturnDictionary(t *testing.T) {
 
 	assert.IsType(t,
 		&interpreter.CompositeValue{},
-		foo.(*interpreter.SomeValue).Value,
+		foo.(*interpreter.SomeValue).
+			InnerValue(inter, interpreter.ReturnEmptyLocationRange),
 	)
 }
 
@@ -6994,7 +6995,8 @@ func TestInterpretSwapResourceDictionaryElementRemoveUsingNil(t *testing.T) {
 
 	assert.IsType(t,
 		&interpreter.CompositeValue{},
-		value.(*interpreter.SomeValue).Value,
+		value.(*interpreter.SomeValue).
+			InnerValue(inter, interpreter.ReturnEmptyLocationRange),
 	)
 }
 
@@ -7193,7 +7195,8 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		values[0],
 	)
 
-	firstValue := values[0].(*interpreter.SomeValue).Value
+	firstValue := values[0].(*interpreter.SomeValue).
+		InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -7214,7 +7217,8 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		values[1],
 	)
 
-	secondValue := values[1].(*interpreter.SomeValue).Value
+	secondValue := values[1].(*interpreter.SomeValue).
+		InnerValue(inter, interpreter.ReturnEmptyLocationRange)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -7570,7 +7574,8 @@ func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
 
 	assert.IsType(t,
 		interpreter.BoundFunctionValue{},
-		inter.Globals["x2"].GetValue().(*interpreter.SomeValue).Value,
+		inter.Globals["x2"].GetValue().(*interpreter.SomeValue).
+			InnerValue(inter, interpreter.ReturnEmptyLocationRange),
 	)
 }
 
@@ -8379,9 +8384,9 @@ func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		&interpreter.SomeValue{
-			Value: interpreter.NewIntValueFromInt64(1),
-		},
+		interpreter.NewSomeValueNonCopying(
+			interpreter.NewIntValueFromInt64(1),
+		),
 		inter.Globals["x"].GetValue(),
 	)
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -2193,7 +2193,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(1),
-		test.GetField(interpreter.ReturnEmptyLocationRange, "foo"),
+		test.GetField(inter, interpreter.ReturnEmptyLocationRange, "foo"),
 	)
 
 	value, err := inter.Invoke("callTest")
@@ -2210,7 +2210,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(3),
-		test.GetField(interpreter.ReturnEmptyLocationRange, "foo"),
+		test.GetField(inter, interpreter.ReturnEmptyLocationRange, "foo"),
 	)
 }
 
@@ -7206,7 +7206,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(2),
-		firstResource.GetField(interpreter.ReturnEmptyLocationRange, "id"),
+		firstResource.GetField(inter, interpreter.ReturnEmptyLocationRange, "id"),
 	)
 
 	require.IsType(t,
@@ -7227,7 +7227,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(1),
-		secondResource.GetField(interpreter.ReturnEmptyLocationRange, "id"),
+		secondResource.GetField(inter, interpreter.ReturnEmptyLocationRange, "id"),
 	)
 }
 

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 
 	"github.com/onflow/atree"
-	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/sema"
 
 	"github.com/onflow/cadence/runtime/tests/checker"
 	. "github.com/onflow/cadence/runtime/tests/utils"

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/onflow/atree"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
@@ -622,6 +623,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("optional", func(t *testing.T) {
@@ -666,6 +669,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("array", func(t *testing.T) {
@@ -710,6 +715,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("dictionary", func(t *testing.T) {
@@ -754,6 +761,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 		})
 
@@ -763,8 +772,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -795,14 +804,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("optional", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -833,14 +844,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("array", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -871,14 +884,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("dictionary", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -909,6 +924,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 		})
 
@@ -918,8 +935,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           var n: Int
 
@@ -949,6 +966,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			// TODO: optional (how?)
@@ -957,8 +976,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           var n: Int
 
@@ -988,6 +1007,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			// TODO: dictionary (how?)
@@ -999,8 +1020,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1024,14 +1045,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("optional", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1055,14 +1078,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("array", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1092,8 +1117,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1117,6 +1142,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
 			})
 		})
 	})
@@ -1129,8 +1156,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1166,14 +1193,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("optional", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1209,14 +1238,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("array", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1252,14 +1283,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("dictionary", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1295,6 +1328,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
 			})
 		})
 
@@ -1304,8 +1339,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1334,14 +1369,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("optional", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1370,14 +1407,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("array", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1406,14 +1445,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("dictionary", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           let n: Int
 
@@ -1442,6 +1483,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 		})
 
@@ -1451,8 +1494,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           var n: Int
 
@@ -1481,6 +1524,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			// TODO: optional (how?)
@@ -1489,8 +1534,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {
                           var n: Int
 
@@ -1519,6 +1564,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			// TODO: dictionary (how?)
@@ -1531,8 +1578,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1555,14 +1602,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("optional", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1585,14 +1634,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("array", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1615,14 +1666,16 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
+
+				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
 			})
 
 			t.Run("dictionary", func(t *testing.T) {
 
 				t.Parallel()
 
-				inter, err := parseCheckAndInterpretWithOptions(t, `
-
+				inter, err := parseCheckAndInterpretWithOptions(t,
+					`
                       resource R {}
 
                       fun test() {
@@ -1645,8 +1698,9 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
-			})
 
+				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
+			})
 		})
 	})
 }

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -608,9 +608,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -655,9 +652,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -702,9 +696,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -749,9 +740,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -793,9 +781,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -834,9 +819,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -875,9 +857,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -916,9 +895,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -959,9 +935,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1001,9 +974,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1040,9 +1010,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1074,9 +1041,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1108,9 +1072,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1142,9 +1103,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1194,9 +1152,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1240,9 +1195,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1286,9 +1238,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1332,9 +1281,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1374,9 +1320,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1413,9 +1356,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1452,9 +1392,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1491,9 +1428,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1533,9 +1467,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1574,9 +1505,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1613,9 +1541,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1646,9 +1571,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1679,9 +1601,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
@@ -1712,9 +1631,6 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
                       }
                     `,
 					ParseCheckAndInterpretOptions{
-						Options: []interpreter.Option{
-							interpreter.WithInvalidatedResourceValidationEnabled(true),
-						},
 						HandleCheckerError: func(err error) {
 							errs := checker.ExpectCheckerErrors(t, err, 1)
 							require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -883,7 +883,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 		storageSize, slabCounts = getSlabStorageSize(t, storage)
 
 		for fieldName, orgFieldValue := range orgFields {
-			fieldValue := testComposite.GetField(fieldName)
+			fieldValue := testComposite.GetField(interpreter.ReturnEmptyLocationRange, fieldName)
 			utils.AssertValuesEqual(t, inter, orgFieldValue, fieldValue)
 		}
 
@@ -915,7 +915,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 		).(*interpreter.CompositeValue)
 
 		for name, orgValue := range orgFields {
-			value := copyOfTestComposite.GetField(name)
+			value := copyOfTestComposite.GetField(interpreter.ReturnEmptyLocationRange, name)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 		}
 
@@ -935,7 +935,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 
 		// go over original values again and check no missing data (no side effect should be found)
 		for name, orgValue := range orgFields {
-			value := testComposite.GetField(name)
+			value := testComposite.GetField(interpreter.ReturnEmptyLocationRange, name)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 		}
 
@@ -958,7 +958,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 
 		for name := range orgFields {
 			composite.RemoveField(inter, interpreter.ReturnEmptyLocationRange, name)
-			value := composite.GetField(name)
+			value := composite.GetField(interpreter.ReturnEmptyLocationRange, name)
 			assert.Nil(t, value)
 		}
 	})
@@ -984,7 +984,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 
 		// Check the elements
 		for fieldName, orgFieldValue := range fields {
-			fieldValue := movedComposite.GetField(fieldName)
+			fieldValue := movedComposite.GetField(interpreter.ReturnEmptyLocationRange, fieldName)
 			utils.AssertValuesEqual(t, inter, orgFieldValue, fieldValue)
 		}
 
@@ -1380,7 +1380,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 			common.Address{},
 		)
 
-		if enum.GetField(sema.EnumRawValueFieldName) == nil {
+		if enum.GetField(interpreter.ReturnEmptyLocationRange, sema.EnumRawValueFieldName) == nil {
 			panic("enum without raw value")
 		}
 
@@ -1687,7 +1687,7 @@ func (m *valueMap) internalKey(key interpreter.Value) interface{} {
 			location:            key.Location,
 			qualifiedIdentifier: key.QualifiedIdentifier,
 			kind:                key.Kind,
-			rawValue:            key.GetField(sema.EnumRawValueFieldName),
+			rawValue:            key.GetField(interpreter.ReturnEmptyLocationRange, sema.EnumRawValueFieldName),
 		}
 	case interpreter.Value:
 		return key

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -274,7 +274,8 @@ func TestRandomMapOperations(t *testing.T) {
 			someValue := removedValue.(*interpreter.SomeValue)
 
 			// Removed value must be same as the original value
-			utils.AssertValuesEqual(t, inter, orgValue, someValue.Value)
+			innerValue := someValue.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			utils.AssertValuesEqual(t, inter, orgValue, innerValue)
 
 			return false
 		})
@@ -332,7 +333,8 @@ func TestRandomMapOperations(t *testing.T) {
 			someValue := removedValue.(*interpreter.SomeValue)
 
 			// Removed value must be same as the original value
-			utils.AssertValuesEqual(t, inter, orgValue, someValue.Value)
+			innerValue := someValue.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			utils.AssertValuesEqual(t, inter, orgValue, innerValue)
 
 			return false
 		})
@@ -410,7 +412,8 @@ func TestRandomMapOperations(t *testing.T) {
 				someValue := removedValue.(*interpreter.SomeValue)
 
 				// Removed value must be same as the original value
-				utils.AssertValuesEqual(t, inter, orgValue, someValue.Value)
+				innerValue := someValue.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+				utils.AssertValuesEqual(t, inter, orgValue, innerValue)
 
 				deleteCount++
 			}
@@ -1214,7 +1217,8 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 			BorrowType: v.BorrowType,
 		}
 	case *interpreter.SomeValue:
-		return interpreter.NewSomeValueNonCopying(deepCopyValue(inter, v.Value))
+		innerValue := v.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+		return interpreter.NewSomeValueNonCopying(deepCopyValue(inter, innerValue))
 	case interpreter.NilValue:
 		return interpreter.NilValue{}
 	default:
@@ -1253,9 +1257,9 @@ func randomStorableValue(inter *interpreter.Interpreter, currentDepth int) inter
 			},
 		}
 	case Some:
-		return &interpreter.SomeValue{
-			Value: randomStorableValue(inter, currentDepth+1),
-		}
+		return interpreter.NewSomeValueNonCopying(
+			randomStorableValue(inter, currentDepth+1),
+		)
 
 	// Hashable
 	default:


### PR DESCRIPTION
Work towards dapperlabs/cadence-private-issues#19

## Description

Add a defensive check for resources: When a resource is transferred (moved), create a new instance (Go struct), instead of reusing the existing one. Also, mark the transferred resource as invalidated, and detect uses after invalidation.

We already had an existing check for uses of referenced resources after their destruction.

Combined, this allows checking the use (transfer or access) of invalidated (transferred or destroyed) resources.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
