### PR TITLE
Fix value transfer type check

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5123,12 +5123,11 @@ func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
 			case *CompositeType:
 				// An unrestricted type `T`
-				// is a subtype of a restricted type `U{Vs}`: if `T == U`.
+				// is a subtype of a restricted type `U{Vs}`: if `T <: U`.
 				//
 				// The owner may freely restrict.
 
-				return typedSubType == typedSuperType.Type
-
+				return IsSubType(typedSubType, typedSuperType.Type)
 			}
 
 			switch subType {

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -1124,3 +1124,33 @@ func TestCheckRestrictedConformance(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestCheckTypeRequirementRestriction(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+	  contract interface CI {
+	      resource interface RI {}
+
+	      resource R: RI {}
+
+	      fun createR(): @R
+	  }
+
+      contract C: CI {
+	      resource R: CI.RI {}
+
+	      fun createR(): @R {
+	          return <- create R()
+	      }
+	  }
+
+      fun test() {
+          let r <- C.createR()
+          let r2: @CI.R{CI.RI} <- r
+          destroy r2
+      }
+    `)
+	require.NoError(t, err)
+}

--- a/runtime/tests/checker/restriction_test.go
+++ b/runtime/tests/checker/restriction_test.go
@@ -44,6 +44,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("struct: no restrictions", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             struct S {}
 
@@ -54,6 +56,8 @@ func TestCheckRestrictedType(t *testing.T) {
 	})
 
 	t.Run("resource: one restriction", func(t *testing.T) {
+
+		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
             resource interface I1 {}
@@ -70,6 +74,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("struct: one restriction", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             struct interface I1 {}
 
@@ -85,6 +91,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("reference to resource restriction", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             resource R {}
 
@@ -97,6 +105,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("reference to struct restriction", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             struct S {}
 
@@ -108,6 +118,8 @@ func TestCheckRestrictedType(t *testing.T) {
 	})
 
 	t.Run("resource: non-conformance restriction", func(t *testing.T) {
+
+		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
             resource interface I {}
@@ -125,6 +137,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("struct: non-conformance restriction", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             struct interface I {}
 
@@ -140,6 +154,8 @@ func TestCheckRestrictedType(t *testing.T) {
 	})
 
 	t.Run("resource: duplicate restriction", func(t *testing.T) {
+
+		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
             resource interface I {}
@@ -157,6 +173,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("struct: duplicate restriction", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             struct interface I {}
 
@@ -173,6 +191,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("restricted resource, with structure interface restriction", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             struct interface I {}
 
@@ -188,6 +208,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("restricted struct, with resource interface restriction", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             resource interface I {}
 
@@ -202,6 +224,8 @@ func TestCheckRestrictedType(t *testing.T) {
 	})
 
 	t.Run("resource: non-concrete restricted type", func(t *testing.T) {
+
+		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
             resource interface I {}
@@ -219,6 +243,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("struct: non-concrete restricted type", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             struct interface I {}
 
@@ -235,6 +261,8 @@ func TestCheckRestrictedType(t *testing.T) {
 
 	t.Run("restricted resource interface ", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             resource interface I {}
 
@@ -243,13 +271,14 @@ func TestCheckRestrictedType(t *testing.T) {
             let r: @I{} <- create R()
         `)
 
-		errs := ExpectCheckerErrors(t, err, 2)
+		errs := ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidRestrictedTypeError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
 	})
 
 	t.Run("restricted struct interface", func(t *testing.T) {
+
+		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
             struct interface I {}
@@ -259,10 +288,39 @@ func TestCheckRestrictedType(t *testing.T) {
             let s: I{} = S()
         `)
 
-		errs := ExpectCheckerErrors(t, err, 2)
+		errs := ExpectCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.InvalidRestrictedTypeError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+	})
+
+	t.Run("restricted type requirement", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+	      contract interface CI {
+	          resource interface RI {}
+
+	          resource R: RI {}
+
+	          fun createR(): @R
+	      }
+
+          contract C: CI {
+	          resource R: CI.RI {}
+
+	          fun createR(): @R {
+	              return <- create R()
+	          }
+	      }
+
+          fun test() {
+              let r <- C.createR()
+              let r2: @CI.R{CI.RI} <- r
+              destroy r2
+          }
+        `)
+		require.NoError(t, err)
 	})
 }
 
@@ -1122,35 +1180,5 @@ func TestCheckRestrictedConformance(t *testing.T) {
       }
     `)
 
-	require.NoError(t, err)
-}
-
-func TestCheckTypeRequirementRestriction(t *testing.T) {
-
-	t.Parallel()
-
-	_, err := ParseAndCheck(t, `
-	  contract interface CI {
-	      resource interface RI {}
-
-	      resource R: RI {}
-
-	      fun createR(): @R
-	  }
-
-      contract C: CI {
-	      resource R: CI.RI {}
-
-	      fun createR(): @R {
-	          return <- create R()
-	      }
-	  }
-
-      fun test() {
-          let r <- C.createR()
-          let r2: @CI.R{CI.RI} <- r
-          destroy r2
-      }
-    `)
 	require.NoError(t, err)
 }

--- a/runtime/tests/interpreter/transfer_test.go
+++ b/runtime/tests/interpreter/transfer_test.go
@@ -34,52 +34,98 @@ func TestInterpretTransferCheck(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &sema.CompositeType{
-		Location:   utils.TestLocation,
-		Identifier: "Fruit",
-		Kind:       common.CompositeKindStructure,
-	}
+	t.Run("String value as composite", func(t *testing.T) {
 
-	valueDeclarations := stdlib.StandardLibraryValues{
-		{
-			Name: "fruit",
-			Type: ty,
-			// NOTE: not an instance of the type
-			ValueFactory: func(_ *interpreter.Interpreter) interpreter.Value {
-				return interpreter.NewStringValue("fruit")
+		t.Parallel()
+
+		ty := &sema.CompositeType{
+			Location:   utils.TestLocation,
+			Identifier: "Fruit",
+			Kind:       common.CompositeKindStructure,
+		}
+
+		valueDeclarations := stdlib.StandardLibraryValues{
+			{
+				Name: "fruit",
+				Type: ty,
+				// NOTE: not an instance of the type
+				ValueFactory: func(_ *interpreter.Interpreter) interpreter.Value {
+					return interpreter.NewStringValue("fruit")
+				},
+				Kind: common.DeclarationKindConstant,
 			},
-			Kind: common.DeclarationKindConstant,
-		},
-	}
+		}
 
-	typeDeclarations := stdlib.StandardLibraryTypes{
-		{
-			Name: ty.Identifier,
-			Type: ty,
-			Kind: common.DeclarationKindStructure,
-		},
-	}
-
-	inter, err := parseCheckAndInterpretWithOptions(t,
-		`
-          fun test() {
-            let alsoFruit: Fruit = fruit
-          }
-        `,
-		ParseCheckAndInterpretOptions{
-			CheckerOptions: []sema.Option{
-				sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
-				sema.WithPredeclaredTypes(typeDeclarations.ToTypeDeclarations()),
+		typeDeclarations := stdlib.StandardLibraryTypes{
+			{
+				Name: ty.Identifier,
+				Type: ty,
+				Kind: common.DeclarationKindStructure,
 			},
-			Options: []interpreter.Option{
-				interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
+		}
+
+		inter, err := parseCheckAndInterpretWithOptions(t,
+			`
+              fun test() {
+                  let alsoFruit: Fruit = fruit
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				CheckerOptions: []sema.Option{
+					sema.WithPredeclaredValues(valueDeclarations.ToSemaValueDeclarations()),
+					sema.WithPredeclaredTypes(typeDeclarations.ToTypeDeclarations()),
+				},
+				Options: []interpreter.Option{
+					interpreter.WithPredeclaredValues(valueDeclarations.ToInterpreterValueDeclarations()),
+				},
 			},
-		},
-	)
-	require.NoError(t, err)
+		)
+		require.NoError(t, err)
 
-	_, err = inter.Invoke("test")
-	require.Error(t, err)
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
 
-	require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
+		require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
+	})
+
+	t.Run("contract and restricted type", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, err := parseCheckAndInterpretWithOptions(t,
+			`
+		      contract interface CI {
+		          resource interface RI {}
+
+		          resource R: RI {}
+
+		          fun createR(): @R
+		      }
+
+              contract C: CI {
+		          resource R: CI.RI {}
+
+		          fun createR(): @R {
+		              return <- create R()
+		          }
+		      }
+
+              fun test() {
+                  let r <- C.createR()
+                  let ref: &CI.R = &r as &CI.R
+                  let restrictedRef: &CI.R{CI.RI} = ref
+                  destroy r
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				Options: []interpreter.Option{
+					makeContractValueHandler(nil, nil, nil),
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Closes #1479 

## Description

When checking `T <: U{Vs}`, we currently require `T == U`, assuming both are composite values. 
However, the latter may actually be a type requirement.

Extend the subtyping check and require `T <: U`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
