### PR TITLE
Add fast-test option to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,15 @@ endif
 .PHONY: test
 test:
 	# test all packages
-	GO111MODULE=on go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race -coverpkg $(COVERPKGS) ./...
+	GO111MODULE=on MallocNanoZone=0 go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race -coverpkg $(COVERPKGS) ./...
 	# remove coverage of empty functions from report
 	sed -i -e 's/^.* 0 0$$//' coverage.txt
 	cd ./languageserver && make test
+
+.PHONY: fast-test
+fast-test:
+	# test all packages
+	GO111MODULE=on go test -parallel 8 ./...
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 .PHONY: test
 test:
 	# test all packages
-	GO111MODULE=on MallocNanoZone=0 go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race -coverpkg $(COVERPKGS) ./...
+	GO111MODULE=on go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race -coverpkg $(COVERPKGS) ./...
 	# remove coverage of empty functions from report
 	sed -i -e 's/^.* 0 0$$//' coverage.txt
 	cd ./languageserver && make test


### PR DESCRIPTION
This adds a `make fast-test` option to just run the basic tests without the coverage and race detection for easier testing locally. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
