### PR TITLE
[LS] Crash reporting

### DIFF
--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -3,6 +3,7 @@ module github.com/onflow/cadence/languageserver
 go 1.16
 
 require (
+	github.com/getsentry/sentry-go v0.13.0
 	github.com/google/uuid v1.3.0
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/mapstructure v1.4.3

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -372,6 +372,7 @@ github.com/gammazero/workerpool v1.1.2/go.mod h1:UelbXcO0zCIGFcufcirHhq2/xtLXJdQ
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getsentry/sentry-go v0.12.0/go.mod h1:NSap0JBYWzHND8oMbyi0+XZhUalc1TBdRL1M71JZW2c=
+github.com/getsentry/sentry-go v0.13.0 h1:20dgTiUSfxRB/EhMPtxcL9ZEbM1ZdR+W/7f7NWD+xWo=
 github.com/getsentry/sentry-go v0.13.0/go.mod h1:EOsfu5ZdvKPfeHYV6pTVQnsjfp30+XA7//UooKNumH0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
@@ -382,6 +383,7 @@ github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
@@ -1399,6 +1401,7 @@ github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/languageserver/jsonrpc2/server.go
+++ b/languageserver/jsonrpc2/server.go
@@ -22,6 +22,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
+	"github.com/getsentry/sentry-go"
 
 	"github.com/sourcegraph/jsonrpc2"
 )
@@ -50,6 +53,8 @@ func (handler *handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *js
 		return
 	}
 
+	defer sentry.Flush(2 * time.Second)
+	defer sentry.Recover()
 	result, err := method(req.Params)
 
 	if req.Notif {

--- a/languageserver/run.sh
+++ b/languageserver/run.sh
@@ -4,7 +4,7 @@ SCRIPTPATH=$(dirname "$0")
 
 
 if [ "$1" = "cadence" ] && [ "$2" = "language-server" ] ; then
-	(cd "$SCRIPTPATH" && go build -gcflags='-N -l' ./cmd/languageserver && ./languageserver "$@");
+	(cd "$SCRIPTPATH" && go build -gcflags="all=-N -l" ./cmd/languageserver && ./languageserver "$@");
 else
 	flow "$@"
 fi

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -376,13 +376,11 @@ func (s *Server) Initialize(
 
 // initCrashReporting set-ups sentry as crash reporting tool, it also sets listener for panics.
 func initCrashReporting(server *Server) {
-	currentVersion := ""
 	sentrySyncTransport := sentry.NewHTTPSyncTransport()
 	sentrySyncTransport.Timeout = time.Second * 3
 
 	_ = sentry.Init(sentry.ClientOptions{
 		Dsn:              "https://7725b80e4d5a4625845270176a6d8bd5@o114654.ingest.sentry.io/6330569",
-		Release:          currentVersion,
 		AttachStacktrace: true,
 		Transport:        sentrySyncTransport,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/onflow/cadence/encoding/json"
@@ -189,6 +190,8 @@ type Server struct {
 	// initializationOptionsHandlers are the functions that are used to handle initialization options sent by the client
 	initializationOptionsHandlers []InitializationOptionsHandler
 	accessCheckMode               sema.AccessCheckMode
+	// reportCrashes decides when the crash is detected should it be reported
+	reportCrashes bool
 }
 
 type Option func(*Server) error
@@ -288,8 +291,10 @@ func NewServer() (*Server, error) {
 	}
 	server.protocolServer = protocol.NewServer(server)
 
-	// Set default commands
+	// init crash reporting
+	initCrashReporting(server)
 
+	// Set default commands
 	for _, command := range server.defaultCommands() {
 		err := server.SetOptions(WithCommand(command))
 		if err != nil {
@@ -369,7 +374,31 @@ func (s *Server) Initialize(
 	return result, nil
 }
 
-const accessCheckModeOption = "accessCheckMode"
+// initCrashReporting set-ups sentry as crash reporting tool, it also sets listener for panics.
+func initCrashReporting(server *Server) {
+	currentVersion := ""
+	sentrySyncTransport := sentry.NewHTTPSyncTransport()
+	sentrySyncTransport.Timeout = time.Second * 3
+
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn:              "https://7725b80e4d5a4625845270176a6d8bd5@o114654.ingest.sentry.io/6330569",
+		Release:          currentVersion,
+		AttachStacktrace: true,
+		Transport:        sentrySyncTransport,
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if server.reportCrashes {
+				return event
+			}
+
+			return nil
+		},
+	})
+}
+
+const (
+	accessCheckModeOption = "accessCheckMode"
+	reportCrashesOption   = "reportCrashes"
+)
 
 func accessCheckModeFromName(name string) sema.AccessCheckMode {
 	switch name {
@@ -400,6 +429,12 @@ func (s *Server) configure(opts interface{}) {
 		s.accessCheckMode = accessCheckModeFromName(accessCheckModeName)
 	} else {
 		s.accessCheckMode = sema.AccessCheckModeStrict
+	}
+
+	if reportCrashesValue, ok := optsMap[reportCrashesOption].(bool); ok {
+		s.reportCrashes = reportCrashesValue
+	} else {
+		s.reportCrashes = true // report by default
 	}
 }
 

--- a/languageserver/test/util.go
+++ b/languageserver/test/util.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"log"
+	"os"
+	"time"
+)
+
+// Utility functions for debugging the language server.
+
+var logFile *os.File
+var outFile *os.File
+
+func SetupLogging() {
+	if logFile != nil {
+		return
+	}
+	logFile, _ = os.OpenFile("debug.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	log.SetOutput(logFile)
+
+	_, _ = logFile.Write(nil) // empty
+}
+
+// SetupDebugStdout reads from stdout and stderr and writes to a file.
+//
+// You can view stdout and stderr by reading a std.log file by using `tail -f ./std.log`.
+func SetupDebugStdout() {
+	if outFile != nil {
+		return
+	}
+	outFile, _ = os.OpenFile("std.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rErr, wErr, _ := os.Pipe()
+	os.Stderr = wErr
+
+	go func() {
+		for {
+			buff := make([]byte, 1024)
+			_, _ = r.Read(buff)
+			_, _ = outFile.Write(buff)
+
+			buffErr := make([]byte, 1024)
+			_, _ = rErr.Read(buffErr)
+			_, _ = outFile.Write(buffErr)
+
+			time.Sleep(500 * time.Millisecond)
+		}
+	}()
+}
+
+// Log is a helper to log to a file during debugging or development.
+//
+// You can view logs by using the command `tail -f ./debug.log` in the root langauge server folder.
+func Log(msg string) {
+	SetupLogging()
+	log.Println(msg)
+}

--- a/languageserver/test/util.go
+++ b/languageserver/test/util.go
@@ -54,7 +54,7 @@ func SetupDebugStdout() {
 // Log is a helper to log to a file during debugging or development.
 //
 // You can view logs by using the command `tail -f ./debug.log` in the root langauge server folder.
-func Log(msg string) {
+func Log(msg ...interface{}) {
 	SetupLogging()
 	log.Println(msg)
 }


### PR DESCRIPTION
Closes #1573 

## Description
This PR implements crash reporting using Sentry. It defaults to enabled but gives an option to be set during server initialization and by the client option.

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
