### PR TITLE
Meter memory for IntValue and UIntValue creation, addition, multiplication, and negation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytecodealliance/wasmtime-go v0.22.0
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/cheekybits/genny v1.0.0
-	github.com/fxamacker/cbor/v2 v2.4.1-0.20220131180238-a68253a1c88b
+	github.com/fxamacker/cbor/v2 v2.4.1-0.20220308180823-1fafba071fa5
 	github.com/go-test/deep v1.0.5
 	github.com/leanovate/gopter v0.2.9
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220131180238-a68253a1c88b h1:mpWsptlw/l0/JH6UfuDuIhI15Xm1WHrNRm5P5uhNzdA=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220131180238-a68253a1c88b/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220308180823-1fafba071fa5 h1:fBOQZlXW1k14MJu6NWxb1S6H5xvpxIt3ENoBT2OkZU8=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220308180823-1fafba071fa5/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.1.0 h1:wXK52nkcBzGM+FyYc3wFYshm+0523BfX7h1XsUJLl70=
 github.com/fxamacker/circlehash v0.1.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -40,4 +40,5 @@ const (
 	MemoryKindInterpretedFunction
 	MemoryKindHostFunction
 	MemoryKindBoundFunction
+	MemoryKindBigInt
 )

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -23,11 +23,12 @@ func _() {
 	_ = x[MemoryKindInterpretedFunction-12]
 	_ = x[MemoryKindHostFunction-13]
 	_ = x[MemoryKindBoundFunction-14]
+	_ = x[MemoryKindBigInt-15]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeBlockNumberArrayDictionaryCompositeOptionalInterpretedFunctionHostFunctionBoundFunction"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeBlockNumberArrayDictionaryCompositeOptionalInterpretedFunctionHostFunctionBoundFunctionBigInt"
 
-var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 46, 52, 57, 67, 76, 84, 103, 115, 128}
+var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 46, 52, 57, 67, 76, 84, 103, 115, 128, 134}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -33,3 +33,10 @@ func NewStringMemoryUsage(length int) MemoryUsage {
 		Amount: uint64(length),
 	}
 }
+
+func NewBigIntMemoryUsage(bytes int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindBigInt,
+		Amount: uint64(bytes),
+	}
+}

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -18,6 +18,11 @@
 
 package common
 
+import (
+	"math/big"
+	"unsafe"
+)
+
 type MemoryUsage struct {
 	Kind   MemoryKind
 	Amount uint64
@@ -39,4 +44,29 @@ func NewBigIntMemoryUsage(bytes int) MemoryUsage {
 		Kind:   MemoryKindBigInt,
 		Amount: uint64(bytes),
 	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+const bigIntWordSize = int(unsafe.Sizeof(big.Word(0)))
+
+func NewPlusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		max(
+			len(a.Bits()),
+			len(b.Bits()),
+		) + bigIntWordSize,
+	)
 }

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -62,17 +62,22 @@ func min(a, b int) int {
 
 const bigIntWordSize = int(unsafe.Sizeof(big.Word(0)))
 
+func BigIntByteLength(v *big.Int) int {
+	return len(v.Bits()) * bigIntWordSize
+}
+
 func NewPlusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
 		max(
-			len(a.Bits()),
-			len(b.Bits()),
+			BigIntByteLength(a),
+			BigIntByteLength(b),
 		) + bigIntWordSize,
 	)
 }
 
 func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		len(a.Bits()) + len(b.Bits()),
+		BigIntByteLength(a) +
+			BigIntByteLength(b),
 	)
 }

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -53,16 +53,11 @@ func max(a, b int) int {
 	return b
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 const bigIntWordSize = int(unsafe.Sizeof(big.Word(0)))
 
 func BigIntByteLength(v *big.Int) int {
+	// NOTE: big.Int.Bits() actually returns bytes:
+	// []big.Word, where big.Word = uint
 	return len(v.Bits()) * bigIntWordSize
 }
 

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -70,3 +70,9 @@ func NewPlusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 		) + bigIntWordSize,
 	)
 }
+
+func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		len(a.Bits()) + len(b.Bits()),
+	)
+}

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -474,7 +474,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	case cadence.Int256:
 		return interpreter.NewInt256ValueFromBigInt(v.Value), nil
 	case cadence.UInt:
-		return interpreter.NewUIntValueFromBigInt(v.Value), nil
+		return importUInt(inter, v), nil
 	case cadence.UInt8:
 		return interpreter.UInt8Value(v), nil
 	case cadence.UInt16:
@@ -558,9 +558,20 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	return nil, fmt.Errorf("cannot import value of type %T", value)
 }
 
-func importInt(inter *interpreter.Interpreter, v cadence.Int) interpreter.Value {
+func importInt(inter *interpreter.Interpreter, v cadence.Int) interpreter.IntValue {
 	memoryUsage := common.NewBigIntMemoryUsage(len(v.Value.Bytes()))
 	return interpreter.NewIntValueFromBigInt(
+		inter,
+		memoryUsage,
+		func() *big.Int {
+			return v.Value
+		},
+	)
+}
+
+func importUInt(inter *interpreter.Interpreter, v cadence.UInt) interpreter.UIntValue {
+	memoryUsage := common.NewBigIntMemoryUsage(len(v.Value.Bytes()))
+	return interpreter.NewUIntValueFromBigInt(
 		inter,
 		memoryUsage,
 		func() *big.Int {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -20,6 +20,7 @@ package runtime
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
@@ -459,7 +460,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	case cadence.Address:
 		return interpreter.NewAddressValue(common.Address(v)), nil
 	case cadence.Int:
-		return interpreter.NewIntValueFromBigInt(v.Value), nil
+		return importInt(inter, v), nil
 	case cadence.Int8:
 		return interpreter.Int8Value(v), nil
 	case cadence.Int16:
@@ -555,6 +556,17 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	}
 
 	return nil, fmt.Errorf("cannot import value of type %T", value)
+}
+
+func importInt(inter *interpreter.Interpreter, v cadence.Int) interpreter.Value {
+	memoryUsage := common.NewBigIntMemoryUsage(len(v.Value.Bytes()))
+	return interpreter.NewIntValueFromBigInt(
+		inter,
+		memoryUsage,
+		func() *big.Int {
+			return v.Value
+		},
+	)
 }
 
 func importString(inter *interpreter.Interpreter, v cadence.String) *interpreter.StringValue {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -271,7 +271,7 @@ func TestExportValue(t *testing.T) {
 		},
 		{
 			label:    "UInt",
-			value:    interpreter.NewUIntValueFromUint64(42),
+			value:    interpreter.NewUnmeteredUIntValueFromUint64(42),
 			expected: cadence.NewUInt(42),
 		},
 		{
@@ -657,7 +657,7 @@ func TestImportValue(t *testing.T) {
 		{
 			label:    "UInt",
 			value:    cadence.NewUInt(42),
-			expected: interpreter.NewUIntValueFromUint64(42),
+			expected: interpreter.NewUnmeteredUIntValueFromUint64(42),
 		},
 		{
 			label:    "UInt8",

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -128,7 +128,7 @@ func TestExportValue(t *testing.T) {
 		{
 			label: "SomeValue",
 			value: interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 			),
 			expected: cadence.NewOptional(cadence.NewInt(42)),
 		},
@@ -176,7 +176,7 @@ func TestExportValue(t *testing.T) {
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
 					common.Address{},
-					interpreter.NewIntValueFromInt64(42),
+					interpreter.NewUnmeteredIntValueFromInt64(42),
 					interpreter.NewUnmeteredStringValue("foo"),
 				)
 			},
@@ -208,9 +208,9 @@ func TestExportValue(t *testing.T) {
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
 					interpreter.NewUnmeteredStringValue("a"),
-					interpreter.NewIntValueFromInt64(1),
+					interpreter.NewUnmeteredIntValueFromInt64(1),
 					interpreter.NewUnmeteredStringValue("b"),
-					interpreter.NewIntValueFromInt64(2),
+					interpreter.NewUnmeteredIntValueFromInt64(2),
 				)
 			},
 			expected: cadence.NewDictionary([]cadence.KeyValuePair{
@@ -231,7 +231,7 @@ func TestExportValue(t *testing.T) {
 		},
 		{
 			label:    "Int",
-			value:    interpreter.NewIntValueFromInt64(42),
+			value:    interpreter.NewUnmeteredIntValueFromInt64(42),
 			expected: cadence.NewInt(42),
 		},
 		{
@@ -365,7 +365,7 @@ func TestExportValue(t *testing.T) {
 			valueFactory: func(inter *interpreter.Interpreter) interpreter.Value {
 				return interpreter.NewAccountKeyValue(
 					inter,
-					interpreter.NewIntValueFromInt64(1),
+					interpreter.NewUnmeteredIntValueFromInt64(1),
 					NewPublicKeyValue(
 						inter,
 						interpreter.ReturnEmptyLocationRange,
@@ -510,7 +510,7 @@ func TestImportValue(t *testing.T) {
 			label: "SomeValue",
 			value: cadence.NewOptional(cadence.NewInt(42)),
 			expected: interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 			),
 		},
 		{
@@ -559,7 +559,7 @@ func TestImportValue(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
 				common.Address{},
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				interpreter.NewUnmeteredStringValue("foo"),
 			),
 			expectedType: &sema.VariableSizedType{
@@ -590,9 +590,9 @@ func TestImportValue(t *testing.T) {
 					ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
 				interpreter.NewUnmeteredStringValue("a"),
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 				interpreter.NewUnmeteredStringValue("b"),
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 			value: cadence.NewDictionary([]cadence.KeyValuePair{
 				{
@@ -617,7 +617,7 @@ func TestImportValue(t *testing.T) {
 		{
 			label:    "Int",
 			value:    cadence.NewInt(42),
-			expected: interpreter.NewIntValueFromInt64(42),
+			expected: interpreter.NewUnmeteredIntValueFromInt64(42),
 		},
 		{
 			label:    "Character",
@@ -2971,7 +2971,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
 
@@ -3016,7 +3016,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
 				common.Address{},
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				interpreter.NewUnmeteredStringValue("foo"),
 			),
 			actual,
@@ -3149,8 +3149,8 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
-			interpreter.NewUnmeteredStringValue("a"), interpreter.NewIntValueFromInt64(1),
-			interpreter.NewUnmeteredStringValue("b"), interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredStringValue("a"), interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 		)
 
 		actual, err := exportValueWithInterpreter(value, nil, seenReferences{})
@@ -3207,8 +3207,8 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeInt,
 				},
-				interpreter.NewUnmeteredStringValue("a"), interpreter.NewIntValueFromInt64(1),
-				interpreter.NewUnmeteredStringValue("b"), interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredStringValue("a"), interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 			actual,
 		)
@@ -3276,7 +3276,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 						KeyType:   interpreter.PrimitiveStaticTypeInt8,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
-					interpreter.Int8Value(1), interpreter.NewIntValueFromInt64(100),
+					interpreter.Int8Value(1), interpreter.NewUnmeteredIntValueFromInt64(100),
 					interpreter.Int8Value(2), interpreter.NewUnmeteredStringValue("hello"),
 				),
 
@@ -3288,7 +3288,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
 					interpreter.Int8Value(1), interpreter.NewUnmeteredStringValue("foo"),
-					interpreter.NewIntValueFromInt64(2), interpreter.NewIntValueFromInt64(50),
+					interpreter.NewUnmeteredIntValueFromInt64(2), interpreter.NewUnmeteredIntValueFromInt64(50),
 				),
 			),
 			actual,
@@ -4383,7 +4383,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		inter,
 		staticArrayType,
 		common.Address{},
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		interpreter.NewUnmeteredStringValue("foo"),
 	)
 

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -200,7 +200,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
               }
             `,
 			arguments: []argument{
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 			},
 			check: expectSuccess,
 		})
@@ -233,7 +233,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
               pub contract Test {}
             `,
 			arguments: []argument{
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 			},
 			check: expectFailure(
 				"Execution failed:\n" +

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -691,7 +691,7 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
 		require.True(b, bool(value.Less(mintAmountValue)))
 
-		sum = sum.Plus(value).(interpreter.UFix64Value)
+		sum = sum.Plus(nil, value).(interpreter.UFix64Value)
 	}
 
 	utils.RequireValuesEqual(b, nil, mintAmountValue, sum)

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -96,7 +96,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				},
 				common.Address{},
 				UInt8Value(4),
-				NewIntValueFromInt64(5),
+				NewUnmeteredIntValueFromInt64(5),
 			): {4, 5},
 		}
 
@@ -133,11 +133,11 @@ func TestByteValueToByte(t *testing.T) {
 		const maxInt8Plus2 = math.MaxInt8 + 2
 
 		invalid := map[Value]byte{
-			UInt64Value(2):               2,
-			NewUInt128ValueFromUint64(3): 3,
-			UInt8Value(4):                4,
-			NewIntValueFromInt64(5):      5,
-			UInt8Value(maxInt8Plus2):     maxInt8Plus2,
+			UInt64Value(2):                   2,
+			NewUInt128ValueFromUint64(3):     3,
+			UInt8Value(4):                    4,
+			NewUnmeteredIntValueFromInt64(5): 5,
+			UInt8Value(maxInt8Plus2):         maxInt8Plus2,
 		}
 
 		for value, expected := range invalid {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -486,7 +486,8 @@ func (d StorableDecoder) decodeUInt() (UIntValue, error) {
 		return UIntValue{}, fmt.Errorf("invalid UInt: got %s, expected positive", bigInt)
 	}
 
-	return NewUIntValueFromBigInt(bigInt), nil
+	// NOTE: already metered by decodeBigInt
+	return NewUnmeteredUIntValueFromBigInt(bigInt), nil
 }
 
 func (d StorableDecoder) decodeUInt8() (UInt8Value, error) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -83,16 +83,13 @@ func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (stri
 }
 
 func decodeBigInt(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (*big.Int, error) {
-	// TODO: meter. requires support in CBOR decoder
-	//
-	//length, err := dec.NextSize()
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if memoryGauge != nil {
-	//	memoryGauge.UseMemory(common.NewBigIntMemoryUsage(int(length)))
-	//}
-	//
+	length, err := dec.NextSize()
+	if err != nil {
+		return nil, err
+	}
+	if memoryGauge != nil {
+		memoryGauge.UseMemory(common.NewBigIntMemoryUsage(int(length)))
+	}
 	return dec.DecodeBigInt()
 }
 

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -82,17 +82,6 @@ func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (stri
 	return dec.DecodeString()
 }
 
-func decodeBigInt(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (*big.Int, error) {
-	length, err := dec.NextSize()
-	if err != nil {
-		return nil, err
-	}
-	if memoryGauge != nil {
-		memoryGauge.UseMemory(common.NewBigIntMemoryUsage(int(length)))
-	}
-	return dec.DecodeBigInt()
-}
-
 func DecodeStorable(
 	decoder *cbor.StreamDecoder,
 	slabStorageID atree.StorageID,
@@ -332,8 +321,20 @@ func (d StorableDecoder) decodeStringValue() (*StringValue, error) {
 	return NewUnmeteredStringValue(str), nil
 }
 
+func (d StorableDecoder) decodeBigInt() (*big.Int, error) {
+	length, err := d.decoder.NextSize()
+	if err != nil {
+		return nil, err
+	}
+	memoryGauge := d.memoryGauge
+	if memoryGauge != nil {
+		memoryGauge.UseMemory(common.NewBigIntMemoryUsage(int(length)))
+	}
+	return d.decoder.DecodeBigInt()
+}
+
 func (d StorableDecoder) decodeInt() (IntValue, error) {
-	bigInt, err := decodeBigInt(d.decoder, d.memoryGauge)
+	bigInt, err := d.decodeBigInt()
 	if err != nil {
 		if err, ok := err.(*cbor.WrongTypeError); ok {
 			return IntValue{}, fmt.Errorf(
@@ -427,7 +428,7 @@ func (d StorableDecoder) decodeInt64() (Int64Value, error) {
 }
 
 func (d StorableDecoder) decodeInt128() (Int128Value, error) {
-	bigInt, err := decodeBigInt(d.decoder, d.memoryGauge)
+	bigInt, err := d.decodeBigInt()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return Int128Value{}, fmt.Errorf("invalid Int128 encoding: %s", e.ActualType.String())
@@ -449,7 +450,7 @@ func (d StorableDecoder) decodeInt128() (Int128Value, error) {
 }
 
 func (d StorableDecoder) decodeInt256() (Int256Value, error) {
-	bigInt, err := decodeBigInt(d.decoder, d.memoryGauge)
+	bigInt, err := d.decodeBigInt()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return Int256Value{}, fmt.Errorf("invalid Int256 encoding: %s", e.ActualType.String())
@@ -471,7 +472,7 @@ func (d StorableDecoder) decodeInt256() (Int256Value, error) {
 }
 
 func (d StorableDecoder) decodeUInt() (UIntValue, error) {
-	bigInt, err := decodeBigInt(d.decoder, d.memoryGauge)
+	bigInt, err := d.decodeBigInt()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return UIntValue{}, fmt.Errorf("invalid UInt encoding: %s", e.ActualType.String())
@@ -546,7 +547,7 @@ func (d StorableDecoder) decodeUInt64() (UInt64Value, error) {
 }
 
 func (d StorableDecoder) decodeUInt128() (UInt128Value, error) {
-	bigInt, err := decodeBigInt(d.decoder, d.memoryGauge)
+	bigInt, err := d.decodeBigInt()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return UInt128Value{}, fmt.Errorf("invalid UInt128 encoding: %s", e.ActualType.String())
@@ -567,7 +568,7 @@ func (d StorableDecoder) decodeUInt128() (UInt128Value, error) {
 }
 
 func (d StorableDecoder) decodeUInt256() (UInt256Value, error) {
-	bigInt, err := decodeBigInt(d.decoder, d.memoryGauge)
+	bigInt, err := d.decodeBigInt()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return UInt256Value{}, fmt.Errorf("invalid UInt256 encoding: %s", e.ActualType.String())

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -1941,7 +1941,7 @@ func TestDivModInt(t *testing.T) {
 		},
 	} {
 		assert.Panics(t, func() {
-			f(NewIntValueFromInt64(1), NewIntValueFromInt64(0))
+			f(NewUnmeteredIntValueFromInt64(1), NewUnmeteredIntValueFromInt64(0))
 		})
 	}
 }
@@ -3314,9 +3314,9 @@ func TestNegativeMod(t *testing.T) {
 				NewInt256ValueFromInt64(-1),
 			},
 			"Int": {
-				NewIntValueFromInt64(-1),
-				NewIntValueFromInt64(5),
-				NewIntValueFromInt64(-1),
+				NewUnmeteredIntValueFromInt64(-1),
+				NewUnmeteredIntValueFromInt64(5),
+				NewUnmeteredIntValueFromInt64(-1),
 			},
 		}
 

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -85,7 +85,7 @@ func TestDivModUInt8(t *testing.T) {
 				a.Div(b)
 			},
 			func(a, b UInt8Value) {
-				a.Mod(b)
+				a.Mod(nil, b)
 			},
 		} {
 			f := func() {
@@ -157,7 +157,7 @@ func TestDivModUInt16(t *testing.T) {
 				a.Div(b)
 			},
 			func(a, b UInt16Value) {
-				a.Mod(b)
+				a.Mod(nil, b)
 			},
 		} {
 			f := func() {
@@ -229,7 +229,7 @@ func TestDivModUInt32(t *testing.T) {
 				a.Div(b)
 			},
 			func(a, b UInt32Value) {
-				a.Mod(b)
+				a.Mod(nil, b)
 			},
 		} {
 			f := func() {
@@ -391,7 +391,7 @@ func TestDivModUInt64(t *testing.T) {
 				a.Div(b)
 			},
 			func(a, b UInt64Value) {
-				a.Mod(b)
+				a.Mod(nil, b)
 			},
 		} {
 			f := func() {
@@ -555,7 +555,7 @@ func TestDivModUInt128(t *testing.T) {
 				a.Div(b)
 			},
 			func(a, b UInt128Value) {
-				a.Mod(b)
+				a.Mod(nil, b)
 			},
 		} {
 			f := func() {
@@ -1225,7 +1225,7 @@ func TestDivModUInt256(t *testing.T) {
 				a.Div(b)
 			},
 			func(a, b UInt256Value) {
-				a.Mod(b)
+				a.Mod(nil, b)
 			},
 		} {
 			f := func() {
@@ -1357,7 +1357,7 @@ func TestModInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(test.b)
+			test.a.Mod(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1484,7 +1484,7 @@ func TestModInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(test.b)
+			test.a.Mod(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1611,7 +1611,7 @@ func TestModInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(test.b)
+			test.a.Mod(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1918,7 +1918,7 @@ func TestModInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(test.b)
+			test.a.Mod(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1937,7 +1937,7 @@ func TestDivModInt(t *testing.T) {
 			a.Div(b)
 		},
 		func(a, b IntValue) {
-			a.Mod(b)
+			a.Mod(nil, b)
 		},
 	} {
 		assert.Panics(t, func() {
@@ -2159,7 +2159,7 @@ func TestModInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(test.b)
+			test.a.Mod(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3066,7 +3066,7 @@ func TestModInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(test.b)
+			test.a.Mod(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3185,7 +3185,7 @@ func TestModFix64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(test.b)
+			test.a.Mod(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3231,7 +3231,7 @@ func TestDivModUFix64(t *testing.T) {
 				a.Div(b)
 			},
 			func(a, b UFix64Value) {
-				a.Mod(b)
+				a.Mod(nil, b)
 			},
 		} {
 
@@ -3329,7 +3329,7 @@ func TestNegativeMod(t *testing.T) {
 		for _, test := range tests {
 			assert.Equal(t,
 				test.expected,
-				test.a.Mod(test.b),
+				test.a.Mod(nil, test.b),
 			)
 		}
 	})
@@ -3353,7 +3353,7 @@ func TestNegativeMod(t *testing.T) {
 		for _, test := range tests {
 			assert.Equal(t,
 				test.expected,
-				test.a.Mod(test.b),
+				test.a.Mod(nil, test.b),
 			)
 		}
 	})

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -1401,7 +1401,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewUIntValueFromUint64(0),
+				value: NewUnmeteredUIntValueFromUint64(0),
 				encoded: []byte{
 					0xd8, CBORTagUIntValue,
 					// positive bignum
@@ -1436,7 +1436,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewUIntValueFromUint64(42),
+				value: NewUnmeteredUIntValueFromUint64(42),
 				encoded: []byte{
 					0xd8, CBORTagUIntValue,
 					// positive bignum
@@ -1458,7 +1458,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewUIntValueFromBigInt(rfcValue),
+				value: NewUnmeteredUIntValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagUIntValue,
@@ -1479,7 +1479,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 		inter, err := NewInterpreter(nil, nil)
 		require.NoError(t, err)
 
-		expected := NewUIntValueFromUint64(1_000_000_000)
+		expected := NewUnmeteredUIntValueFromUint64(1_000_000_000)
 
 		maxInlineElementSize := atree.MaxInlineArrayElementSize
 		for len(expected.BigInt.Bytes()) < int(maxInlineElementSize+1) {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -401,7 +401,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewIntValueFromInt64(0),
+				value: NewUnmeteredIntValueFromInt64(0),
 				encoded: []byte{
 					0xd8, CBORTagIntValue,
 					// positive bignum
@@ -418,7 +418,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewIntValueFromInt64(42),
+				value: NewUnmeteredIntValueFromInt64(42),
 				encoded: []byte{
 					0xd8, CBORTagIntValue,
 					// positive bignum
@@ -436,7 +436,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewIntValueFromInt64(-1),
+				value: NewUnmeteredIntValueFromInt64(-1),
 				encoded: []byte{
 					0xd8, CBORTagIntValue,
 					// negative bignum
@@ -453,7 +453,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewIntValueFromInt64(-42),
+				value: NewUnmeteredIntValueFromInt64(-42),
 				encoded: []byte{
 					0xd8, CBORTagIntValue,
 					// negative bignum
@@ -478,7 +478,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewIntValueFromBigInt(setString),
+				value: NewUnmeteredIntValueFromBigInt(setString),
 				encoded: []byte{
 					0xd8, CBORTagIntValue,
 					// negative bignum
@@ -500,7 +500,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		testEncodeDecode(t,
 			encodeDecodeTest{
-				value: NewIntValueFromBigInt(bigInt),
+				value: NewUnmeteredIntValueFromBigInt(bigInt),
 				encoded: []byte{
 					// tag
 					0xd8, CBORTagIntValue,
@@ -518,7 +518,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		t.Parallel()
 
-		expected := NewIntValueFromInt64(1_000_000_000)
+		expected := NewUnmeteredIntValueFromInt64(1_000_000_000)
 
 		maxInlineElementSize := atree.MaxInlineArrayElementSize
 		for len(expected.BigInt.Bytes()) < int(maxInlineElementSize+1) {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -518,11 +518,14 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		t.Parallel()
 
+		inter, err := NewInterpreter(nil, nil)
+		require.NoError(t, err)
+
 		expected := NewUnmeteredIntValueFromInt64(1_000_000_000)
 
 		maxInlineElementSize := atree.MaxInlineArrayElementSize
 		for len(expected.BigInt.Bytes()) < int(maxInlineElementSize+1) {
-			expected = expected.Mul(expected).(IntValue)
+			expected = expected.Mul(inter, expected).(IntValue)
 		}
 
 		testEncodeDecode(t,
@@ -1473,11 +1476,14 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 
 		t.Parallel()
 
+		inter, err := NewInterpreter(nil, nil)
+		require.NoError(t, err)
+
 		expected := NewUIntValueFromUint64(1_000_000_000)
 
 		maxInlineElementSize := atree.MaxInlineArrayElementSize
 		for len(expected.BigInt.Bytes()) < int(maxInlineElementSize+1) {
-			expected = expected.Mul(expected).(UIntValue)
+			expected = expected.Mul(inter, expected).(UIntValue)
 		}
 
 		testEncodeDecode(t,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1801,8 +1801,9 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 	for i, enumCase := range enumCases {
 
-		rawValue := convert(
-			NewIntValueFromInt64(int64(i)),
+		// TODO: replace, avoid conversion
+		rawValue := interpreter.convert(
+			NewIntValueFromInt64(interpreter, int64(i)),
 			intType,
 			compositeType.EnumRawType,
 		)
@@ -2147,11 +2148,11 @@ func (interpreter *Interpreter) ConvertAndBox(
 	value Value,
 	valueType, targetType sema.Type,
 ) Value {
-	value = convert(value, valueType, targetType)
+	value = interpreter.convert(value, valueType, targetType)
 	return interpreter.BoxOptional(getLocationRange, value, targetType)
 }
 
-func convert(value Value, valueType, targetType sema.Type) Value {
+func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.Type) Value {
 	if valueType == nil {
 		return value
 	}
@@ -2165,7 +2166,7 @@ func convert(value Value, valueType, targetType sema.Type) Value {
 	switch unwrappedTargetType {
 	case sema.IntType:
 		if !valueType.Equal(unwrappedTargetType) {
-			return ConvertInt(value)
+			return ConvertInt(interpreter, value)
 		}
 
 	case sema.UIntType:
@@ -2699,8 +2700,8 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.IntTypeName,
 		functionType: sema.NumberConversionFunctionType(sema.IntType),
-		convert: func(_ *Interpreter, value Value) Value {
-			return ConvertInt(value)
+		convert: func(interpreter *Interpreter, value Value) Value {
+			return ConvertInt(interpreter, value)
 		},
 	},
 	{

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2171,7 +2171,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 
 	case sema.UIntType:
 		if !valueType.Equal(unwrappedTargetType) {
-			return ConvertUInt(value)
+			return ConvertUInt(interpreter, value)
 		}
 
 	// Int*
@@ -2707,10 +2707,10 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.UIntTypeName,
 		functionType: sema.NumberConversionFunctionType(sema.UIntType),
-		convert: func(_ *Interpreter, value Value) Value {
-			return ConvertUInt(value)
+		convert: func(interpreter *Interpreter, value Value) Value {
+			return ConvertUInt(interpreter, value)
 		},
-		min: NewUIntValueFromBigInt(sema.UIntTypeMin),
+		min: NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
 	},
 	{
 		name:         sema.Int8TypeName,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -447,16 +447,16 @@ func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerEx
 	}
 
 	// The ranges are checked at the checker level.
-	// Hence it is safe to create the value without validation.
-	return NewIntValue(value, typ)
+	// Hence, it is safe to create the value without validation.
+	return NewIntegerValueFromBigInt(value, typ)
 
 }
 
-// NewIntValue creates a Cadence interpreter value of a given subtype.
+// NewIntegerValueFromBigInt creates a Cadence interpreter value of a given subtype.
 // This method assumes the range validations are done prior to calling this method. (i.e: at semantic level)
 //
-func NewIntValue(value *big.Int, intSubType sema.Type) Value {
-	switch intSubType {
+func NewIntegerValueFromBigInt(value *big.Int, integerSubType sema.Type) Value {
+	switch integerSubType {
 	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
 		// TODO: meter
 		return NewUnmeteredIntValueFromBigInt(value)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -415,7 +415,7 @@ func (interpreter *Interpreter) VisitUnaryExpression(expression *ast.UnaryExpres
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
-		return integerValue.Negate()
+		return integerValue.Negate(interpreter)
 
 	case ast.OperationMove:
 		interpreter.invalidateResource(value)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -448,20 +448,32 @@ func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerEx
 
 	// The ranges are checked at the checker level.
 	// Hence, it is safe to create the value without validation.
-	return NewIntegerValueFromBigInt(value, typ)
+	return interpreter.NewIntegerValueFromBigInt(value, typ)
 
 }
 
 // NewIntegerValueFromBigInt creates a Cadence interpreter value of a given subtype.
 // This method assumes the range validations are done prior to calling this method. (i.e: at semantic level)
 //
-func NewIntegerValueFromBigInt(value *big.Int, integerSubType sema.Type) Value {
+func (interpreter *Interpreter) NewIntegerValueFromBigInt(value *big.Int, integerSubType sema.Type) Value {
 	switch integerSubType {
 	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
-		// TODO: meter
+		memoryGauge := interpreter.memoryGauge
+		if memoryGauge != nil {
+			memoryUsage := common.NewBigIntMemoryUsage(
+				common.BigIntByteLength(value),
+			)
+			memoryGauge.UseMemory(memoryUsage)
+		}
 		return NewUnmeteredIntValueFromBigInt(value)
 	case sema.UIntType:
-		// TODO: meter
+		memoryGauge := interpreter.memoryGauge
+		if memoryGauge != nil {
+			memoryUsage := common.NewBigIntMemoryUsage(
+				common.BigIntByteLength(value),
+			)
+			memoryGauge.UseMemory(memoryUsage)
+		}
 		return NewUnmeteredUIntValueFromBigInt(value)
 
 	// Int*

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -458,7 +458,8 @@ func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerEx
 func NewIntValue(value *big.Int, intSubType sema.Type) Value {
 	switch intSubType {
 	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
-		return NewIntValueFromBigInt(value)
+		// TODO: meter
+		return NewUnmeteredIntValueFromBigInt(value)
 	case sema.UIntType:
 		return NewUIntValueFromBigInt(value)
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -224,7 +224,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.Mul(right)
+		return left.Mul(interpreter, right)
 
 	case ast.OperationDiv:
 		left, leftOk := leftValue.(NumberValue)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -216,7 +216,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.Mod(right)
+		return left.Mod(interpreter, right)
 
 	case ast.OperationMul:
 		left, leftOk := leftValue.(NumberValue)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -200,7 +200,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.Plus(right)
+		return left.Plus(interpreter, right)
 
 	case ast.OperationMinus:
 		left, leftOk := leftValue.(NumberValue)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -461,7 +461,8 @@ func NewIntValue(value *big.Int, intSubType sema.Type) Value {
 		// TODO: meter
 		return NewUnmeteredIntValueFromBigInt(value)
 	case sema.UIntType:
-		return NewUIntValueFromBigInt(value)
+		// TODO: meter
+		return NewUnmeteredUIntValueFromBigInt(value)
 
 	// Int*
 	case sema.Int8Type:

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -348,7 +348,9 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 		}
 
 		if indexVariable != nil {
-			indexVariable.SetValue(indexVariable.GetValue().(IntValue).Plus(intOne))
+			currentIndex := indexVariable.GetValue().(IntValue)
+			nextIndex := currentIndex.Plus(interpreter, intOne)
+			indexVariable.SetValue(nextIndex)
 		}
 	}
 }

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -279,6 +279,8 @@ func (interpreter *Interpreter) VisitWhileStatement(statement *ast.WhileStatemen
 	}
 }
 
+var intOne = NewUnmeteredIntValueFromInt64(1)
+
 func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) ast.Repr {
 
 	interpreter.activations.PushNewWithCurrent()
@@ -306,11 +308,10 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 	}
 
 	var indexVariable *Variable
-	var one = NewIntValueFromInt64(1)
 	if statement.Index != nil {
 		indexVariable = interpreter.declareVariable(
 			statement.Index.Identifier,
-			NewIntValueFromInt64(0),
+			NewIntValueFromInt64(interpreter, 0),
 		)
 	}
 
@@ -347,7 +348,7 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) a
 		}
 
 		if indexVariable != nil {
-			indexVariable.SetValue(indexVariable.GetValue().(IntValue).Plus(one))
+			indexVariable.SetValue(indexVariable.GetValue().(IntValue).Plus(intOne))
 		}
 	}
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -98,7 +98,7 @@ func TestInterpreterTracing(t *testing.T) {
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
-			interpreter.NewUnmeteredStringValue("test"), interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredStringValue("test"), interpreter.NewUnmeteredIntValueFromInt64(42),
 		)
 		require.NotNil(t, dict)
 		fmt.Println(traceOps)

--- a/runtime/interpreter/minus_test.go
+++ b/runtime/interpreter/minus_test.go
@@ -2584,8 +2584,8 @@ func TestMinusUInt(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			a := NewUIntValueFromUint64(test.a)
-			b := NewUIntValueFromUint64(test.b)
+			a := NewUnmeteredUIntValueFromUint64(test.a)
+			b := NewUnmeteredUIntValueFromUint64(test.b)
 			a.Minus(b)
 		}
 		if test.valid {

--- a/runtime/interpreter/mul_test.go
+++ b/runtime/interpreter/mul_test.go
@@ -162,7 +162,7 @@ func TestMulUInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -308,7 +308,7 @@ func TestMulUInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -454,7 +454,7 @@ func TestMulUInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -611,7 +611,7 @@ func TestMulUInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -770,7 +770,7 @@ func TestMulUInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1438,7 +1438,7 @@ func TestMulUInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1617,7 +1617,7 @@ func TestMulInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1805,7 +1805,7 @@ func TestMulInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1976,7 +1976,7 @@ func TestMulInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2132,7 +2132,7 @@ func TestMulInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2290,7 +2290,7 @@ func TestMulInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2961,7 +2961,7 @@ func TestMulInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(test.b)
+			test.a.Mul(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/negate_test.go
+++ b/runtime/interpreter/negate_test.go
@@ -35,37 +35,37 @@ func TestNegate(t *testing.T) {
 
 	t.Run("Int8", func(t *testing.T) {
 		assert.Panics(t, func() {
-			Int8Value(math.MinInt8).Negate()
+			Int8Value(math.MinInt8).Negate(nil)
 		})
 	})
 
 	t.Run("Int16", func(t *testing.T) {
 		assert.Panics(t, func() {
-			Int16Value(math.MinInt16).Negate()
+			Int16Value(math.MinInt16).Negate(nil)
 		})
 	})
 
 	t.Run("Int32", func(t *testing.T) {
 		assert.Panics(t, func() {
-			Int32Value(math.MinInt32).Negate()
+			Int32Value(math.MinInt32).Negate(nil)
 		})
 	})
 
 	t.Run("Int64", func(t *testing.T) {
 		assert.Panics(t, func() {
-			Int64Value(math.MinInt64).Negate()
+			Int64Value(math.MinInt64).Negate(nil)
 		})
 	})
 
 	t.Run("Int128", func(t *testing.T) {
 		assert.Panics(t, func() {
-			Int128Value{new(big.Int).Set(sema.Int128TypeMinIntBig)}.Negate()
+			Int128Value{new(big.Int).Set(sema.Int128TypeMinIntBig)}.Negate(nil)
 		})
 	})
 
 	t.Run("Int256", func(t *testing.T) {
 		assert.Panics(t, func() {
-			Int256Value{new(big.Int).Set(sema.Int256TypeMinIntBig)}.Negate()
+			Int256Value{new(big.Int).Set(sema.Int256TypeMinIntBig)}.Negate(nil)
 		})
 	})
 }

--- a/runtime/interpreter/number_test.go
+++ b/runtime/interpreter/number_test.go
@@ -128,7 +128,7 @@ func TestOverEstimateFixedPointStringLength(t *testing.T) {
 			return OverEstimateFixedPointStringLength(v, scale) >= len(v.String())+1+scale
 		},
 		gen.Int64().Map(func(v int64) NumberValue {
-			return NewIntValueFromInt64(v)
+			return NewUnmeteredIntValueFromInt64(v)
 		}),
 		gen.Int(),
 	))
@@ -158,7 +158,10 @@ func TestOverEstimateFixedPointStringLength(t *testing.T) {
 	} {
 		assert.LessOrEqual(t,
 			len(strconv.Itoa(v))+1+testScale,
-			OverEstimateFixedPointStringLength(NewIntValueFromInt64(int64(v)), testScale),
+			OverEstimateFixedPointStringLength(
+				NewUnmeteredIntValueFromInt64(int64(v)),
+				testScale,
+			),
 		)
 	}
 }

--- a/runtime/interpreter/plus_test.go
+++ b/runtime/interpreter/plus_test.go
@@ -130,7 +130,7 @@ func TestPlusUInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -242,7 +242,7 @@ func TestPlusUInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -353,7 +353,7 @@ func TestPlusUInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -681,7 +681,7 @@ func TestPlusUInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -808,7 +808,7 @@ func TestPlusUInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1276,7 +1276,7 @@ func TestPlusUInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1388,7 +1388,7 @@ func TestPlusInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1500,7 +1500,7 @@ func TestPlusInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1612,7 +1612,7 @@ func TestPlusInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1940,7 +1940,7 @@ func TestPlusInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2067,7 +2067,7 @@ func TestPlusInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2500,7 +2500,7 @@ func TestPlusInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(test.b)
+			test.a.Plus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -6319,9 +6319,14 @@ func (v UIntValue) Plus(interpreter *Interpreter, other NumberValue) NumberValue
 		})
 	}
 
-	res := new(big.Int)
-	res.Add(v.BigInt, o.BigInt)
-	return UIntValue{res}
+	return NewUIntValueFromBigInt(
+		interpreter,
+		common.NewPlusBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Add(v.BigInt, o.BigInt)
+		},
+	)
 }
 
 func (v UIntValue) SaturatingPlus(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -6406,9 +6411,14 @@ func (v UIntValue) Mul(interpreter *Interpreter, other NumberValue) NumberValue 
 		})
 	}
 
-	res := new(big.Int)
-	res.Mul(v.BigInt, o.BigInt)
-	return UIntValue{res}
+	return NewUIntValueFromBigInt(
+		interpreter,
+		common.NewMulBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Mul(v.BigInt, o.BigInt)
+		},
+	)
 }
 
 func (v UIntValue) SaturatingMul(interpreter *Interpreter, other NumberValue) NumberValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2344,7 +2344,7 @@ func (v *ArrayValue) Slice(
 type NumberValue interface {
 	EquatableValue
 	ToInt() int
-	Negate() NumberValue
+	Negate(*Interpreter) NumberValue
 	Plus(interpreter *Interpreter, other NumberValue) NumberValue
 	SaturatingPlus(interpreter *Interpreter, other NumberValue) NumberValue
 	Minus(other NumberValue) NumberValue
@@ -2603,8 +2603,14 @@ func (v IntValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v IntValue) Negate() NumberValue {
-	return IntValue{new(big.Int).Neg(v.BigInt)}
+func (v IntValue) Negate(interpreter *Interpreter) NumberValue {
+	return NewIntValueFromBigInt(
+		interpreter,
+		common.NewBigIntMemoryUsage(len(v.BigInt.Bits())),
+		func() *big.Int {
+			return new(big.Int).Neg(v.BigInt)
+		},
+	)
 }
 
 func (v IntValue) Plus(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -3047,7 +3053,7 @@ func (v Int8Value) ToInt() int {
 	return int(v)
 }
 
-func (v Int8Value) Negate() NumberValue {
+func (v Int8Value) Negate(*Interpreter) NumberValue {
 	// INT32-C
 	if v == math.MinInt8 {
 		panic(OverflowError{})
@@ -3546,7 +3552,7 @@ func (v Int16Value) ToInt() int {
 	return int(v)
 }
 
-func (v Int16Value) Negate() NumberValue {
+func (v Int16Value) Negate(*Interpreter) NumberValue {
 	// INT32-C
 	if v == math.MinInt16 {
 		panic(OverflowError{})
@@ -4047,7 +4053,7 @@ func (v Int32Value) ToInt() int {
 	return int(v)
 }
 
-func (v Int32Value) Negate() NumberValue {
+func (v Int32Value) Negate(*Interpreter) NumberValue {
 	// INT32-C
 	if v == math.MinInt32 {
 		panic(OverflowError{})
@@ -4548,7 +4554,7 @@ func (v Int64Value) ToInt() int {
 	return int(v)
 }
 
-func (v Int64Value) Negate() NumberValue {
+func (v Int64Value) Negate(*Interpreter) NumberValue {
 	// INT32-C
 	if v == math.MinInt64 {
 		panic(OverflowError{})
@@ -5069,7 +5075,7 @@ func (v Int128Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int128Value) Negate() NumberValue {
+func (v Int128Value) Negate(*Interpreter) NumberValue {
 	// INT32-C
 	//   if v == Int128TypeMinIntBig {
 	//       ...
@@ -5655,7 +5661,7 @@ func (v Int256Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int256Value) Negate() NumberValue {
+func (v Int256Value) Negate(*Interpreter) NumberValue {
 	// INT32-C
 	//   if v == Int256TypeMinIntBig {
 	//       ...
@@ -6262,7 +6268,7 @@ func (v UIntValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UIntValue) Negate() NumberValue {
+func (v UIntValue) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -6705,7 +6711,7 @@ func (v UInt8Value) ToInt() int {
 	return int(v)
 }
 
-func (v UInt8Value) Negate() NumberValue {
+func (v UInt8Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -7143,7 +7149,7 @@ func (v UInt16Value) RecursiveString(_ SeenReferences) string {
 func (v UInt16Value) ToInt() int {
 	return int(v)
 }
-func (v UInt16Value) Negate() NumberValue {
+func (v UInt16Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -7587,7 +7593,7 @@ func (v UInt32Value) ToInt() int {
 	return int(v)
 }
 
-func (v UInt32Value) Negate() NumberValue {
+func (v UInt32Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -8056,7 +8062,7 @@ func (v UInt64Value) ToBigInt() *big.Int {
 	return new(big.Int).SetUint64(uint64(v))
 }
 
-func (v UInt64Value) Negate() NumberValue {
+func (v UInt64Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -8523,7 +8529,7 @@ func (v UInt128Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt128Value) Negate() NumberValue {
+func (v UInt128Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -8639,7 +8645,7 @@ func (v UInt128Value) SaturatingMinus(other NumberValue) NumberValue {
 	return UInt128Value{diff}
 }
 
-func (v UInt128Value) Mod(other NumberValue) NumberValue {
+func (v UInt128Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9063,7 +9069,7 @@ func (v UInt256Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt256Value) Negate() NumberValue {
+func (v UInt256Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -9580,7 +9586,7 @@ func (v Word8Value) ToInt() int {
 	return int(v)
 }
 
-func (v Word8Value) Negate() NumberValue {
+func (v Word8Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -9928,7 +9934,7 @@ func (v Word16Value) RecursiveString(_ SeenReferences) string {
 func (v Word16Value) ToInt() int {
 	return int(v)
 }
-func (v Word16Value) Negate() NumberValue {
+func (v Word16Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -10279,7 +10285,7 @@ func (v Word32Value) ToInt() int {
 	return int(v)
 }
 
-func (v Word32Value) Negate() NumberValue {
+func (v Word32Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -10655,7 +10661,7 @@ func (v Word64Value) ToBigInt() *big.Int {
 	return new(big.Int).SetUint64(uint64(v))
 }
 
-func (v Word64Value) Negate() NumberValue {
+func (v Word64Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 
@@ -11029,7 +11035,7 @@ func (v Fix64Value) ToInt() int {
 	return int(v / sema.Fix64Factor)
 }
 
-func (v Fix64Value) Negate() NumberValue {
+func (v Fix64Value) Negate(*Interpreter) NumberValue {
 	// INT32-C
 	if v == math.MinInt64 {
 		panic(OverflowError{})
@@ -11479,7 +11485,7 @@ func (v UFix64Value) ToInt() int {
 	return int(v / sema.Fix64Factor)
 }
 
-func (v UFix64Value) Negate() NumberValue {
+func (v UFix64Value) Negate(*Interpreter) NumberValue {
 	panic(errors.NewUnreachableError())
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2500,11 +2500,14 @@ type IntValue struct {
 	BigInt *big.Int
 }
 
+const int64Size = int(unsafe.Sizeof(int64(0)))
+
+var int64BigIntMemoryUsage = common.NewBigIntMemoryUsage(int64Size)
+
 func NewIntValueFromInt64(memoryGauge common.MemoryGauge, value int64) IntValue {
-	const int64Size = int(unsafe.Sizeof(int64(0)))
 	return NewIntValueFromBigInt(
 		memoryGauge,
-		common.NewBigIntMemoryUsage(int64Size),
+		int64BigIntMemoryUsage,
 		func() *big.Int {
 			return big.NewInt(value)
 		},
@@ -6193,11 +6196,14 @@ type UIntValue struct {
 	BigInt *big.Int
 }
 
+const uint64Size = int(unsafe.Sizeof(uint64(0)))
+
+var uint64BigIntMemoryUsage = common.NewBigIntMemoryUsage(uint64Size)
+
 func NewUIntValueFromUint64(memoryGauge common.MemoryGauge, value uint64) UIntValue {
-	const uint64Size = int(unsafe.Sizeof(uint64(0)))
 	return NewUIntValueFromBigInt(
 		memoryGauge,
-		common.NewBigIntMemoryUsage(uint64Size),
+		uint64BigIntMemoryUsage,
 		func() *big.Int {
 			return new(big.Int).SetUint64(value)
 		},

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2349,7 +2349,7 @@ type NumberValue interface {
 	SaturatingPlus(interpreter *Interpreter, other NumberValue) NumberValue
 	Minus(other NumberValue) NumberValue
 	SaturatingMinus(other NumberValue) NumberValue
-	Mod(other NumberValue) NumberValue
+	Mod(interpreter *Interpreter, other NumberValue) NumberValue
 	Mul(interpreter *Interpreter, other NumberValue) NumberValue
 	SaturatingMul(interpreter *Interpreter, other NumberValue) NumberValue
 	Div(other NumberValue) NumberValue
@@ -2672,7 +2672,7 @@ func (v IntValue) SaturatingMinus(other NumberValue) NumberValue {
 	return v.Minus(other)
 }
 
-func (v IntValue) Mod(other NumberValue) NumberValue {
+func (v IntValue) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3131,7 +3131,7 @@ func (v Int8Value) SaturatingMinus(other NumberValue) NumberValue {
 	return v - o
 }
 
-func (v Int8Value) Mod(other NumberValue) NumberValue {
+func (v Int8Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3630,7 +3630,7 @@ func (v Int16Value) SaturatingMinus(other NumberValue) NumberValue {
 	return v - o
 }
 
-func (v Int16Value) Mod(other NumberValue) NumberValue {
+func (v Int16Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4131,7 +4131,7 @@ func (v Int32Value) SaturatingMinus(other NumberValue) NumberValue {
 	return v - o
 }
 
-func (v Int32Value) Mod(other NumberValue) NumberValue {
+func (v Int32Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4636,7 +4636,7 @@ func (v Int64Value) SaturatingMinus(other NumberValue) NumberValue {
 	return v - o
 }
 
-func (v Int64Value) Mod(other NumberValue) NumberValue {
+func (v Int64Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5208,7 +5208,7 @@ func (v Int128Value) SaturatingMinus(other NumberValue) NumberValue {
 	return Int128Value{res}
 }
 
-func (v Int128Value) Mod(other NumberValue) NumberValue {
+func (v Int128Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5794,7 +5794,7 @@ func (v Int256Value) SaturatingMinus(other NumberValue) NumberValue {
 	return Int256Value{res}
 }
 
-func (v Int256Value) Mod(other NumberValue) NumberValue {
+func (v Int256Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6334,7 +6334,7 @@ func (v UIntValue) SaturatingMinus(other NumberValue) NumberValue {
 	return UIntValue{res}
 }
 
-func (v UIntValue) Mod(other NumberValue) NumberValue {
+func (v UIntValue) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6783,7 +6783,7 @@ func (v UInt8Value) SaturatingMinus(other NumberValue) NumberValue {
 	return diff
 }
 
-func (v UInt8Value) Mod(other NumberValue) NumberValue {
+func (v UInt8Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7221,7 +7221,7 @@ func (v UInt16Value) SaturatingMinus(other NumberValue) NumberValue {
 	return diff
 }
 
-func (v UInt16Value) Mod(other NumberValue) NumberValue {
+func (v UInt16Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7666,7 +7666,7 @@ func (v UInt32Value) SaturatingMinus(other NumberValue) NumberValue {
 	return diff
 }
 
-func (v UInt32Value) Mod(other NumberValue) NumberValue {
+func (v UInt32Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8139,7 +8139,7 @@ func (v UInt64Value) SaturatingMinus(other NumberValue) NumberValue {
 	return diff
 }
 
-func (v UInt64Value) Mod(other NumberValue) NumberValue {
+func (v UInt64Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9179,7 +9179,7 @@ func (v UInt256Value) SaturatingMinus(other NumberValue) NumberValue {
 	return UInt256Value{diff}
 }
 
-func (v UInt256Value) Mod(other NumberValue) NumberValue {
+func (v UInt256Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9618,7 +9618,7 @@ func (v Word8Value) SaturatingMinus(_ NumberValue) NumberValue {
 	panic(errors.UnreachableError{})
 }
 
-func (v Word8Value) Mod(other NumberValue) NumberValue {
+func (v Word8Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9966,7 +9966,7 @@ func (v Word16Value) SaturatingMinus(_ NumberValue) NumberValue {
 	panic(errors.UnreachableError{})
 }
 
-func (v Word16Value) Mod(other NumberValue) NumberValue {
+func (v Word16Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10317,7 +10317,7 @@ func (v Word32Value) SaturatingMinus(_ NumberValue) NumberValue {
 	panic(errors.UnreachableError{})
 }
 
-func (v Word32Value) Mod(other NumberValue) NumberValue {
+func (v Word32Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10693,7 +10693,7 @@ func (v Word64Value) SaturatingMinus(_ NumberValue) NumberValue {
 	panic(errors.UnreachableError{})
 }
 
-func (v Word64Value) Mod(other NumberValue) NumberValue {
+func (v Word64Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11210,7 +11210,7 @@ func (v Fix64Value) SaturatingDiv(other NumberValue) NumberValue {
 	return Fix64Value(result.Int64())
 }
 
-func (v Fix64Value) Mod(other NumberValue) NumberValue {
+func (v Fix64Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11230,7 +11230,8 @@ func (v Fix64Value) Mod(other NumberValue) NumberValue {
 		})
 	}
 	truncatedQuotient := (int64(quotient) / sema.Fix64Factor) * sema.Fix64Factor
-	return v.Minus(Fix64Value(truncatedQuotient).Mul(nil, o))
+	return v.Minus(Fix64Value(truncatedQuotient).
+		Mul(interpreter, o))
 }
 
 func (v Fix64Value) Less(other NumberValue) BoolValue {
@@ -11631,7 +11632,7 @@ func (v UFix64Value) SaturatingDiv(other NumberValue) NumberValue {
 	return v.Div(other)
 }
 
-func (v UFix64Value) Mod(other NumberValue) NumberValue {
+func (v UFix64Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11651,7 +11652,8 @@ func (v UFix64Value) Mod(other NumberValue) NumberValue {
 		})
 	}
 	truncatedQuotient := (uint64(quotient) / sema.Fix64Factor) * sema.Fix64Factor
-	return v.Minus(UFix64Value(truncatedQuotient).Mul(nil, o))
+	return v.Minus(UFix64Value(truncatedQuotient).
+		Mul(interpreter, o))
 }
 
 func (v UFix64Value) Less(other NumberValue) BoolValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2591,7 +2591,7 @@ func (v IntValue) ToInt() int {
 }
 
 func (v IntValue) ByteLength() int {
-	return len(v.BigInt.Bits())
+	return common.BigIntByteLength(v.BigInt)
 }
 
 func (v IntValue) ToBigInt() *big.Int {
@@ -2609,7 +2609,9 @@ func (v IntValue) RecursiveString(_ SeenReferences) string {
 func (v IntValue) Negate(interpreter *Interpreter) NumberValue {
 	return NewIntValueFromBigInt(
 		interpreter,
-		common.NewBigIntMemoryUsage(len(v.BigInt.Bits())),
+		common.NewBigIntMemoryUsage(
+			common.BigIntByteLength(v.BigInt),
+		),
 		func() *big.Int {
 			return new(big.Int).Neg(v.BigInt)
 		},
@@ -5063,7 +5065,7 @@ func (v Int128Value) ToInt() int {
 }
 
 func (v Int128Value) ByteLength() int {
-	return len(v.BigInt.Bits())
+	return common.BigIntByteLength(v.BigInt)
 }
 
 func (v Int128Value) ToBigInt() *big.Int {
@@ -5649,7 +5651,7 @@ func (v Int256Value) ToInt() int {
 }
 
 func (v Int256Value) ByteLength() int {
-	return len(v.BigInt.Bits())
+	return common.BigIntByteLength(v.BigInt)
 }
 
 func (v Int256Value) ToBigInt() *big.Int {
@@ -6290,7 +6292,7 @@ func (v UIntValue) ToInt() int {
 }
 
 func (v UIntValue) ByteLength() int {
-	return len(v.BigInt.Bits())
+	return common.BigIntByteLength(v.BigInt)
 }
 
 func (v UIntValue) ToBigInt() *big.Int {
@@ -8561,7 +8563,7 @@ func (v UInt128Value) ToInt() int {
 }
 
 func (v UInt128Value) ByteLength() int {
-	return len(v.BigInt.Bits())
+	return common.BigIntByteLength(v.BigInt)
 }
 
 func (v UInt128Value) ToBigInt() *big.Int {
@@ -9101,7 +9103,7 @@ func (v UInt256Value) ToInt() int {
 }
 
 func (v UInt256Value) ByteLength() int {
-	return len(v.BigInt.Bits())
+	return common.BigIntByteLength(v.BigInt)
 }
 
 func (v UInt256Value) ToBigInt() *big.Int {

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -900,7 +900,7 @@ func TestStringer(t *testing.T) {
 					Type: PrimitiveStaticTypeAnyStruct,
 				},
 				common.Address{},
-				NewIntValueFromInt64(10),
+				NewUnmeteredIntValueFromInt64(10),
 				NewUnmeteredStringValue("TEST"),
 			),
 			expected: "[10, \"TEST\"]",
@@ -1066,7 +1066,7 @@ func TestVisitor(t *testing.T) {
 	}
 
 	var value Value
-	value = NewIntValueFromInt64(42)
+	value = NewUnmeteredIntValueFromInt64(42)
 	value = NewUnmeteredSomeValueNonCopying(value)
 	value = NewArrayValue(
 		inter,
@@ -1203,15 +1203,15 @@ func TestGetHashInput(t *testing.T) {
 			expected: append([]byte{byte(HashInputTypeUInt256)}, sema.UInt256TypeMaxIntBig.Bytes()...),
 		},
 		"Int": {
-			value:    NewIntValueFromInt64(10),
+			value:    NewUnmeteredIntValueFromInt64(10),
 			expected: []byte{byte(HashInputTypeInt), 10},
 		},
 		"Int small": {
-			value:    NewIntValueFromBigInt(sema.Int256TypeMinIntBig),
+			value:    NewUnmeteredIntValueFromBigInt(sema.Int256TypeMinIntBig),
 			expected: append([]byte{byte(HashInputTypeInt)}, sema.Int256TypeMinIntBig.Bytes()...),
 		},
 		"Int large": {
-			value:    NewIntValueFromBigInt(sema.Int256TypeMaxIntBig),
+			value:    NewUnmeteredIntValueFromBigInt(sema.Int256TypeMaxIntBig),
 			expected: append([]byte{byte(HashInputTypeInt)}, sema.Int256TypeMaxIntBig.Bytes()...),
 		},
 		"Int8": {
@@ -3150,9 +3150,9 @@ func TestPublicKeyValue(t *testing.T) {
 				Type: PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			NewIntValueFromInt64(1),
-			NewIntValueFromInt64(7),
-			NewIntValueFromInt64(3),
+			NewUnmeteredIntValueFromInt64(1),
+			NewUnmeteredIntValueFromInt64(7),
+			NewUnmeteredIntValueFromInt64(3),
 		)
 
 		sigAlgo := stdlib.NewSignatureAlgorithmCase(
@@ -3202,9 +3202,9 @@ func TestPublicKeyValue(t *testing.T) {
 				Type: PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			NewIntValueFromInt64(int64(publicKeyBytes[0])),
-			NewIntValueFromInt64(int64(publicKeyBytes[1])),
-			NewIntValueFromInt64(int64(publicKeyBytes[2])),
+			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[0])),
+			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[1])),
+			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[2])),
 		)
 
 		sigAlgo := stdlib.NewSignatureAlgorithmCase(

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -794,7 +794,7 @@ func TestStringer(t *testing.T) {
 
 	stringerTests := map[string]testCase{
 		"UInt": {
-			value:    NewUIntValueFromUint64(10),
+			value:    NewUnmeteredUIntValueFromUint64(10),
 			expected: "10",
 		},
 		"UInt8": {
@@ -1119,15 +1119,15 @@ func TestGetHashInput(t *testing.T) {
 
 	stringerTests := map[string]testCase{
 		"UInt": {
-			value:    NewUIntValueFromUint64(10),
+			value:    NewUnmeteredUIntValueFromUint64(10),
 			expected: []byte{byte(HashInputTypeUInt), 10},
 		},
 		"UInt min": {
-			value:    NewUIntValueFromUint64(0),
+			value:    NewUnmeteredUIntValueFromUint64(0),
 			expected: []byte{byte(HashInputTypeUInt), 0},
 		},
 		"UInt large": {
-			value:    NewUIntValueFromBigInt(sema.UInt256TypeMaxIntBig),
+			value:    NewUnmeteredUIntValueFromBigInt(sema.UInt256TypeMaxIntBig),
 			expected: append([]byte{byte(HashInputTypeUInt)}, sema.UInt256TypeMaxIntBig.Bytes()...),
 		},
 		"UInt8": {
@@ -3050,7 +3050,7 @@ func TestNumberValue_Equal(t *testing.T) {
 	t.Parallel()
 
 	testValues := map[string]EquatableValue{
-		"UInt":    NewUIntValueFromUint64(10),
+		"UInt":    NewUnmeteredUIntValueFromUint64(10),
 		"UInt8":   UInt8Value(8),
 		"UInt16":  UInt16Value(16),
 		"UInt32":  UInt32Value(32),

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -175,7 +175,11 @@ func integerLiteralValue(
 		},
 	)
 
-	convertedValue, err := convertIntValue(intValue, ty)
+	convertedValue, err := convertIntValue(
+		memoryGauge,
+		intValue,
+		ty,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +187,14 @@ func integerLiteralValue(
 	return ExportValue(convertedValue, nil)
 }
 
-func convertIntValue(intValue interpreter.IntValue, ty sema.Type) (interpreter.Value, error) {
+func convertIntValue(
+	memoryGauge common.MemoryGauge,
+	intValue interpreter.IntValue,
+	ty sema.Type,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	switch ty {
 	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
@@ -202,7 +213,7 @@ func convertIntValue(intValue interpreter.IntValue, ty sema.Type) (interpreter.V
 		return interpreter.ConvertInt256(intValue), nil
 
 	case sema.UIntType:
-		return interpreter.ConvertUInt(intValue), nil
+		return interpreter.ConvertUInt(memoryGauge, intValue), nil
 	case sema.UInt8Type:
 		return interpreter.ConvertUInt8(intValue), nil
 	case sema.UInt16Type:

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -3518,7 +3518,7 @@ func NewAccountKeyValue(
 ) interpreter.Value {
 	return interpreter.NewAccountKeyValue(
 		inter,
-		interpreter.NewIntValueFromInt64(int64(accountKey.KeyIndex)),
+		interpreter.NewIntValueFromInt64(inter, int64(accountKey.KeyIndex)),
 		NewPublicKeyValue(
 			inter,
 			getLocationRange,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3315,7 +3315,7 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 			"helloMultiArg",
 			[]interpreter.Value{
 				interpreter.NewUnmeteredStringValue("number"),
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				interpreter.AddressValue(addressValue),
 			},
 			[]sema.Type{
@@ -3342,7 +3342,7 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 			"helloMultiArg",
 			[]interpreter.Value{
 				interpreter.NewUnmeteredStringValue("number"),
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 			},
 			[]sema.Type{
 				sema.StringType,
@@ -3366,7 +3366,7 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 			},
 			"helloArg",
 			[]interpreter.Value{
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 			},
 			[]sema.Type{
 				sema.IntType,

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -675,7 +675,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 
@@ -812,7 +812,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -33,7 +33,7 @@ import (
 
 var integerTestValues = map[string]interpreter.NumberValue{
 	// Int*
-	"Int":    interpreter.NewIntValueFromInt64(60),
+	"Int":    interpreter.NewUnmeteredIntValueFromInt64(60),
 	"Int8":   interpreter.Int8Value(60),
 	"Int16":  interpreter.Int16Value(60),
 	"Int32":  interpreter.Int32Value(60),

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -41,7 +41,7 @@ var integerTestValues = map[string]interpreter.NumberValue{
 	"Int128": interpreter.NewInt128ValueFromInt64(60),
 	"Int256": interpreter.NewInt256ValueFromInt64(60),
 	// UInt*
-	"UInt":    interpreter.NewUIntValueFromUint64(60),
+	"UInt":    interpreter.NewUnmeteredUIntValueFromUint64(60),
 	"UInt8":   interpreter.UInt8Value(60),
 	"UInt16":  interpreter.UInt16Value(60),
 	"UInt32":  interpreter.UInt32Value(60),
@@ -550,9 +550,9 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 		sema.UIntType: {
 			subtract: testCalls{
 				underflow: testCall{
-					interpreter.NewUIntValueFromBigInt(sema.UIntTypeMin),
-					interpreter.NewUIntValueFromUint64(2),
-					interpreter.NewUIntValueFromBigInt(sema.UIntTypeMin),
+					interpreter.NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
+					interpreter.NewUnmeteredUIntValueFromUint64(2),
+					interpreter.NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
 				},
 			},
 		},

--- a/runtime/tests/interpreter/bitwise_test.go
+++ b/runtime/tests/interpreter/bitwise_test.go
@@ -30,7 +30,7 @@ import (
 var bitwiseTestValueFunctions = map[string]func(int) interpreter.NumberValue{
 	// Int*
 	"Int": func(v int) interpreter.NumberValue {
-		return interpreter.NewIntValueFromInt64(int64(v))
+		return interpreter.NewUnmeteredIntValueFromInt64(int64(v))
 	},
 	"Int8": func(v int) interpreter.NumberValue {
 		return interpreter.Int8Value(v)

--- a/runtime/tests/interpreter/bitwise_test.go
+++ b/runtime/tests/interpreter/bitwise_test.go
@@ -52,7 +52,7 @@ var bitwiseTestValueFunctions = map[string]func(int) interpreter.NumberValue{
 	},
 	// UInt*
 	"UInt": func(v int) interpreter.NumberValue {
-		return interpreter.NewUIntValueFromUint64(uint64(v))
+		return interpreter.NewUnmeteredUIntValueFromUint64(uint64(v))
 	},
 	"UInt8": func(v int) interpreter.NumberValue {
 		return interpreter.UInt8Value(v)

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -150,7 +150,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 		})
@@ -202,7 +202,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 		})
@@ -237,7 +237,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 		})
@@ -375,7 +375,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 		})
@@ -427,7 +427,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 		})
@@ -462,7 +462,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			RequireValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(42),
+				interpreter.NewUnmeteredIntValueFromInt64(42),
 				value,
 			)
 		})

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -49,12 +49,12 @@ func TestInterpretFunctionPreCondition(t *testing.T) {
 
 	_, err := inter.Invoke(
 		"test",
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
-	zero := interpreter.NewIntValueFromInt64(0)
+	zero := interpreter.NewUnmeteredIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
@@ -77,12 +77,12 @@ func TestInterpretFunctionPostCondition(t *testing.T) {
 
 	_, err := inter.Invoke(
 		"test",
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
-	zero := interpreter.NewIntValueFromInt64(0)
+	zero := interpreter.NewUnmeteredIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
@@ -104,13 +104,13 @@ func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
 
 	_, err := inter.Invoke(
 		"test",
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
 
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
-	zero := interpreter.NewIntValueFromInt64(0)
+	zero := interpreter.NewUnmeteredIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
@@ -244,7 +244,7 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 
 	_, err := inter.Invoke(
 		"test",
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
 
 	var conditionErr interpreter.ConditionError
@@ -255,7 +255,7 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 		conditionErr.Message,
 	)
 
-	zero := interpreter.NewIntValueFromInt64(0)
+	zero := interpreter.NewUnmeteredIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
@@ -283,7 +283,7 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 
 	_, err := inter.Invoke(
 		"test",
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
@@ -293,7 +293,7 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 		conditionErr.Message,
 	)
 
-	zero := interpreter.NewIntValueFromInt64(0)
+	zero := interpreter.NewUnmeteredIntValueFromInt64(0)
 	value, err := inter.Invoke("test", zero)
 	require.NoError(t, err)
 
@@ -427,22 +427,22 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			_, err = inter.Invoke("callTest", interpreter.NewIntValueFromInt64(0))
+			_, err = inter.Invoke("callTest", interpreter.NewUnmeteredIntValueFromInt64(0))
 
 			var conditionErr interpreter.ConditionError
 			require.ErrorAs(t, err, &conditionErr)
 
-			value, err := inter.Invoke("callTest", interpreter.NewIntValueFromInt64(1))
+			value, err := inter.Invoke("callTest", interpreter.NewUnmeteredIntValueFromInt64(1))
 			require.NoError(t, err)
 
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 				value,
 			)
 
-			_, err = inter.Invoke("callTest", interpreter.NewIntValueFromInt64(2))
+			_, err = inter.Invoke("callTest", interpreter.NewUnmeteredIntValueFromInt64(2))
 
 			require.ErrorAs(t, err, &conditionErr)
 		})
@@ -555,7 +555,7 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 							interpreter.WithStorage(storage),
 							makeContractValueHandler(
 								[]interpreter.Value{
-									interpreter.NewIntValueFromInt64(value),
+									interpreter.NewUnmeteredIntValueFromInt64(value),
 								},
 								[]sema.Type{
 									sema.IntType,
@@ -587,7 +587,7 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 						err = inter.Interpret()
 						require.NoError(t, err)
 
-						_, err = inter.Invoke("test", interpreter.NewIntValueFromInt64(value))
+						_, err = inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(value))
 						check(err)
 					}
 				})
@@ -646,7 +646,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("-1", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(-1))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(-1))
 
 		var conditionErr interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)
@@ -658,7 +658,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	})
 
 	t.Run("0", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(0))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(0))
 
 		var conditionErr interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)
@@ -667,7 +667,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	})
 
 	t.Run("1", func(t *testing.T) {
-		value, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
+		value, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(1))
 		require.NoError(t, err)
 
 		assert.IsType(t,
@@ -677,7 +677,7 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 	})
 
 	t.Run("2", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(2))
 		require.IsType(t,
 			interpreter.Error{},
 			err,
@@ -726,7 +726,7 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
     `)
 
 	t.Run("1", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(1))
 		require.Error(t, err)
 
 		require.IsType(t,
@@ -745,12 +745,12 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 	})
 
 	t.Run("2", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(2))
 		require.NoError(t, err)
 	})
 
 	t.Run("3", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(3))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(3))
 		require.Error(t, err)
 
 		require.IsType(t,
@@ -821,7 +821,7 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 	require.NoError(t, err)
 
 	t.Run("1", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(1))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(1))
 		require.Error(t, err)
 
 		require.IsType(t,
@@ -840,12 +840,12 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 	})
 
 	t.Run("2", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(2))
 		require.NoError(t, err)
 	})
 
 	t.Run("3", func(t *testing.T) {
-		_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(3))
+		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(3))
 		require.Error(t, err)
 
 		require.IsType(t,

--- a/runtime/tests/interpreter/declaration_test.go
+++ b/runtime/tests/interpreter/declaration_test.go
@@ -100,7 +100,7 @@ func TestInterpretShadowingInFunction(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		result,
 	)
 }

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -52,7 +52,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 
 	tests := []test{
 		{sema.IntType, "42", interpreter.NewUnmeteredIntValueFromInt64(42)},
-		{sema.UIntType, "42", interpreter.NewUIntValueFromUint64(42)},
+		{sema.UIntType, "42", interpreter.NewUnmeteredUIntValueFromUint64(42)},
 		{sema.Int8Type, "42", interpreter.Int8Value(42)},
 		{sema.Int16Type, "42", interpreter.Int16Value(42)},
 		{sema.Int32Type, "42", interpreter.Int32Value(42)},

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -51,7 +51,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 	}
 
 	tests := []test{
-		{sema.IntType, "42", interpreter.NewIntValueFromInt64(42)},
+		{sema.IntType, "42", interpreter.NewUnmeteredIntValueFromInt64(42)},
 		{sema.UIntType, "42", interpreter.NewUIntValueFromUint64(42)},
 		{sema.Int8Type, "42", interpreter.Int8Value(42)},
 		{sema.Int16Type, "42", interpreter.Int16Value(42)},
@@ -1071,7 +1071,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 						)
 
 						expectedValue := interpreter.NewUnmeteredSomeValueNonCopying(
-							interpreter.NewIntValueFromInt64(42),
+							interpreter.NewUnmeteredIntValueFromInt64(42),
 						)
 
 						AssertValuesEqual(
@@ -1179,7 +1179,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 						)
 
 						expectedElements := []interpreter.Value{
-							interpreter.NewIntValueFromInt64(42),
+							interpreter.NewUnmeteredIntValueFromInt64(42),
 						}
 
 						yValue := inter.Globals["y"].GetValue()
@@ -1327,7 +1327,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 								KeyType:   interpreter.PrimitiveStaticTypeString,
 								ValueType: interpreter.PrimitiveStaticTypeInt,
 							},
-							interpreter.NewUnmeteredStringValue("test"), interpreter.NewIntValueFromInt64(42),
+							interpreter.NewUnmeteredStringValue("test"), interpreter.NewUnmeteredIntValueFromInt64(42),
 						)
 
 						AssertValuesEqual(

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -48,7 +48,7 @@ func TestInterpretForStatement(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(10),
+		interpreter.NewUnmeteredIntValueFromInt64(10),
 		value,
 	)
 }
@@ -73,7 +73,7 @@ func TestInterpretForStatementWithIndex(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(6),
+		interpreter.NewUnmeteredIntValueFromInt64(6),
 		value,
 	)
 }
@@ -102,7 +102,7 @@ func TestInterpretForStatementWithStoredIndex(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(6),
+		interpreter.NewUnmeteredIntValueFromInt64(6),
 		value,
 	)
 }
@@ -128,7 +128,7 @@ func TestInterpretForStatementWithReturn(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(4),
+		interpreter.NewUnmeteredIntValueFromInt64(4),
 		value,
 	)
 }
@@ -160,8 +160,8 @@ func TestInterpretForStatementWithContinue(t *testing.T) {
 		t,
 		inter,
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(4),
-			interpreter.NewIntValueFromInt64(5),
+			interpreter.NewUnmeteredIntValueFromInt64(4),
+			interpreter.NewUnmeteredIntValueFromInt64(5),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -190,7 +190,7 @@ func TestInterpretForStatementWithBreak(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(4),
+		interpreter.NewUnmeteredIntValueFromInt64(4),
 		value,
 	)
 }

--- a/runtime/tests/interpreter/if_test.go
+++ b/runtime/tests/interpreter/if_test.go
@@ -105,7 +105,7 @@ func TestInterpretIfStatement(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(expected),
+				interpreter.NewUnmeteredIntValueFromInt64(expected),
 				value,
 			)
 		})
@@ -133,19 +133,19 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 	t.Run("2", func(t *testing.T) {
 		value, err := inter.Invoke(
 			"test",
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		)
 		require.NoError(t, err)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 			inter.Globals["branch"].GetValue(),
 		)
 	})
@@ -156,13 +156,13 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(0),
+			interpreter.NewUnmeteredIntValueFromInt64(0),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 			inter.Globals["branch"].GetValue(),
 		)
 	})
@@ -188,19 +188,19 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 	t.Run("2", func(t *testing.T) {
 		value, err := inter.Invoke(
 			"test",
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		)
 		require.NoError(t, err)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 			inter.Globals["branch"].GetValue(),
 		)
 	})
@@ -211,13 +211,13 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(0),
+			interpreter.NewUnmeteredIntValueFromInt64(0),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 			inter.Globals["branch"].GetValue(),
 		)
 
@@ -245,21 +245,21 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 	t.Run("2", func(t *testing.T) {
 		value, err := inter.Invoke(
 			"test",
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		)
 		require.NoError(t, err)
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 			inter.Globals["branch"].GetValue(),
 		)
 	})
@@ -272,14 +272,14 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(0),
+				interpreter.NewUnmeteredIntValueFromInt64(0),
 			),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 			inter.Globals["branch"].GetValue(),
 		)
 	})
@@ -306,21 +306,21 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 	t.Run("2", func(t *testing.T) {
 		value, err := inter.Invoke(
 			"test",
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		)
 		require.NoError(t, err)
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 			inter.Globals["branch"].GetValue(),
 		)
 
@@ -333,14 +333,14 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 			t,
 			inter,
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(0),
+				interpreter.NewUnmeteredIntValueFromInt64(0),
 			),
 			value,
 		)
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 			inter.Globals["branch"].GetValue(),
 		)
 	})

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -313,7 +313,7 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		value,
 	)
 }

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -43,7 +43,7 @@ var testIntegerTypesAndValues = map[string]interpreter.Value{
 	"Int128": interpreter.NewInt128ValueFromInt64(50),
 	"Int256": interpreter.NewInt256ValueFromInt64(50),
 	// UInt*
-	"UInt":    interpreter.NewUIntValueFromUint64(50),
+	"UInt":    interpreter.NewUnmeteredUIntValueFromUint64(50),
 	"UInt8":   interpreter.UInt8Value(50),
 	"UInt16":  interpreter.UInt16Value(50),
 	"UInt32":  interpreter.UInt32Value(50),
@@ -523,14 +523,14 @@ func TestInterpretIntegerConversion(t *testing.T) {
 			}(),
 		},
 		sema.UIntType: {
-			fortyTwo: interpreter.NewUIntValueFromUint64(42),
-			min:      interpreter.NewUIntValueFromUint64(0),
+			fortyTwo: interpreter.NewUnmeteredUIntValueFromUint64(42),
+			min:      interpreter.NewUnmeteredUIntValueFromUint64(0),
 			// UInt does not actually have a maximum, but create a "large" value,
 			// which can be used for testing against other types
 			max: func() interpreter.Value {
 				i := big.NewInt(1)
 				i.Lsh(i, 1000)
-				return interpreter.NewUIntValueFromBigInt(i)
+				return interpreter.NewUnmeteredUIntValueFromBigInt(i)
 			}(),
 		},
 		sema.UInt8Type: {
@@ -705,7 +705,7 @@ func TestInterpretIntegerMinMax(t *testing.T) {
 	testCases := map[sema.Type]testCase{
 		sema.IntType: {},
 		sema.UIntType: {
-			min: interpreter.NewUIntValueFromUint64(0),
+			min: interpreter.NewUnmeteredUIntValueFromUint64(0),
 		},
 		sema.UInt8Type: {
 			min: interpreter.UInt8Value(0),

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -35,7 +35,7 @@ import (
 
 var testIntegerTypesAndValues = map[string]interpreter.Value{
 	// Int*
-	"Int":    interpreter.NewIntValueFromInt64(50),
+	"Int":    interpreter.NewUnmeteredIntValueFromInt64(50),
 	"Int8":   interpreter.Int8Value(50),
 	"Int16":  interpreter.Int16Value(50),
 	"Int32":  interpreter.Int32Value(50),
@@ -506,20 +506,20 @@ func TestInterpretIntegerConversion(t *testing.T) {
 
 	testValues := map[*sema.NumericType]values{
 		sema.IntType: {
-			fortyTwo: interpreter.NewIntValueFromInt64(42),
+			fortyTwo: interpreter.NewUnmeteredIntValueFromInt64(42),
 			// Int does not actually have a minimum, but create a "large" value,
 			// which can be used for testing against other types
 			min: func() interpreter.Value {
 				i := big.NewInt(-1)
 				i.Lsh(i, 1000)
-				return interpreter.NewIntValueFromBigInt(i)
+				return interpreter.NewUnmeteredIntValueFromBigInt(i)
 			}(),
 			// Int does not actually have a maximum, but create a "large" value,
 			// which can be used for testing against other types
 			max: func() interpreter.Value {
 				i := big.NewInt(1)
 				i.Lsh(i, 1000)
-				return interpreter.NewIntValueFromBigInt(i)
+				return interpreter.NewUnmeteredIntValueFromBigInt(i)
 			}(),
 		},
 		sema.UIntType: {

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -280,7 +280,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				numberValue.Plus(numberValue),
+				numberValue.Plus(inter, numberValue),
 				inter.Globals["x"].GetValue(),
 			)
 		})
@@ -323,7 +323,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(
-					numberValue.Plus(numberValue),
+					numberValue.Plus(inter, numberValue),
 				),
 				inter.Globals["x"].GetValue(),
 			)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6716,7 +6716,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		},
 		// UInt*
 		"UInt": {
-			value: interpreter.NewUIntValueFromUint64(42),
+			value: interpreter.NewUnmeteredUIntValueFromUint64(42),
 			ty:    sema.UIntType,
 		},
 		"UInt8": {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -247,7 +247,7 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		inter.Globals["x"].GetValue(),
 	)
 
@@ -261,7 +261,7 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		inter.Globals["z"].GetValue(),
 	)
 
@@ -281,8 +281,8 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
 		inter.Globals["b"].GetValue(),
 	)
@@ -311,7 +311,7 @@ func TestInterpretDeclarations(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		value,
 	)
 }
@@ -360,7 +360,7 @@ func TestInterpretLexicalScope(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(10),
+		interpreter.NewUnmeteredIntValueFromInt64(10),
 		inter.Globals["x"].GetValue(),
 	)
 
@@ -370,7 +370,7 @@ func TestInterpretLexicalScope(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(10),
+		interpreter.NewUnmeteredIntValueFromInt64(10),
 		value,
 	)
 
@@ -380,7 +380,7 @@ func TestInterpretLexicalScope(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(10),
+		interpreter.NewUnmeteredIntValueFromInt64(10),
 		value,
 	)
 }
@@ -397,7 +397,7 @@ func TestInterpretFunctionSideEffects(t *testing.T) {
        }
     `)
 
-	newValue := interpreter.NewIntValueFromInt64(42)
+	newValue := interpreter.NewUnmeteredIntValueFromInt64(42)
 
 	value, err := inter.Invoke("test", newValue)
 	require.NoError(t, err)
@@ -439,14 +439,14 @@ func TestInterpretNoHoisting(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		value,
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -465,14 +465,14 @@ func TestInterpretFunctionExpressionsAndScope(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(10),
+		interpreter.NewUnmeteredIntValueFromInt64(10),
 		inter.Globals["x"].GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -495,7 +495,7 @@ func TestInterpretVariableAssignment(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		value,
 	)
 }
@@ -516,7 +516,7 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["x"].GetValue(),
 	)
 
@@ -526,14 +526,14 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		value,
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -554,7 +554,7 @@ func TestInterpretConstantRedeclaration(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["x"].GetValue(),
 	)
 
@@ -564,7 +564,7 @@ func TestInterpretConstantRedeclaration(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		value,
 	)
 }
@@ -583,8 +583,8 @@ func TestInterpretParameters(t *testing.T) {
        }
     `)
 
-	a := interpreter.NewIntValueFromInt64(24)
-	b := interpreter.NewIntValueFromInt64(42)
+	a := interpreter.NewUnmeteredIntValueFromInt64(24)
+	b := interpreter.NewUnmeteredIntValueFromInt64(42)
 
 	value, err := inter.Invoke("returnA", a, b)
 	require.NoError(t, err)
@@ -618,7 +618,7 @@ func TestInterpretArrayIndexing(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		value,
 	)
 }
@@ -641,7 +641,7 @@ func TestInterpretInvalidArrayIndexing(t *testing.T) {
                }
             `)
 
-			indexValue := interpreter.NewIntValueFromInt64(int64(index))
+			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
@@ -688,8 +688,8 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 			Type: interpreter.PrimitiveStaticTypeInt,
 		},
 		common.Address{},
-		interpreter.NewIntValueFromInt64(0),
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
 	RequireValuesEqual(
@@ -718,7 +718,7 @@ func TestInterpretInvalidArrayIndexingAssignment(t *testing.T) {
                }
             `)
 
-			indexValue := interpreter.NewIntValueFromInt64(int64(index))
+			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
@@ -791,7 +791,7 @@ func TestInterpretInvalidStringIndexing(t *testing.T) {
                }
             `)
 
-			indexValue := interpreter.NewIntValueFromInt64(int64(index))
+			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
 
 			var indexErr interpreter.StringIndexOutOfBoundsError
@@ -1015,7 +1015,7 @@ func TestInterpretReturns(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		value,
 	)
 }
@@ -1563,7 +1563,7 @@ func TestInterpretExpressionStatement(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["x"].GetValue(),
 	)
 
@@ -1573,14 +1573,14 @@ func TestInterpretExpressionStatement(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		value,
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -1605,7 +1605,7 @@ func TestInterpretConditionalOperator(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		value,
 	)
 
@@ -1615,7 +1615,7 @@ func TestInterpretConditionalOperator(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		value,
 	)
 }
@@ -1653,14 +1653,14 @@ func TestInterpretRecursionFib(t *testing.T) {
 
 	value, err := inter.Invoke(
 		"fib",
-		interpreter.NewIntValueFromInt64(14),
+		interpreter.NewUnmeteredIntValueFromInt64(14),
 	)
 	require.NoError(t, err)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(377),
+		interpreter.NewUnmeteredIntValueFromInt64(377),
 		value,
 	)
 }
@@ -1681,14 +1681,14 @@ func TestInterpretRecursionFactorial(t *testing.T) {
 
 	value, err := inter.Invoke(
 		"factorial",
-		interpreter.NewIntValueFromInt64(5),
+		interpreter.NewUnmeteredIntValueFromInt64(5),
 	)
 	require.NoError(t, err)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(120),
+		interpreter.NewUnmeteredIntValueFromInt64(120),
 		value,
 	)
 }
@@ -1705,14 +1705,14 @@ func TestInterpretUnaryIntegerNegation(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(-2),
+		interpreter.NewUnmeteredIntValueFromInt64(-2),
 		inter.Globals["x"].GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -1792,7 +1792,7 @@ func TestInterpretHostFunction(t *testing.T) {
 			a := invocation.Arguments[0].(interpreter.IntValue).ToBigInt()
 			b := invocation.Arguments[1].(interpreter.IntValue).ToBigInt()
 			value := new(big.Int).Add(a, b)
-			return interpreter.NewIntValueFromBigInt(value)
+			return interpreter.NewUnmeteredIntValueFromBigInt(value)
 		},
 	)
 
@@ -1830,7 +1830,7 @@ func TestInterpretHostFunction(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		inter.Globals["a"].GetValue(),
 	)
 }
@@ -1879,7 +1879,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 				invocation.Arguments[0],
 			)
 
@@ -2141,7 +2141,7 @@ func TestInterpretStructureDeclarationWithField(t *testing.T) {
       }
     `)
 
-	newValue := interpreter.NewIntValueFromInt64(42)
+	newValue := interpreter.NewUnmeteredIntValueFromInt64(42)
 
 	value, err := inter.Invoke("test", newValue)
 	require.NoError(t, err)
@@ -2170,7 +2170,7 @@ func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
       }
     `)
 
-	newValue := interpreter.NewIntValueFromInt64(42)
+	newValue := interpreter.NewUnmeteredIntValueFromInt64(42)
 
 	value, err := inter.Invoke("test", newValue)
 	require.NoError(t, err)
@@ -2208,7 +2208,7 @@ func TestInterpretStructureFunctionCall(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		inter.Globals["value"].GetValue(),
 	)
 }
@@ -2246,7 +2246,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		test.GetField(inter, interpreter.ReturnEmptyLocationRange, "foo"),
 	)
 
@@ -2263,7 +2263,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		test.GetField(inter, interpreter.ReturnEmptyLocationRange, "foo"),
 	)
 }
@@ -2289,7 +2289,7 @@ func TestInterpretStructureInitializesConstant(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		actual,
 	)
 }
@@ -2325,7 +2325,7 @@ func TestInterpretStructureFunctionMutatesSelf(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		value,
 	)
 }
@@ -2612,8 +2612,8 @@ func TestInterpretArrayCopy(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(0),
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(0),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		value,
 	)
@@ -2652,9 +2652,9 @@ func TestInterpretStructCopyInArray(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		value,
 	)
@@ -2680,7 +2680,7 @@ func TestInterpretMutuallyRecursiveFunctions(t *testing.T) {
       }
     `)
 
-	four := interpreter.NewIntValueFromInt64(4)
+	four := interpreter.NewUnmeteredIntValueFromInt64(4)
 
 	value, err := inter.Invoke("isEven", four)
 	require.NoError(t, err)
@@ -2724,7 +2724,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["tests"].GetValue(),
 	)
 
@@ -2739,7 +2739,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		inter.Globals["tests"].GetValue(),
 	)
 
@@ -2754,7 +2754,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["tests"].GetValue(),
 	)
 }
@@ -2772,7 +2772,7 @@ func TestInterpretOptionalVariableDeclaration(t *testing.T) {
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
 		inter.Globals["x"].GetValue(),
@@ -2791,7 +2791,7 @@ func TestInterpretOptionalParameterInvokedExternal(t *testing.T) {
 
 	value, err := inter.Invoke(
 		"test",
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 	require.NoError(t, err)
 
@@ -2800,7 +2800,7 @@ func TestInterpretOptionalParameterInvokedExternal(t *testing.T) {
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
 		value,
@@ -2829,7 +2829,7 @@ func TestInterpretOptionalParameterInvokedInternal(t *testing.T) {
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
 		value,
@@ -2846,7 +2846,7 @@ func TestInterpretOptionalReturn(t *testing.T) {
       }
     `)
 
-	value, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(2))
+	value, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(2))
 	require.NoError(t, err)
 
 	AssertValuesEqual(
@@ -2854,7 +2854,7 @@ func TestInterpretOptionalReturn(t *testing.T) {
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
 		value,
@@ -2888,7 +2888,7 @@ func TestInterpretOptionalAssignment(t *testing.T) {
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
 		inter.Globals["x"].GetValue(),
@@ -2966,7 +2966,7 @@ func TestInterpretSomeReturnValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		value,
 	)
@@ -2990,7 +2990,7 @@ func TestInterpretSomeReturnValueFromDictionary(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		value,
 	)
@@ -3010,7 +3010,7 @@ func TestInterpretNilCoalescingNilIntToOptional(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
 	)
@@ -3030,7 +3030,7 @@ func TestInterpretNilCoalescingNilIntToOptionals(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
 	)
@@ -3049,7 +3049,7 @@ func TestInterpretNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
 	)
@@ -3084,7 +3084,7 @@ func TestInterpretNilCoalescingNilInt(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -3101,7 +3101,7 @@ func TestInterpretNilCoalescingNilLiteralInt(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -3130,7 +3130,7 @@ func TestInterpretNilCoalescingShortCircuitLeftSuccess(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		inter.Globals["test"].GetValue(),
 	)
 
@@ -3173,7 +3173,7 @@ func TestInterpretNilCoalescingShortCircuitLeftFailure(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["test"].GetValue(),
 	)
 
@@ -3221,7 +3221,7 @@ func TestInterpretNilCoalescingOptionalAnyStructSome(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -3240,7 +3240,7 @@ func TestInterpretNilCoalescingOptionalRightHandSide(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["z"].GetValue(),
 	)
@@ -3260,7 +3260,7 @@ func TestInterpretNilCoalescingBothOptional(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["z"].GetValue(),
 	)
@@ -3280,7 +3280,7 @@ func TestInterpretNilCoalescingBothOptionalLeftNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
 		inter.Globals["z"].GetValue(),
 	)
@@ -3708,7 +3708,7 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 					Options: []interpreter.Option{
 						makeContractValueHandler(
 							[]interpreter.Value{
-								interpreter.NewIntValueFromInt64(1),
+								interpreter.NewUnmeteredIntValueFromInt64(1),
 							},
 							[]sema.Type{
 								sema.IntType,
@@ -3725,7 +3725,7 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 				inter.Globals["x"].GetValue(),
 			)
 		})
@@ -3793,7 +3793,7 @@ func TestInterpretInterfaceFunctionUse(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 				inter.Globals["val"].GetValue(),
 			)
 		})
@@ -3879,7 +3879,7 @@ func TestInterpretImport(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		value,
 	)
 }
@@ -3995,8 +3995,8 @@ func TestInterpretDictionary(t *testing.T) {
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
-		interpreter.NewUnmeteredStringValue("a"), interpreter.NewIntValueFromInt64(1),
-		interpreter.NewUnmeteredStringValue("b"), interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredStringValue("a"), interpreter.NewUnmeteredIntValueFromInt64(1),
+		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
 	actualDict := inter.Globals["x"].GetValue()
@@ -4023,9 +4023,9 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
-		interpreter.NewUnmeteredStringValue("c"), interpreter.NewIntValueFromInt64(3),
-		interpreter.NewUnmeteredStringValue("a"), interpreter.NewIntValueFromInt64(1),
-		interpreter.NewUnmeteredStringValue("b"), interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredStringValue("c"), interpreter.NewUnmeteredIntValueFromInt64(3),
+		interpreter.NewUnmeteredStringValue("a"), interpreter.NewUnmeteredIntValueFromInt64(1),
+		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
 	actualDict := inter.Globals["x"].GetValue()
@@ -4053,7 +4053,7 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["a"].GetValue(),
 	)
@@ -4062,7 +4062,7 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
 		inter.Globals["b"].GetValue(),
 	)
@@ -4089,7 +4089,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["a"].GetValue(),
 	)
@@ -4098,7 +4098,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
 		inter.Globals["b"].GetValue(),
 	)
@@ -4237,7 +4237,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewIntValueFromInt64(23)),
+		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewUnmeteredIntValueFromInt64(23)),
 		newValue,
 	)
 
@@ -4246,7 +4246,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 		inter,
 		[]interpreter.Value{
 			interpreter.NewUnmeteredStringValue("abc"),
-			interpreter.NewIntValueFromInt64(23),
+			interpreter.NewUnmeteredIntValueFromInt64(23),
 		},
 		dictionaryKeyValues(actualDict),
 	)
@@ -4279,8 +4279,8 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
-		interpreter.NewUnmeteredStringValue("def"), interpreter.NewIntValueFromInt64(42),
-		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewIntValueFromInt64(23),
+		interpreter.NewUnmeteredStringValue("def"), interpreter.NewUnmeteredIntValueFromInt64(42),
+		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
 	actualDict := inter.Globals["x"].GetValue().(*interpreter.DictionaryValue)
@@ -4301,7 +4301,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewIntValueFromInt64(23)),
+		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewUnmeteredIntValueFromInt64(23)),
 		newValue,
 	)
 
@@ -4310,9 +4310,9 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 		inter,
 		[]interpreter.Value{
 			interpreter.NewUnmeteredStringValue("abc"),
-			interpreter.NewIntValueFromInt64(23),
+			interpreter.NewUnmeteredIntValueFromInt64(23),
 			interpreter.NewUnmeteredStringValue("def"),
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 		},
 		dictionaryKeyValues(actualDict),
 	)
@@ -4345,7 +4345,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
-		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewIntValueFromInt64(23),
+		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
 	actualDict := inter.Globals["x"].GetValue().(*interpreter.DictionaryValue)
@@ -4376,7 +4376,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 
 		[]interpreter.Value{
 			interpreter.NewUnmeteredStringValue("abc"),
-			interpreter.NewIntValueFromInt64(23),
+			interpreter.NewUnmeteredIntValueFromInt64(23),
 		},
 		dictionaryKeyValues(actualDict),
 	)
@@ -4394,7 +4394,7 @@ func TestInterpretOptionalAnyStruct(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
 		inter.Globals["x"].GetValue(),
 	)
@@ -4413,7 +4413,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
 		inter.Globals["x"].GetValue(),
 	)
@@ -4422,7 +4422,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
 		inter.Globals["y"].GetValue(),
 	)
@@ -4442,7 +4442,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(23),
+			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
 		inter.Globals["x"].GetValue(),
 	)
@@ -4450,7 +4450,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(23),
+		interpreter.NewUnmeteredIntValueFromInt64(23),
 		inter.Globals["y"].GetValue(),
 	)
 
@@ -4458,7 +4458,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(23),
+			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
 		inter.Globals["z"].GetValue(),
 	)
@@ -4484,7 +4484,7 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		inter.Globals["y"].GetValue(),
 	)
 
@@ -4492,7 +4492,7 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
 		inter.Globals["z"].GetValue(),
 	)
@@ -4727,7 +4727,7 @@ func TestInterpretArrayLength(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -4744,13 +4744,13 @@ func TestInterpretStringLength(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(4),
+		interpreter.NewUnmeteredIntValueFromInt64(4),
 		inter.Globals["x"].GetValue(),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(4),
+		interpreter.NewUnmeteredIntValueFromInt64(4),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -4853,10 +4853,10 @@ func TestInterpretArrayAppend(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(4),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(4),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -4884,10 +4884,10 @@ func TestInterpretArrayAppendBound(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(4),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(4),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -4914,10 +4914,10 @@ func TestInterpretArrayAppendAll(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(4),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(4),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -4945,10 +4945,10 @@ func TestInterpretArrayAppendAllBound(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(4),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(4),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -4974,10 +4974,10 @@ func TestInterpretArrayConcat(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(4),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(4),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -5004,10 +5004,10 @@ func TestInterpretArrayConcatBound(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(4),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(4),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -5034,8 +5034,8 @@ func TestInterpretArrayConcatDoesNotModifyOriginalArray(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -5056,30 +5056,30 @@ func TestInterpretArrayInsert(t *testing.T) {
 			name:  "start",
 			index: 0,
 			expectedValues: []interpreter.Value{
-				interpreter.NewIntValueFromInt64(100),
-				interpreter.NewIntValueFromInt64(1),
-				interpreter.NewIntValueFromInt64(2),
-				interpreter.NewIntValueFromInt64(3),
+				interpreter.NewUnmeteredIntValueFromInt64(100),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(3),
 			},
 		},
 		{
 			name:  "middle",
 			index: 1,
 			expectedValues: []interpreter.Value{
-				interpreter.NewIntValueFromInt64(1),
-				interpreter.NewIntValueFromInt64(100),
-				interpreter.NewIntValueFromInt64(2),
-				interpreter.NewIntValueFromInt64(3),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(100),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(3),
 			},
 		},
 		{
 			name:  "end",
 			index: 3,
 			expectedValues: []interpreter.Value{
-				interpreter.NewIntValueFromInt64(1),
-				interpreter.NewIntValueFromInt64(2),
-				interpreter.NewIntValueFromInt64(3),
-				interpreter.NewIntValueFromInt64(100),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(3),
+				interpreter.NewUnmeteredIntValueFromInt64(100),
 			},
 		},
 	} {
@@ -5094,7 +5094,7 @@ func TestInterpretArrayInsert(t *testing.T) {
               }
             `)
 
-			_, err := inter.Invoke("test", interpreter.NewIntValueFromInt64(int64(testCase.index)))
+			_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(int64(testCase.index)))
 			require.NoError(t, err)
 
 			actualArray := inter.Globals["x"].GetValue()
@@ -5131,7 +5131,7 @@ func TestInterpretInvalidArrayInsert(t *testing.T) {
                }
             `)
 
-			indexValue := interpreter.NewIntValueFromInt64(int64(index))
+			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
@@ -5172,8 +5172,8 @@ func TestInterpretArrayRemove(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -5181,7 +5181,7 @@ func TestInterpretArrayRemove(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -5205,7 +5205,7 @@ func TestInterpretInvalidArrayRemove(t *testing.T) {
                }
             `)
 
-			indexValue := interpreter.NewIntValueFromInt64(int64(index))
+			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
@@ -5246,8 +5246,8 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -5255,7 +5255,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -5311,8 +5311,8 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 		inter,
 
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -5320,7 +5320,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		inter.Globals["y"].GetValue(),
 	)
 }
@@ -5605,7 +5605,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 
 		[]interpreter.Value{
 			interpreter.NewUnmeteredStringValue("def"),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		},
 		dictionaryKeyValues(actualDict),
 	)
@@ -5614,7 +5614,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["removed"].GetValue(),
 	)
@@ -5639,9 +5639,9 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 		inter,
 		[]interpreter.Value{
 			interpreter.NewUnmeteredStringValue("abc"),
-			interpreter.NewIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
 			interpreter.NewUnmeteredStringValue("def"),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		},
 		dictionaryKeyValues(actualDict),
 	)
@@ -5650,7 +5650,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["inserted"].GetValue(),
 	)
@@ -5707,9 +5707,9 @@ func TestInterpretDictionaryValues(t *testing.T) {
 		t,
 		inter,
 		[]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
 		},
 		arrayElements(inter, arrayValue),
 	)
@@ -5891,7 +5891,7 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["destroys"].GetValue(),
 	)
 
@@ -5901,14 +5901,14 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		value,
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["destroys"].GetValue(),
 	)
 }
@@ -5943,7 +5943,7 @@ func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
 	RequireValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["destroys"].GetValue(),
 	)
 
@@ -5953,7 +5953,7 @@ func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["destroys"].GetValue(),
 	)
 }
@@ -5983,7 +5983,7 @@ func TestInterpretClosure(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		value,
 	)
 
@@ -5993,7 +5993,7 @@ func TestInterpretClosure(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		value,
 	)
 
@@ -6003,7 +6003,7 @@ func TestInterpretClosure(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(3),
+		interpreter.NewUnmeteredIntValueFromInt64(3),
 		value,
 	)
 }
@@ -6122,8 +6122,8 @@ func TestInterpretSwapVariables(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(3),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
 		value,
 	)
@@ -6162,8 +6162,8 @@ func TestInterpretSwapArrayAndField(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		value,
 	)
@@ -6311,7 +6311,7 @@ func TestInterpretResourceDestroyArray(t *testing.T) {
 	RequireValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 
@@ -6321,7 +6321,7 @@ func TestInterpretResourceDestroyArray(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 }
@@ -6348,7 +6348,7 @@ func TestInterpretResourceDestroyDictionary(t *testing.T) {
 	RequireValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 
@@ -6358,7 +6358,7 @@ func TestInterpretResourceDestroyDictionary(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 }
@@ -6385,7 +6385,7 @@ func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
 	RequireValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 
@@ -6395,7 +6395,7 @@ func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 }
@@ -6422,7 +6422,7 @@ func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
 	RequireValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 
@@ -6432,7 +6432,7 @@ func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(0),
+		interpreter.NewUnmeteredIntValueFromInt64(0),
 		inter.Globals["destructionCount"].GetValue(),
 	)
 }
@@ -6549,37 +6549,37 @@ func TestInterpretEmitEvent(t *testing.T) {
 	fields1 := []interpreter.CompositeField{
 		{
 			Name:  "to",
-			Value: interpreter.NewIntValueFromInt64(1),
+			Value: interpreter.NewUnmeteredIntValueFromInt64(1),
 		},
 		{
 			Name:  "from",
-			Value: interpreter.NewIntValueFromInt64(2),
+			Value: interpreter.NewUnmeteredIntValueFromInt64(2),
 		},
 	}
 
 	fields2 := []interpreter.CompositeField{
 		{
 			Name:  "to",
-			Value: interpreter.NewIntValueFromInt64(3),
+			Value: interpreter.NewUnmeteredIntValueFromInt64(3),
 		},
 		{
 			Name:  "from",
-			Value: interpreter.NewIntValueFromInt64(4),
+			Value: interpreter.NewUnmeteredIntValueFromInt64(4),
 		},
 	}
 
 	fields3 := []interpreter.CompositeField{
 		{
 			Name:  "to",
-			Value: interpreter.NewIntValueFromInt64(1),
+			Value: interpreter.NewUnmeteredIntValueFromInt64(1),
 		},
 		{
 			Name:  "from",
-			Value: interpreter.NewIntValueFromInt64(2),
+			Value: interpreter.NewUnmeteredIntValueFromInt64(2),
 		},
 		{
 			Name:  "amount",
-			Value: interpreter.NewIntValueFromInt64(100),
+			Value: interpreter.NewUnmeteredIntValueFromInt64(100),
 		},
 	}
 
@@ -6687,7 +6687,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		},
 		// Int*
 		"Int": {
-			value: interpreter.NewIntValueFromInt64(42),
+			value: interpreter.NewUnmeteredIntValueFromInt64(42),
 			ty:    sema.IntType,
 		},
 		"Int8": {
@@ -7125,9 +7125,9 @@ func TestInterpretReferenceUse(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
 		value,
 	)
@@ -7176,9 +7176,9 @@ func TestInterpretReferenceUseAccess(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(0),
-			interpreter.NewIntValueFromInt64(1),
-			interpreter.NewIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(0),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
 		value,
 	)
@@ -7262,7 +7262,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		firstResource.GetField(inter, interpreter.ReturnEmptyLocationRange, "id"),
 	)
 
@@ -7284,7 +7284,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(1),
+		interpreter.NewUnmeteredIntValueFromInt64(1),
 		secondResource.GetField(inter, interpreter.ReturnEmptyLocationRange, "id"),
 	)
 }
@@ -7511,7 +7511,7 @@ func TestInterpretCastingIntLiteralToAnyStruct(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -7527,7 +7527,7 @@ func TestInterpretCastingIntLiteralToOptional(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewIntValueFromInt64(42)),
+		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewUnmeteredIntValueFromInt64(42)),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -7588,7 +7588,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
 		inter.Globals["x2"].GetValue(),
 	)
@@ -7664,7 +7664,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(42),
+			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
 		inter.Globals["x2"].GetValue(),
 	)
@@ -7709,7 +7709,7 @@ func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -7751,7 +7751,7 @@ func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(42),
+		interpreter.NewUnmeteredIntValueFromInt64(42),
 		inter.Globals["x"].GetValue(),
 	)
 }
@@ -7910,8 +7910,8 @@ func TestInterpretFungibleTokenContract(t *testing.T) {
 				Size: 2,
 			},
 			common.Address{},
-			interpreter.NewIntValueFromInt64(40),
-			interpreter.NewIntValueFromInt64(60),
+			interpreter.NewUnmeteredIntValueFromInt64(40),
+			interpreter.NewUnmeteredIntValueFromInt64(60),
 		),
 		value,
 	)
@@ -8109,7 +8109,7 @@ func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
 		GetMember(inter, interpreter.ReturnEmptyLocationRange, "i")
 
 	require.IsType(t,
-		interpreter.NewIntValueFromInt64(2),
+		interpreter.NewUnmeteredIntValueFromInt64(2),
 		i,
 	)
 }
@@ -8153,7 +8153,7 @@ func TestInterpretNonStorageReference(t *testing.T) {
 
 	AssertValuesEqual(
 		t,
-		inter, interpreter.NewIntValueFromInt64(3), value)
+		inter, interpreter.NewUnmeteredIntValueFromInt64(3), value)
 }
 
 func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
@@ -8439,7 +8439,7 @@ func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		inter.Globals["x"].GetValue(),
 	)
@@ -8962,7 +8962,7 @@ func TestInterpretForce(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredSomeValueNonCopying(
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 			),
 			inter.Globals["x"].GetValue(),
 		)
@@ -8970,7 +8970,7 @@ func TestInterpretForce(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 			inter.Globals["y"].GetValue(),
 		)
 	})
@@ -9005,7 +9005,7 @@ func TestInterpretForce(t *testing.T) {
 		AssertValuesEqual(
 			t,
 			inter,
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 			inter.Globals["y"].GetValue(),
 		)
 	})
@@ -9403,15 +9403,15 @@ func TestInterpretInternalAssignment(t *testing.T) {
 				inter,
 				stringIntDictionaryStaticType,
 				interpreter.NewUnmeteredStringValue("a"),
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 				interpreter.NewUnmeteredStringValue("b"),
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 			interpreter.NewDictionaryValue(
 				inter,
 				stringIntDictionaryStaticType,
 				interpreter.NewUnmeteredStringValue("a"),
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 			),
 		),
 		value,
@@ -9465,7 +9465,7 @@ func BenchmarkInterpretRecursionFib(b *testing.B) {
        }
    `)
 
-	expected := interpreter.NewIntValueFromInt64(377)
+	expected := interpreter.NewUnmeteredIntValueFromInt64(377)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -9474,7 +9474,7 @@ func BenchmarkInterpretRecursionFib(b *testing.B) {
 
 		result, err := inter.Invoke(
 			"fib",
-			interpreter.NewIntValueFromInt64(14),
+			interpreter.NewUnmeteredIntValueFromInt64(14),
 		)
 		require.NoError(b, err)
 		RequireValuesEqual(b, inter, expected, result)
@@ -9701,7 +9701,7 @@ func TestInterpretArrayFirstIndex(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
 		value,
 	)
@@ -9755,7 +9755,7 @@ func TestInterpretOptionalReference(t *testing.T) {
 	require.Equal(
 		t,
 		&interpreter.EphemeralReferenceValue{
-			Value:        interpreter.NewIntValueFromInt64(1),
+			Value:        interpreter.NewUnmeteredIntValueFromInt64(1),
 			BorrowedType: sema.IntType,
 		},
 		value,

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -706,8 +706,7 @@ func TestInterpretIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		// TODO: meter literals
-		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindBigInt))
+		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("addition", func(t *testing.T) {
@@ -726,8 +725,9 @@ func TestInterpretIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// creation: 8 + 8
 		// result: 16 = max(8, 8) + 8
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
+		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("multiplication", func(t *testing.T) {
@@ -746,8 +746,9 @@ func TestInterpretIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// creation: 8 + 8
 		// result: 16 = 8 + 8
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
+		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("negation", func(t *testing.T) {
@@ -767,8 +768,9 @@ func TestInterpretIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// creation: 8
 		// result: 8 = 8
-		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindBigInt))
+		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
 	})
 }
 
@@ -792,8 +794,8 @@ func TestInterpretUIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		// TODO: meter literals
-		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindBigInt))
+		// creation: 8
+		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("addition", func(t *testing.T) {
@@ -812,8 +814,9 @@ func TestInterpretUIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// creation: 8 + 8
 		// result: 16 = max(8, 8) + 8
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
+		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("multiplication", func(t *testing.T) {
@@ -832,8 +835,9 @@ func TestInterpretUIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// creation: 8 + 8
 		// result: 16 = 8 + 8
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
+		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("negation", func(t *testing.T) {
@@ -853,7 +857,8 @@ func TestInterpretUIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// creation: 8
 		// result: 8 = 8
-		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindBigInt))
+		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
 	})
 }

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -731,7 +731,7 @@ func TestInterpretGetType(t *testing.T) {
 			storageMap.WriteValue(
 				inter,
 				storagePath.Identifier,
-				interpreter.NewIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
 			)
 
 			result, err := inter.Invoke("test")

--- a/runtime/tests/interpreter/switch_test.go
+++ b/runtime/tests/interpreter/switch_test.go
@@ -62,8 +62,8 @@ func TestInterpretSwitchStatement(t *testing.T) {
 		require.NoError(t, err)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
-			interpreter.BoolValue(true):  interpreter.NewIntValueFromInt64(1),
-			interpreter.BoolValue(false): interpreter.NewIntValueFromInt64(2),
+			interpreter.BoolValue(true):  interpreter.NewUnmeteredIntValueFromInt64(1),
+			interpreter.BoolValue(false): interpreter.NewUnmeteredIntValueFromInt64(2),
 		} {
 
 			actual, err := inter.Invoke("test", argument)
@@ -100,10 +100,10 @@ func TestInterpretSwitchStatement(t *testing.T) {
 		require.NoError(t, err)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1): interpreter.NewUnmeteredStringValue("1"),
-			interpreter.NewIntValueFromInt64(2): interpreter.NewUnmeteredStringValue("2"),
-			interpreter.NewIntValueFromInt64(3): interpreter.NewUnmeteredStringValue("3"),
-			interpreter.NewIntValueFromInt64(4): interpreter.NewUnmeteredStringValue("3"),
+			interpreter.NewUnmeteredIntValueFromInt64(1): interpreter.NewUnmeteredStringValue("1"),
+			interpreter.NewUnmeteredIntValueFromInt64(2): interpreter.NewUnmeteredStringValue("2"),
+			interpreter.NewUnmeteredIntValueFromInt64(3): interpreter.NewUnmeteredStringValue("3"),
+			interpreter.NewUnmeteredIntValueFromInt64(4): interpreter.NewUnmeteredStringValue("3"),
 		} {
 
 			actual, err := inter.Invoke("test", argument)
@@ -141,10 +141,10 @@ func TestInterpretSwitchStatement(t *testing.T) {
 		require.NoError(t, err)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1): interpreter.NewUnmeteredStringValue("4"),
-			interpreter.NewIntValueFromInt64(2): interpreter.NewUnmeteredStringValue("2"),
-			interpreter.NewIntValueFromInt64(3): interpreter.NewUnmeteredStringValue("3"),
-			interpreter.NewIntValueFromInt64(4): interpreter.NewUnmeteredStringValue("3"),
+			interpreter.NewUnmeteredIntValueFromInt64(1): interpreter.NewUnmeteredStringValue("4"),
+			interpreter.NewUnmeteredIntValueFromInt64(2): interpreter.NewUnmeteredStringValue("2"),
+			interpreter.NewUnmeteredIntValueFromInt64(3): interpreter.NewUnmeteredStringValue("3"),
+			interpreter.NewUnmeteredIntValueFromInt64(4): interpreter.NewUnmeteredStringValue("3"),
 		} {
 
 			actual, err := inter.Invoke("test", argument)
@@ -172,16 +172,16 @@ func TestInterpretSwitchStatement(t *testing.T) {
         `)
 
 		for argument, expectedValues := range map[interpreter.Value][]interpreter.Value{
-			interpreter.NewIntValueFromInt64(1): {
+			interpreter.NewUnmeteredIntValueFromInt64(1): {
 				interpreter.NewUnmeteredStringValue("1"),
 			},
-			interpreter.NewIntValueFromInt64(2): {
+			interpreter.NewUnmeteredIntValueFromInt64(2): {
 				interpreter.NewUnmeteredStringValue("2"),
 			},
-			interpreter.NewIntValueFromInt64(3): {
+			interpreter.NewUnmeteredIntValueFromInt64(3): {
 				interpreter.NewUnmeteredStringValue("3"),
 			},
-			interpreter.NewIntValueFromInt64(4): {
+			interpreter.NewUnmeteredIntValueFromInt64(4): {
 				interpreter.NewUnmeteredStringValue("3"),
 			},
 		} {
@@ -236,10 +236,10 @@ func TestInterpretSwitchStatement(t *testing.T) {
 			{
 				[]interpreter.Value{
 					interpreter.NewUnmeteredSomeValueNonCopying(
-						interpreter.NewIntValueFromInt64(1),
+						interpreter.NewUnmeteredIntValueFromInt64(1),
 					),
 					interpreter.NewUnmeteredSomeValueNonCopying(
-						interpreter.NewIntValueFromInt64(1),
+						interpreter.NewUnmeteredIntValueFromInt64(1),
 					),
 				},
 				interpreter.NewUnmeteredStringValue("1"),
@@ -248,7 +248,7 @@ func TestInterpretSwitchStatement(t *testing.T) {
 				[]interpreter.Value{
 					interpreter.NilValue{},
 					interpreter.NewUnmeteredSomeValueNonCopying(
-						interpreter.NewIntValueFromInt64(1),
+						interpreter.NewUnmeteredIntValueFromInt64(1),
 					),
 				},
 				interpreter.NewUnmeteredStringValue("2"),
@@ -256,10 +256,10 @@ func TestInterpretSwitchStatement(t *testing.T) {
 			{
 				[]interpreter.Value{
 					interpreter.NewUnmeteredSomeValueNonCopying(
-						interpreter.NewIntValueFromInt64(1),
+						interpreter.NewUnmeteredIntValueFromInt64(1),
 					),
 					interpreter.NewUnmeteredSomeValueNonCopying(
-						interpreter.NewIntValueFromInt64(2),
+						interpreter.NewUnmeteredIntValueFromInt64(2),
 					),
 				},
 				interpreter.NewUnmeteredStringValue("3"),

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -255,7 +255,7 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		arguments := []interpreter.Value{
-			interpreter.NewIntValueFromInt64(1),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.BoolValue(true),
 		}
 
@@ -281,7 +281,7 @@ func TestInterpretTransactions(t *testing.T) {
 			[]interpreter.Value{
 				interpreter.AddressValue{},
 				interpreter.BoolValue(true),
-				interpreter.NewIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(1),
 			},
 			arrayElements(inter, values.(*interpreter.ArrayValue)),
 		)

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1094,7 +1094,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 	case interpreter.IntValue:
 		var n big.Int
 		n.Set(v.BigInt)
-		return interpreter.NewIntValueFromBigInt(&n)
+		return interpreter.NewUnmeteredIntValueFromBigInt(&n)
 	case interpreter.Int8Value,
 		interpreter.Int16Value,
 		interpreter.Int32Value,
@@ -1276,7 +1276,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 
 	// Int
 	case Int:
-		return interpreter.NewIntValueFromInt64(int64(sign()) * rand.Int63())
+		return interpreter.NewUnmeteredIntValueFromInt64(int64(sign()) * rand.Int63())
 	case Int8:
 		return interpreter.Int8Value(randomInt(math.MaxUint8))
 	case Int16:

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1113,7 +1113,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 	case interpreter.UIntValue:
 		var n big.Int
 		n.Set(v.BigInt)
-		return interpreter.NewUIntValueFromBigInt(&n)
+		return interpreter.NewUnmeteredUIntValueFromBigInt(&n)
 	case interpreter.UInt8Value,
 		interpreter.UInt16Value,
 		interpreter.UInt32Value,
@@ -1292,7 +1292,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 
 	// UInt
 	case UInt:
-		return interpreter.NewUIntValueFromUint64(rand.Uint64())
+		return interpreter.NewUnmeteredUIntValueFromUint64(rand.Uint64())
 	case UInt8:
 		return interpreter.UInt8Value(randomInt(math.MaxUint8))
 	case UInt16:

--- a/runtime/tests/interpreter/while_test.go
+++ b/runtime/tests/interpreter/while_test.go
@@ -49,7 +49,7 @@ func TestInterpretWhileStatement(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(6),
+		interpreter.NewUnmeteredIntValueFromInt64(6),
 		value,
 	)
 }
@@ -77,7 +77,7 @@ func TestInterpretWhileStatementWithReturn(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(6),
+		interpreter.NewUnmeteredIntValueFromInt64(6),
 		value,
 	)
 }
@@ -107,7 +107,7 @@ func TestInterpretWhileStatementWithContinue(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(6),
+		interpreter.NewUnmeteredIntValueFromInt64(6),
 		value,
 	)
 }
@@ -135,7 +135,7 @@ func TestInterpretWhileStatementWithBreak(t *testing.T) {
 	AssertValuesEqual(
 		t,
 		inter,
-		interpreter.NewIntValueFromInt64(5),
+		interpreter.NewUnmeteredIntValueFromInt64(5),
 		value,
 	)
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -1,3 +1,4 @@
+//go:build wasmtime
 // +build wasmtime
 
 /*
@@ -124,7 +125,7 @@ func NewVM(wasm []byte) (VM, error) {
 			return nil, wasmtime.NewTrap(store, fmt.Sprintf("add: invalid right: %#+v", right))
 		}
 
-		return leftNumber.Plus(rightNumber), nil
+		return leftNumber.Plus(nil, rightNumber), nil
 	})
 
 	// NOTE: wasmtime currently does not support specifying imports by name,


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
