### PR TITLE
Refactor to meter address value before creation, whenever possible

### DIFF
--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -226,7 +226,7 @@ func TestExportValue(t *testing.T) {
 		},
 		{
 			label:    "Address",
-			value:    interpreter.NewUnmeteredAddressValue([]byte{0x1}),
+			value:    interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 			expected: cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 0, 0, 1}),
 		},
 		{
@@ -611,7 +611,7 @@ func TestImportValue(t *testing.T) {
 		},
 		{
 			label:    "Address",
-			expected: interpreter.NewUnmeteredAddressValue([]byte{0x1}),
+			expected: interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 			value:    cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 0, 0, 1}),
 		},
 		{

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -770,9 +770,8 @@ func (d StorableDecoder) decodeAddress() (AddressValue, error) {
 		return AddressValue{}, err
 	}
 
-	// metered at start of method
-	address := NewUnmeteredAddressValue(addressBytes)
-	return address, nil
+	// Already metered at the start of this method
+	return NewUnmeteredAddressValueFromBytes(addressBytes), nil
 }
 
 func (d StorableDecoder) decodePath() (PathValue, error) {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -2880,7 +2880,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 		t.Parallel()
 
 		value := &CapabilityValue{
-			Address: NewUnmeteredAddressValue([]byte{0x2}),
+			Address: NewUnmeteredAddressValueFromBytes([]byte{0x2}),
 			Path:    privatePathValue,
 		}
 
@@ -2922,7 +2922,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 		t.Parallel()
 
 		value := &CapabilityValue{
-			Address:    NewUnmeteredAddressValue([]byte{0x2}),
+			Address:    NewUnmeteredAddressValueFromBytes([]byte{0x2}),
 			Path:       privatePathValue,
 			BorrowType: PrimitiveStaticTypeBool,
 		}
@@ -2967,7 +2967,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 		t.Parallel()
 
 		value := &CapabilityValue{
-			Address: NewUnmeteredAddressValue([]byte{0x3}),
+			Address: NewUnmeteredAddressValueFromBytes([]byte{0x3}),
 			Path:    publicPathValue,
 		}
 
@@ -3010,7 +3010,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 		t.Parallel()
 
 		value := &CapabilityValue{
-			Address:    NewUnmeteredAddressValue([]byte{0x3}),
+			Address:    NewUnmeteredAddressValueFromBytes([]byte{0x3}),
 			Path:       publicPathValue,
 			BorrowType: PrimitiveStaticTypeBool,
 		}
@@ -3056,7 +3056,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 		t.Parallel()
 
 		capabilityValue := &CapabilityValue{
-			Address:    NewUnmeteredAddressValue([]byte{0x3}),
+			Address:    NewUnmeteredAddressValueFromBytes([]byte{0x3}),
 			Path:       publicPathValue,
 			BorrowType: PrimitiveStaticTypePublicAccount,
 		}

--- a/runtime/interpreter/errors_test.go
+++ b/runtime/interpreter/errors_test.go
@@ -31,7 +31,7 @@ func TestOverwriteError_Error(t *testing.T) {
 
 	require.EqualError(t,
 		OverwriteError{
-			Address: NewUnmeteredAddressValue([]byte{0x1}),
+			Address: NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 			Path: PathValue{
 				Domain:     common.PathDomainStorage,
 				Identifier: "test",

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -444,7 +444,7 @@ func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerEx
 
 	if _, ok := typ.(*sema.AddressType); ok {
 		common.UseConstantMemory(interpreter, common.MemoryKindAddress)
-		return NewUnmeteredAddressValue(value.Bytes())
+		return NewUnmeteredAddressValueFromBytes(value.Bytes())
 	}
 
 	// The ranges are checked at the checker level.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16652,38 +16652,49 @@ func (*EphemeralReferenceValue) DeepRemove(_ *Interpreter) {
 //
 type AddressValue common.Address
 
-func NewUnmeteredAddressValue(b []byte) AddressValue {
+func NewUnmeteredAddressValueFromBytes(b []byte) AddressValue {
 	result := AddressValue{}
 	copy(result[common.AddressLength-len(b):], b)
 	return result
 }
 
+// NewAddressValue constructs an address-value from a `common.Address`.
+//
+// NOTE:
+// This method must only be used if the `address` value is already constructed,
+// and/or already loaded onto memory. This is a convenient method for better performance.
+// If the `address` needs to be constructed, the `NewAddressValueFromConstructor` must be used.
+//
 func NewAddressValue(
 	memoryGauge common.MemoryGauge,
 	address common.Address,
 ) AddressValue {
 	common.UseConstantMemory(memoryGauge, common.MemoryKindAddress)
-	return NewUnmeteredAddressValue(address[:])
+	return NewUnmeteredAddressValueFromBytes(address[:])
 }
 
-func NewAddressValueFromBytes(
+func NewAddressValueFromConstructor(
 	memoryGauge common.MemoryGauge,
-	address []byte,
+	addressConstructor func() common.Address,
 ) AddressValue {
 	common.UseConstantMemory(memoryGauge, common.MemoryKindAddress)
-	return NewUnmeteredAddressValue(address)
+	address := addressConstructor()
+	return NewUnmeteredAddressValueFromBytes(address[:])
 }
 
 func ConvertAddress(memoryGauge common.MemoryGauge, value Value) AddressValue {
-	var result common.Address
+	converter := func() (result common.Address) {
+		uint64Value := ConvertUInt64(memoryGauge, value)
 
-	uint64Value := ConvertUInt64(memoryGauge, value)
+		binary.BigEndian.PutUint64(
+			result[:common.AddressLength],
+			uint64(uint64Value),
+		)
 
-	binary.BigEndian.PutUint64(
-		result[:common.AddressLength],
-		uint64(uint64Value),
-	)
-	return NewAddressValue(memoryGauge, result)
+		return
+	}
+
+	return NewAddressValueFromConstructor(memoryGauge, converter)
 }
 
 var _ Value = AddressValue{}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -961,7 +961,7 @@ func TestStringer(t *testing.T) {
 			expected: `{"b": 99, "a": 42}`,
 		},
 		"Address": {
-			value:    NewUnmeteredAddressValue([]byte{0, 0, 0, 0, 0, 0, 0, 1}),
+			value:    NewUnmeteredAddressValueFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1}),
 			expected: "0x0000000000000001",
 		},
 		"composite": {
@@ -1041,7 +1041,7 @@ func TestStringer(t *testing.T) {
 					Domain:     common.PathDomainStorage,
 					Identifier: "foo",
 				},
-				Address:    NewUnmeteredAddressValue([]byte{1, 2, 3, 4, 5}),
+				Address:    NewUnmeteredAddressValueFromBytes([]byte{1, 2, 3, 4, 5}),
 				BorrowType: PrimitiveStaticTypeInt,
 			},
 			expected: "Capability<Int>(address: 0x0000000102030405, path: /storage/foo)",
@@ -1052,7 +1052,7 @@ func TestStringer(t *testing.T) {
 					Domain:     common.PathDomainStorage,
 					Identifier: "foo",
 				},
-				Address: NewUnmeteredAddressValue([]byte{1, 2, 3, 4, 5}),
+				Address: NewUnmeteredAddressValueFromBytes([]byte{1, 2, 3, 4, 5}),
 			},
 			expected: "Capability(address: 0x0000000102030405, path: /storage/foo)",
 		},
@@ -1430,7 +1430,7 @@ func TestGetHashInput(t *testing.T) {
 			},
 		},
 		"Address": {
-			value:    NewUnmeteredAddressValue([]byte{0, 0, 0, 0, 0, 0, 0, 1}),
+			value:    NewUnmeteredAddressValueFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1}),
 			expected: []byte{byte(HashInputTypeAddress), 0, 0, 0, 0, 0, 0, 0, 1},
 		},
 		"enum": {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2874,7 +2874,7 @@ func TestRuntimePublicAccountAddress(t *testing.T) {
 
 	var loggedMessages []string
 
-	address := interpreter.NewUnmeteredAddressValue([]byte{0x42})
+	address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x42})
 
 	runtimeInterface := &testRuntimeInterface{
 		getSigningAccounts: func() ([]Address, error) {
@@ -4303,7 +4303,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 		},
 		storage: newTestLedger(nil, nil),
 		createAccount: func(payer Address) (address Address, err error) {
-			result := interpreter.NewUnmeteredAddressValue([]byte{nextAccount})
+			result := interpreter.NewUnmeteredAddressValueFromBytes([]byte{nextAccount})
 			nextAccount++
 			return result.ToAddress(), nil
 		},

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -142,7 +142,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -188,7 +188,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -240,7 +240,7 @@ func TestInterpretAuthAccount_type(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountStorables := testAccount(
 			t,
@@ -331,7 +331,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -412,7 +412,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -516,7 +516,7 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -556,7 +556,7 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -590,7 +590,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -720,7 +720,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, getAccountValues := testAccount(
 			t,
@@ -872,7 +872,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 				t.Parallel()
 
-				address := interpreter.NewUnmeteredAddressValue([]byte{42})
+				address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 				inter, getAccountValues := testAccount(
 					t,
@@ -1022,7 +1022,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 				t.Parallel()
 
-				address := interpreter.NewUnmeteredAddressValue([]byte{42})
+				address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 				inter, getAccountValues := testAccount(
 					t,
@@ -1166,7 +1166,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 	})
 
 	t.Run("link to same path", func(t *testing.T) {
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		test := func(capabilityDomain common.PathDomain) {
 			inter, getAccountValues := testAccount(
@@ -1256,7 +1256,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 	})
 
 	t.Run("link same storage", func(t *testing.T) {
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		test := func(capabilityDomain common.PathDomain) {
 			inter, getAccountValues := testAccount(
@@ -1375,7 +1375,7 @@ func TestInterpretAuthAccount_unlink(t *testing.T) {
 
 				t.Parallel()
 
-				address := interpreter.NewUnmeteredAddressValue([]byte{42})
+				address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 				inter, getAccountValues := testAccount(
 					t,
@@ -1446,7 +1446,7 @@ func TestInterpretAuthAccount_unlink(t *testing.T) {
 
 				t.Parallel()
 
-				address := interpreter.NewUnmeteredAddressValue([]byte{42})
+				address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 				inter, getAccountValues := testAccount(
 					t,
@@ -1520,7 +1520,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 			t.Parallel()
 
-			address := interpreter.NewUnmeteredAddressValue([]byte{42})
+			address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 			inter, getAccountValues := testAccount(
 				t,
@@ -1598,7 +1598,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 			t.Parallel()
 
-			address := interpreter.NewUnmeteredAddressValue([]byte{42})
+			address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 			inter, getAccountValues := testAccount(
 				t,
@@ -1733,7 +1733,7 @@ func TestInterpretAccount_getCapability(t *testing.T) {
 
 				t.Run(testName, func(t *testing.T) {
 
-					address := interpreter.NewUnmeteredAddressValue([]byte{42})
+					address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 					inter, _ := testAccount(
 						t,
@@ -1800,7 +1800,7 @@ func TestInterpretAccount_BalanceFields(t *testing.T) {
 
 			t.Run(testName, func(t *testing.T) {
 
-				address := interpreter.NewUnmeteredAddressValue([]byte{42})
+				address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 				code := fmt.Sprintf(
 					`
@@ -1861,7 +1861,7 @@ func TestInterpretAccount_StorageFields(t *testing.T) {
 					fieldName,
 				)
 
-				address := interpreter.NewUnmeteredAddressValue([]byte{42})
+				address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 				inter, _ := testAccount(
 					t,

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -36,7 +36,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, _ := testAccount(
 			t,
@@ -261,7 +261,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, _ := testAccount(
 			t,
@@ -491,7 +491,7 @@ func TestInterpretCapability_check(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, _ := testAccount(
 			t,
@@ -708,7 +708,7 @@ func TestInterpretCapability_check(t *testing.T) {
 
 		t.Parallel()
 
-		address := interpreter.NewUnmeteredAddressValue([]byte{42})
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 		inter, _ := testAccount(
 			t,
@@ -926,7 +926,7 @@ func TestInterpretCapability_address(t *testing.T) {
 
 	t.Parallel()
 
-	address := interpreter.NewUnmeteredAddressValue([]byte{42})
+	address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
 	inter, _ := testAccount(
 		t,

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -895,7 +895,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		owner := newTestPublicAccountValue(
 			inter,
-			interpreter.NewUnmeteredAddressValue(common.Address{0x1}.Bytes()),
+			interpreter.NewUnmeteredAddressValueFromBytes(common.Address{0x1}.Bytes()),
 		)
 
 		_, err := inter.Invoke("test", owner)

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -47,7 +47,7 @@ func TestInterpretEquality(t *testing.T) {
 			Type: &sema.CapabilityType{},
 			ValueFactory: func(_ *interpreter.Interpreter) interpreter.Value {
 				return &interpreter.CapabilityValue{
-					Address: interpreter.NewUnmeteredAddressValue([]byte{0x1}),
+					Address: interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 					Path: interpreter.PathValue{
 						Domain:     common.PathDomainStorage,
 						Identifier: "something",

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6682,7 +6682,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		},
 		"Address": {
 			literal: `0x1`,
-			value:   interpreter.NewUnmeteredAddressValue([]byte{0x1}),
+			value:   interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 			ty:      &sema.AddressType{},
 		},
 		// Int*

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1144,7 +1144,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 		b := v[:]
 		data := make([]byte, len(b))
 		copy(data, b)
-		return interpreter.NewUnmeteredAddressValue(data)
+		return interpreter.NewUnmeteredAddressValueFromBytes(data)
 	case interpreter.Fix64Value:
 		return interpreter.NewFix64ValueWithInteger(int64(v.ToInt()))
 	case interpreter.UFix64Value:
@@ -1406,7 +1406,7 @@ func sign() int {
 func randomAddressValue() interpreter.AddressValue {
 	data := make([]byte, 8)
 	rand.Read(data)
-	return interpreter.NewUnmeteredAddressValue(data)
+	return interpreter.NewUnmeteredAddressValueFromBytes(data)
 }
 
 func randomPathValue() interpreter.PathValue {


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description

Just a refactor, to delay the creation of address whenever possible.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
