### PR TITLE
Add metering for locations

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1744,7 +1744,7 @@ func TestDecodeFixedPoints(t *testing.T) {
 
 					enc := fmt.Sprintf(`{ "type": "%s", "value": "%s"}`, ty.ID(), tt.input)
 
-					actual, err := json.Decode([]byte(enc))
+					actual, err := json.Decode(nil, []byte(enc))
 
 					if tt.check != nil {
 						tt.check(t, actual, err)
@@ -1761,7 +1761,7 @@ func TestDecodeFixedPoints(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := json.Decode([]byte(`{"type": "Fix64", "value": "1.-1"}`))
+		_, err := json.Decode(nil, []byte(`{"type": "Fix64", "value": "1.-1"}`))
 		assert.Error(t, err)
 	})
 
@@ -1769,7 +1769,7 @@ func TestDecodeFixedPoints(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := json.Decode([]byte(`{"type": "Fix64", "value": "1.+1"}`))
+		_, err := json.Decode(nil, []byte(`{"type": "Fix64", "value": "1.+1"}`))
 		assert.Error(t, err)
 	})
 
@@ -1777,7 +1777,7 @@ func TestDecodeFixedPoints(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := json.Decode([]byte(`{"type": "Fix64", "value": ".1"}`))
+		_, err := json.Decode(nil, []byte(`{"type": "Fix64", "value": ".1"}`))
 		assert.Error(t, err)
 	})
 
@@ -1785,7 +1785,7 @@ func TestDecodeFixedPoints(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := json.Decode([]byte(`{"type": "Fix64", "value": "1."}`))
+		_, err := json.Decode(nil, []byte(`{"type": "Fix64", "value": "1."}`))
 		assert.Error(t, err)
 	})
 }
@@ -1864,7 +1864,7 @@ func TestDecodeInvalidType(t *testing.T) {
 			}
 		}
 	`
-		_, err := json.Decode([]byte(encodedValue))
+		_, err := json.Decode(nil, []byte(encodedValue))
 		require.Error(t, err)
 		assert.Equal(t, "failed to decode value: invalid JSON Cadence structure. invalid type ID: ``", err.Error())
 	})
@@ -1881,7 +1881,7 @@ func TestDecodeInvalidType(t *testing.T) {
 			}
 		}
 	`
-		_, err := json.Decode([]byte(encodedValue))
+		_, err := json.Decode(nil, []byte(encodedValue))
 		require.Error(t, err)
 		assert.Equal(t, "failed to decode value: invalid JSON Cadence structure. invalid type ID: `I.Foo`", err.Error())
 	})
@@ -1898,7 +1898,7 @@ func TestDecodeInvalidType(t *testing.T) {
 			}
 		}
 	`
-		_, err := json.Decode([]byte(encodedValue))
+		_, err := json.Decode(nil, []byte(encodedValue))
 		require.Error(t, err)
 		assert.Equal(t, "failed to decode value: invalid JSON Cadence structure. invalid type ID: `N.PublicKey`", err.Error())
 	})
@@ -1921,7 +1921,7 @@ func testEncode(t *testing.T, val cadence.Value, expectedJSON string) (actualJSO
 }
 
 func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value) {
-	decodedVal, err := json.Decode([]byte(actualJSON))
+	decodedVal, err := json.Decode(nil, []byte(actualJSON))
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedVal, decodedVal)
@@ -1950,7 +1950,7 @@ func TestNonUTF8StringEncoding(t *testing.T) {
 	encodedValue, err := json.Encode(stringValue)
 	require.NoError(t, err)
 
-	decodedValue, err := json.Decode(encodedValue)
+	decodedValue, err := json.Decode(nil, encodedValue)
 	require.NoError(t, err)
 
 	// Decoded value must be a valid utf8 string

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -117,9 +117,12 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 				events = append(events, event)
 				return nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -835,7 +838,7 @@ func accountKeyExportedValue(
 }
 
 func getAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *testRuntimeInterface {
-	return &testRuntimeInterface{
+	runtimeInterface := &testRuntimeInterface{
 		storage: newTestLedger(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
@@ -888,10 +891,14 @@ func getAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *testRunt
 			storage.events = append(storage.events, event)
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
 		},
 	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
+	}
+	return runtimeInterface
 }
 
 func addAuthAccountKey(t *testing.T, runtime Runtime, runtimeInterface *testRuntimeInterface) {

--- a/runtime/cmd/check/main.go
+++ b/runtime/cmd/check/main.go
@@ -222,7 +222,7 @@ func runPath(
 
 	codes := map[common.LocationID]string{}
 
-	location := common.StringLocation(path)
+	location := common.NewStringLocation(nil, path)
 
 	func() {
 		defer func() {

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -146,7 +146,8 @@ func PrepareInterpreter(filename string, debugger *interpreter.Debugger) (*inter
 
 	codes := map[common.LocationID]string{}
 
-	location := common.StringLocation(filename)
+	// do not need to meter this as it's a one-off overhead
+	location := common.NewStringLocation(nil, filename)
 
 	program, must := PrepareProgramFromFile(location, codes)
 

--- a/runtime/cmd/compile/main.go
+++ b/runtime/cmd/compile/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	path := args[1]
 
-	location := common.StringLocation(path)
+	location := common.NewStringLocation(nil, path)
 
 	codes := map[common.LocationID]string{}
 

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -106,7 +106,7 @@ func (s stdoutOutput) Append(r result) {
 	}
 
 	if r.Error != nil {
-		location := common.StringLocation(r.Path)
+		location := common.NewStringLocation(nil, r.Path)
 		printErr := pretty.NewErrorPrettyPrinter(os.Stdout, true).
 			PrettyPrintError(r.Error, location, map[common.LocationID]string{location.ID(): r.Code})
 		if printErr != nil {

--- a/runtime/common/addresslocation.go
+++ b/runtime/common/addresslocation.go
@@ -36,6 +36,14 @@ type AddressLocation struct {
 	Name    string
 }
 
+func NewAddressLocation(gauge MemoryGauge, addr Address, name string) AddressLocation {
+	UseMemory(gauge, NewConstantMemoryUsage(MemoryKindAddressLocation))
+	return AddressLocation{
+		Address: addr,
+		Name:    name,
+	}
+}
+
 func (l AddressLocation) String() string {
 	if l.Name == "" {
 		return l.Address.String()

--- a/runtime/common/addresslocation.go
+++ b/runtime/common/addresslocation.go
@@ -104,13 +104,13 @@ func (l AddressLocation) MarshalJSON() ([]byte, error) {
 func init() {
 	RegisterTypeIDDecoder(
 		AddressLocationPrefix,
-		func(typeID string) (location Location, qualifiedIdentifier string, err error) {
-			return decodeAddressLocationTypeID(typeID)
+		func(gauge MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error) {
+			return decodeAddressLocationTypeID(gauge, typeID)
 		},
 	)
 }
 
-func decodeAddressLocationTypeID(typeID string) (AddressLocation, string, error) {
+func decodeAddressLocationTypeID(gauge MemoryGauge, typeID string) (AddressLocation, string, error) {
 
 	const errorMessagePrefix = "invalid address location type ID"
 
@@ -206,10 +206,7 @@ func decodeAddressLocationTypeID(typeID string) (AddressLocation, string, error)
 		return AddressLocation{}, "", err
 	}
 
-	location := AddressLocation{
-		Address: address,
-		Name:    name,
-	}
+	location := NewAddressLocation(gauge, address, name)
 
 	return location, qualifiedIdentifier, nil
 }

--- a/runtime/common/addresslocation_test.go
+++ b/runtime/common/addresslocation_test.go
@@ -58,7 +58,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeAddressLocationTypeID("")
+		_, _, err := decodeAddressLocationTypeID(nil, "")
 		require.EqualError(t, err, "invalid address location type ID: missing prefix")
 	})
 
@@ -66,7 +66,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeAddressLocationTypeID("A")
+		_, _, err := decodeAddressLocationTypeID(nil, "A")
 		require.EqualError(t, err, "invalid address location type ID: missing location")
 	})
 
@@ -74,7 +74,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeAddressLocationTypeID("A.0000000000000001")
+		_, _, err := decodeAddressLocationTypeID(nil, "A.0000000000000001")
 		require.EqualError(t, err, "invalid address location type ID: missing qualified identifier")
 	})
 
@@ -82,7 +82,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeAddressLocationTypeID("X.0000000000000001.T")
+		_, _, err := decodeAddressLocationTypeID(nil, "X.0000000000000001.T")
 		require.EqualError(t, err, "invalid address location type ID: invalid prefix: expected \"A\", got \"X\"")
 	})
 
@@ -90,7 +90,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeAddressLocationTypeID("A.0000000000000001.T")
+		location, qualifiedIdentifier, err := decodeAddressLocationTypeID(nil, "A.0000000000000001.T")
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -107,7 +107,7 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeAddressLocationTypeID("A.0000000000000001.T.U")
+		location, qualifiedIdentifier, err := decodeAddressLocationTypeID(nil, "A.0000000000000001.T.U")
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/runtime/common/identifierlocation.go
+++ b/runtime/common/identifierlocation.go
@@ -77,13 +77,13 @@ func (l IdentifierLocation) MarshalJSON() ([]byte, error) {
 func init() {
 	RegisterTypeIDDecoder(
 		IdentifierLocationPrefix,
-		func(typeID string) (location Location, qualifiedIdentifier string, err error) {
-			return decodeIdentifierLocationTypeID(typeID)
+		func(gauge MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error) {
+			return decodeIdentifierLocationTypeID(gauge, typeID)
 		},
 	)
 }
 
-func decodeIdentifierLocationTypeID(typeID string) (IdentifierLocation, string, error) {
+func decodeIdentifierLocationTypeID(gauge MemoryGauge, typeID string) (IdentifierLocation, string, error) {
 
 	const errorMessagePrefix = "invalid identifier location type ID"
 

--- a/runtime/common/identifierlocation.go
+++ b/runtime/common/identifierlocation.go
@@ -30,6 +30,11 @@ const IdentifierLocationPrefix = "I"
 //
 type IdentifierLocation string
 
+func NewIdentifierLocation(gauge MemoryGauge, id string) IdentifierLocation {
+	UseMemory(gauge, NewRawStringMemoryUsage(len(id)))
+	return IdentifierLocation(id)
+}
+
 func (l IdentifierLocation) ID() LocationID {
 	return NewLocationID(
 		IdentifierLocationPrefix,

--- a/runtime/common/identifierlocation_test.go
+++ b/runtime/common/identifierlocation_test.go
@@ -54,7 +54,7 @@ func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeIdentifierLocationTypeID("")
+		_, _, err := decodeIdentifierLocationTypeID(nil, "")
 		require.EqualError(t, err, "invalid identifier location type ID: missing prefix")
 	})
 
@@ -62,7 +62,7 @@ func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeIdentifierLocationTypeID("I")
+		_, _, err := decodeIdentifierLocationTypeID(nil, "I")
 		require.EqualError(t, err, "invalid identifier location type ID: missing location")
 	})
 
@@ -70,7 +70,7 @@ func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeIdentifierLocationTypeID("I.test")
+		_, _, err := decodeIdentifierLocationTypeID(nil, "I.test")
 		require.EqualError(t, err, "invalid identifier location type ID: missing qualified identifier")
 	})
 
@@ -78,7 +78,7 @@ func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeIdentifierLocationTypeID("X.test.T")
+		_, _, err := decodeIdentifierLocationTypeID(nil, "X.test.T")
 		require.EqualError(t, err, "invalid identifier location type ID: invalid prefix: expected \"I\", got \"X\"")
 	})
 
@@ -86,7 +86,7 @@ func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeIdentifierLocationTypeID("I.test.T")
+		location, qualifiedIdentifier, err := decodeIdentifierLocationTypeID(nil, "I.test.T")
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -100,7 +100,7 @@ func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeIdentifierLocationTypeID("I.test.T.U")
+		location, qualifiedIdentifier, err := decodeIdentifierLocationTypeID(nil, "I.test.T.U")
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/runtime/common/location.go
+++ b/runtime/common/location.go
@@ -104,7 +104,7 @@ func NewTypeIDFromQualifiedName(location Location, qualifiedIdentifier string) T
 	return location.TypeID(qualifiedIdentifier)
 }
 
-type TypeIDDecoder func(typeID string) (location Location, qualifiedIdentifier string, err error)
+type TypeIDDecoder func(gauge MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error)
 
 var typeIDDecoders = map[string]TypeIDDecoder{}
 
@@ -115,7 +115,7 @@ func RegisterTypeIDDecoder(prefix string, decoder TypeIDDecoder) {
 	typeIDDecoders[prefix] = decoder
 }
 
-func DecodeTypeID(typeID string) (location Location, qualifiedIdentifier string, err error) {
+func DecodeTypeID(gauge MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error) {
 	pieces := strings.Split(typeID, ".")
 
 	if len(pieces) < 1 {
@@ -135,7 +135,7 @@ func DecodeTypeID(typeID string) (location Location, qualifiedIdentifier string,
 		return nil, typeID, nil
 	}
 
-	return decoder(typeID)
+	return decoder(gauge, typeID)
 }
 
 // HasImportLocation

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -49,4 +49,6 @@ const (
 	MemoryKindBoundFunction
 	MemoryKindBigInt
 	MemoryKindRawString
+	MemoryKindAddressLocation
+	MemoryKindBytes
 )

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -32,11 +32,13 @@ func _() {
 	_ = x[MemoryKindBoundFunction-21]
 	_ = x[MemoryKindBigInt-22]
 	_ = x[MemoryKindRawString-23]
+	_ = x[MemoryKindAddressLocation-24]
+	_ = x[MemoryKindBytes-25]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawString"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringAddressLocationBytes"
 
-var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231}
+var _MemoryKind_index = [...]uint8{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 246, 251}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -53,6 +53,13 @@ func NewRawStringMemoryUsage(length int) MemoryUsage {
 	}
 }
 
+func NewBytesMemoryUsage(length int) MemoryUsage {
+	return MemoryUsage{
+		Kind:   MemoryKindBytes,
+		Amount: uint64(length) + 1, // +1 to account for empty arrays
+	}
+}
+
 func NewBigIntMemoryUsage(bytes int) MemoryUsage {
 	return MemoryUsage{
 		Kind:   MemoryKindBigInt,

--- a/runtime/common/repllocation.go
+++ b/runtime/common/repllocation.go
@@ -66,7 +66,7 @@ func (l REPLLocation) MarshalJSON() ([]byte, error) {
 func init() {
 	RegisterTypeIDDecoder(
 		REPLLocationPrefix,
-		func(typeID string) (location Location, qualifiedIdentifier string, err error) {
+		func(_ MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error) {
 			return decodeREPLLocationTypeID(typeID)
 		},
 	)

--- a/runtime/common/scriptlocation.go
+++ b/runtime/common/scriptlocation.go
@@ -78,13 +78,13 @@ func (l ScriptLocation) MarshalJSON() ([]byte, error) {
 func init() {
 	RegisterTypeIDDecoder(
 		ScriptLocationPrefix,
-		func(typeID string) (location Location, qualifiedIdentifier string, err error) {
-			return decodeScriptLocationTypeID(typeID)
+		func(gauge MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error) {
+			return decodeScriptLocationTypeID(gauge, typeID)
 		},
 	)
 }
 
-func decodeScriptLocationTypeID(typeID string) (ScriptLocation, string, error) {
+func decodeScriptLocationTypeID(gauge MemoryGauge, typeID string) (ScriptLocation, string, error) {
 
 	const errorMessagePrefix = "invalid script location type ID"
 

--- a/runtime/common/scriptlocation.go
+++ b/runtime/common/scriptlocation.go
@@ -118,6 +118,8 @@ func decodeScriptLocationTypeID(gauge MemoryGauge, typeID string) (ScriptLocatio
 	}
 
 	location, err := hex.DecodeString(parts[1])
+	UseMemory(gauge, NewBytesMemoryUsage(len(location)))
+
 	if err != nil {
 		return nil, "", fmt.Errorf(
 			"%s: invalid location: %w",

--- a/runtime/common/scriptlocation.go
+++ b/runtime/common/scriptlocation.go
@@ -31,6 +31,11 @@ const ScriptLocationPrefix = "s"
 //
 type ScriptLocation []byte
 
+func NewScriptLocation(gauge MemoryGauge, script []byte) ScriptLocation {
+	UseMemory(gauge, NewBytesMemoryUsage(len(script)))
+	return ScriptLocation(script)
+}
+
 func (l ScriptLocation) ID() LocationID {
 	return NewLocationID(
 		ScriptLocationPrefix,

--- a/runtime/common/scriptlocation_test.go
+++ b/runtime/common/scriptlocation_test.go
@@ -46,7 +46,7 @@ func TestScriptLocation_MarshalJSON(t *testing.T) {
 	)
 }
 
-func TestdecodeScriptLocationTypeID(t *testing.T) {
+func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/common/scriptlocation_test.go
+++ b/runtime/common/scriptlocation_test.go
@@ -46,7 +46,7 @@ func TestScriptLocation_MarshalJSON(t *testing.T) {
 	)
 }
 
-func TestDecodeScriptLocationTypeID(t *testing.T) {
+func TestdecodeScriptLocationTypeID(t *testing.T) {
 
 	t.Parallel()
 
@@ -54,7 +54,7 @@ func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeScriptLocationTypeID("")
+		_, _, err := decodeScriptLocationTypeID(nil, "")
 		require.EqualError(t, err, "invalid script location type ID: missing prefix")
 	})
 
@@ -62,7 +62,7 @@ func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeScriptLocationTypeID("s")
+		_, _, err := decodeScriptLocationTypeID(nil, "s")
 		require.EqualError(t, err, "invalid script location type ID: missing location")
 	})
 
@@ -70,7 +70,7 @@ func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeScriptLocationTypeID("s.test")
+		_, _, err := decodeScriptLocationTypeID(nil, "s.test")
 		require.EqualError(t, err, "invalid script location type ID: missing qualified identifier")
 	})
 
@@ -78,7 +78,7 @@ func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeScriptLocationTypeID("X.test.T")
+		_, _, err := decodeScriptLocationTypeID(nil, "X.test.T")
 		require.EqualError(t, err, "invalid script location type ID: invalid prefix: expected \"s\", got \"X\"")
 	})
 
@@ -86,7 +86,7 @@ func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeScriptLocationTypeID("s.0102.T")
+		location, qualifiedIdentifier, err := decodeScriptLocationTypeID(nil, "s.0102.T")
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -100,7 +100,7 @@ func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeScriptLocationTypeID("s.0102.T.U")
+		location, qualifiedIdentifier, err := decodeScriptLocationTypeID(nil, "s.0102.T.U")
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -116,7 +116,7 @@ func decodeStringLocationTypeID(gauge MemoryGauge, typeID string) (StringLocatio
 		)
 	}
 
-	location := StringLocation(parts[1])
+	location := NewStringLocation(gauge, parts[1])
 	qualifiedIdentifier := parts[2]
 
 	return location, qualifiedIdentifier, nil

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -30,6 +30,11 @@ const StringLocationPrefix = "S"
 //
 type StringLocation string
 
+func NewStringLocation(gauge MemoryGauge, id string) StringLocation {
+	UseMemory(gauge, NewRawStringMemoryUsage(len(id)))
+	return StringLocation(id)
+}
+
 func (l StringLocation) ID() LocationID {
 	return NewLocationID(
 		StringLocationPrefix,

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -77,13 +77,13 @@ func (l StringLocation) MarshalJSON() ([]byte, error) {
 func init() {
 	RegisterTypeIDDecoder(
 		StringLocationPrefix,
-		func(typeID string) (location Location, qualifiedIdentifier string, err error) {
-			return decodeStringLocationTypeID(typeID)
+		func(gauge MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error) {
+			return decodeStringLocationTypeID(gauge, typeID)
 		},
 	)
 }
 
-func decodeStringLocationTypeID(typeID string) (StringLocation, string, error) {
+func decodeStringLocationTypeID(gauge MemoryGauge, typeID string) (StringLocation, string, error) {
 
 	const errorMessagePrefix = "invalid string location type ID"
 

--- a/runtime/common/stringlocation_test.go
+++ b/runtime/common/stringlocation_test.go
@@ -46,7 +46,7 @@ func TestStringLocation_MarshalJSON(t *testing.T) {
 	)
 }
 
-func TestdecodeStringLocationTypeID(t *testing.T) {
+func TestDecodeStringLocationTypeID(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/common/stringlocation_test.go
+++ b/runtime/common/stringlocation_test.go
@@ -46,7 +46,7 @@ func TestStringLocation_MarshalJSON(t *testing.T) {
 	)
 }
 
-func TestDecodeStringLocationTypeID(t *testing.T) {
+func TestdecodeStringLocationTypeID(t *testing.T) {
 
 	t.Parallel()
 
@@ -54,7 +54,7 @@ func TestDecodeStringLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeStringLocationTypeID("")
+		_, _, err := decodeStringLocationTypeID(nil, "")
 		require.EqualError(t, err, "invalid string location type ID: missing prefix")
 	})
 
@@ -62,7 +62,7 @@ func TestDecodeStringLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeStringLocationTypeID("S")
+		_, _, err := decodeStringLocationTypeID(nil, "S")
 		require.EqualError(t, err, "invalid string location type ID: missing location")
 	})
 
@@ -70,7 +70,7 @@ func TestDecodeStringLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeStringLocationTypeID("S.test")
+		_, _, err := decodeStringLocationTypeID(nil, "S.test")
 		require.EqualError(t, err, "invalid string location type ID: missing qualified identifier")
 	})
 
@@ -78,7 +78,7 @@ func TestDecodeStringLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeStringLocationTypeID("X.test.T")
+		_, _, err := decodeStringLocationTypeID(nil, "X.test.T")
 		require.EqualError(t, err, "invalid string location type ID: invalid prefix: expected \"S\", got \"X\"")
 	})
 
@@ -86,7 +86,7 @@ func TestDecodeStringLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeStringLocationTypeID("S.test.T")
+		location, qualifiedIdentifier, err := decodeStringLocationTypeID(nil, "S.test.T")
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -100,7 +100,7 @@ func TestDecodeStringLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeStringLocationTypeID("S.test.T.U")
+		location, qualifiedIdentifier, err := decodeStringLocationTypeID(nil, "S.test.T.U")
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/runtime/common/transactionlocation.go
+++ b/runtime/common/transactionlocation.go
@@ -31,6 +31,11 @@ const TransactionLocationPrefix = "t"
 //
 type TransactionLocation []byte
 
+func NewTransactionLocation(gauge MemoryGauge, script []byte) TransactionLocation {
+	UseMemory(gauge, NewBytesMemoryUsage(len(script)))
+	return TransactionLocation(script)
+}
+
 func (l TransactionLocation) ID() LocationID {
 	return NewLocationID(
 		TransactionLocationPrefix,

--- a/runtime/common/transactionlocation.go
+++ b/runtime/common/transactionlocation.go
@@ -78,13 +78,13 @@ func (l TransactionLocation) MarshalJSON() ([]byte, error) {
 func init() {
 	RegisterTypeIDDecoder(
 		TransactionLocationPrefix,
-		func(typeID string) (location Location, qualifiedIdentifier string, err error) {
-			return decodeTransactionLocationTypeID(typeID)
+		func(gauge MemoryGauge, typeID string) (location Location, qualifiedIdentifier string, err error) {
+			return decodeTransactionLocationTypeID(gauge, typeID)
 		},
 	)
 }
 
-func decodeTransactionLocationTypeID(typeID string) (TransactionLocation, string, error) {
+func decodeTransactionLocationTypeID(gauge MemoryGauge, typeID string) (TransactionLocation, string, error) {
 
 	const errorMessagePrefix = "invalid transaction location type ID"
 

--- a/runtime/common/transactionlocation.go
+++ b/runtime/common/transactionlocation.go
@@ -118,6 +118,8 @@ func decodeTransactionLocationTypeID(gauge MemoryGauge, typeID string) (Transact
 	}
 
 	location, err := hex.DecodeString(parts[1])
+	UseMemory(gauge, NewBytesMemoryUsage(len(location)))
+
 	if err != nil {
 		return nil, "", fmt.Errorf(
 			"%s: invalid location: %w",

--- a/runtime/common/transactionlocation_test.go
+++ b/runtime/common/transactionlocation_test.go
@@ -54,7 +54,7 @@ func TestDecodeTransactionLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeTransactionLocationTypeID("")
+		_, _, err := decodeTransactionLocationTypeID(nil, "")
 		require.EqualError(t, err, "invalid transaction location type ID: missing prefix")
 	})
 
@@ -62,7 +62,7 @@ func TestDecodeTransactionLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeTransactionLocationTypeID("t")
+		_, _, err := decodeTransactionLocationTypeID(nil, "t")
 		require.EqualError(t, err, "invalid transaction location type ID: missing location")
 	})
 
@@ -70,7 +70,7 @@ func TestDecodeTransactionLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeTransactionLocationTypeID("t.test")
+		_, _, err := decodeTransactionLocationTypeID(nil, "t.test")
 		require.EqualError(t, err, "invalid transaction location type ID: missing qualified identifier")
 	})
 
@@ -78,7 +78,7 @@ func TestDecodeTransactionLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeTransactionLocationTypeID("X.test.T")
+		_, _, err := decodeTransactionLocationTypeID(nil, "X.test.T")
 		require.EqualError(t, err, "invalid transaction location type ID: invalid prefix: expected \"t\", got \"X\"")
 	})
 
@@ -86,7 +86,7 @@ func TestDecodeTransactionLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeTransactionLocationTypeID("t.0102.T")
+		location, qualifiedIdentifier, err := decodeTransactionLocationTypeID(nil, "t.0102.T")
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -100,7 +100,7 @@ func TestDecodeTransactionLocationTypeID(t *testing.T) {
 
 		t.Parallel()
 
-		location, qualifiedIdentifier, err := decodeTransactionLocationTypeID("t.0102.T.U")
+		location, qualifiedIdentifier, err := decodeTransactionLocationTypeID(nil, "t.0102.T.U")
 		require.NoError(t, err)
 
 		assert.Equal(t,

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -2114,9 +2114,12 @@ func executeTestScript(t *testing.T, script string, arg cadence.Value) (cadence.
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: newTestLedger(nil, nil),
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
 		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	scriptParam := Script{
@@ -3407,13 +3410,16 @@ func TestRuntimeStringValueImport(t *testing.T) {
 		validated := false
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(s string) {
 				assert.True(t, utf8.ValidString(s))
 				validated = true
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3457,13 +3463,16 @@ func TestTypeValueImport(t *testing.T) {
 		var ok bool
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(s string) {
 				assert.Equal(t, s, "\"Int\"")
 				ok = true
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3503,9 +3512,12 @@ func TestTypeValueImport(t *testing.T) {
 		rt := NewInterpreterRuntime()
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3555,13 +3567,16 @@ func TestCapabilityValueImport(t *testing.T) {
 		var ok bool
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(s string) {
 				assert.Equal(t, s, "Capability<&Int>(address: 0x0100000000000000, path: /public/foo)")
 				ok = true
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3603,9 +3618,12 @@ func TestCapabilityValueImport(t *testing.T) {
 		rt := NewInterpreterRuntime()
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3646,9 +3664,12 @@ func TestCapabilityValueImport(t *testing.T) {
 		rt := NewInterpreterRuntime()
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3689,11 +3710,14 @@ func TestCapabilityValueImport(t *testing.T) {
 		rt := NewInterpreterRuntime()
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(s string) {
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3741,11 +3765,14 @@ func TestCapabilityValueImport(t *testing.T) {
 		rt := NewInterpreterRuntime()
 
 		runtimeInterface := &testRuntimeInterface{
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(s string) {
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3831,14 +3858,16 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 					runtimeInterface := &testRuntimeInterface{
 						storage: storage,
-						decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-							return json.Decode(b)
-						},
-
 						validatePublicKey: func(publicKey *PublicKey) error {
 							publicKeyValidated = true
 							return publicKeyActualError
 						},
+						meterMemory: func(_ common.MemoryUsage) error {
+							return nil
+						},
+					}
+					runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+						return json.Decode(runtimeInterface, b)
 					}
 
 					_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -3898,9 +3927,6 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			verifySignature: func(
 				signature []byte,
 				tag string,
@@ -3912,6 +3938,12 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 				verifyInvoked = true
 				return true, nil
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 		addPublicKeyValidation(runtimeInterface, nil)
 
@@ -3945,9 +3977,12 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -3983,9 +4018,12 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4014,9 +4052,12 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4049,9 +4090,12 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4125,9 +4169,12 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := rt.ExecuteScript(
@@ -4190,9 +4237,12 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := rt.ExecuteScript(
@@ -4256,13 +4306,16 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			validatePublicKey: func(publicKey *PublicKey) error {
 				publicKeyValidated = true
 				return nil
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		value, err := rt.ExecuteScript(
@@ -4326,13 +4379,16 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			validatePublicKey: func(publicKey *PublicKey) error {
 				publicKeyValidated = true
 				return nil
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		value, err := rt.ExecuteScript(
@@ -4674,9 +4730,12 @@ func TestNestedStructArgPassing(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		value, err := rt.ExecuteScript(
@@ -4737,11 +4796,13 @@ func TestNestedStructArgPassing(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
 		}
-
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
+		}
 		_, err := rt.ExecuteScript(
 			Script{
 				Source: []byte(script),

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/encoding/json"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -322,9 +323,12 @@ func TestRuntimeSignatureAlgorithmImport(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 	runtimeInterface := &testRuntimeInterface{
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
 		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	const script = `
@@ -406,12 +410,15 @@ func TestRuntimeHashAlgorithmImport(t *testing.T) {
 				}
 				return []byte{4, 5, 6}, nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(message string) {
 				logs = append(logs, message)
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		value, err := runtime.ExecuteScript(
@@ -747,9 +754,6 @@ func TestTraversingMerkleProof(t *testing.T) {
 
 	runtimeInterface := &testRuntimeInterface{
 		storage: storage,
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
-		},
 		hash: func(
 			data []byte,
 			tag string,
@@ -779,6 +783,12 @@ func TestTraversingMerkleProof(t *testing.T) {
 		log: func(message string) {
 			logMessages = append(logMessages, message)
 		},
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
+		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	_, err := runtime.ExecuteScript(

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -543,9 +543,12 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			events = append(events, event)
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
 		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1724,6 +1724,7 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 		return nil, err
 	}
 
+	common.UseMemory(d.memoryGauge, common.NewBytesMemoryUsage(len(encodedAddress)))
 	address, err := common.BytesToAddress(encodedAddress)
 	if err != nil {
 		return nil, err

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1743,7 +1743,7 @@ func (d LocationDecoder) decodeTransactionLocation() (common.Location, error) {
 		return nil, err
 	}
 
-	return common.TransactionLocation(s), nil
+	return common.NewTransactionLocation(d.memoryGauge, s), nil
 }
 
 func (d LocationDecoder) decodeScriptLocation() (common.Location, error) {
@@ -1758,5 +1758,5 @@ func (d LocationDecoder) decodeScriptLocation() (common.Location, error) {
 		return nil, err
 	}
 
-	return common.ScriptLocation(s), nil
+	return common.NewScriptLocation(d.memoryGauge, s), nil
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1642,7 +1642,7 @@ func (d LocationDecoder) decodeStringLocation() (common.Location, error) {
 		return nil, err
 	}
 
-	return common.StringLocation(s), nil
+	return common.NewStringLocation(d.memoryGauge, s), nil
 }
 
 func (d LocationDecoder) decodeIdentifierLocation() (common.Location, error) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -775,7 +775,7 @@ func (d StorableDecoder) decodeAddress() (AddressValue, error) {
 	return NewUnmeteredAddressValueFromBytes(addressBytes), nil
 }
 
-func (d StorableDecoder) decodeAddressBytes() ([]byte, error) {
+func (d LocationDecoder) decodeAddressBytes() ([]byte, error) {
 	// Check the address length and validate before decoding.
 	length, err := d.decoder.NextSize()
 	if err != nil {
@@ -1691,10 +1691,7 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 	// Address
 
 	// Decode address at array index encodedAddressLocationAddressFieldKey
-	//
-	// TODO: Use `decodeAddressBytes` and remove the `checkEncodedAddressLength` below
-	//       when memory metering of locations is implemented.
-	encodedAddress, err := d.decoder.DecodeBytes()
+	encodedAddress, err := d.decodeAddressBytes()
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
@@ -1705,7 +1702,6 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 		return nil, err
 	}
 
-	err = checkEncodedAddressLength(len(encodedAddress))
 	if err != nil {
 		return nil, err
 	}
@@ -1724,7 +1720,6 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 		return nil, err
 	}
 
-	common.UseMemory(d.memoryGauge, common.NewBytesMemoryUsage(len(encodedAddress)))
 	address, err := common.BytesToAddress(encodedAddress)
 	if err != nil {
 		return nil, err

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1724,11 +1724,7 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	return common.AddressLocation{
-		Address: address,
-		Name:    name,
-	}, nil
+	return common.NewAddressLocation(d.memoryGauge, address, name), nil
 }
 
 func (d LocationDecoder) decodeTransactionLocation() (common.Location, error) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2928,7 +2928,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 }
 
 func lookupInterface(interpreter *Interpreter, typeID string) (*sema.InterfaceType, error) {
-	location, qualifiedIdentifier, err := common.DecodeTypeID(typeID)
+	location, qualifiedIdentifier, err := common.DecodeTypeID(interpreter, typeID)
 	// if the typeID is invalid, return nil
 	if err != nil {
 		return nil, err
@@ -2943,7 +2943,7 @@ func lookupInterface(interpreter *Interpreter, typeID string) (*sema.InterfaceTy
 }
 
 func lookupComposite(interpreter *Interpreter, typeID string) (*sema.CompositeType, error) {
-	location, qualifiedIdentifier, err := common.DecodeTypeID(typeID)
+	location, qualifiedIdentifier, err := common.DecodeTypeID(interpreter, typeID)
 	// if the typeID is invalid, return nil
 	if err != nil {
 		return nil, err

--- a/runtime/missingmember_test.go
+++ b/runtime/missingmember_test.go
@@ -2065,9 +2065,12 @@ pub contract ItemNFT: NonFungibleToken {
 			events = append(events, event)
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
 		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -3884,9 +3887,12 @@ pub contract AuctionDutch {
 		log: func(message string) {
 			println(message)
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
 		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -611,9 +611,8 @@ func parseHexadecimalLocation(literal string) common.AddressLocation {
 		panic(err)
 	}
 
-	return common.AddressLocation{
-		Address: address,
-	}
+	// TODO: add gauge when we meter parsing
+	return common.NewAddressLocation(nil, address, "")
 }
 
 // parseEventDeclaration parses an event declaration.

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -385,7 +385,8 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 		case lexer.TokenString:
 			parsedString, errs := parseStringLiteral(p.current.Value.(string))
 			p.report(errs...)
-			location = common.StringLocation(parsedString)
+			// TODO: add meter to this
+			location = common.NewStringLocation(nil, parsedString)
 
 		case lexer.TokenHexadecimalIntegerLiteral:
 			location = parseHexadecimalLocation(p.current.Value.(string))

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -81,9 +82,12 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 		addPublicKeyValidation(runtimeInterface, nil)
 
@@ -546,9 +550,12 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 		runtimeInterface := &testRuntimeInterface{
 			storage: storage,
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
 			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 		addPublicKeyValidation(runtimeInterface, nil)
 

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -125,9 +126,12 @@ func TestRLPDecodeString(t *testing.T) {
 
 			runtimeInterface := &testRuntimeInterface{
 				storage: newTestLedger(nil, nil),
-				decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-					return json.Decode(b)
+				meterMemory: func(_ common.MemoryUsage) error {
+					return nil
 				},
+			}
+			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(runtimeInterface, b)
 			}
 
 			result, err := runtime.ExecuteScript(
@@ -281,9 +285,12 @@ func TestRLPDecodeList(t *testing.T) {
 
 			runtimeInterface := &testRuntimeInterface{
 				storage: newTestLedger(nil, nil),
-				decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-					return json.Decode(b)
+				meterMemory: func(_ common.MemoryUsage) error {
+					return nil
 				},
+			}
+			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(runtimeInterface, b)
 			}
 
 			result, err := runtime.ExecuteScript(

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2537,10 +2537,7 @@ func (r *interpreterRuntime) newAuthAccountContractsChangeFunction(
 
 			// Check the code
 
-			location := common.AddressLocation{
-				Address: address,
-				Name:    nameArgument,
-			}
+			location := common.NewAddressLocation(invocation.Interpreter, address, nameArgument)
 
 			context := startContext.WithLocation(location)
 

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -21,10 +21,11 @@ package runtime
 import (
 	"testing"
 
-	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/tests/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 type testMemoryGauge struct {

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -1,0 +1,94 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testMemoryGauge struct {
+	meter map[common.MemoryKind]uint64
+}
+
+func newTestMemoryGauge() *testMemoryGauge {
+	return &testMemoryGauge{
+		meter: make(map[common.MemoryKind]uint64),
+	}
+}
+
+func (g *testMemoryGauge) MeterMemory(usage common.MemoryUsage) error {
+	g.meter[usage.Kind] += usage.Amount
+	return nil
+}
+
+func (g *testMemoryGauge) getMemory(kind common.MemoryKind) uint64 {
+	return g.meter[kind]
+}
+
+func TestInterpreterAddressLocationMetering(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("add contract", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		pub struct S {}
+
+		pub fun main() {
+			let s = CompositeType("A.0000000000000001.S")
+		}
+        `
+		meter := newTestMemoryGauge()
+		var accountCode []byte
+		runtimeInterface := &testRuntimeInterface{
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{{42}}, nil
+			},
+			storage: newTestLedger(nil, nil),
+			meterMemory: func(usage common.MemoryUsage) error {
+				return meter.MeterMemory(usage)
+			},
+			getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+				return accountCode, nil
+			},
+		}
+
+		runtime := newTestInterpreterRuntime()
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: []byte(script),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  utils.TestLocation,
+			},
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAddressLocation))
+		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindRawString))
+	})
+}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/json"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -1194,12 +1195,15 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 				getSigningAccounts: func() ([]Address, error) {
 					return tc.authorizers, nil
 				},
-				decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-					return jsoncdc.Decode(b)
-				},
 				log: func(message string) {
 					loggedMessages = append(loggedMessages, message)
 				},
+				meterMemory: func(_ common.MemoryUsage) error {
+					return nil
+				},
+			}
+			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(runtimeInterface, b)
 			}
 
 			err := rt.ExecuteTransaction(
@@ -1525,12 +1529,15 @@ func TestRuntimeScriptArguments(t *testing.T) {
 
 			runtimeInterface := &testRuntimeInterface{
 				storage: storage,
-				decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-					return jsoncdc.Decode(b)
-				},
 				log: func(message string) {
 					loggedMessages = append(loggedMessages, message)
 				},
+				meterMemory: func(_ common.MemoryUsage) error {
+					return nil
+				},
+			}
+			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(runtimeInterface, b)
 			}
 
 			_, err := rt.ExecuteScript(
@@ -6567,9 +6574,12 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 
 			runtimeInterface := &testRuntimeInterface{
 				storage: storage,
-				decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-					return jsoncdc.Decode(b)
+				meterMemory: func(_ common.MemoryUsage) error {
+					return nil
 				},
+			}
+			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(runtimeInterface, b)
 			}
 
 			_, err := runtime.ExecuteScript(
@@ -6845,12 +6855,15 @@ func TestRuntimeStackOverflow(t *testing.T) {
 			events = append(events, event)
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return jsoncdc.Decode(b)
-		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
+		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -248,7 +248,7 @@ func (l FlowLocation) MarshalJSON() ([]byte, error) {
 func init() {
 	common.RegisterTypeIDDecoder(
 		FlowLocationPrefix,
-		func(typeID string) (location common.Location, qualifiedIdentifier string, err error) {
+		func(_ common.MemoryGauge, typeID string) (location common.Location, qualifiedIdentifier string, err error) {
 			return decodeFlowLocationTypeID(typeID)
 		},
 	)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -771,13 +771,16 @@ func TestRuntimeTopShotContractDeployment(t *testing.T) {
 			code = []byte(accountCodes[location.ID()])
 			return code, nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return json.Decode(b)
-		},
 		emitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
+		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	err = runtime.ExecuteTransaction(
@@ -869,12 +872,15 @@ func TestRuntimeTopShotBatchTransfer(t *testing.T) {
 			events = append(events, event)
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return json.Decode(b)
-		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
+		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -1154,12 +1160,15 @@ func TestRuntimeBatchMintAndTransfer(t *testing.T) {
 			events = append(events, event)
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return json.Decode(b)
-		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
+		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -2234,9 +2243,12 @@ transaction {
 			events = append(events, event)
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(b)
+		meterMemory: func(_ common.MemoryUsage) error {
+			return nil
 		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		return json.Decode(runtimeInterface, b)
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -2364,12 +2376,15 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				events = append(events, event)
 				return nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		nextTransactionLocation := newTransactionLocationGenerator()
@@ -2496,12 +2511,15 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				events = append(events, event)
 				return nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		nextTransactionLocation := newTransactionLocationGenerator()
@@ -2634,12 +2652,15 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				events = append(events, event)
 				return nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		nextTransactionLocation := newTransactionLocationGenerator()
@@ -2759,12 +2780,15 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				events = append(events, event)
 				return nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		nextTransactionLocation := newTransactionLocationGenerator()
@@ -2882,12 +2906,15 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				events = append(events, event)
 				return nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
-			},
 			log: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		nextTransactionLocation := newTransactionLocationGenerator()

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -6526,3 +6526,28 @@ func TestInterpretLinkValueMetering(t *testing.T) {
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindLinkValue))
 	})
 }
+
+func TestInterpretAddressLocationMetering(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("creation", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := `
+			import 
+            pub fun main() {
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		// creation: 2
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindNumber))
+	})
+}

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -223,7 +223,7 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(14), meter.getMemory(common.MemoryKindString))
-		assert.Equal(t, uint64(51), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(66), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindComposite))
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindVariable))
 	})
@@ -297,7 +297,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(11), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
 	})
 
@@ -324,7 +324,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(34), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindComposite))
 	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7669,28 +7669,3 @@ func TestInterpreterStringLocationMetering(t *testing.T) {
 		assert.Equal(t, uint64(5), meter.getMemory(common.MemoryKindRawString))
 	})
 }
-
-func TestInterpreterAddressLocationMetering(t *testing.T) {
-
-	t.Parallel()
-
-	t.Run("add contract", func(t *testing.T) {
-		t.Parallel()
-
-		script := `
-		struct S {}
-
-		pub fun main(account: AuthAccount) {
-			let s = CompositeType("S")
-		}
-        `
-		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
-
-		account := newTestAuthAccountValue(inter, interpreter.AddressValue{})
-		_, err := inter.Invoke("main", account)
-		require.NoError(t, err)
-
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAddressLocation))
-	})
-}

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -52,12 +52,15 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-				return json.Decode(b)
-			},
 			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
 				return nil, nil
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		nextTransactionLocation := newTransactionLocationGenerator()
@@ -99,12 +102,15 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
-			decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-				return json.Decode(b)
-			},
 			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
 				return nil, nil
 			},
+			meterMemory: func(_ common.MemoryUsage) error {
+				return nil
+			},
+		}
+		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		nextTransactionLocation := newTransactionLocationGenerator()


### PR DESCRIPTION
Works towards https://github.com/dapperlabs/cadence-private-issues/issues/2

This adds metering for `AddressLocation`, `StringLocation`, `ScriptLocation` and `TransactionLocation` values. 
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
