### PR TITLE
Improve string metering

### DIFF
--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -27,9 +27,9 @@ type MemoryGauge interface {
 	UseMemory(usage MemoryUsage)
 }
 
-func NewStringMemoryUsage(amount uint64) MemoryUsage {
+func NewStringMemoryUsage(length int) MemoryUsage {
 	return MemoryUsage{
 		Kind:   MemoryKindString,
-		Amount: amount,
+		Amount: uint64(length),
 	}
 }

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -558,7 +558,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 }
 
 func importString(inter *interpreter.Interpreter, v cadence.String) *interpreter.StringValue {
-	memoryUsage := common.NewStringMemoryUsage(uint64(len(v)))
+	memoryUsage := common.NewStringMemoryUsage(len(v))
 	return interpreter.NewStringValue(
 		inter,
 		memoryUsage,

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -4604,7 +4604,7 @@ func TestRuntimeStaticTypeAvailability(t *testing.T) {
 }
 
 func newTestInterpreter(tb testing.TB) *interpreter.Interpreter {
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		nil,
@@ -4616,6 +4616,10 @@ func newTestInterpreter(tb testing.TB) *interpreter.Interpreter {
 	require.NoError(tb, err)
 
 	return inter
+}
+
+func newUnmeteredInMemoryStorage() interpreter.Storage {
+	return interpreter.NewInMemoryStorage(nil)
 }
 
 func TestNestedStructArgPassing(t *testing.T) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -53,13 +53,30 @@ func (e UnsupportedTagDecodingError) Error() string {
 	)
 }
 
+type InvalidStringLengthError struct {
+	Length uint64
+}
+
+func (e InvalidStringLengthError) Error() string {
+	return fmt.Sprintf(
+		"invalid string length: got %d, expected max %d",
+		e.Length,
+		math.MaxInt,
+	)
+}
+
 func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (string, error) {
 	length, err := dec.NextSize()
 	if err != nil {
 		return "", err
 	}
+	if length > math.MaxInt {
+		return "", InvalidStringLengthError{
+			Length: length,
+		}
+	}
 	if memoryGauge != nil {
-		memoryGauge.UseMemory(common.NewStringMemoryUsage(length))
+		memoryGauge.UseMemory(common.NewStringMemoryUsage(int(length)))
 	}
 	return dec.DecodeString()
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -61,7 +61,7 @@ func (e InvalidStringLengthError) Error() string {
 	return fmt.Sprintf(
 		"invalid string length: got %d, expected max %d",
 		e.Length,
-		math.MaxInt,
+		goMaxInt,
 	)
 }
 
@@ -70,7 +70,7 @@ func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (stri
 	if err != nil {
 		return "", err
 	}
-	if length > math.MaxInt {
+	if length > goMaxInt {
 		return "", InvalidStringLengthError{
 			Length: length,
 		}

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -36,7 +36,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 
 	address := common.Address{0x1}
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := NewInterpreter(
 		nil,
@@ -94,4 +94,8 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	}
 
 	require.Equal(t, 1, count)
+}
+
+func newUnmeteredInMemoryStorage() InMemoryStorage {
+	return NewInMemoryStorage(nil)
 }

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -56,7 +56,7 @@ var testOwner = common.MustBytesToAddress([]byte{0x42})
 func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 
 	if test.storage == nil {
-		test.storage = NewInMemoryStorage(nil)
+		test.storage = newUnmeteredInMemoryStorage()
 	}
 
 	var encoded []byte

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3415,7 +3415,7 @@ var stringFunction = func() Value {
 
 				inter := invocation.Interpreter
 				memoryUsage := common.NewStringMemoryUsage(
-					uint64(argument.Count()) * 2,
+					safeMul(argument.Count(), 2),
 				)
 				return NewStringValue(
 					inter,

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -35,7 +35,7 @@ func setupInterpreterWithTracingCallBack(
 	t *testing.T,
 	tracingCallback func(opName string),
 ) *interpreter.Interpreter {
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 	inter, err := interpreter.NewInterpreter(
 		&interpreter.Program{},
 		utils.TestLocation,

--- a/runtime/interpreter/number.go
+++ b/runtime/interpreter/number.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func OverEstimateNumberStringLength(value NumberValue) uint64 {
+func OverEstimateNumberStringLength(value NumberValue) int {
 	switch value := value.(type) {
 	case BigNumberValue:
 		return OverEstimateBigIntStringLength(value.ToBigInt())
@@ -41,11 +41,11 @@ func OverEstimateNumberStringLength(value NumberValue) uint64 {
 	}
 }
 
-func OverEstimateFixedPointStringLength(integerPart NumberValue, scale uint64) uint64 {
+func OverEstimateFixedPointStringLength(integerPart NumberValue, scale int) int {
 	return OverEstimateNumberStringLength(integerPart) + 1 + scale
 }
 
-func OverEstimateIntStringLength(n int) uint64 {
+func OverEstimateIntStringLength(n int) int {
 	switch {
 	case n < 0:
 		// Handle math.MinInt
@@ -57,11 +57,11 @@ func OverEstimateIntStringLength(n int) uint64 {
 	}
 }
 
-func OverEstimateUintStringLength(n uint) uint64 {
-	return uint64(math.Floor(math.Log10(float64(n))) + 1)
+func OverEstimateUintStringLength(n uint) int {
+	return int(math.Floor(math.Log10(float64(n))) + 1)
 }
 
-func OverEstimateBigIntStringLength(n *big.Int) uint64 {
+func OverEstimateBigIntStringLength(n *big.Int) int {
 	// From https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10:
 	//   By the relationship log10(v) = log2(v) / log2(10), we need to multiply it by 1/log2(10),
 	//   which is approximately 1233/4096, or 1233 followed by a right shift of 12.
@@ -74,7 +74,7 @@ func OverEstimateBigIntStringLength(n *big.Int) uint64 {
 	//   To be sure it's always an upper bound (over-estimation), just use *1234,
 	//   since 1233/4096 is just smaller than 1/log2(10), but 1234/4096 becomes bigger.
 	//
-	l := uint64(n.BitLen()*1234)>>12 + 1
+	l := n.BitLen()*1234>>12 + 1
 	if n.Sign() < 0 {
 		return l + 1
 	} else {

--- a/runtime/interpreter/number.go
+++ b/runtime/interpreter/number.go
@@ -25,6 +25,10 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
+const goIntSize = 32 << (^uint(0) >> 63) // 32 or 64
+const goMaxInt = 1<<(goIntSize-1) - 1
+const goMinInt = -1 << (goIntSize - 1)
+
 func OverEstimateNumberStringLength(value NumberValue) int {
 	switch value := value.(type) {
 	case BigNumberValue:

--- a/runtime/interpreter/number_test.go
+++ b/runtime/interpreter/number_test.go
@@ -30,10 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const goIntSize = 32 << (^uint(0) >> 63) // 32 or 64
-const goMaxInt = 1<<(goIntSize-1) - 1
-const goMinInt = -1 << (goIntSize - 1)
-
 func TestOverEstimateIntStringLength(t *testing.T) {
 
 	properties := gopter.NewProperties(nil)

--- a/runtime/interpreter/number_test.go
+++ b/runtime/interpreter/number_test.go
@@ -40,7 +40,7 @@ func TestOverEstimateIntStringLength(t *testing.T) {
 
 	properties.Property("estimate is greater or equal to actual length", prop.ForAll(
 		func(v int) bool {
-			return OverEstimateIntStringLength(v) >= uint64(len(strconv.Itoa(v)))
+			return OverEstimateIntStringLength(v) >= len(strconv.Itoa(v))
 		},
 		gen.Int(),
 	))
@@ -67,7 +67,7 @@ func TestOverEstimateIntStringLength(t *testing.T) {
 		goMaxInt,
 	} {
 		assert.LessOrEqual(t,
-			uint64(len(strconv.Itoa(v))),
+			len(strconv.Itoa(v)),
 			OverEstimateIntStringLength(v),
 		)
 	}
@@ -79,7 +79,7 @@ func TestOverEstimateBigIntStringLength(t *testing.T) {
 
 	properties.Property("estimate is greater or equal to actual length", prop.ForAll(
 		func(v *big.Int) bool {
-			return OverEstimateBigIntStringLength(v) >= uint64(len(v.String()))
+			return OverEstimateBigIntStringLength(v) >= len(v.String())
 		},
 		gen.Int64().Map(func(v int64) *big.Int {
 			b := big.NewInt(v)
@@ -111,13 +111,13 @@ func TestOverEstimateBigIntStringLength(t *testing.T) {
 		}(),
 	} {
 		assert.LessOrEqual(t,
-			uint64(len(v.String())),
+			len(v.String()),
 			OverEstimateBigIntStringLength(v),
 		)
 
 		neg := new(big.Int).Neg(v)
 		assert.LessOrEqual(t,
-			uint64(len(neg.String())),
+			len(neg.String()),
 			OverEstimateBigIntStringLength(neg),
 		)
 	}
@@ -128,13 +128,13 @@ func TestOverEstimateFixedPointStringLength(t *testing.T) {
 	properties := gopter.NewProperties(nil)
 
 	properties.Property("estimate is greater or equal to actual length", prop.ForAll(
-		func(v NumberValue, scale uint64) bool {
-			return OverEstimateFixedPointStringLength(v, scale) >= uint64(len(v.String()))+1+scale
+		func(v NumberValue, scale int) bool {
+			return OverEstimateFixedPointStringLength(v, scale) >= len(v.String())+1+scale
 		},
 		gen.Int64().Map(func(v int64) NumberValue {
 			return NewIntValueFromInt64(v)
 		}),
-		gen.UInt64(),
+		gen.Int(),
 	))
 
 	properties.TestingRun(t)
@@ -161,7 +161,7 @@ func TestOverEstimateFixedPointStringLength(t *testing.T) {
 		goMaxInt,
 	} {
 		assert.LessOrEqual(t,
-			uint64(len(strconv.Itoa(v))+1+testScale),
+			len(strconv.Itoa(v))+1+testScale,
 			OverEstimateFixedPointStringLength(NewIntValueFromInt64(int64(v)), testScale),
 		)
 	}

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -36,7 +36,7 @@ func TestCompositeStorage(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := NewInterpreter(
 		nil,
@@ -99,7 +99,7 @@ func TestArrayStorage(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		inter, err := NewInterpreter(
 			nil,
@@ -162,7 +162,7 @@ func TestArrayStorage(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		inter, err := NewInterpreter(
 			nil,
@@ -225,7 +225,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		inter, err := NewInterpreter(
 			nil,
@@ -281,7 +281,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		inter, err := NewInterpreter(
 			nil,
@@ -330,7 +330,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		inter, err := NewInterpreter(
 			nil,
@@ -378,7 +378,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		inter, err := NewInterpreter(
 			nil,
@@ -426,7 +426,7 @@ func TestStorageOverwriteAndRemove(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := NewInterpreter(
 		nil,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -180,9 +180,9 @@ type ReferenceTrackedResourceKindedValue interface {
 
 func safeAdd(a, b int) int {
 	// INT32-C
-	if (b > 0) && (a > (math.MaxInt - b)) {
+	if (b > 0) && (a > (goMaxInt - b)) {
 		panic(OverflowError{})
-	} else if (b < 0) && (a < (math.MinInt - b)) {
+	} else if (b < 0) && (a < (goMinInt - b)) {
 		panic(UnderflowError{})
 	}
 	return a + b
@@ -193,24 +193,24 @@ func safeMul(a, b int) int {
 	if a > 0 {
 		if b > 0 {
 			// positive * positive = positive. overflow?
-			if a > (math.MaxInt / b) {
+			if a > (goMaxInt / b) {
 				panic(OverflowError{})
 			}
 		} else {
 			// positive * negative = negative. underflow?
-			if b < (math.MinInt / a) {
+			if b < (goMinInt / a) {
 				panic(UnderflowError{})
 			}
 		}
 	} else {
 		if b > 0 {
 			// negative * positive = negative. underflow?
-			if a < (math.MinInt / b) {
+			if a < (goMinInt / b) {
 				panic(UnderflowError{})
 			}
 		} else {
 			// negative * negative = positive. overflow?
-			if (a != 0) && (b < (math.MaxInt / a)) {
+			if (a != 0) && (b < (goMaxInt / a)) {
 				panic(OverflowError{})
 			}
 		}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -62,7 +62,7 @@ func TestOwnerNewArray(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -101,7 +101,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -152,7 +152,7 @@ func TestOwnerArrayElement(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -190,7 +190,7 @@ func TestOwnerArraySetIndex(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -238,7 +238,7 @@ func TestOwnerArrayAppend(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -280,7 +280,7 @@ func TestOwnerArrayInsert(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -322,7 +322,7 @@ func TestOwnerArrayRemove(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -362,7 +362,7 @@ func TestOwnerNewDictionary(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -405,7 +405,7 @@ func TestOwnerDictionary(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -448,7 +448,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -503,7 +503,7 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -553,7 +553,7 @@ func TestOwnerDictionaryInsertNonExisting(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -604,7 +604,7 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -661,7 +661,7 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration()
 	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
@@ -1517,7 +1517,7 @@ func TestEphemeralReferenceTypeConformance(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	// Obtain a self referencing (cyclic) ephemeral reference value.
 
@@ -3134,7 +3134,7 @@ func TestPublicKeyValue(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		inter, err := NewInterpreter(
 			nil,
@@ -3178,7 +3178,7 @@ func TestPublicKeyValue(t *testing.T) {
 
 		t.Parallel()
 
-		storage := NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		fakeError := fakeError{}
 
@@ -3335,7 +3335,7 @@ func checkHashable(ty types.Type) error {
 
 func newTestInterpreter(tb testing.TB) *Interpreter {
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := NewInterpreter(
 		nil,
@@ -3353,7 +3353,7 @@ func TestNonStorable(t *testing.T) {
 
 	t.Parallel()
 
-	storage := NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	code := `
       pub struct Foo {

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -295,7 +295,7 @@ func stringState(l *lexer) stateFn {
 	memoryGauge := l.memoryGauge
 	if memoryGauge != nil {
 		memoryGauge.UseMemory(
-			common.NewStringMemoryUsage(uint64(l.wordLength())),
+			common.NewStringMemoryUsage(l.wordLength()),
 		)
 	}
 	l.emitValue(TokenString)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -3021,8 +3021,14 @@ func (r *interpreterRuntime) newAccountContractsGetNamesFunction(
 
 		values := make([]interpreter.Value, len(names))
 		for i, name := range names {
-			// TODO: meter?
-			values[i] = interpreter.NewUnmeteredStringValue(name)
+			memoryUsage := common.NewStringMemoryUsage(len(name))
+			values[i] = interpreter.NewStringValue(
+				inter,
+				memoryUsage,
+				func() string {
+					return name
+				},
+			)
 		}
 
 		return interpreter.NewArrayValue(

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
+func newUnmeteredInMemoryStorage() interpreter.InMemoryStorage {
+	return interpreter.NewInMemoryStorage(nil)
+}
+
 func TestAssert(t *testing.T) {
 
 	t.Parallel()
@@ -43,7 +47,7 @@ func TestAssert(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
@@ -102,7 +106,7 @@ func TestPanic(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -68,7 +68,7 @@ func TestInterpretCompositeValue(t *testing.T) {
 // Utility methods
 func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	// 'fruit' composite type
 	fruitType := &sema.CompositeType{

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -547,7 +547,7 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 
 					if compositeKind == common.CompositeKindContract {
 
-						storage := interpreter.NewInMemoryStorage(nil)
+						storage := newUnmeteredInMemoryStorage()
 
 						inter, err := interpreter.NewInterpreter(
 							interpreter.ProgramFromChecker(checker),
@@ -574,7 +574,7 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 						_, err = inter.Invoke("test")
 						check(err)
 					} else {
-						storage := interpreter.NewInMemoryStorage(nil)
+						storage := newUnmeteredInMemoryStorage()
 
 						inter, err := interpreter.NewInterpreter(
 							interpreter.ProgramFromChecker(checker),

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -266,7 +266,7 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -181,6 +181,10 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 	return inter, err
 }
 
+func newUnmeteredInMemoryStorage() interpreter.InMemoryStorage {
+	return interpreter.NewInMemoryStorage(nil)
+}
+
 func constructorArguments(compositeKind common.CompositeKind, arguments string) string {
 	switch compositeKind {
 	case common.CompositeKindContract:
@@ -1806,7 +1810,7 @@ func TestInterpretHostFunction(t *testing.T) {
 	err = checker.Check()
 	require.NoError(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
@@ -1911,7 +1915,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 	err = checker.Check()
 	require.NoError(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
@@ -3839,7 +3843,7 @@ func TestInterpretImport(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
@@ -3935,7 +3939,7 @@ func TestInterpretImportError(t *testing.T) {
 		stdlib.PanicFunction,
 	}.ToInterpreterValueDeclarations()
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
@@ -4630,7 +4634,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 		valueDeclarations := standardLibraryFunctions.ToSemaValueDeclarations()
 		values := standardLibraryFunctions.ToInterpreterValueDeclarations()
 
-		storage := interpreter.NewInMemoryStorage(nil)
+		storage := newUnmeteredInMemoryStorage()
 
 		var err error
 		inter, err = parseCheckAndInterpretWithOptions(t,
@@ -6059,7 +6063,7 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
@@ -6644,7 +6648,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		Members:    sema.NewStringMemberOrderedMap(),
 	}
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		nil,
@@ -8027,7 +8031,7 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -711,7 +711,7 @@ func TestInterpretGetType(t *testing.T) {
 			valueDeclarations := standardLibraryFunctions.ToSemaValueDeclarations()
 			values := standardLibraryFunctions.ToInterpreterValueDeclarations()
 
-			storage := interpreter.NewInMemoryStorage(nil)
+			storage := newUnmeteredInMemoryStorage()
 
 			inter, err := parseCheckAndInterpretWithOptions(t,
 				testCase.code,

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -97,7 +97,7 @@ func TestInterpretStatementHandler(t *testing.T) {
 	var nextInterpreterID int
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
 		importingChecker.Location,
@@ -225,7 +225,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
 	var nextInterpreterID int
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
@@ -365,7 +365,7 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
 	var nextInterpreterID int
 	interpreterIDs := map[*interpreter.Interpreter]int{}
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),
 		importingChecker.Location,

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -84,7 +84,7 @@ func TestInterpretResourceUUID(t *testing.T) {
 
 	var uuid uint64
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(importingChecker),

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package interpreter
+package interpreter_test
 
 import (
 	"flag"
@@ -58,7 +58,7 @@ func TestRandomMapOperations(t *testing.T) {
 	fmt.Printf("Seed used for map opearations test: %d \n", seed)
 	rand.Seed(seed)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 	inter, err := interpreter.NewInterpreter(
 		&interpreter.Program{
 			Program:     ast.NewProgram([]ast.Declaration{}),
@@ -497,7 +497,7 @@ func TestRandomArrayOperations(t *testing.T) {
 	fmt.Printf("Seed used for array opearations test: %d \n", seed)
 	rand.Seed(seed)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 	inter, err := interpreter.NewInterpreter(
 		&interpreter.Program{
 			Program:     ast.NewProgram([]ast.Declaration{}),
@@ -855,7 +855,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 	fmt.Printf("Seed used for compsoite opearations test: %d \n", seed)
 	rand.Seed(seed)
 
-	storage := interpreter.NewInMemoryStorage(nil)
+	storage := newUnmeteredInMemoryStorage()
 	inter, err := interpreter.NewInterpreter(
 		&interpreter.Program{
 			Program:     ast.NewProgram([]ast.Declaration{}),


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description

- Add utilities for creating unmetered in-memory storage
- String length has type `int`, so default to it. Check for overflow
- Meter strings constructed from FVM results

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
