### PR TITLE
revert "Remove addPublicKey and removePublicKey"

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -88,6 +88,19 @@ to the `prepare` phase of the transaction.
 
       let keys: AuthAccount.Keys
 
+      // Key management
+
+      // Adds a public key to the account.
+      // The public key must be encoded together with their signature algorithm, hashing algorithm and weight.
+      // This method is currently deprecated and is available only for the backward compatibility.
+      // `keys.add` method can be use instead.
+      fun addPublicKey(_ publicKey: [UInt8])
+
+      // Revokes the key at the given index.
+      // This method is currently deprecated and is available only for the backward compatibility.
+      // `keys.revoke` method can be use instead.
+      fun removePublicKey(_ index: Int)
+
       // Account storage API (see the section below for documentation)
 
       fun save<T>(_ value: T, to: StoragePath)
@@ -233,6 +246,23 @@ transaction(publicKey: [UInt8]) {
 }
 ```
 
+<Callout type="info">
+⚠️  Note: Keys can also be added using the `addPublicKey` function.
+However, this method is currently deprecated and is available only for the backward compatibility.
+The `addPublicKey` method accepts the public key encoded together with their signature algorithm,
+hashing algorithm and weight.
+
+```cadence
+transaction(key: [UInt8]) {
+    prepare(signer: AuthAccount) {
+        let account = AuthAccount(payer: signer)
+        account.addPublicKey(key)
+    }
+}
+```
+</Callout>
+
+
 #### Get Account Keys
 
 Keys that are added to an account can be retrieved using `get()` function, using the index of the key.
@@ -267,6 +297,11 @@ transaction() {
     }
 }
 ```
+
+<Callout type="info">
+⚠️  Note: Keys can also be removed using the `removePublicKey` function.
+However, this method is deprecated and is available only for the backward compatibility.
+</Callout>
 
 ## Account Storage
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -118,7 +118,7 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 				return nil
 			},
 			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(b)
+				return json.Decode(nil, b)
 			},
 		}
 

--- a/runtime/interpreter/account.go
+++ b/runtime/interpreter/account.go
@@ -42,12 +42,16 @@ func NewAuthAccountValue(
 	accountAvailableBalanceGet func() UFix64Value,
 	storageUsedGet func(interpreter *Interpreter) UInt64Value,
 	storageCapacityGet func(interpreter *Interpreter) UInt64Value,
+	addPublicKeyFunction FunctionValue,
+	removePublicKeyFunction FunctionValue,
 	contractsConstructor func() Value,
 	keysConstructor func() Value,
 ) Value {
 
 	fields := map[string]Value{
-		sema.AuthAccountAddressField: address,
+		sema.AuthAccountAddressField:         address,
+		sema.AuthAccountAddPublicKeyField:    addPublicKeyFunction,
+		sema.AuthAccountRemovePublicKeyField: removePublicKeyFunction,
 		sema.AuthAccountGetCapabilityField: accountGetCapabilityFunction(
 			inter,
 			address,

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func ByteArrayValueToByteSlice(interpreter *Interpreter, value Value) ([]byte, error) {
+func ByteArrayValueToByteSlice(memoryGauge common.MemoryGauge, value Value) ([]byte, error) {
 	array, ok := value.(*ArrayValue)
 	if !ok {
 		return nil, errors.New("value is not an array")
@@ -34,9 +34,9 @@ func ByteArrayValueToByteSlice(interpreter *Interpreter, value Value) ([]byte, e
 	result := make([]byte, 0, array.Count())
 
 	var err error
-	array.Iterate(interpreter, func(element Value) (resume bool) {
+	array.Iterate(memoryGauge, func(element Value) (resume bool) {
 		var b byte
-		b, err = ByteValueToByte(interpreter, element)
+		b, err = ByteValueToByte(memoryGauge, element)
 		if err != nil {
 			return false
 		}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -487,6 +487,8 @@ func (r *interpreterRuntime) newAuthAccountValue(
 		accountAvailableBalanceGetFunction(addressValue, context.Interface),
 		storageUsedGetFunction(addressValue, context.Interface, storage),
 		storageCapacityGetFunction(addressValue, context.Interface, storage),
+		r.newAddPublicKeyFunction(addressValue, context.Interface),
+		r.newRemovePublicKeyFunction(addressValue, context.Interface),
 		func() interpreter.Value {
 			return r.newAuthAccountContracts(
 				inter,
@@ -1929,6 +1931,96 @@ func storageCapacityGetFunction(
 		)
 
 	}
+}
+
+func (r *interpreterRuntime) newAddPublicKeyFunction(
+	addressValue interpreter.AddressValue,
+	runtimeInterface Interface,
+) *interpreter.HostFunctionValue {
+
+	// Converted addresses can be cached and don't have to be recomputed on each function invocation
+	address := addressValue.ToAddress()
+
+	return interpreter.NewHostFunctionValue(
+		func(invocation interpreter.Invocation) interpreter.Value {
+			publicKeyValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(runtimeErrors.NewUnreachableError())
+			}
+
+			publicKey, err := interpreter.ByteArrayValueToByteSlice(publicKeyValue)
+			if err != nil {
+				panic("addPublicKey requires the first argument to be a byte array")
+			}
+
+			wrapPanic(func() {
+				err = runtimeInterface.AddEncodedAccountKey(address, publicKey)
+			})
+			if err != nil {
+				panic(err)
+			}
+
+			inter := invocation.Interpreter
+
+			r.emitAccountEvent(
+				stdlib.AccountKeyAddedEventType,
+				runtimeInterface,
+				[]exportableValue{
+					newExportableValue(addressValue, inter),
+					newExportableValue(publicKeyValue, inter),
+				},
+			)
+
+			return interpreter.VoidValue{}
+		},
+		sema.AuthAccountTypeAddPublicKeyFunctionType,
+	)
+}
+
+func (r *interpreterRuntime) newRemovePublicKeyFunction(
+	addressValue interpreter.AddressValue,
+	runtimeInterface Interface,
+) *interpreter.HostFunctionValue {
+
+	// Converted addresses can be cached and don't have to be recomputed on each function invocation
+	address := addressValue.ToAddress()
+
+	return interpreter.NewHostFunctionValue(
+		func(invocation interpreter.Invocation) interpreter.Value {
+			index, ok := invocation.Arguments[0].(interpreter.IntValue)
+			if !ok {
+				panic(runtimeErrors.NewUnreachableError())
+			}
+
+			var publicKey []byte
+			var err error
+			wrapPanic(func() {
+				publicKey, err = runtimeInterface.RevokeEncodedAccountKey(address, index.ToInt())
+			})
+			if err != nil {
+				panic(err)
+			}
+
+			inter := invocation.Interpreter
+
+			publicKeyValue := interpreter.ByteSliceToByteArrayValue(
+				inter,
+				publicKey,
+			)
+
+			r.emitAccountEvent(
+				stdlib.AccountKeyRemovedEventType,
+				runtimeInterface,
+				[]exportableValue{
+					newExportableValue(addressValue, inter),
+					newExportableValue(publicKeyValue, inter),
+				},
+			)
+
+			return interpreter.VoidValue{}
+		},
+		sema.AuthAccountTypeRemovePublicKeyFunctionType,
+	)
 }
 
 // recordContractValue records the update of the given contract value.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -487,8 +487,8 @@ func (r *interpreterRuntime) newAuthAccountValue(
 		accountAvailableBalanceGetFunction(addressValue, context.Interface),
 		storageUsedGetFunction(addressValue, context.Interface, storage),
 		storageCapacityGetFunction(addressValue, context.Interface, storage),
-		r.newAddPublicKeyFunction(addressValue, context.Interface),
-		r.newRemovePublicKeyFunction(addressValue, context.Interface),
+		r.newAddPublicKeyFunction(inter, addressValue, context.Interface),
+		r.newRemovePublicKeyFunction(inter, addressValue, context.Interface),
 		func() interpreter.Value {
 			return r.newAuthAccountContracts(
 				inter,
@@ -1934,6 +1934,7 @@ func storageCapacityGetFunction(
 }
 
 func (r *interpreterRuntime) newAddPublicKeyFunction(
+	gauge common.MemoryGauge,
 	addressValue interpreter.AddressValue,
 	runtimeInterface Interface,
 ) *interpreter.HostFunctionValue {
@@ -1942,13 +1943,14 @@ func (r *interpreterRuntime) newAddPublicKeyFunction(
 	address := addressValue.ToAddress()
 
 	return interpreter.NewHostFunctionValue(
+		gauge,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			publicKeyValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
 				panic(runtimeErrors.NewUnreachableError())
 			}
 
-			publicKey, err := interpreter.ByteArrayValueToByteSlice(publicKeyValue)
+			publicKey, err := interpreter.ByteArrayValueToByteSlice(gauge, publicKeyValue)
 			if err != nil {
 				panic("addPublicKey requires the first argument to be a byte array")
 			}
@@ -1978,6 +1980,7 @@ func (r *interpreterRuntime) newAddPublicKeyFunction(
 }
 
 func (r *interpreterRuntime) newRemovePublicKeyFunction(
+	gauge common.MemoryGauge,
 	addressValue interpreter.AddressValue,
 	runtimeInterface Interface,
 ) *interpreter.HostFunctionValue {
@@ -1986,6 +1989,7 @@ func (r *interpreterRuntime) newRemovePublicKeyFunction(
 	address := addressValue.ToAddress()
 
 	return interpreter.NewHostFunctionValue(
+		gauge,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			index, ok := invocation.Arguments[0].(interpreter.IntValue)
 			if !ok {

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -99,13 +99,13 @@ var AuthAccountType = func() *CompositeType {
 			AuthAccountTypeAddPublicKeyFunctionType,
 			authAccountTypeAddPublicKeyFunctionDocString,
 		),
-		NewPublicFunctionMember(
+		NewUnmeteredPublicFunctionMember(
 			authAccountType,
 			AuthAccountRemovePublicKeyField,
 			AuthAccountTypeRemovePublicKeyFunctionType,
 			authAccountTypeRemovePublicKeyFunctionDocString,
 		),
-		NewPublicFunctionMember(
+		NewUnmeteredPublicFunctionMember(
 			authAccountType,
 			AuthAccountSaveField,
 			AuthAccountTypeSaveFunctionType,

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -28,6 +28,8 @@ const AuthAccountBalanceField = "balance"
 const AuthAccountAvailableBalanceField = "availableBalance"
 const AuthAccountStorageUsedField = "storageUsed"
 const AuthAccountStorageCapacityField = "storageCapacity"
+const AuthAccountAddPublicKeyField = "addPublicKey"
+const AuthAccountRemovePublicKeyField = "removePublicKey"
 const AuthAccountSaveField = "save"
 const AuthAccountLoadField = "load"
 const AuthAccountTypeField = "type"
@@ -92,6 +94,18 @@ var AuthAccountType = func() *CompositeType {
 			accountTypeStorageCapacityFieldDocString,
 		),
 		NewUnmeteredPublicFunctionMember(
+			authAccountType,
+			AuthAccountAddPublicKeyField,
+			AuthAccountTypeAddPublicKeyFunctionType,
+			authAccountTypeAddPublicKeyFunctionDocString,
+		),
+		NewPublicFunctionMember(
+			authAccountType,
+			AuthAccountRemovePublicKeyField,
+			AuthAccountTypeRemovePublicKeyFunctionType,
+			authAccountTypeRemovePublicKeyFunctionDocString,
+		),
+		NewPublicFunctionMember(
 			authAccountType,
 			AuthAccountSaveField,
 			AuthAccountTypeSaveFunctionType,
@@ -163,6 +177,44 @@ var AuthAccountType = func() *CompositeType {
 	authAccountType.Fields = getFieldNames(members)
 	return authAccountType
 }()
+
+var AuthAccountTypeAddPublicKeyFunctionType = &FunctionType{
+	Parameters: []*Parameter{
+		{
+			Label:      ArgumentLabelNotRequired,
+			Identifier: "key",
+			TypeAnnotation: NewTypeAnnotation(
+				ByteArrayType,
+			),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		VoidType,
+	),
+}
+
+const authAccountTypeAddPublicKeyFunctionDocString = `
+Adds the given byte representation of a public key to the account's keys
+`
+
+var AuthAccountTypeRemovePublicKeyFunctionType = &FunctionType{
+	Parameters: []*Parameter{
+		{
+			Label:      ArgumentLabelNotRequired,
+			Identifier: "index",
+			TypeAnnotation: NewTypeAnnotation(
+				IntType,
+			),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		VoidType,
+	),
+}
+
+const authAccountTypeRemovePublicKeyFunctionDocString = `
+Removes the public key at the given index from the account's keys
+`
 
 var AuthAccountTypeSaveFunctionType = func() *FunctionType {
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -8768,6 +8768,8 @@ func newTestAuthAccountValue(
 		returnZeroUFix64,
 		returnZeroUInt64,
 		returnZeroUInt64,
+		panicFunction,
+		panicFunction,
 		func() interpreter.Value {
 			return interpreter.NewAuthAccountContractsValue(
 				inter,


### PR DESCRIPTION
Closes #1602 

## Description

We want to minimize the set of breaking changes for testing memory metering and for secure cadence.

PR being reverted: https://github.com/onflow/cadence/pull/1515

Reversions on the flow-go side are unnecessary because the changes there are compatible either way: I switched the tests and a script to use the V2 API for adding and removing keys. Both APIs are supported.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
