### PR TITLE
Check use of invalidated resources at runtime

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4593,6 +4593,10 @@ func (interpreter *Interpreter) startResourceTracking(
 	identifier string,
 	hasPosition ast.HasPosition,
 ) {
+	if !interpreter.invalidatedResourceValidationEnabled {
+		return
+	}
+
 	if value == nil || !value.IsResourceKinded(interpreter) {
 		return
 	}
@@ -4634,6 +4638,10 @@ func (interpreter *Interpreter) checkInvalidatedResourceUse(
 	identifier string,
 	hasPosition ast.HasPosition,
 ) {
+	if !interpreter.invalidatedResourceValidationEnabled {
+		return
+	}
+
 	if value == nil || !value.IsResourceKinded(interpreter) {
 		return
 	}
@@ -4664,6 +4672,10 @@ func (interpreter *Interpreter) checkInvalidatedResourceUse(
 }
 
 func (interpreter *Interpreter) invalidateResource(value Value) {
+	if !interpreter.invalidatedResourceValidationEnabled {
+		return
+	}
+
 	if value == nil || !value.IsResourceKinded(interpreter) {
 		return
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -13750,12 +13750,6 @@ func (v *SomeValue) NeedsStoreTo(address atree.Address) bool {
 }
 
 func (v *SomeValue) IsResourceKinded(interpreter *Interpreter) bool {
-	// Assumption: inner-value of an optional could only be nil
-	// if it is a resource and has been invalidated/destroyed.
-	if v.value == nil {
-		return true
-	}
-
 	return v.value.IsResourceKinded(interpreter)
 }
 

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -1725,6 +1725,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1751,6 +1752,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1784,6 +1786,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1811,6 +1814,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1837,6 +1841,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1867,6 +1872,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1894,6 +1900,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1921,6 +1928,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1952,6 +1960,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -1983,6 +1992,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -2013,6 +2023,7 @@ func TestCheckResourceInvalidationWithConditionalExprInDestroy(t *testing.T) {
 			},
 		},
 	)
+	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.Error(t, err)
@@ -2053,6 +2064,7 @@ func TestInterpretResourceUseAfterInvalidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
@@ -2089,6 +2101,7 @@ func TestInterpretResourceUseAfterInvalidation(t *testing.T) {
 				},
 			},
 		)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/19

## Description

This adds second layer of runtime validation to check use of invalidated (moved/destroyed) resources. This check relies on:
- An external mapping, which keeps the resource-to-variable mapping.
- Assumes there could be at-most one mapping for each resource value at any given time.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
