### PR TITLE
Add a checker option to short-circuit error reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,4 +8,5 @@ coverage:
     patch:
       default:
         target: 100%
+        threshold: 5%
         informational: false

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -124,7 +124,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 						Range:        ast.NewRangeFromPositioned(checker.memoryGauge, leftHandExpression),
 					},
 				)
-			} else if checker.lintEnabled && IsSubType(leftHandType, rightHandType) {
+			} else if checker.lintingEnabled && IsSubType(leftHandType, rightHandType) {
 
 				switch expression.Operation {
 				case ast.OperationFailableCast:
@@ -162,7 +162,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 		// the inferred-type of the expression. i.e: exprActualType == rightHandType
 		// Then, it is not possible to determine whether the target type is redundant.
 		// Therefore, don't check for redundant casts, if there are errors.
-		if checker.lintEnabled &&
+		if checker.lintingEnabled &&
 			!hasErrors &&
 			isRedundantCast(leftHandExpression, exprActualType, rightHandType, checker.expectedType) {
 			checker.hint(

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -44,7 +44,7 @@ func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) as
 	if !ok {
 		// A non-optional type is forced. Suggest removing it
 
-		if checker.lintEnabled {
+		if checker.lintingEnabled {
 			checker.hint(
 				&RemovalHint{
 					Description: "unnecessary force operator",

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -250,7 +250,9 @@ func WithLintingEnabled(enabled bool) Option {
 }
 
 // WithErrorShortCircuitingEnabled returns a checker option which enables/disables
-// error short-circuiting.
+// error short-circuiting in the checker.
+// When enabled, the checker will stop running once it encounters an error.
+// When disabled (the default), the checker reports the error then continues checking.
 //
 func WithErrorShortCircuitingEnabled(enabled bool) Option {
 	return func(checker *Checker) error {

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -115,7 +115,8 @@ type Checker struct {
 	checkHandler                       CheckHandlerFunc
 	expectedType                       Type
 	memberAccountAccessHandler         MemberAccountAccessHandlerFunc
-	lintEnabled                        bool
+	lintingEnabled                     bool
+	errorShortCircuitingEnabled        bool
 	// memoryGauge is used for metering memory usage
 	memoryGauge common.MemoryGauge
 }
@@ -243,7 +244,17 @@ func WithPositionInfoEnabled(enabled bool) Option {
 //
 func WithLintingEnabled(enabled bool) Option {
 	return func(checker *Checker) error {
-		checker.lintEnabled = enabled
+		checker.lintingEnabled = enabled
+		return nil
+	}
+}
+
+// WithErrorShortCircuitingEnabled returns a checker option which enables/disables
+// error short-circuiting.
+//
+func WithErrorShortCircuitingEnabled(enabled bool) Option {
+	return func(checker *Checker) error {
+		checker.errorShortCircuitingEnabled = enabled
 		return nil
 	}
 }
@@ -302,8 +313,11 @@ func (checker *Checker) SubChecker(program *ast.Program, location common.Locatio
 		WithAccessCheckMode(checker.accessCheckMode),
 		WithValidTopLevelDeclarationsHandler(checker.validTopLevelDeclarationsHandler),
 		WithCheckHandler(checker.checkHandler),
-		WithImportHandler(checker.importHandler),
 		WithLocationHandler(checker.locationHandler),
+		WithImportHandler(checker.importHandler),
+		WithPositionInfoEnabled(checker.positionInfoEnabled),
+		WithLintingEnabled(checker.lintingEnabled),
+		WithErrorShortCircuitingEnabled(checker.errorShortCircuitingEnabled),
 	)
 }
 
@@ -375,11 +389,29 @@ func (checker *Checker) IsChecked() bool {
 	return checker.isChecked
 }
 
+type stopChecking struct{}
+
 func (checker *Checker) Check() error {
 	if !checker.IsChecked() {
 		checker.Elaboration.setIsChecking(true)
 		checker.errors = nil
 		check := func() {
+			if checker.errorShortCircuitingEnabled {
+				defer func() {
+					switch recovered := recover().(type) {
+					case stopChecking:
+						// checking should stop
+						break
+					case nil:
+						// nothing was recovered
+						break
+					default:
+						// re-panic what was recovered
+						panic(recovered)
+					}
+				}()
+			}
+
 			checker.Program.Accept(checker)
 		}
 		if checker.checkHandler != nil {
@@ -415,6 +447,9 @@ func (checker *Checker) report(err error) {
 		return
 	}
 	checker.errors = append(checker.errors, err)
+	if checker.errorShortCircuitingEnabled {
+		panic(stopChecking{})
+	}
 }
 
 func (checker *Checker) hint(hint Hint) {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3275,14 +3275,14 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 		switch argument := argument.(type) {
 		case *ast.IntegerExpression:
 			if CheckIntegerLiteral(nil, argument, targetType, checker.report) {
-				if checker.lintEnabled {
+				if checker.lintingEnabled {
 					suggestIntegerLiteralConversionReplacement(checker, argument, targetType, invocationRange)
 				}
 			}
 
 		case *ast.FixedPointExpression:
 			if CheckFixedPointLiteral(nil, argument, targetType, checker.report) {
-				if checker.lintEnabled {
+				if checker.lintingEnabled {
 					suggestFixedPointLiteralConversionReplacement(checker, targetType, argument, invocationRange)
 				}
 			}

--- a/runtime/tests/checker/errors_test.go
+++ b/runtime/tests/checker/errors_test.go
@@ -1,0 +1,51 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package checker
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckErrorShortCircuiting(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+          let x: Type<X<X<X>>>? = nil
+        `,
+		ParseAndCheckOptions{
+			Options: []sema.Option{
+				sema.WithErrorShortCircuitingEnabled(true),
+			},
+		},
+	)
+
+	// There are actually 6 errors in total,
+	// 3 "cannot find type in this scope",
+	// and 3 "cannot instantiate non-parameterized type",
+	// but we enabled error short-circuiting
+
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+}

--- a/runtime/tests/checker/errors_test.go
+++ b/runtime/tests/checker/errors_test.go
@@ -21,8 +21,9 @@ package checker
 import (
 	"testing"
 
-	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 func TestCheckErrorShortCircuiting(t *testing.T) {


### PR DESCRIPTION
## Description

We can short-circuit error reporting in some environments. For example, we want to report all errors in a developer tool, but we do not need to report all errors on-chain.

Add a checker option which stops error reporting after the first reported error. 
The new option is disabled by default, but should be enabled in the flow-go EN.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
