### PR TITLE
String metering is length + 1 to account for empty strings

### DIFF
--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -30,6 +30,6 @@ type MemoryGauge interface {
 func NewStringMemoryUsage(length int) MemoryUsage {
 	return MemoryUsage{
 		Kind:   MemoryKindString,
-		Amount: uint64(length),
+		Amount: uint64(length) + 1, // +1 to account for empty strings
 	}
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -119,7 +119,7 @@ func TestRuntimeDictionaryMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindString))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindDictionary))
 	})
 
@@ -180,7 +180,7 @@ func TestRuntimeCompositeMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(39), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
 	})
 


### PR DESCRIPTION
Related to https://github.com/dapperlabs/cadence-private-issues/issues/2.

## Description

An array of a million empty strings would be metered as if it were an empty array. This patch fixes that by metering every string as `length + 1` instead of simply `length`.

______

<!-- Complete: -->

- [X] Targeted PR against `feature/memory-metering` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
