### PR TITLE
Meter additional container length as a function of original size

### DIFF
--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -163,7 +163,6 @@ func NewDictionaryAdditionalSizeUsage(originalSize, additionalSize int) MemoryUs
 	}
 	return MemoryUsage{
 		Kind: MemoryKindDictionarySize,
-		// size of b+ tree grows logarithmically with the size of the tree
 		Amount: newAmount,
 	}
 }

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -128,10 +128,10 @@ func NewArrayMemoryUsages(length int) (MemoryUsage, MemoryUsage) {
 		}
 }
 
-func NewArrayLengthUsage(length int) MemoryUsage {
+func NewArrayAdditionalLengthUsage(originalLength, additionalLength int) MemoryUsage {
 	return MemoryUsage{
 		Kind:   MemoryKindArrayLength,
-		Amount: uint64(length),
+		Amount: uint64(originalLength + additionalLength),
 	}
 }
 
@@ -145,10 +145,10 @@ func NewDictionaryMemoryUsages(length int) (MemoryUsage, MemoryUsage) {
 		}
 }
 
-func NewDictionarySizeUsage(length int) MemoryUsage {
+func NewDictionaryAdditionalSizeUsage(originalSize, additionalSize int) MemoryUsage {
 	return MemoryUsage{
 		Kind:   MemoryKindDictionarySize,
-		Amount: uint64(length),
+		Amount: uint64(originalSize + additionalSize),
 	}
 }
 

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"math"
 	"math/big"
 	"unsafe"
 )
@@ -129,9 +130,16 @@ func NewArrayMemoryUsages(length int) (MemoryUsage, MemoryUsage) {
 }
 
 func NewArrayAdditionalLengthUsage(originalLength, additionalLength int) MemoryUsage {
+	var newAmount uint64
+	if originalLength <= 1 {
+		newAmount = uint64(originalLength + additionalLength)
+	} else {
+		// size of b+ tree grows logarithmically with the size of the tree
+		newAmount = uint64(math.Log2(float64(originalLength)) + float64(additionalLength))
+	}
 	return MemoryUsage{
 		Kind:   MemoryKindArrayLength,
-		Amount: uint64(originalLength + additionalLength),
+		Amount: newAmount,
 	}
 }
 
@@ -146,9 +154,17 @@ func NewDictionaryMemoryUsages(length int) (MemoryUsage, MemoryUsage) {
 }
 
 func NewDictionaryAdditionalSizeUsage(originalSize, additionalSize int) MemoryUsage {
+	var newAmount uint64
+	if originalSize <= 1 {
+		newAmount = uint64(originalSize + additionalSize)
+	} else {
+		// size of b+ tree grows logarithmically with the size of the tree
+		newAmount = uint64(math.Log2(float64(originalSize)) + float64(additionalSize))
+	}
 	return MemoryUsage{
-		Kind:   MemoryKindDictionarySize,
-		Amount: uint64(originalSize + additionalSize),
+		Kind: MemoryKindDictionarySize,
+		// size of b+ tree grows logarithmically with the size of the tree
+		Amount: newAmount,
 	}
 }
 

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -162,7 +162,7 @@ func NewDictionaryAdditionalSizeUsage(originalSize, additionalSize int) MemoryUs
 		newAmount = uint64(math.Log2(float64(originalSize)) + float64(additionalSize))
 	}
 	return MemoryUsage{
-		Kind: MemoryKindDictionarySize,
+		Kind:   MemoryKindDictionarySize,
 		Amount: newAmount,
 	}
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1651,7 +1651,7 @@ func (v *ArrayValue) RecursiveString(seenReferences SeenReferences) string {
 func (v *ArrayValue) Append(interpreter *Interpreter, getLocationRange func() LocationRange, element Value) {
 
 	// length increases by 1
-	common.UseMemory(interpreter, common.NewArrayLengthUsage(1))
+	common.UseMemory(interpreter, common.NewArrayAdditionalLengthUsage(int(v.array.Count()), 1))
 
 	interpreter.checkContainerMutation(v.Type.ElementType(), element, getLocationRange)
 
@@ -1700,7 +1700,7 @@ func (v *ArrayValue) Insert(interpreter *Interpreter, getLocationRange func() Lo
 	}
 
 	// length increases by 1
-	common.UseMemory(interpreter, common.NewArrayLengthUsage(1))
+	common.UseMemory(interpreter, common.NewArrayAdditionalLengthUsage(int(v.array.Count()), 1))
 
 	interpreter.checkContainerMutation(v.Type.ElementType(), element, getLocationRange)
 
@@ -15575,7 +15575,7 @@ func (v *DictionaryValue) Insert(
 ) OptionalValue {
 
 	// length increases by 1
-	common.UseMemory(interpreter, common.NewDictionarySizeUsage(1))
+	common.UseMemory(interpreter, common.NewDictionaryAdditionalSizeUsage(int(v.dictionary.Count()), 1))
 
 	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, getLocationRange)
 	interpreter.checkContainerMutation(v.Type.ValueType, value, getLocationRange)

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -127,6 +127,7 @@ func TestInterpretArrayMetering(t *testing.T) {
             pub fun main() {
                 let x: [Int8] = []
                 x.append(3)
+				x.append(4)
             }
         `
 
@@ -137,7 +138,7 @@ func TestInterpretArrayMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayBase))
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindArrayLength))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindArrayLength))
 	})
 
 	t.Run("insert", func(t *testing.T) {
@@ -147,6 +148,7 @@ func TestInterpretArrayMetering(t *testing.T) {
             pub fun main() {
                 let x: [Int8] = []
                 x.insert(at:0, 3)
+				x.insert(at:1, 3)
             }
         `
 
@@ -157,7 +159,7 @@ func TestInterpretArrayMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayBase))
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindArrayLength))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindArrayLength))
 	})
 }
 
@@ -234,6 +236,7 @@ func TestInterpretDictionaryMetering(t *testing.T) {
             pub fun main() {
                 let x: {Int8: String} = {}
                 x.insert(key: 5, "")
+				x.insert(key: 4, "")
             }
         `
 
@@ -244,7 +247,7 @@ func TestInterpretDictionaryMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindDictionaryBase))
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindDictionarySize))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindDictionarySize))
 	})
 }
 

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -60,12 +60,12 @@ func TestInterpretArrayMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-                pub fun main() {
-                    let x: [Int8] = []
-                    let y: [[String]] = [[]]
-                    let z: [[[Bool]]] = [[[]]]
-                }
-            `
+                      pub fun main() {
+                          let x: [Int8] = []
+                          let y: [[String]] = [[]]
+                          let z: [[[Bool]]] = [[[]]]
+                      }
+                  `
 
 		meter := newTestMemoryGauge()
 		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
@@ -82,13 +82,13 @@ func TestInterpretArrayMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-                    pub fun main() {
-                        let values: [[Int8]] = [[], [], []]
-                        for value in values {
-                          let a = value
-                        }
-                    }
-                `
+                          pub fun main() {
+                              let values: [[Int8]] = [[], [], []]
+                              for value in values {
+                                let a = value
+                              }
+                          }
+                      `
 
 		meter := newTestMemoryGauge()
 		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
@@ -105,11 +105,11 @@ func TestInterpretArrayMetering(t *testing.T) {
 		t.Parallel()
 
 		script := `
-                pub fun main() {
-                    let x: [Int8] = []
-                    x.contains(5)
-                }
-            `
+                      pub fun main() {
+                          let x: [Int8] = []
+                          x.contains(5)
+                      }
+                  `
 
 		meter := newTestMemoryGauge()
 		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
@@ -127,7 +127,7 @@ func TestInterpretArrayMetering(t *testing.T) {
             pub fun main() {
                 let x: [Int8] = []
                 x.append(3)
-				x.append(4)
+                        x.append(4)
             }
         `
 
@@ -141,14 +141,18 @@ func TestInterpretArrayMetering(t *testing.T) {
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindArrayLength))
 	})
 
-	t.Run("insert", func(t *testing.T) {
+	t.Run("append many", func(t *testing.T) {
 		t.Parallel()
 
 		script := `
             pub fun main() {
                 let x: [Int8] = []
-                x.insert(at:0, 3)
-				x.insert(at:1, 3)
+                x.append(0) // adds 1
+                        x.append(1) // adds 2
+                        x.append(2) // adds 2
+                        x.append(3) // adds 2
+                        x.append(4) // adds 3
+                        x.append(5) // adds 3
             }
         `
 
@@ -159,7 +163,53 @@ func TestInterpretArrayMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayBase))
+		assert.Equal(t, uint64(13), meter.getMemory(common.MemoryKindArrayLength))
+	})
+
+	t.Run("insert", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+                        pub fun main() {
+                            let x: [Int8] = []
+                            x.insert(at:0, 3)
+                                    x.insert(at:1, 3)
+                        }
+                    `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayBase))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindArrayLength))
+	})
+
+	t.Run("insert many", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+                        pub fun main() {
+                            let x: [Int8] = []
+                            x.insert(at:0, 3) // adds 1
+                                    x.insert(at:1, 3) // adds 2
+                                    x.insert(at:2, 3) // adds 2
+                                    x.insert(at:3, 3) // adds 2
+                                    x.insert(at:4, 3) // adds 3
+                                    x.insert(at:5, 3) // adds 3
+                        }
+                    `
+
+		meter := newTestMemoryGauge()
+		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayBase))
+		assert.Equal(t, uint64(13), meter.getMemory(common.MemoryKindArrayLength))
 	})
 }
 
@@ -236,7 +286,7 @@ func TestInterpretDictionaryMetering(t *testing.T) {
             pub fun main() {
                 let x: {Int8: String} = {}
                 x.insert(key: 5, "")
-				x.insert(key: 4, "")
+                        x.insert(key: 4, "")
             }
         `
 


### PR DESCRIPTION
Arrays and dictionaries, being backed by atrees underneath, do not consume a linear amount of memory as they grow. Rather, the size of these structures increases faster and faster the larger they become, as more nodes need to be added at higher levels of the tree as the number of leaves increases. 

Based on discussion with @ramtinms, we can use `log(Count())` of the underlying tree to (over)estimate the amount of overhead necessary to grow the tree. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
