### PR TITLE
Add memory metering for optional values

### DIFF
--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -36,6 +36,7 @@ const (
 	MemoryKindArray
 	MemoryKindDictionary
 	MemoryKindComposite
+	MemoryKindOptional
 	MemoryKindInterpretedFunction
 	MemoryKindHostFunction
 	MemoryKindBoundFunction

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -19,14 +19,15 @@ func _() {
 	_ = x[MemoryKindArray-8]
 	_ = x[MemoryKindDictionary-9]
 	_ = x[MemoryKindComposite-10]
-	_ = x[MemoryKindInterpretedFunction-11]
-	_ = x[MemoryKindHostFunction-12]
-	_ = x[MemoryKindBoundFunction-13]
+	_ = x[MemoryKindOptional-11]
+	_ = x[MemoryKindInterpretedFunction-12]
+	_ = x[MemoryKindHostFunction-13]
+	_ = x[MemoryKindBoundFunction-14]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeBlockNumberArrayDictionaryCompositeInterpretedFunctionHostFunctionBoundFunction"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeBlockNumberArrayDictionaryCompositeOptionalInterpretedFunctionHostFunctionBoundFunction"
 
-var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 46, 52, 57, 67, 76, 95, 107, 120}
+var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 46, 52, 57, 67, 76, 84, 103, 115, 128}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -646,7 +646,7 @@ func importOptionalValue(
 		return nil, err
 	}
 
-	return interpreter.NewSomeValueNonCopying(innerValue), nil
+	return interpreter.NewSomeValueNonCopying(inter, innerValue), nil
 }
 
 func importArrayValue(

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -127,7 +127,7 @@ func TestExportValue(t *testing.T) {
 		},
 		{
 			label: "SomeValue",
-			value: interpreter.NewSomeValueNonCopying(
+			value: interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(42),
 			),
 			expected: cadence.NewOptional(cadence.NewInt(42)),
@@ -509,7 +509,7 @@ func TestImportValue(t *testing.T) {
 		{
 			label: "SomeValue",
 			value: cadence.NewOptional(cadence.NewInt(42)),
-			expected: interpreter.NewSomeValueNonCopying(
+			expected: interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(42),
 			),
 		},

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -1,0 +1,81 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func testUseMemory(meter map[common.MemoryKind]uint64) func(common.MemoryUsage) {
+	return func(usage common.MemoryUsage) {
+		current, ok := meter[usage.Kind]
+		if !ok {
+			current = 0
+		}
+		meter[usage.Kind] = current + usage.Amount
+	}
+}
+
+func TestImportedValueMemoryMetering(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	t.Run("optional", func(t *testing.T) {
+		t.Parallel()
+
+		script := []byte(`
+            pub fun main(x: String?) {}
+        `)
+
+		meter := make(map[common.MemoryKind]uint64)
+
+		runtimeInterface := &testRuntimeInterface{
+			useMemory: testUseMemory(meter),
+			decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+				return jsoncdc.Decode(b)
+			},
+		}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+				Arguments: encodeArgs([]cadence.Value{
+					cadence.NewOptional(cadence.String("hello")),
+				}),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  utils.TestLocation,
+			},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), meter[common.MemoryKindOptional])
+	})
+}

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -70,7 +70,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 		dictValue,
 	)
 
-	optionalValue := NewSomeValueNonCopying(arrayValue)
+	optionalValue := NewUnmeteredSomeValueNonCopying(arrayValue)
 
 	compositeValue := newTestCompositeValue(inter, address)
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -2360,7 +2360,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewSomeValueNonCopying(NilValue{}),
+				value: NewUnmeteredSomeValueNonCopying(NilValue{}),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagSomeValue,
@@ -2378,7 +2378,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewSomeValueNonCopying(expectedString),
+				value: NewUnmeteredSomeValueNonCopying(expectedString),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagSomeValue,
@@ -2400,7 +2400,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewSomeValueNonCopying(BoolValue(true)),
+				value: NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagSomeValue,
@@ -2429,7 +2429,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 			}
 		}
 
-		expected := NewSomeValueNonCopying(str)
+		expected := NewUnmeteredSomeValueNonCopying(str)
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
@@ -2463,7 +2463,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 			}
 		}
 
-		expected := NewSomeValueNonCopying(str)
+		expected := NewUnmeteredSomeValueNonCopying(str)
 
 		testEncodeDecode(t,
 			encodeDecodeTest{

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -57,7 +57,7 @@ func TestInspectValue(t *testing.T) {
 			dictValue,
 		)
 
-		optionalValue := NewSomeValueNonCopying(arrayValue)
+		optionalValue := NewUnmeteredSomeValueNonCopying(arrayValue)
 
 		compositeValue = newTestCompositeValue(inter, common.Address{})
 		compositeValue.SetMember(

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1877,7 +1877,7 @@ func EnumConstructorFunction(
 				return NilValue{}
 			}
 
-			return NewSomeValueNonCopying(caseValue)
+			return NewSomeValueNonCopying(invocation.Interpreter, caseValue)
 		},
 		sema.EnumConstructorType(enumType),
 	)
@@ -2303,7 +2303,7 @@ func (interpreter *Interpreter) BoxOptional(
 			return inner
 
 		default:
-			value = NewSomeValueNonCopying(value)
+			value = NewSomeValueNonCopying(interpreter, value)
 		}
 
 		targetType = optionalType.Type
@@ -2687,7 +2687,7 @@ func (interpreter *Interpreter) writeStored(
 
 type ValueConverterDeclaration struct {
 	name         string
-	convert      func(Value) Value
+	convert      func(*Interpreter, Value) Value
 	min          Value
 	max          Value
 	functionType *sema.FunctionType
@@ -2699,14 +2699,14 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.IntTypeName,
 		functionType: sema.NumberConversionFunctionType(sema.IntType),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertInt(value)
 		},
 	},
 	{
 		name:         sema.UIntTypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UIntType),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUInt(value)
 		},
 		min: NewUIntValueFromBigInt(sema.UIntTypeMin),
@@ -2714,7 +2714,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int8TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int8Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertInt8(value)
 		},
 		min: Int8Value(math.MinInt8),
@@ -2723,7 +2723,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int16TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int16Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertInt16(value)
 		},
 		min: Int16Value(math.MinInt16),
@@ -2732,7 +2732,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int32TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int32Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertInt32(value)
 		},
 		min: Int32Value(math.MinInt32),
@@ -2741,7 +2741,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int64TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int64Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertInt64(value)
 		},
 		min: Int64Value(math.MinInt64),
@@ -2750,7 +2750,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int128TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int128Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertInt128(value)
 		},
 		min: NewInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
@@ -2759,7 +2759,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int256TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int256Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertInt256(value)
 		},
 		min: NewInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
@@ -2768,7 +2768,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UInt8TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UInt8Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUInt8(value)
 		},
 		min: UInt8Value(0),
@@ -2777,7 +2777,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UInt16TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UInt16Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUInt16(value)
 		},
 		min: UInt16Value(0),
@@ -2786,7 +2786,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UInt32TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UInt32Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUInt32(value)
 		},
 		min: UInt32Value(0),
@@ -2795,7 +2795,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UInt64TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UInt64Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUInt64(value)
 		},
 		min: UInt64Value(0),
@@ -2804,7 +2804,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UInt128TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UInt128Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUInt128(value)
 		},
 		min: NewUInt128ValueFromUint64(0),
@@ -2813,7 +2813,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UInt256TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UInt256Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUInt256(value)
 		},
 		min: NewUInt256ValueFromUint64(0),
@@ -2822,7 +2822,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Word8TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Word8Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertWord8(value)
 		},
 		min: Word8Value(0),
@@ -2831,7 +2831,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Word16TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Word16Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertWord16(value)
 		},
 		min: Word16Value(0),
@@ -2840,7 +2840,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Word32TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Word32Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertWord32(value)
 		},
 		min: Word32Value(0),
@@ -2849,7 +2849,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Word64TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Word64Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertWord64(value)
 		},
 		min: Word64Value(0),
@@ -2858,7 +2858,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Fix64TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Fix64Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertFix64(value)
 		},
 		min: Fix64Value(math.MinInt64),
@@ -2867,7 +2867,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UFix64TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UFix64Type),
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertUFix64(value)
 		},
 		min: UFix64Value(0),
@@ -2876,7 +2876,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.AddressTypeName,
 		functionType: sema.AddressConversionFunctionType,
-		convert: func(value Value) Value {
+		convert: func(_ *Interpreter, value Value) Value {
 			return ConvertAddress(value)
 		},
 	},
@@ -2977,11 +2977,15 @@ func init() {
 					return NilValue{}
 				}
 
-				return NewSomeValueNonCopying(TypeValue{
-					Type: DictionaryStaticType{
-						KeyType:   keyType,
-						ValueType: valueType,
-					}})
+				return NewSomeValueNonCopying(
+					invocation.Interpreter,
+					TypeValue{
+						Type: DictionaryStaticType{
+							KeyType:   keyType,
+							ValueType: valueType,
+						},
+					},
+				)
 			},
 			sema.DictionaryTypeFunctionType,
 		))
@@ -3002,9 +3006,12 @@ func init() {
 					return NilValue{}
 				}
 
-				return NewSomeValueNonCopying(TypeValue{
-					Type: ConvertSemaToStaticType(composite),
-				})
+				return NewSomeValueNonCopying(
+					invocation.Interpreter,
+					TypeValue{
+						Type: ConvertSemaToStaticType(composite),
+					},
+				)
 			},
 			sema.CompositeTypeFunctionType,
 		),
@@ -3026,9 +3033,12 @@ func init() {
 					return NilValue{}
 				}
 
-				return NewSomeValueNonCopying(TypeValue{
-					Type: ConvertSemaToStaticType(interfaceType),
-				})
+				return NewSomeValueNonCopying(
+					invocation.Interpreter,
+					TypeValue{
+						Type: ConvertSemaToStaticType(interfaceType),
+					},
+				)
 			},
 			sema.InterfaceTypeFunctionType,
 		),
@@ -3156,12 +3166,15 @@ func RestrictedTypeFunction(invocation Invocation) Value {
 		return NilValue{}
 	}
 
-	return NewSomeValueNonCopying(TypeValue{
-		Type: &RestrictedStaticType{
-			Type:         ConvertSemaToStaticType(ty),
-			Restrictions: staticRestrictions,
+	return NewSomeValueNonCopying(
+		interpreter,
+		TypeValue{
+			Type: &RestrictedStaticType{
+				Type:         ConvertSemaToStaticType(ty),
+				Restrictions: staticRestrictions,
+			},
 		},
-	})
+	)
 }
 
 func defineBaseFunctions(activation *VariableActivation) {
@@ -3187,7 +3200,7 @@ var converterFunctionValues = func() []converterFunction {
 		convert := declaration.convert
 		converterFunctionValue := NewUnmeteredHostFunctionValue(
 			func(invocation Invocation) Value {
-				return convert(invocation.Arguments[0])
+				return convert(invocation.Interpreter, invocation.Arguments[0])
 			},
 			declaration.functionType,
 		)
@@ -3333,6 +3346,7 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 				}
 
 				return NewSomeValueNonCopying(
+					invocation.Interpreter,
 					TypeValue{
 						Type: CapabilityStaticType{
 							BorrowType: ty,
@@ -3759,6 +3773,7 @@ func (interpreter *Interpreter) authAccountTypeFunction(addressValue AddressValu
 			}
 
 			return NewSomeValueNonCopying(
+				invocation.Interpreter,
 				TypeValue{
 					Type: value.StaticType(),
 				},
@@ -3837,7 +3852,7 @@ func (interpreter *Interpreter) authAccountReadFunction(addressValue AddressValu
 				interpreter.writeStored(address, domain, identifier, nil)
 			}
 
-			return NewSomeValueNonCopying(transferredValue)
+			return NewSomeValueNonCopying(invocation.Interpreter, transferredValue)
 		},
 
 		// same as sema.AuthAccountTypeCopyFunctionType
@@ -3889,7 +3904,7 @@ func (interpreter *Interpreter) authAccountBorrowFunction(addressValue AddressVa
 				return NilValue{}
 			}
 
-			return NewSomeValueNonCopying(reference)
+			return NewSomeValueNonCopying(invocation.Interpreter, reference)
 		},
 		sema.AuthAccountTypeBorrowFunctionType,
 	)
@@ -3953,6 +3968,7 @@ func (interpreter *Interpreter) authAccountLinkFunction(addressValue AddressValu
 			)
 
 			return NewSomeValueNonCopying(
+				invocation.Interpreter,
 				&CapabilityValue{
 					Address:    addressValue,
 					Path:       newCapabilityPath,
@@ -3993,7 +4009,7 @@ func (interpreter *Interpreter) accountGetLinkTargetFunction(addressValue Addres
 				return NilValue{}
 			}
 
-			return NewSomeValueNonCopying(link.TargetPath)
+			return NewSomeValueNonCopying(invocation.Interpreter, link.TargetPath)
 		},
 		sema.AccountTypeGetLinkTargetFunctionType,
 	)
@@ -4090,7 +4106,7 @@ func (interpreter *Interpreter) capabilityBorrowFunction(
 				return NilValue{}
 			}
 
-			return NewSomeValueNonCopying(reference)
+			return NewSomeValueNonCopying(invocation.Interpreter, reference)
 		},
 		sema.CapabilityTypeBorrowFunctionType(borrowType),
 	)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -149,7 +149,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 
 			if isOptional {
 				if _, ok := resultValue.(OptionalValue); !ok {
-					resultValue = NewSomeValueNonCopying(resultValue)
+					resultValue = NewSomeValueNonCopying(interpreter, resultValue)
 				}
 			}
 
@@ -720,7 +720,7 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 	// If this is invocation is optional chaining, wrap the result
 	// as an optional, as the result is expected to be an optional
 	if isOptionalChaining {
-		resultValue = NewSomeValueNonCopying(resultValue)
+		resultValue = NewSomeValueNonCopying(interpreter, resultValue)
 	}
 
 	return resultValue
@@ -814,7 +814,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 			// The failable cast may upcast to an optional type, e.g. `1 as? Int?`, so box
 			value = interpreter.BoxOptional(getLocationRange, value, expectedType)
 
-			return NewSomeValueNonCopying(value)
+			return NewSomeValueNonCopying(interpreter, value)
 
 		case ast.OperationForceCast:
 			if !isSubType {
@@ -881,11 +881,14 @@ func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *as
 		case *SomeValue:
 			getLocationRange := locationRangeGetter(interpreter.Location, referenceExpression.Expression)
 
-			return NewSomeValueNonCopying(&EphemeralReferenceValue{
-				Authorized:   innerBorrowType.Authorized,
-				Value:        result.InnerValue(interpreter, getLocationRange),
-				BorrowedType: innerBorrowType.Type,
-			})
+			return NewSomeValueNonCopying(
+				interpreter,
+				&EphemeralReferenceValue{
+					Authorized:   innerBorrowType.Authorized,
+					Value:        result.InnerValue(interpreter, getLocationRange),
+					BorrowedType: innerBorrowType.Type,
+				},
+			)
 		case NilValue:
 			return NilValue{}
 		default:

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -41,7 +41,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 			&sema.OptionalType{Type: sema.BoolType},
 		)
 		assert.Equal(t,
-			NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			value,
 		)
 	})
@@ -51,11 +51,11 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 
 		value := inter.BoxOptional(
 			ReturnEmptyLocationRange,
-			NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			&sema.OptionalType{Type: sema.BoolType},
 		)
 		assert.Equal(t,
-			NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			value,
 		)
 	})
@@ -65,12 +65,12 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 
 		value := inter.BoxOptional(
 			ReturnEmptyLocationRange,
-			NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
-			NewSomeValueNonCopying(
-				NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(
+				NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			),
 			value,
 		)
@@ -97,7 +97,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		// NOTE:
 		value := inter.BoxOptional(
 			ReturnEmptyLocationRange,
-			NewSomeValueNonCopying(NilValue{}),
+			NewUnmeteredSomeValueNonCopying(NilValue{}),
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
 		assert.Equal(t,
@@ -122,7 +122,7 @@ func TestInterpreterBoxing(t *testing.T) {
 				inter := newTestInterpreter(t)
 
 				assert.Equal(t,
-					NewSomeValueNonCopying(
+					NewUnmeteredSomeValueNonCopying(
 						BoolValue(true),
 					),
 					inter.ConvertAndBox(
@@ -139,12 +139,12 @@ func TestInterpreterBoxing(t *testing.T) {
 				inter := newTestInterpreter(t)
 
 				assert.Equal(t,
-					NewSomeValueNonCopying(
+					NewUnmeteredSomeValueNonCopying(
 						BoolValue(true),
 					),
 					inter.ConvertAndBox(
 						ReturnEmptyLocationRange,
-						NewSomeValueNonCopying(BoolValue(true)),
+						NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 						&sema.OptionalType{Type: sema.BoolType},
 						&sema.OptionalType{Type: anyType},
 					),

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -257,7 +257,7 @@ func TestDictionaryStorage(t *testing.T) {
 			inter,
 			ReturnEmptyLocationRange,
 			entryKey,
-			NewSomeValueNonCopying(entryValue),
+			NewUnmeteredSomeValueNonCopying(entryValue),
 		)
 
 		require.Equal(t, 1, storage.BasicSlabStorage.Count())
@@ -297,7 +297,7 @@ func TestDictionaryStorage(t *testing.T) {
 				ValueType: PrimitiveStaticTypeAnyStruct,
 			},
 			NewUnmeteredStringValue("test"),
-			NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 		)
 
 		require.NotEqual(t, atree.StorageIDUndefined, value.StorageID())
@@ -346,7 +346,7 @@ func TestDictionaryStorage(t *testing.T) {
 				ValueType: PrimitiveStaticTypeAnyStruct,
 			},
 			NewUnmeteredStringValue("test"),
-			NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 		)
 
 		require.NotEqual(t, atree.StorageIDUndefined, value.StorageID())
@@ -407,7 +407,7 @@ func TestDictionaryStorage(t *testing.T) {
 			inter,
 			ReturnEmptyLocationRange,
 			NewUnmeteredStringValue("test"),
-			NewSomeValueNonCopying(BoolValue(true)),
+			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 		)
 
 		require.Equal(t, 1, storage.BasicSlabStorage.Count())

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -539,7 +539,7 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 		inter,
 		ReturnEmptyLocationRange,
 		keyValue,
-		NewSomeValueNonCopying(value),
+		NewUnmeteredSomeValueNonCopying(value),
 	)
 
 	queriedValue, _ := dictionary.Get(inter, ReturnEmptyLocationRange, keyValue)
@@ -882,7 +882,7 @@ func TestStringer(t *testing.T) {
 			expected: "false",
 		},
 		"some": {
-			value:    NewSomeValueNonCopying(BoolValue(true)),
+			value:    NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			expected: "true",
 		},
 		"nil": {
@@ -1067,7 +1067,7 @@ func TestVisitor(t *testing.T) {
 
 	var value Value
 	value = NewIntValueFromInt64(42)
-	value = NewSomeValueNonCopying(value)
+	value = NewUnmeteredSomeValueNonCopying(value)
 	value = NewArrayValue(
 		inter,
 		VariableSizedStaticType{
@@ -1965,10 +1965,10 @@ func TestSomeValue_Equal(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		require.True(t,
-			NewSomeValueNonCopying(NewUnmeteredStringValue("test")).Equal(
+			NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("test")).Equal(
 				inter,
 				ReturnEmptyLocationRange,
-				NewSomeValueNonCopying(NewUnmeteredStringValue("test")),
+				NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("test")),
 			),
 		)
 	})
@@ -1980,10 +1980,10 @@ func TestSomeValue_Equal(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		require.False(t,
-			NewSomeValueNonCopying(NewUnmeteredStringValue("test")).Equal(
+			NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("test")).Equal(
 				inter,
 				ReturnEmptyLocationRange,
-				NewSomeValueNonCopying(NewUnmeteredStringValue("foo")),
+				NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("foo")),
 			),
 		)
 	})
@@ -1995,7 +1995,7 @@ func TestSomeValue_Equal(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		require.False(t,
-			NewSomeValueNonCopying(NewUnmeteredStringValue("1")).Equal(
+			NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("1")).Equal(
 				inter,
 				ReturnEmptyLocationRange,
 				UInt8Value(1),

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2369,7 +2369,7 @@ func (r *interpreterRuntime) newGetBlockFunction(runtimeInterface Interface) int
 			return interpreter.NilValue{}
 		}
 
-		return interpreter.NewSomeValueNonCopying(block)
+		return interpreter.NewSomeValueNonCopying(invocation.Interpreter, block)
 	}
 }
 
@@ -2878,6 +2878,7 @@ func (r *interpreterRuntime) newAccountContractsGetFunction(
 
 			if len(code) > 0 {
 				return interpreter.NewSomeValueNonCopying(
+					invocation.Interpreter,
 					interpreter.NewDeployedContractValue(
 						invocation.Interpreter,
 						addressValue,
@@ -2983,6 +2984,7 @@ func (r *interpreterRuntime) newAuthAccountContractsRemoveFunction(
 				)
 
 				return interpreter.NewSomeValueNonCopying(
+					invocation.Interpreter,
 					interpreter.NewDeployedContractValue(
 						invocation.Interpreter,
 						addressValue,
@@ -3300,6 +3302,7 @@ func (r *interpreterRuntime) newAccountKeysGetFunction(
 			inter := invocation.Interpreter
 
 			return interpreter.NewSomeValueNonCopying(
+				inter,
 				NewAccountKeyValue(
 					inter,
 					invocation.GetLocationRange,
@@ -3358,6 +3361,7 @@ func (r *interpreterRuntime) newAccountKeysRevokeFunction(
 			)
 
 			return interpreter.NewSomeValueNonCopying(
+				inter,
 				NewAccountKeyValue(
 					inter,
 					invocation.GetLocationRange,
@@ -3629,6 +3633,7 @@ func blsAggregateSignatures(
 	aggregatedSignatureValue := interpreter.ByteSliceToByteArrayValue(inter, aggregatedSignature)
 
 	return interpreter.NewSomeValueNonCopying(
+		inter,
 		aggregatedSignatureValue,
 	)
 }
@@ -3678,6 +3683,7 @@ func blsAggregatePublicKeys(
 	)
 
 	return interpreter.NewSomeValueNonCopying(
+		inter,
 		aggregatedPublicKeyValue,
 	)
 }

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -286,7 +286,7 @@ func TestInterpretAuthAccount_type(t *testing.T) {
 		value, err = inter.Invoke("typeAt")
 		require.NoError(t, err)
 		require.Equal(t,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.TypeValue{
 					Type: interpreter.CompositeStaticType{
 						Location:            utils.TestLocation,
@@ -309,7 +309,7 @@ func TestInterpretAuthAccount_type(t *testing.T) {
 		value, err = inter.Invoke("typeAt")
 		require.NoError(t, err)
 		require.Equal(t,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.TypeValue{
 					Type: interpreter.CompositeStaticType{
 						Location:            utils.TestLocation,

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -923,7 +923,7 @@ func TestInterpretContainerMutationAfterNilCoalescing(t *testing.T) {
 	utils.RequireValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("test"),
 		),
 		result,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -122,7 +122,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 								AssertValuesEqual(
 									t,
 									inter,
-									interpreter.NewSomeValueNonCopying(
+									interpreter.NewUnmeteredSomeValueNonCopying(
 										test.expected,
 									),
 									inter.Globals["z"].GetValue(),
@@ -219,7 +219,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 						AssertValuesEqual(
 							t,
 							inter,
-							interpreter.NewSomeValueNonCopying(
+							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.VoidValue{},
 							),
 							inter.Globals["y"].GetValue(),
@@ -311,7 +311,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 						AssertValuesEqual(
 							t,
 							inter,
-							interpreter.NewSomeValueNonCopying(
+							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.NewUnmeteredStringValue("test"),
 							),
 							inter.Globals["y"].GetValue(),
@@ -402,7 +402,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 						AssertValuesEqual(
 							t,
 							inter,
-							interpreter.NewSomeValueNonCopying(
+							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.BoolValue(true),
 							),
 							inter.Globals["y"].GetValue(),
@@ -497,7 +497,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 						AssertValuesEqual(
 							t,
 							inter,
-							interpreter.NewSomeValueNonCopying(
+							interpreter.NewUnmeteredSomeValueNonCopying(
 								addressValue,
 							),
 							inter.Globals["z"].GetValue(),
@@ -1070,7 +1070,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							),
 						)
 
-						expectedValue := interpreter.NewSomeValueNonCopying(
+						expectedValue := interpreter.NewUnmeteredSomeValueNonCopying(
 							interpreter.NewIntValueFromInt64(42),
 						)
 
@@ -1094,7 +1094,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							AssertValuesEqual(
 								t,
 								inter,
-								interpreter.NewSomeValueNonCopying(
+								interpreter.NewUnmeteredSomeValueNonCopying(
 									expectedValue,
 								),
 								inter.Globals["z"].GetValue(),
@@ -1340,7 +1340,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 						AssertValuesEqual(
 							t,
 							inter,
-							interpreter.NewSomeValueNonCopying(
+							interpreter.NewUnmeteredSomeValueNonCopying(
 								expectedDictionary,
 							),
 							inter.Globals["z"].GetValue(),
@@ -3531,7 +3531,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 						AssertValuesEqual(
 							t,
 							inter,
-							interpreter.NewSomeValueNonCopying(
+							interpreter.NewUnmeteredSomeValueNonCopying(
 								capabilityValue,
 							),
 							inter.Globals["y"].GetValue(),

--- a/runtime/tests/interpreter/if_test.go
+++ b/runtime/tests/interpreter/if_test.go
@@ -251,7 +251,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(2),
 			),
 			value,
@@ -271,7 +271,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(0),
 			),
 			value,
@@ -312,7 +312,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(2),
 			),
 			value,
@@ -332,7 +332,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(0),
 			),
 			value,

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -239,7 +239,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *t
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewSomeValueNonCopying(value),
+				interpreter.NewUnmeteredSomeValueNonCopying(value),
 				inter.Globals["x"].GetValue(),
 			)
 		})
@@ -310,7 +310,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewSomeValueNonCopying(value),
+				interpreter.NewUnmeteredSomeValueNonCopying(value),
 				inter.Globals["x"].GetValue(),
 			)
 
@@ -322,7 +322,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
 					numberValue.Plus(numberValue),
 				),
 				inter.Globals["x"].GetValue(),
@@ -384,7 +384,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewSomeValueNonCopying(value),
+				interpreter.NewUnmeteredSomeValueNonCopying(value),
 				inter.Globals["x"].GetValue(),
 			)
 		})
@@ -448,7 +448,7 @@ func TestInterpretIntegerLiteralTypeConversionInReturnOptional(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewSomeValueNonCopying(value),
+				interpreter.NewUnmeteredSomeValueNonCopying(value),
 				result,
 			)
 		})

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -2770,8 +2770,8 @@ func TestInterpretOptionalVariableDeclaration(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
-			interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(2),
 			),
 		),
@@ -2798,8 +2798,8 @@ func TestInterpretOptionalParameterInvokedExternal(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
-			interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(2),
 			),
 		),
@@ -2827,8 +2827,8 @@ func TestInterpretOptionalParameterInvokedInternal(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
-			interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(2),
 			),
 		),
@@ -2852,8 +2852,8 @@ func TestInterpretOptionalReturn(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
-			interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(2),
 			),
 		),
@@ -2886,8 +2886,8 @@ func TestInterpretOptionalAssignment(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
-			interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(2),
 			),
 		),
@@ -2965,7 +2965,7 @@ func TestInterpretSomeReturnValue(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		value,
@@ -2989,7 +2989,7 @@ func TestInterpretSomeReturnValueFromDictionary(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		value,
@@ -3009,7 +3009,7 @@ func TestInterpretNilCoalescingNilIntToOptional(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
@@ -3029,7 +3029,7 @@ func TestInterpretNilCoalescingNilIntToOptionals(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
@@ -3048,7 +3048,7 @@ func TestInterpretNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
@@ -3239,7 +3239,7 @@ func TestInterpretNilCoalescingOptionalRightHandSide(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["z"].GetValue(),
@@ -3259,7 +3259,7 @@ func TestInterpretNilCoalescingBothOptional(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["z"].GetValue(),
@@ -3279,7 +3279,7 @@ func TestInterpretNilCoalescingBothOptionalLeftNil(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(2),
 		),
 		inter.Globals["z"].GetValue(),
@@ -3499,7 +3499,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("42"),
 			),
 			inter.Globals["result"].GetValue(),
@@ -4052,7 +4052,7 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["a"].GetValue(),
@@ -4061,7 +4061,7 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(2),
 		),
 		inter.Globals["b"].GetValue(),
@@ -4088,7 +4088,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["a"].GetValue(),
@@ -4097,7 +4097,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(2),
 		),
 		inter.Globals["b"].GetValue(),
@@ -4118,7 +4118,7 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
 		inter.Globals["a"].GetValue(),
@@ -4127,7 +4127,7 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
 		inter.Globals["b"].GetValue(),
@@ -4165,21 +4165,21 @@ func TestInterpretDictionaryIndexingType(t *testing.T) {
     `)
 
 	assert.Equal(t,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
 		inter.Globals["a"].GetValue(),
 	)
 
 	assert.Equal(t,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
 		inter.Globals["b"].GetValue(),
 	)
 
 	assert.Equal(t,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("c"),
 		),
 		inter.Globals["c"].GetValue(),
@@ -4197,7 +4197,7 @@ func TestInterpretDictionaryIndexingType(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("f"),
 		),
 		inter.Globals["f"].GetValue(),
@@ -4237,7 +4237,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(interpreter.NewIntValueFromInt64(23)),
+		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewIntValueFromInt64(23)),
 		newValue,
 	)
 
@@ -4301,7 +4301,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(interpreter.NewIntValueFromInt64(23)),
+		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewIntValueFromInt64(23)),
 		newValue,
 	)
 
@@ -4393,7 +4393,7 @@ func TestInterpretOptionalAnyStruct(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(42),
 		),
 		inter.Globals["x"].GetValue(),
@@ -4412,7 +4412,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(42),
 		),
 		inter.Globals["x"].GetValue(),
@@ -4421,7 +4421,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(42),
 		),
 		inter.Globals["y"].GetValue(),
@@ -4441,7 +4441,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(23),
 		),
 		inter.Globals["x"].GetValue(),
@@ -4457,7 +4457,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(23),
 		),
 		inter.Globals["z"].GetValue(),
@@ -4491,7 +4491,7 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(42),
 		),
 		inter.Globals["z"].GetValue(),
@@ -5613,7 +5613,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["removed"].GetValue(),
@@ -5649,7 +5649,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["inserted"].GetValue(),
@@ -5766,7 +5766,7 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
 				inter.Globals["v"].GetValue(),
@@ -6810,7 +6810,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 		tests[fmt.Sprintf("%s?", validType)] =
 			testValue{
-				value:   interpreter.NewSomeValueNonCopying(testCase.value),
+				value:   interpreter.NewUnmeteredSomeValueNonCopying(testCase.value),
 				literal: testCase.literal,
 			}
 
@@ -7353,10 +7353,10 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 					},
 				},
 				common.Address{},
-				interpreter.NewSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
-				interpreter.NewSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
 			),
@@ -7439,10 +7439,10 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 					},
 				},
 				common.Address{},
-				interpreter.NewSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
-				interpreter.NewSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
 			),
@@ -7527,7 +7527,7 @@ func TestInterpretCastingIntLiteralToOptional(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(interpreter.NewIntValueFromInt64(42)),
+		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewIntValueFromInt64(42)),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -7587,7 +7587,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(42),
 		),
 		inter.Globals["x2"].GetValue(),
@@ -7663,7 +7663,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(42),
 		),
 		inter.Globals["x2"].GetValue(),
@@ -8438,7 +8438,7 @@ func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
@@ -8732,7 +8732,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		inter,
 		[]interpreter.Value{
 			interpreter.NilValue{},
-			interpreter.NewSomeValueNonCopying(interpreter.AddressValue(address)),
+			interpreter.NewUnmeteredSomeValueNonCopying(interpreter.AddressValue(address)),
 		},
 		arrayElements(inter, result.(*interpreter.ArrayValue)),
 	)
@@ -8961,7 +8961,7 @@ func TestInterpretForce(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewIntValueFromInt64(1),
 			),
 			inter.Globals["x"].GetValue(),
@@ -9700,7 +9700,7 @@ func TestInterpretArrayFirstIndex(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewSomeValueNonCopying(
+		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewIntValueFromInt64(1),
 		),
 		value,
@@ -9783,7 +9783,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 
 		require.Equal(
 			t,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.TypeValue{
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
@@ -9805,7 +9805,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 
 		require.Equal(
 			t,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.TypeValue{
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
@@ -9827,7 +9827,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 
 		require.Equal(
 			t,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.TypeValue{
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -561,3 +561,45 @@ func TestRuntimeBoundFunctionMetering(t *testing.T) {
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindBoundFunction))
 	})
 }
+
+func TestRuntimeOptionalValueMetering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("simple optional value", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: String? = "hello"
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindOptional))
+	})
+
+	t.Run("dictionary get", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: {Int8: String} = {1: "foo", 2: "bar"}
+                let y = x[0]
+                let z = x[1]
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindOptional))
+	})
+}

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -588,7 +588,7 @@ func TestInterpretResourceReferenceAfterMove(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("testValue"),
 			),
 			value,
@@ -752,7 +752,7 @@ func TestInterpretReferenceUseAfterShiftStatementMove(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.AddressValue{1},
 			),
 			r1Address,
@@ -766,7 +766,7 @@ func TestInterpretReferenceUseAfterShiftStatementMove(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.AddressValue{1},
 			),
 			r2Address,

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -138,7 +138,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,
@@ -204,7 +204,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,
@@ -258,7 +258,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,
@@ -326,7 +326,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,
@@ -377,7 +377,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,
@@ -443,7 +443,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,
@@ -497,7 +497,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,
@@ -565,7 +565,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewSomeValueNonCopying(
+			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("test"),
 			),
 			value,

--- a/runtime/tests/interpreter/switch_test.go
+++ b/runtime/tests/interpreter/switch_test.go
@@ -235,10 +235,10 @@ func TestInterpretSwitchStatement(t *testing.T) {
 		for _, testCase := range []testCase{
 			{
 				[]interpreter.Value{
-					interpreter.NewSomeValueNonCopying(
+					interpreter.NewUnmeteredSomeValueNonCopying(
 						interpreter.NewIntValueFromInt64(1),
 					),
-					interpreter.NewSomeValueNonCopying(
+					interpreter.NewUnmeteredSomeValueNonCopying(
 						interpreter.NewIntValueFromInt64(1),
 					),
 				},
@@ -247,7 +247,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 			{
 				[]interpreter.Value{
 					interpreter.NilValue{},
-					interpreter.NewSomeValueNonCopying(
+					interpreter.NewUnmeteredSomeValueNonCopying(
 						interpreter.NewIntValueFromInt64(1),
 					),
 				},
@@ -255,10 +255,10 @@ func TestInterpretSwitchStatement(t *testing.T) {
 			},
 			{
 				[]interpreter.Value{
-					interpreter.NewSomeValueNonCopying(
+					interpreter.NewUnmeteredSomeValueNonCopying(
 						interpreter.NewIntValueFromInt64(1),
 					),
-					interpreter.NewSomeValueNonCopying(
+					interpreter.NewUnmeteredSomeValueNonCopying(
 						interpreter.NewIntValueFromInt64(2),
 					),
 				},

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1218,7 +1218,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 		}
 	case *interpreter.SomeValue:
 		innerValue := v.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
-		return interpreter.NewSomeValueNonCopying(deepCopyValue(inter, innerValue))
+		return interpreter.NewUnmeteredSomeValueNonCopying(deepCopyValue(inter, innerValue))
 	case interpreter.NilValue:
 		return interpreter.NilValue{}
 	default:
@@ -1257,7 +1257,7 @@ func randomStorableValue(inter *interpreter.Interpreter, currentDepth int) inter
 			},
 		}
 	case Some:
-		return interpreter.NewSomeValueNonCopying(
+		return interpreter.NewUnmeteredSomeValueNonCopying(
 			randomStorableValue(inter, currentDepth+1),
 		)
 


### PR DESCRIPTION
work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description



______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
