### PR TITLE
Check address length before decoding

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -738,8 +738,7 @@ func (d StorableDecoder) decodeSome() (SomeStorable, error) {
 	}, nil
 }
 
-func checkEncodedAddressLength(addressBytes []byte) error {
-	actualLength := len(addressBytes)
+func checkEncodedAddressLength(actualLength int) error {
 	const expectedLength = common.AddressLength
 	if actualLength > expectedLength {
 		return fmt.Errorf(
@@ -752,9 +751,7 @@ func checkEncodedAddressLength(addressBytes []byte) error {
 }
 
 func (d StorableDecoder) decodeAddress() (AddressValue, error) {
-	common.UseConstantMemory(d.memoryGauge, common.MemoryKindAddress)
-
-	addressBytes, err := d.decoder.DecodeBytes()
+	addressBytes, err := d.decodeAddressBytes()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return AddressValue{}, fmt.Errorf(
@@ -765,13 +762,25 @@ func (d StorableDecoder) decodeAddress() (AddressValue, error) {
 		return AddressValue{}, err
 	}
 
-	err = checkEncodedAddressLength(addressBytes)
+	// Already metered at `decodeAddressBytes()`
+	return NewUnmeteredAddressValueFromBytes(addressBytes), nil
+}
+
+func (d StorableDecoder) decodeAddressBytes() ([]byte, error) {
+	// Check the address length and validate before decoding.
+	length, err := d.decoder.NextSize()
 	if err != nil {
-		return AddressValue{}, err
+		return nil, err
 	}
 
-	// Already metered at the start of this method
-	return NewUnmeteredAddressValueFromBytes(addressBytes), nil
+	lengthErr := checkEncodedAddressLength(int(length))
+	if lengthErr != nil {
+		return nil, lengthErr
+	}
+
+	common.UseConstantMemory(d.memoryGauge, common.MemoryKindAddress)
+
+	return d.decoder.DecodeBytes()
 }
 
 func (d StorableDecoder) decodePath() (PathValue, error) {
@@ -1673,6 +1682,9 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 	// Address
 
 	// Decode address at array index encodedAddressLocationAddressFieldKey
+	//
+	// TODO: Use `decodeAddressBytes` and remove the `checkEncodedAddressLength` below
+	//       when memory metering of locations is implemented.
 	encodedAddress, err := d.decoder.DecodeBytes()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
@@ -1684,7 +1696,7 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 		return nil, err
 	}
 
-	err = checkEncodedAddressLength(encodedAddress)
+	err = checkEncodedAddressLength(len(encodedAddress))
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -443,8 +443,7 @@ func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerEx
 	value := expression.Value
 
 	if _, ok := typ.(*sema.AddressType); ok {
-		common.UseConstantMemory(interpreter, common.MemoryKindAddress)
-		return NewUnmeteredAddressValueFromBytes(value.Bytes())
+		return NewAddressValueFromBytes(interpreter, value.Bytes)
 	}
 
 	// The ranges are checked at the checker level.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16652,6 +16652,11 @@ func (*EphemeralReferenceValue) DeepRemove(_ *Interpreter) {
 //
 type AddressValue common.Address
 
+func NewAddressValueFromBytes(memoryGauge common.MemoryGauge, constructor func() []byte) AddressValue {
+	common.UseConstantMemory(memoryGauge, common.MemoryKindAddress)
+	return NewUnmeteredAddressValueFromBytes(constructor())
+}
+
 func NewUnmeteredAddressValueFromBytes(b []byte) AddressValue {
 	result := AddressValue{}
 	copy(result[common.AddressLength-len(b):], b)


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description

@robert-e-davidson3 and I had a discussion regarding this in PR https://github.com/onflow/cadence/pull/1442#discussion_r828514562 and decided not to change this, until the behaviour is confirmed.

Came across this thread yesterday and realized it has been already discussed in https://axiomzen.slack.com/archives/CG0B7CJAJ/p1646701886736249 and concluded that it's safe to use `NextSize` to get the size of `bytes` before decoding.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
