### PR TITLE
Reads of missing storage maps should not cause creation

### DIFF
--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -211,7 +211,7 @@ type interpreterStorage struct {
 
 var _ interpreter.Storage = &interpreterStorage{}
 
-func (i interpreterStorage) GetStorageMap(_ common.Address, _ string) *interpreter.StorageMap {
+func (i interpreterStorage) GetStorageMap(_ common.Address, _ string, _ bool) *interpreter.StorageMap {
 	panic("unexpected GetStorageMap call")
 }
 

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -218,9 +218,12 @@ func TestRuntimeContract(t *testing.T) {
 		// so getting the storage map here once upfront would result in outdated data
 
 		getContractValueExists := func() bool {
-			return NewStorage(storage).
-				GetStorageMap(signerAddress, StorageDomainContract).
-				ValueExists("Test")
+			storageMap := NewStorage(storage).
+				GetStorageMap(signerAddress, StorageDomainContract, false)
+			if storageMap == nil {
+				return false
+			}
+			return storageMap.ValueExists("Test")
 		}
 
 		t.Run("add", func(t *testing.T) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -314,7 +314,7 @@ func (c TypeCodes) Merge(codes TypeCodes) {
 
 type Storage interface {
 	atree.SlabStorage
-	GetStorageMap(address common.Address, domain string) *StorageMap
+	GetStorageMap(address common.Address, domain string, createIfNotExists bool) *StorageMap
 	CheckHealth() error
 }
 
@@ -2664,7 +2664,10 @@ func (interpreter *Interpreter) storedValueExists(
 	domain string,
 	identifier string,
 ) bool {
-	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain)
+	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain, false)
+	if accountStorage == nil {
+		return false
+	}
 	return accountStorage.ValueExists(identifier)
 }
 
@@ -2673,7 +2676,10 @@ func (interpreter *Interpreter) ReadStored(
 	domain string,
 	identifier string,
 ) Value {
-	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain)
+	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain, false)
+	if accountStorage == nil {
+		return nil
+	}
 	return accountStorage.ReadValue(identifier)
 }
 
@@ -2683,7 +2689,7 @@ func (interpreter *Interpreter) writeStored(
 	identifier string,
 	value Value,
 ) {
-	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain)
+	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain, true)
 	accountStorage.WriteValue(interpreter, identifier, value)
 }
 

--- a/runtime/interpreter/storage.go
+++ b/runtime/interpreter/storage.go
@@ -167,10 +167,16 @@ func NewInMemoryStorage() InMemoryStorage {
 	}
 }
 
-func (i InMemoryStorage) GetStorageMap(address common.Address, domain string) (storageMap *StorageMap) {
+func (i InMemoryStorage) GetStorageMap(
+	address common.Address,
+	domain string,
+	createIfNotExists bool,
+) (
+	storageMap *StorageMap,
+) {
 	key := StorageKey{address, domain}
 	storageMap = i.StorageMaps[key]
-	if storageMap == nil {
+	if storageMap == nil && createIfNotExists {
 		storageMap = NewStorageMap(i, atree.Address(address))
 		i.StorageMaps[key] = storageMap
 	}

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -448,8 +448,7 @@ func TestStorageOverwriteAndRemove(t *testing.T) {
 
 	const identifier = "test"
 
-	storageMap := storage.GetStorageMap(address, "storage")
-
+	storageMap := storage.GetStorageMap(address, "storage", true)
 	storageMap.WriteValue(inter, identifier, array1)
 
 	// Overwriting delete any existing child slabs

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1998,8 +1998,11 @@ func (r *interpreterRuntime) loadContract(
 			storageMap := storage.GetStorageMap(
 				location.Address,
 				StorageDomainContract,
+				false,
 			)
-			storedValue = storageMap.ReadValue(location.Name)
+			if storageMap != nil {
+				storedValue = storageMap.ReadValue(location.Name)
+			}
 		}
 
 		if storedValue == nil {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -5562,17 +5562,6 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	deploy := utils.DeploymentTransaction("Test", contract)
 
-	setupTx := []byte(`
-      import Test from 0xCADE
-
-       transaction {
-
-          prepare(signer: AuthAccount) {
-              signer.save(<-Test.createR(), to: /storage/r)
-          }
-       }
-    `)
-
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -5650,7 +5639,16 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	err = runtime.ExecuteTransaction(
 		Script{
-			Source: setupTx,
+			Source: []byte(`
+              import Test from 0xCADE
+
+               transaction {
+
+                  prepare(signer: AuthAccount) {
+                      signer.save(<-Test.createR(), to: /storage/r)
+                  }
+               }
+            `),
 		},
 		Context{
 			Interface: runtimeInterface,
@@ -5666,12 +5664,12 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 				addressValue[:],
 				[]byte("storage"),
 			},
-			// storage domain storage map
+			// resource value
 			{
 				addressValue[:],
 				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3},
 			},
-			// resource value
+			// storage domain storage map
 			{
 				addressValue[:],
 				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4},
@@ -5736,7 +5734,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 			// resource value
 			{
 				addressValue[:],
-				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4},
+				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3},
 			},
 		},
 		writes,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4644,7 +4644,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 			nil,
 		)
 
-		storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier())
+		storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier(), true)
 		storageMap.WriteValue(inter, storagePath.Identifier, r)
 
 		result, err := inter.Invoke("testInvalidUnauthorized")

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -727,7 +727,7 @@ func TestInterpretGetType(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier())
+			storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier(), true)
 			storageMap.WriteValue(
 				inter,
 				storagePath.Identifier,


### PR DESCRIPTION
## Description

Storage maps should only be created when they are written to, not as a side-effect of reading them.

Discovered / investigated by @janezpodhostnik in onflow/flow-go#2256 🙏 

Related discussions:
- https://axiomzen.slack.com/archives/C015ABLUV41/p1649161639155899
- https://axiomzen.slack.com/archives/C015G65HR2P/p1649195928939989

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
