### PR TITLE
Add tests for casting references inside containers

### DIFF
--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3748,3 +3748,50 @@ func TestInterpretFunctionTypeCasting(t *testing.T) {
 		require.Equal(t, interpreter.NewStringValue("hello from foo.bar"), result)
 	})
 }
+
+func TestInterpretReferenceCasting(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("array", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+            fun test() {
+                let x = bar()
+                let y = [&x as &AnyStruct]
+                let z = y as! [&bar{foo}]
+            }
+
+            struct interface foo {}
+
+            struct bar: foo {}
+        `
+
+		inter := parseCheckAndInterpret(t, code)
+
+		_, err := inter.Invoke("test")
+		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	})
+
+	t.Run("dictionary", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+            fun test() {
+                let x = bar()
+                let y = {"a": &x as &AnyStruct}
+                let z = y as! {String: &bar{foo}}
+            }
+
+            struct interface foo {}
+
+            struct bar: foo {}
+        `
+
+		inter := parseCheckAndInterpret(t, code)
+
+		_, err := inter.Invoke("test")
+		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	})
+}


### PR DESCRIPTION
## Description

Follow-up on https://github.com/onflow/cadence/pull/1487. Adds tests to verify the behaviour of reference casting, within containers.

The previous dynamic-type based checking also had used the same "sema-type based" sub-type checking at runtime. e.g:
- Arrays: https://github.com/onflow/cadence/blob/6789e35121fee034222e4dd37c68bcead14333b6/runtime/interpreter/interpreter.go#L3022-L3025
- Dictionaries: https://github.com/onflow/cadence/blob/6789e35121fee034222e4dd37c68bcead14333b6/runtime/interpreter/interpreter.go#L3060-L3063

So relying only on "sema-type" based checking (now with static types), doesn't introduce any regressions, since sema-type checking is the more restricted one of the two.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
