### PR TITLE
Show stack trace in runtime error

### DIFF
--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -179,6 +179,6 @@ func PrepareInterpreter(filename string, debugger *interpreter.Debugger) (*inter
 }
 
 func ExitWithError(message string) {
-	fmt.Println(pretty.FormatErrorMessage(message, true))
+	fmt.Println(pretty.FormatErrorMessage(pretty.ErrorPrefix, message, true))
 	os.Exit(1)
 }

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -170,6 +170,11 @@ func PrepareInterpreter(filename string, debugger *interpreter.Debugger) (*inter
 			return uuid, nil
 		}),
 		interpreter.WithDebugger(debugger),
+		interpreter.WithImportLocationHandler(
+			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+				panic("Importing programs is not supported yet")
+			},
+		),
 	)
 	must(err)
 

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -58,7 +58,8 @@ func TestRuntimeError(t *testing.T) {
 		require.EqualError(
 			t,
 			err,
-			"Execution failed:\nerror: unexpected token: identifier\n"+
+			"Execution failed:\n"+
+				"error: unexpected token: identifier\n"+
 				" --> 01:1:0\n"+
 				"  |\n"+
 				"1 | X\n"+
@@ -109,6 +110,7 @@ func TestRuntimeError(t *testing.T) {
             pub fun main() {
                 let a: UInt8 = 255
                 let b: UInt8 = 1
+                // overflow
                 a + b
             }
         `)
@@ -129,10 +131,11 @@ func TestRuntimeError(t *testing.T) {
 		require.EqualError(
 			t,
 			err,
-			"Execution failed:\nerror: overflow\n"+
-				" --> 01:5:16\n"+
+			"Execution failed:\n"+
+				"error: overflow\n"+
+				" --> 01:6:16\n"+
 				"  |\n"+
-				"5 |                 a + b\n"+
+				"6 |                 a + b\n"+
 				"  |                 ^^^^^\n",
 		)
 	})
@@ -234,6 +237,7 @@ func TestRuntimeError(t *testing.T) {
             pub fun add() {
                 let a: UInt8 = 255
                 let b: UInt8 = 1
+                // overflow
                 a + b
             }
         `)
@@ -271,11 +275,18 @@ func TestRuntimeError(t *testing.T) {
 		require.EqualError(
 			t,
 			err,
-			"Execution failed:\nerror: overflow\n"+
-				" --> imported:5:16\n"+
+			"Execution failed:\n"+
+				" --> 01:5:16\n"+
 				"  |\n"+
-				"5 |                 a + b\n"+
-				"  |                 ^^^^^\n",
+				"5 |                 add()\n"+
+				"  |                 ^^^^^\n"+
+				"\n"+
+				"error: overflow\n"+
+				" --> imported:6:16\n"+
+				"  |\n"+
+				"6 |                 a + b\n"+
+				"  |                 ^^^^^\n"+
+				"",
 		)
 	})
 

--- a/runtime/errors/errors.go
+++ b/runtime/errors/errors.go
@@ -66,3 +66,9 @@ type ParentError interface {
 	error
 	ChildErrors() []error
 }
+
+// HasPrefix is an interface for errors that provide a custom prefix
+//
+type HasPrefix interface {
+	Prefix() string
+}

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -45,8 +45,9 @@ func (e *unsupportedOperation) Error() string {
 
 // Error is the containing type for all errors produced by the interpreter.
 type Error struct {
-	Err      error
-	Location common.Location
+	Err        error
+	Location   common.Location
+	StackTrace []Invocation
 }
 
 func (e Error) Unwrap() error {
@@ -58,10 +59,42 @@ func (e Error) Error() string {
 }
 
 func (e Error) ChildErrors() []error {
-	return []error{e.Err}
+	errs := make([]error, 0, 1+len(e.StackTrace))
+
+	for _, invocation := range e.StackTrace {
+		locationRange := invocation.GetLocationRange()
+		if locationRange.Location == nil {
+			continue
+		}
+
+		errs = append(
+			errs,
+			StackTraceError{
+				LocationRange: locationRange,
+			},
+		)
+	}
+
+	return append(errs, e.Err)
 }
 
 func (e Error) ImportLocation() common.Location {
+	return e.Location
+}
+
+type StackTraceError struct {
+	LocationRange
+}
+
+func (e StackTraceError) Error() string {
+	return ""
+}
+
+func (e StackTraceError) Prefix() string {
+	return ""
+}
+
+func (e StackTraceError) ImportLocation() common.Location {
 	return e.Location
 }
 

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -30,37 +30,6 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-// Invocation
-//
-type Invocation struct {
-	Self               MemberAccessibleValue
-	Arguments          []Value
-	ArgumentTypes      []sema.Type
-	TypeParameterTypes *sema.TypeParameterTypeOrderedMap
-	GetLocationRange   func() LocationRange
-	Interpreter        *Interpreter
-}
-
-func NewInvocation(
-	interpreter *Interpreter,
-	self MemberAccessibleValue,
-	arguments []Value,
-	argumentTypes []sema.Type,
-	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
-	getLocationRange func() LocationRange,
-) Invocation {
-	common.UseMemory(interpreter, common.InvocationMemoryUsage)
-
-	return Invocation{
-		Self:               self,
-		Arguments:          arguments,
-		ArgumentTypes:      argumentTypes,
-		TypeParameterTypes: typeParameterTypes,
-		GetLocationRange:   getLocationRange,
-		Interpreter:        interpreter,
-	}
-}
-
 // FunctionValue
 //
 type FunctionValue interface {

--- a/runtime/interpreter/invocation.go
+++ b/runtime/interpreter/invocation.go
@@ -1,0 +1,71 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+// Invocation
+//
+type Invocation struct {
+	Self               MemberAccessibleValue
+	Arguments          []Value
+	ArgumentTypes      []sema.Type
+	TypeParameterTypes *sema.TypeParameterTypeOrderedMap
+	GetLocationRange   func() LocationRange
+	Interpreter        *Interpreter
+}
+
+func NewInvocation(
+	interpreter *Interpreter,
+	self MemberAccessibleValue,
+	arguments []Value,
+	argumentTypes []sema.Type,
+	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
+	getLocationRange func() LocationRange,
+) Invocation {
+	common.UseMemory(interpreter, common.InvocationMemoryUsage)
+
+	return Invocation{
+		Self:               self,
+		Arguments:          arguments,
+		ArgumentTypes:      argumentTypes,
+		TypeParameterTypes: typeParameterTypes,
+		GetLocationRange:   getLocationRange,
+		Interpreter:        interpreter,
+	}
+}
+
+// CallStack is the stack of invocations (call stack).
+//
+type CallStack struct {
+	Invocations []Invocation
+}
+
+func (i *CallStack) Push(invocation Invocation) {
+	i.Invocations = append(i.Invocations, invocation)
+}
+
+func (i *CallStack) Pop() {
+	depth := len(i.Invocations)
+	i.Invocations[depth-1] = Invocation{}
+	i.Invocations = i.Invocations[:depth-1]
+}

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -19,7 +19,6 @@
 package runtime
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,10 +152,7 @@ func TestRLPDecodeString(t *testing.T) {
 			)
 			if len(test.expectedErrMsg) > 0 {
 				require.Error(t, err)
-				assert.True(t, strings.HasPrefix(
-					err.Error(),
-					"Execution failed:\nerror: "+test.expectedErrMsg,
-				))
+				assert.ErrorContains(t, err, test.expectedErrMsg)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t,
@@ -312,10 +308,7 @@ func TestRLPDecodeList(t *testing.T) {
 			)
 			if len(test.expectedErrMsg) > 0 {
 				require.Error(t, err)
-				assert.True(t, strings.HasPrefix(
-					err.Error(),
-					"Execution failed:\nerror: "+test.expectedErrMsg,
-				))
+				assert.ErrorContains(t, err, test.expectedErrMsg)
 			} else {
 				require.NoError(t, err)
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -3898,52 +3898,74 @@ func TestInterpretImportError(t *testing.T) {
 
 	t.Parallel()
 
+	const importedLocation1 = common.StringLocation("imported1")
+	const importedLocation2 = common.StringLocation("imported2")
+
+	var importedChecker1, importedChecker2 *sema.Checker
+
 	valueDeclarations :=
 		stdlib.StandardLibraryFunctions{
 			stdlib.PanicFunction,
 		}.ToSemaValueDeclarations()
 
-	importedChecker, err := checker.ParseAndCheckWithOptions(t,
-		`
-          pub fun answer(): Int {
-              return panic("?!")
-          }
-        `,
-		checker.ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithPredeclaredValues(valueDeclarations),
+	parseAndCheck := func(code string, location common.Location) *sema.Checker {
+		checker, err := checker.ParseAndCheckWithOptions(t,
+			code,
+			checker.ParseAndCheckOptions{
+				Location: location,
+				Options: []sema.Option{
+					sema.WithPredeclaredValues(valueDeclarations),
+					sema.WithImportHandler(
+						func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+							switch importedLocation {
+							case importedLocation1:
+								return sema.ElaborationImport{
+									Elaboration: importedChecker1.Elaboration,
+								}, nil
+							case importedLocation2:
+								return sema.ElaborationImport{
+									Elaboration: importedChecker2.Elaboration,
+								}, nil
+							default:
+								assert.FailNow(t, "invalid location")
+								return nil, nil
+							}
+						},
+					),
+				},
 			},
-		},
-	)
-	require.NoError(t, err)
+		)
+		require.NoError(t, err)
+		return checker
+	}
 
-	importingChecker, err := checker.ParseAndCheckWithOptions(t,
-		`
-          import answer from "imported"
+	const importedCode1 = `
+      pub fun realAnswer(): Int {
+          return panic("?!")
+      }
+    `
 
-          pub fun test(): Int {
-              return answer()
-          }
-        `,
-		checker.ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithPredeclaredValues(valueDeclarations),
-				sema.WithImportHandler(
-					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						assert.Equal(t,
-							ImportedLocation,
-							importedLocation,
-						)
+	importedChecker1 = parseAndCheck(importedCode1, importedLocation1)
 
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
-			},
-		},
-	)
-	require.NoError(t, err)
+	const importedCode2 = `
+	  import realAnswer from "imported1"
+
+      pub fun answer(): Int {
+          return realAnswer()
+      }
+    `
+
+	importedChecker2 = parseAndCheck(importedCode2, importedLocation2)
+
+	const code = `
+      import answer from "imported2"
+
+      pub fun test(): Int {
+          return answer()
+      }
+    `
+
+	mainChecker := parseAndCheck(code, TestLocation)
 
 	values := stdlib.StandardLibraryFunctions{
 		stdlib.PanicFunction,
@@ -3952,16 +3974,21 @@ func TestInterpretImportError(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	inter, err := interpreter.NewInterpreter(
-		interpreter.ProgramFromChecker(importingChecker),
-		importingChecker.Location,
+		interpreter.ProgramFromChecker(mainChecker),
+		mainChecker.Location,
 		interpreter.WithStorage(storage),
 		interpreter.WithPredeclaredValues(values),
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
-				assert.Equal(t,
-					ImportedLocation,
-					location,
-				)
+				var importedChecker *sema.Checker
+				switch location {
+				case importedLocation1:
+					importedChecker = importedChecker1
+				case importedLocation2:
+					importedChecker = importedChecker2
+				default:
+					assert.FailNow(t, "invalid location")
+				}
 
 				program := interpreter.ProgramFromChecker(importedChecker)
 				subInterpreter, err := inter.NewSubInterpreter(program, location)
@@ -3981,6 +4008,37 @@ func TestInterpretImportError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
+
+	var sb strings.Builder
+	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
+		PrettyPrintError(
+			err,
+			mainChecker.Location,
+			map[common.LocationID]string{
+				TestLocation.ID():      code,
+				importedLocation1.ID(): importedCode1,
+				importedLocation2.ID(): importedCode2,
+			},
+		)
+	require.NoError(t, printErr)
+	assert.Equal(t,
+		" --> test:5:17\n"+
+			"  |\n"+
+			"5 |           return answer()\n"+
+			"  |                  ^^^^^^^^\n"+
+			"\n"+
+			" --> imported2:5:17\n"+
+			"  |\n"+
+			"5 |           return realAnswer()\n"+
+			"  |                  ^^^^^^^^^^^^\n"+
+			"\n"+
+			"error: panic: ?!\n"+
+			" --> imported1:3:17\n"+
+			"  |\n"+
+			"3 |           return panic(\"?!\")\n"+
+			"  |                  ^^^^^^^^^^^\n",
+		sb.String(),
+	)
 
 	var panicErr stdlib.PanicError
 	require.ErrorAs(t, err, &panicErr)


### PR DESCRIPTION
## Description

Add a call stack to the interpreter (stack of invocations), and include the stack trace in runtime errors.

For example, given a program `add.cdc`:

```kotlin
pub fun add() {
    UInt8.max + 1
}

pub fun main() {
    add()
}
```

The error is now reported as follows:

<img width="283" alt="Screen Shot 2022-04-01 at 10 49 41 AM" src="https://user-images.githubusercontent.com/51661/161316052-7830e82f-70cb-44ed-82df-24cf480dd063.png">

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
