### PR TITLE
Finish memory metering for Int and UInt operations

### DIFF
--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -138,3 +138,21 @@ func NewBitwiseAndBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 		),
 	)
 }
+
+func NewBitwiseLeftShiftBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		BigIntByteLength(a) +
+			BigIntByteLength(b),
+	)
+}
+
+func NewBitwiseRightShiftBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		max(
+			BigIntByteLength(a),
+			BigIntByteLength(b),
+		),
+	)
+}

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -96,3 +96,13 @@ func NewModBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 		),
 	)
 }
+
+func NewDivBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		max(
+			BigIntByteLength(a),
+			BigIntByteLength(b),
+		),
+	)
+}

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -63,7 +63,7 @@ func BigIntByteLength(v *big.Int) int {
 
 func NewPlusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -73,7 +73,7 @@ func NewPlusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewMinusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -83,7 +83,7 @@ func NewMinusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		BigIntByteLength(a) +
 			BigIntByteLength(b),
 	)
@@ -91,7 +91,7 @@ func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewModBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -101,7 +101,7 @@ func NewModBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewDivBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -111,7 +111,7 @@ func NewDivBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewBitwiseOrBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -121,7 +121,7 @@ func NewBitwiseOrBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewBitwiseXorBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -131,7 +131,7 @@ func NewBitwiseXorBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewBitwiseAndBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -141,7 +141,7 @@ func NewBitwiseAndBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewBitwiseLeftShiftBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		BigIntByteLength(a) +
 			BigIntByteLength(b),
 	)
@@ -149,7 +149,7 @@ func NewBitwiseLeftShiftBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewBitwiseRightShiftBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
-		// TODO:
+		// TODO: https://github.com/dapperlabs/cadence-private-issues/issues/32
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -70,6 +70,16 @@ func NewPlusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	)
 }
 
+func NewMinusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		max(
+			BigIntByteLength(a),
+			BigIntByteLength(b),
+		),
+	)
+}
+
 func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
 		BigIntByteLength(a) +

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -63,6 +63,7 @@ func BigIntByteLength(v *big.Int) int {
 
 func NewPlusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
+		// TODO:
 		max(
 			BigIntByteLength(a),
 			BigIntByteLength(b),
@@ -82,6 +83,7 @@ func NewMinusBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 
 func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
+		// TODO:
 		BigIntByteLength(a) +
 			BigIntByteLength(b),
 	)
@@ -98,6 +100,36 @@ func NewModBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 }
 
 func NewDivBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		max(
+			BigIntByteLength(a),
+			BigIntByteLength(b),
+		),
+	)
+}
+
+func NewBitwiseOrBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		max(
+			BigIntByteLength(a),
+			BigIntByteLength(b),
+		),
+	)
+}
+
+func NewBitwiseXorBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		max(
+			BigIntByteLength(a),
+			BigIntByteLength(b),
+		),
+	)
+}
+
+func NewBitwiseAndBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 	return NewBigIntMemoryUsage(
 		// TODO:
 		max(

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -86,3 +86,13 @@ func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 			BigIntByteLength(b),
 	)
 }
+
+func NewModBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
+	return NewBigIntMemoryUsage(
+		// TODO:
+		max(
+			BigIntByteLength(a),
+			BigIntByteLength(b),
+		),
+	)
+}

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -3327,10 +3328,13 @@ func TestNegativeMod(t *testing.T) {
 			}
 		}
 
+		inter, err := NewInterpreter(nil, nil)
+		require.NoError(t, err)
+
 		for _, test := range tests {
 			assert.Equal(t,
 				test.expected,
-				test.a.Mod(nil, test.b),
+				test.a.Mod(inter, test.b),
 			)
 		}
 	})

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -82,7 +82,7 @@ func TestDivModUInt8(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt8Value){
 			func(a, b UInt8Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt8Value) {
 				a.Mod(nil, b)
@@ -154,7 +154,7 @@ func TestDivModUInt16(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt16Value){
 			func(a, b UInt16Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt16Value) {
 				a.Mod(nil, b)
@@ -226,7 +226,7 @@ func TestDivModUInt32(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt32Value){
 			func(a, b UInt32Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt32Value) {
 				a.Mod(nil, b)
@@ -388,7 +388,7 @@ func TestDivModUInt64(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt64Value){
 			func(a, b UInt64Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt64Value) {
 				a.Mod(nil, b)
@@ -552,7 +552,7 @@ func TestDivModUInt128(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt128Value){
 			func(a, b UInt128Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt128Value) {
 				a.Mod(nil, b)
@@ -1222,7 +1222,7 @@ func TestDivModUInt256(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt256Value){
 			func(a, b UInt256Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt256Value) {
 				a.Mod(nil, b)
@@ -1294,7 +1294,7 @@ func TestDivInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1421,7 +1421,7 @@ func TestDivInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1548,7 +1548,7 @@ func TestDivInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1765,7 +1765,7 @@ func TestDivInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1934,7 +1934,7 @@ func TestDivModInt(t *testing.T) {
 
 	for _, f := range []func(a, b IntValue){
 		func(a, b IntValue) {
-			a.Div(b)
+			a.Div(nil, b)
 		},
 		func(a, b IntValue) {
 			a.Mod(nil, b)
@@ -2048,7 +2048,7 @@ func TestDivInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2613,7 +2613,7 @@ func TestDivInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3120,7 +3120,7 @@ func TestDivFix64(t *testing.T) {
 		f := func() {
 			a := NewFix64ValueWithInteger(test.a)
 			b := NewFix64ValueWithInteger(test.b)
-			a.Div(b)
+			a.Div(nil, b)
 		}
 
 		if test.valid {
@@ -3133,24 +3133,24 @@ func TestDivFix64(t *testing.T) {
 	assert.Equal(t,
 		Fix64Value(1),
 		NewFix64ValueWithInteger(1).
-			Div(NewFix64ValueWithInteger(sema.Fix64Factor)),
+			Div(nil, NewFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(0),
 		NewFix64ValueWithInteger(1).
-			Div(Fix64Value(Fix64MaxValue)),
+			Div(nil, Fix64Value(Fix64MaxValue)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(0),
 		Fix64Value(1).
-			Div(NewFix64ValueWithInteger(2)),
+			Div(nil, NewFix64ValueWithInteger(2)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(1535399),
-		NewFix64ValueWithInteger(1543219).Div(NewFix64ValueWithInteger(100509284)),
+		NewFix64ValueWithInteger(1543219).Div(nil, NewFix64ValueWithInteger(100509284)),
 	)
 }
 
@@ -3228,7 +3228,7 @@ func TestDivModUFix64(t *testing.T) {
 
 		for _, f := range []func(a, b UFix64Value){
 			func(a, b UFix64Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UFix64Value) {
 				a.Mod(nil, b)
@@ -3252,24 +3252,25 @@ func TestDivModUFix64(t *testing.T) {
 	assert.Equal(t,
 		UFix64Value(1),
 		NewUFix64ValueWithInteger(1).
-			Div(NewUFix64ValueWithInteger(sema.Fix64Factor)),
+			Div(nil, NewUFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(0),
 		NewUFix64ValueWithInteger(1).
-			Div(UFix64Value(UFix64MaxValue)),
+			Div(nil, UFix64Value(UFix64MaxValue)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(0),
 		UFix64Value(1).
-			Div(NewUFix64ValueWithInteger(2)),
+			Div(nil, NewUFix64ValueWithInteger(2)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(1535399),
-		NewUFix64ValueWithInteger(1543219).Div(NewUFix64ValueWithInteger(100509284)),
+		NewUFix64ValueWithInteger(1543219).
+			Div(nil, NewUFix64ValueWithInteger(100509284)),
 	)
 }
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -240,7 +240,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.BitwiseOr(right)
+		return left.BitwiseOr(interpreter, right)
 
 	case ast.OperationBitwiseXor:
 		left, leftOk := leftValue.(IntegerValue)
@@ -248,7 +248,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.BitwiseXor(right)
+		return left.BitwiseXor(interpreter, right)
 
 	case ast.OperationBitwiseAnd:
 		left, leftOk := leftValue.(IntegerValue)
@@ -256,7 +256,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.BitwiseAnd(right)
+		return left.BitwiseAnd(interpreter, right)
 
 	case ast.OperationBitwiseLeftShift:
 		left, leftOk := leftValue.(IntegerValue)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -208,7 +208,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.Minus(right)
+		return left.Minus(interpreter, right)
 
 	case ast.OperationMod:
 		left, leftOk := leftValue.(NumberValue)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -264,7 +264,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.BitwiseLeftShift(right)
+		return left.BitwiseLeftShift(interpreter, right)
 
 	case ast.OperationBitwiseRightShift:
 		left, leftOk := leftValue.(IntegerValue)
@@ -272,7 +272,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.BitwiseRightShift(right)
+		return left.BitwiseRightShift(interpreter, right)
 
 	case ast.OperationLess:
 		left, leftOk := leftValue.(NumberValue)

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -232,7 +232,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.Div(right)
+		return left.Div(interpreter, right)
 
 	case ast.OperationBitwiseOr:
 		left, leftOk := leftValue.(IntegerValue)

--- a/runtime/interpreter/minus_test.go
+++ b/runtime/interpreter/minus_test.go
@@ -127,7 +127,7 @@ func TestMinusUInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -238,7 +238,7 @@ func TestMinusUInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -349,7 +349,7 @@ func TestMinusUInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -676,7 +676,7 @@ func TestMinusUInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -789,7 +789,7 @@ func TestMinusUInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1244,7 +1244,7 @@ func TestMinusUInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1355,7 +1355,7 @@ func TestMinusInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1467,7 +1467,7 @@ func TestMinusInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1578,7 +1578,7 @@ func TestMinusInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1905,7 +1905,7 @@ func TestMinusInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2018,7 +2018,7 @@ func TestMinusInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2473,7 +2473,7 @@ func TestMinusInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2586,7 +2586,7 @@ func TestMinusUInt(t *testing.T) {
 		f := func() {
 			a := NewUnmeteredUIntValueFromUint64(test.a)
 			b := NewUnmeteredUIntValueFromUint64(test.b)
-			a.Minus(b)
+			a.Minus(nil, b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/minus_test.go
+++ b/runtime/interpreter/minus_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/onflow/cadence/runtime/interpreter"
 )
@@ -2582,11 +2583,14 @@ func TestMinusUInt(t *testing.T) {
 		{0xff, 0xff, true},
 	}
 
+	inter, err := NewInterpreter(nil, nil)
+	require.NoError(t, err)
+
 	for _, test := range tests {
 		f := func() {
 			a := NewUnmeteredUIntValueFromUint64(test.a)
 			b := NewUnmeteredUIntValueFromUint64(test.b)
-			a.Minus(nil, b)
+			a.Minus(inter, b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2485,9 +2485,9 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 
 type IntegerValue interface {
 	NumberValue
-	BitwiseOr(other IntegerValue) IntegerValue
-	BitwiseXor(other IntegerValue) IntegerValue
-	BitwiseAnd(other IntegerValue) IntegerValue
+	BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue
+	BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue
+	BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue
 	BitwiseLeftShift(other IntegerValue) IntegerValue
 	BitwiseRightShift(other IntegerValue) IntegerValue
 }
@@ -2876,7 +2876,7 @@ func (v IntValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []by
 	return buffer
 }
 
-func (v IntValue) BitwiseOr(other IntegerValue) IntegerValue {
+func (v IntValue) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -2886,12 +2886,17 @@ func (v IntValue) BitwiseOr(other IntegerValue) IntegerValue {
 		})
 	}
 
-	res := new(big.Int)
-	res.Or(v.BigInt, o.BigInt)
-	return IntValue{res}
+	return NewIntValueFromBigInt(
+		interpreter,
+		common.NewBitwiseOrBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Or(v.BigInt, o.BigInt)
+		},
+	)
 }
 
-func (v IntValue) BitwiseXor(other IntegerValue) IntegerValue {
+func (v IntValue) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -2901,12 +2906,17 @@ func (v IntValue) BitwiseXor(other IntegerValue) IntegerValue {
 		})
 	}
 
-	res := new(big.Int)
-	res.Xor(v.BigInt, o.BigInt)
-	return IntValue{res}
+	return NewIntValueFromBigInt(
+		interpreter,
+		common.NewBitwiseXorBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Xor(v.BigInt, o.BigInt)
+		},
+	)
 }
 
-func (v IntValue) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v IntValue) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -2916,9 +2926,14 @@ func (v IntValue) BitwiseAnd(other IntegerValue) IntegerValue {
 		})
 	}
 
-	res := new(big.Int)
-	res.And(v.BigInt, o.BigInt)
-	return IntValue{res}
+	return NewIntValueFromBigInt(
+		interpreter,
+		common.NewBitwiseAndBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.And(v.BigInt, o.BigInt)
+		},
+	)
 }
 
 func (v IntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
@@ -3396,7 +3411,7 @@ func ConvertInt8(value Value) Int8Value {
 	return Int8Value(res)
 }
 
-func (v Int8Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Int8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3409,7 +3424,7 @@ func (v Int8Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Int8Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Int8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3422,7 +3437,7 @@ func (v Int8Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Int8Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Int8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3895,7 +3910,7 @@ func ConvertInt16(value Value) Int16Value {
 	return Int16Value(res)
 }
 
-func (v Int16Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Int16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3908,7 +3923,7 @@ func (v Int16Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Int16Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Int16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3921,7 +3936,7 @@ func (v Int16Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Int16Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Int16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4396,7 +4411,7 @@ func ConvertInt32(value Value) Int32Value {
 	return Int32Value(res)
 }
 
-func (v Int32Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Int32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4409,7 +4424,7 @@ func (v Int32Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Int32Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Int32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4422,7 +4437,7 @@ func (v Int32Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Int32Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Int32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4896,7 +4911,7 @@ func ConvertInt64(value Value) Int64Value {
 	return Int64Value(res)
 }
 
-func (v Int64Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Int64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4909,7 +4924,7 @@ func (v Int64Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Int64Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Int64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4922,7 +4937,7 @@ func (v Int64Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Int64Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Int64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5462,7 +5477,7 @@ func ConvertInt128(value Value) Int128Value {
 	return NewInt128ValueFromBigInt(v)
 }
 
-func (v Int128Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Int128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5477,7 +5492,7 @@ func (v Int128Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return Int128Value{res}
 }
 
-func (v Int128Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Int128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5492,7 +5507,7 @@ func (v Int128Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return Int128Value{res}
 }
 
-func (v Int128Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Int128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6048,7 +6063,7 @@ func ConvertInt256(value Value) Int256Value {
 	return NewInt256ValueFromBigInt(v)
 }
 
-func (v Int256Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Int256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6063,7 +6078,7 @@ func (v Int256Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return Int256Value{res}
 }
 
-func (v Int256Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Int256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6078,7 +6093,7 @@ func (v Int256Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return Int256Value{res}
 }
 
-func (v Int256Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Int256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6491,7 +6506,6 @@ func (v UIntValue) Div(interpreter *Interpreter, other NumberValue) NumberValue 
 		interpreter,
 		common.NewDivBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
-
 			res := new(big.Int)
 			// INT33-C
 			if o.BigInt.Cmp(res) == 0 {
@@ -6601,7 +6615,7 @@ func (v UIntValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []b
 	return buffer
 }
 
-func (v UIntValue) BitwiseOr(other IntegerValue) IntegerValue {
+func (v UIntValue) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6611,12 +6625,17 @@ func (v UIntValue) BitwiseOr(other IntegerValue) IntegerValue {
 		})
 	}
 
-	res := new(big.Int)
-	res.Or(v.BigInt, o.BigInt)
-	return UIntValue{res}
+	return NewUIntValueFromBigInt(
+		interpreter,
+		common.NewBitwiseOrBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Or(v.BigInt, o.BigInt)
+		},
+	)
 }
 
-func (v UIntValue) BitwiseXor(other IntegerValue) IntegerValue {
+func (v UIntValue) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6626,12 +6645,17 @@ func (v UIntValue) BitwiseXor(other IntegerValue) IntegerValue {
 		})
 	}
 
-	res := new(big.Int)
-	res.Xor(v.BigInt, o.BigInt)
-	return UIntValue{res}
+	return NewUIntValueFromBigInt(
+		interpreter,
+		common.NewBitwiseXorBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Xor(v.BigInt, o.BigInt)
+		},
+	)
 }
 
-func (v UIntValue) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v UIntValue) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6641,9 +6665,14 @@ func (v UIntValue) BitwiseAnd(other IntegerValue) IntegerValue {
 		})
 	}
 
-	res := new(big.Int)
-	res.And(v.BigInt, o.BigInt)
-	return UIntValue{res}
+	return NewUIntValueFromBigInt(
+		interpreter,
+		common.NewBitwiseAndBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.And(v.BigInt, o.BigInt)
+		},
+	)
 }
 
 func (v UIntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
@@ -7062,7 +7091,7 @@ func ConvertUInt8(value Value) UInt8Value {
 	return UInt8Value(res)
 }
 
-func (v UInt8Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v UInt8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7075,7 +7104,7 @@ func (v UInt8Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v UInt8Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v UInt8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7088,7 +7117,7 @@ func (v UInt8Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v UInt8Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v UInt8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7500,7 +7529,7 @@ func ConvertUInt16(value Value) UInt16Value {
 	return UInt16Value(res)
 }
 
-func (v UInt16Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v UInt16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7513,7 +7542,7 @@ func (v UInt16Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v UInt16Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v UInt16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7525,7 +7554,7 @@ func (v UInt16Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v UInt16Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v UInt16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7944,7 +7973,7 @@ func ConvertUInt32(value Value) UInt32Value {
 	return UInt32Value(res)
 }
 
-func (v UInt32Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v UInt32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7957,7 +7986,7 @@ func (v UInt32Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v UInt32Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v UInt32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7969,7 +7998,7 @@ func (v UInt32Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v UInt32Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v UInt32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8415,7 +8444,7 @@ func ConvertUInt64(value Value) UInt64Value {
 	return UInt64Value(res)
 }
 
-func (v UInt64Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v UInt64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8428,7 +8457,7 @@ func (v UInt64Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v UInt64Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v UInt64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8440,7 +8469,7 @@ func (v UInt64Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v UInt64Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v UInt64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8933,7 +8962,7 @@ func ConvertUInt128(value Value) UInt128Value {
 	return NewUInt128ValueFromBigInt(v)
 }
 
-func (v UInt128Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v UInt128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8948,7 +8977,7 @@ func (v UInt128Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return UInt128Value{res}
 }
 
-func (v UInt128Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v UInt128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8963,7 +8992,7 @@ func (v UInt128Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return UInt128Value{res}
 }
 
-func (v UInt128Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v UInt128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9473,7 +9502,7 @@ func ConvertUInt256(value Value) UInt256Value {
 	return NewUInt256ValueFromBigInt(v)
 }
 
-func (v UInt256Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v UInt256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9488,7 +9517,7 @@ func (v UInt256Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return UInt256Value{res}
 }
 
-func (v UInt256Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v UInt256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9503,7 +9532,7 @@ func (v UInt256Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return UInt256Value{res}
 }
 
-func (v UInt256Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v UInt256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9844,7 +9873,7 @@ func ConvertWord8(value Value) Word8Value {
 	return Word8Value(ConvertUInt8(value))
 }
 
-func (v Word8Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Word8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9857,7 +9886,7 @@ func (v Word8Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Word8Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Word8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9869,7 +9898,7 @@ func (v Word8Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Word8Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Word8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10192,7 +10221,7 @@ func ConvertWord16(value Value) Word16Value {
 	return Word16Value(ConvertUInt16(value))
 }
 
-func (v Word16Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Word16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10205,7 +10234,7 @@ func (v Word16Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Word16Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Word16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10217,7 +10246,7 @@ func (v Word16Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Word16Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Word16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10543,7 +10572,7 @@ func ConvertWord32(value Value) Word32Value {
 	return Word32Value(ConvertUInt32(value))
 }
 
-func (v Word32Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Word32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10556,7 +10585,7 @@ func (v Word32Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Word32Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Word32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10568,7 +10597,7 @@ func (v Word32Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Word32Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Word32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10919,7 +10948,7 @@ func ConvertWord64(value Value) Word64Value {
 	return Word64Value(ConvertUInt64(value))
 }
 
-func (v Word64Value) BitwiseOr(other IntegerValue) IntegerValue {
+func (v Word64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10932,7 +10961,7 @@ func (v Word64Value) BitwiseOr(other IntegerValue) IntegerValue {
 	return v | o
 }
 
-func (v Word64Value) BitwiseXor(other IntegerValue) IntegerValue {
+func (v Word64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10944,7 +10973,7 @@ func (v Word64Value) BitwiseXor(other IntegerValue) IntegerValue {
 	return v ^ o
 }
 
-func (v Word64Value) BitwiseAnd(other IntegerValue) IntegerValue {
+func (v Word64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2701,13 +2701,18 @@ func (v IntValue) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
 		})
 	}
 
-	res := new(big.Int)
-	// INT33-C
-	if o.BigInt.Cmp(res) == 0 {
-		panic(DivisionByZeroError{})
-	}
-	res.Rem(v.BigInt, o.BigInt)
-	return IntValue{res}
+	return NewIntValueFromBigInt(
+		interpreter,
+		common.NewModBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			// INT33-C
+			if o.BigInt.Cmp(res) == 0 {
+				panic(DivisionByZeroError{})
+			}
+			return res.Rem(v.BigInt, o.BigInt)
+		},
+	)
 }
 
 func (v IntValue) Mul(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -6414,13 +6419,19 @@ func (v UIntValue) Mod(interpreter *Interpreter, other NumberValue) NumberValue 
 		})
 	}
 
-	res := new(big.Int)
-	// INT33-C
-	if o.BigInt.Cmp(res) == 0 {
-		panic(DivisionByZeroError{})
-	}
-	res.Rem(v.BigInt, o.BigInt)
-	return UIntValue{res}
+	return NewUIntValueFromBigInt(
+		interpreter,
+		common.NewModBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			// INT33-C
+			if o.BigInt.Cmp(res) == 0 {
+				panic(DivisionByZeroError{})
+			}
+			res.Rem(v.BigInt, o.BigInt)
+			return res
+		},
+	)
 }
 
 func (v UIntValue) Mul(interpreter *Interpreter, other NumberValue) NumberValue {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -773,6 +773,28 @@ func TestInterpretIntMetering(t *testing.T) {
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
 	})
 
+	t.Run("division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 / 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
 	t.Run("modulo", func(t *testing.T) {
 
 		t.Parallel()
@@ -926,6 +948,28 @@ func TestInterpretUIntMetering(t *testing.T) {
 		// creation: 8 + 8
 		// result: 16 = 8 + 8
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 as UInt / 2 as UInt
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("modulo", func(t *testing.T) {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -725,6 +725,7 @@ func TestInterpretIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
 		// creation: 8 + 8
 		// result: 16 = max(8, 8) + 8
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
@@ -768,6 +769,7 @@ func TestInterpretIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
 		// creation: 8 + 8
 		// result: 16 = 8 + 8
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
@@ -883,14 +885,13 @@ func TestInterpretIntMetering(t *testing.T) {
 		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
 	})
 
-	t.Run("negation", func(t *testing.T) {
+	t.Run("bitwise left-shift", func(t *testing.T) {
 
 		t.Parallel()
 
 		script := `
             pub fun main() {
-                let x = 1
-		        let y = -x
+                let x = 10 << 2
             }
         `
 
@@ -900,6 +901,52 @@ func TestInterpretIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
+		// creation: 8 + 8
+		// result: 16 = 8 + 8
+		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("bitwise right-shift", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 >> 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("negation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 1
+                let y = -x
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
 		// creation: 8
 		// result: 8 = 8
 		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
@@ -946,6 +993,7 @@ func TestInterpretUIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
 		// creation: 8 + 8
 		// result: 16 = max(8, 8) + 8
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
@@ -1011,6 +1059,7 @@ func TestInterpretUIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
 		// creation: 8 + 8
 		// result: 16 = 8 + 8
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
@@ -1126,14 +1175,13 @@ func TestInterpretUIntMetering(t *testing.T) {
 		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
 	})
 
-	t.Run("negation", func(t *testing.T) {
+	t.Run("bitwise left-shift", func(t *testing.T) {
 
 		t.Parallel()
 
 		script := `
             pub fun main() {
-                let x = 1
-		        let y = -x
+                let x = 10 as UInt << 2 as UInt
             }
         `
 
@@ -1143,6 +1191,52 @@ func TestInterpretUIntMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
+		// TODO:
+		// creation: 8 + 8
+		// result: 16 = 8 + 8
+		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("bitwise right-shift", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 as UInt >> 2 as UInt
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("negation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 1
+                let y = -x
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
 		// creation: 8
 		// result: 8 = 8
 		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -817,6 +817,72 @@ func TestInterpretIntMetering(t *testing.T) {
 		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
 	})
 
+	t.Run("bitwise or", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 | 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("bitwise xor", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 ^ 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("bitwise and", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 & 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
 	t.Run("negation", func(t *testing.T) {
 
 		t.Parallel()
@@ -979,6 +1045,72 @@ func TestInterpretUIntMetering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x = 10 as UInt % 2 as UInt
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("bitwise or", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 as UInt | 2 as UInt
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("bitwise xor", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 as UInt ^ 2 as UInt
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("bitwise and", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 as UInt & 2 as UInt
             }
         `
 

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -730,6 +730,28 @@ func TestInterpretIntMetering(t *testing.T) {
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
 	})
 
+	t.Run("subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 1 - 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
 	t.Run("multiplication", func(t *testing.T) {
 
 		t.Parallel()
@@ -817,6 +839,50 @@ func TestInterpretUIntMetering(t *testing.T) {
 		// creation: 8 + 8
 		// result: 16 = max(8, 8) + 8
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 3 as UInt - 2 as UInt
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("saturating subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = (1 as UInt).saturatingSubtract(2 as UInt)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("multiplication", func(t *testing.T) {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -773,6 +773,28 @@ func TestInterpretIntMetering(t *testing.T) {
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
 	})
 
+	t.Run("modulo", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 % 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
+	})
+
 	t.Run("negation", func(t *testing.T) {
 
 		t.Parallel()
@@ -904,6 +926,28 @@ func TestInterpretUIntMetering(t *testing.T) {
 		// creation: 8 + 8
 		// result: 16 = 8 + 8
 		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindBigInt))
+	})
+
+	t.Run("modulo", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x = 10 as UInt % 2 as UInt
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// TODO:
+		// creation: 8 + 8
+		// result: 8 = max(8, 8)
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindBigInt))
 	})
 
 	t.Run("negation", func(t *testing.T) {


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

The formulas for calculating estimated memory usage of big-int operations will get replaced with proper ones as soon as they are available, i.e. once https://github.com/dapperlabs/cadence-private-issues/issues/32 is complete

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
