### PR TITLE
Transfer indexing expression

### DIFF
--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -74,24 +74,45 @@ func (interpreter *Interpreter) identifierExpressionGetterSetter(identifierExpre
 // for the target index expression
 //
 func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast.IndexExpression) getterSetter {
-	target := interpreter.evalExpression(indexExpression.TargetExpression).(ValueIndexableValue)
-	indexingValue := interpreter.evalExpression(indexExpression.IndexingExpression)
+
 	getLocationRange := locationRangeGetter(interpreter.Location, indexExpression)
-	_, isNestedResourceMove := interpreter.Program.Elaboration.IsNestedResourceMoveExpression[indexExpression]
+
+	target := interpreter.evalExpression(indexExpression.TargetExpression).(ValueIndexableValue)
+
+	// Evaluate, transfer, and convert the indexing value,
+	// as it is essentially an "argument" of the get/set operation
+
+	elaboration := interpreter.Program.Elaboration
+
+	indexedType := elaboration.IndexExpressionIndexedTypes[indexExpression]
+	indexingType := elaboration.IndexExpressionIndexingTypes[indexExpression]
+
+	transferredIndexingValue := interpreter.transferAndConvert(
+		interpreter.evalExpression(indexExpression.IndexingExpression),
+		indexingType,
+		indexedType.IndexingType(),
+		locationRangeGetter(
+			interpreter.Location,
+			indexExpression.IndexingExpression,
+		),
+	)
+
+	_, isNestedResourceMove := elaboration.IsNestedResourceMoveExpression[indexExpression]
+
 	return getterSetter{
 		target: target,
 		get: func(_ bool) Value {
 			if isNestedResourceMove {
-				return target.RemoveKey(interpreter, getLocationRange, indexingValue)
+				return target.RemoveKey(interpreter, getLocationRange, transferredIndexingValue)
 			} else {
-				return target.GetKey(interpreter, getLocationRange, indexingValue)
+				return target.GetKey(interpreter, getLocationRange, transferredIndexingValue)
 			}
 		},
 		set: func(value Value) {
 			if isNestedResourceMove {
-				target.InsertKey(interpreter, getLocationRange, indexingValue, value)
+				target.InsertKey(interpreter, getLocationRange, transferredIndexingValue, value)
 			} else {
-				target.SetKey(interpreter, getLocationRange, indexingValue, value)
+				target.SetKey(interpreter, getLocationRange, transferredIndexingValue, value)
 			}
 		},
 	}

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -272,10 +272,9 @@ func (checker *Checker) visitIndexExpression(
 		return InvalidType
 	}
 
-	elementType := checker.visitValueIndexingExpression(
-		indexedType,
+	indexingType := checker.VisitExpression(
 		indexExpression.IndexingExpression,
-		isAssignment,
+		indexedType.IndexingType(),
 	)
 
 	if isAssignment && !indexedType.AllowsValueIndexingAssignment() {
@@ -287,17 +286,12 @@ func (checker *Checker) visitIndexExpression(
 		)
 	}
 
+	elementType := indexedType.ElementType(isAssignment)
+
 	checker.checkUnusedExpressionResourceLoss(elementType, targetExpression)
 
+	checker.Elaboration.IndexExpressionIndexedTypes[indexExpression] = indexedType
+	checker.Elaboration.IndexExpressionIndexingTypes[indexExpression] = indexingType
+
 	return elementType
-}
-
-func (checker *Checker) visitValueIndexingExpression(
-	indexedType ValueIndexableType,
-	indexingExpression ast.Expression,
-	isAssignment bool,
-) Type {
-	checker.VisitExpression(indexingExpression, indexedType.IndexingType())
-
-	return indexedType.ElementType(isAssignment)
 }

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -88,6 +88,8 @@ type Elaboration struct {
 	// Only to make the go-compiler happy with semver compatibility.
 	// TODO: Remove
 	IsResourceMoveIndexExpression map[*ast.IndexExpression]bool
+	IndexExpressionIndexedTypes   map[*ast.IndexExpression]ValueIndexableType
+	IndexExpressionIndexingTypes  map[*ast.IndexExpression]Type
 }
 
 func NewElaboration() *Elaboration {
@@ -141,6 +143,8 @@ func NewElaboration() *Elaboration {
 		EffectivePredeclaredValues:          map[string]ValueDeclaration{},
 		EffectivePredeclaredTypes:           map[string]TypeDeclaration{},
 		ReferenceExpressionBorrowTypes:      map[*ast.ReferenceExpression]*ReferenceType{},
+		IndexExpressionIndexedTypes:         map[*ast.IndexExpression]ValueIndexableType{},
+		IndexExpressionIndexingTypes:        map[*ast.IndexExpression]Type{},
 	}
 }
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -2755,3 +2755,177 @@ func TestRuntimeNoAtreeSendOnClosedChannelDuringCommit(t *testing.T) {
 		}
 	})
 }
+
+// TestRuntimeStorageEnumCase tests the writing an enum case to storage,
+// reading it back from storage, as well as using it to index into a dictionary.
+//
+func TestRuntimeStorageEnumCase(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	address := common.MustBytesToAddress([]byte{0x1})
+
+	accountCodes := map[common.LocationID][]byte{}
+	var events []cadence.Event
+	var loggedMessages []string
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestLedger(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{address}, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			accountCodes[location.ID()] = code
+			return nil
+		},
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			code = accountCodes[location.ID()]
+			return code, nil
+		},
+		emitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
+		},
+		log: func(message string) {
+			loggedMessages = append(loggedMessages, message)
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	// Deploy contract
+
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: utils.DeploymentTransaction(
+				"C",
+				[]byte(`
+                  pub contract C {
+
+                    pub enum E: UInt8 {
+                        pub case A
+                        pub case B
+                    }
+
+                    pub resource R {
+                        pub let id: UInt64
+                        pub let e: E
+
+                        init(id: UInt64, e: E) {
+                            self.id = id
+                            self.e = e
+                        }
+                    }
+
+                    pub fun createR(id: UInt64, e: E): @R {
+                        return <- create R(id: id, e: e)
+                    }
+
+                    pub resource Collection {
+                        pub var rs: @{UInt64: R}
+
+                        init () {
+                            self.rs <- {}
+                        }
+
+                        pub fun withdraw(id: UInt64): @R {
+                            return <- self.rs.remove(key: id)!
+                        }
+
+                        pub fun deposit(_ r: @R) {
+
+                            let counts: {E: UInt64} = {}
+                            log(r.e)
+                            counts[r.e] = 42 // test indexing expression is transferred properly
+                            log(r.e)
+
+                            let oldR <- self.rs[r.id] <-! r
+                            destroy oldR
+                        }
+
+                        destroy() {
+                             destroy self.rs
+                        }
+                    }
+
+                    pub fun createEmptyCollection(): @Collection {
+                      return <- create Collection()
+                    }
+                  }
+                `),
+			),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	// Store enum case
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: []byte(`
+              import C from 0x1
+
+              transaction {
+                  prepare(signer: AuthAccount) {
+                      signer.save(<-C.createEmptyCollection(), to: /storage/collection)
+                      let collection = signer.borrow<&C.Collection>(from: /storage/collection)!
+                      collection.deposit(<-C.createR(id: 0, e: C.E.B))
+                  }
+               }
+            `),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	// Load enum case
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: []byte(`
+              import C from 0x1
+
+              transaction {
+                  prepare(signer: AuthAccount) {
+                      let collection = signer.borrow<&C.Collection>(from: /storage/collection)!
+                      let r <- collection.withdraw(id: 0)
+                      log(r.e)
+                      destroy r
+                  }
+               }
+            `),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]string{
+			"A.0000000000000001.C.E(rawValue: 1)",
+			"A.0000000000000001.C.E(rawValue: 1)",
+			"A.0000000000000001.C.E(rawValue: 1)",
+		},
+		loggedMessages,
+	)
+}

--- a/runtime/tests/interpreter/indexing_test.go
+++ b/runtime/tests/interpreter/indexing_test.go
@@ -1,0 +1,74 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+)
+
+// TestInterpretIndexingExpressionTransfer tests if the indexing value
+// (not the value that is indexed into) is properly transferred.
+// If the indexing value is used for an assignment,
+// it will be transferred into the indexed value,
+// and as part of it, will get removed.
+// Ensure the *copy* is removed, and not *not the original*.
+//
+func TestInterpretIndexingExpressionTransfer(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t,
+		`
+          enum E: UInt8 {
+              case First
+              case Second
+              case Third
+          }
+
+          resource R {
+              let e: E
+              init(e: E) {
+                  self.e = e
+              }
+          }
+
+          fun test(): UInt8 {
+              let r <- create R(e: E.Third)
+              let counts: {E: UInt64} = {}
+              counts[r.e] = 42
+              let res = r.e.rawValue
+              destroy r
+              return res
+          }
+        `,
+	)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		// E.Third.rawValue
+		interpreter.UInt8Value(2),
+		result,
+	)
+}

--- a/runtime/tests/interpreter/indexing_test.go
+++ b/runtime/tests/interpreter/indexing_test.go
@@ -31,7 +31,7 @@ import (
 // If the indexing value is used for an assignment,
 // it will be transferred into the indexed value,
 // and as part of it, will get removed.
-// Ensure the *copy* is removed, and not *not the original*.
+// Ensure the *copy* is removed, and *not the original*.
 //
 func TestInterpretIndexingExpressionTransfer(t *testing.T) {
 


### PR DESCRIPTION
## Description

When evaluating an index expression (`c[i]`), the indexing expression (`i`) must be transfered (copied) before calling the mutation operation on the value-indexable value (e.g. dictionary) resulting from the evaluation of the indexed expression (`c`), e.g. `DictionaryValue.SetKey` for `c[i] = v`. This is important, because the atree-based containers assume the arguments to operations are transferred already (copies), which need to be removed from storage.

Once merged into `v0.23` I'll publish a bugfix release and merge this commit into `master`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
