### PR TITLE
do not wrap conditional in ${{}}

### DIFF
--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -50,7 +50,7 @@ jobs:
       # create feature branch if needed
       - name: Create feature/secure-cadence branch
         uses: peterjgrainger/action-create-branch@v2.0.1
-        if: ${{ env.BASE_BRANCH == "feature/secure-cadence" }}
+        if: env.BASE_BRANCH == "feature/secure-cadence"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/sync-flow-go.yml
+++ b/.github/workflows/sync-flow-go.yml
@@ -50,7 +50,7 @@ jobs:
       # create feature branch if needed
       - name: Create feature/secure-cadence branch
         uses: peterjgrainger/action-create-branch@v2.0.1
-        if: env.BASE_BRANCH == "feature/secure-cadence"
+        if: env.BASE_BRANCH == 'feature/secure-cadence'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Attempt to fix workflow failures like this one: https://github.com/onflow/cadence/actions/runs/1929973038

## Description

There's a syntax error in the `sync-flow-go.yml` workflow file. Another condition in that file omits thee `${{ ... }}` wrapper so I am trying that.

I don't know how to test these changes so I'm doing so live. I believe the scope of potential damage is limited to the current situation where the automatic PRs for syncing cadence and flow-go aren't created.

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
