### PR TITLE
Pool lexers to reduce allocations and improve performance

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,7 +63,7 @@ jobs:
           export PATH=$PATH:$(go env GOPATH)/bin
           GO111MODULE=off go get golang.org/x/perf/cmd/benchstat
           echo "BENCHSTAT<<EOF" >> $GITHUB_ENV
-          echo "$(benchstat -html -sort delta old.txt new.txt | sed  '/<title/,/<\/style>/d' | sed 's/<!doctype html>//g')" >> $GITHUB_ENV
+          echo "$(benchstat -html -sort name old.txt new.txt | sed  '/<title/,/<\/style>/d' | sed 's/<!doctype html>//g')" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Find existing comment on PR
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run benchmark on current branch
         run: |
-          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' ) | tee new.txt
+          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' ) | tee new.txt
       # the package replace line above is to make the results table more readable, since it is not fragmented by package
       
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run benchmark on base branch
         run: |
-          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' ) | tee old.txt
+          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/runtime/' ) | tee old.txt
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison
@@ -81,7 +81,7 @@ jobs:
           body: |
             ## Cadence [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison
             This branch with compared with the base branch ${{  github.event.pull_request.base.label }} commit ${{ github.event.pull_request.base.sha }}
-            The command `for i in {1..N}; do go test ./... -run=XXX -bench=. -shuffle=on; done` was used.
+            The command `for i in {1..N}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done` was used.
             Bench tests were run a total of ${{ steps.settings.outputs.benchmark_repetitions }} times on each branch.
             ## Results
             ${{ env.BENCHSTAT }}

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -103,6 +103,7 @@ func Lex(input string) TokenStream {
 		prevEndOffset: 0,
 		current:       EOF,
 		prev:          EOF,
+		tokens:        make([]Token, 0, 2048),
 	}
 	l.run(rootState)
 	return l

--- a/runtime/parser2/lexer/tokenstream.go
+++ b/runtime/parser2/lexer/tokenstream.go
@@ -25,4 +25,5 @@ type TokenStream interface {
 	Revert(cursor int)
 	// Input returns the whole input as source code
 	Input() string
+	Reclaim()
 }

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -56,6 +56,7 @@ type parser struct {
 func Parse(input string, parse func(*parser) interface{}) (result interface{}, errors []error) {
 	// create a lexer, which turns the input string into tokens
 	tokens := lexer.Lex(input)
+	defer tokens.Reclaim()
 	return ParseTokenStream(tokens, parse)
 }
 
@@ -432,7 +433,9 @@ func ParseArgumentList(input string) (arguments ast.Arguments, errs []error) {
 }
 
 func ParseProgram(input string) (program *ast.Program, err error) {
-	return ParseProgramFromTokenStream(lexer.Lex(input))
+	tokens := lexer.Lex(input)
+	defer tokens.Reclaim()
+	return ParseProgramFromTokenStream(tokens)
 }
 
 func ParseProgramFromTokenStream(input lexer.TokenStream) (program *ast.Program, err error) {


### PR DESCRIPTION
## Description

@simonhf pointed out that execution is allocating a lot of memory, specifically emitting tokens in the token stream (`append` on a slice). Pre-allocating an array reduces the overhead of append.

I then also realized that the token stream itself is allocated and not used after parsing, so we can reduce allocations by introducing an object pool for lexers.

This significantly reduces amount of allocated memory and also increases performance as a side-effect.

Also, improve the benchmarking workflow:
- Enable memory statistics for all benchmarks
- Sort benchmarks by name. This makes it easier to find benchmarks in the output (e.g. see performance improvement -> check memory benchmark results)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
