### PR TITLE
Forbid reinitialization of variable, resource-kinded fields

### DIFF
--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -725,6 +725,17 @@ func (e *AssignmentToConstantMemberError) Error() string {
 
 func (*AssignmentToConstantMemberError) isSemanticError() {}
 
+type FieldReinitializationError struct {
+	Name string
+	ast.Range
+}
+
+func (e *FieldReinitializationError) Error() string {
+	return fmt.Sprintf("invalid reinitialization of field: `%s`", e.Name)
+}
+
+func (*FieldReinitializationError) isSemanticError() {}
+
 // FieldUninitializedError
 
 type FieldUninitializedError struct {


### PR DESCRIPTION
## Description

In addition to constant fields, also variable resource-kinded fields may not be re-initialized.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
