### PR TITLE
[LS] Debugging documentation and utility functions

### DIFF
--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -45,3 +45,27 @@ make wasm
 
 The integration tests for the Cadence Language Server are written in TypeScript
 and can be found in the [`test` directory](https://github.com/onflow/cadence/tree/master/languageserver/test).
+
+
+### Debugging
+
+#### GoLang and VSCode
+You can setup debugging of Language Server in VSCode by first going in `VSCode Cadence > 
+Extension Settings` and under `Cadence: Flow Command` putting absolute location of `run.sh` script 
+found in this directory (example: `/Users/dapper/Dev/cadence/languageserver/run.sh`).
+
+After you set the run script you should follow ["Attach to a process on a local machine" tutorial to debug the language server in GoLand](https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-2-build-the-application).
+
+**M1 Problems**
+Currently running `gops` on OSX ARM architecture won't work. A workaround for debugging is to use 
+functionality in `tests/util.go`. You can use utility functions to log to a file like so:
+```go
+test.Log("test log")
+```
+And at the same time run the command in your terminal:
+```bash
+tail -f ./debug.log
+```
+Doing so you should see the output of all Log calls you make. 
+
+*Note: this method works on all architectures*

--- a/languageserver/run.sh
+++ b/languageserver/run.sh
@@ -4,7 +4,7 @@ SCRIPTPATH=$(dirname "$0")
 
 
 if [ "$1" = "cadence" ] && [ "$2" = "language-server" ] ; then
-	(cd "$SCRIPTPATH" && go build -gcflags='-N -l' ./cmd/languageserver && ./languageserver "$@");
+	(cd "$SCRIPTPATH" && go build -gcflags="all=-N -l" ./cmd/languageserver && ./languageserver "$@");
 else
 	flow "$@"
 fi

--- a/languageserver/test/util.go
+++ b/languageserver/test/util.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test
 
 import (

--- a/languageserver/test/util.go
+++ b/languageserver/test/util.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"log"
+	"os"
+	"time"
+)
+
+// Utility functions for debugging the language server.
+
+var logFile *os.File
+var outFile *os.File
+
+func SetupLogging() {
+	if logFile != nil {
+		return
+	}
+	logFile, _ = os.OpenFile("debug.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	log.SetOutput(logFile)
+
+	_, _ = logFile.Write(nil) // empty
+}
+
+// SetupDebugStdout reads from stdout and stderr and writes to a file.
+//
+// You can view stdout and stderr by reading a std.log file by using `tail -f ./std.log`.
+func SetupDebugStdout() {
+	if outFile != nil {
+		return
+	}
+	outFile, _ = os.OpenFile("std.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	rErr, wErr, _ := os.Pipe()
+	os.Stderr = wErr
+
+	go func() {
+		for {
+			buff := make([]byte, 1024)
+			_, _ = r.Read(buff)
+			_, _ = outFile.Write(buff)
+
+			buffErr := make([]byte, 1024)
+			_, _ = rErr.Read(buffErr)
+			_, _ = outFile.Write(buffErr)
+
+			time.Sleep(500 * time.Millisecond)
+		}
+	}()
+}
+
+// Log is a helper to log to a file during debugging or development.
+//
+// You can view logs by using the command `tail -f ./debug.log` in the root langauge server folder.
+func Log(msg ...interface{}) {
+	SetupLogging()
+	log.Println(msg)
+}


### PR DESCRIPTION
## Description
This PR updates the `run.sh` script, adds a description on how to debug, and also adds utility functions that can be used to debug on OSX ARM architecture. 

______

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
