### PR TITLE
Fix CI typo feature-secure-cadence

### DIFF
--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -1,6 +1,6 @@
 # Open a PR in flow-go when a PR in cadence is merged
 # The PR in flow-go is based on the last opened `auto-cadence-upgrade/*` if it exists.
-# Otherwise, it's based on the feature-secure-cadence branch.
+# Otherwise, it's based on the feature/secure-cadence branch.
 name: Sync flow-go
 
 # Only run on pull requests merged to master
@@ -33,7 +33,7 @@ jobs:
           repository: onflow/flow-go
       
       # get the latest update branch name to base the PR on that branch
-      # else, use the "feature-secure-cadence" branch
+      # else, use the "feature/secure-cadence" branch
       - name: Get onflow/flow-go base branch name
         run: |
           git fetch
@@ -48,13 +48,13 @@ jobs:
           echo "NEW_BRANCH=$NEW_BRANCH" >> $GITHUB_ENV
 
       # create feature branch if needed
-      - name: Create feature-secure-cadence branch
+      - name: Create feature/secure-cadence branch
         uses: peterjgrainger/action-create-branch@v2.0.1
-        if: ${{ env.BASE_BRANCH == "feature-secure-cadence" }}
+        if: ${{ env.BASE_BRANCH == "feature/secure-cadence" }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: feature-secure-cadence
+          branch: feature/secure-cadence
           ref: master
 
       # checkout the correct branch of the remote repo


### PR DESCRIPTION
Closes nothing this is a quick fix for merged code.

## Description

I changed one of the feature-secure-cadence instances to feature/secure-cadence but not the others.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
