### PR TITLE
Suggest optional chaining when member access is on optional type

### DIFF
--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -703,6 +703,13 @@ func (e *NotDeclaredMemberError) Error() string {
 }
 
 func (e *NotDeclaredMemberError) SecondaryError() string {
+	if optionalType, ok := e.Type.(*OptionalType); ok {
+		members := optionalType.Type.GetMembers()
+		name := e.Name
+		if _, ok := members[name]; ok {
+			return fmt.Sprintf("type is optional, consider optional-chaining: ?.%s", name)
+		}
+	}
 	return "unknown member"
 }
 
@@ -1807,7 +1814,11 @@ type InvalidResourceAssignmentError struct {
 }
 
 func (e *InvalidResourceAssignmentError) Error() string {
-	return "cannot assign to resource-typed target. consider force assigning (<-!) or swapping (<->)"
+	return "cannot assign to resource-typed target"
+}
+
+func (e *InvalidResourceAssignmentError) SecondaryError() string {
+	return "consider force assigning (<-!) or swapping (<->)"
 }
 
 func (*InvalidResourceAssignmentError) isSemanticError() {}

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
@@ -171,6 +172,9 @@ func ExpectCheckerErrors(t *testing.T, err error, count int) []error {
 
 	for _, checkerErr := range errs {
 		_ = checkerErr.Error()
+		if hasSecondaryError, ok := checkerErr.(errors.SecondaryError); ok {
+			_ = hasSecondaryError.SecondaryError()
+		}
 	}
 
 	return errs


### PR DESCRIPTION
## Description

Took 10 minutes to improve the developer experience: 

Developers often attempt to access a member of an optional type. 
The existing error is correct (the optional type does not have the requested member), but is not helpful.

When then the unwrapped type has the requested member, suggest optional chaining instead of a direct access.

Also, increase coverage for all errors, by producing their secondary error, if available.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
