### PR TITLE
Update the crypto doc

### DIFF
--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -9,22 +9,25 @@ are supported by the language natively.
 
 ```cadence
 pub enum HashAlgorithm: UInt8 {
-    /// SHA2_256 is Secure Hashing Algorithm 2 (SHA-2) with a 256-bit digest.
+    /// SHA2_256 is SHA-2 with a 256-bit digest (also referred to as SHA256).
     pub case SHA2_256 = 1
 
-    /// SHA2_384 is Secure Hashing Algorithm 2 (SHA-2) with a 384-bit digest.
+    /// SHA2_384 is SHA-2 with a 384-bit digest (also referred to as  SHA384).
     pub case SHA2_384 = 2
 
-    /// SHA3_256 is Secure Hashing Algorithm 3 (SHA-3) with a 256-bit digest.
+    /// SHA3_256 is SHA-3 with a 256-bit digest.
     pub case SHA3_256 = 3
 
-    /// SHA3_384 is Secure Hashing Algorithm 3 (SHA-3) with a 384-bit digest.
+    /// SHA3_384 is SHA-3 with a 384-bit digest.
     pub case SHA3_384 = 4
 
-    /// KMAC128_BLS_BLS12_381 is an instance of KECCAK Message Authentication Code (KMAC128) mac algorithm,
-    /// that can be used as the hashing algorithm for BLS signature scheme on the curve BLS12-381.
-    /// This is a customized version of KMAC128 that is compatible with the hashing to curve
-    /// used in BLS signatures.
+    /// KMAC128_BLS_BLS12_381 is an instance of KECCAK Message Authentication Code (KMAC128) mac algorithm.
+    /// Although this is a MAC algorithm, KMAC is included in this list as it can be used hash 
+    /// when the key is used a non-public customizer.
+    /// KMAC128_BLS_BLS12_381 is used in particular as the hashing algorithm for the BLS signature scheme on the curve BLS12-381.
+    /// It is a customized version of KMAC128 that is compatible with the hashing to curve
+    /// used in BLS signatures. 
+    /// It is the same hasher used by signatures in the internal Flow protocol. 
     pub case KMAC128_BLS_BLS12_381 = 5
 
     /// KECCAK_256 is the legacy Keccak algorithm with a 256-bits digest, as per the original submission to the NIST SHA3 competition.
@@ -39,27 +42,12 @@ pub enum HashAlgorithm: UInt8 {
 }
 ```
 
-- `hash` hashes the input data using the input hashing algorithm.
-  If `KMAC128_BLS_BLS12_381` is used, data is hashed using the standard MAC `KMAC128(customizer, key, data, length)` with the following inputs:
-    - `customizer` is the UTF-8 encoding of `"H2C"`
-    - `key` is the UTF-8 encoding of `"APP_BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`
-    - `data` is the input data to hash
-    - `length` is 1024 bytes
+The hash algorithms provide two ways to hash input data into digests, `hash` and `hashWithTag`. 
 
-- `hashWithTag` hashes data along with a tag.
-  This allows instanciating independent hashing functions customized with a domain separation tag.
-  This is implemented differently depending on the hashing algorithm:
-    - `SHA2_256`, `SHA2_384`, `SHA3_256`, `SHA3_384`:
-      The hashed message is `bytes(tag) || data` where `bytes()` is the UTF-8 encoding of the input string,
-      padded with zeros till 32 bytes.
-      The tags accepted must not exceed 32 bytes.
-      If the tag used is empty, no data prefix is applied, and the hashed message is simply `data`.
-    - `KMAC128_BLS_BLS12_381`: this is a call to standard `KMAC128(customizer, key, data, length)` with the following inputs:
-      - `customizer` is the UTF-8 encoding of `"H2C"`
-      - `key` is the UTF-8 encoding of `"APP_" || tag || "BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`
-      - `data` is the input data to hash
-      - `length` is 1024 bytes
+## Hashing
 
+`hash` hashes the input data using the chosen hashing algorithm. The `KMAC` output is configured with 
+specific inputs (detailed under [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381))
 
 For example, to compute a SHA3-256 hash:
 
@@ -67,6 +55,37 @@ For example, to compute a SHA3-256 hash:
 let data: [UInt8] = [1, 2, 3]
 let digest = HashAlgorithm.SHA3_256.hash(data)
 ```
+
+## Hashing with a domain tag
+
+`hashWithTag` hashes the input data along with an input tag.
+It allows instanciating independent hashing functions customized with a domain separation tag (DST).
+For most of the hashing algorithms, mixing the data with the tag is done by pre-fixing the data with the tag and
+hashing the result.
+
+- `SHA2_256`, `SHA2_384`, `SHA3_256`, `SHA3_384`, `KECCAK_256`:
+  If the tag in non-empty, the hashed message is `bytes(tag) || data` where `bytes()` is the UTF-8 encoding of the input string,
+  padded with zeros till 32 bytes. 
+  The tags accepted must not exceed 32 bytes.
+  If the tag used is empty, no data prefix is applied, and the hashed message is simply `data` (same as `hash`'s output).
+- `KMAC128_BLS_BLS12_381`: refer to [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381) for details.
+
+
+###KMAC128 for BLS on BLS12_381
+
+`KMAC128_BLS_BLS12_381` is an instance of KECCAK-based KMAC128.
+Although this is a MAC algorithm, KMAC can be used as a hash when the key is used as a non-private customizer.
+`KMAC128_BLS_BLS12_381` is used in particular as the hashing algorithm for the BLS signature scheme on the curve BLS12-381.
+It is a customized instance of KMAC128 and is compatible with the hashing to curve used by BLS signatures. 
+It is the same hasher used by the internal Flow protocol, and can be used to verify Flow protocol signatures on-chain. 
+
+To define the MAC instance, `KMAC128(customizer, key, data, length)` is instanciated with the following parameters 
+(as referred to by the NIST [SHA-3 Derived Functions](https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-185.pdf)):
+  - `customizer` is the UTF-8 encoding of `"H2C"`
+  - `key` is the UTF-8 encoding of `"APP_BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"` when `hash` is used. Is include the input `tag`
+  when `hashWithTag` is used, key becomes the UTF-8 encoding of `"APP_" || tag || "BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`.
+  - `data` is the input data to hash
+  - `length` is 1024 bytes
 
 ## Signing Algorithms
 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -132,6 +132,9 @@ struct PublicKey {
 }
 ```
 
+`PublicKey` supports two methods `verify` and `verifyPoP`. 
+`verifyPoP` will be covered under [BLS multi-signature](### Proof of Possession).
+
 A `PublicKey` can be constructed using the raw key and the signing algorithm.
 
 ```cadence
@@ -233,7 +236,7 @@ While KMAC128 is used as a hash-to-field method resulting in two field elements,
 
 A valid signature would be generated using the expected `signedData` and `domainSeparationTag`, as well the same hashing to curve process. 
 
-## BLS
+## BLS multi-signature
 
 <Callout type="info">
 
@@ -241,27 +244,52 @@ A valid signature would be generated using the expected `signedData` and `domain
 
 </Callout>
 
-The BLS signature scheme also supports two additional operations on keys and signatures.
-They are defined in the built-in `BLS` contract, which does not need to be imported.
+The BLS signature scheme allows efficient multi-signature features. Multiple signatures can be aggregated
+into a single signature which can be verified against an aggregated public key. This allows authenticating
+multiple signers with a single signature verification. 
+While BLS provides multiple aggregation techniques,
+Cadence supports the basic aggregation tools that still cover a wide list of use-cases. 
+These tools are defined in the built-in `BLS` contract, which does not need to be imported.
 
-- `cadence•fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?`
+### Proof of Possession (PoP)
 
-  Aggregates multiple BLS signatures into one,
-  considering the proof of possession as a defence against the rogue attacks.
+Multi-signature verification in BLS requires a defense against rogue public-key attacks. Multiple ways are 
+available to protect BLS verification. Cadence provides the proof of possession of private key as a defense tool. 
+The proof of possession of private key is a BLS signature over the public key bytes. 
+The PoP signature follows the same requirements of a BLS signature (detailed in [Signature verification](### Signature verification)),
+except it uses a special domain separation tag. The key expected to be used in KMAC128 is the UTF-8 encoding of `"POP_BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`.
+The expected message to be signed by the PoP is the serialization of the BLS public key corresponding to the signing private key ([serialization details](## PublicKey)).
+The PoP can only be verified by the `PublicKey` method `verifyPoP`. 
 
-  Signatures could be generated from the same or distinct messages, they
-  could also be the aggregation of other signatures.
-  The order of the signatures in the slice does not matter since the aggregation is commutative.
-  No subgroup membership check is performed on the input signatures.
-  The function returns nil if the array is empty or if decoding one of the signature fails.
+### BLS signature aggregation
 
-- `cadence•fun aggregatePublicKeys(_ publicKeys: [PublicKey]): PublicKey?`
+`cadence•fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?`
 
-  Aggregates multiple BLS public keys into one.
+Aggregates multiple BLS signatures into one. 
+Signatures could be generated from the same or distinct messages, they
+could also be the aggregation of other signatures.
+The order of the signatures in the slice does not matter since the aggregation is commutative.
+There is no subgroup membership check performed on the input signatures.
+The function errors if the array is empty or if decoding one of the signature fails.
 
-  The order of the public keys in the slice does not matter since the aggregation is commutative.
-  No subgroup membership check is performed on the input keys.
-  The function returns nil if the array is empty or any of the input keys is not a BLS key.
+The output signature can be verified against an aggregated public key to authenticate multiple 
+signers at once. Since the `verify` method accepts a single data to verify against, it is only possible to 
+verfiy multiple signatures of the same message on Cadence. 
+
+### BLS public key aggregation
+
+`cadence•fun aggregatePublicKeys(_ publicKeys: [PublicKey]): PublicKey?`
+
+Aggregates multiple BLS public keys into one.
+
+The order of the public keys in the slice does not matter since the aggregation is commutative.
+The input keys are guaranteed to be in the correct subgroup since subgroup membership is checked
+at the key creatiom time. 
+The function errors nil if the array is empty or any of the input keys is not a BLS key.
+
+The output public key can be used to verify aggregated signatures to authenticate multiple 
+signers at once. Since the `verify` method accepts a single data to verify against, it is only possible to 
+verfiy multiple signatures of the same message on Cadence. 
 
 ## Crypto Contract
 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -208,10 +208,10 @@ A valid input to `verify()` depends on the signature scheme used:
      and `bytes()` is the bytes big-endian encoding of the input integer left padded by zeros to the byte-length of the curve order.
      The signature is 64 bytes-long for both curves.
    - `signedData` is the arbitrary message to verify the signature against.
-   - `domainSeparationTag` is the domain tag used for signing. Any tag value can be used (check the [`hashWithTag` function](#hashing) for more details).
-   - `hashAlgorithm` is either `SHA2_256` or `SHA3_256`. It is the algorithm used to hash the message along with the given tag (check the [`hashWithTag` function](#hashing) for more details).
+   - `domainSeparationTag` is the domain tag used for signing. Multiple valid tag values can be used (check the [`hashWithTag` function](#hashing) for more details).
+   - `hashAlgorithm` is either `SHA2_256`, `SHA3_256` or `KECCAK_256`. It is the algorithm used to hash the message along with the given tag (check the [`hashWithTag` function](#hashing) for more details).
 
-As noted in [`hashWithTag` function](#hashing) for `SHA2_256` and `SHA3_256`, using an empty `tag` results in hashing the input data only. If a signature verification
+As noted in [`hashWithTag` function](#hashing) for `SHA2_256`, `SHA3_256` and `KECCAK_256, using an empty `tag` results in hashing the input data only. If a signature verification
 needs to be done against data without any domain tag, this can be done by using an empty domain tag `""`.
 
 - BLS (`BLS_BLS_12_381`):

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -133,6 +133,12 @@ struct PublicKey {
 }
 ```
 
+<Callout type="info">
+
+🚧 Status: VerifyPoP is going to be available in an upcoming release of Cadence
+
+</Callout>
+
 `PublicKey` supports two methods `verify` and `verifyPoP`. 
 `verifyPoP` will be covered under [BLS multi-signature](#proof-of-possession-pop).
 
@@ -162,6 +168,12 @@ The raw key value depends on the supported signature scheme:
   A public key is 96-bytes long.
 
 ### Public Key validation
+
+<Callout type="info">
+
+🚧 Status: Validation at creation time is going to be available in an upcoming release of Cadence
+
+</Callout>
 
 A public key is validated at the time of creation. Only valid public keys can be created.
 The validation of the public key depends on the supported signature scheme:
@@ -214,8 +226,14 @@ The inputs to `verify` depend on the signature scheme used:
   and `bytes()` is the bytes big-endian encoding left padded by zeros to the byte-length of the curve order.
   The signature is 64 bytes-long for both curves. 
   - `signedData` is the arbitrary message to verify the signature against.
-  - `domainSeparationTag` is the expected domain tag. Multiple valid tag values can be used (check the `hashWithTag`[function](#hashing) for more details).
+  - `domainSeparationTag` is the expected domain tag. Multiple valid tag values can be used (check [`hashWithTag`](#hashing) for more details).
   - `hashAlgorithm` is either `SHA2_256`, `SHA3_256` or `KECCAK_256`. It is the algorithm used to hash the message along with the given tag (check the `hashWithTag`[function](#hashing) for more details).
+
+<Callout type="info">
+
+🚧 Status: ECDSA verificaction with any tag is going to be available in an upcoming release of Cadence
+
+</Callout>
 
 As noted in [`hashWithTag`](#hashing) for `SHA2_256`, `SHA3_256` and `KECCAK_256, using an empty `tag` results in hashing the input data only. If a signature verification
 needs to be done against data without any domain tag, this can be done by using an empty domain tag `""`.

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -73,7 +73,7 @@ hashing the result.
 
 ###KMAC128 for BLS on BLS12_381
 
-`KMAC128_BLS_BLS12_381` is an instance of KECCAK-based KMAC128.
+`KMAC128_BLS_BLS12_381` is an instance of cSHAKE-based KMAC128.
 Although this is a MAC algorithm, KMAC can be used as a hash when the key is used as a non-private customizer.
 `KMAC128_BLS_BLS12_381` is used in particular as the hashing algorithm for the BLS signature scheme on the curve BLS12-381.
 It is a customized instance of KMAC128 and is compatible with the hashing to curve used by BLS signatures. 
@@ -101,8 +101,8 @@ pub enum SignatureAlgorithm: UInt8 {
     pub case ECDSA_secp256k1 = 2
 
     /// BLS_BLS12_381 is BLS signature scheme on the BLS12-381 curve.
-    /// The scheme is set-up so that signatures are in G_1 (curve over the prime field)
-    /// while public keys are in G_2 (curve over the prime field extension).
+    /// The scheme is set-up so that signatures are in G_1 (subgroup of the curve over the prime field)
+    /// while public keys are in G_2 (subgroup of the curve over the prime field extension).
     pub case BLS_BLS12_381 = 3
 }
 ```
@@ -166,7 +166,7 @@ The validation of the public key depends on the supported signature scheme:
 
 - `BLS_BLS_12_381`:
   The given key is correctly serialized following the compressed serialization in [IETF draft-irtf-cfrg-pairing-friendly-curves-08](https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-08.html#name-point-serialization-procedu).
-  The coordinates represent valid prime field extension elemnents. The resulting point is on the curve, and is on the correct subgroup. 
+  The coordinates represent valid prime field extension elemnents. The resulting point is on the curve, and is on the correct subgroup G_2. 
 
 Since the validation happen only at the time of creation, public keys are immutable.
 
@@ -201,30 +201,37 @@ let isValid = pk.verify(
 // `isValid` is false
 ```
 
-A valid input to `verify()` depends on the signature scheme used:
+The inputs to `verify` depend on the signature scheme used:
 
 - ECDSA (`ECDSA_P256` and `ECDSA_secp256k1`):
-   - `signature` is the couple `(r,s)`. It is serialized as `bytes(r) || bytes(s)`, where `||` is the concatenation operation,
-     and `bytes()` is the bytes big-endian encoding of the input integer left padded by zeros to the byte-length of the curve order.
-     The signature is 64 bytes-long for both curves.
-   - `signedData` is the arbitrary message to verify the signature against.
-   - `domainSeparationTag` is the domain tag used for signing. Multiple valid tag values can be used (check the [`hashWithTag` function](#hashing) for more details).
-   - `hashAlgorithm` is either `SHA2_256`, `SHA3_256` or `KECCAK_256`. It is the algorithm used to hash the message along with the given tag (check the [`hashWithTag` function](#hashing) for more details).
+  - `signature` expects the couple `(r,s)`. It is serialized as `bytes(r) || bytes(s)`, where `||` is the concatenation operation,
+  and `bytes()` is the bytes big-endian encoding of the input integer left padded by zeros to the byte-length of the curve order.
+  The signature is 64 bytes-long for both curves. 
+  - `signedData` is the arbitrary message to verify the signature against.
+  - `domainSeparationTag` is the expected domain tag. Multiple valid tag values can be used (check the `hashWithTag`[function](#hashing) for more details).
+  - `hashAlgorithm` is either `SHA2_256`, `SHA3_256` or `KECCAK_256`. It is the algorithm used to hash the message along with the given tag (check the `hashWithTag`[function](#hashing) for more details).
 
 As noted in [`hashWithTag` function](#hashing) for `SHA2_256`, `SHA3_256` and `KECCAK_256, using an empty `tag` results in hashing the input data only. If a signature verification
 needs to be done against data without any domain tag, this can be done by using an empty domain tag `""`.
 
+ECDSA verification is implemented as defined in ANS X9.62 (also referred by [FIPS 186-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) and [SEC 1, Version 2.0](https://www.secg.org/sec1-v2.pdf)).
+A valid signature would be generated using the expected `signedData`, `domainSeparationTag` and `hashAlgorithm` used to verify. 
+
 - BLS (`BLS_BLS_12_381`):
-   - `signature` is a G_1 (curve over the prime field) point.
-     The encoding follows the compressed serialization defined in the [IETF draft-irtf-cfrg-pairing-friendly-curves-08](https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-08.html#name-point-serialization-procedu).
-     A signature is 48-bytes long.
-   - `signedData` is the arbitrary message to verify the signature against.
-   - `domainSeparationTag` is the domain tag used for signing. All tags are accepted.
-   - `hashAlgorithm` is the algorithm used to hash the message along with the given tag (check `hashWithTag` function for more details).
-     Only `KMAC128_BLS_BLS12_381` is accepted.
+  - `signature` expects a G_1 (subgroup of the curve over the prime field) point.
+  The encoding follows the compressed serialization defined in the [IETF draft-irtf-cfrg-pairing-friendly-curves-08](https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-08.html#name-point-serialization-procedu).
+  A signature is 48-bytes long. 
+  - `signedData` is the arbitrary message to verify the signature against.
+  - `domainSeparationTag` is the expected domain tag. All tags are accepted (check [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381)).
+  - `hashAlgorithm` only accepts `KMAC128_BLS_BLS12_381`. It is the algorithm used to hash the message along with the given tag (check [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381)).
 
 BLS verification performs the necessary membership check of the signature while the membership check of the public key is performed at the creation of the `PublicKey` object
 and not repeated during the signature verification. 
+
+The verificaction uses a hash-to-curve algorithm to hash the `signedData` into a `G_1` point, following the `hash_to_curve` method described in the [Hashing to Elliptic Curves draft](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#section-3).
+While KMAC128 is used as a hash-to-field method resulting in two field elements, the mapping to curve is implemented using the [simplified SWU](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#section-6.6.3).
+
+A valid signature would be generated using the expected `signedData` and `domainSeparationTag`, as well the same hashing to curve process. 
 
 ## BLS
 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -127,8 +127,9 @@ struct PublicKey {
     ): Bool
 
     /// Verifies the proof of possession of the private key.
-    /// This function is only implemented if the signature algorithm of the public key is BLS (BLS_BLS12_381).
-    /// It errors if called with any other signature algorithm. 
+    /// This function is only implemented if the signature algorithm
+    /// of the public key is BLS (BLS_BLS12_381).
+    /// If called with any other signature algorithm, the program aborts
     pub fun verifyPoP(_ proof: [UInt8]): Bool
 }
 ```
@@ -291,7 +292,7 @@ Signatures could be generated from the same or distinct messages, they
 could also be the aggregation of other signatures.
 The order of the signatures in the slice does not matter since the aggregation is commutative.
 There is no subgroup membership check performed on the input signatures.
-The function errors if the array is empty or if decoding one of the signature fails.
+If the array is empty or if decoding one of the signature fails, the program aborts
 
 The output signature can be verified against an aggregated public key to authenticate multiple 
 signers at once. Since the `verify` method accepts a single data to verify against, it is only possible to 
@@ -306,7 +307,7 @@ Aggregates multiple BLS public keys into one.
 The order of the public keys in the slice does not matter since the aggregation is commutative.
 The input keys are guaranteed to be in the correct subgroup since subgroup membership is checked
 at the key creatiom time. 
-The function errors if the array is empty or any of the input keys is not a BLS key.
+If the array is empty or any of the input keys is not a BLS key, the program aborts
 
 The output public key can be used to verify aggregated signatures to authenticate multiple 
 signers at once. Since the `verify` method accepts a single data to verify against, it is only possible to 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -126,7 +126,8 @@ struct PublicKey {
     ): Bool
 
     /// Verifies the proof of possession of the private key.
-    /// This function is only implemented if the signature algorithm of the public key is BLS, it errors if called with any other signature algorithm. 
+    /// This function is only implemented if the signature algorithm of the public key is BLS (BLS_BLS12_381).
+    /// It errors if called with any other signature algorithm. 
     pub fun verifyPoP(_ proof: [UInt8]): Bool
 }
 ```
@@ -143,9 +144,9 @@ let publicKey = PublicKey(
 The raw key value depends on the supported signature scheme:
 
 - `ECDSA_P256` and `ECDSA_secp256k1`:
-  The public key is a curve point `(X,Y)` where `X` and `Y` are two prime field elements.
+  The public key is an uncompressed curve point `(X,Y)` where `X` and `Y` are two prime field elements.
   The raw key is represented as `bytes(X) || bytes(Y)`, where `||` is the concatenation operation,
-  and `bytes()` is the bytes big-endian encoding of the input integer padded by zeros to the byte-length of the field prime.
+  and `bytes()` is the bytes big-endian encoding of the input integer left padded by zeros to the byte-length of the field prime.
   The raw public key is 64-bytes long.
 
 - `BLS_BLS_12_381`:
@@ -154,8 +155,20 @@ The raw key value depends on the supported signature scheme:
   [IETF draft-irtf-cfrg-pairing-friendly-curves-08](https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-08.html#name-point-serialization-procedu).
   A public key is 96-bytes long.
 
+### Public Key validation
 
-A public key is validated at the time of creation. Hence, public keys are immutable.
+A public key is validated at the time of creation. Only valid public keys can be created.
+The validation of the public key depends on the supported signature scheme:
+
+- `ECDSA_P256` and `ECDSA_secp256k1`:
+  The given `X` and `Y` coordinates are correctly serialized, represent valid prime field elements, and the resulting
+  point is on the correct curve (no subgroup check needed since the cofactor of both supported curves is 1).
+
+- `BLS_BLS_12_381`:
+  The given key is correctly serialized following the compressed serialization in [IETF draft-irtf-cfrg-pairing-friendly-curves-08](https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-08.html#name-point-serialization-procedu).
+  The coordinates represent valid prime field extension elemnents. The resulting point is on the curve, and is on the correct subgroup. 
+
+Since the validation happen only at the time of creation, public keys are immutable.
 
 ```cadence
 publicKey.signatureAlgorithm = SignatureAlgorithm.ECDSA_secp256k1   // Not allowed
@@ -188,16 +201,18 @@ let isValid = pk.verify(
 // `isValid` is false
 ```
 
-The inputs to `verify()` depend on the signature scheme used:
+A valid input to `verify()` depends on the signature scheme used:
 
 - ECDSA (`ECDSA_P256` and `ECDSA_secp256k1`):
-   - `signature` is the couple `(r,s)`. It is represented as `bytes(r) || bytes(s)`, where `||` is the concatenation operation,
-     and `bytes()` is the bytes big-endian encoding of the input integer padded by zeros to the byte-length of the curve order.
+   - `signature` is the couple `(r,s)`. It is serialized as `bytes(r) || bytes(s)`, where `||` is the concatenation operation,
+     and `bytes()` is the bytes big-endian encoding of the input integer left padded by zeros to the byte-length of the curve order.
      The signature is 64 bytes-long for both curves.
    - `signedData` is the arbitrary message to verify the signature against.
-   - `domainSeparationTag` is the domain tag used for signing. The interface only accepts the the user tag `"FLOW-V0.0-user"`.
-   - `hashAlgorithm` is the algorithm used to hash the message along with the given tag (check the [`hashWithTag` function](#hashing) for more details).
-     Only `SHA2_256` or `SHA3_256` are accepted.
+   - `domainSeparationTag` is the domain tag used for signing. Any tag value can be used (check the [`hashWithTag` function](#hashing) for more details).
+   - `hashAlgorithm` is either `SHA2_256` or `SHA3_256`. It is the algorithm used to hash the message along with the given tag (check the [`hashWithTag` function](#hashing) for more details).
+
+As noted in [`hashWithTag` function](#hashing) for `SHA2_256` and `SHA3_256`, using an empty `tag` results in hashing the input data only. If a signature verification
+needs to be done against data without any domain tag, this can be done by using an empty domain tag `""`.
 
 - BLS (`BLS_BLS_12_381`):
    - `signature` is a G_1 (curve over the prime field) point.
@@ -208,7 +223,8 @@ The inputs to `verify()` depend on the signature scheme used:
    - `hashAlgorithm` is the algorithm used to hash the message along with the given tag (check `hashWithTag` function for more details).
      Only `KMAC128_BLS_BLS12_381` is accepted.
 
-BLS verification performs the necessary membership check of the signature while the membership check of the public key is performed at the creation of the `PublicKey` object.
+BLS verification performs the necessary membership check of the signature while the membership check of the public key is performed at the creation of the `PublicKey` object
+and not repeated during the signature verification. 
 
 ## BLS
 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -134,12 +134,6 @@ struct PublicKey {
 }
 ```
 
-<Callout type="info">
-
-🚧 Status: VerifyPoP is going to be available in an upcoming release of Cadence
-
-</Callout>
-
 `PublicKey` supports two methods `verify` and `verifyPoP`. 
 `verifyPoP` will be covered under [BLS multi-signature](#proof-of-possession-pop).
 
@@ -169,12 +163,6 @@ The raw key value depends on the supported signature scheme:
   A public key is 96-bytes long.
 
 ### Public Key validation
-
-<Callout type="info">
-
-🚧 Status: Validation at creation time is going to be available in an upcoming release of Cadence
-
-</Callout>
 
 A public key is validated at the time of creation. Only valid public keys can be created.
 The validation of the public key depends on the supported signature scheme:
@@ -230,12 +218,6 @@ The inputs to `verify` depend on the signature scheme used:
   - `domainSeparationTag` is the expected domain tag. Multiple valid tag values can be used (check [`hashWithTag`](#hashing) for more details).
   - `hashAlgorithm` is either `SHA2_256`, `SHA3_256` or `KECCAK_256`. It is the algorithm used to hash the message along with the given tag (check the `hashWithTag`[function](#hashing) for more details).
 
-<Callout type="info">
-
-🚧 Status: ECDSA verificaction with any tag is going to be available in an upcoming release of Cadence
-
-</Callout>
-
 As noted in [`hashWithTag`](#hashing) for `SHA2_256`, `SHA3_256` and `KECCAK_256, using an empty `tag` results in hashing the input data only. If a signature verification
 needs to be done against data without any domain tag, this can be done by using an empty domain tag `""`.
 
@@ -259,12 +241,6 @@ While KMAC128 is used as a hash-to-field method resulting in two field elements,
 A valid signature would be generated using the expected `signedData` and `domainSeparationTag`, as well the same hashing to curve process. 
 
 ## BLS multi-signature
-
-<Callout type="info">
-
-🚧 Status: This API is going to be available in an upcoming release of Cadence
-
-</Callout>
 
 BLS signature scheme allows efficient multi-signature features. Multiple signatures can be aggregated
 into a single signature which can be verified against an aggregated public key. This allows authenticating

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -46,10 +46,11 @@ The hash algorithms provide two ways to hash input data into digests, `hash` and
 
 ## Hashing
 
-`hash` hashes the input data using the chosen hashing algorithm. The `KMAC` output is configured with 
-specific inputs (detailed under [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381))
+`hash` hashes the input data using the chosen hashing algorithm. 
+`KMAC` is the only MAC algorithm on the list 
+and configured with specific parameters (detailed in [KMAC128 for BLS](#KMAC128-for-BLS))
 
-For example, to compute a SHA3-256 hash:
+For example, to compute a SHA3-256 digest:
 
 ```cadence
 let data: [UInt8] = [1, 2, 3]
@@ -64,16 +65,16 @@ For most of the hashing algorithms, mixing the data with the tag is done by pre-
 hashing the result.
 
 - `SHA2_256`, `SHA2_384`, `SHA3_256`, `SHA3_384`, `KECCAK_256`:
-  If the tag in non-empty, the hashed message is `bytes(tag) || data` where `bytes()` is the UTF-8 encoding of the input string,
+  If the tag is non-empty, the hashed message is `bytes(tag) || data` where `bytes()` is the UTF-8 encoding of the input string,
   padded with zeros till 32 bytes. 
-  The tags accepted must not exceed 32 bytes.
-  If the tag used is empty, no data prefix is applied, and the hashed message is simply `data` (same as `hash`'s output).
-- `KMAC128_BLS_BLS12_381`: refer to [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381) for details.
+  Therefore tags must not exceed 32 bytes.
+  If the tag used is empty, no data prefix is applied, and the hashed message is simply `data` (same as `hash` output).
+- `KMAC128_BLS_BLS12_381`: refer to [KMAC128 for BLS](#KMAC128-for-BLS) for details.
 
 
-###KMAC128 for BLS on BLS12_381
+### KMAC128 for BLS
 
-`KMAC128_BLS_BLS12_381` is an instance of cSHAKE-based KMAC128.
+`KMAC128_BLS_BLS12_381` is an instance of the cSHAKE-based KMAC128.
 Although this is a MAC algorithm, KMAC can be used as a hash when the key is used as a non-private customizer.
 `KMAC128_BLS_BLS12_381` is used in particular as the hashing algorithm for the BLS signature scheme on the curve BLS12-381.
 It is a customized instance of KMAC128 and is compatible with the hashing to curve used by BLS signatures. 
@@ -81,11 +82,11 @@ It is the same hasher used by the internal Flow protocol, and can be used to ver
 
 To define the MAC instance, `KMAC128(customizer, key, data, length)` is instanciated with the following parameters 
 (as referred to by the NIST [SHA-3 Derived Functions](https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-185.pdf)):
-  - `customizer` is the UTF-8 encoding of `"H2C"`
-  - `key` is the UTF-8 encoding of `"APP_BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"` when `hash` is used. Is include the input `tag`
-  when `hashWithTag` is used, key becomes the UTF-8 encoding of `"APP_" || tag || "BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`.
-  - `data` is the input data to hash
-  - `length` is 1024 bytes
+  - `customizer` is the UTF-8 encoding of `"H2C"`.
+  - `key` is the UTF-8 encoding of `"APP_BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"` when `hash` is used. It includes the input `tag`
+  when `hashWithTag` is used and key becomes the UTF-8 encoding of `"APP_" || tag || "BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`.
+  - `data` is the input data to hash.
+  - `length` is 1024 bytes.
 
 ## Signing Algorithms
 
@@ -94,10 +95,10 @@ are supported by the language natively.
 
 ```cadence
 pub enum SignatureAlgorithm: UInt8 {
-    /// ECDSA_P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the NIST P-256 curve.
+    /// ECDSA_P256 is ECDSA on the NIST P-256 curve.
     pub case ECDSA_P256 = 1
 
-    /// ECDSA_secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve.
+    /// ECDSA_secp256k1 is ECDSA on the secp256k1 curve.
     pub case ECDSA_secp256k1 = 2
 
     /// BLS_BLS12_381 is BLS signature scheme on the BLS12-381 curve.
@@ -133,7 +134,9 @@ struct PublicKey {
 ```
 
 `PublicKey` supports two methods `verify` and `verifyPoP`. 
-`verifyPoP` will be covered under [BLS multi-signature](### Proof of Possession).
+`verifyPoP` will be covered under [BLS multi-signature](#proof-of-possession-pop).
+
+### Public Key construction
 
 A `PublicKey` can be constructed using the raw key and the signing algorithm.
 
@@ -149,7 +152,7 @@ The raw key value depends on the supported signature scheme:
 - `ECDSA_P256` and `ECDSA_secp256k1`:
   The public key is an uncompressed curve point `(X,Y)` where `X` and `Y` are two prime field elements.
   The raw key is represented as `bytes(X) || bytes(Y)`, where `||` is the concatenation operation,
-  and `bytes()` is the bytes big-endian encoding of the input integer left padded by zeros to the byte-length of the field prime.
+  and `bytes()` is the bytes big-endian encoding left padded by zeros to the byte-length of the field prime.
   The raw public key is 64-bytes long.
 
 - `BLS_BLS_12_381`:
@@ -208,13 +211,13 @@ The inputs to `verify` depend on the signature scheme used:
 
 - ECDSA (`ECDSA_P256` and `ECDSA_secp256k1`):
   - `signature` expects the couple `(r,s)`. It is serialized as `bytes(r) || bytes(s)`, where `||` is the concatenation operation,
-  and `bytes()` is the bytes big-endian encoding of the input integer left padded by zeros to the byte-length of the curve order.
+  and `bytes()` is the bytes big-endian encoding left padded by zeros to the byte-length of the curve order.
   The signature is 64 bytes-long for both curves. 
   - `signedData` is the arbitrary message to verify the signature against.
   - `domainSeparationTag` is the expected domain tag. Multiple valid tag values can be used (check the `hashWithTag`[function](#hashing) for more details).
   - `hashAlgorithm` is either `SHA2_256`, `SHA3_256` or `KECCAK_256`. It is the algorithm used to hash the message along with the given tag (check the `hashWithTag`[function](#hashing) for more details).
 
-As noted in [`hashWithTag` function](#hashing) for `SHA2_256`, `SHA3_256` and `KECCAK_256, using an empty `tag` results in hashing the input data only. If a signature verification
+As noted in [`hashWithTag`](#hashing) for `SHA2_256`, `SHA3_256` and `KECCAK_256, using an empty `tag` results in hashing the input data only. If a signature verification
 needs to be done against data without any domain tag, this can be done by using an empty domain tag `""`.
 
 ECDSA verification is implemented as defined in ANS X9.62 (also referred by [FIPS 186-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) and [SEC 1, Version 2.0](https://www.secg.org/sec1-v2.pdf)).
@@ -225,13 +228,13 @@ A valid signature would be generated using the expected `signedData`, `domainSep
   The encoding follows the compressed serialization defined in the [IETF draft-irtf-cfrg-pairing-friendly-curves-08](https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-08.html#name-point-serialization-procedu).
   A signature is 48-bytes long. 
   - `signedData` is the arbitrary message to verify the signature against.
-  - `domainSeparationTag` is the expected domain tag. All tags are accepted (check [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381)).
-  - `hashAlgorithm` only accepts `KMAC128_BLS_BLS12_381`. It is the algorithm used to hash the message along with the given tag (check [KMAC128_BLS_BLS12_381](###KMAC128 for BLS on BLS12_381)).
+  - `domainSeparationTag` is the expected domain tag. All tags are accepted (check [KMAC128 for BLS](#KMAC128-for-BLS)).
+  - `hashAlgorithm` only accepts `KMAC128_BLS_BLS12_381`. It is the algorithm used to hash the message along with the given tag (check [KMAC128 for BLS](#KMAC128-for-BLS)).
 
 BLS verification performs the necessary membership check of the signature while the membership check of the public key is performed at the creation of the `PublicKey` object
 and not repeated during the signature verification. 
 
-The verificaction uses a hash-to-curve algorithm to hash the `signedData` into a `G_1` point, following the `hash_to_curve` method described in the [Hashing to Elliptic Curves draft](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#section-3).
+The verificaction uses a hash-to-curve algorithm to hash the `signedData` into a `G_1` point, following the `hash_to_curve` method described in the [draft-irtf-cfrg-hash-to-curve-14](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#section-3).
 While KMAC128 is used as a hash-to-field method resulting in two field elements, the mapping to curve is implemented using the [simplified SWU](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#section-6.6.3).
 
 A valid signature would be generated using the expected `signedData` and `domainSeparationTag`, as well the same hashing to curve process. 
@@ -244,22 +247,22 @@ A valid signature would be generated using the expected `signedData` and `domain
 
 </Callout>
 
-The BLS signature scheme allows efficient multi-signature features. Multiple signatures can be aggregated
+BLS signature scheme allows efficient multi-signature features. Multiple signatures can be aggregated
 into a single signature which can be verified against an aggregated public key. This allows authenticating
 multiple signers with a single signature verification. 
 While BLS provides multiple aggregation techniques,
-Cadence supports the basic aggregation tools that still cover a wide list of use-cases. 
+Cadence supports basic aggregation tools that cover a wide list of use-cases. 
 These tools are defined in the built-in `BLS` contract, which does not need to be imported.
 
 ### Proof of Possession (PoP)
 
 Multi-signature verification in BLS requires a defense against rogue public-key attacks. Multiple ways are 
-available to protect BLS verification. Cadence provides the proof of possession of private key as a defense tool. 
-The proof of possession of private key is a BLS signature over the public key bytes. 
-The PoP signature follows the same requirements of a BLS signature (detailed in [Signature verification](### Signature verification)),
+available to protect BLS verification. The language provides the proof of possession of private key as a defense tool. 
+The proof of possession of private key is a BLS signature over the public key itself. 
+The PoP signature follows the same requirements of a BLS signature (detailed in [Signature verification](#Signature-verification)),
 except it uses a special domain separation tag. The key expected to be used in KMAC128 is the UTF-8 encoding of `"POP_BLS_SIG_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`.
-The expected message to be signed by the PoP is the serialization of the BLS public key corresponding to the signing private key ([serialization details](## PublicKey)).
-The PoP can only be verified by the `PublicKey` method `verifyPoP`. 
+The expected message to be signed by the PoP is the serialization of the BLS public key corresponding to the signing private key ([serialization details](#PublicKey)).
+The PoP can only be verified using the `PublicKey` method `verifyPoP`. 
 
 ### BLS signature aggregation
 
@@ -274,7 +277,7 @@ The function errors if the array is empty or if decoding one of the signature fa
 
 The output signature can be verified against an aggregated public key to authenticate multiple 
 signers at once. Since the `verify` method accepts a single data to verify against, it is only possible to 
-verfiy multiple signatures of the same message on Cadence. 
+verfiy multiple signatures of the same message. 
 
 ### BLS public key aggregation
 
@@ -289,7 +292,7 @@ The function errors nil if the array is empty or any of the input keys is not a 
 
 The output public key can be used to verify aggregated signatures to authenticate multiple 
 signers at once. Since the `verify` method accepts a single data to verify against, it is only possible to 
-verfiy multiple signatures of the same message on Cadence. 
+verfiy multiple signatures of the same message. 
 
 ## Crypto Contract
 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -306,7 +306,7 @@ Aggregates multiple BLS public keys into one.
 The order of the public keys in the slice does not matter since the aggregation is commutative.
 The input keys are guaranteed to be in the correct subgroup since subgroup membership is checked
 at the key creatiom time. 
-The function errors nil if the array is empty or any of the input keys is not a BLS key.
+The function errors if the array is empty or any of the input keys is not a BLS key.
 
 The output public key can be used to verify aggregated signatures to authenticate multiple 
 signers at once. Since the `verify` method accepts a single data to verify against, it is only possible to 

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -293,11 +293,11 @@ func newNativeEnumType(
 const SignatureAlgorithmTypeName = "SignatureAlgorithm"
 
 const SignatureAlgorithmDocStringECDSA_P256 = `
-ECDSA_P256 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the NIST P-256 curve
+ECDSA_P256 is ECDSA on the NIST P-256 curve
 `
 
 const SignatureAlgorithmDocStringECDSA_secp256k1 = `
-ECDSA_secp256k1 is Elliptic Curve Digital Signature Algorithm (ECDSA) on the secp256k1 curve
+ECDSA_secp256k1 is ECDSA on the secp256k1 curve
 `
 
 const SignatureAlgorithmDocStringBLS_BLS12_381 = `

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -302,8 +302,8 @@ ECDSA_secp256k1 is ECDSA on the secp256k1 curve
 
 const SignatureAlgorithmDocStringBLS_BLS12_381 = `
 BLS_BLS12_381 is BLS signature scheme on the BLS12-381 curve.
-The scheme is set-up so that signatures are in G_1 (curve over the prime field)
-while public keys are in G_2 (curve over the prime field extension).
+The scheme is set-up so that signatures are in G_1 (subgroup of the curve over the prime field)
+while public keys are in G_2 (subgroup of the curve over the prime field extension).
 `
 
 const HashAlgorithmTypeName = "HashAlgorithm"

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -309,26 +309,29 @@ while public keys are in G_2 (curve over the prime field extension).
 const HashAlgorithmTypeName = "HashAlgorithm"
 
 const HashAlgorithmDocStringSHA2_256 = `
-SHA2_256 is Secure Hashing Algorithm 2 (SHA-2) with a 256-bit digest
+SHA2_256 is SHA-2 with a 256-bit digest (also referred to as SHA256)
 `
 
 const HashAlgorithmDocStringSHA2_384 = `
-SHA2_384 is Secure Hashing Algorithm 2 (SHA-2) with a 384-bit digest
+SHA2_384 is SHA-2 with a 384-bit digest (also referred to as  SHA384)
 `
 
 const HashAlgorithmDocStringSHA3_256 = `
-SHA3_256 is Secure Hashing Algorithm 3 (SHA-3) with a 256-bit digest
+SHA3_256 is SHA-3 with a 256-bit digest
 `
 
 const HashAlgorithmDocStringSHA3_384 = `
-SHA3_384 is Secure Hashing Algorithm 3 (SHA-3) with a 384-bit digest
+SHA3_384 is SHA-3 with a 384-bit digest
 `
 
 const HashAlgorithmDocStringKMAC128_BLS_BLS12_381 = `
-KMAC128_BLS_BLS12_381 is an instance of KECCAK Message Authentication Code (KMAC128) mac algorithm,
-that can be used as the hashing algorithm for BLS signature scheme on the curve BLS12-381.
-This is a customized version of KMAC128 that is compatible with the hashing to curve 
-used in BLS signatures.
+KMAC128_BLS_BLS12_381 is an instance of KECCAK Message Authentication Code (KMAC128) mac algorithm.
+Although this is a MAC algorithm, KMAC is included in this list as it can be used as a hash 
+when the key is used as a non-private customizer.
+KMAC128_BLS_BLS12_381 is used in particular as the hashing algorithm for the BLS signature scheme on the curve BLS12-381.
+It is a customized version of KMAC128 that is compatible with the hashing to curve
+used in BLS signatures. 
+It is the same hasher used by signatures in the internal Flow protocol.
 `
 const HashAlgorithmDocStringKECCAK_256 = `
 KECCAK_256 is the legacy Keccak algorithm with a 256-bits digest, as per the original submission to the NIST SHA3 competition.

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6258,9 +6258,10 @@ the given tag and data, using this public key and the given hash algorithm
 `
 
 const publicKeyVerifyPoPFunctionDocString = `
-Verifies the proof of possession of the private key. This function is 
-only implemented if the signature algorithm of the public key is BLS, 
-it returns false if called with any other signature algorithm.
+Verifies the proof of possession of the private key.
+This function is only implemented if the signature algorithm
+of the public key is BLS (BLS_BLS12_381).
+If called with any other signature algorithm, the program aborts
 `
 
 // PublicKeyType represents the public key associated with an account key.


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/1021

## Description

April mainnet spork updates the Flow Virtual Machine (FVM) implementation and some cryptography features in it. 
This PR updates the doc to match the new functionalities provided by Cadence and the FVM after the upcoming spork. 
It also provides more details on how to generate signatures that Cadence/FVM consider valid.



