### PR TITLE
Add support for Fx prefix for addresses

### DIFF
--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -114,6 +114,14 @@ This format includes less type information than a complete [ABI](https://en.wiki
 }
 ```
 
+```json
+{
+  "type": "Address",
+  "value": "Fx0" // as hex-encoded string with Fx prefix
+}
+```
+
+
 ### Example
 
 ```json

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -253,7 +253,7 @@ func decodeAddress(valueJSON interface{}) cadence.Address {
 	v := toString(valueJSON)
 
 	// must include 0x prefix
-	if v[:2] != "0x" {
+	if v[:2] != "0x" && v[:2] != "Fx" {
 		// TODO: improve error message
 		panic(ErrInvalidJSONCadence)
 	}

--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -113,6 +113,7 @@ func (a Address) HexWithPrefix() string {
 // HexToAddress converts a hex string to an Address.
 func HexToAddress(h string) (Address, error) {
 	trimmed := strings.TrimPrefix(h, "0x")
+	trimmed = strings.TrimPrefix(trimmed, "Fx")
 	if len(trimmed)%2 == 1 {
 		trimmed = "0" + trimmed
 	}

--- a/runtime/common/address_test.go
+++ b/runtime/common/address_test.go
@@ -252,5 +252,9 @@ func TestAddress_HexToAddress(t *testing.T) {
 		address, err = HexToAddress("0x" + test.literal)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, address)
+
+		address, err = HexToAddress("Fx" + test.literal)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, address)
 	}
 }

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -361,12 +361,14 @@ func (l *lexer) scanOctalRemainder() {
 }
 
 func (l *lexer) scanHexadecimalRemainder() {
-	l.acceptWhile(func(r rune) bool {
-		return (r >= '0' && r <= '9') ||
-			(r >= 'a' && r <= 'f') ||
-			(r >= 'A' && r <= 'F') ||
-			r == '_'
-	})
+	l.acceptWhile(isHexRune)
+}
+
+func isHexRune(r rune) bool {
+	return (r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'f') ||
+		(r >= 'A' && r <= 'F') ||
+		r == '_'
 }
 
 func (l *lexer) scanDecimalOrFixedPointRemainder() TokenType {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3928,8 +3928,9 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 
 	deploy := utils.DeploymentTransaction("FungibleToken", []byte(basicFungibleTokenContract))
 
+	// TODO replace `Fx` with `0x` and add `Fx` tests
 	setup1Transaction := []byte(`
-      import FungibleToken from 0x01
+      import FungibleToken from Fx01
 
       transaction {
 


### PR DESCRIPTION
Closes #398

## Description

Addresses can start with `Fx`.

Lexer reads tokens starting with `Fx` as hexadecimals if followed by a valid hex rune. So `Fx0123456789abcdef` is a valid number.

Related changes to treat `Fx` as a valid beginning to hex numbers.

______

WIP:
- [ ] Revert altered test to use `0x` prefix for import.
- [ ] Add tests that use `Fx` prefix for addresses.

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
