### PR TITLE
atree string value metering

### DIFF
--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -48,4 +48,5 @@ const (
 	MemoryKindHostFunction
 	MemoryKindBoundFunction
 	MemoryKindBigInt
+	MemoryKindRawString
 )

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -31,11 +31,12 @@ func _() {
 	_ = x[MemoryKindHostFunction-20]
 	_ = x[MemoryKindBoundFunction-21]
 	_ = x[MemoryKindBigInt-22]
+	_ = x[MemoryKindRawString-23]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigInt"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawString"
 
-var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222}
+var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -46,6 +46,13 @@ func NewStringMemoryUsage(length int) MemoryUsage {
 	}
 }
 
+func NewRawStringMemoryUsage(length int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindRawString,
+		Amount: uint64(length) + 1, // +1 to account for empty strings
+	}
+}
+
 func NewBigIntMemoryUsage(bytes int) MemoryUsage {
 	return MemoryUsage{
 		Kind:   MemoryKindBigInt,

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -759,7 +759,7 @@ func importAddress(inter *interpreter.Interpreter, v cadence.Address) interprete
 
 func importPathValue(inter *interpreter.Interpreter, v cadence.Path) interpreter.PathValue {
 	// meter the Path's Identifier since path is just a container
-	common.UseMemory(inter, common.NewStringMemoryUsage(len(v.Identifier)))
+	common.UseMemory(inter, common.NewRawStringMemoryUsage(len(v.Identifier)))
 
 	return interpreter.NewPathValue(
 		inter,

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -489,7 +489,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 		},
 		{
 			TypeName:   "Path",
-			MemoryKind: common.MemoryKindString,
+			MemoryKind: common.MemoryKindRawString,
 			Weight:     3 + 1,
 			TypeInstance: cadence.Path{
 				Domain:     "storage",
@@ -532,7 +532,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 		},
 		{
 			TypeName:   "Capability",
-			MemoryKind: common.MemoryKindString,
+			MemoryKind: common.MemoryKindRawString,
 			Weight:     13 + 1,
 			TypeInstance: cadence.Capability{
 				Path: cadence.Path{

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -93,8 +93,9 @@ func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge, strin
 	}
 
 	common.UseMemory(memoryGauge, common.MemoryUsage{
-		Kind:   stringKind,
-		Amount: length,
+		Kind: stringKind,
+		// + 1 to account for empty string
+		Amount: length + 1,
 	})
 
 	return dec.DecodeString()

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -81,7 +81,7 @@ func decodeCharacter(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (s
 	return dec.DecodeString()
 }
 
-func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (string, error) {
+func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge, stringKind common.MemoryKind) (string, error) {
 	length, err := dec.NextSize()
 	if err != nil {
 		return "", err
@@ -92,7 +92,10 @@ func decodeString(dec *cbor.StreamDecoder, memoryGauge common.MemoryGauge) (stri
 		}
 	}
 
-	common.UseMemory(memoryGauge, common.NewStringMemoryUsage(int(length)))
+	common.UseMemory(memoryGauge, common.MemoryUsage{
+		Kind:   stringKind,
+		Amount: length,
+	})
 
 	return dec.DecodeString()
 }
@@ -166,10 +169,11 @@ func (d StorableDecoder) decodeStorable() (atree.Storable, error) {
 		storable = NewUnmeteredNilValue()
 
 	case cbor.TextStringType:
-		str, err := decodeString(d.decoder, d.memoryGauge)
+		str, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 		if err != nil {
 			return nil, err
 		}
+		// already metered by decodeString
 		storable = StringAtreeValue(str)
 
 	case cbor.TagType:
@@ -337,7 +341,7 @@ func (d StorableDecoder) decodeCharacter() (CharacterValue, error) {
 }
 
 func (d StorableDecoder) decodeStringValue() (*StringValue, error) {
-	str, err := decodeString(d.decoder, d.memoryGauge)
+	str, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindString)
 	if err != nil {
 		if err, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
@@ -813,7 +817,7 @@ func (d StorableDecoder) decodePath() (PathValue, error) {
 	}
 
 	// Decode identifier at array index encodedPathValueIdentifierFieldKey
-	identifier, err := decodeString(d.decoder, d.memoryGauge)
+	identifier, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return EmptyPathValue, fmt.Errorf(
@@ -1127,7 +1131,7 @@ func (d TypeDecoder) decodeCompositeStaticType() (StaticType, error) {
 	}
 
 	// Decode qualified identifier at array index encodedCompositeStaticTypeQualifiedIdentifierFieldKey
-	qualifiedIdentifier, err := decodeString(d.decoder, d.memoryGauge)
+	qualifiedIdentifier, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
@@ -1177,7 +1181,7 @@ func (d TypeDecoder) decodeInterfaceStaticType() (InterfaceStaticType, error) {
 	}
 
 	// Decode qualified identifier at array index encodedInterfaceStaticTypeQualifiedIdentifierFieldKey
-	qualifiedIdentifier, err := decodeString(d.decoder, d.memoryGauge)
+	qualifiedIdentifier, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return InterfaceStaticType{},
@@ -1494,7 +1498,7 @@ func (d TypeDecoder) decodeCompositeTypeInfo() (atree.TypeInfo, error) {
 		return nil, err
 	}
 
-	qualifiedIdentifier, err := decodeString(d.decoder, d.memoryGauge)
+	qualifiedIdentifier, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		return nil, err
 	}
@@ -1618,7 +1622,7 @@ func (d LocationDecoder) DecodeLocation() (common.Location, error) {
 }
 
 func (d LocationDecoder) decodeStringLocation() (common.Location, error) {
-	s, err := decodeString(d.decoder, d.memoryGauge)
+	s, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
@@ -1633,7 +1637,7 @@ func (d LocationDecoder) decodeStringLocation() (common.Location, error) {
 }
 
 func (d LocationDecoder) decodeIdentifierLocation() (common.Location, error) {
-	s, err := decodeString(d.decoder, d.memoryGauge)
+	s, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
@@ -1693,7 +1697,7 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 	// Name
 
 	// Decode name at array index encodedAddressLocationNameFieldKey
-	name, err := decodeString(d.decoder, d.memoryGauge)
+	name, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -969,7 +969,7 @@ func (interpreter *Interpreter) VisitPathExpression(expression *ast.PathExpressi
 	domain := common.PathDomainFromIdentifier(expression.Domain.Identifier)
 
 	// meter the Path's Identifier since path is just a container
-	common.UseMemory(interpreter, common.NewStringMemoryUsage(len(expression.Identifier.Identifier)))
+	common.UseMemory(interpreter, common.NewRawStringMemoryUsage(len(expression.Identifier.Identifier)))
 
 	return NewPathValue(
 		interpreter,

--- a/runtime/interpreter/stringatreevalue.go
+++ b/runtime/interpreter/stringatreevalue.go
@@ -20,6 +20,7 @@ package interpreter
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/runtime/common"
 )
 
@@ -40,7 +41,7 @@ func (v StringAtreeValue) Storable(
 }
 
 func NewStringAtreeValue(gauge common.MemoryGauge, s string) StringAtreeValue {
-	gauge.MeterMemory(common.NewRawStringMemoryUsage(len(s)))
+	common.UseMemory(gauge, common.NewRawStringMemoryUsage(len(s)))
 	return StringAtreeValue(s)
 }
 

--- a/runtime/interpreter/stringatreevalue.go
+++ b/runtime/interpreter/stringatreevalue.go
@@ -20,6 +20,7 @@ package interpreter
 
 import (
 	"github.com/onflow/atree"
+	"github.com/onflow/cadence/runtime/common"
 )
 
 type StringAtreeValue string
@@ -36,6 +37,11 @@ func (v StringAtreeValue) Storable(
 	error,
 ) {
 	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+}
+
+func NewStringAtreeValue(gauge common.MemoryGauge, s string) StringAtreeValue {
+	gauge.MeterMemory(common.NewRawStringMemoryUsage(len(s)))
+	return StringAtreeValue(s)
 }
 
 func (v StringAtreeValue) ByteSize() uint32 {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -13778,7 +13778,7 @@ func (v *CompositeValue) SetMember(
 	existingStorable, err := v.dictionary.Set(
 		StringAtreeComparator,
 		StringAtreeHashInput,
-		StringAtreeValue(name),
+		NewStringAtreeValue(interpreter, name),
 		value,
 	)
 	if err != nil {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -122,7 +122,7 @@ func TestInterpretDictionaryMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(5), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindString))
 		assert.Equal(t, uint64(10), meter.getMemory(common.MemoryKindDictionary))
 	})
 
@@ -180,8 +180,8 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(11), meter.getMemory(common.MemoryKindString))
-		assert.Equal(t, uint64(39), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(14), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(51), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindComposite))
 	})
 
@@ -253,10 +253,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		// 2 from field a
-		// 4 from type id of field a
-		// 2 from overhead of field a
-		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(11), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
 	})
 
@@ -283,13 +280,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		// 2 from field a
-		// 2 from field b
-		// 4 from type id of field a
-		// 4 from type id of field b
-		// 2 from overhead of field a
-		// 2 from overhead of field b
-		assert.Equal(t, uint64(17), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
 	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -122,7 +122,7 @@ func TestInterpretDictionaryMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(5), meter.getMemory(common.MemoryKindString))
 		assert.Equal(t, uint64(10), meter.getMemory(common.MemoryKindDictionary))
 	})
 
@@ -180,7 +180,8 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(11), meter.getMemory(common.MemoryKindString))
+		assert.Equal(t, uint64(39), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindComposite))
 	})
 
@@ -205,6 +206,91 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(30), meter.getMemory(common.MemoryKindComposite))
+	})
+}
+
+func TestInterpretCompositeFieldMetering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		            pub struct S {}
+		            pub fun main() {
+		                let s = S()
+		            }
+		        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
+	})
+
+	t.Run("1 field", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+	            pub struct S {
+					pub let a: String
+	                init(_ a: String) {
+	                    self.a = a
+	                }
+				}
+	            pub fun main() {
+	                let s = S("a")
+	            }
+	        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// 2 from field a
+		// 4 from type id of field a
+		// 2 from overhead of field a
+		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
+	})
+
+	t.Run("2 field", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub struct S {
+				pub let a: String
+				pub let b: String
+                init(_ a: String, _ b: String) {
+                    self.a = a
+					self.b = b
+                }
+			}
+            pub fun main() {
+                let s = S("a", "b")
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// 2 from field a
+		// 2 from field b
+		// 4 from type id of field a
+		// 4 from type id of field b
+		// 2 from overhead of field a
+		// 2 from overhead of field b
+		assert.Equal(t, uint64(17), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
 	})
 }
 


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description

Composite type field keys are `atreeStringValue`s, which consume memory and need to be metered. Here, we create a new `MemoryKindRawString` which is used to meter raw strings, rather than `StringValue`s. This comes into play when composite or other complex types like `Path`, `Location` or `Composite` fields are being metered. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
