### PR TITLE
Fix parsing of reference expressions

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -29,8 +29,10 @@ import (
 	"github.com/onflow/cadence/runtime/parser2/lexer"
 )
 
+const exprBindingPowerGap = 10
+
 const (
-	exprLeftBindingPowerTernary = 10 * (iota + 2)
+	exprLeftBindingPowerTernary = exprBindingPowerGap * (iota + 2)
 	exprLeftBindingPowerLogicalOr
 	exprLeftBindingPowerLogicalAnd
 	exprLeftBindingPowerComparison
@@ -1117,8 +1119,7 @@ func defineReferenceExpression() {
 		lexer.TokenAmpersand,
 		func(p *parser, token lexer.Token) ast.Expression {
 			p.skipSpaceAndComments(true)
-			// TODO: maybe require above unary
-			expression := parseExpression(p, lowestBindingPower)
+			expression := parseExpression(p, exprLeftBindingPowerCasting-exprBindingPowerGap)
 
 			p.skipSpaceAndComments(true)
 

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -1878,6 +1878,111 @@ func TestParseReference(t *testing.T) {
 	)
 }
 
+func TestParseNilCoelesceReference(t *testing.T) {
+
+	t.Parallel()
+
+	result, errs := ParseExpression(`
+          &xs["a"] as &Int? ?? 1
+        `)
+	require.Empty(t, errs)
+
+	utils.AssertEqualWithDiff(t,
+		&ast.BinaryExpression{
+			Operation: ast.OperationNilCoalesce,
+			Left: &ast.ReferenceExpression{
+				Expression: &ast.IndexExpression{
+					TargetExpression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "xs",
+							Pos: ast.Position{
+								Offset: 12,
+								Line:   2,
+								Column: 11,
+							},
+						},
+					},
+					IndexingExpression: &ast.StringExpression{
+						Value: "a",
+						Range: ast.Range{
+							StartPos: ast.Position{
+								Offset: 15,
+								Line:   2,
+								Column: 14,
+							},
+							EndPos: ast.Position{
+								Offset: 17,
+								Line:   2,
+								Column: 16,
+							},
+						},
+					},
+					Range: ast.Range{
+						StartPos: ast.Position{
+							Offset: 14,
+							Line:   2,
+							Column: 13,
+						},
+						EndPos: ast.Position{
+							Offset: 18,
+							Line:   2,
+							Column: 17,
+						},
+					},
+				},
+				Type: &ast.OptionalType{
+					Type: &ast.ReferenceType{
+						Authorized: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "Int",
+								Pos: ast.Position{
+									Offset: 24,
+									Line:   2,
+									Column: 23,
+								},
+							},
+						},
+						StartPos: ast.Position{
+							Offset: 23,
+							Line:   2,
+							Column: 22,
+						},
+					},
+					EndPos: ast.Position{
+						Offset: 27,
+						Line:   2,
+						Column: 26,
+					},
+				},
+				StartPos: ast.Position{
+					Offset: 11,
+					Line:   2,
+					Column: 10,
+				},
+			},
+			Right: &ast.IntegerExpression{
+				PositiveLiteral: "1",
+				Value:           big.NewInt(1),
+				Base:            10,
+				Range: ast.Range{
+					StartPos: ast.Position{
+						Offset: 32,
+						Line:   2,
+						Column: 31,
+					},
+					EndPos: ast.Position{
+						Offset: 32,
+						Line:   2,
+						Column: 31,
+					},
+				},
+			},
+		},
+		result,
+	)
+}
+
 func TestParseCasts(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -1071,6 +1071,26 @@ func TestCheckReferenceExpressionOfOptional(t *testing.T) {
 	})
 }
 
+func TestCheckNilCoalesceReference(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheckWithPanic(t, `
+      let xs = {"a": 1}
+      let ref = &xs["a"] as &Int? ?? panic("no a")
+    `)
+	require.NoError(t, err)
+
+	refValueType := RequireGlobalValue(t, checker.Elaboration, "ref")
+
+	assert.Equal(t,
+		&sema.ReferenceType{
+			Type: sema.IntType,
+		},
+		refValueType,
+	)
+}
+
 func TestCheckInvalidReferenceExpressionNonReferenceAmbiguous(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
## Description

Reference expressions are parsed by parsing them as a casting expression.

Currently the reference operator `&` parses _any_ expression, which leads to confusing error messages for valid programs.
For example, currently an expression `&v as &T? ?? panic("no v")` is parsed as a reference to a nil-coalescing operation (`??`), instead of a nil-coalescing operation of a reference expression.

Only parse an expression which has a precedence as high as a casting expression, the expression kind we expect to parse.

This is not a breaking change: Previously the expressions were not accepted, now they will be.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
