### PR TITLE
Refactor token types to avoid switch-case in metering

### DIFF
--- a/runtime/parser2/lexer/memory_usage.go
+++ b/runtime/parser2/lexer/memory_usage.go
@@ -65,56 +65,22 @@ var tripleWidthTokenMemoryUsage = common.NewSyntaxTokenMemoryUsage(3)
 //     - And other similar tokens, such as ?, //, /*
 //
 func (l *lexer) typeMemoryUsage(tokenType TokenType) common.MemoryUsage {
-	switch tokenType {
+	switch {
+
+	// non-syntax tokens
+	case tokenType < TokenPlaceHolderSingleWidthTokenStart:
+		panic(errors.NewUnreachableError())
 
 	// 1-length tokens
-	case TokenPlus,
-		TokenMinus,
-		TokenStar,
-		TokenSlash,
-		TokenPercent,
-		TokenParenOpen,
-		TokenParenClose,
-		TokenBraceOpen,
-		TokenBraceClose,
-		TokenBracketOpen,
-		TokenBracketClose,
-		TokenQuestionMark,
-		TokenComma,
-		TokenColon,
-		TokenDot,
-		TokenSemicolon,
-		TokenLess,
-		TokenGreater,
-		TokenEqual,
-		TokenExclamationMark,
-		TokenVerticalBar,
-		TokenAmpersand,
-		TokenCaret,
-		TokenAt,
-		TokenPragma:
+	case tokenType < TokenPlaceHolderDoubleWidthTokenStart:
 		return singleWidthTokenMemoryUsage
 
 	// 2-length tokens
-	case TokenDoubleQuestionMark,
-		TokenQuestionMarkDot,
-		TokenLeftArrow,
-		TokenLessEqual,
-		TokenLessLess,
-		TokenGreaterEqual,
-		TokenEqualEqual,
-		TokenNotEqual,
-		TokenBlockCommentStart,
-		TokenBlockCommentEnd,
-		TokenAmpersandAmpersand,
-		TokenVerticalBarVerticalBar:
+	case tokenType < TokenPlaceHolderTripleWidthTokenStart:
 		return doubleWidthTokenMemoryUsage
 
 	// 3-length tokens
-	case TokenLeftArrowExclamation,
-		TokenSwap,
-		TokenAsExclamationMark,
-		TokenAsQuestionMark:
+	case tokenType < TokenMax:
 		return tripleWidthTokenMemoryUsage
 
 	default:

--- a/runtime/parser2/lexer/tokentype.go
+++ b/runtime/parser2/lexer/tokentype.go
@@ -38,12 +38,18 @@ const (
 	TokenFixedPointNumberLiteral
 	TokenIdentifier
 	TokenString
+	TokenBlockCommentContent
+	TokenLineComment
+
+	// TokenPlaceHolderSingleWidthTokenStart is not an actual token, just a placeholder
+	// to mark the start of tokens consist of one codepoint.
+	TokenPlaceHolderSingleWidthTokenStart
+
 	TokenPlus
 	TokenMinus
 	TokenStar
 	TokenSlash
 	TokenPercent
-	TokenDoubleQuestionMark
 	TokenParenOpen
 	TokenParenClose
 	TokenBraceOpen
@@ -51,36 +57,46 @@ const (
 	TokenBracketOpen
 	TokenBracketClose
 	TokenQuestionMark
-	TokenQuestionMarkDot
 	TokenComma
 	TokenColon
 	TokenDot
 	TokenSemicolon
-	TokenLeftArrow
-	TokenLeftArrowExclamation
-	TokenSwap
 	TokenLess
+	TokenGreater
+	TokenEqual
+	TokenExclamationMark
+	TokenVerticalBar
+	TokenAmpersand
+	TokenCaret
+	TokenAt
+	TokenPragma
+
+	// TokenPlaceHolderDoubleWidthTokenStart is not an actual token, just a placeholder
+	// to mark the start of tokens consist of two codepoints.
+	TokenPlaceHolderDoubleWidthTokenStart
+
+	TokenDoubleQuestionMark
+	TokenQuestionMarkDot
+	TokenLeftArrow
 	TokenLessEqual
 	TokenLessLess
-	TokenGreater
 	TokenGreaterEqual
-	TokenEqual
 	TokenEqualEqual
-	TokenExclamationMark
 	TokenNotEqual
 	TokenBlockCommentStart
 	TokenBlockCommentEnd
-	TokenBlockCommentContent
-	TokenLineComment
-	TokenAmpersand
 	TokenAmpersandAmpersand
-	TokenCaret
-	TokenVerticalBar
 	TokenVerticalBarVerticalBar
-	TokenAt
+
+	// TokenPlaceHolderTripleWidthTokenStart is not an actual token, just a placeholder
+	// to mark the start of tokens consist of three codepoints.
+	TokenPlaceHolderTripleWidthTokenStart
+
+	TokenLeftArrowExclamation
+	TokenSwap
 	TokenAsExclamationMark
 	TokenAsQuestionMark
-	TokenPragma
+
 	// NOTE: not an actual token, must be last item
 	TokenMax
 )
@@ -88,6 +104,13 @@ const (
 func init() {
 	// ensure all tokens have its string format
 	for t := TokenType(0); t < TokenMax; t++ {
+		switch t {
+		case TokenPlaceHolderSingleWidthTokenStart,
+			TokenPlaceHolderDoubleWidthTokenStart,
+			TokenPlaceHolderTripleWidthTokenStart:
+			continue
+		}
+
 		_ = t.String()
 	}
 }


### PR DESCRIPTION
## Description

A quick refactor to eliminate the switch-case which is error-prone (e.g: when adding new token types, etc.).
 - Re-ordered the tokens according to their width
 - Added 3 placeholders in between to separate the tokens with different widths.
 - Use the placeholders to switch, instead of switching based on each token.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
