### PR TITLE
[0.23] Expand interpreter tracing for composite, array and dictionary types (backport #1450)

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2519,6 +2519,8 @@ func (interpreter *Interpreter) NewSubInterpreter(
 			interpreter.BLSAggregateSignaturesHandler,
 			interpreter.BLSAggregatePublicKeysHandler,
 		),
+		WithOnRecordTraceHandler(interpreter.onRecordTrace),
+		WithTracingEnabled(interpreter.tracingEnabled),
 	}
 
 	return NewInterpreter(

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -531,8 +531,12 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 	// tracing
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
+		invokedExpression := invocationExpression.InvokedExpression.String()
 		defer func() {
-			interpreter.reportFunctionTrace(invocationExpression.InvokedExpression.String(), time.Since(startTime))
+			interpreter.reportFunctionTrace(
+				invokedExpression,
+				time.Since(startTime),
+			)
 		}()
 	}
 

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -43,7 +43,10 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportImportTrace(resolvedLocation.Location.String(), time.Since(startTime))
+			interpreter.reportImportTrace(
+				resolvedLocation.Location.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -1,7 +1,7 @@
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2022 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,25 +35,25 @@ const (
 	tracingDictionaryPrefix = "dictionary."
 	tracingCompositePrefix  = "composite."
 
-	// Value operation prefixes
-	tracingConstructPrefix             = "construct."
-	tracingTransferPrefix              = "transfer."
-	tracingConformsToDynamicTypePrefix = "conformsToDynamicType."
-	tracingClonePrefix                 = "clone."
-	tracingDeepRemovePrefix            = "deepRemove."
-	tracingDestroyPrefix               = "distroy."
+	// Value operation postfixes
+	tracingConstructPostfix             = "construct"
+	tracingTransferPostfix              = "transfer"
+	tracingConformsToDynamicTypePostfix = "conformsToDynamicType"
+	tracingClonePostfix                 = "clone"
+	tracingDeepRemovePostfix            = "deepRemove"
+	tracingDestroyPostfix               = "distroy"
 
-	// ValueIndexable operation prefixes
+	// ValueIndexable operation postfixes
 	// TODO enable these
-	// tracingGetKeyPrefix    = "getKey."
-	// tracingSetKeyPrefix    = "setKey."
-	// tracingRemoveKeyPrefix = "removeKey."
-	// tracingInsertKeyPrefix = "insertKey."
+	// tracingGetKeyPostfix    = "getKey."
+	// tracingSetKeyPostfix    = "setKey."
+	// tracingRemoveKeyPostfix = "removeKey."
+	// tracingInsertKeyPostfix = "insertKey."
 
-	// MemberAccessible operation prefixes
-	tracingGetMemberPrefix    = "getMember."
-	tracingSetMemberPrefix    = "setMember."
-	tracingRemoveMemberPrefix = "removeMember."
+	// MemberAccessible operation postfixes
+	tracingGetMemberPostfix    = "getMember"
+	tracingSetMemberPostfix    = "setMember"
+	tracingRemoveMemberPostfix = "removeMember"
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
@@ -77,51 +77,51 @@ func prepareArrayAndMapValueTraceLogs(typeInfo string, count int) []opentracing.
 }
 
 func (interpreter *Interpreter) reportArrayValueConstructTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDestroyPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportArrayValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConformsToDynamicTypePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueConstructTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDeepRemovePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDestroyPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.LogRecord {
@@ -138,37 +138,37 @@ func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.Lo
 }
 
 func (interpreter *Interpreter) reportCompositeValueConstructTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueCloneTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueDeepRemoveTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDeepRemovePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDeepRemovePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueDestroyTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDestroyPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDestroyPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueTransferTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingTransferPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingTransferPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueConformsToDynamicTypeTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -39,7 +39,6 @@ const (
 	tracingConstructPostfix             = "construct"
 	tracingTransferPostfix              = "transfer"
 	tracingConformsToDynamicTypePostfix = "conformsToDynamicType"
-	tracingClonePostfix                 = "clone"
 	tracingDeepRemovePostfix            = "deepRemove"
 	tracingDestroyPostfix               = "destroy"
 
@@ -73,10 +72,6 @@ func (interpreter *Interpreter) reportArrayValueConstructTrace(typeInfo string, 
 	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
-func (interpreter *Interpreter) reportArrayValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
-}
-
 func (interpreter *Interpreter) reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
 	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
@@ -95,10 +90,6 @@ func (interpreter *Interpreter) reportArrayValueConformsToDynamicTypeTrace(typeI
 
 func (interpreter *Interpreter) reportDictionaryValueConstructTrace(typeInfo string, count int, duration time.Duration) {
 	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
-}
-
-func (interpreter *Interpreter) reportDictionaryValueCloneTrace(typeInfo string, count int, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
@@ -136,10 +127,6 @@ func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.Lo
 
 func (interpreter *Interpreter) reportCompositeValueConstructTrace(owner, typeID, kind string, duration time.Duration) {
 	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
-}
-
-func (interpreter *Interpreter) reportCompositeValueCloneTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
 func (interpreter *Interpreter) reportCompositeValueDeepRemoveTrace(owner, typeID, kind string, duration time.Duration) {

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -43,17 +43,10 @@ const (
 	tracingDeepRemovePostfix            = "deepRemove"
 	tracingDestroyPostfix               = "distroy"
 
-	// ValueIndexable operation postfixes
-	// TODO enable these
-	// tracingGetKeyPostfix    = "getKey."
-	// tracingSetKeyPostfix    = "setKey."
-	// tracingRemoveKeyPostfix = "removeKey."
-	// tracingInsertKeyPostfix = "insertKey."
-
-	// MemberAccessible operation postfixes
-	tracingGetMemberPostfix    = "getMember"
-	tracingSetMemberPostfix    = "setMember"
-	tracingRemoveMemberPostfix = "removeMember"
+	// MemberAccessible operation prefixes
+	tracingGetMemberPrefix    = "getMember."
+	tracingSetMemberPrefix    = "setMember."
+	tracingRemoveMemberPrefix = "removeMember."
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
@@ -124,6 +117,10 @@ func (interpreter *Interpreter) reportDictionaryValueConformsToDynamicTypeTrace(
 	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePostfix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
+func (interpreter *Interpreter) reportDictionaryValueGetMemberTrace(typeInfo string, count int, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingGetMemberPrefix+name, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
 func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.LogRecord {
 	return []opentracing.LogRecord{
 		{
@@ -161,14 +158,14 @@ func (interpreter *Interpreter) reportCompositeValueConformsToDynamicTypeTrace(o
 	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
-func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPrefix+name, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
-func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPrefix+name, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }
 
-func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind string, duration time.Duration) {
-	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPostfix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind, name string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPrefix+name, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -41,7 +41,7 @@ const (
 	tracingConformsToDynamicTypePostfix = "conformsToDynamicType"
 	tracingClonePostfix                 = "clone"
 	tracingDeepRemovePostfix            = "deepRemove"
-	tracingDestroyPostfix               = "distroy"
+	tracingDestroyPostfix               = "destroy"
 
 	// MemberAccessible operation prefixes
 	tracingGetMemberPrefix    = "getMember."

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -26,11 +26,34 @@ import (
 )
 
 const (
-	tracingFunctionPrefix   = "function."
-	tracingImportPrefix     = "import."
+	// common
+	tracingFunctionPrefix = "function."
+	tracingImportPrefix   = "import."
+
+	// type prefixes
 	tracingArrayPrefix      = "array."
 	tracingDictionaryPrefix = "dictionary."
-	tracingTransferPrefix   = "transfer."
+	tracingCompositePrefix  = "composite."
+
+	// Value operation prefixes
+	tracingConstructPrefix             = "construct."
+	tracingTransferPrefix              = "transfer."
+	tracingConformsToDynamicTypePrefix = "conformsToDynamicType."
+	tracingClonePrefix                 = "clone."
+	tracingDeepRemovePrefix            = "deepRemove."
+	tracingDestroyPrefix               = "distroy."
+
+	// ValueIndexable operation prefixes
+	// TODO enable these
+	// tracingGetKeyPrefix    = "getKey."
+	// tracingSetKeyPrefix    = "setKey."
+	// tracingRemoveKeyPrefix = "removeKey."
+	// tracingInsertKeyPrefix = "insertKey."
+
+	// MemberAccessible operation prefixes
+	tracingGetMemberPrefix    = "getMember."
+	tracingSetMemberPrefix    = "setMember."
+	tracingRemoveMemberPrefix = "removeMember."
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
@@ -41,8 +64,8 @@ func (interpreter *Interpreter) reportImportTrace(importPath string, duration ti
 	interpreter.onRecordTrace(interpreter, tracingImportPrefix+importPath, duration, nil)
 }
 
-func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	logs := []opentracing.LogRecord{
+func prepareArrayAndMapValueTraceLogs(typeInfo string, count int) []opentracing.LogRecord {
+	return []opentracing.LogRecord{
 		{
 			Timestamp: time.Now(),
 			Fields: []log.Field{
@@ -51,18 +74,101 @@ func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, c
 			},
 		},
 	}
-	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, logs)
+}
+
+func (interpreter *Interpreter) reportArrayValueConstructTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueCloneTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueTransferTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportArrayValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingArrayPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueConstructTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConstructPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueCloneTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingClonePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDeepRemovePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueDestroyTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingDestroyPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
 }
 
 func (interpreter *Interpreter) reportDictionaryValueTransferTrace(typeInfo string, count int, duration time.Duration) {
-	logs := []opentracing.LogRecord{
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func (interpreter *Interpreter) reportDictionaryValueConformsToDynamicTypeTrace(typeInfo string, count int, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingConformsToDynamicTypePrefix, duration, prepareArrayAndMapValueTraceLogs(typeInfo, count))
+}
+
+func prepareCompositeValueTraceLogs(owner, typeID, kind string) []opentracing.LogRecord {
+	return []opentracing.LogRecord{
 		{
 			Timestamp: time.Now(),
 			Fields: []log.Field{
-				log.Int("count", count),
-				log.String("type", typeInfo),
+				log.String("owner", owner),
+				log.String("typeID", typeID),
+				log.String("kind", kind),
 			},
 		},
 	}
-	interpreter.onRecordTrace(interpreter, tracingDictionaryPrefix+tracingTransferPrefix, duration, logs)
+}
+
+func (interpreter *Interpreter) reportCompositeValueConstructTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConstructPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueCloneTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingClonePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueDeepRemoveTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDeepRemovePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueDestroyTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingDestroyPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueTransferTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingTransferPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueConformsToDynamicTypeTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingConformsToDynamicTypePrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingGetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingSetMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
+}
+
+func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(owner, typeID, kind string, duration time.Duration) {
+	interpreter.onRecordTrace(interpreter, tracingCompositePrefix+tracingRemoveMemberPrefix, duration, prepareCompositeValueTraceLogs(owner, typeID, kind))
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -1,0 +1,91 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpreterTracing(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("composite tracing", func(t *testing.T) {
+		storage := interpreter.NewInMemoryStorage()
+
+		elaboration := sema.NewElaboration()
+		elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+
+		traceOps := make([]string, 0)
+		inter, err := interpreter.NewInterpreter(
+			&interpreter.Program{
+				Elaboration: elaboration,
+			},
+			utils.TestLocation,
+			interpreter.WithOnRecordTraceHandler(
+				func(inter *interpreter.Interpreter,
+					operationName string,
+					duration time.Duration,
+					logs []opentracing.LogRecord) {
+					traceOps = append(traceOps, operationName)
+				},
+			),
+			interpreter.WithStorage(storage),
+			interpreter.WithTracingEnabled(true),
+		)
+		require.NoError(t, err)
+
+		owner := common.Address{0x1}
+
+		value := newTestCompositeValue(inter, owner)
+
+		require.Equal(t, len(traceOps), 1)
+		require.Equal(t, traceOps[0], "composite.construct")
+
+		cloned := value.Clone(inter)
+		require.NotNil(t, cloned)
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "composite.clone")
+
+		cloned.DeepRemove(inter)
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "composite.deepRemove")
+
+		array := interpreter.NewArrayValue(
+			inter,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.PrimitiveStaticTypeAnyStruct,
+			},
+			common.Address{},
+			value,
+		)
+		require.NotNil(t, array)
+		require.Equal(t, len(traceOps), 5)
+		require.Equal(t, traceOps[3], "composite.transfer")
+		require.Equal(t, traceOps[4], "array.construct")
+	})
+}

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -76,17 +76,33 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 3)
 		require.Equal(t, traceOps[2], "composite.deepRemove")
 
+		value.SetMember(inter, nil, "abc", interpreter.NilValue{})
+		require.Equal(t, len(traceOps), 4)
+		require.Equal(t, traceOps[3], "composite.setMember.abc")
+
+		value.GetMember(inter, nil, "abc")
+		require.Equal(t, len(traceOps), 5)
+		require.Equal(t, traceOps[4], "composite.getMember.abc")
+
+		value.RemoveMember(inter, nil, "abc")
+		require.Equal(t, len(traceOps), 6)
+		require.Equal(t, traceOps[5], "composite.removeMember.abc")
+
+		value.Destroy(inter, nil)
+		require.Equal(t, len(traceOps), 7)
+		require.Equal(t, traceOps[6], "composite.destroy")
+
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			common.Address{},
-			value,
+			cloned,
 		)
 		require.NotNil(t, array)
-		require.Equal(t, len(traceOps), 5)
-		require.Equal(t, traceOps[3], "composite.transfer")
-		require.Equal(t, traceOps[4], "array.construct")
+		require.Equal(t, len(traceOps), 9)
+		require.Equal(t, traceOps[7], "composite.transfer")
+		require.Equal(t, traceOps[8], "array.construct")
 	})
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -22,12 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInterpreterTracing(t *testing.T) {

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/onflow/atree"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
 
@@ -76,18 +77,9 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 1)
 		require.Equal(t, traceOps[0], "array.construct")
 
-		cloned := array.Clone(inter)
-		require.NotNil(t, cloned)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "array.clone")
-
-		cloned.DeepRemove(inter)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "array.deepRemove")
-
 		array.Destroy(inter, nil)
-		require.Equal(t, len(traceOps), 4)
-		require.Equal(t, traceOps[3], "array.destroy")
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "array.destroy")
 	})
 
 	t.Run("dictionary tracing", func(t *testing.T) {
@@ -108,18 +100,9 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 1)
 		require.Equal(t, traceOps[0], "dictionary.construct")
 
-		cloned := dict.Clone(inter)
-		require.NotNil(t, cloned)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "dictionary.clone")
-
-		cloned.DeepRemove(inter)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "dictionary.deepRemove")
-
 		dict.Destroy(inter, nil)
-		require.Equal(t, len(traceOps), 4)
-		require.Equal(t, traceOps[3], "dictionary.destroy")
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "dictionary.destroy")
 	})
 
 	t.Run("composite tracing", func(t *testing.T) {
@@ -134,42 +117,25 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 1)
 		require.Equal(t, traceOps[0], "composite.construct")
 
-		cloned := value.Clone(inter)
-		require.NotNil(t, cloned)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "composite.clone")
-
-		cloned.DeepRemove(inter)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "composite.deepRemove")
-
 		value.SetMember(inter, nil, "abc", interpreter.NilValue{})
-		require.Equal(t, len(traceOps), 4)
-		require.Equal(t, traceOps[3], "composite.setMember.abc")
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "composite.setMember.abc")
 
 		value.GetMember(inter, nil, "abc")
-		require.Equal(t, len(traceOps), 5)
-		require.Equal(t, traceOps[4], "composite.getMember.abc")
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "composite.getMember.abc")
 
 		value.RemoveMember(inter, nil, "abc")
-		require.Equal(t, len(traceOps), 6)
-		require.Equal(t, traceOps[5], "composite.removeMember.abc")
+		require.Equal(t, len(traceOps), 4)
+		require.Equal(t, traceOps[3], "composite.removeMember.abc")
 
 		value.Destroy(inter, nil)
-		require.Equal(t, len(traceOps), 7)
-		require.Equal(t, traceOps[6], "composite.destroy")
+		require.Equal(t, len(traceOps), 5)
+		require.Equal(t, traceOps[4], "composite.destroy")
 
-		array := interpreter.NewArrayValue(
-			inter,
-			interpreter.VariableSizedStaticType{
-				Type: interpreter.PrimitiveStaticTypeAnyStruct,
-			},
-			common.Address{},
-			cloned,
-		)
+		array := value.Transfer(inter, nil, atree.Address{}, false, nil)
 		require.NotNil(t, array)
-		require.Equal(t, len(traceOps), 9)
-		require.Equal(t, traceOps[7], "composite.transfer")
-		require.Equal(t, traceOps[8], "array.construct")
+		require.Equal(t, len(traceOps), 6)
+		require.Equal(t, traceOps[5], "composite.transfer")
 	})
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -83,6 +83,53 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, traceOps[3], "array.destroy")
 	})
 
+	t.Run("dictionary tracing", func(t *testing.T) {
+		storage := interpreter.NewInMemoryStorage()
+
+		traceOps := make([]string, 0)
+		inter, err := interpreter.NewInterpreter(
+			&interpreter.Program{},
+			utils.TestLocation,
+			interpreter.WithOnRecordTraceHandler(
+				func(inter *interpreter.Interpreter,
+					operationName string,
+					duration time.Duration,
+					logs []opentracing.LogRecord) {
+					traceOps = append(traceOps, operationName)
+				},
+			),
+			interpreter.WithStorage(storage),
+			interpreter.WithTracingEnabled(true),
+		)
+		require.NoError(t, err)
+
+		dict := interpreter.NewDictionaryValue(
+			inter,
+			interpreter.DictionaryStaticType{
+				KeyType:   interpreter.PrimitiveStaticTypeString,
+				ValueType: interpreter.PrimitiveStaticTypeInt,
+			},
+			interpreter.NewStringValue("test"), interpreter.NewIntValueFromInt64(42),
+		)
+		require.NotNil(t, dict)
+		fmt.Println(traceOps)
+		require.Equal(t, len(traceOps), 1)
+		require.Equal(t, traceOps[0], "dictionary.construct")
+
+		cloned := dict.Clone(inter)
+		require.NotNil(t, cloned)
+		require.Equal(t, len(traceOps), 2)
+		require.Equal(t, traceOps[1], "dictionary.clone")
+
+		cloned.DeepRemove(inter)
+		require.Equal(t, len(traceOps), 3)
+		require.Equal(t, traceOps[2], "dictionary.deepRemove")
+
+		dict.Destroy(inter, nil)
+		require.Equal(t, len(traceOps), 4)
+		require.Equal(t, traceOps[3], "dictionary.destroy")
+	})
+
 	t.Run("composite tracing", func(t *testing.T) {
 		storage := interpreter.NewInMemoryStorage()
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -930,7 +930,11 @@ func NewArrayValueWithIterator(
 		startTime := time.Now()
 		defer func() {
 			// TODO figure out how to pass member counts here without iterating
-			interpreter.reportArrayValueConstructTrace(arrayType.String(), -1, time.Since(startTime))
+			interpreter.reportArrayValueConstructTrace(
+				arrayType.String(),
+				-1,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1018,7 +1022,11 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueDestroyTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueDestroyTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1426,7 +1434,11 @@ func (v *ArrayValue) ConformsToDynamicType(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueConformsToDynamicTypeTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueConformsToDynamicTypeTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1510,7 +1522,11 @@ func (v *ArrayValue) Transfer(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueTransferTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueTransferTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -1602,7 +1618,11 @@ func (v *ArrayValue) DeepRemove(interpreter *Interpreter) {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportArrayValueDeepRemoveTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportArrayValueDeepRemoveTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -10870,7 +10890,12 @@ func NewCompositeValue(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueConstructTrace(address.String(), qualifiedIdentifier, kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueConstructTrace(
+				address.String(),
+				qualifiedIdentifier,
+				kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -10973,7 +10998,12 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueDestroyTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueDestroyTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11006,7 +11036,13 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueGetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
+			interpreter.reportCompositeValueGetMemberTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11122,7 +11158,13 @@ func (v *CompositeValue) RemoveMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueRemoveMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
+			interpreter.reportCompositeValueRemoveMemberTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11168,7 +11210,13 @@ func (v *CompositeValue) SetMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueSetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
+			interpreter.reportCompositeValueSetMemberTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11351,7 +11399,12 @@ func (v *CompositeValue) ConformsToDynamicType(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueConformsToDynamicTypeTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueConformsToDynamicTypeTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11465,7 +11518,12 @@ func (v *CompositeValue) Transfer(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueTransferTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueTransferTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11574,7 +11632,12 @@ func (v *CompositeValue) DeepRemove(interpreter *Interpreter) {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueDeepRemoveTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueDeepRemoveTrace(
+				v.GetOwner().String(),
+				string(v.TypeID()),
+				v.Kind.String(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11716,7 +11779,11 @@ func NewDictionaryValueWithAddress(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueConstructTrace(dictionaryType.String(), len(keysAndValues)/2, time.Since(startTime))
+			interpreter.reportDictionaryValueConstructTrace(
+				dictionaryType.String(),
+				len(keysAndValues)/2,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11829,7 +11896,11 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueDestroyTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueDestroyTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -11966,7 +12037,12 @@ func (v *DictionaryValue) GetMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueGetMemberTrace(v.Type.String(), v.Count(), name, time.Since(startTime))
+			interpreter.reportDictionaryValueGetMemberTrace(
+				v.Type.String(),
+				v.Count(),
+				name,
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12232,7 +12308,11 @@ func (v *DictionaryValue) ConformsToDynamicType(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueConformsToDynamicTypeTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueConformsToDynamicTypeTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12356,7 +12436,11 @@ func (v *DictionaryValue) Transfer(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueTransferTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueTransferTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 
@@ -12461,7 +12545,11 @@ func (v *DictionaryValue) DeepRemove(interpreter *Interpreter) {
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportDictionaryValueDeepRemoveTrace(v.Type.String(), v.Count(), time.Since(startTime))
+			interpreter.reportDictionaryValueDeepRemoveTrace(
+				v.Type.String(),
+				v.Count(),
+				time.Since(startTime),
+			)
 		}()
 	}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -11006,7 +11006,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueGetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueGetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
 		}()
 	}
 
@@ -11122,7 +11122,7 @@ func (v *CompositeValue) RemoveMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueRemoveMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueRemoveMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
 		}()
 	}
 
@@ -11168,7 +11168,7 @@ func (v *CompositeValue) SetMember(
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 		defer func() {
-			interpreter.reportCompositeValueSetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), time.Since(startTime))
+			interpreter.reportCompositeValueSetMemberTrace(v.GetOwner().String(), string(v.TypeID()), v.Kind.String(), name, time.Since(startTime))
 		}()
 	}
 
@@ -11962,6 +11962,13 @@ func (v *DictionaryValue) GetMember(
 	getLocationRange func() LocationRange,
 	name string,
 ) Value {
+
+	if interpreter.tracingEnabled {
+		startTime := time.Now()
+		defer func() {
+			interpreter.reportDictionaryValueGetMemberTrace(v.Type.String(), v.Count(), name, time.Since(startTime))
+		}()
+	}
 
 	switch name {
 	case "length":

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -24,8 +24,10 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/onflow/atree"
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -95,6 +97,17 @@ func parseCheckAndInterpretWithOptions(
 			interpreter.WithStorage(interpreter.NewInMemoryStorage()),
 			interpreter.WithAtreeValueValidationEnabled(true),
 			interpreter.WithAtreeStorageValidationEnabled(true),
+			interpreter.WithOnRecordTraceHandler(
+				func(
+					_ *interpreter.Interpreter,
+					_ string,
+					_ time.Duration,
+					_ []opentracing.LogRecord,
+				) {
+					// NO-OP
+				},
+			),
+			interpreter.WithTracingEnabled(true),
 		},
 		options.Options...,
 	)


### PR DESCRIPTION
<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
