### PR TITLE
Memory metering for variables

### DIFF
--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -49,4 +49,5 @@ const (
 	MemoryKindBoundFunction
 	MemoryKindBigInt
 	MemoryKindRawString
+	MemoryKindVariable
 )

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -32,11 +32,12 @@ func _() {
 	_ = x[MemoryKindBoundFunction-21]
 	_ = x[MemoryKindBigInt-22]
 	_ = x[MemoryKindRawString-23]
+	_ = x[MemoryKindVariable-24]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawString"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariable"
 
-var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231}
+var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -340,6 +340,7 @@ func TestMemoryMeteringErrors(t *testing.T) {
 		return &testRuntimeInterface{
 			meterMemory: func(usage common.MemoryUsage) error {
 				if usage.Kind == common.MemoryKindInterpretedFunction ||
+					usage.Kind == common.MemoryKindVariable ||
 					usage.Kind == common.MemoryKindVoid {
 					return nil
 				}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3239,7 +3239,7 @@ var converterFunctionValues = func() []converterFunction {
 			if converterFunctionValue.NestedVariables == nil {
 				converterFunctionValue.NestedVariables = map[string]*Variable{}
 			}
-			// these variables are do need to be metered as they are only ever declared once,
+			// these variables are not needed to be metered as they are only ever declared once,
 			// and can be considered base interpreter overhead
 			converterFunctionValue.NestedVariables[name] = NewVariableWithValue(nil, value)
 		}
@@ -3427,7 +3427,7 @@ func defineBaseValue(activation *VariableActivation, name string, value Value) {
 	if activation.Find(name) != nil {
 		panic(errors.NewUnreachableError())
 	}
-	// these variables are do need to be metered as they are only ever declared once,
+	// these variables are not needed to be metered as they are only ever declared once,
 	// and can be considered base interpreter overhead
 	activation.Set(name, NewVariableWithValue(nil, value))
 }
@@ -3450,7 +3450,7 @@ var stringFunction = func() Value {
 		if functionValue.NestedVariables == nil {
 			functionValue.NestedVariables = map[string]*Variable{}
 		}
-		// these variables are do need to be metered as they are only ever declared once,
+		// these variables are not needed to be metered as they are only ever declared once,
 		// and can be considered base interpreter overhead
 		functionValue.NestedVariables[name] = NewVariableWithValue(nil, value)
 	}

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -38,15 +38,17 @@ func (v *Variable) SetValue(value Value) {
 	v.value = value
 }
 
+var variableMemoryUsage = common.NewConstantMemoryUsage(common.MemoryKindVariable)
+
 func NewVariableWithValue(gauge common.MemoryGauge, value Value) *Variable {
-	common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
+	common.UseMemory(gauge, variableMemoryUsage)
 	return &Variable{
 		value: value,
 	}
 }
 
 func NewVariableWithGetter(gauge common.MemoryGauge, getter func() Value) *Variable {
-	common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
+	common.UseMemory(gauge, variableMemoryUsage)
 	return &Variable{
 		getter: getter,
 	}

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -18,6 +18,8 @@
 
 package interpreter
 
+import "github.com/onflow/cadence/runtime/common"
+
 type Variable struct {
 	value  Value
 	getter func() Value
@@ -36,13 +38,19 @@ func (v *Variable) SetValue(value Value) {
 	v.value = value
 }
 
-func NewVariableWithValue(value Value) *Variable {
+func NewVariableWithValue(gauge common.MemoryGauge, value Value) *Variable {
+	if gauge != nil {
+		common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
+	}
 	return &Variable{
 		value: value,
 	}
 }
 
-func NewVariableWithGetter(getter func() Value) *Variable {
+func NewVariableWithGetter(gauge common.MemoryGauge, getter func() Value) *Variable {
+	if gauge != nil {
+		common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
+	}
 	return &Variable{
 		getter: getter,
 	}

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -39,18 +39,14 @@ func (v *Variable) SetValue(value Value) {
 }
 
 func NewVariableWithValue(gauge common.MemoryGauge, value Value) *Variable {
-	if gauge != nil {
-		common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
-	}
+	common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
 	return &Variable{
 		value: value,
 	}
 }
 
 func NewVariableWithGetter(gauge common.MemoryGauge, getter func() Value) *Variable {
-	if gauge != nil {
-		common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
-	}
+	common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindVariable))
 	return &Variable{
 		getter: getter,
 	}

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -147,7 +147,7 @@ func cryptoAlgorithmEnumValue(
 		caseValue := caseConstructor(inter, rawValue)
 		caseValues[i] = caseValue
 		constructorNestedVariables[enumCase.Name()] =
-			interpreter.NewVariableWithValue(caseValue)
+			interpreter.NewVariableWithValue(inter, caseValue)
 	}
 
 	return interpreter.EnumConstructorFunction(

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -79,6 +79,7 @@ func TestInterpretArrayMetering(t *testing.T) {
 		// 3 for dynamic type check of z
 		// 14 from value transfer
 		assert.Equal(t, uint64(29), meter.getMemory(common.MemoryKindArray))
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindVariable))
 	})
 
 	t.Run("iteration", func(t *testing.T) {
@@ -100,6 +101,7 @@ func TestInterpretArrayMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(33), meter.getMemory(common.MemoryKindArray))
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindVariable))
 	})
 }
 
@@ -124,6 +126,7 @@ func TestInterpretDictionaryMetering(t *testing.T) {
 
 		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindString))
 		assert.Equal(t, uint64(10), meter.getMemory(common.MemoryKindDictionary))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindVariable))
 	})
 
 	t.Run("iteration", func(t *testing.T) {
@@ -145,6 +148,7 @@ func TestInterpretDictionaryMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(30), meter.getMemory(common.MemoryKindDictionary))
+		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindVariable))
 	})
 }
 
@@ -183,6 +187,7 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		assert.Equal(t, uint64(14), meter.getMemory(common.MemoryKindString))
 		assert.Equal(t, uint64(51), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindComposite))
+		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindVariable))
 	})
 
 	t.Run("iteration", func(t *testing.T) {
@@ -206,6 +211,7 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(30), meter.getMemory(common.MemoryKindComposite))
+		assert.Equal(t, uint64(7), meter.getMemory(common.MemoryKindVariable))
 	})
 }
 

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -86,13 +86,13 @@ func TestInterpretArrayMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-	            pub fun main() {
-	                let values: [[Int8]] = [[], [], []]
-	                for value in values {
-	                  let a = value
-	                }
-	            }
-	        `
+                pub fun main() {
+                    let values: [[Int8]] = [[], [], []]
+                    for value in values {
+                      let a = value
+                    }
+                }
+            `
 
 		meter := newTestMemoryGauge()
 		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
@@ -222,11 +222,11 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-		            pub struct S {}
-		            pub fun main() {
-		                let s = S()
-		            }
-		        `
+                    pub struct S {}
+                    pub fun main() {
+                        let s = S()
+                    }
+                `
 
 		meter := newTestMemoryGauge()
 		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
@@ -242,16 +242,16 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-	            pub struct S {
-					pub let a: String
-	                init(_ a: String) {
-	                    self.a = a
-	                }
-				}
-	            pub fun main() {
-	                let s = S("a")
-	            }
-	        `
+                pub struct S {
+                    pub let a: String
+                    init(_ a: String) {
+                        self.a = a
+                    }
+                }
+                pub fun main() {
+                    let s = S("a")
+                }
+            `
 
 		meter := newTestMemoryGauge()
 		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
@@ -268,13 +268,13 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 
 		script := `
             pub struct S {
-				pub let a: String
-				pub let b: String
+                pub let a: String
+                pub let b: String
                 init(_ a: String, _ b: String) {
                     self.a = a
-					self.b = b
+                    self.b = b
                 }
-			}
+            }
             pub fun main() {
                 let s = S("a", "b")
             }
@@ -3316,7 +3316,7 @@ func TestInterpretInt8Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int8 = 3 % 2
+                let x: Int8 = 3 % 2
             }
         `
 
@@ -3338,7 +3338,7 @@ func TestInterpretInt8Metering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: Int8 = 1
-		        let y: Int8 = -x
+                let y: Int8 = -x
             }
         `
 
@@ -3359,7 +3359,7 @@ func TestInterpretInt8Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int8 = 3 | 2
+                let x: Int8 = 3 | 2
             }
         `
 
@@ -3380,7 +3380,7 @@ func TestInterpretInt8Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int8 = 3 ^ 2
+                let x: Int8 = 3 ^ 2
             }
         `
 
@@ -3401,7 +3401,7 @@ func TestInterpretInt8Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int8 = 3 & 2
+                let x: Int8 = 3 & 2
             }
         `
 
@@ -3422,7 +3422,7 @@ func TestInterpretInt8Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int8 = 3 << 2
+                let x: Int8 = 3 << 2
             }
         `
 
@@ -3443,7 +3443,7 @@ func TestInterpretInt8Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int8 = 3 >> 2
+                let x: Int8 = 3 >> 2
             }
         `
 
@@ -3660,7 +3660,7 @@ func TestInterpretInt16Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int16 = 3 % 2
+                let x: Int16 = 3 % 2
             }
         `
 
@@ -3682,7 +3682,7 @@ func TestInterpretInt16Metering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: Int16 = 1
-		        let y: Int16 = -x
+                let y: Int16 = -x
             }
         `
 
@@ -3703,7 +3703,7 @@ func TestInterpretInt16Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int16 = 3 | 2
+                let x: Int16 = 3 | 2
             }
         `
 
@@ -3724,7 +3724,7 @@ func TestInterpretInt16Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int16 = 3 ^ 2
+                let x: Int16 = 3 ^ 2
             }
         `
 
@@ -3745,7 +3745,7 @@ func TestInterpretInt16Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int16 = 3 & 2
+                let x: Int16 = 3 & 2
             }
         `
 
@@ -3766,7 +3766,7 @@ func TestInterpretInt16Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int16 = 3 << 2
+                let x: Int16 = 3 << 2
             }
         `
 
@@ -3787,7 +3787,7 @@ func TestInterpretInt16Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int16 = 3 >> 2
+                let x: Int16 = 3 >> 2
             }
         `
 
@@ -4004,7 +4004,7 @@ func TestInterpretInt32Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int32 = 3 % 2
+                let x: Int32 = 3 % 2
             }
         `
 
@@ -4026,7 +4026,7 @@ func TestInterpretInt32Metering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: Int32 = 1
-		        let y: Int32 = -x
+                let y: Int32 = -x
             }
         `
 
@@ -4047,7 +4047,7 @@ func TestInterpretInt32Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int32 = 3 | 2
+                let x: Int32 = 3 | 2
             }
         `
 
@@ -4068,7 +4068,7 @@ func TestInterpretInt32Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int32 = 3 ^ 2
+                let x: Int32 = 3 ^ 2
             }
         `
 
@@ -4089,7 +4089,7 @@ func TestInterpretInt32Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int32 = 3 & 2
+                let x: Int32 = 3 & 2
             }
         `
 
@@ -4110,7 +4110,7 @@ func TestInterpretInt32Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int32 = 3 << 2
+                let x: Int32 = 3 << 2
             }
         `
 
@@ -4131,7 +4131,7 @@ func TestInterpretInt32Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int32 = 3 >> 2
+                let x: Int32 = 3 >> 2
             }
         `
 
@@ -4348,7 +4348,7 @@ func TestInterpretInt64Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int64 = 3 % 2
+                let x: Int64 = 3 % 2
             }
         `
 
@@ -4370,7 +4370,7 @@ func TestInterpretInt64Metering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: Int64 = 1
-		        let y: Int64 = -x
+                let y: Int64 = -x
             }
         `
 
@@ -4391,7 +4391,7 @@ func TestInterpretInt64Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int64 = 3 | 2
+                let x: Int64 = 3 | 2
             }
         `
 
@@ -4412,7 +4412,7 @@ func TestInterpretInt64Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int64 = 3 ^ 2
+                let x: Int64 = 3 ^ 2
             }
         `
 
@@ -4433,7 +4433,7 @@ func TestInterpretInt64Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int64 = 3 & 2
+                let x: Int64 = 3 & 2
             }
         `
 
@@ -4454,7 +4454,7 @@ func TestInterpretInt64Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int64 = 3 << 2
+                let x: Int64 = 3 << 2
             }
         `
 
@@ -4475,7 +4475,7 @@ func TestInterpretInt64Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int64 = 3 >> 2
+                let x: Int64 = 3 >> 2
             }
         `
 
@@ -4692,7 +4692,7 @@ func TestInterpretInt128Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int128 = 3 % 2
+                let x: Int128 = 3 % 2
             }
         `
 
@@ -4714,7 +4714,7 @@ func TestInterpretInt128Metering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: Int128 = 1
-		        let y: Int128 = -x
+                let y: Int128 = -x
             }
         `
 
@@ -4735,7 +4735,7 @@ func TestInterpretInt128Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int128 = 3 | 2
+                let x: Int128 = 3 | 2
             }
         `
 
@@ -4756,7 +4756,7 @@ func TestInterpretInt128Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int128 = 3 ^ 2
+                let x: Int128 = 3 ^ 2
             }
         `
 
@@ -4777,7 +4777,7 @@ func TestInterpretInt128Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int128 = 3 & 2
+                let x: Int128 = 3 & 2
             }
         `
 
@@ -4798,7 +4798,7 @@ func TestInterpretInt128Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int128 = 3 << 2
+                let x: Int128 = 3 << 2
             }
         `
 
@@ -4819,7 +4819,7 @@ func TestInterpretInt128Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int128 = 3 >> 2
+                let x: Int128 = 3 >> 2
             }
         `
 
@@ -5036,7 +5036,7 @@ func TestInterpretInt256Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int256 = 3 % 2
+                let x: Int256 = 3 % 2
             }
         `
 
@@ -5058,7 +5058,7 @@ func TestInterpretInt256Metering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: Int256 = 1
-		        let y: Int256 = -x
+                let y: Int256 = -x
             }
         `
 
@@ -5079,7 +5079,7 @@ func TestInterpretInt256Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int256 = 3 | 2
+                let x: Int256 = 3 | 2
             }
         `
 
@@ -5100,7 +5100,7 @@ func TestInterpretInt256Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int256 = 3 ^ 2
+                let x: Int256 = 3 ^ 2
             }
         `
 
@@ -5121,7 +5121,7 @@ func TestInterpretInt256Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int256 = 3 & 2
+                let x: Int256 = 3 & 2
             }
         `
 
@@ -5142,7 +5142,7 @@ func TestInterpretInt256Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int256 = 3 << 2
+                let x: Int256 = 3 << 2
             }
         `
 
@@ -5163,7 +5163,7 @@ func TestInterpretInt256Metering(t *testing.T) {
 
 		script := `
             pub fun main() {
-		        let x: Int256 = 3 >> 2
+                let x: Int256 = 3 >> 2
             }
         `
 
@@ -6145,7 +6145,7 @@ func TestInterpretBoolMetering(t *testing.T) {
 
 		script := `
             pub fun main() {
-				!true
+                !true
             }
         `
 		meter := newTestMemoryGauge()
@@ -6162,7 +6162,7 @@ func TestInterpretBoolMetering(t *testing.T) {
 
 		script := `
             pub fun main() {
-				true == true
+                true == true
             }
         `
 		meter := newTestMemoryGauge()
@@ -6179,7 +6179,7 @@ func TestInterpretBoolMetering(t *testing.T) {
 
 		script := `
             pub fun main() {
-				true == false
+                true == false
             }
         `
 		meter := newTestMemoryGauge()
@@ -6196,7 +6196,7 @@ func TestInterpretBoolMetering(t *testing.T) {
 
 		script := `
             pub fun main() {
-				true != false
+                true != false
             }
         `
 		meter := newTestMemoryGauge()
@@ -6255,7 +6255,7 @@ func TestInterpretVoidMetering(t *testing.T) {
 
 		script := `
             pub fun main(): Bool {
-				return true
+                return true
             }
         `
 		meter := newTestMemoryGauge()
@@ -6300,7 +6300,7 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-		  resource R {}
+          resource R {}
 
           pub fun main(): &Int {
               let x: Int = 1
@@ -6322,7 +6322,7 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-		  resource R {}
+          resource R {}
 
           pub fun main(): &Int {
               let x: Int? = 1
@@ -6370,7 +6370,7 @@ func TestInterpretCharacterMetering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: Character = "a"
-				let y = x
+                let y = x
             }
         `
 		meter := newTestMemoryGauge()
@@ -6392,7 +6392,7 @@ func TestInterpretCharacterMetering(t *testing.T) {
 		script := `
             pub fun main() {
                 let x: String = "a"
-				let y: Character = x[0]
+                let y: Character = x[0]
             }
         `
 		meter := newTestMemoryGauge()
@@ -6451,7 +6451,7 @@ func TestInterpretPathValueMetering(t *testing.T) {
 
 		script := `
             pub fun main() {
-				let x = /public/bar
+                let x = /public/bar
             }
         `
 		meter := newTestMemoryGauge()
@@ -6468,7 +6468,7 @@ func TestInterpretPathValueMetering(t *testing.T) {
 
 		script := `
             pub fun main() {
-				let x = PublicPath(identifier: "bar")
+                let x = PublicPath(identifier: "bar")
             }
         `
 		meter := newTestMemoryGauge()
@@ -6488,12 +6488,12 @@ func TestInterpretCapabilityValueMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-			resource R {}
+            resource R {}
 
             pub fun main(account: AuthAccount) {
-				let r <- create R()
-				account.save(<-r, to: /storage/r)
-				let x = account.link<&R>(/public/capo, target: /storage/r)
+                let r <- create R()
+                account.save(<-r, to: /storage/r)
+                let x = account.link<&R>(/public/capo, target: /storage/r)
             }
         `
 		meter := newTestMemoryGauge()
@@ -6515,10 +6515,10 @@ func TestInterpretLinkValueMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-			resource R {}
+            resource R {}
 
             pub fun main(account: AuthAccount) {
-				account.link<&R>(/public/capo, target: /private/p)
+                account.link<&R>(/public/capo, target: /private/p)
             }
         `
 		meter := newTestMemoryGauge()
@@ -6530,5 +6530,81 @@ func TestInterpretLinkValueMetering(t *testing.T) {
 
 		// Metered twice only when Atree validation is enabled.
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindLinkValue))
+	})
+}
+
+func TestVariableMetering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("globals", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            var a = 3
+            let b = false
+
+            pub fun main() {
+                
+            }
+        `
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindVariable))
+	})
+
+	t.Run("params", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main(a: String, b: Bool) {
+                
+            }
+        `
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main", interpreter.NewUnmeteredStringValue(""), interpreter.NewUnmeteredBoolValue(false))
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindVariable))
+	})
+
+	t.Run("nested params", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                var x = fun (x: String, y: Bool) {}
+            }
+        `
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindVariable))
+	})
+
+	t.Run("applied nested params", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                var x = fun (x: String, y: Bool) {}
+                x("", false)
+            }
+        `
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindVariable))
 	})
 }


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

## Description

As discussed in the issue above, we need to meter variables as well as values, as only metering values does not accurately capture all cases, such as one where variables are created many times from the same values, as in a loop. This adds a new memory kind for variables and meters a constant each time a new variable is created. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
