### PR TITLE
Don't report errors for invalid types

### DIFF
--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -43,23 +43,23 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) as
 		)
 	}
 
+	checkExpectedType := func(valueType, expectedType Type) Type {
+		if !valueType.IsInvalidType() &&
+			!IsSameTypeKind(valueType, expectedType) {
+
+			reportInvalidUnaryOperator(expectedType)
+			return InvalidType
+		}
+
+		return valueType
+	}
+
 	switch expression.Operation {
 	case ast.OperationNegate:
-		expectedType := BoolType
-		if !IsSameTypeKind(valueType, expectedType) {
-			reportInvalidUnaryOperator(expectedType)
-			return InvalidType
-		}
-		return valueType
+		return checkExpectedType(valueType, BoolType)
 
 	case ast.OperationMinus:
-		expectedType := SignedNumberType
-		if !IsSameTypeKind(valueType, expectedType) {
-			reportInvalidUnaryOperator(expectedType)
-			return InvalidType
-		}
-
-		return valueType
+		return checkExpectedType(valueType, SignedNumberType)
 
 	case ast.OperationMove:
 		if !valueType.IsInvalidType() &&

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -67,13 +67,15 @@ func (checker *Checker) visitVariableDeclaration(declaration *ast.VariableDeclar
 		optionalType, isOptional := valueType.(*OptionalType)
 
 		if !isOptional || optionalType.Equal(declarationType) {
-			checker.report(
-				&TypeMismatchError{
-					ExpectedType: &OptionalType{},
-					ActualType:   valueType,
-					Range:        ast.NewRangeFromPositioned(declaration.Value),
-				},
-			)
+			if !valueType.IsInvalidType() {
+				checker.report(
+					&TypeMismatchError{
+						ExpectedType: &OptionalType{},
+						ActualType:   valueType,
+						Range:        ast.NewRangeFromPositioned(declaration.Value),
+					},
+				)
+			}
 		} else if declarationType == nil {
 			declarationType = optionalType.Type
 		}

--- a/runtime/tests/checker/if_test.go
+++ b/runtime/tests/checker/if_test.go
@@ -107,6 +107,21 @@ func TestCheckIfStatementTestWithDeclaration(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCheckInvalidIfStatementTestWithDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test() {
+          if let y = x {}
+      }
+    `)
+
+	errs := ExpectCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+}
+
 func TestCheckInvalidIfStatementTestWithDeclarationReferenceInElse(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -48,11 +48,30 @@ func TestCheckUnaryBooleanNegation(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheck(t, `
-      let a = !true
-	`)
+	t.Run("valid", func(t *testing.T) {
 
-	require.NoError(t, err)
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let a = !true
+	    `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let a = !x
+	    `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
+
 }
 
 func TestCheckInvalidUnaryIntegerNegationOfBoolean(t *testing.T) {
@@ -72,11 +91,30 @@ func TestCheckUnaryIntegerNegation(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheck(t, `
-      let a = -1
-	`)
+	t.Run("valid", func(t *testing.T) {
 
-	require.NoError(t, err)
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let a = -1
+	    `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let a = -x
+	    `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
+
 }
 
 type operationTest struct {


### PR DESCRIPTION
## Description

While analyzing contracts I noticed several unnecessary error messages for invalid types, which are results for previous errors.

Just like everywhere else already, don't report errors for unexpected invalid types for:
- Unary expressions, e.g. for unary negation. 
  Reported an error like `expected Bool, got <<invalid>>`
- Optional-binding variable declaration (e.g `if let nonOpt = opt { ... }`). 
  Reported an error like `expected optional, got <<invalid>>`
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
