### PR TITLE
Improve constant-sized type parsing

### DIFF
--- a/runtime/parser2/lexer/tokentype.go
+++ b/runtime/parser2/lexer/tokentype.go
@@ -206,3 +206,17 @@ func (t TokenType) String() string {
 		panic(errors.NewUnreachableError())
 	}
 }
+
+func (t TokenType) IsIntegerLiteral() bool {
+	switch t {
+	case TokenBinaryIntegerLiteral,
+		TokenOctalIntegerLiteral,
+		TokenDecimalIntegerLiteral,
+		TokenHexadecimalIntegerLiteral,
+		TokenUnknownBaseIntegerLiteral:
+		return true
+
+	default:
+		return false
+	}
+}

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -222,16 +222,21 @@ func defineArrayType() {
 
 				p.skipSpaceAndComments(true)
 
-				numberExpression := parseExpression(p, lowestBindingPower)
+				if !p.current.Type.IsIntegerLiteral() {
+					p.report(fmt.Errorf("expected positive integer size for constant sized type"))
 
-				integerExpression, ok := numberExpression.(*ast.IntegerExpression)
-				if !ok {
-					p.report(fmt.Errorf(
-						"expected integer size for constant sized type, got %s",
-						numberExpression,
-					))
+					// Skip the invalid non-integer literal token
+					p.next()
+
 				} else {
-					size = integerExpression
+					numberExpression := parseExpression(p, lowestBindingPower)
+
+					integerExpression, ok := numberExpression.(*ast.IntegerExpression)
+					if !ok || integerExpression.Value.Sign() < 0 {
+						p.report(fmt.Errorf("expected positive integer size for constant sized type"))
+					} else {
+						size = integerExpression
+					}
 				}
 			}
 

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -137,6 +137,38 @@ func TestParseArrayType(t *testing.T) {
 		)
 	})
 
+	t.Run("constant, invalid size", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseType("[Int ; X ]")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: `expected positive integer size for constant sized type`,
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+				},
+			},
+			errs,
+		)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.VariableSizedType{
+				Type: &ast.NominalType{
+					Identifier: ast.Identifier{
+						Identifier: "Int",
+						Pos:        ast.Position{Offset: 1, Line: 1, Column: 1},
+					},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+					EndPos:   ast.Position{Offset: 9, Line: 1, Column: 9},
+				},
+			},
+			result,
+		)
+	})
+
 }
 
 func TestParseOptionalType(t *testing.T) {

--- a/runtime/parser2/type_test.go
+++ b/runtime/parser2/type_test.go
@@ -137,6 +137,29 @@ func TestParseArrayType(t *testing.T) {
 		)
 	})
 
+	t.Run("constant, negative size", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseType("[Int ; -2 ]")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: `expected positive integer size for constant sized type`,
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+				},
+				// TODO: improve/avoid error by skipping full negative integer literal
+				&SyntaxError{
+					Message: `expected token ']'`,
+					Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
+				},
+			},
+			errs,
+		)
+
+		require.Nil(t, result)
+	})
+
 	t.Run("constant, invalid size", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -1079,17 +1079,6 @@ func TestCheckInvalidConstantSizedArrayDeclarationOutOfRangeSize(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("negative", func(t *testing.T) {
-
-		_, err := ParseAndCheck(t, `
-          let x: [Int; -1] = []
-		`)
-
-		errs := ExpectCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.InvalidConstantSizedTypeSizeError{}, errs[0])
-	})
-
 	t.Run("too large", func(t *testing.T) {
 
 		tooLarge := new(big.Int).SetUint64(math.MaxUint64)


### PR DESCRIPTION
## Description

Optimize parsing of the size in constant-sized types by directly checking for an integer literal.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
