### PR TITLE
Run language server with Delve

### DIFF
--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -45,3 +45,26 @@ make wasm
 
 The integration tests for the Cadence Language Server are written in TypeScript
 and can be found in the [`test` directory](https://github.com/onflow/cadence/tree/master/languageserver/test).
+
+### Development and Debugging
+
+You can configure the Visual Studio Code extension to use the source of the server in this directory,
+instead of the Flow CLI binary, and allowing this server to be debugged, e.g. using GoLand:
+
+1. Ensure the [Delve](https://github.com/go-delve/delve) debugger is installed, for example by running:
+    ```shell
+    $ go install github.com/go-delve/delve/cmd/dlv@latest
+    ```
+4. In Visual Studio Code, go to Settings
+5. Search for `Cadence: Flow Command`, and enter the full path to the `run.sh` script
+   found in this directory (for example: `/Users/dapper/Dev/cadence/languageserver/run.sh`).
+
+This will re-build the language server each time it is restarted
+(e.g. using the `Cadence: Restart Language Server` command).
+
+In addition, it will start the language server through the Delve debugger, by default on port 2345.
+This allows you to connect to the debugger and debug the server.
+
+If you are using GoLand, you can follow
+["Create the Go Remote run/debug configuration on the client computer"](https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-3-create-the-remote-run-debug-configuration-on-the-client-computer).
+Leave the hostname as `localhost`.

--- a/languageserver/run.sh
+++ b/languageserver/run.sh
@@ -2,9 +2,10 @@
 
 SCRIPTPATH=$(dirname "$0")
 
-
 if [ "$1" = "cadence" ] && [ "$2" = "language-server" ] ; then
-	(cd "$SCRIPTPATH" && go build -gcflags='-N -l' ./cmd/languageserver && ./languageserver "$@");
+	(cd "$SCRIPTPATH" && \
+		go build -gcflags="all=-N -l" ./cmd/languageserver && \
+		dlv --log-dest 2 --continue --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec ./languageserver "$@");
 else
 	flow "$@"
 fi


### PR DESCRIPTION
## Description

Improve the ability to debug the language server, by running it directly with Delve.

This removes the need for `gops`, which is used in the current process of attaching to a running with GoLand, but does not work on M1 machines.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
