### PR TITLE
[0.23] Fix overflow error in UInt to int conversion

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -5447,7 +5447,7 @@ func (UIntValue) StaticType() StaticType {
 }
 
 func (v UIntValue) ToInt() int {
-	if v.BigInt.IsInt64() {
+	if !v.BigInt.IsInt64() {
 		panic(OverflowError{})
 	}
 	return int(v.BigInt.Int64())

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -21,6 +21,7 @@ package interpreter_test
 import (
 	"fmt"
 	"go/types"
+	"math/big"
 	"testing"
 
 	"golang.org/x/tools/go/packages"
@@ -3225,4 +3226,97 @@ type fakeError struct{}
 
 func (fakeError) Error() string {
 	return "fake error for testing"
+}
+
+func TestNumberValueIntegerConversion(t *testing.T) {
+
+	t.Parallel()
+
+	type converter struct {
+		convert func(NumberValue) (result interface{}, convertible bool)
+		check   func(t *testing.T, result interface{}) bool
+	}
+
+	test := func(
+		t *testing.T,
+		numericType sema.Type,
+		testValue NumberValue,
+		converter converter,
+	) {
+
+		result, convertible := converter.convert(testValue)
+		if !convertible {
+			return
+		}
+		converter.check(t, result)
+	}
+
+	testValues := map[*sema.NumericType]NumberValue{
+		sema.IntType:     NewIntValueFromInt64(42),
+		sema.UIntType:    NewUIntValueFromUint64(42),
+		sema.UInt8Type:   UInt8Value(42),
+		sema.UInt16Type:  UInt16Value(42),
+		sema.UInt32Type:  UInt32Value(42),
+		sema.UInt64Type:  UInt64Value(42),
+		sema.UInt128Type: NewUInt128ValueFromUint64(42),
+		sema.UInt256Type: NewUInt256ValueFromUint64(42),
+		sema.Word8Type:   Word8Value(42),
+		sema.Word16Type:  Word16Value(42),
+		sema.Word32Type:  Word32Value(42),
+		sema.Word64Type:  Word64Value(42),
+		sema.Int8Type:    Int8Value(42),
+		sema.Int16Type:   Int16Value(42),
+		sema.Int32Type:   Int32Value(42),
+		sema.Int64Type:   Int64Value(42),
+		sema.Int128Type:  NewInt128ValueFromInt64(42),
+		sema.Int256Type:  NewInt256ValueFromInt64(42),
+	}
+
+	for _, ty := range sema.AllIntegerTypes {
+		// Only test leaf types
+		switch ty {
+		case sema.IntegerType, sema.SignedIntegerType:
+			continue
+		}
+
+		_, ok := testValues[ty.(*sema.NumericType)]
+		require.True(t, ok, "missing expected value for type %s", ty.String())
+	}
+
+	converters := map[string]converter{
+		"ToInt": {
+			convert: func(value NumberValue) (interface{}, bool) {
+				return value.ToInt(), true
+			},
+			check: func(t *testing.T, result interface{}) bool {
+				return assert.Equal(t, 42, result)
+			},
+		},
+		"ToBigInt": {
+			convert: func(value NumberValue) (interface{}, bool) {
+				bigNumberValue, ok := value.(BigNumberValue)
+				if !ok {
+					return nil, false
+				}
+				return bigNumberValue.ToBigInt(), true
+			},
+			check: func(t *testing.T, result interface{}) bool {
+				return assert.Equal(t, big.NewInt(42), result)
+			},
+		},
+	}
+
+	for numericType, testValue := range testValues {
+
+		t.Run(numericType.String(), func(t *testing.T) {
+
+			for converterName, converter := range converters {
+
+				t.Run(converterName, func(t *testing.T) {
+					test(t, numericType, testValue, converter)
+				})
+
+			}
+		})
+	}
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1136,11 +1136,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			if tc.check != nil {
 				tc.check(t, err)
 			} else {
-				if !assert.NoError(t, err) {
-					for err := err; err != nil; err = errors.Unwrap(err) {
-						t.Log(err)
-					}
-				}
+				assert.NoError(t, err)
 				assert.ElementsMatch(t, tc.expectedLogs, loggedMessages)
 			}
 		})
@@ -1467,11 +1463,7 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			if tt.check != nil {
 				tt.check(t, err)
 			} else {
-				if !assert.NoError(t, err) {
-					for err := err; err != nil; err = errors.Unwrap(err) {
-						t.Log(err)
-					}
-				}
+				assert.NoError(t, err)
 				assert.ElementsMatch(t, tt.expectedLogs, loggedMessages)
 			}
 		})


### PR DESCRIPTION
## Description

The function `UIntValue.ToInt` was incorrectly rejecting valid values, which caused a simple program like the following to fail with an overflow error, even though it should not:

```kotlin
Welcome to Cadence v0.23.2!
Type '.help' for assistance.

1> [""][0 as UInt]
panic: overflow
```

This was a regression introduced in #1208.

Fix the bug and also add tests covering all number types/values' `ToInt` and also `ToBigInt`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
