### PR TITLE
Add memory metering for AST declaration elements

### DIFF
--- a/runtime/ast/argument.go
+++ b/runtime/ast/argument.go
@@ -21,6 +21,8 @@ package ast
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/onflow/cadence/runtime/common"
 )
 
 type Argument struct {
@@ -29,6 +31,29 @@ type Argument struct {
 	LabelEndPos          *Position `json:",omitempty"`
 	TrailingSeparatorPos Position
 	Expression           Expression
+}
+
+func NewArgument(
+	memoryGauge common.MemoryGauge,
+	label string,
+	labelStartPos,
+	labelEndPos *Position,
+	expression Expression,
+) *Argument {
+	common.UseMemory(memoryGauge, common.ArgumentMemoryUsage)
+	return &Argument{
+		Label:         label,
+		LabelStartPos: labelStartPos,
+		LabelEndPos:   labelEndPos,
+		Expression:    expression,
+	}
+}
+
+func NewUnlabeledArgument(memoryGauge common.MemoryGauge, expression Expression) *Argument {
+	common.UseMemory(memoryGauge, common.ArgumentMemoryUsage)
+	return &Argument{
+		Expression: expression,
+	}
 }
 
 func (a *Argument) StartPosition() Position {

--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -22,11 +22,22 @@ import (
 	"encoding/json"
 
 	"github.com/turbolent/prettier"
+
+	"github.com/onflow/cadence/runtime/common"
 )
 
 type Block struct {
 	Statements []Statement
 	Range
+}
+
+func NewBlock(memoryGauge common.MemoryGauge, statements []Statement, astRange Range) *Block {
+	common.UseMemory(memoryGauge, common.BlockMemoryUsage)
+
+	return &Block{
+		Statements: statements,
+		Range:      astRange,
+	}
 }
 
 func (b *Block) IsEmpty() bool {

--- a/runtime/ast/composite.go
+++ b/runtime/ast/composite.go
@@ -38,6 +38,29 @@ type CompositeDeclaration struct {
 	Range
 }
 
+func NewCompositeDeclaration(
+	memoryGauge common.MemoryGauge,
+	access Access,
+	compositeKind common.CompositeKind,
+	identifier Identifier,
+	conformances []*NominalType,
+	members *Members,
+	docString string,
+	declarationRange Range,
+) *CompositeDeclaration {
+	common.UseMemory(memoryGauge, common.CompositeDeclarationMemoryUsage)
+
+	return &CompositeDeclaration{
+		Access:        access,
+		CompositeKind: compositeKind,
+		Identifier:    identifier,
+		Conformances:  conformances,
+		Members:       members,
+		DocString:     docString,
+		Range:         declarationRange,
+	}
+}
+
 func (d *CompositeDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitCompositeDeclaration(d)
 }

--- a/runtime/ast/composite.go
+++ b/runtime/ast/composite.go
@@ -118,6 +118,27 @@ type FieldDeclaration struct {
 	Range
 }
 
+func NewFieldDeclaration(
+	memoryGauge common.MemoryGauge,
+	access Access,
+	variableKind VariableKind,
+	identifier Identifier,
+	typeAnnotation *TypeAnnotation,
+	docString string,
+	declRange Range,
+) *FieldDeclaration {
+	common.UseMemory(memoryGauge, common.FieldDeclarationMemoryUsage)
+
+	return &FieldDeclaration{
+		Access:         access,
+		VariableKind:   variableKind,
+		Identifier:     identifier,
+		TypeAnnotation: typeAnnotation,
+		DocString:      docString,
+		Range:          declRange,
+	}
+}
+
 func (d *FieldDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitFieldDeclaration(d)
 }
@@ -167,6 +188,23 @@ type EnumCaseDeclaration struct {
 	Identifier Identifier
 	DocString  string
 	StartPos   Position `json:"-"`
+}
+
+func NewEnumCaseDeclaration(
+	memoryGauge common.MemoryGauge,
+	access Access,
+	identifier Identifier,
+	docString string,
+	startPos Position,
+) *EnumCaseDeclaration {
+	common.UseMemory(memoryGauge, common.EnumCaseDeclarationMemoryUsage)
+
+	return &EnumCaseDeclaration{
+		Access:     access,
+		Identifier: identifier,
+		DocString:  docString,
+		StartPos:   startPos,
+	}
 }
 
 func (d *EnumCaseDeclaration) Accept(visitor Visitor) Repr {

--- a/runtime/ast/function_declaration.go
+++ b/runtime/ast/function_declaration.go
@@ -34,6 +34,29 @@ type FunctionDeclaration struct {
 	StartPos             Position `json:"-"`
 }
 
+func NewFunctionDeclaration(
+	gauge common.MemoryGauge,
+	access Access,
+	identifier Identifier,
+	parameterList *ParameterList,
+	returnTypeAnnotation *TypeAnnotation,
+	functionBlock *FunctionBlock,
+	startPos Position,
+	docString string,
+) *FunctionDeclaration {
+	common.UseMemory(gauge, common.FunctionDeclarationMemoryUsage)
+
+	return &FunctionDeclaration{
+		Access:               access,
+		Identifier:           identifier,
+		ParameterList:        parameterList,
+		ReturnTypeAnnotation: returnTypeAnnotation,
+		FunctionBlock:        functionBlock,
+		StartPos:             startPos,
+		DocString:            docString,
+	}
+}
+
 func (d *FunctionDeclaration) StartPosition() Position {
 	return d.StartPos
 }

--- a/runtime/ast/function_declaration.go
+++ b/runtime/ast/function_declaration.go
@@ -135,6 +135,19 @@ type SpecialFunctionDeclaration struct {
 	FunctionDeclaration *FunctionDeclaration
 }
 
+func NewSpecialFunctionDeclaration(
+	gauge common.MemoryGauge,
+	kind common.DeclarationKind,
+	funcDecl *FunctionDeclaration,
+) *SpecialFunctionDeclaration {
+	common.UseMemory(gauge, common.SpecialFunctionDeclarationMemoryUsage)
+
+	return &SpecialFunctionDeclaration{
+		Kind:                kind,
+		FunctionDeclaration: funcDecl,
+	}
+}
+
 func (d *SpecialFunctionDeclaration) StartPosition() Position {
 	return d.FunctionDeclaration.StartPosition()
 }

--- a/runtime/ast/import.go
+++ b/runtime/ast/import.go
@@ -33,6 +33,23 @@ type ImportDeclaration struct {
 	Range
 }
 
+func NewImportDeclaration(
+	gauge common.MemoryGauge,
+	identifiers []Identifier,
+	location common.Location,
+	declRange Range,
+	locationPos Position,
+) *ImportDeclaration {
+	common.UseMemory(gauge, common.ImportDeclarationMemoryUsage)
+
+	return &ImportDeclaration{
+		Identifiers: identifiers,
+		Location:    location,
+		Range:       declRange,
+		LocationPos: locationPos,
+	}
+}
+
 func (*ImportDeclaration) isDeclaration() {}
 
 func (*ImportDeclaration) isStatement() {}

--- a/runtime/ast/interface.go
+++ b/runtime/ast/interface.go
@@ -35,6 +35,27 @@ type InterfaceDeclaration struct {
 	Range
 }
 
+func NewInterfaceDeclaration(
+	gauge common.MemoryGauge,
+	access Access,
+	compositeKind common.CompositeKind,
+	identifier Identifier,
+	members *Members,
+	docString string,
+	declRange Range,
+) *InterfaceDeclaration {
+	common.UseMemory(gauge, common.InterfaceDeclarationMemoryUsage)
+
+	return &InterfaceDeclaration{
+		Access:        access,
+		CompositeKind: compositeKind,
+		Identifier:    identifier,
+		Members:       members,
+		DocString:     docString,
+		Range:         declRange,
+	}
+}
+
 func (d *InterfaceDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitInterfaceDeclaration(d)
 }

--- a/runtime/ast/pragma.go
+++ b/runtime/ast/pragma.go
@@ -31,6 +31,15 @@ type PragmaDeclaration struct {
 	Range
 }
 
+func NewPragmaDeclaration(gauge common.MemoryGauge, expression Expression, declRange Range) *PragmaDeclaration {
+	common.UseMemory(gauge, common.PragmaDeclarationMemoryUsage)
+
+	return &PragmaDeclaration{
+		Expression: expression,
+		Range:      declRange,
+	}
+}
+
 func (*PragmaDeclaration) isDeclaration() {}
 
 func (*PragmaDeclaration) isStatement() {}

--- a/runtime/ast/transaction_declaration.go
+++ b/runtime/ast/transaction_declaration.go
@@ -35,6 +35,31 @@ type TransactionDeclaration struct {
 	Range
 }
 
+func NewTransactionDeclaration(
+	gauge common.MemoryGauge,
+	parameterList *ParameterList,
+	fields []*FieldDeclaration,
+	prepare *SpecialFunctionDeclaration,
+	preConditions *Conditions,
+	postConditions *Conditions,
+	execute *SpecialFunctionDeclaration,
+	docString string,
+	declRange Range,
+) *TransactionDeclaration {
+	common.UseMemory(gauge, common.TransactionDeclarationMemoryUsage)
+
+	return &TransactionDeclaration{
+		ParameterList:  parameterList,
+		Fields:         fields,
+		Prepare:        prepare,
+		PreConditions:  preConditions,
+		PostConditions: postConditions,
+		Execute:        execute,
+		DocString:      docString,
+		Range:          declRange,
+	}
+}
+
 func (d *TransactionDeclaration) Accept(visitor Visitor) Repr {
 	return visitor.VisitTransactionDeclaration(d)
 }

--- a/runtime/ast/variable_declaration.go
+++ b/runtime/ast/variable_declaration.go
@@ -40,6 +40,40 @@ type VariableDeclaration struct {
 	DocString         string
 }
 
+func NewVariableDeclaration(
+	gauge common.MemoryGauge,
+	access Access,
+	isLet bool,
+	identifier Identifier,
+	typeAnnotation *TypeAnnotation,
+	value Expression,
+	transfer *Transfer,
+	startPos Position,
+	secondTransfer *Transfer,
+	secondValue Expression,
+	docString string,
+) *VariableDeclaration {
+	common.UseMemory(gauge, common.VariableDeclarationMemoryUsage)
+
+	return &VariableDeclaration{
+		Access:         access,
+		IsConstant:     isLet,
+		Identifier:     identifier,
+		TypeAnnotation: typeAnnotation,
+		Value:          value,
+		Transfer:       transfer,
+		StartPos:       startPos,
+		SecondTransfer: secondTransfer,
+		SecondValue:    secondValue,
+		DocString:      docString,
+	}
+}
+
+func NewEmptyVariableDeclaration(gauge common.MemoryGauge) *VariableDeclaration {
+	common.UseMemory(gauge, common.VariableDeclarationMemoryUsage)
+	return &VariableDeclaration{}
+}
+
 func (d *VariableDeclaration) StartPosition() Position {
 	return d.StartPos
 }

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -68,4 +68,5 @@ const (
 
 	MemoryKindIdentifier
 	MemoryKindArgument
+	MemoryKindBlock
 )

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -69,6 +69,12 @@ const (
 	MemoryKindIdentifier
 	MemoryKindArgument
 	MemoryKindBlock
+	MemoryKindFunctionDeclaration
 	MemoryKindCompositeDeclaration
 	MemoryKindInterfaceDeclaration
+	MemoryKindEnumCaseDeclaration
+	MemoryKindFieldDeclaration
+	MemoryKindTransactionDeclaration
+	MemoryKindImportDeclaration
+	MemoryKindVariableDeclaration
 )

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -67,4 +67,5 @@ const (
 	// AST nodes
 
 	MemoryKindIdentifier
+	MemoryKindArgument
 )

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -69,4 +69,6 @@ const (
 	MemoryKindIdentifier
 	MemoryKindArgument
 	MemoryKindBlock
+	MemoryKindCompositeDeclaration
+	MemoryKindInterfaceDeclaration
 )

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -77,4 +77,6 @@ const (
 	MemoryKindTransactionDeclaration
 	MemoryKindImportDeclaration
 	MemoryKindVariableDeclaration
+	MemoryKindSpecialFunctionDeclaration
+	MemoryKindPragmaDeclaration
 )

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -48,11 +48,13 @@ func _() {
 	_ = x[MemoryKindTransactionDeclaration-37]
 	_ = x[MemoryKindImportDeclaration-38]
 	_ = x[MemoryKindVariableDeclaration-39]
+	_ = x[MemoryKindSpecialFunctionDeclaration-40]
+	_ = x[MemoryKindPragmaDeclaration-41]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifierArgumentBlockFunctionDeclarationCompositeDeclarationInterfaceDeclarationEnumCaseDeclarationFieldDeclarationTransactionDeclarationImportDeclarationVariableDeclaration"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifierArgumentBlockFunctionDeclarationCompositeDeclarationInterfaceDeclarationEnumCaseDeclarationFieldDeclarationTransactionDeclarationImportDeclarationVariableDeclarationSpecialFunctionDeclarationPragmaDeclaration"
 
-var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306, 314, 319, 338, 358, 378, 397, 413, 435, 452, 471}
+var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306, 314, 319, 338, 358, 378, 397, 413, 435, 452, 471, 497, 514}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -40,13 +40,19 @@ func _() {
 	_ = x[MemoryKindIdentifier-29]
 	_ = x[MemoryKindArgument-30]
 	_ = x[MemoryKindBlock-31]
-	_ = x[MemoryKindCompositeDeclaration-32]
-	_ = x[MemoryKindInterfaceDeclaration-33]
+	_ = x[MemoryKindFunctionDeclaration-32]
+	_ = x[MemoryKindCompositeDeclaration-33]
+	_ = x[MemoryKindInterfaceDeclaration-34]
+	_ = x[MemoryKindEnumCaseDeclaration-35]
+	_ = x[MemoryKindFieldDeclaration-36]
+	_ = x[MemoryKindTransactionDeclaration-37]
+	_ = x[MemoryKindImportDeclaration-38]
+	_ = x[MemoryKindVariableDeclaration-39]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifierArgumentBlockCompositeDeclarationInterfaceDeclaration"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifierArgumentBlockFunctionDeclarationCompositeDeclarationInterfaceDeclarationEnumCaseDeclarationFieldDeclarationTransactionDeclarationImportDeclarationVariableDeclaration"
 
-var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306, 314, 319, 339, 359}
+var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306, 314, 319, 338, 358, 378, 397, 413, 435, 452, 471}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -40,11 +40,13 @@ func _() {
 	_ = x[MemoryKindIdentifier-29]
 	_ = x[MemoryKindArgument-30]
 	_ = x[MemoryKindBlock-31]
+	_ = x[MemoryKindCompositeDeclaration-32]
+	_ = x[MemoryKindInterfaceDeclaration-33]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifierArgumentBlock"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifierArgumentBlockCompositeDeclarationInterfaceDeclaration"
 
-var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306, 314, 319}
+var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306, 314, 319, 339, 359}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/memorykind_string.go
+++ b/runtime/common/memorykind_string.go
@@ -38,11 +38,13 @@ func _() {
 	_ = x[MemoryKindTokenNumericLiteral-27]
 	_ = x[MemoryKindTokenSyntax-28]
 	_ = x[MemoryKindIdentifier-29]
+	_ = x[MemoryKindArgument-30]
+	_ = x[MemoryKindBlock-31]
 }
 
-const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifier"
+const _MemoryKind_name = "UnknownBoolAddressStringCharacterMetaTypeNumberArrayDictionaryCompositeOptionalNilVoidTypeValuePathValueCapabilityValueLinkValueStorageReferenceValueEphemeralReferenceValueInterpretedFunctionHostFunctionBoundFunctionBigIntRawStringVariableTokenIdentifierTokenCommentTokenNumericLiteralTokenSyntaxIdentifierArgumentBlock"
 
-var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306}
+var _MemoryKind_index = [...]uint16{0, 7, 11, 18, 24, 33, 41, 47, 52, 62, 71, 79, 82, 86, 95, 104, 119, 128, 149, 172, 191, 203, 216, 222, 231, 239, 254, 266, 285, 296, 306, 314, 319}
 
 func (i MemoryKind) String() string {
 	if i >= MemoryKind(len(_MemoryKind_index)-1) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -33,17 +33,19 @@ type MemoryGauge interface {
 }
 
 var (
-	IdentifierMemoryUsage             = NewConstantMemoryUsage(MemoryKindIdentifier)
-	ArgumentMemoryUsage               = NewConstantMemoryUsage(MemoryKindArgument)
-	BlockMemoryUsage                  = NewConstantMemoryUsage(MemoryKindBlock)
-	FunctionDeclarationMemoryUsage    = NewConstantMemoryUsage(MemoryKindFunctionDeclaration)
-	CompositeDeclarationMemoryUsage   = NewConstantMemoryUsage(MemoryKindCompositeDeclaration)
-	InterfaceDeclarationMemoryUsage   = NewConstantMemoryUsage(MemoryKindInterfaceDeclaration)
-	ImportDeclarationMemoryUsage      = NewConstantMemoryUsage(MemoryKindImportDeclaration)
-	TransactionDeclarationMemoryUsage = NewConstantMemoryUsage(MemoryKindTransactionDeclaration)
-	FieldDeclarationMemoryUsage       = NewConstantMemoryUsage(MemoryKindFieldDeclaration)
-	EnumCaseDeclarationMemoryUsage    = NewConstantMemoryUsage(MemoryKindEnumCaseDeclaration)
-	VariableDeclarationMemoryUsage    = NewConstantMemoryUsage(MemoryKindVariableDeclaration)
+	IdentifierMemoryUsage                 = NewConstantMemoryUsage(MemoryKindIdentifier)
+	ArgumentMemoryUsage                   = NewConstantMemoryUsage(MemoryKindArgument)
+	BlockMemoryUsage                      = NewConstantMemoryUsage(MemoryKindBlock)
+	FunctionDeclarationMemoryUsage        = NewConstantMemoryUsage(MemoryKindFunctionDeclaration)
+	CompositeDeclarationMemoryUsage       = NewConstantMemoryUsage(MemoryKindCompositeDeclaration)
+	InterfaceDeclarationMemoryUsage       = NewConstantMemoryUsage(MemoryKindInterfaceDeclaration)
+	ImportDeclarationMemoryUsage          = NewConstantMemoryUsage(MemoryKindImportDeclaration)
+	TransactionDeclarationMemoryUsage     = NewConstantMemoryUsage(MemoryKindTransactionDeclaration)
+	FieldDeclarationMemoryUsage           = NewConstantMemoryUsage(MemoryKindFieldDeclaration)
+	EnumCaseDeclarationMemoryUsage        = NewConstantMemoryUsage(MemoryKindEnumCaseDeclaration)
+	VariableDeclarationMemoryUsage        = NewConstantMemoryUsage(MemoryKindVariableDeclaration)
+	SpecialFunctionDeclarationMemoryUsage = NewConstantMemoryUsage(MemoryKindSpecialFunctionDeclaration)
+	PragmaDeclarationMemoryUsage          = NewConstantMemoryUsage(MemoryKindPragmaDeclaration)
 )
 
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -35,6 +35,7 @@ type MemoryGauge interface {
 var (
 	IdentifierMemoryUsage = NewConstantMemoryUsage(MemoryKindIdentifier)
 	ArgumentMemoryUsage   = NewConstantMemoryUsage(MemoryKindArgument)
+	BlockMemoryUsage   = NewConstantMemoryUsage(MemoryKindBlock)
 )
 
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -33,9 +33,11 @@ type MemoryGauge interface {
 }
 
 var (
-	IdentifierMemoryUsage = NewConstantMemoryUsage(MemoryKindIdentifier)
-	ArgumentMemoryUsage   = NewConstantMemoryUsage(MemoryKindArgument)
-	BlockMemoryUsage   = NewConstantMemoryUsage(MemoryKindBlock)
+	IdentifierMemoryUsage           = NewConstantMemoryUsage(MemoryKindIdentifier)
+	ArgumentMemoryUsage             = NewConstantMemoryUsage(MemoryKindArgument)
+	BlockMemoryUsage                = NewConstantMemoryUsage(MemoryKindBlock)
+	CompositeDeclarationMemoryUsage = NewConstantMemoryUsage(MemoryKindCompositeDeclaration)
+	InterfaceDeclarationMemoryUsage = NewConstantMemoryUsage(MemoryKindInterfaceDeclaration)
 )
 
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -33,11 +33,17 @@ type MemoryGauge interface {
 }
 
 var (
-	IdentifierMemoryUsage           = NewConstantMemoryUsage(MemoryKindIdentifier)
-	ArgumentMemoryUsage             = NewConstantMemoryUsage(MemoryKindArgument)
-	BlockMemoryUsage                = NewConstantMemoryUsage(MemoryKindBlock)
-	CompositeDeclarationMemoryUsage = NewConstantMemoryUsage(MemoryKindCompositeDeclaration)
-	InterfaceDeclarationMemoryUsage = NewConstantMemoryUsage(MemoryKindInterfaceDeclaration)
+	IdentifierMemoryUsage             = NewConstantMemoryUsage(MemoryKindIdentifier)
+	ArgumentMemoryUsage               = NewConstantMemoryUsage(MemoryKindArgument)
+	BlockMemoryUsage                  = NewConstantMemoryUsage(MemoryKindBlock)
+	FunctionDeclarationMemoryUsage    = NewConstantMemoryUsage(MemoryKindFunctionDeclaration)
+	CompositeDeclarationMemoryUsage   = NewConstantMemoryUsage(MemoryKindCompositeDeclaration)
+	InterfaceDeclarationMemoryUsage   = NewConstantMemoryUsage(MemoryKindInterfaceDeclaration)
+	ImportDeclarationMemoryUsage      = NewConstantMemoryUsage(MemoryKindImportDeclaration)
+	TransactionDeclarationMemoryUsage = NewConstantMemoryUsage(MemoryKindTransactionDeclaration)
+	FieldDeclarationMemoryUsage       = NewConstantMemoryUsage(MemoryKindFieldDeclaration)
+	EnumCaseDeclarationMemoryUsage    = NewConstantMemoryUsage(MemoryKindEnumCaseDeclaration)
+	VariableDeclarationMemoryUsage    = NewConstantMemoryUsage(MemoryKindVariableDeclaration)
 )
 
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -32,7 +32,10 @@ type MemoryGauge interface {
 	MeterMemory(usage MemoryUsage) error
 }
 
-var IdentifierMemoryUsage = NewConstantMemoryUsage(MemoryKindIdentifier)
+var (
+	IdentifierMemoryUsage = NewConstantMemoryUsage(MemoryKindIdentifier)
+	ArgumentMemoryUsage   = NewConstantMemoryUsage(MemoryKindArgument)
+)
 
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {
 	if gauge == nil {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1702,10 +1702,6 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	// Name
 
 	// Decode name at array index encodedAddressLocationNameFieldKey

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -211,9 +211,11 @@ func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.Switch
 		runStatements := func() ast.Repr {
 			// NOTE: the new block ensures that a new scope is introduced
 
-			block := &ast.Block{
-				Statements: switchCase.Statements,
-			}
+			block := ast.NewBlock(
+				interpreter,
+				switchCase.Statements,
+				ReturnEmptyRange(),
+			)
 
 			result := block.Accept(interpreter)
 

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -652,10 +652,16 @@ func parseEventDeclaration(
 	initializer :=
 		&ast.SpecialFunctionDeclaration{
 			Kind: common.DeclarationKindInitializer,
-			FunctionDeclaration: &ast.FunctionDeclaration{
-				ParameterList: parameterList,
-				StartPos:      parameterList.StartPos,
-			},
+			FunctionDeclaration: ast.NewFunctionDeclaration(
+				p.memoryGauge,
+				ast.AccessNotSpecified,
+				ast.NewEmptyIdentifier(p.memoryGauge, ast.EmptyPosition),
+				nil,
+				nil,
+				nil,
+				parameterList.StartPos,
+				"",
+			),
 		}
 
 	members := ast.NewMembers([]ast.Declaration{
@@ -1082,13 +1088,16 @@ func parseSpecialFunctionDeclaration(
 
 	return &ast.SpecialFunctionDeclaration{
 		Kind: declarationKind,
-		FunctionDeclaration: &ast.FunctionDeclaration{
-			Access:        access,
-			Identifier:    identifier,
-			ParameterList: parameterList,
-			FunctionBlock: functionBlock,
-			StartPos:      startPos,
-		},
+		FunctionDeclaration: ast.NewFunctionDeclaration(
+			p.memoryGauge,
+			access,
+			identifier,
+			parameterList,
+			nil,
+			functionBlock,
+			startPos,
+			"",
+		),
 	}
 }
 

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -662,17 +662,19 @@ func parseEventDeclaration(
 		initializer,
 	})
 
-	return &ast.CompositeDeclaration{
-		Access:        access,
-		CompositeKind: common.CompositeKindEvent,
-		Identifier:    identifier,
-		Members:       members,
-		DocString:     docString,
-		Range: ast.Range{
+	return ast.NewCompositeDeclaration(
+		p.memoryGauge,
+		access,
+		common.CompositeKindEvent,
+		identifier,
+		nil,
+		members,
+		docString,
+		ast.Range{
 			StartPos: startPos,
 			EndPos:   parameterList.EndPos,
 		},
-	}
+	)
 }
 
 // parseCompositeKind parses a composite kind.
@@ -863,24 +865,26 @@ func parseCompositeOrInterfaceDeclaration(
 			panic(fmt.Errorf("unexpected conformances"))
 		}
 
-		return &ast.InterfaceDeclaration{
-			Access:        access,
-			CompositeKind: compositeKind,
-			Identifier:    identifier,
-			Members:       members,
-			DocString:     docString,
-			Range:         declarationRange,
-		}
+		return ast.NewInterfaceDeclaration(
+			p.memoryGauge,
+			access,
+			compositeKind,
+			identifier,
+			members,
+			docString,
+			declarationRange,
+		)
 	} else {
-		return &ast.CompositeDeclaration{
-			Access:        access,
-			CompositeKind: compositeKind,
-			Identifier:    identifier,
-			Conformances:  conformances,
-			Members:       members,
-			DocString:     docString,
-			Range:         declarationRange,
-		}
+		return ast.NewCompositeDeclaration(
+			p.memoryGauge,
+			access,
+			compositeKind,
+			identifier,
+			conformances,
+			members,
+			docString,
+			declarationRange,
+		)
 	}
 }
 

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -751,17 +751,18 @@ func parseFieldWithVariableKind(
 
 	typeAnnotation := parseTypeAnnotation(p)
 
-	return &ast.FieldDeclaration{
-		Access:         access,
-		VariableKind:   variableKind,
-		Identifier:     identifier,
-		TypeAnnotation: typeAnnotation,
-		DocString:      docString,
-		Range: ast.Range{
+	return ast.NewFieldDeclaration(
+		p.memoryGauge,
+		access,
+		variableKind,
+		identifier,
+		typeAnnotation,
+		docString,
+		ast.Range{
 			StartPos: startPos,
 			EndPos:   typeAnnotation.EndPosition(),
 		},
-	}
+	)
 }
 
 // parseCompositeOrInterfaceDeclaration parses an event declaration.
@@ -1025,17 +1026,18 @@ func parseFieldDeclarationWithoutVariableKind(
 
 	typeAnnotation := parseTypeAnnotation(p)
 
-	return &ast.FieldDeclaration{
-		Access:         access,
-		VariableKind:   ast.VariableKindNotSpecified,
-		Identifier:     identifier,
-		TypeAnnotation: typeAnnotation,
-		DocString:      docString,
-		Range: ast.Range{
+	return ast.NewFieldDeclaration(
+		p.memoryGauge,
+		access,
+		ast.VariableKindNotSpecified,
+		identifier,
+		typeAnnotation,
+		docString,
+		ast.Range{
 			StartPos: startPos,
 			EndPos:   typeAnnotation.EndPosition(),
 		},
-	}
+	)
 }
 
 func parseSpecialFunctionDeclaration(
@@ -1121,10 +1123,11 @@ func parseEnumCase(
 	// Skip the identifier
 	p.next()
 
-	return &ast.EnumCaseDeclaration{
-		Access:     access,
-		Identifier: identifier,
-		DocString:  docString,
-		StartPos:   startPos,
-	}
+	return ast.NewEnumCaseDeclaration(
+		p.memoryGauge,
+		access,
+		identifier,
+		docString,
+		startPos,
+	)
 }

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -352,13 +352,14 @@ func parsePragmaDeclaration(p *parser) *ast.PragmaDeclaration {
 	startPos := p.current.StartPosition()
 	p.next()
 	expr := parseExpression(p, lowestBindingPower)
-	return &ast.PragmaDeclaration{
-		Range: ast.Range{
+	return ast.NewPragmaDeclaration(
+		p.memoryGauge,
+		expr,
+		ast.Range{
 			StartPos: startPos,
 			EndPos:   expr.EndPosition(),
 		},
-		Expression: expr,
-	}
+	)
 }
 
 // parseImportDeclaration parses an import declaration
@@ -651,20 +652,20 @@ func parseEventDeclaration(
 
 	parameterList := parseParameterList(p)
 
-	initializer :=
-		&ast.SpecialFunctionDeclaration{
-			Kind: common.DeclarationKindInitializer,
-			FunctionDeclaration: ast.NewFunctionDeclaration(
-				p.memoryGauge,
-				ast.AccessNotSpecified,
-				ast.NewEmptyIdentifier(p.memoryGauge, ast.EmptyPosition),
-				nil,
-				nil,
-				nil,
-				parameterList.StartPos,
-				"",
-			),
-		}
+	initializer := ast.NewSpecialFunctionDeclaration(
+		p.memoryGauge,
+		common.DeclarationKindInitializer,
+		ast.NewFunctionDeclaration(
+			p.memoryGauge,
+			ast.AccessNotSpecified,
+			ast.NewEmptyIdentifier(p.memoryGauge, ast.EmptyPosition),
+			nil,
+			nil,
+			nil,
+			parameterList.StartPos,
+			"",
+		),
+	)
 
 	members := ast.NewMembers([]ast.Declaration{
 		initializer,
@@ -1088,9 +1089,10 @@ func parseSpecialFunctionDeclaration(
 		declarationKind = common.DeclarationKindPrepare
 	}
 
-	return &ast.SpecialFunctionDeclaration{
-		Kind: declarationKind,
-		FunctionDeclaration: ast.NewFunctionDeclaration(
+	return ast.NewSpecialFunctionDeclaration(
+		p.memoryGauge,
+		declarationKind,
+		ast.NewFunctionDeclaration(
 			p.memoryGauge,
 			access,
 			identifier,
@@ -1100,7 +1102,7 @@ func parseSpecialFunctionDeclaration(
 			startPos,
 			"",
 		),
-	}
+	)
 }
 
 // parseEnumCase parses a field which has a variable kind.

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -559,15 +559,16 @@ func parseImportDeclaration(p *parser) *ast.ImportDeclaration {
 		))
 	}
 
-	return &ast.ImportDeclaration{
-		Identifiers: identifiers,
-		Location:    location,
-		Range: ast.Range{
+	return ast.NewImportDeclaration(
+		p.memoryGauge,
+		identifiers,
+		location,
+		ast.Range{
 			StartPos: startPosition,
 			EndPos:   endPos,
 		},
-		LocationPos: locationPos,
-	}
+		locationPos,
+	)
 }
 
 // isNextTokenCommaOrFrom check whether the token to follow is a comma or a from token.

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -659,7 +659,7 @@ func parseEventDeclaration(
 			p.memoryGauge,
 			ast.AccessNotSpecified,
 			ast.NewEmptyIdentifier(p.memoryGauge, ast.EmptyPosition),
-			nil,
+			parameterList,
 			nil,
 			nil,
 			parameterList.StartPos,

--- a/runtime/parser2/declaration.go
+++ b/runtime/parser2/declaration.go
@@ -294,18 +294,19 @@ func parseVariableDeclaration(
 		secondValue = parseExpression(p, lowestBindingPower)
 	}
 
-	variableDeclaration := &ast.VariableDeclaration{
-		Access:         access,
-		IsConstant:     isLet,
-		Identifier:     identifier,
-		TypeAnnotation: typeAnnotation,
-		Value:          value,
-		Transfer:       transfer,
-		StartPos:       startPos,
-		SecondTransfer: secondTransfer,
-		SecondValue:    secondValue,
-		DocString:      docString,
-	}
+	variableDeclaration := ast.NewVariableDeclaration(
+		p.memoryGauge,
+		access,
+		isLet,
+		identifier,
+		typeAnnotation,
+		value,
+		transfer,
+		startPos,
+		secondTransfer,
+		secondValue,
+		docString,
+	)
 
 	castingExpression, leftIsCasting := value.(*ast.CastingExpression)
 	if leftIsCasting {

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -981,16 +981,15 @@ func parseArgument(p *parser) *ast.Argument {
 	}
 
 	if len(label) > 0 {
-		return &ast.Argument{
-			Label:         label,
-			LabelStartPos: &labelStartPos,
-			LabelEndPos:   &labelEndPos,
-			Expression:    expr,
-		}
+		return ast.NewArgument(
+			p.memoryGauge,
+			label,
+			&labelStartPos,
+			&labelEndPos,
+			expr,
+		)
 	}
-	return &ast.Argument{
-		Expression: expr,
-	}
+	return ast.NewUnlabeledArgument(p.memoryGauge, expr)
 }
 
 func defineNestedExpression() {

--- a/runtime/parser2/function.go
+++ b/runtime/parser2/function.go
@@ -20,7 +20,6 @@ package parser2
 
 import (
 	"fmt"
-
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/parser2/lexer"
 )
@@ -210,15 +209,16 @@ func parseFunctionDeclaration(
 	parameterList, returnTypeAnnotation, functionBlock :=
 		parseFunctionParameterListAndRest(p, functionBlockIsOptional)
 
-	return &ast.FunctionDeclaration{
-		Access:               access,
-		Identifier:           identifier,
-		ParameterList:        parameterList,
-		ReturnTypeAnnotation: returnTypeAnnotation,
-		FunctionBlock:        functionBlock,
-		StartPos:             startPos,
-		DocString:            docString,
-	}
+	return ast.NewFunctionDeclaration(
+		p.memoryGauge,
+		access,
+		identifier,
+		parameterList,
+		returnTypeAnnotation,
+		functionBlock,
+		startPos,
+		docString,
+	)
 }
 
 func parseFunctionParameterListAndRest(

--- a/runtime/parser2/function.go
+++ b/runtime/parser2/function.go
@@ -20,6 +20,7 @@ package parser2
 
 import (
 	"fmt"
+
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/parser2/lexer"
 )

--- a/runtime/parser2/statement.go
+++ b/runtime/parser2/statement.go
@@ -165,14 +165,16 @@ func parseFunctionDeclarationOrFunctionExpressionStatement(p *parser) ast.Statem
 		parameterList, returnTypeAnnotation, functionBlock :=
 			parseFunctionParameterListAndRest(p, false)
 
-		return &ast.FunctionDeclaration{
-			Access:               ast.AccessNotSpecified,
-			Identifier:           identifier,
-			ParameterList:        parameterList,
-			ReturnTypeAnnotation: returnTypeAnnotation,
-			FunctionBlock:        functionBlock,
-			StartPos:             startPos,
-		}
+		return ast.NewFunctionDeclaration(
+			p.memoryGauge,
+			ast.AccessNotSpecified,
+			identifier,
+			parameterList,
+			returnTypeAnnotation,
+			functionBlock,
+			startPos,
+			"",
+		)
 	} else {
 		parameterList, returnTypeAnnotation, functionBlock :=
 			parseFunctionParameterListAndRest(p, false)

--- a/runtime/parser2/statement.go
+++ b/runtime/parser2/statement.go
@@ -311,10 +311,11 @@ func parseIfStatement(p *parser) *ast.IfStatement {
 
 	for i := length - 2; i >= 0; i-- {
 		outer := ifStatements[i]
-		outer.Else = &ast.Block{
-			Statements: []ast.Statement{result},
-			Range:      ast.NewRangeFromPositioned(result),
-		}
+		outer.Else = ast.NewBlock(
+			p.memoryGauge,
+			[]ast.Statement{result},
+			ast.NewRangeFromPositioned(result),
+		)
 		result = outer
 	}
 
@@ -399,13 +400,14 @@ func parseBlock(p *parser) *ast.Block {
 	})
 	endToken := p.mustOne(lexer.TokenBraceClose)
 
-	return &ast.Block{
-		Statements: statements,
-		Range: ast.Range{
+	return ast.NewBlock(
+		p.memoryGauge,
+		statements,
+		ast.Range{
 			StartPos: startToken.StartPos,
 			EndPos:   endToken.EndPos,
 		},
-	}
+	)
 }
 
 func parseFunctionBlock(p *parser) *ast.FunctionBlock {
@@ -438,13 +440,14 @@ func parseFunctionBlock(p *parser) *ast.FunctionBlock {
 	endToken := p.mustOne(lexer.TokenBraceClose)
 
 	return &ast.FunctionBlock{
-		Block: &ast.Block{
-			Statements: statements,
-			Range: ast.Range{
+		Block: ast.NewBlock(
+			p.memoryGauge,
+			statements,
+			ast.Range{
 				StartPos: startToken.StartPos,
 				EndPos:   endToken.EndPos,
 			},
-		},
+		),
 		PreConditions:  preConditions,
 		PostConditions: postConditions,
 	}

--- a/runtime/parser2/transaction.go
+++ b/runtime/parser2/transaction.go
@@ -157,19 +157,20 @@ func parseTransactionDeclaration(p *parser, docString string) *ast.TransactionDe
 		}
 	}
 
-	return &ast.TransactionDeclaration{
-		ParameterList:  parameterList,
-		Fields:         fields,
-		Prepare:        prepare,
-		PreConditions:  preConditions,
-		PostConditions: postConditions,
-		Execute:        execute,
-		DocString:      docString,
-		Range: ast.Range{
+	return ast.NewTransactionDeclaration(
+		p.memoryGauge,
+		parameterList,
+		fields,
+		prepare,
+		preConditions,
+		postConditions,
+		execute,
+		docString,
+		ast.Range{
 			StartPos: startPos,
 			EndPos:   endPos,
 		},
-	}
+	)
 }
 
 func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration) {
@@ -217,14 +218,17 @@ func parseTransactionExecute(p *parser) *ast.SpecialFunctionDeclaration {
 
 	return &ast.SpecialFunctionDeclaration{
 		Kind: common.DeclarationKindExecute,
-		FunctionDeclaration: &ast.FunctionDeclaration{
-			Access:        ast.AccessNotSpecified,
-			Identifier:    identifier,
-			ParameterList: &ast.ParameterList{},
-			FunctionBlock: &ast.FunctionBlock{
+		FunctionDeclaration: ast.NewFunctionDeclaration(
+			p.memoryGauge,
+			ast.AccessNotSpecified,
+			identifier,
+			&ast.ParameterList{},
+			nil,
+			&ast.FunctionBlock{
 				Block: block,
 			},
-			StartPos: identifier.Pos,
-		},
+			identifier.Pos,
+			"",
+		),
 	}
 }

--- a/runtime/parser2/transaction.go
+++ b/runtime/parser2/transaction.go
@@ -216,9 +216,10 @@ func parseTransactionExecute(p *parser) *ast.SpecialFunctionDeclaration {
 
 	block := parseBlock(p)
 
-	return &ast.SpecialFunctionDeclaration{
-		Kind: common.DeclarationKindExecute,
-		FunctionDeclaration: ast.NewFunctionDeclaration(
+	return ast.NewSpecialFunctionDeclaration(
+		p.memoryGauge,
+		common.DeclarationKindExecute,
+		ast.NewFunctionDeclaration(
 			p.memoryGauge,
 			ast.AccessNotSpecified,
 			identifier,
@@ -230,5 +231,5 @@ func parseTransactionExecute(p *parser) *ast.SpecialFunctionDeclaration {
 			identifier.Pos,
 			"",
 		),
-	}
+	)
 }

--- a/runtime/sema/check_switch.go
+++ b/runtime/sema/check_switch.go
@@ -171,12 +171,13 @@ func (checker *Checker) checkSwitchCaseStatements(switchCase *ast.SwitchCase) {
 
 	// NOTE: the block ensures that the statements are checked in a new scope
 
-	block := &ast.Block{
-		Statements: switchCase.Statements,
-		Range: ast.Range{
+	block := ast.NewBlock(
+		checker.memoryGauge,
+		switchCase.Statements,
+		ast.Range{
 			StartPos: switchCase.Statements[0].StartPosition(),
 			EndPos:   switchCase.EndPos,
 		},
-	}
+	)
 	block.Accept(checker)
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2193,14 +2193,12 @@ func (checker *Checker) rewritePostConditions(postConditions []*ast.Condition) P
 
 			// NOTE: no need to check the before statements or update elaboration here:
 			// The before statements are visited/checked later
-
-			variableDeclaration := &ast.VariableDeclaration{
-				Identifier: extractedExpression.Identifier,
-				Transfer: &ast.Transfer{
-					Operation: ast.TransferOperationCopy,
-				},
-				Value: extractedExpression.Expression,
+			variableDeclaration := ast.NewEmptyVariableDeclaration(checker.memoryGauge)
+			variableDeclaration.Identifier = extractedExpression.Identifier
+			variableDeclaration.Transfer = &ast.Transfer{
+				Operation: ast.TransferOperationCopy,
 			}
+			variableDeclaration.Value = extractedExpression.Expression
 
 			beforeStatements = append(beforeStatements,
 				variableDeclaration,

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7888,4 +7888,28 @@ func TestInterpretASTMetering(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint64(7), meter.getMemory(common.MemoryKindBlock))
 	})
+
+	t.Run("declarations", func(t *testing.T) {
+		script := `
+            pub fun main() {}
+
+            pub struct A {}
+
+            pub struct interface B {}
+
+            pub resource C {}
+
+            pub resource interface D {}
+
+            pub enum E: Int8 {}
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindCompositeDeclaration))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindInterfaceDeclaration))
+	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7918,6 +7918,8 @@ func TestInterpretASTMetering(t *testing.T) {
                 pub case b
                 pub case c
             }
+
+            transaction {}
         `
 
 		meter := newTestMemoryGauge()
@@ -7925,9 +7927,11 @@ func TestInterpretASTMetering(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindFunctionDeclaration))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindCompositeDeclaration))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindInterfaceDeclaration))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindEnumCaseDeclaration))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindFieldDeclaration))
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindTransactionDeclaration))
 	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7896,7 +7896,12 @@ func TestInterpretASTMetering(t *testing.T) {
 		script := `
             import Foo from 0x42
 
-            pub fun main() {}
+            pub let x = 1
+            pub var y = 2
+
+            pub fun main() {
+                var z = 3
+            }
 
             pub struct A {
                 pub var a: String
@@ -7980,5 +7985,6 @@ func TestInterpretASTMetering(t *testing.T) {
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindFieldDeclaration))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindTransactionDeclaration))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindImportDeclaration))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindVariableDeclaration))
 	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7893,15 +7893,31 @@ func TestInterpretASTMetering(t *testing.T) {
 		script := `
             pub fun main() {}
 
-            pub struct A {}
+            pub struct A {
+                pub var a: String
+
+                init() {
+                    self.a = "hello"
+                }
+            }
 
             pub struct interface B {}
 
-            pub resource C {}
+            pub resource C {
+                let a: Int
+
+                init() {
+                    self.a = 6
+                }
+            }
 
             pub resource interface D {}
 
-            pub enum E: Int8 {}
+            pub enum E: Int8 {
+                pub case a
+                pub case b
+                pub case c
+            }
         `
 
 		meter := newTestMemoryGauge()
@@ -7911,5 +7927,7 @@ func TestInterpretASTMetering(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindCompositeDeclaration))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindInterfaceDeclaration))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindEnumCaseDeclaration))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindFieldDeclaration))
 	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7829,3 +7829,31 @@ func TestInterpretIdentifierMetering(t *testing.T) {
 		assert.Equal(t, uint64(15), meter.getMemory(common.MemoryKindIdentifier))
 	})
 }
+
+func TestInterpretASTMetering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("arguments", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            pub fun main() {
+                foo(a: "hello", b: 23)
+                bar("hello", 23)
+            }
+
+            pub fun foo(a: String, b: Int) {
+            }
+
+            pub fun bar(_ a: String, _ b: Int) {
+            }
+        `
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindArgument))
+	})
+}

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7930,6 +7930,8 @@ func TestInterpretASTMetering(t *testing.T) {
             }
 
             transaction {}
+
+            #pragma
         `
 
 		importedChecker, err := checker.ParseAndCheckWithOptions(t,
@@ -7978,6 +7980,7 @@ func TestInterpretASTMetering(t *testing.T) {
 
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
+
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindFunctionDeclaration))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindCompositeDeclaration))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindInterfaceDeclaration))
@@ -7986,5 +7989,7 @@ func TestInterpretASTMetering(t *testing.T) {
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindTransactionDeclaration))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindImportDeclaration))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindVariableDeclaration))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindSpecialFunctionDeclaration))
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindPragmaDeclaration))
 	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7856,4 +7856,36 @@ func TestInterpretASTMetering(t *testing.T) {
 
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindArgument))
 	})
+
+	t.Run("blocks", func(t *testing.T) {
+		script := `
+            pub fun main() {
+                var i = 0
+                if i != 0 {
+                    i = 0
+                }
+
+                while i < 2 {
+                    i = i + 1
+                }
+
+                var a = "foo"
+                switch i {
+                    case 1:
+                        a = "foo_1"
+                    case 2:
+                        a = "foo_2"
+                    case 3:
+                        a = "foo_3"
+                }
+            }
+        `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(7), meter.getMemory(common.MemoryKindBlock))
+	})
 }

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7966,6 +7966,7 @@ func TestInterpretASTMetering(t *testing.T) {
 				Location: utils.ImportedLocation,
 			},
 		)
+		require.NoError(t, err)
 
 		meter := newTestMemoryGauge()
 		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/35

## Description

Add memory metering for:
- FunctionDeclaration
- CompositeDeclaration
- InterfaceDeclaration
- EnumCaseDeclaration
- FieldDeclaration
- TransactionDeclaration
- ImportDeclaration
- VariableDeclaration
- SpecialFunctionDeclaration
- PragmaDeclaration
- Argument
- Block

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
