### PR TITLE
fix double count memory

### DIFF
--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -107,7 +107,6 @@ type InterfaceStaticType struct {
 
 var _ StaticType = InterfaceStaticType{}
 
-// TODO when is this called?
 func NewInterfaceStaticType(
 	memoryGauge common.MemoryGauge,
 	location common.Location,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -463,7 +463,6 @@ func (VoidValue) Walk(_ *Interpreter, _ func(Value)) {
 }
 
 func (VoidValue) StaticType(interpreter *Interpreter) StaticType {
-	common.UseConstantMemory(interpreter, common.MemoryKindPrimitiveStaticType)
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeVoid)
 }
 


### PR DESCRIPTION
Works toward #1503 

## Description

Found a bug from merging: double counting memory for void primitive type.

Also removed dev reminder "TODO".

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
