### PR TITLE
Commit storage before getting account storage capacity

### DIFF
--- a/runtime/interpreter/account.go
+++ b/runtime/interpreter/account.go
@@ -43,7 +43,7 @@ func NewAuthAccountValue(
 	accountBalanceGet func() UFix64Value,
 	accountAvailableBalanceGet func() UFix64Value,
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
-	storageCapacityGet func() UInt64Value,
+	storageCapacityGet func(interpreter *Interpreter) UInt64Value,
 	addPublicKeyFunction FunctionValue,
 	removePublicKeyFunction FunctionValue,
 	contractsConstructor func() Value,
@@ -86,8 +86,8 @@ func NewAuthAccountValue(
 		sema.AuthAccountStorageUsedField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return storageUsedGet(inter)
 		},
-		sema.AuthAccountStorageCapacityField: func(_ *Interpreter, _ func() LocationRange) Value {
-			return storageCapacityGet()
+		sema.AuthAccountStorageCapacityField: func(inter *Interpreter, _ func() LocationRange) Value {
+			return storageCapacityGet(inter)
 		},
 		sema.AuthAccountTypeField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return inter.authAccountTypeFunction(address)
@@ -154,7 +154,7 @@ func NewPublicAccountValue(
 	accountBalanceGet func() UFix64Value,
 	accountAvailableBalanceGet func() UFix64Value,
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
-	storageCapacityGet func() UInt64Value,
+	storageCapacityGet func(interpreter *Interpreter) UInt64Value,
 	keysConstructor func() Value,
 	contractsConstructor func() Value,
 ) Value {
@@ -193,8 +193,8 @@ func NewPublicAccountValue(
 		sema.PublicAccountStorageUsedField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return storageUsedGet(inter)
 		},
-		sema.PublicAccountStorageCapacityField: func(_ *Interpreter, _ func() LocationRange) Value {
-			return storageCapacityGet()
+		sema.PublicAccountStorageCapacityField: func(inter *Interpreter, _ func() LocationRange) Value {
+			return storageCapacityGet(inter)
 		},
 		sema.PublicAccountGetTargetLinkField: func(inter *Interpreter, _ func() LocationRange) Value {
 			return inter.accountGetLinkTargetFunction(address)

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -126,7 +126,7 @@ func testAccount(
 	return inter, getAccountValues
 }
 
-func returnZeroUInt64() interpreter.UInt64Value {
+func returnZeroUInt64(_ *interpreter.Interpreter) interpreter.UInt64Value {
 	return interpreter.UInt64Value(0)
 }
 


### PR DESCRIPTION
Closes #1367

## Description

Commit to storage before getting account storage capacity.
Otherwise it won't update when FLOW tokens are moved.
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
