### PR TITLE
Fix field initialization: nested intersection should not override outer set

### DIFF
--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -191,8 +191,8 @@ func (checker *Checker) checkConditionalBranches(
 		} else if elseReturnInfo.DefinitelyHalted {
 			functionActivation.InitializationInfo.InitializedFieldMembers = thenInitializedMembers
 		} else {
-			functionActivation.InitializationInfo.InitializedFieldMembers =
-				thenInitializedMembers.Intersection(elseInitializedMembers)
+			functionActivation.InitializationInfo.InitializedFieldMembers.
+				AddIntersection(thenInitializedMembers, elseInitializedMembers)
 		}
 	}
 

--- a/runtime/sema/member_set.go
+++ b/runtime/sema/member_set.go
@@ -93,23 +93,17 @@ func (ms *MemberSet) ForEach(cb func(member *Member) error) error {
 	return nil
 }
 
-// Intersection returns a new set containing all members that exist in this and the given set.
+// AddIntersection adds the members that exist in both given member sets.
 //
-func (ms *MemberSet) Intersection(otherMS *MemberSet) *MemberSet {
+func (ms *MemberSet) AddIntersection(a, b *MemberSet) {
 
-	result := NewMemberSet(nil)
-
-	_ = ms.ForEach(func(member *Member) error {
-		if !otherMS.Contains(member) {
-			return nil
+	_ = a.ForEach(func(member *Member) error {
+		if b.Contains(member) {
+			ms.Add(member)
 		}
-
-		result.Add(member)
 
 		return nil
 	})
-
-	return result
 }
 
 // Clone returns a new child member set that contains all entries of this parent set.

--- a/runtime/sema/member_set_test.go
+++ b/runtime/sema/member_set_test.go
@@ -209,6 +209,7 @@ func TestMemberSet_Intersection(t *testing.T) {
 	memberB := &sema.Member{}
 	memberC := &sema.Member{}
 	memberD := &sema.Member{}
+	memberE := &sema.Member{}
 
 	A := sema.NewMemberSet(nil)
 	A.Add(memberA)
@@ -225,11 +226,14 @@ func TestMemberSet_Intersection(t *testing.T) {
 	ADC := AD.Clone()
 	ADC.Add(memberC)
 
-	result := ABC.Intersection(ADC)
-	assert.True(t, result.Contains(memberA))
-	assert.False(t, result.Contains(memberB))
-	assert.True(t, result.Contains(memberC))
-	assert.False(t, result.Contains(memberD))
+	ACE := sema.NewMemberSet(nil)
+	ACE.Add(memberE)
+	ACE.AddIntersection(ABC, ADC)
+	assert.True(t, ACE.Contains(memberA))
+	assert.False(t, ACE.Contains(memberB))
+	assert.True(t, ACE.Contains(memberC))
+	assert.False(t, ACE.Contains(memberD))
+	assert.True(t, ACE.Contains(memberE))
 
 	assert.True(t, A.Contains(memberA))
 	assert.False(t, A.Contains(memberB))


### PR DESCRIPTION
Closes #1523 

## Description

If-statement branches are checked using [`Checker.checkConditionalBranches`](https://github.com/onflow/cadence/blob/86f8b58fd259ea0f80b3fa3e74a92587d6a0cd3f/runtime/sema/check_conditional.go#L145-L145).
It temporarily creates a new child member set, checks each branch with the temporary member set (using [`Checker.checkWithInitializedMembers`](https://github.com/onflow/cadence/blob/86f8b58fd259ea0f80b3fa3e74a92587d6a0cd3f/runtime/sema/checker.go#L1646-L1661), then "merges" the result by building an intersection (a field is considered initialized if it was initialized in both branches).

The existing implementation was overwriting the outer if-statements member set.

Instead, mutate the current member set in-place when computing the intersection.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
