### PR TITLE
Add memory metering for `Int8`, `Int16`, `Int32` and `Int64` Values

### DIFF
--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -76,3 +76,18 @@ func NewMulBigIntMemoryUsage(a, b *big.Int) MemoryUsage {
 			BigIntByteLength(b),
 	)
 }
+
+func NewNumberMemoryUsage(bytes int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindNumber,
+		Amount: uint64(bytes),
+	}
+}
+
+func UseMemory(gauge MemoryGauge, usage MemoryUsage) {
+	if gauge == nil {
+		return
+	}
+
+	gauge.UseMemory(usage)
+}

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -466,7 +466,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	case cadence.Int16:
 		return importInt16(inter, v), nil
 	case cadence.Int32:
-		return interpreter.Int32Value(v), nil
+		return importInt32(inter, v), nil
 	case cadence.Int64:
 		return interpreter.Int64Value(v), nil
 	case cadence.Int128:
@@ -583,6 +583,16 @@ func importInt16(inter *interpreter.Interpreter, v cadence.Int16) interpreter.In
 		inter,
 		func() int16 {
 			return int16(v)
+		},
+	)
+}
+
+
+func importInt32(inter *interpreter.Interpreter, v cadence.Int32) interpreter.Int32Value {
+	return interpreter.NewInt32Value(
+		inter,
+		func() int32 {
+			return int32(v)
 		},
 	)
 }

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -468,7 +468,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	case cadence.Int32:
 		return importInt32(inter, v), nil
 	case cadence.Int64:
-		return interpreter.Int64Value(v), nil
+		return importInt64(inter, v), nil
 	case cadence.Int128:
 		return interpreter.NewInt128ValueFromBigInt(v.Value), nil
 	case cadence.Int256:
@@ -587,12 +587,20 @@ func importInt16(inter *interpreter.Interpreter, v cadence.Int16) interpreter.In
 	)
 }
 
-
 func importInt32(inter *interpreter.Interpreter, v cadence.Int32) interpreter.Int32Value {
 	return interpreter.NewInt32Value(
 		inter,
 		func() int32 {
 			return int32(v)
+		},
+	)
+}
+
+func importInt64(inter *interpreter.Interpreter, v cadence.Int64) interpreter.Int64Value {
+	return interpreter.NewInt64Value(
+		inter,
+		func() int64 {
+			return int64(v)
 		},
 	)
 }

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -464,7 +464,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	case cadence.Int8:
 		return importInt8(inter, v), nil
 	case cadence.Int16:
-		return interpreter.Int16Value(v), nil
+		return importInt16(inter, v), nil
 	case cadence.Int32:
 		return interpreter.Int32Value(v), nil
 	case cadence.Int64:
@@ -574,6 +574,15 @@ func importInt8(inter *interpreter.Interpreter, v cadence.Int8) interpreter.Int8
 		inter,
 		func() int8 {
 			return int8(v)
+		},
+	)
+}
+
+func importInt16(inter *interpreter.Interpreter, v cadence.Int16) interpreter.Int16Value {
+	return interpreter.NewInt16Value(
+		inter,
+		func() int16 {
+			return int16(v)
 		},
 	)
 }

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -462,7 +462,7 @@ func importValue(inter *interpreter.Interpreter, value cadence.Value, expectedTy
 	case cadence.Int:
 		return importInt(inter, v), nil
 	case cadence.Int8:
-		return interpreter.Int8Value(v), nil
+		return importInt8(inter, v), nil
 	case cadence.Int16:
 		return interpreter.Int16Value(v), nil
 	case cadence.Int32:
@@ -565,6 +565,15 @@ func importInt(inter *interpreter.Interpreter, v cadence.Int) interpreter.IntVal
 		memoryUsage,
 		func() *big.Int {
 			return v.Value
+		},
+	)
+}
+
+func importInt8(inter *interpreter.Interpreter, v cadence.Int8) interpreter.Int8Value {
+	return interpreter.NewInt8Value(
+		inter,
+		func() int8 {
+			return int8(v)
 		},
 	)
 }

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -32,11 +32,7 @@ import (
 
 func testUseMemory(meter map[common.MemoryKind]uint64) func(common.MemoryUsage) {
 	return func(usage common.MemoryUsage) {
-		current, ok := meter[usage.Kind]
-		if !ok {
-			current = 0
-		}
-		meter[usage.Kind] = current + usage.Amount
+		meter[usage.Kind] += usage.Amount
 	}
 }
 
@@ -46,7 +42,31 @@ func TestImportedValueMemoryMetering(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	t.Run("optional", func(t *testing.T) {
+	runtimeInterface := func(meter map[common.MemoryKind]uint64) *testRuntimeInterface {
+		return &testRuntimeInterface{
+			useMemory: testUseMemory(meter),
+			decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+				return jsoncdc.Decode(b)
+			},
+		}
+	}
+
+	executeScript := func(script []byte, meter map[common.MemoryKind]uint64, args ...cadence.Value) {
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source:    script,
+				Arguments: encodeArgs(args),
+			},
+			Context{
+				Interface: runtimeInterface(meter),
+				Location:  utils.TestLocation,
+			},
+		)
+
+		require.NoError(t, err)
+	}
+
+	t.Run("Optional", func(t *testing.T) {
 		t.Parallel()
 
 		script := []byte(`
@@ -55,27 +75,60 @@ func TestImportedValueMemoryMetering(t *testing.T) {
 
 		meter := make(map[common.MemoryKind]uint64)
 
-		runtimeInterface := &testRuntimeInterface{
-			useMemory: testUseMemory(meter),
-			decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-				return jsoncdc.Decode(b)
-			},
-		}
-
-		_, err := runtime.ExecuteScript(
-			Script{
-				Source: script,
-				Arguments: encodeArgs([]cadence.Value{
-					cadence.NewOptional(cadence.String("hello")),
-				}),
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  utils.TestLocation,
-			},
+		executeScript(
+			script,
+			meter,
+			cadence.NewOptional(cadence.String("hello")),
 		)
 
-		require.NoError(t, err)
 		assert.Equal(t, uint64(1), meter[common.MemoryKindOptional])
+	})
+
+	t.Run("Int8", func(t *testing.T) {
+		t.Parallel()
+
+		script := []byte(`
+            pub fun main(x: Int8) {}
+        `)
+
+		meter := make(map[common.MemoryKind]uint64)
+		executeScript(script, meter, cadence.NewInt8(2))
+		assert.Equal(t, uint64(1), meter[common.MemoryKindNumber])
+	})
+
+	t.Run("Int16", func(t *testing.T) {
+		t.Parallel()
+
+		script := []byte(`
+            pub fun main(x: Int16) {}
+        `)
+
+		meter := make(map[common.MemoryKind]uint64)
+		executeScript(script, meter, cadence.NewInt16(2))
+		assert.Equal(t, uint64(2), meter[common.MemoryKindNumber])
+	})
+
+	t.Run("Int32", func(t *testing.T) {
+		t.Parallel()
+
+		script := []byte(`
+            pub fun main(x: Int32) {}
+        `)
+
+		meter := make(map[common.MemoryKind]uint64)
+		executeScript(script, meter, cadence.NewInt32(2))
+		assert.Equal(t, uint64(4), meter[common.MemoryKindNumber])
+	})
+
+	t.Run("Int64", func(t *testing.T) {
+		t.Parallel()
+
+		script := []byte(`
+            pub fun main(x: Int64) {}
+        `)
+
+		meter := make(map[common.MemoryKind]uint64)
+		executeScript(script, meter, cadence.NewInt64(2))
+		assert.Equal(t, uint64(8), meter[common.MemoryKindNumber])
 	})
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -82,6 +82,11 @@ func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (stri
 	return dec.DecodeString()
 }
 
+func decodeInt64(d StorableDecoder) (int64, error) {
+	common.UseMemory(d.memoryGauge, int64MemoryUsage)
+	return d.decoder.DecodeInt64()
+}
+
 func DecodeStorable(
 	decoder *cbor.StreamDecoder,
 	slabStorageID atree.StorageID,
@@ -350,9 +355,7 @@ func (d StorableDecoder) decodeInt() (IntValue, error) {
 }
 
 func (d StorableDecoder) decodeInt8() (Int8Value, error) {
-	common.UseMemory(d.memoryGauge, int8MemoryUsage)
-
-	v, err := d.decoder.DecodeInt64()
+	v, err := decodeInt64(d)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return 0, fmt.Errorf("unknown Int8 encoding: %s", e.ActualType.String())
@@ -371,14 +374,12 @@ func (d StorableDecoder) decodeInt8() (Int8Value, error) {
 		return 0, fmt.Errorf("invalid Int8: got %d, expected max %d", v, max)
 	}
 
-	// Already metered at the start of this function
+	// Already metered at `decodeInt64` function
 	return NewUnmeteredInt8Value(int8(v)), nil
 }
 
 func (d StorableDecoder) decodeInt16() (Int16Value, error) {
-	common.UseMemory(d.memoryGauge, int16MemoryUsage)
-
-	v, err := d.decoder.DecodeInt64()
+	v, err := decodeInt64(d)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return 0, fmt.Errorf("unknown Int16 encoding: %s", e.ActualType.String())
@@ -397,14 +398,12 @@ func (d StorableDecoder) decodeInt16() (Int16Value, error) {
 		return 0, fmt.Errorf("invalid Int16: got %d, expected max %d", v, max)
 	}
 
-	// Already metered at the start of this function
+	// Already metered at `decodeInt64` function
 	return NewUnmeteredInt16Value(int16(v)), nil
 }
 
 func (d StorableDecoder) decodeInt32() (Int32Value, error) {
-	common.UseMemory(d.memoryGauge, int32MemoryUsage)
-
-	v, err := d.decoder.DecodeInt64()
+	v, err := decodeInt64(d)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return 0, fmt.Errorf("unknown Int32 encoding: %s", e.ActualType.String())
@@ -422,14 +421,12 @@ func (d StorableDecoder) decodeInt32() (Int32Value, error) {
 		return 0, fmt.Errorf("invalid Int32: got %d, expected max %d", v, max)
 	}
 
-	// Already metered at the start of this function
+	// Already metered at `decodeInt64` function
 	return NewUnmeteredInt32Value(int32(v)), nil
 }
 
 func (d StorableDecoder) decodeInt64() (Int64Value, error) {
-	common.UseMemory(d.memoryGauge, int64MemoryUsage)
-
-	v, err := d.decoder.DecodeInt64()
+	v, err := decodeInt64(d)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return 0, fmt.Errorf("unknown Int64 encoding: %s", e.ActualType.String())
@@ -437,7 +434,7 @@ func (d StorableDecoder) decodeInt64() (Int64Value, error) {
 		return 0, err
 	}
 
-	// Already metered at the start of this function
+	// Already metered at `decodeInt64` function
 	return NewUnmeteredInt64Value(v), nil
 }
 

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -402,6 +402,8 @@ func (d StorableDecoder) decodeInt16() (Int16Value, error) {
 }
 
 func (d StorableDecoder) decodeInt32() (Int32Value, error) {
+	common.UseMemory(d.memoryGauge, int32MemoryUsage)
+
 	v, err := d.decoder.DecodeInt64()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
@@ -419,7 +421,9 @@ func (d StorableDecoder) decodeInt32() (Int32Value, error) {
 	if v > max {
 		return 0, fmt.Errorf("invalid Int32: got %d, expected max %d", v, max)
 	}
-	return Int32Value(v), nil
+
+	// Already metered at the start of this function
+	return NewUnmeteredInt32Value(int32(v)), nil
 }
 
 func (d StorableDecoder) decodeInt64() (Int64Value, error) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -427,6 +427,8 @@ func (d StorableDecoder) decodeInt32() (Int32Value, error) {
 }
 
 func (d StorableDecoder) decodeInt64() (Int64Value, error) {
+	common.UseMemory(d.memoryGauge, int64MemoryUsage)
+
 	v, err := d.decoder.DecodeInt64()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
@@ -435,7 +437,8 @@ func (d StorableDecoder) decodeInt64() (Int64Value, error) {
 		return 0, err
 	}
 
-	return Int64Value(v), nil
+	// Already metered at the start of this function
+	return NewUnmeteredInt64Value(v), nil
 }
 
 func (d StorableDecoder) decodeInt128() (Int128Value, error) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -350,6 +350,8 @@ func (d StorableDecoder) decodeInt() (IntValue, error) {
 }
 
 func (d StorableDecoder) decodeInt8() (Int8Value, error) {
+	common.UseMemory(d.memoryGauge, int8MemoryUsage)
+
 	v, err := d.decoder.DecodeInt64()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
@@ -369,7 +371,8 @@ func (d StorableDecoder) decodeInt8() (Int8Value, error) {
 		return 0, fmt.Errorf("invalid Int8: got %d, expected max %d", v, max)
 	}
 
-	return Int8Value(v), nil
+	// Already metered at the start of this function
+	return NewUnmeteredInt8Value(int8(v)), nil
 }
 
 func (d StorableDecoder) decodeInt16() (Int16Value, error) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -376,6 +376,8 @@ func (d StorableDecoder) decodeInt8() (Int8Value, error) {
 }
 
 func (d StorableDecoder) decodeInt16() (Int16Value, error) {
+	common.UseMemory(d.memoryGauge, int16MemoryUsage)
+
 	v, err := d.decoder.DecodeInt64()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
@@ -394,7 +396,9 @@ func (d StorableDecoder) decodeInt16() (Int16Value, error) {
 	if v > max {
 		return 0, fmt.Errorf("invalid Int16: got %d, expected max %d", v, max)
 	}
-	return Int16Value(v), nil
+
+	// Already metered at the start of this function
+	return NewUnmeteredInt16Value(int16(v)), nil
 }
 
 func (d StorableDecoder) decodeInt32() (Int32Value, error) {

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -79,13 +79,15 @@ func TestDivModUInt8(t *testing.T) {
 		{0xff, 0xff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt8Value){
 			func(a, b UInt8Value) {
-				a.Div(nil, b)
+				a.Div(inter, b)
 			},
 			func(a, b UInt8Value) {
-				a.Mod(nil, b)
+				a.Mod(inter, b)
 			},
 		} {
 			f := func() {
@@ -151,13 +153,15 @@ func TestDivModUInt16(t *testing.T) {
 		{0xfff, 0xffff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt16Value){
 			func(a, b UInt16Value) {
-				a.Div(nil, b)
+				a.Div(inter, b)
 			},
 			func(a, b UInt16Value) {
-				a.Mod(nil, b)
+				a.Mod(inter, b)
 			},
 		} {
 			f := func() {
@@ -223,13 +227,15 @@ func TestDivModUInt32(t *testing.T) {
 		{0xffffffff, 0xffffffff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt32Value){
 			func(a, b UInt32Value) {
-				a.Div(nil, b)
+				a.Div(inter, b)
 			},
 			func(a, b UInt32Value) {
-				a.Mod(nil, b)
+				a.Mod(inter, b)
 			},
 		} {
 			f := func() {
@@ -385,13 +391,15 @@ func TestDivModUInt64(t *testing.T) {
 		{0xffffffffffffffff, 0xffffffffffffffff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt64Value){
 			func(a, b UInt64Value) {
-				a.Div(nil, b)
+				a.Div(inter, b)
 			},
 			func(a, b UInt64Value) {
-				a.Mod(nil, b)
+				a.Mod(inter, b)
 			},
 		} {
 			f := func() {
@@ -549,13 +557,15 @@ func TestDivModUInt128(t *testing.T) {
 		{uint128("0xffffffffffffffffffffffffffffffff"), uint128("0xffffffffffffffffffffffffffffffff"), true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt128Value){
 			func(a, b UInt128Value) {
-				a.Div(nil, b)
+				a.Div(inter, b)
 			},
 			func(a, b UInt128Value) {
-				a.Mod(nil, b)
+				a.Mod(inter, b)
 			},
 		} {
 			f := func() {
@@ -1219,13 +1229,15 @@ func TestDivModUInt256(t *testing.T) {
 		},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt256Value){
 			func(a, b UInt256Value) {
-				a.Div(nil, b)
+				a.Div(inter, b)
 			},
 			func(a, b UInt256Value) {
-				a.Mod(nil, b)
+				a.Mod(inter, b)
 			},
 		} {
 			f := func() {
@@ -1292,9 +1304,11 @@ func TestDivInt8(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(nil, test.b)
+			test.a.Div(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1355,9 +1369,11 @@ func TestModInt8(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(nil, test.b)
+			test.a.Mod(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1419,9 +1435,11 @@ func TestDivInt16(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(nil, test.b)
+			test.a.Div(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1482,9 +1500,11 @@ func TestModInt16(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(nil, test.b)
+			test.a.Mod(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1546,9 +1566,11 @@ func TestDivInt32(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(nil, test.b)
+			test.a.Div(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1609,9 +1631,11 @@ func TestModInt32(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(nil, test.b)
+			test.a.Mod(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1763,9 +1787,11 @@ func TestDivInt64(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(nil, test.b)
+			test.a.Div(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1916,9 +1942,11 @@ func TestModInt64(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(nil, test.b)
+			test.a.Mod(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1932,12 +1960,14 @@ func TestDivModInt(t *testing.T) {
 
 	t.Parallel()
 
+	inter := newTestInterpreter(t)
+
 	for _, f := range []func(a, b IntValue){
 		func(a, b IntValue) {
-			a.Div(nil, b)
+			a.Div(inter, b)
 		},
 		func(a, b IntValue) {
-			a.Mod(nil, b)
+			a.Mod(inter, b)
 		},
 	} {
 		assert.Panics(t, func() {
@@ -2046,9 +2076,11 @@ func TestDivInt128(t *testing.T) {
 		{int128("-0x00000000000000000000000000000001"), int128("-0x00000000000000000000000000000001"), true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(nil, test.b)
+			test.a.Div(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2157,9 +2189,11 @@ func TestModInt128(t *testing.T) {
 		{int128("-0x00000000000000000000000000000001"), int128("-0x00000000000000000000000000000001"), true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(nil, test.b)
+			test.a.Mod(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2611,9 +2645,11 @@ func TestDivInt256(t *testing.T) {
 		},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(nil, test.b)
+			test.a.Div(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3064,9 +3100,11 @@ func TestModInt256(t *testing.T) {
 		},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(nil, test.b)
+			test.a.Mod(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3115,12 +3153,14 @@ func TestDivFix64(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 
 		f := func() {
 			a := NewFix64ValueWithInteger(test.a)
 			b := NewFix64ValueWithInteger(test.b)
-			a.Div(nil, b)
+			a.Div(inter, b)
 		}
 
 		if test.valid {
@@ -3133,24 +3173,24 @@ func TestDivFix64(t *testing.T) {
 	assert.Equal(t,
 		Fix64Value(1),
 		NewFix64ValueWithInteger(1).
-			Div(nil, NewFix64ValueWithInteger(sema.Fix64Factor)),
+			Div(inter, NewFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(0),
 		NewFix64ValueWithInteger(1).
-			Div(nil, Fix64Value(Fix64MaxValue)),
+			Div(inter, Fix64Value(Fix64MaxValue)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(0),
 		Fix64Value(1).
-			Div(nil, NewFix64ValueWithInteger(2)),
+			Div(inter, NewFix64ValueWithInteger(2)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(1535399),
-		NewFix64ValueWithInteger(1543219).Div(nil, NewFix64ValueWithInteger(100509284)),
+		NewFix64ValueWithInteger(1543219).Div(inter, NewFix64ValueWithInteger(100509284)),
 	)
 }
 
@@ -3183,9 +3223,11 @@ func TestModFix64(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mod(nil, test.b)
+			test.a.Mod(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3224,14 +3266,16 @@ func TestDivModUFix64(t *testing.T) {
 		{ufix64MaxIntDividend + 1, 2, false},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 
 		for _, f := range []func(a, b UFix64Value){
 			func(a, b UFix64Value) {
-				a.Div(nil, b)
+				a.Div(inter, b)
 			},
 			func(a, b UFix64Value) {
-				a.Mod(nil, b)
+				a.Mod(inter, b)
 			},
 		} {
 
@@ -3252,24 +3296,24 @@ func TestDivModUFix64(t *testing.T) {
 	assert.Equal(t,
 		UFix64Value(1),
 		NewUFix64ValueWithInteger(1).
-			Div(nil, NewUFix64ValueWithInteger(sema.Fix64Factor)),
+			Div(inter, NewUFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(0),
 		NewUFix64ValueWithInteger(1).
-			Div(nil, UFix64Value(UFix64MaxValue)),
+			Div(inter, UFix64Value(UFix64MaxValue)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(0),
 		UFix64Value(1).
-			Div(nil, NewUFix64ValueWithInteger(2)),
+			Div(inter, NewUFix64ValueWithInteger(2)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(1535399),
-		NewUFix64ValueWithInteger(1543219).Div(nil, NewUFix64ValueWithInteger(100509284)),
+		NewUFix64ValueWithInteger(1543219).Div(inter, NewUFix64ValueWithInteger(100509284)),
 	)
 }
 
@@ -3326,10 +3370,12 @@ func TestNegativeMod(t *testing.T) {
 			}
 		}
 
+		inter := newTestInterpreter(t)
+
 		for _, test := range tests {
 			assert.Equal(t,
 				test.expected,
-				test.a.Mod(nil, test.b),
+				test.a.Mod(inter, test.b),
 			)
 		}
 	})
@@ -3350,10 +3396,12 @@ func TestNegativeMod(t *testing.T) {
 			}
 		}
 
+		inter := newTestInterpreter(t)
+
 		for _, test := range tests {
 			assert.Equal(t,
 				test.expected,
-				test.a.Mod(nil, test.b),
+				test.a.Mod(inter, test.b),
 			)
 		}
 	})

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -82,7 +82,7 @@ func TestDivModUInt8(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt8Value){
 			func(a, b UInt8Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt8Value) {
 				a.Mod(nil, b)
@@ -154,7 +154,7 @@ func TestDivModUInt16(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt16Value){
 			func(a, b UInt16Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt16Value) {
 				a.Mod(nil, b)
@@ -226,7 +226,7 @@ func TestDivModUInt32(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt32Value){
 			func(a, b UInt32Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt32Value) {
 				a.Mod(nil, b)
@@ -388,7 +388,7 @@ func TestDivModUInt64(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt64Value){
 			func(a, b UInt64Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt64Value) {
 				a.Mod(nil, b)
@@ -552,7 +552,7 @@ func TestDivModUInt128(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt128Value){
 			func(a, b UInt128Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt128Value) {
 				a.Mod(nil, b)
@@ -1222,7 +1222,7 @@ func TestDivModUInt256(t *testing.T) {
 	for _, test := range tests {
 		for _, f := range []func(a, b UInt256Value){
 			func(a, b UInt256Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UInt256Value) {
 				a.Mod(nil, b)
@@ -1294,7 +1294,7 @@ func TestDivInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1421,7 +1421,7 @@ func TestDivInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1548,7 +1548,7 @@ func TestDivInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1765,7 +1765,7 @@ func TestDivInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1934,7 +1934,7 @@ func TestDivModInt(t *testing.T) {
 
 	for _, f := range []func(a, b IntValue){
 		func(a, b IntValue) {
-			a.Div(b)
+			a.Div(nil, b)
 		},
 		func(a, b IntValue) {
 			a.Mod(nil, b)
@@ -2048,7 +2048,7 @@ func TestDivInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2613,7 +2613,7 @@ func TestDivInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Div(test.b)
+			test.a.Div(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -3120,7 +3120,7 @@ func TestDivFix64(t *testing.T) {
 		f := func() {
 			a := NewFix64ValueWithInteger(test.a)
 			b := NewFix64ValueWithInteger(test.b)
-			a.Div(b)
+			a.Div(nil, b)
 		}
 
 		if test.valid {
@@ -3133,24 +3133,24 @@ func TestDivFix64(t *testing.T) {
 	assert.Equal(t,
 		Fix64Value(1),
 		NewFix64ValueWithInteger(1).
-			Div(NewFix64ValueWithInteger(sema.Fix64Factor)),
+			Div(nil, NewFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(0),
 		NewFix64ValueWithInteger(1).
-			Div(Fix64Value(Fix64MaxValue)),
+			Div(nil, Fix64Value(Fix64MaxValue)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(0),
 		Fix64Value(1).
-			Div(NewFix64ValueWithInteger(2)),
+			Div(nil, NewFix64ValueWithInteger(2)),
 	)
 
 	assert.Equal(t,
 		Fix64Value(1535399),
-		NewFix64ValueWithInteger(1543219).Div(NewFix64ValueWithInteger(100509284)),
+		NewFix64ValueWithInteger(1543219).Div(nil, NewFix64ValueWithInteger(100509284)),
 	)
 }
 
@@ -3228,7 +3228,7 @@ func TestDivModUFix64(t *testing.T) {
 
 		for _, f := range []func(a, b UFix64Value){
 			func(a, b UFix64Value) {
-				a.Div(b)
+				a.Div(nil, b)
 			},
 			func(a, b UFix64Value) {
 				a.Mod(nil, b)
@@ -3252,24 +3252,24 @@ func TestDivModUFix64(t *testing.T) {
 	assert.Equal(t,
 		UFix64Value(1),
 		NewUFix64ValueWithInteger(1).
-			Div(NewUFix64ValueWithInteger(sema.Fix64Factor)),
+			Div(nil, NewUFix64ValueWithInteger(sema.Fix64Factor)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(0),
 		NewUFix64ValueWithInteger(1).
-			Div(UFix64Value(UFix64MaxValue)),
+			Div(nil, UFix64Value(UFix64MaxValue)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(0),
 		UFix64Value(1).
-			Div(NewUFix64ValueWithInteger(2)),
+			Div(nil, NewUFix64ValueWithInteger(2)),
 	)
 
 	assert.Equal(t,
 		UFix64Value(1535399),
-		NewUFix64ValueWithInteger(1543219).Div(NewUFix64ValueWithInteger(100509284)),
+		NewUFix64ValueWithInteger(1543219).Div(nil, NewUFix64ValueWithInteger(100509284)),
 	)
 }
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2182,7 +2182,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 
 	case sema.Int16Type:
 		if !valueType.Equal(unwrappedTargetType) {
-			return ConvertInt16(value)
+			return ConvertInt16(interpreter, value)
 		}
 
 	case sema.Int32Type:
@@ -2724,11 +2724,11 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int16TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int16Type),
-		convert: func(_ *Interpreter, value Value) Value {
-			return ConvertInt16(value)
+		convert: func(inter *Interpreter, value Value) Value {
+			return ConvertInt16(inter, value)
 		},
-		min: Int16Value(math.MinInt16),
-		max: Int16Value(math.MaxInt16),
+		min: NewUnmeteredInt16Value(math.MinInt16),
+		max: NewUnmeteredInt16Value(math.MaxInt16),
 	},
 	{
 		name:         sema.Int32TypeName,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2192,7 +2192,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 
 	case sema.Int64Type:
 		if !valueType.Equal(unwrappedTargetType) {
-			return ConvertInt64(value)
+			return ConvertInt64(interpreter, value)
 		}
 
 	case sema.Int128Type:
@@ -2742,11 +2742,11 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int64TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int64Type),
-		convert: func(_ *Interpreter, value Value) Value {
-			return ConvertInt64(value)
+		convert: func(interpreter *Interpreter, value Value) Value {
+			return ConvertInt64(interpreter, value)
 		},
-		min: Int64Value(math.MinInt64),
-		max: Int64Value(math.MaxInt64),
+		min: NewUnmeteredInt64Value(math.MinInt64),
+		max: NewUnmeteredInt64Value(math.MaxInt64),
 	},
 	{
 		name:         sema.Int128TypeName,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2177,7 +2177,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 	// Int*
 	case sema.Int8Type:
 		if !valueType.Equal(unwrappedTargetType) {
-			return ConvertInt8(value)
+			return ConvertInt8(interpreter, value)
 		}
 
 	case sema.Int16Type:
@@ -2715,11 +2715,11 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int8TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int8Type),
-		convert: func(_ *Interpreter, value Value) Value {
-			return ConvertInt8(value)
+		convert: func(inter *Interpreter, value Value) Value {
+			return ConvertInt8(inter, value)
 		},
-		min: Int8Value(math.MinInt8),
-		max: Int8Value(math.MaxInt8),
+		min: NewUnmeteredInt8Value(math.MinInt8),
+		max: NewUnmeteredInt8Value(math.MaxInt8),
 	},
 	{
 		name:         sema.Int16TypeName,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2187,7 +2187,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 
 	case sema.Int32Type:
 		if !valueType.Equal(unwrappedTargetType) {
-			return ConvertInt32(value)
+			return ConvertInt32(interpreter, value)
 		}
 
 	case sema.Int64Type:
@@ -2715,8 +2715,8 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int8TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int8Type),
-		convert: func(inter *Interpreter, value Value) Value {
-			return ConvertInt8(inter, value)
+		convert: func(interpreter *Interpreter, value Value) Value {
+			return ConvertInt8(interpreter, value)
 		},
 		min: NewUnmeteredInt8Value(math.MinInt8),
 		max: NewUnmeteredInt8Value(math.MaxInt8),
@@ -2724,8 +2724,8 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int16TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int16Type),
-		convert: func(inter *Interpreter, value Value) Value {
-			return ConvertInt16(inter, value)
+		convert: func(interpreter *Interpreter, value Value) Value {
+			return ConvertInt16(interpreter, value)
 		},
 		min: NewUnmeteredInt16Value(math.MinInt16),
 		max: NewUnmeteredInt16Value(math.MaxInt16),
@@ -2733,11 +2733,11 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.Int32TypeName,
 		functionType: sema.NumberConversionFunctionType(sema.Int32Type),
-		convert: func(_ *Interpreter, value Value) Value {
-			return ConvertInt32(value)
+		convert: func(interpreter *Interpreter, value Value) Value {
+			return ConvertInt32(interpreter, value)
 		},
-		min: Int32Value(math.MinInt32),
-		max: Int32Value(math.MaxInt32),
+		min: NewUnmeteredInt32Value(math.MinInt32),
+		max: NewUnmeteredInt32Value(math.MaxInt32),
 	},
 	{
 		name:         sema.Int64TypeName,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -208,7 +208,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.Minus(right)
+		return left.Minus(interpreter, right)
 
 	case ast.OperationMod:
 		left, leftOk := leftValue.(NumberValue)
@@ -232,7 +232,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		if !leftOk || !rightOk {
 			error(right)
 		}
-		return left.Div(right)
+		return left.Div(interpreter, right)
 
 	case ast.OperationBitwiseOr:
 		left, leftOk := leftValue.(IntegerValue)
@@ -478,7 +478,12 @@ func (interpreter *Interpreter) NewIntegerValueFromBigInt(value *big.Int, intege
 
 	// Int*
 	case sema.Int8Type:
-		return Int8Value(value.Int64())
+		return NewInt8Value(
+			interpreter,
+			func() int8 {
+				return int8(value.Int64())
+			},
+		)
 	case sema.Int16Type:
 		return Int16Value(value.Int64())
 	case sema.Int32Type:

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -485,11 +485,26 @@ func (interpreter *Interpreter) NewIntegerValueFromBigInt(value *big.Int, intege
 			},
 		)
 	case sema.Int16Type:
-		return Int16Value(value.Int64())
+		return NewInt16Value(
+			interpreter,
+			func() int16 {
+				return int16(value.Int64())
+			},
+		)
 	case sema.Int32Type:
-		return Int32Value(value.Int64())
+		return NewInt32Value(
+			interpreter,
+			func() int32 {
+				return int32(value.Int64())
+			},
+		)
 	case sema.Int64Type:
-		return Int64Value(value.Int64())
+		return NewInt64Value(
+			interpreter,
+			func() int64 {
+				return value.Int64()
+			},
+		)
 	case sema.Int128Type:
 		return NewInt128ValueFromBigInt(value)
 	case sema.Int256Type:

--- a/runtime/interpreter/minus_test.go
+++ b/runtime/interpreter/minus_test.go
@@ -127,7 +127,7 @@ func TestMinusUInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -238,7 +238,7 @@ func TestMinusUInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -349,7 +349,7 @@ func TestMinusUInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -676,7 +676,7 @@ func TestMinusUInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -789,7 +789,7 @@ func TestMinusUInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1244,7 +1244,7 @@ func TestMinusUInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1355,7 +1355,7 @@ func TestMinusInt8(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1467,7 +1467,7 @@ func TestMinusInt16(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1578,7 +1578,7 @@ func TestMinusInt32(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1905,7 +1905,7 @@ func TestMinusInt64(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2018,7 +2018,7 @@ func TestMinusInt128(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2473,7 +2473,7 @@ func TestMinusInt256(t *testing.T) {
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(test.b)
+			test.a.Minus(nil, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2586,7 +2586,7 @@ func TestMinusUInt(t *testing.T) {
 		f := func() {
 			a := NewUnmeteredUIntValueFromUint64(test.a)
 			b := NewUnmeteredUIntValueFromUint64(test.b)
-			a.Minus(b)
+			a.Minus(nil, b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/minus_test.go
+++ b/runtime/interpreter/minus_test.go
@@ -125,9 +125,11 @@ func TestMinusUInt8(t *testing.T) {
 		{0xff, 0xff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -236,9 +238,11 @@ func TestMinusUInt16(t *testing.T) {
 		{0xffff, 0xffff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -347,9 +351,11 @@ func TestMinusUInt32(t *testing.T) {
 		{0xffffffff, 0xffffffff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -674,9 +680,11 @@ func TestMinusUInt64(t *testing.T) {
 		{0xffffffffffffffff, 0xffffffffffffffff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -787,9 +795,11 @@ func TestMinusUInt128(t *testing.T) {
 		{uint128("0xffffffffffffffffffffffffffffffff"), uint128("0xffffffffffffffffffffffffffffffff"), true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1242,9 +1252,11 @@ func TestMinusUInt256(t *testing.T) {
 		},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1353,9 +1365,11 @@ func TestMinusInt8(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1465,9 +1479,11 @@ func TestMinusInt16(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1576,9 +1592,11 @@ func TestMinusInt32(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1903,9 +1921,11 @@ func TestMinusInt64(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2016,9 +2036,11 @@ func TestMinusInt128(t *testing.T) {
 		{int128("-0x00000000000000000000000000000001"), int128("-0x00000000000000000000000000000001"), true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2471,9 +2493,11 @@ func TestMinusInt256(t *testing.T) {
 		},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Minus(nil, test.b)
+			test.a.Minus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2582,11 +2606,13 @@ func TestMinusUInt(t *testing.T) {
 		{0xff, 0xff, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
 			a := NewUnmeteredUIntValueFromUint64(test.a)
 			b := NewUnmeteredUIntValueFromUint64(test.b)
-			a.Minus(nil, b)
+			a.Minus(inter, b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/mul_test.go
+++ b/runtime/interpreter/mul_test.go
@@ -1615,9 +1615,11 @@ func TestMulInt8(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(nil, test.b)
+			test.a.Mul(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1803,9 +1805,11 @@ func TestMulInt16(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(nil, test.b)
+			test.a.Mul(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1974,9 +1978,11 @@ func TestMulInt32(t *testing.T) {
 		{-1, -1, true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(nil, test.b)
+			test.a.Mul(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2130,9 +2136,11 @@ func TestMulInt64(t *testing.T) {
 		{0xffffffff, 0x100000002, false},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(nil, test.b)
+			test.a.Mul(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2288,9 +2296,11 @@ func TestMulInt128(t *testing.T) {
 		{int128("-0x00000000000000000000000000000001"), int128("-0x00000000000000000000000000000001"), true},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Mul(nil, test.b)
+			test.a.Mul(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/plus_test.go
+++ b/runtime/interpreter/plus_test.go
@@ -128,9 +128,11 @@ func TestPlusUInt8(t *testing.T) {
 		{0xff, 0xff, false},
 	}
 
+	inter := newTestInterpreter(t)
+
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -239,10 +241,11 @@ func TestPlusUInt16(t *testing.T) {
 		{0xfffe, 0xffff, false},
 		{0xffff, 0xffff, false},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -350,10 +353,11 @@ func TestPlusUInt32(t *testing.T) {
 		{0xfffffffe, 0xffffffff, false},
 		{0xffffffff, 0xffffffff, false},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -678,10 +682,11 @@ func TestPlusUInt64(t *testing.T) {
 		{0xfffffffffffffffe, 0xffffffffffffffff, false},
 		{0xffffffffffffffff, 0xffffffffffffffff, false},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -805,10 +810,11 @@ func TestPlusUInt128(t *testing.T) {
 		{uint128("0xfffffffffffffffffffffffffffffffe"), uint128("0xffffffffffffffffffffffffffffffff"), false},
 		{uint128("0xffffffffffffffffffffffffffffffff"), uint128("0xffffffffffffffffffffffffffffffff"), false},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1273,10 +1279,11 @@ func TestPlusUInt256(t *testing.T) {
 			false,
 		},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1385,10 +1392,11 @@ func TestPlusInt8(t *testing.T) {
 		{-2, -1, true},
 		{-1, -1, true},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1497,10 +1505,11 @@ func TestPlusInt16(t *testing.T) {
 		{-2, -1, true},
 		{-1, -1, true},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1609,10 +1618,11 @@ func TestPlusInt32(t *testing.T) {
 		{-2, -1, true},
 		{-1, -1, true},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -1937,10 +1947,11 @@ func TestPlusInt64(t *testing.T) {
 		{-2, -1, true},
 		{-1, -1, true},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2064,10 +2075,11 @@ func TestPlusInt128(t *testing.T) {
 		{int128("-0x00000000000000000000000000000002"), int128("-0x00000000000000000000000000000001"), true},
 		{int128("-0x00000000000000000000000000000001"), int128("-0x00000000000000000000000000000001"), true},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)
@@ -2497,10 +2509,11 @@ func TestPlusInt256(t *testing.T) {
 			true,
 		},
 	}
+	inter := newTestInterpreter(t)
 
 	for _, test := range tests {
 		f := func() {
-			test.a.Plus(nil, test.b)
+			test.a.Plus(inter, test.b)
 		}
 		if test.valid {
 			assert.NotPanics(t, f)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -3022,7 +3022,9 @@ func (IntValue) ChildStorables() []atree.Storable {
 
 type Int8Value int8
 
-var int8MemoryUsage = common.NewNumberMemoryUsage(int(unsafe.Sizeof(Int8Value(0))))
+const int8Size = int(unsafe.Sizeof(Int8Value(0)))
+
+var int8MemoryUsage = common.NewNumberMemoryUsage(int8Size)
 
 func NewInt8Value(gauge common.MemoryGauge, valueGetter func() int8) Int8Value {
 	common.UseMemory(gauge, int8MemoryUsage)
@@ -3580,7 +3582,9 @@ func (Int8Value) ChildStorables() []atree.Storable {
 
 type Int16Value int16
 
-var int16MemoryUsage = common.NewNumberMemoryUsage(int(unsafe.Sizeof(Int16Value(0))))
+const int16Size = int(unsafe.Sizeof(Int16Value(0)))
+
+var int16MemoryUsage = common.NewNumberMemoryUsage(int16Size)
 
 func NewInt16Value(gauge common.MemoryGauge, valueGetter func() int16) Int16Value {
 	common.UseMemory(gauge, int16MemoryUsage)
@@ -4140,7 +4144,9 @@ func (Int16Value) ChildStorables() []atree.Storable {
 
 type Int32Value int32
 
-var int32MemoryUsage = common.NewNumberMemoryUsage(int(unsafe.Sizeof(Int32Value(0))))
+const int32Size = int(unsafe.Sizeof(Int32Value(0)))
+
+var int32MemoryUsage = common.NewNumberMemoryUsage(int32Size)
 
 func NewInt32Value(gauge common.MemoryGauge, valueGetter func() int32) Int32Value {
 	common.UseMemory(gauge, int32MemoryUsage)
@@ -4700,7 +4706,7 @@ func (Int32Value) ChildStorables() []atree.Storable {
 
 type Int64Value int64
 
-var int64MemoryUsage = common.NewNumberMemoryUsage(int(unsafe.Sizeof(Int64Value(0))))
+var int64MemoryUsage = common.NewNumberMemoryUsage(int64Size)
 
 func NewInt64Value(gauge common.MemoryGauge, valueGetter func() int64) Int64Value {
 	common.UseMemory(gauge, int64MemoryUsage)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4140,6 +4140,18 @@ func (Int16Value) ChildStorables() []atree.Storable {
 
 type Int32Value int32
 
+var int32MemoryUsage = common.NewNumberMemoryUsage(int(unsafe.Sizeof(Int32Value(0))))
+
+func NewInt32Value(gauge common.MemoryGauge, valueGetter func() int32) Int32Value {
+	common.UseMemory(gauge, int32MemoryUsage)
+
+	return NewUnmeteredInt32Value(valueGetter())
+}
+
+func NewUnmeteredInt32Value(value int32) Int32Value {
+	return Int32Value(value)
+}
+
 var _ Value = Int32Value(0)
 var _ atree.Storable = Int32Value(0)
 var _ NumberValue = Int32Value(0)
@@ -4180,12 +4192,17 @@ func (v Int32Value) ToInt() int {
 	return int(v)
 }
 
-func (v Int32Value) Negate(*Interpreter) NumberValue {
+func (v Int32Value) Negate(interpreter *Interpreter) NumberValue {
 	// INT32-C
 	if v == math.MinInt32 {
 		panic(OverflowError{})
 	}
-	return -v
+
+	valueGetter := func() int32 {
+		return int32(-v)
+	}
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) Plus(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4204,7 +4221,12 @@ func (v Int32Value) Plus(interpreter *Interpreter, other NumberValue) NumberValu
 	} else if (o < 0) && (v < (math.MinInt32 - o)) {
 		panic(UnderflowError{})
 	}
-	return v + o
+
+	valueGetter := func() int32 {
+		return int32(v + o)
+	}
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) SaturatingPlus(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4217,13 +4239,17 @@ func (v Int32Value) SaturatingPlus(interpreter *Interpreter, other NumberValue) 
 		})
 	}
 
-	// INT32-C
-	if (o > 0) && (v > (math.MaxInt32 - o)) {
-		return Int32Value(math.MaxInt32)
-	} else if (o < 0) && (v < (math.MinInt32 - o)) {
-		return Int32Value(math.MinInt32)
+	valueGetter := func() int32 {
+		// INT32-C
+		if (o > 0) && (v > (math.MaxInt32 - o)) {
+			return math.MaxInt32
+		} else if (o < 0) && (v < (math.MinInt32 - o)) {
+			return math.MinInt32
+		}
+		return int32(v + o)
 	}
-	return v + o
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) Minus(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4242,7 +4268,12 @@ func (v Int32Value) Minus(interpreter *Interpreter, other NumberValue) NumberVal
 	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
 		panic(UnderflowError{})
 	}
-	return v - o
+
+	valueGetter := func() int32 {
+		return int32(v - o)
+	}
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) SaturatingMinus(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4255,13 +4286,17 @@ func (v Int32Value) SaturatingMinus(interpreter *Interpreter, other NumberValue)
 		})
 	}
 
-	// INT32-C
-	if (o > 0) && (v < (math.MinInt32 + o)) {
-		return Int32Value(math.MinInt32)
-	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
-		return Int32Value(math.MaxInt32)
+	valueGetter := func() int32 {
+		// INT32-C
+		if (o > 0) && (v < (math.MinInt32 + o)) {
+			return math.MinInt32
+		} else if (o < 0) && (v > (math.MaxInt32 + o)) {
+			return math.MaxInt32
+		}
+		return int32(v - o)
 	}
-	return v - o
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4278,7 +4313,12 @@ func (v Int32Value) Mod(interpreter *Interpreter, other NumberValue) NumberValue
 	if o == 0 {
 		panic(DivisionByZeroError{})
 	}
-	return v % o
+
+	valueGetter := func() int32 {
+		return int32(v % o)
+	}
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) Mul(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4317,7 +4357,12 @@ func (v Int32Value) Mul(interpreter *Interpreter, other NumberValue) NumberValue
 			}
 		}
 	}
-	return v * o
+
+	valueGetter := func() int32 {
+		return int32(v * o)
+	}
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) SaturatingMul(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4330,33 +4375,37 @@ func (v Int32Value) SaturatingMul(interpreter *Interpreter, other NumberValue) N
 		})
 	}
 
-	// INT32-C
-	if v > 0 {
-		if o > 0 {
-			// positive * positive = positive. overflow?
-			if v > (math.MaxInt32 / o) {
-				return Int32Value(math.MaxInt32)
+	valueGetter := func() int32 {
+		// INT32-C
+		if v > 0 {
+			if o > 0 {
+				// positive * positive = positive. overflow?
+				if v > (math.MaxInt32 / o) {
+					return math.MaxInt32
+				}
+			} else {
+				// positive * negative = negative. underflow?
+				if o < (math.MinInt32 / v) {
+					return math.MinInt32
+				}
 			}
 		} else {
-			// positive * negative = negative. underflow?
-			if o < (math.MinInt32 / v) {
-				return Int32Value(math.MinInt32)
+			if o > 0 {
+				// negative * positive = negative. underflow?
+				if v < (math.MinInt32 / o) {
+					return math.MinInt32
+				}
+			} else {
+				// negative * negative = positive. overflow?
+				if (v != 0) && (o < (math.MaxInt32 / v)) {
+					return math.MaxInt32
+				}
 			}
 		}
-	} else {
-		if o > 0 {
-			// negative * positive = negative. underflow?
-			if v < (math.MinInt32 / o) {
-				return Int32Value(math.MinInt32)
-			}
-		} else {
-			// negative * negative = positive. overflow?
-			if (v != 0) && (o < (math.MaxInt32 / v)) {
-				return Int32Value(math.MaxInt32)
-			}
-		}
+		return int32(v * o)
 	}
-	return v * o
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) Div(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4376,7 +4425,12 @@ func (v Int32Value) Div(interpreter *Interpreter, other NumberValue) NumberValue
 	} else if (v == math.MinInt32) && (o == -1) {
 		panic(OverflowError{})
 	}
-	return v / o
+
+	valueGetter := func() int32 {
+		return int32(v / o)
+	}
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) SaturatingDiv(interpreter *Interpreter, other NumberValue) NumberValue {
@@ -4389,14 +4443,19 @@ func (v Int32Value) SaturatingDiv(interpreter *Interpreter, other NumberValue) N
 		})
 	}
 
-	// INT33-C
-	// https://golang.org/ref/spec#Integer_operators
-	if o == 0 {
-		panic(DivisionByZeroError{})
-	} else if (v == math.MinInt32) && (o == -1) {
-		return Int32Value(math.MaxInt32)
+	valueGetter := func() int32 {
+		// INT33-C
+		// https://golang.org/ref/spec#Integer_operators
+		if o == 0 {
+			panic(DivisionByZeroError{})
+		} else if (v == math.MinInt32) && (o == -1) {
+			return math.MaxInt32
+		}
+
+		return int32(v / o)
 	}
-	return v / o
+
+	return NewInt32Value(interpreter, valueGetter)
 }
 
 func (v Int32Value) Less(other NumberValue) BoolValue {
@@ -4468,33 +4527,33 @@ func (v Int32Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []
 	return scratch[:5]
 }
 
-func ConvertInt32(value Value) Int32Value {
-	var res int32
+func ConvertInt32(memoryGauge common.MemoryGauge, value Value) Int32Value {
+	converter := func() int32 {
+		switch value := value.(type) {
+		case BigNumberValue:
+			v := value.ToBigInt()
+			if v.Cmp(sema.Int32TypeMaxInt) > 0 {
+				panic(OverflowError{})
+			} else if v.Cmp(sema.Int32TypeMinInt) < 0 {
+				panic(UnderflowError{})
+			}
+			return int32(v.Int64())
 
-	switch value := value.(type) {
-	case BigNumberValue:
-		v := value.ToBigInt()
-		if v.Cmp(sema.Int32TypeMaxInt) > 0 {
-			panic(OverflowError{})
-		} else if v.Cmp(sema.Int32TypeMinInt) < 0 {
-			panic(UnderflowError{})
+		case NumberValue:
+			v := value.ToInt()
+			if v > math.MaxInt32 {
+				panic(OverflowError{})
+			} else if v < math.MinInt32 {
+				panic(UnderflowError{})
+			}
+			return int32(v)
+
+		default:
+			panic(errors.NewUnreachableError())
 		}
-		res = int32(v.Int64())
-
-	case NumberValue:
-		v := value.ToInt()
-		if v > math.MaxInt32 {
-			panic(OverflowError{})
-		} else if v < math.MinInt32 {
-			panic(UnderflowError{})
-		}
-		res = int32(v)
-
-	default:
-		panic(errors.NewUnreachableError())
 	}
 
-	return Int32Value(res)
+	return NewInt32Value(memoryGauge, converter)
 }
 
 func (v Int32Value) BitwiseOr(other IntegerValue) IntegerValue {

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -204,7 +204,7 @@ func convertIntValue(
 	case sema.Int16Type:
 		return interpreter.ConvertInt16(memoryGauge, intValue), nil
 	case sema.Int32Type:
-		return interpreter.ConvertInt32(intValue), nil
+		return interpreter.ConvertInt32(memoryGauge, intValue), nil
 	case sema.Int64Type:
 		return interpreter.ConvertInt64(intValue), nil
 	case sema.Int128Type:

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -202,7 +202,7 @@ func convertIntValue(
 	case sema.Int8Type:
 		return interpreter.ConvertInt8(memoryGauge, intValue), nil
 	case sema.Int16Type:
-		return interpreter.ConvertInt16(intValue), nil
+		return interpreter.ConvertInt16(memoryGauge, intValue), nil
 	case sema.Int32Type:
 		return interpreter.ConvertInt32(intValue), nil
 	case sema.Int64Type:

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -200,7 +200,7 @@ func convertIntValue(
 	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
 		return intValue, nil
 	case sema.Int8Type:
-		return interpreter.ConvertInt8(intValue), nil
+		return interpreter.ConvertInt8(memoryGauge, intValue), nil
 	case sema.Int16Type:
 		return interpreter.ConvertInt16(intValue), nil
 	case sema.Int32Type:

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -206,7 +206,7 @@ func convertIntValue(
 	case sema.Int32Type:
 		return interpreter.ConvertInt32(memoryGauge, intValue), nil
 	case sema.Int64Type:
-		return interpreter.ConvertInt64(intValue), nil
+		return interpreter.ConvertInt64(memoryGauge, intValue), nil
 	case sema.Int128Type:
 		return interpreter.ConvertInt128(intValue), nil
 	case sema.Int256Type:

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -862,3 +862,959 @@ func TestInterpretUIntMetering(t *testing.T) {
 		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindBigInt))
 	})
 }
+
+func TestInterpretInt8Metering(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("creation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1 + 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two operands (literals): 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1
+                let y: Int8 = x.saturatingAdd(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1 - 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two operands (literals): 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1
+                let y: Int8 = x.saturatingSubtract(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1 * 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two operands (literals): 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1
+                let y: Int8 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 3 / 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two operands (literals): 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 3
+                let y: Int8 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("modulus", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+		        let x: Int8 = 3 % 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 1 + 1
+		// result: 1
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("negation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int8 = 1
+		        let y: Int8 = -x
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// x: 1
+		// y: 1
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindNumber))
+	})
+}
+
+func TestInterpretInt16Metering(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("creation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1 + 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1
+                let y: Int16 = x.saturatingAdd(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1 - 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1
+                let y: Int16 = x.saturatingSubtract(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1 * 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1
+                let y: Int16 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 3 / 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 3
+                let y: Int16 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("modulus", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+		        let x: Int16 = 3 % 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 2 + 2
+		// result: 2
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("negation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int16 = 1
+		        let y: Int16 = -x
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// x: 2
+		// y: 2
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindNumber))
+	})
+}
+
+func TestInterpretInt32Metering(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("creation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1 + 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1
+                let y: Int32 = x.saturatingAdd(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1 - 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1
+                let y: Int32 = x.saturatingSubtract(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1 * 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1
+                let y: Int32 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 3 / 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 3
+                let y: Int32 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("modulus", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+		        let x: Int32 = 3 % 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 4 + 4
+		// result: 4
+		assert.Equal(t, uint64(12), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("negation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int32 = 1
+		        let y: Int32 = -x
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// x: 4
+		// y: 4
+		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindNumber))
+	})
+}
+
+func TestInterpretInt64Metering(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("creation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1 + 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating addition", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1
+                let y: Int64 = x.saturatingAdd(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1 - 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating subtraction", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1
+                let y: Int64 = x.saturatingSubtract(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1 * 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating multiplication", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1
+                let y: Int64 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 3 / 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("saturating division", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 3
+                let y: Int64 = x.saturatingMultiply(2)
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("modulus", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+		        let x: Int64 = 3 % 2
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// two literals: 8 + 8
+		// result: 8
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindNumber))
+	})
+
+	t.Run("negation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                let x: Int64 = 1
+		        let y: Int64 = -x
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// x: 8
+		// y: 8
+		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindNumber))
+	})
+}


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
