### PR TITLE
Add test-cases for container value iteration metering

### DIFF
--- a/runtime/interpreter/storage.go
+++ b/runtime/interpreter/storage.go
@@ -51,6 +51,11 @@ func MustConvertStoredValue(value atree.Value) Value {
 }
 
 func ConvertStoredValue(value atree.Value) (Value, error) {
+	// TODO: Meter container values created below.
+	//   This is currently technically challenging because, this method is used in various
+	//   places directly/indirectly, where the interpreter instance is not available.
+	//   e.g: Iterator(), value walk(), RecursiveString(), String() method of values, etc.
+
 	switch value := value.(type) {
 	case *atree.Array:
 		return &ArrayValue{

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -55,75 +55,157 @@ func (g *testMemoryGauge) getMemory(kind common.MemoryKind) uint64 {
 func TestRuntimeArrayMetering(t *testing.T) {
 	t.Parallel()
 
-	script := `
-        pub fun main() {
-            let x: [Int8] = []
-            let y: [[String]] = [[]]
-            let z: [[[Bool]]] = [[[]]]
-        }
-    `
+	t.Run("creation", func(t *testing.T) {
+		t.Parallel()
 
-	meter := newTestMemoryGauge()
-	inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		script := `
+            pub fun main() {
+                let x: [Int8] = []
+                let y: [[String]] = [[]]
+                let z: [[[Bool]]] = [[[]]]
+            }
+        `
 
-	_, err := inter.Invoke("main")
-	require.NoError(t, err)
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
 
-	assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindArray))
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindArray))
+	})
+
+	t.Run("iteration", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let values: [[Int8]] = [[], [], []]
+                for value in values {
+                  let a = value
+                }
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// Iteration create new values for array typed elements.
+		// Currently, these are not metered. Only the initial 4-values are captured.
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindArray))
+	})
 }
 
 func TestRuntimeDictionaryMetering(t *testing.T) {
 	t.Parallel()
 
-	script := `
-        pub fun main() {
-            let x: {Int8: String} = {}
-            let y: {String: {Int8: String}} = {"a": {}}
-        }
-    `
+	t.Run("creation", func(t *testing.T) {
+		t.Parallel()
 
-	meter := newTestMemoryGauge()
-	inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		script := `
+            pub fun main() {
+                let x: {Int8: String} = {}
+                let y: {String: {Int8: String}} = {"a": {}}
+            }
+        `
 
-	_, err := inter.Invoke("main")
-	require.NoError(t, err)
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
 
-	assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindString))
-	assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindDictionary))
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindDictionary))
+	})
+
+	t.Run("iteration", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let values: [{Int8: String}] = [{}, {}, {}]
+                for value in values {
+                  let a = value
+                }
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// Iteration create new values for dictionary typed elements.
+		// Currently, these are not metered. Only the initial 3-values are captured.
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindDictionary))
+	})
 }
 
 func TestRuntimeCompositeMetering(t *testing.T) {
 	t.Parallel()
 
-	script := `
-        pub struct S {
-        }
+	t.Run("creation", func(t *testing.T) {
+		t.Parallel()
 
-        pub resource R {
-            pub let a: String
-            pub let b: String
+		script := `
+            pub struct S {}
 
-            init(a: String, b: String) {
-                self.a = a
-                self.b = b
+            pub resource R {
+                pub let a: String
+                pub let b: String
+
+                init(a: String, b: String) {
+                    self.a = a
+                    self.b = b
+                }
             }
-        }
 
-        pub fun main() {
-            let s = S()
-            let r <- create R(a: "a", b: "b")
-            destroy r
-        }
-    `
+            pub fun main() {
+                let s = S()
+                let r <- create R(a: "a", b: "b")
+                destroy r
+            }
+        `
 
-	meter := newTestMemoryGauge()
-	inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
 
-	_, err := inter.Invoke("main")
-	require.NoError(t, err)
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
 
-	assert.Equal(t, uint64(39), meter.getMemory(common.MemoryKindString))
-	assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
+		assert.Equal(t, uint64(39), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
+	})
+
+	t.Run("iteration", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub struct S {}
+
+            pub fun main() {
+                let values = [S(), S(), S()]
+                for value in values {
+                  let a = value
+                }
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// Iteration create new values for composite typed elements.
+		// Currently, these are not metered. Only the initial 3-values are captured.
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindComposite))
+	})
 }
 
 func TestRuntimeInterpretedFunctionMetering(t *testing.T) {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -93,6 +93,7 @@ func TestRuntimeArrayMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
 		// Iteration create new values for array typed elements.
 		// Currently, these are not metered. Only the initial 4-values are captured.
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindArray))
@@ -140,6 +141,7 @@ func TestRuntimeDictionaryMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
 		// Iteration create new values for dictionary typed elements.
 		// Currently, these are not metered. Only the initial 3-values are captured.
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindDictionary))
@@ -202,6 +204,7 @@ func TestRuntimeCompositeMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
 		// Iteration create new values for composite typed elements.
 		// Currently, these are not metered. Only the initial 3-values are captured.
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindComposite))


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description

Container values created when converting atree-value to cadence value (`ConvertStoredValue`) is not metered at the moment.

This is due to the technical complexity, as `ConvertStoredValue` method is used in various places directly/indirectly, where the interpreter instance is not available. e.g: Iterator(), walk(), RecursiveString(), String() methods of values, etc.

We should probably meter these as well, but asserting the current behavior for the moment.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
