### PR TITLE
Nil elements when reslicing

### DIFF
--- a/runtime/activations/activations.go
+++ b/runtime/activations/activations.go
@@ -189,7 +189,9 @@ func (a *ValueTypeActivations) Pop() {
 	if count < 1 {
 		return
 	}
-	a.activations = a.activations[:count-1]
+	lastIndex := count - 1
+	a.activations[lastIndex] = nil
+	a.activations = a.activations[:lastIndex]
 }
 
 // CurrentOrNew returns the current activation,

--- a/runtime/compiler/local_activations.go
+++ b/runtime/compiler/local_activations.go
@@ -187,7 +187,9 @@ func (a *LocalActivations) Pop() {
 	if count < 1 {
 		return
 	}
-	a.activations = a.activations[:count-1]
+	lastIndex := count - 1
+	a.activations[lastIndex] = nil
+	a.activations = a.activations[:lastIndex]
 }
 
 // CurrentOrNew returns the current activation,

--- a/runtime/interpreter/variable_activations.go
+++ b/runtime/interpreter/variable_activations.go
@@ -187,7 +187,9 @@ func (a *VariableActivations) Pop() {
 	if count < 1 {
 		return
 	}
-	a.activations = a.activations[:count-1]
+	lastIndex := count - 1
+	a.activations[lastIndex] = nil
+	a.activations = a.activations[:lastIndex]
 }
 
 // CurrentOrNew returns the current activation,

--- a/runtime/sema/function_activations.go
+++ b/runtime/sema/function_activations.go
@@ -62,6 +62,7 @@ func (a *FunctionActivations) EnterFunction(functionType *FunctionType, valueAct
 
 func (a *FunctionActivations) LeaveFunction() {
 	lastIndex := len(a.activations) - 1
+	a.activations[lastIndex] = nil
 	a.activations = a.activations[:lastIndex]
 }
 

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -196,6 +196,7 @@ func (a *VariableActivations) Leave(getEndPosition func() ast.Position) {
 	}
 	lastIndex := count - 1
 	activation := a.activations[lastIndex]
+	a.activations[lastIndex] = nil
 	a.activations = a.activations[:lastIndex]
 	for _, callback := range activation.LeaveCallbacks {
 		callback(getEndPosition)


### PR DESCRIPTION
## Description

When reslicing to pop pointer-typed elements, ensure to nil the removed elements to not leak memory.
See https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
