### PR TITLE
Add memory metering for tokens

### DIFF
--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -60,7 +60,7 @@ const (
 	// Tokens
 
 	MemoryKindTokenIdentifier
-	MemoryKindTokenBlockCommentContent
+	MemoryKindTokenComment
 	MemoryKindTokenNumericLiteral
 	MemoryKindTokenSyntax
 )

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -26,6 +26,9 @@ type MemoryKind uint
 
 const (
 	MemoryKindUnknown MemoryKind = iota
+
+	// Values
+
 	MemoryKindBool
 	MemoryKindAddress
 	MemoryKindString
@@ -48,6 +51,16 @@ const (
 	MemoryKindHostFunction
 	MemoryKindBoundFunction
 	MemoryKindBigInt
+
+	// Misc
+
 	MemoryKindRawString
 	MemoryKindVariable
+
+	// Tokens
+
+	MemoryKindTokenIdentifier
+	MemoryKindTokenBlockCommentContent
+	MemoryKindTokenNumericLiteral
+	MemoryKindTokenSyntax
 )

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -33,11 +33,15 @@ func _() {
 	_ = x[MemoryKindBigInt-22]
 	_ = x[MemoryKindRawString-23]
 	_ = x[MemoryKindVariable-24]
+	_ = x[MemoryKindTokenIdentifier-25]
+	_ = x[MemoryKindTokenComment-26]
+	_ = x[MemoryKindTokenNumericLiteral-27]
+	_ = x[MemoryKindTokenSyntax-28]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariable"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntax"
 
-var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239}
+var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -28,8 +28,6 @@ type MemoryUsage struct {
 	Amount uint64
 }
 
-var EmptyUsage = MemoryUsage{}
-
 type MemoryGauge interface {
 	MeterMemory(usage MemoryUsage) error
 }
@@ -216,7 +214,7 @@ func NewNumberMemoryUsage(bytes int) MemoryUsage {
 
 func NewCommentTokenMemoryUsage(length int) MemoryUsage {
 	return MemoryUsage{
-		Kind:   MemoryKindTokenBlockCommentContent,
+		Kind:   MemoryKindTokenComment,
 		Amount: uint64(length),
 	}
 }

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -28,8 +28,21 @@ type MemoryUsage struct {
 	Amount uint64
 }
 
+var EmptyUsage = MemoryUsage{}
+
 type MemoryGauge interface {
 	MeterMemory(usage MemoryUsage) error
+}
+
+func UseMemory(gauge MemoryGauge, usage MemoryUsage) {
+	if gauge == nil {
+		return
+	}
+
+	err := gauge.MeterMemory(usage)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func NewConstantMemoryUsage(kind MemoryKind) MemoryUsage {
@@ -201,13 +214,30 @@ func NewNumberMemoryUsage(bytes int) MemoryUsage {
 	}
 }
 
-func UseMemory(gauge MemoryGauge, usage MemoryUsage) {
-	if gauge == nil {
-		return
+func NewCommentTokenMemoryUsage(length int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindTokenBlockCommentContent,
+		Amount: uint64(length),
 	}
+}
 
-	err := gauge.MeterMemory(usage)
-	if err != nil {
-		panic(err)
+func NewIdentifierTokenMemoryUsage(length int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindTokenIdentifier,
+		Amount: uint64(length),
+	}
+}
+
+func NewNumericLiteralTokenMemoryUsage(length int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindTokenNumericLiteral,
+		Amount: uint64(length),
+	}
+}
+
+func NewSyntaxTokenMemoryUsage(length int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindTokenSyntax,
+		Amount: uint64(length),
 	}
 }

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -370,12 +370,11 @@ func TestMemoryMeteringErrors(t *testing.T) {
 	runtimeInterface := func(meter memoryMeter) *testRuntimeInterface {
 		return &testRuntimeInterface{
 			meterMemory: func(usage common.MemoryUsage) error {
-				if usage.Kind == common.MemoryKindInterpretedFunction ||
-					usage.Kind == common.MemoryKindVariable ||
-					usage.Kind == common.MemoryKindVoid {
-					return nil
+				if usage.Kind == common.MemoryKindString ||
+					usage.Kind == common.MemoryKindArray {
+					return testMemoryError{}
 				}
-				return testMemoryError{}
+				return nil
 			},
 			decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
 				return jsoncdc.Decode(b)

--- a/runtime/parser2/benchmark_test.go
+++ b/runtime/parser2/benchmark_test.go
@@ -199,9 +199,10 @@ func (g *testMemoryGauge) MeterMemory(usage common.MemoryUsage) error {
 func BenchmarkParseFungibleToken(b *testing.B) {
 
 	b.Run("Without memory metering", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			b.ReportAllocs()
+		b.ReportAllocs()
+		b.ResetTimer()
 
+		for i := 0; i < b.N; i++ {
 			_, err := ParseProgram(fungibleTokenContract, nil)
 			if err != nil {
 				b.Fatal(err)
@@ -210,7 +211,6 @@ func BenchmarkParseFungibleToken(b *testing.B) {
 	})
 
 	b.Run("With memory metering", func(b *testing.B) {
-
 		meter := &testMemoryGauge{
 			meter: make(map[common.MemoryKind]uint64),
 		}
@@ -220,7 +220,6 @@ func BenchmarkParseFungibleToken(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			_, err := ParseProgram(fungibleTokenContract, meter)
-
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -270,10 +270,30 @@ func (l *lexer) endPos() position {
 }
 
 func (l *lexer) emitType(ty TokenType) {
+	if l.memoryGauge != nil {
+		usage := l.typeMemoryUsage(ty)
+
+		// Don't use `common.MemoryUsae()` to avoid redundant `nil` check.
+		err := l.memoryGauge.MeterMemory(usage)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	l.emit(ty, nil, l.startPosition(), true)
 }
 
 func (l *lexer) emitValue(ty TokenType) {
+	if l.memoryGauge != nil {
+		usage := l.valueMemoryUsage(ty)
+
+		// Don't use `common.MemoryUsae()` to avoid redundant `nil` check.
+		err := l.memoryGauge.MeterMemory(usage)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	l.emit(ty, l.word(), l.startPosition(), true)
 }
 

--- a/runtime/parser2/lexer/memory_usage.go
+++ b/runtime/parser2/lexer/memory_usage.go
@@ -1,0 +1,121 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lexer
+
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+)
+
+// valueMemoryUsage returns the memory usage, given the token type of the value.
+//
+// NOTE: This assumes the token-type can only be one of:
+//     - TokenString
+//     - TokenIdentifier
+//     - TokenBlockCommentContent
+//     - TokenLineComment
+//     - Any numeric literal (e.g: integer, fixed-point, etc.)
+//
+func (l *lexer) valueMemoryUsage(tokenType TokenType) common.MemoryUsage {
+	switch tokenType {
+	case TokenString:
+		return common.NewStringMemoryUsage(l.wordLength())
+	case TokenIdentifier:
+		return common.NewIdentifierTokenMemoryUsage(l.wordLength())
+	case TokenBlockCommentContent, TokenLineComment:
+		return common.NewCommentTokenMemoryUsage(l.wordLength())
+	default:
+		return common.NewNumericLiteralTokenMemoryUsage(l.wordLength())
+	}
+}
+
+// singleWidthTokenMemoryUsage is the memory consumed by a token consist of one codepoint.
+var singleWidthTokenMemoryUsage = common.NewSyntaxTokenMemoryUsage(1)
+
+// doubleWidthTokenMemoryUsage is the memory consumed by a token consist of two codepoints.
+var doubleWidthTokenMemoryUsage = common.NewSyntaxTokenMemoryUsage(2)
+
+// tripleWidthTokenMemoryUsage is the memory consumed by a token consist of three codepoints.
+var tripleWidthTokenMemoryUsage = common.NewSyntaxTokenMemoryUsage(3)
+
+// typeMemoryUsage returns the memory usage, given the token type of the type.
+//
+// NOTE: This assumes the token-type is always a syntax token.
+//  e.g:
+//     - logical and mathematical operators such as +, - /, *, etc.
+//     - Separators such as {, }, (, ), dot, coma, colons, etc.
+//     - And other similar tokens, such as ?, //, /*
+//
+func (l *lexer) typeMemoryUsage(tokenType TokenType) common.MemoryUsage {
+	switch tokenType {
+
+	// 1-length tokens
+	case TokenPlus,
+		TokenMinus,
+		TokenStar,
+		TokenSlash,
+		TokenPercent,
+		TokenParenOpen,
+		TokenParenClose,
+		TokenBraceOpen,
+		TokenBraceClose,
+		TokenBracketOpen,
+		TokenBracketClose,
+		TokenQuestionMark,
+		TokenComma,
+		TokenColon,
+		TokenDot,
+		TokenSemicolon,
+		TokenLess,
+		TokenGreater,
+		TokenEqual,
+		TokenExclamationMark,
+		TokenVerticalBar,
+		TokenAmpersand,
+		TokenCaret,
+		TokenAt,
+		TokenPragma:
+		return singleWidthTokenMemoryUsage
+
+	// 2-length tokens
+	case TokenDoubleQuestionMark,
+		TokenQuestionMarkDot,
+		TokenLeftArrow,
+		TokenLessEqual,
+		TokenLessLess,
+		TokenGreaterEqual,
+		TokenEqualEqual,
+		TokenNotEqual,
+		TokenBlockCommentStart,
+		TokenBlockCommentEnd,
+		TokenAmpersandAmpersand,
+		TokenVerticalBarVerticalBar:
+		return doubleWidthTokenMemoryUsage
+
+	// 3-length tokens
+	case TokenLeftArrowExclamation,
+		TokenSwap,
+		TokenAsExclamationMark,
+		TokenAsQuestionMark:
+		return tripleWidthTokenMemoryUsage
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}

--- a/runtime/parser2/lexer/memory_usage.go
+++ b/runtime/parser2/lexer/memory_usage.go
@@ -33,15 +33,17 @@ import (
 //     - Any numeric literal (e.g: integer, fixed-point, etc.)
 //
 func (l *lexer) valueMemoryUsage(tokenType TokenType) common.MemoryUsage {
+	tokenLength := l.wordLength()
+
 	switch tokenType {
 	case TokenString:
-		return common.NewStringMemoryUsage(l.wordLength())
+		return common.NewStringMemoryUsage(tokenLength)
 	case TokenIdentifier:
-		return common.NewIdentifierTokenMemoryUsage(l.wordLength())
+		return common.NewIdentifierTokenMemoryUsage(tokenLength)
 	case TokenBlockCommentContent, TokenLineComment:
-		return common.NewCommentTokenMemoryUsage(l.wordLength())
+		return common.NewCommentTokenMemoryUsage(tokenLength)
 	default:
-		return common.NewNumericLiteralTokenMemoryUsage(l.wordLength())
+		return common.NewNumericLiteralTokenMemoryUsage(tokenLength)
 	}
 }
 
@@ -54,7 +56,7 @@ var doubleWidthTokenMemoryUsage = common.NewSyntaxTokenMemoryUsage(2)
 // tripleWidthTokenMemoryUsage is the memory consumed by a token consist of three codepoints.
 var tripleWidthTokenMemoryUsage = common.NewSyntaxTokenMemoryUsage(3)
 
-// typeMemoryUsage returns the memory usage, given the token type of the type.
+// typeMemoryUsage returns the memory usage, given the type of a syntax token.
 //
 // NOTE: This assumes the token-type is always a syntax token.
 //  e.g:

--- a/runtime/parser2/lexer/state.go
+++ b/runtime/parser2/lexer/state.go
@@ -20,8 +20,6 @@ package lexer
 
 import (
 	"fmt"
-
-	"github.com/onflow/cadence/runtime/common"
 )
 
 const keywordAs = "as"
@@ -292,7 +290,6 @@ func identifierState(l *lexer) stateFn {
 
 func stringState(l *lexer) stateFn {
 	l.scanString('"')
-	common.UseMemory(l.memoryGauge, common.NewStringMemoryUsage(l.wordLength()))
 	l.emitValue(TokenString)
 	return rootState
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -19,8 +19,6 @@
 package interpreter_test
 
 import (
-	"github.com/onflow/cadence/runtime/parser2"
-	"github.com/onflow/cadence/runtime/tests/checker"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -7673,7 +7671,7 @@ func TestTokenMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		// keywords + func/var names
-		assert.Equal(t, uint64(49), meter.getMemory(common.MemoryKindTokenIdentifier))
+		assert.Equal(t, uint64(48), meter.getMemory(common.MemoryKindTokenIdentifier))
 	})
 
 	t.Run("syntax tokens", func(t *testing.T) {
@@ -7716,7 +7714,7 @@ func TestTokenMetering(t *testing.T) {
 		// Line comment start is not emitted
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindTokenSyntax))
 
-		assert.Equal(t, uint64(75), meter.getMemory(common.MemoryKindTokenBlockCommentContent))
+		assert.Equal(t, uint64(75), meter.getMemory(common.MemoryKindTokenComment))
 	})
 
 	t.Run("numeric literals", func(t *testing.T) {
@@ -7737,36 +7735,5 @@ func TestTokenMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(13), meter.getMemory(common.MemoryKindTokenNumericLiteral))
-	})
-}
-
-func BenchmarkTokenMetering(b *testing.B) {
-
-	code := ``
-	b.Run("With metering", func(b *testing.B) {
-		meter := newTestMemoryGauge()
-
-		for i := 0; i < b.N; i++ {
-			_, err := checker.ParseAndCheckWithOptionsAndMemoryMetering(
-				b,
-				code,
-				checker.ParseAndCheckOptions{
-					Options: []sema.Option{},
-				},
-				meter,
-			)
-
-			assert.NoError(b, err)
-		}
-	})
-
-	b.Run("Without metering", func(b *testing.B) {
-		meter := newTestMemoryGauge()
-
-		for i := 0; i < b.N; i++ {
-			_, err := parser2.ParseProgram(code, meter)
-
-			assert.NoError(b, err)
-		}
 	})
 }


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/2

Also added a test to benchmark parsing with and without metering. Didn't show me a much difference between the two.

```
goos: darwin
goarch: amd64
pkg: github.com/onflow/cadence/runtime/parser2
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz

BenchmarkParseFungibleToken/Without_memory_metering-8         	    6214	    163507 ns/op	  198849 B/op	    1074 allocs/op
BenchmarkParseFungibleToken/With_memory_metering-8            	    6052	    167140 ns/op	  198849 B/op	    1074 allocs/op
```
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
