### PR TITLE
Limit number of tokens which can be replayed (reparsed)

### DIFF
--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -5717,3 +5717,34 @@ func TestParseInvalidNegativeIntegerLiteralWithIncorrectPrefix(t *testing.T) {
 
 	require.Error(t, err)
 }
+
+func TestParseReplayLimit(t *testing.T) {
+
+	t.Parallel()
+
+	var builder strings.Builder
+	builder.WriteString("let t = T")
+	for i := 0; i < 100; i++ {
+		builder.WriteString("<T")
+	}
+	builder.WriteString(">()")
+
+	code := builder.String()
+	_, errs := ParseProgram(code)
+	utils.AssertEqualWithDiff(t,
+		Error{
+			Code: code,
+			Errors: []error{
+				&SyntaxError{
+					Message: fmt.Sprintf("program too ambiguous, replay limit of %d tokens exceeded", replayLimit),
+					Pos: ast.Position{
+						Offset: 210,
+						Line:   1,
+						Column: 210,
+					},
+				},
+			},
+		},
+		errs,
+	)
+}

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -5736,7 +5736,7 @@ func TestParseReplayLimit(t *testing.T) {
 			Code: code,
 			Errors: []error{
 				&SyntaxError{
-					Message: fmt.Sprintf("program too ambiguous, replay limit of %d tokens exceeded", replayLimit),
+					Message: fmt.Sprintf("program too ambiguous, replay limit of %d tokens exceeded", tokenReplayLimit),
 					Pos: ast.Position{
 						Offset: 210,
 						Line:   1,

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -250,6 +250,7 @@ func (p *parser) replayBuffered() {
 	backtrackCursor := p.backtrackingCursorStack[lastIndex]
 
 	replayedCount := p.replayedTokensCount + uint(cursor-backtrackCursor)
+	// Check for overflow (uint) and for exceeding the limit
 	if replayedCount < p.replayedTokensCount || replayedCount > tokenReplayLimit {
 		panic(fmt.Errorf("program too ambiguous, replay limit of %d tokens exceeded", tokenReplayLimit))
 	}

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -45,8 +45,9 @@ type parser struct {
 	backtrackingCursorStack []int
 	// bufferedErrorsStack is the stack of parsing errors encountered during buffering
 	bufferedErrorsStack [][]error
-	// replayedCount is the number of replayed tokens
-	replayedCount uint
+	// replayedTokensCount is the number of replayed tokens since starting the initial buffering.
+	// It is reset when the buffered tokens get accepted. This keeps errors local.
+	replayedTokensCount uint
 }
 
 // Parse creates a lexer to scan the given input string,
@@ -229,11 +230,14 @@ func (p *parser) acceptBuffered() {
 			bufferedErrors...,
 		)
 	}
+
+	// Reset the replayed tokens count
+	p.replayedTokensCount = 0
 }
 
-// replayLimit is a sensible limit for how many tokens may be replayed
-// while parsing a program
-const replayLimit = 2 << 12
+// tokenReplayLimit is a sensible limit for how many tokens may be replayed
+// until the replay buffer is accepted.
+const tokenReplayLimit = 2 << 12
 
 func (p *parser) replayBuffered() {
 
@@ -245,11 +249,11 @@ func (p *parser) replayBuffered() {
 	lastIndex := len(p.backtrackingCursorStack) - 1
 	backtrackCursor := p.backtrackingCursorStack[lastIndex]
 
-	replayedCount := p.replayedCount + uint(cursor-backtrackCursor)
-	if replayedCount < p.replayedCount || replayedCount > replayLimit {
-		panic(fmt.Errorf("program too ambiguous, replay limit of %d tokens exceeded", replayLimit))
+	replayedCount := p.replayedTokensCount + uint(cursor-backtrackCursor)
+	if replayedCount < p.replayedTokensCount || replayedCount > tokenReplayLimit {
+		panic(fmt.Errorf("program too ambiguous, replay limit of %d tokens exceeded", tokenReplayLimit))
 	}
-	p.replayedCount = replayedCount
+	p.replayedTokensCount = replayedCount
 
 	p.tokens.Revert(backtrackCursor)
 	p.next()


### PR DESCRIPTION
## Description

The parser may reparse parts of the program in cases of ambiguity.

Limit this to a sensible number of tokens. We may want to adjust this limit.

I validated this limit by parsing all Mainnet contracts and all of them remain parsable.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
