### PR TITLE
Check reference expression operator

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1234,6 +1234,7 @@ func (e *FunctionExpression) MarshalJSON() ([]byte, error) {
 type CastingExpression struct {
 	Expression                Expression
 	Operation                 Operation
+	OperationPos              Position
 	TypeAnnotation            *TypeAnnotation
 	ParentVariableDeclaration *VariableDeclaration `json:"-"`
 }

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -1483,7 +1483,8 @@ func TestCastingExpression_MarshalJSON(t *testing.T) {
 				Pos:        Position{Offset: 1, Line: 2, Column: 3},
 			},
 		},
-		Operation: OperationForceCast,
+		Operation:    OperationForceCast,
+		OperationPos: Position{Offset: 10, Line: 11, Column: 12},
 		TypeAnnotation: &TypeAnnotation{
 			IsResource: true,
 			Type: &NominalType{
@@ -1514,6 +1515,7 @@ func TestCastingExpression_MarshalJSON(t *testing.T) {
                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
             },
             "Operation": "OperationForceCast",
+            "OperationPos": {"Offset": 10, "Line": 11, "Column": 12},
             "TypeAnnotation": {
                "IsResource": true,
                "AnnotatedType": {

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -828,8 +828,9 @@ func defineCastingExpression() {
 			case keywordAs:
 				right := parseTypeAnnotation(parser)
 				return &ast.CastingExpression{
-					Operation:      ast.OperationCast,
 					Expression:     left,
+					Operation:      ast.OperationCast,
+					OperationPos:   t.StartPos,
 					TypeAnnotation: right,
 				}
 			default:
@@ -861,8 +862,9 @@ func defineCastingExpression() {
 			return func(parser *parser, t lexer.Token, left ast.Expression) ast.Expression {
 				right := parseTypeAnnotation(parser)
 				return &ast.CastingExpression{
-					Operation:      operation,
 					Expression:     left,
+					Operation:      operation,
+					OperationPos:   t.StartPos,
 					TypeAnnotation: right,
 				}
 			}
@@ -1125,6 +1127,17 @@ func defineReferenceExpression() {
 			castingExpression, ok := expression.(*ast.CastingExpression)
 			if !ok {
 				panic(fmt.Errorf("expected casting expression"))
+			}
+
+			if castingExpression.Operation != ast.OperationCast {
+				p.report(&SyntaxError{
+					Message: fmt.Sprintf(
+						"invalid operator: got %q, expected %q",
+						castingExpression.Operation.Symbol(),
+						ast.OperationCast.Symbol(),
+					),
+					Pos: castingExpression.OperationPos,
+				})
 			}
 
 			return &ast.ReferenceExpression{


### PR DESCRIPTION
Closes #1406 

## Description

Reference expressions and casting expressions have the same syntax, so reference expressions are parsed by parsing casting expressions. 

Ensure the casting expression has the correct operator (`as`).

At least make the current syntax / parsing strict, but we still might want to change the syntax has discussed.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
