### PR TITLE
Track inner values of resource-kinded optionals

### DIFF
--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -901,10 +901,15 @@ func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *as
 
 			getLocationRange := locationRangeGetter(interpreter.Location, referenceExpression.Expression)
 
+			innerValue := result.InnerValue(interpreter, getLocationRange)
+			if result, ok := innerValue.(ReferenceTrackedResourceKindedValue); ok {
+				interpreter.trackReferencedResourceKindedValue(result.StorageID(), result)
+			}
+
 			return NewSomeValueNonCopying(
 				&EphemeralReferenceValue{
 					Authorized:   innerBorrowType.Authorized,
-					Value:        result.InnerValue(interpreter, getLocationRange),
+					Value:        innerValue,
 					BorrowedType: innerBorrowType.Type,
 				},
 			)

--- a/runtime/missingmember_test.go
+++ b/runtime/missingmember_test.go
@@ -4968,7 +4968,7 @@ transaction {
 		{setupAccount2Tx, exampleNFTAddress},
 		{mintTokensTx, exampleTokenAddress},
 		{createSaleTx, exampleTokenAddress},
-		//	{purchaseTx, exampleTokenAddress},
+		{purchaseTx, exampleTokenAddress},
 	} {
 		signerAddress = tx.signer
 
@@ -4983,19 +4983,4 @@ transaction {
 		)
 		require.NoError(t, err)
 	}
-	signerAddress = exampleTokenAddress
-
-	err = runtime.ExecuteTransaction(
-		Script{
-			Source: []byte(purchaseTx),
-		},
-		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-		},
-	)
-	// TODO: this should not error
-	require.Error(t, err)
-	require.Equal(t, err.Error(),
-		"Execution failed:\nerror: missing value for member `id`\n   --> 0000000000000003.ExampleMarketplace:141:16\n")
 }

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -2335,3 +2335,39 @@ func TestInterpreterResourceDoubleWrappedCondition(t *testing.T) {
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 }
+
+func TestInterpretOptionalResourceReference(t *testing.T) {
+
+	t.Parallel()
+
+	address := interpreter.NewAddressValueFromBytes([]byte{42})
+
+	inter, _ := testAccount(
+		t,
+		address,
+		true,
+		`
+		resource R {
+			pub let id: Int
+	
+			init() {
+				self.id = 1
+			}
+		}
+	
+		fun test() {
+			account.save(<-{0 : <-create R()}, to: /storage/x)
+			let collection = account.borrow<&{Int: R}>(from: /storage/x)!
+	
+			let resourceRef = (&collection[0] as &R?)!
+			let token <- collection.remove(key: 0)!
+	
+			let x = resourceRef.id
+			destroy token
+		}				
+		`,
+	)
+
+	_, err := inter.Invoke("test")
+	require.NoError(t, err)
+}

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -1831,8 +1831,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
             fun test() {
                 let r <- create R()
-	            destroy (<- r)
-	            destroy r
+                destroy (<- r)
+                destroy r
             }`,
 			ParseCheckAndInterpretOptions{
 				HandleCheckerError: func(err error) {
@@ -1862,7 +1862,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
             fun test() {
                 let r <- create R()
-	            f(<- (<- r))
+                f(<- (<- r))
                 destroy r
             }`,
 			ParseCheckAndInterpretOptions{
@@ -2115,26 +2115,26 @@ func TestInterpreterResourcePreCondition(t *testing.T) {
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
-		resource S {}
+        resource S {}
 
-		struct interface Receiver {
-			pub fun deposit(from: @S) {
-				post {
-					from != nil: ""
-				}
-			}
-		}
-		
-		struct Vault: Receiver {
-			pub fun deposit(from: @S) {
-				destroy from
-			}
-		}
+        struct interface Receiver {
+            pub fun deposit(from: @S) {
+                post {
+                    from != nil: ""
+                }
+            }
+        }
+        
+        struct Vault: Receiver {
+            pub fun deposit(from: @S) {
+                destroy from
+            }
+        }
     
-	
-		fun test() {
-			Vault().deposit(from: <-create S())
-		}`,
+    
+        fun test() {
+            Vault().deposit(from: <-create S())
+        }`,
 		ParseCheckAndInterpretOptions{
 			Options: []interpreter.Option{
 				interpreter.WithInvalidatedResourceValidationEnabled(true),
@@ -2153,26 +2153,26 @@ func TestInterpreterResourcePostCondition(t *testing.T) {
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
-		resource S {}
+        resource S {}
 
-		struct interface Receiver {
-			pub fun deposit(from: @S) {
-				post {
-					from != nil: ""
-				}
-			}
-		}
-		
-		struct Vault: Receiver {
-			pub fun deposit(from: @S) {
-				destroy from
-			}
-		}
+        struct interface Receiver {
+            pub fun deposit(from: @S) {
+                post {
+                    from != nil: ""
+                }
+            }
+        }
+        
+        struct Vault: Receiver {
+            pub fun deposit(from: @S) {
+                destroy from
+            }
+        }
     
-	
-		fun test() {
-			Vault().deposit(from: <-create S())
-		}`,
+    
+        fun test() {
+            Vault().deposit(from: <-create S())
+        }`,
 		ParseCheckAndInterpretOptions{
 			Options: []interpreter.Option{
 				interpreter.WithInvalidatedResourceValidationEnabled(true),
@@ -2191,35 +2191,35 @@ func TestInterpreterResourcePreAndPostCondition(t *testing.T) {
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
-		resource S {}
+        resource S {}
 
-		struct interface Receiver {
-			pub fun deposit(from: @S) {
-				pre {
-					from != nil: ""
-				}
-				post {
-					from != nil: ""
-				}
-			}
-		}
-		
-		struct Vault: Receiver {
-			pub fun deposit(from: @S) {
-				pre {
-					from != nil: ""
-				}
-				post {
-					1 > 0: ""
-				}
-				destroy from
-			}
-		}
+        struct interface Receiver {
+            pub fun deposit(from: @S) {
+                pre {
+                    from != nil: ""
+                }
+                post {
+                    from != nil: ""
+                }
+            }
+        }
+        
+        struct Vault: Receiver {
+            pub fun deposit(from: @S) {
+                pre {
+                    from != nil: ""
+                }
+                post {
+                    1 > 0: ""
+                }
+                destroy from
+            }
+        }
     
-	
-		fun test() {
-			Vault().deposit(from: <-create S())
-		}`,
+    
+        fun test() {
+            Vault().deposit(from: <-create S())
+        }`,
 		ParseCheckAndInterpretOptions{
 			Options: []interpreter.Option{
 				interpreter.WithInvalidatedResourceValidationEnabled(true),
@@ -2238,35 +2238,35 @@ func TestInterpreterResourceConditionAdditionalParam(t *testing.T) {
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
-		resource S {}
+        resource S {}
 
-		struct interface Receiver {
-			pub fun deposit(from: @S, other: UInt64) {
-				pre {
-					from != nil: ""
-				}
-				post {
-					other > 0: ""
-				}
-			}
-		}
-		
-		struct Vault: Receiver {
-			pub fun deposit(from: @S, other: UInt64) {
-				pre {
-					from != nil: ""
-				}
-				post {
-					other > 0: ""
-				}
-				destroy from
-			}
-		}
+        struct interface Receiver {
+            pub fun deposit(from: @S, other: UInt64) {
+                pre {
+                    from != nil: ""
+                }
+                post {
+                    other > 0: ""
+                }
+            }
+        }
+        
+        struct Vault: Receiver {
+            pub fun deposit(from: @S, other: UInt64) {
+                pre {
+                    from != nil: ""
+                }
+                post {
+                    other > 0: ""
+                }
+                destroy from
+            }
+        }
     
-	
-		fun test() {
-			Vault().deposit(from: <-create S(), other: 42)
-		}`,
+    
+        fun test() {
+            Vault().deposit(from: <-create S(), other: 42)
+        }`,
 		ParseCheckAndInterpretOptions{
 			Options: []interpreter.Option{
 				interpreter.WithInvalidatedResourceValidationEnabled(true),
@@ -2285,45 +2285,45 @@ func TestInterpreterResourceDoubleWrappedCondition(t *testing.T) {
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
-		resource S {}
+        resource S {}
 
-		struct interface A {
-			pub fun deposit(from: @S) {
-				pre {
-					from != nil: ""
-				}
-				post {
-					from != nil: ""
-				}
-			}
-		}
-		
-		struct interface B {
-			pub fun deposit(from: @S) {
-				pre {
-					from != nil: ""
-				}
-				post {
-					from != nil: ""
-				}
-			}
-		}
-	
-	    struct Vault: A, B {
-			pub fun deposit(from: @S) {
-				pre {
-					from != nil: ""
-				}
-				post {
-					1 > 0: ""
-				}
-				destroy from
-			}
-		}
-	
-		fun test() {
-			Vault().deposit(from: <-create S())
-		}`,
+        struct interface A {
+            pub fun deposit(from: @S) {
+                pre {
+                    from != nil: ""
+                }
+                post {
+                    from != nil: ""
+                }
+            }
+        }
+        
+        struct interface B {
+            pub fun deposit(from: @S) {
+                pre {
+                    from != nil: ""
+                }
+                post {
+                    from != nil: ""
+                }
+            }
+        }
+    
+        struct Vault: A, B {
+            pub fun deposit(from: @S) {
+                pre {
+                    from != nil: ""
+                }
+                post {
+                    1 > 0: ""
+                }
+                destroy from
+            }
+        }
+    
+        fun test() {
+            Vault().deposit(from: <-create S())
+        }`,
 		ParseCheckAndInterpretOptions{
 			Options: []interpreter.Option{
 				interpreter.WithInvalidatedResourceValidationEnabled(true),
@@ -2347,25 +2347,61 @@ func TestInterpretOptionalResourceReference(t *testing.T) {
 		address,
 		true,
 		`
-		resource R {
-			pub let id: Int
-	
-			init() {
-				self.id = 1
-			}
-		}
-	
-		fun test() {
-			account.save(<-{0 : <-create R()}, to: /storage/x)
-			let collection = account.borrow<&{Int: R}>(from: /storage/x)!
-	
-			let resourceRef = (&collection[0] as &R?)!
-			let token <- collection.remove(key: 0)!
-	
-			let x = resourceRef.id
-			destroy token
-		}				
-		`,
+        resource R {
+            pub let id: Int
+    
+            init() {
+                self.id = 1
+            }
+        }
+    
+        fun test() {
+            account.save(<-{0 : <-create R()}, to: /storage/x)
+            let collection = account.borrow<&{Int: R}>(from: /storage/x)!
+    
+            let resourceRef = (&collection[0] as &R?)!
+            let token <- collection.remove(key: 0)
+			
+            let x = resourceRef.id
+            destroy token
+        }                
+        `,
+	)
+
+	_, err := inter.Invoke("test")
+	require.NoError(t, err)
+}
+
+func TestInterpretArrayOptionalResourceReference(t *testing.T) {
+
+	t.Parallel()
+
+	address := interpreter.NewAddressValueFromBytes([]byte{42})
+
+	inter, _ := testAccount(
+		t,
+		address,
+		true,
+		`
+        resource R {
+            pub let id: Int
+    
+            init() {
+                self.id = 1
+            }
+        }
+    
+        fun test() {
+            account.save(<-[<-create R()], to: /storage/x)
+            let collection = account.borrow<&[R?]>(from: /storage/x)!
+    
+            let resourceRef = (&collection[0] as &R?)!
+            let token <- collection.remove(at: 0)
+			
+            let x = resourceRef.id
+            destroy token
+        }                
+        `,
 	)
 
 	_, err := inter.Invoke("test")


### PR DESCRIPTION
Closes #1539

## Description

With the change in https://github.com/onflow/cadence/pull/1303, it is no longer possible to obtain a reference to an optional value, as all such references are automatically transformed into optional references. However, these references were not properly tracked by the logic added in https://github.com/onflow/cadence/pull/1344, meaning that the linked issue was still possible despite the cause seemingly being removed. This adds proper tracking for the inner values of resource-kinded optionals. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
