### PR TITLE
cadence.Value.Type method back to original param list

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -281,7 +281,7 @@ func (d *Decoder) decodeAddress(valueJSON interface{}) cadence.Address {
 		panic(ErrInvalidJSONCadence)
 	}
 
-	return cadence.BytesToAddress(d.gauge, b)
+	return cadence.BytesToMeteredAddress(d.gauge, b)
 }
 
 func (d *Decoder) decodeBigInt(valueJSON interface{}) *big.Int {

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -532,8 +532,8 @@ func (d *Decoder) decodeWord64(valueJSON interface{}) cadence.Word64 {
 }
 
 func (d *Decoder) decodeFix64(valueJSON interface{}) cadence.Fix64 {
-	v, err := cadence.NewMeteredFix64(d.gauge, func() (int64, error) {
-		return cadence.ParseFix64(toString(valueJSON))
+	v, err := cadence.NewMeteredFix64(d.gauge, func() (string, error) {
+		return toString(valueJSON), nil
 	})
 	if err != nil {
 		// TODO: improve error message
@@ -543,8 +543,8 @@ func (d *Decoder) decodeFix64(valueJSON interface{}) cadence.Fix64 {
 }
 
 func (d *Decoder) decodeUFix64(valueJSON interface{}) cadence.UFix64 {
-	v, err := cadence.NewMeteredUFix64(d.gauge, func() (uint64, error) {
-		return cadence.ParseUFix64(toString(valueJSON))
+	v, err := cadence.NewMeteredUFix64(d.gauge, func() (string, error) {
+		return toString(valueJSON), nil
 	})
 	if err != nil {
 		// TODO: improve error message

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -666,7 +666,8 @@ func (d *Decoder) decodeCompositeField(valueJSON interface{}) (cadence.Value, ca
 	value := obj.GetValue(d, valueKey)
 
 	// Unmetered because decodeCompositeField is metered in decodeComposite and called nowhere else
-	field := cadence.NewField(name, value.Type(d.gauge))
+	// Type is still metered.
+	field := cadence.NewField(name, value.MeteredType(d.gauge))
 
 	return value, field
 }
@@ -686,7 +687,7 @@ func (d *Decoder) decodeStruct(valueJSON interface{}) cadence.Struct {
 		panic(ErrInvalidJSONCadence)
 	}
 
-	return structure.WithType(cadence.NewStructType(
+	return structure.WithType(cadence.NewMeteredStructType(
 		d.gauge,
 		comp.location,
 		comp.qualifiedIdentifier,
@@ -709,7 +710,7 @@ func (d *Decoder) decodeResource(valueJSON interface{}) cadence.Resource {
 	if err != nil {
 		panic(ErrInvalidJSONCadence)
 	}
-	return resource.WithType(cadence.NewResourceType(
+	return resource.WithType(cadence.NewMeteredResourceType(
 		d.gauge,
 		comp.location,
 		comp.qualifiedIdentifier,
@@ -733,7 +734,7 @@ func (d *Decoder) decodeEvent(valueJSON interface{}) cadence.Event {
 		panic(ErrInvalidJSONCadence)
 	}
 
-	return event.WithType(cadence.NewEventType(
+	return event.WithType(cadence.NewMeteredEventType(
 		d.gauge,
 		comp.location,
 		comp.qualifiedIdentifier,
@@ -757,7 +758,7 @@ func (d *Decoder) decodeContract(valueJSON interface{}) cadence.Contract {
 		panic(ErrInvalidJSONCadence)
 	}
 
-	return contract.WithType(cadence.NewContractType(
+	return contract.WithType(cadence.NewMeteredContractType(
 		d.gauge,
 		comp.location,
 		comp.qualifiedIdentifier,
@@ -781,7 +782,7 @@ func (d *Decoder) decodeEnum(valueJSON interface{}) cadence.Enum {
 		panic(ErrInvalidJSONCadence)
 	}
 
-	return enum.WithType(cadence.NewEnumType(
+	return enum.WithType(cadence.NewMeteredEnumType(
 		d.gauge,
 		comp.location,
 		comp.qualifiedIdentifier,
@@ -892,7 +893,7 @@ func (d *Decoder) decodeFunctionType(returnValue, parametersValue, id interface{
 	parameters := d.decodeParamTypes(toSlice(parametersValue))
 	returnType := d.decodeType(returnValue)
 
-	return cadence.NewFunctionType(
+	return cadence.NewMeteredFunctionType(
 		d.gauge,
 		"",
 		parameters,
@@ -916,7 +917,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 
 	switch kind {
 	case "Struct":
-		return cadence.NewStructType(
+		return cadence.NewMeteredStructType(
 			d.gauge,
 			location,
 			id,
@@ -924,7 +925,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 			inits,
 		)
 	case "Resource":
-		return cadence.NewResourceType(
+		return cadence.NewMeteredResourceType(
 			d.gauge,
 			location,
 			id,
@@ -932,7 +933,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 			inits,
 		)
 	case "Event":
-		return cadence.NewEventType(
+		return cadence.NewMeteredEventType(
 			d.gauge,
 			location,
 			id,
@@ -940,7 +941,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 			inits[0],
 		)
 	case "Contract":
-		return cadence.NewContractType(
+		return cadence.NewMeteredContractType(
 			d.gauge,
 			location,
 			id,
@@ -948,7 +949,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 			inits,
 		)
 	case "StructInterface":
-		return cadence.NewStructInterfaceType(
+		return cadence.NewMeteredStructInterfaceType(
 			d.gauge,
 			location,
 			id,
@@ -956,7 +957,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 			inits,
 		)
 	case "ResourceInterface":
-		return cadence.NewResourceInterfaceType(
+		return cadence.NewMeteredResourceInterfaceType(
 			d.gauge,
 			location,
 			id,
@@ -964,7 +965,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 			inits,
 		)
 	case "ContractInterface":
-		return cadence.NewContractInterfaceType(
+		return cadence.NewMeteredContractInterfaceType(
 			d.gauge,
 			location,
 			id,
@@ -972,7 +973,7 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 			inits,
 		)
 	case "Enum":
-		return cadence.NewEnumType(
+		return cadence.NewMeteredEnumType(
 			d.gauge,
 			location,
 			id,
@@ -996,7 +997,7 @@ func (d *Decoder) decodeRestrictedType(
 		restrictions = append(restrictions, d.decodeType(restriction))
 	}
 
-	return cadence.NewRestrictedType(
+	return cadence.NewMeteredRestrictedType(
 		d.gauge,
 		"",
 		typ,
@@ -1023,140 +1024,140 @@ func (d *Decoder) decodeType(valueJSON interface{}) cadence.Type {
 		typeValue := obj.Get(typeKey)
 		return d.decodeRestrictedType(typeValue, toSlice(restrictionsValue), typeIDValue)
 	case "Optional":
-		return cadence.NewOptionalType(
+		return cadence.NewMeteredOptionalType(
 			d.gauge,
 			d.decodeType(obj.Get(typeKey)),
 		)
 	case "VariableSizedArray":
-		return cadence.NewVariableSizedArrayType(
+		return cadence.NewMeteredVariableSizedArrayType(
 			d.gauge,
 			d.decodeType(obj.Get(typeKey)),
 		)
 	case "Capability":
-		return cadence.NewCapabilityType(
+		return cadence.NewMeteredCapabilityType(
 			d.gauge,
 			d.decodeType(obj.Get(typeKey)),
 		)
 	case "Dictionary":
-		return cadence.NewDictionaryType(
+		return cadence.NewMeteredDictionaryType(
 			d.gauge,
 			d.decodeType(obj.Get(keyKey)),
 			d.decodeType(obj.Get(valueKey)),
 		)
 	case "ConstantSizedArray":
 		size := toUInt(obj.Get(sizeKey))
-		return cadence.NewConstantSizedArrayType(
+		return cadence.NewMeteredConstantSizedArrayType(
 			d.gauge,
 			size,
 			d.decodeType(obj.Get(typeKey)),
 		)
 	case "Reference":
 		auth := toBool(obj.Get(authorizedKey))
-		return cadence.NewReferenceType(
+		return cadence.NewMeteredReferenceType(
 			d.gauge,
 			auth,
 			d.decodeType(obj.Get(typeKey)),
 		)
 	case "Any":
-		return cadence.NewAnyType(d.gauge)
+		return cadence.NewMeteredAnyType(d.gauge)
 	case "AnyStruct":
-		return cadence.NewAnyStructType(d.gauge)
+		return cadence.NewMeteredAnyStructType(d.gauge)
 	case "AnyResource":
-		return cadence.NewAnyResourceType(d.gauge)
+		return cadence.NewMeteredAnyResourceType(d.gauge)
 	case "Type":
-		return cadence.NewMetaType(d.gauge)
+		return cadence.NewMeteredMetaType(d.gauge)
 	case "Void":
-		return cadence.NewVoidType(d.gauge)
+		return cadence.NewMeteredVoidType(d.gauge)
 	case "Never":
-		return cadence.NewNeverType(d.gauge)
+		return cadence.NewMeteredNeverType(d.gauge)
 	case "Bool":
-		return cadence.NewBoolType(d.gauge)
+		return cadence.NewMeteredBoolType(d.gauge)
 	case "String":
-		return cadence.NewStringType(d.gauge)
+		return cadence.NewMeteredStringType(d.gauge)
 	case "Character":
-		return cadence.NewCharacterType(d.gauge)
+		return cadence.NewMeteredCharacterType(d.gauge)
 	case "Bytes":
-		return cadence.NewBytesType(d.gauge)
+		return cadence.NewMeteredBytesType(d.gauge)
 	case "Address":
-		return cadence.NewAddressType(d.gauge)
+		return cadence.NewMeteredAddressType(d.gauge)
 	case "Number":
-		return cadence.NewNumberType(d.gauge)
+		return cadence.NewMeteredNumberType(d.gauge)
 	case "SignedNumber":
-		return cadence.NewSignedNumberType(d.gauge)
+		return cadence.NewMeteredSignedNumberType(d.gauge)
 	case "Integer":
-		return cadence.NewIntegerType(d.gauge)
+		return cadence.NewMeteredIntegerType(d.gauge)
 	case "SignedInteger":
-		return cadence.NewSignedIntegerType(d.gauge)
+		return cadence.NewMeteredSignedIntegerType(d.gauge)
 	case "FixedPoint":
-		return cadence.NewFixedPointType(d.gauge)
+		return cadence.NewMeteredFixedPointType(d.gauge)
 	case "SignedFixedPoint":
-		return cadence.NewSignedFixedPointType(d.gauge)
+		return cadence.NewMeteredSignedFixedPointType(d.gauge)
 	case "Int":
-		return cadence.NewIntType(d.gauge)
+		return cadence.NewMeteredIntType(d.gauge)
 	case "Int8":
-		return cadence.NewInt8Type(d.gauge)
+		return cadence.NewMeteredInt8Type(d.gauge)
 	case "Int16":
-		return cadence.NewInt16Type(d.gauge)
+		return cadence.NewMeteredInt16Type(d.gauge)
 	case "Int32":
-		return cadence.NewInt32Type(d.gauge)
+		return cadence.NewMeteredInt32Type(d.gauge)
 	case "Int64":
-		return cadence.NewInt64Type(d.gauge)
+		return cadence.NewMeteredInt64Type(d.gauge)
 	case "Int128":
-		return cadence.NewInt128Type(d.gauge)
+		return cadence.NewMeteredInt128Type(d.gauge)
 	case "Int256":
-		return cadence.NewInt256Type(d.gauge)
+		return cadence.NewMeteredInt256Type(d.gauge)
 	case "UInt":
-		return cadence.NewUIntType(d.gauge)
+		return cadence.NewMeteredUIntType(d.gauge)
 	case "UInt8":
-		return cadence.NewUInt8Type(d.gauge)
+		return cadence.NewMeteredUInt8Type(d.gauge)
 	case "UInt16":
-		return cadence.NewUInt16Type(d.gauge)
+		return cadence.NewMeteredUInt16Type(d.gauge)
 	case "UInt32":
-		return cadence.NewUInt32Type(d.gauge)
+		return cadence.NewMeteredUInt32Type(d.gauge)
 	case "UInt64":
-		return cadence.NewUInt64Type(d.gauge)
+		return cadence.NewMeteredUInt64Type(d.gauge)
 	case "UInt128":
-		return cadence.NewUInt128Type(d.gauge)
+		return cadence.NewMeteredUInt128Type(d.gauge)
 	case "UInt256":
-		return cadence.NewUInt256Type(d.gauge)
+		return cadence.NewMeteredUInt256Type(d.gauge)
 	case "Word8":
-		return cadence.NewWord8Type(d.gauge)
+		return cadence.NewMeteredWord8Type(d.gauge)
 	case "Word16":
-		return cadence.NewWord16Type(d.gauge)
+		return cadence.NewMeteredWord16Type(d.gauge)
 	case "Word32":
-		return cadence.NewWord32Type(d.gauge)
+		return cadence.NewMeteredWord32Type(d.gauge)
 	case "Word64":
-		return cadence.NewWord64Type(d.gauge)
+		return cadence.NewMeteredWord64Type(d.gauge)
 	case "Fix64":
-		return cadence.NewFix64Type(d.gauge)
+		return cadence.NewMeteredFix64Type(d.gauge)
 	case "UFix64":
-		return cadence.NewUFix64Type(d.gauge)
+		return cadence.NewMeteredUFix64Type(d.gauge)
 	case "Path":
-		return cadence.NewPathType(d.gauge)
+		return cadence.NewMeteredPathType(d.gauge)
 	case "CapabilityPath":
-		return cadence.NewCapabilityPathType(d.gauge)
+		return cadence.NewMeteredCapabilityPathType(d.gauge)
 	case "StoragePath":
-		return cadence.NewStoragePathType(d.gauge)
+		return cadence.NewMeteredStoragePathType(d.gauge)
 	case "PublicPath":
-		return cadence.NewPublicPathType(d.gauge)
+		return cadence.NewMeteredPublicPathType(d.gauge)
 	case "PrivatePath":
-		return cadence.NewPrivatePathType(d.gauge)
+		return cadence.NewMeteredPrivatePathType(d.gauge)
 	case "AuthAccount":
-		return cadence.NewAuthAccountType(d.gauge)
+		return cadence.NewMeteredAuthAccountType(d.gauge)
 	case "PublicAccount":
-		return cadence.NewPublicAccountType(d.gauge)
+		return cadence.NewMeteredPublicAccountType(d.gauge)
 	case "AuthAccount.Keys":
-		return cadence.NewAuthAccountKeysType(d.gauge)
+		return cadence.NewMeteredAuthAccountKeysType(d.gauge)
 	case "PublicAccount.Keys":
-		return cadence.NewPublicAccountKeysType(d.gauge)
+		return cadence.NewMeteredPublicAccountKeysType(d.gauge)
 	case "AuthAccount.Contracts":
-		return cadence.NewAuthAccountContractsType(d.gauge)
+		return cadence.NewMeteredAuthAccountContractsType(d.gauge)
 	case "PublicAccount.Contracts":
-		return cadence.NewPublicAccountContractsType(d.gauge)
+		return cadence.NewMeteredPublicAccountContractsType(d.gauge)
 	case "DeployedContract":
-		return cadence.NewDeployedContractType(d.gauge)
+		return cadence.NewMeteredDeployedContractType(d.gauge)
 	case "AccountKey":
-		return cadence.NewAccountKeyType(d.gauge)
+		return cadence.NewMeteredAccountKeyType(d.gauge)
 	default:
 		fieldsValue := obj.Get(fieldsKey)
 		typeIDValue := toString(obj.Get(typeIDKey))

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -165,7 +165,7 @@ func TestEncodeAddress(t *testing.T) {
 
 	testEncodeAndDecode(
 		t,
-		cadence.BytesToUnmeteredAddress([]byte{1, 2, 3, 4, 5}),
+		cadence.BytesToAddress([]byte{1, 2, 3, 4, 5}),
 		`{"type":"Address","value":"0x0000000102030405"}`,
 	)
 }
@@ -1562,7 +1562,7 @@ func TestEncodeCapability(t *testing.T) {
 		t,
 		cadence.Capability{
 			Path:       cadence.NewPath("storage", "foo"),
-			Address:    cadence.BytesToUnmeteredAddress([]byte{1, 2, 3, 4, 5}),
+			Address:    cadence.BytesToAddress([]byte{1, 2, 3, 4, 5}),
 			BorrowType: cadence.IntType{},
 		},
 		`{"type":"Capability","value":{"path":{"type":"Path","value":{"domain":"storage","identifier":"foo"}},"borrowType":{"kind":"Int"},"address":"0x0000000102030405"}}`,

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -771,7 +771,7 @@ var SignAlgoType = ExportedBuiltinType(sema.SignatureAlgorithmType).(*cadence.En
 var HashAlgoType = ExportedBuiltinType(sema.HashAlgorithmType).(*cadence.EnumType)
 
 func ExportedBuiltinType(internalType sema.Type) cadence.Type {
-	return ExportType(nil, internalType, map[sema.TypeID]cadence.Type{})
+	return ExportType(internalType, map[sema.TypeID]cadence.Type{})
 }
 
 func newBytesValue(bytes []byte) cadence.Array {

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -148,10 +148,10 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 			assert.Len(t, keys, tt.keyCount)
 			assert.Equal(t, tt.expected, keys)
 
-			assert.EqualValues(t, stdlib.AccountCreatedEventType.ID(), events[0].Type(nil).ID())
+			assert.EqualValues(t, stdlib.AccountCreatedEventType.ID(), events[0].Type().ID())
 
 			for _, event := range events[1:] {
-				assert.EqualValues(t, stdlib.AccountKeyAddedEventType.ID(), event.Type(nil).ID())
+				assert.EqualValues(t, stdlib.AccountKeyAddedEventType.ID(), event.Type().ID())
 			}
 		})
 	}
@@ -449,12 +449,12 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 
 	assert.EqualValues(t,
 		stdlib.AccountCreatedEventType.ID(),
-		storage.events[0].Type(nil).ID(),
+		storage.events[0].Type().ID(),
 	)
 
 	assert.EqualValues(t,
 		stdlib.AccountKeyAddedEventType.ID(),
-		storage.events[1].Type(nil).ID(),
+		storage.events[1].Type().ID(),
 	)
 }
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -797,11 +797,7 @@ func accountKeyExportedValue(
 	isRevoked bool,
 ) cadence.Struct {
 
-	parsed, err := cadence.ParseUFix64(weight)
-	if err != nil {
-		panic(err)
-	}
-	weightUFix64, err := cadence.NewUFix64(parsed)
+	weightUFix64, err := cadence.NewUFix64(weight)
 	if err != nil {
 		panic(err)
 	}

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -265,7 +265,7 @@ func TestRuntimeContract(t *testing.T) {
 				)
 
 				require.Len(t, events, 1)
-				assert.EqualValues(t, stdlib.AccountContractAddedEventType.ID(), events[0].Type(inter).ID())
+				assert.EqualValues(t, stdlib.AccountContractAddedEventType.ID(), events[0].Type().ID())
 
 			} else {
 				require.Error(t, err)
@@ -355,7 +355,7 @@ func TestRuntimeContract(t *testing.T) {
 			)
 
 			require.Len(t, events, 1)
-			assert.EqualValues(t, stdlib.AccountContractUpdatedEventType.ID(), events[0].Type(inter).ID())
+			assert.EqualValues(t, stdlib.AccountContractUpdatedEventType.ID(), events[0].Type().ID())
 		})
 
 		t.Run("remove", func(t *testing.T) {
@@ -390,7 +390,7 @@ func TestRuntimeContract(t *testing.T) {
 			)
 
 			require.Len(t, events, 1)
-			assert.EqualValues(t, stdlib.AccountContractRemovedEventType.ID(), events[0].Type(inter).ID())
+			assert.EqualValues(t, stdlib.AccountContractRemovedEventType.ID(), events[0].Type().ID())
 
 			contractValueExists := getContractValueExists()
 			require.False(t, contractValueExists)
@@ -441,7 +441,7 @@ func TestRuntimeContract(t *testing.T) {
 				)
 
 				require.Len(t, events, 1)
-				assert.EqualValues(t, stdlib.AccountContractAddedEventType.ID(), events[0].Type(inter).ID())
+				assert.EqualValues(t, stdlib.AccountContractAddedEventType.ID(), events[0].Type().ID())
 
 			} else {
 				require.Error(t, err)
@@ -490,8 +490,8 @@ func TestRuntimeContract(t *testing.T) {
 			)
 
 			require.Len(t, events, 2)
-			assert.EqualValues(t, stdlib.AccountContractRemovedEventType.ID(), events[0].Type(inter).ID())
-			assert.EqualValues(t, stdlib.AccountContractAddedEventType.ID(), events[1].Type(inter).ID())
+			assert.EqualValues(t, stdlib.AccountContractRemovedEventType.ID(), events[0].Type().ID())
+			assert.EqualValues(t, stdlib.AccountContractAddedEventType.ID(), events[1].Type().ID())
 
 			contractValueExists := getContractValueExists()
 

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -60,7 +60,7 @@ func ExportType(
 		case *sema.FunctionType:
 			return exportFunctionType(gauge, t, results)
 		case *sema.AddressType:
-			return cadence.NewAddressType(gauge)
+			return cadence.NewMeteredAddressType(gauge)
 		case *sema.ReferenceType:
 			return exportReferenceType(gauge, t, results)
 		case *sema.RestrictedType:
@@ -71,105 +71,105 @@ func ExportType(
 
 		switch t {
 		case sema.NumberType:
-			return cadence.NewNumberType(gauge)
+			return cadence.NewMeteredNumberType(gauge)
 		case sema.SignedNumberType:
-			return cadence.NewSignedNumberType(gauge)
+			return cadence.NewMeteredSignedNumberType(gauge)
 		case sema.IntegerType:
-			return cadence.NewIntegerType(gauge)
+			return cadence.NewMeteredIntegerType(gauge)
 		case sema.SignedIntegerType:
-			return cadence.NewSignedIntegerType(gauge)
+			return cadence.NewMeteredSignedIntegerType(gauge)
 		case sema.FixedPointType:
-			return cadence.NewFixedPointType(gauge)
+			return cadence.NewMeteredFixedPointType(gauge)
 		case sema.SignedFixedPointType:
-			return cadence.NewSignedFixedPointType(gauge)
+			return cadence.NewMeteredSignedFixedPointType(gauge)
 		case sema.IntType:
-			return cadence.NewIntType(gauge)
+			return cadence.NewMeteredIntType(gauge)
 		case sema.Int8Type:
-			return cadence.NewInt8Type(gauge)
+			return cadence.NewMeteredInt8Type(gauge)
 		case sema.Int16Type:
-			return cadence.NewInt16Type(gauge)
+			return cadence.NewMeteredInt16Type(gauge)
 		case sema.Int32Type:
-			return cadence.NewInt32Type(gauge)
+			return cadence.NewMeteredInt32Type(gauge)
 		case sema.Int64Type:
-			return cadence.NewInt64Type(gauge)
+			return cadence.NewMeteredInt64Type(gauge)
 		case sema.Int128Type:
-			return cadence.NewInt128Type(gauge)
+			return cadence.NewMeteredInt128Type(gauge)
 		case sema.Int256Type:
-			return cadence.NewInt256Type(gauge)
+			return cadence.NewMeteredInt256Type(gauge)
 		case sema.UIntType:
-			return cadence.NewUIntType(gauge)
+			return cadence.NewMeteredUIntType(gauge)
 		case sema.UInt8Type:
-			return cadence.NewUInt8Type(gauge)
+			return cadence.NewMeteredUInt8Type(gauge)
 		case sema.UInt16Type:
-			return cadence.NewUInt16Type(gauge)
+			return cadence.NewMeteredUInt16Type(gauge)
 		case sema.UInt32Type:
-			return cadence.NewUInt32Type(gauge)
+			return cadence.NewMeteredUInt32Type(gauge)
 		case sema.UInt64Type:
-			return cadence.NewUInt64Type(gauge)
+			return cadence.NewMeteredUInt64Type(gauge)
 		case sema.UInt128Type:
-			return cadence.NewUInt128Type(gauge)
+			return cadence.NewMeteredUInt128Type(gauge)
 		case sema.UInt256Type:
-			return cadence.NewUInt256Type(gauge)
+			return cadence.NewMeteredUInt256Type(gauge)
 		case sema.Word8Type:
-			return cadence.NewWord8Type(gauge)
+			return cadence.NewMeteredWord8Type(gauge)
 		case sema.Word16Type:
-			return cadence.NewWord16Type(gauge)
+			return cadence.NewMeteredWord16Type(gauge)
 		case sema.Word32Type:
-			return cadence.NewWord32Type(gauge)
+			return cadence.NewMeteredWord32Type(gauge)
 		case sema.Word64Type:
-			return cadence.NewWord64Type(gauge)
+			return cadence.NewMeteredWord64Type(gauge)
 		case sema.Fix64Type:
-			return cadence.NewFix64Type(gauge)
+			return cadence.NewMeteredFix64Type(gauge)
 		case sema.UFix64Type:
-			return cadence.NewUFix64Type(gauge)
+			return cadence.NewMeteredUFix64Type(gauge)
 		case sema.PathType:
-			return cadence.NewPathType(gauge)
+			return cadence.NewMeteredPathType(gauge)
 		case sema.StoragePathType:
-			return cadence.NewStoragePathType(gauge)
+			return cadence.NewMeteredStoragePathType(gauge)
 		case sema.PrivatePathType:
-			return cadence.NewPrivatePathType(gauge)
+			return cadence.NewMeteredPrivatePathType(gauge)
 		case sema.PublicPathType:
-			return cadence.NewPublicPathType(gauge)
+			return cadence.NewMeteredPublicPathType(gauge)
 		case sema.CapabilityPathType:
-			return cadence.NewCapabilityPathType(gauge)
+			return cadence.NewMeteredCapabilityPathType(gauge)
 		case sema.NeverType:
-			return cadence.NewNeverType(gauge)
+			return cadence.NewMeteredNeverType(gauge)
 		case sema.VoidType:
-			return cadence.NewVoidType(gauge)
+			return cadence.NewMeteredVoidType(gauge)
 		case sema.InvalidType:
 			return nil
 		case sema.MetaType:
-			return cadence.NewMetaType(gauge)
+			return cadence.NewMeteredMetaType(gauge)
 		case sema.BoolType:
-			return cadence.NewBoolType(gauge)
+			return cadence.NewMeteredBoolType(gauge)
 		case sema.CharacterType:
-			return cadence.NewCharacterType(gauge)
+			return cadence.NewMeteredCharacterType(gauge)
 		case sema.AnyType:
-			return cadence.NewAnyType(gauge)
+			return cadence.NewMeteredAnyType(gauge)
 		case sema.AnyStructType:
-			return cadence.NewAnyStructType(gauge)
+			return cadence.NewMeteredAnyStructType(gauge)
 		case sema.AnyResourceType:
-			return cadence.NewAnyResourceType(gauge)
+			return cadence.NewMeteredAnyResourceType(gauge)
 		case sema.BlockType:
-			return cadence.NewBlockType(gauge)
+			return cadence.NewMeteredBlockType(gauge)
 		case sema.StringType:
-			return cadence.NewStringType(gauge)
+			return cadence.NewMeteredStringType(gauge)
 		case sema.AccountKeyType:
-			return cadence.NewAccountKeyType(gauge)
+			return cadence.NewMeteredAccountKeyType(gauge)
 		case sema.PublicAccountContractsType:
-			return cadence.NewPublicAccountContractsType(gauge)
+			return cadence.NewMeteredPublicAccountContractsType(gauge)
 		case sema.AuthAccountContractsType:
-			return cadence.NewAuthAccountContractsType(gauge)
+			return cadence.NewMeteredAuthAccountContractsType(gauge)
 		case sema.PublicAccountKeysType:
-			return cadence.NewPublicAccountKeysType(gauge)
+			return cadence.NewMeteredPublicAccountKeysType(gauge)
 		case sema.AuthAccountKeysType:
-			return cadence.NewAuthAccountKeysType(gauge)
+			return cadence.NewMeteredAuthAccountKeysType(gauge)
 		case sema.PublicAccountType:
-			return cadence.NewPublicAccountType(gauge)
+			return cadence.NewMeteredPublicAccountType(gauge)
 		case sema.AuthAccountType:
-			return cadence.NewAuthAccountType(gauge)
+			return cadence.NewMeteredAuthAccountType(gauge)
 		case sema.DeployedContractType:
-			return cadence.NewDeployedContractType(gauge)
+			return cadence.NewMeteredDeployedContractType(gauge)
 		}
 
 		panic(fmt.Sprintf("cannot export type of type %T", t))
@@ -183,7 +183,7 @@ func ExportType(
 func exportOptionalType(gauge common.MemoryGauge, t *sema.OptionalType, results map[sema.TypeID]cadence.Type) cadence.Type {
 	convertedType := ExportType(gauge, t.Type, results)
 
-	return cadence.NewOptionalType(
+	return cadence.NewMeteredOptionalType(
 		gauge,
 		convertedType,
 	)
@@ -192,13 +192,13 @@ func exportOptionalType(gauge common.MemoryGauge, t *sema.OptionalType, results 
 func exportVariableSizedType(gauge common.MemoryGauge, t *sema.VariableSizedType, results map[sema.TypeID]cadence.Type) cadence.Type {
 	convertedElement := ExportType(gauge, t.Type, results)
 
-	return cadence.NewVariableSizedArrayType(gauge, convertedElement)
+	return cadence.NewMeteredVariableSizedArrayType(gauge, convertedElement)
 }
 
 func exportConstantSizedType(gauge common.MemoryGauge, t *sema.ConstantSizedType, results map[sema.TypeID]cadence.Type) cadence.Type {
 	convertedElement := ExportType(gauge, t.Type, results)
 
-	return cadence.NewConstantSizedArrayType(
+	return cadence.NewMeteredConstantSizedArrayType(
 		gauge,
 		uint(t.Size),
 		convertedElement,
@@ -231,7 +231,7 @@ func exportCompositeType(
 
 	switch t.Kind {
 	case common.CompositeKindStructure:
-		result = cadence.NewStructType(
+		result = cadence.NewMeteredStructType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -240,7 +240,7 @@ func exportCompositeType(
 		)
 
 	case common.CompositeKindResource:
-		result = cadence.NewResourceType(
+		result = cadence.NewMeteredResourceType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -249,7 +249,7 @@ func exportCompositeType(
 		)
 
 	case common.CompositeKindEvent:
-		result = cadence.NewEventType(
+		result = cadence.NewMeteredEventType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -258,7 +258,7 @@ func exportCompositeType(
 		)
 
 	case common.CompositeKindContract:
-		result = cadence.NewContractType(
+		result = cadence.NewMeteredContractType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -267,7 +267,7 @@ func exportCompositeType(
 		)
 
 	case common.CompositeKindEnum:
-		result = cadence.NewEnumType(
+		result = cadence.NewMeteredEnumType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -322,7 +322,7 @@ func exportInterfaceType(
 
 	switch t.CompositeKind {
 	case common.CompositeKindStructure:
-		result = cadence.NewStructInterfaceType(
+		result = cadence.NewMeteredStructInterfaceType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -331,7 +331,7 @@ func exportInterfaceType(
 		)
 
 	case common.CompositeKindResource:
-		result = cadence.NewResourceInterfaceType(
+		result = cadence.NewMeteredResourceInterfaceType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -340,7 +340,7 @@ func exportInterfaceType(
 		)
 
 	case common.CompositeKindContract:
-		result = cadence.NewContractInterfaceType(
+		result = cadence.NewMeteredContractInterfaceType(
 			gauge,
 			t.Location,
 			t.QualifiedIdentifier(),
@@ -376,7 +376,7 @@ func exportDictionaryType(
 	convertedKeyType := ExportType(gauge, t.KeyType, results)
 	convertedElementType := ExportType(gauge, t.ValueType, results)
 
-	return cadence.NewDictionaryType(
+	return cadence.NewMeteredDictionaryType(
 		gauge,
 		convertedKeyType,
 		convertedElementType,
@@ -407,7 +407,7 @@ func exportFunctionType(
 
 	convertedReturnType := ExportType(gauge, t.ReturnTypeAnnotation.Type, results)
 
-	return cadence.NewFunctionType(
+	return cadence.NewMeteredFunctionType(
 		gauge,
 		"",
 		convertedParameters,
@@ -422,7 +422,7 @@ func exportReferenceType(
 ) cadence.ReferenceType {
 	convertedType := ExportType(gauge, t.Type, results)
 
-	return cadence.NewReferenceType(
+	return cadence.NewMeteredReferenceType(
 		gauge,
 		t.Authorized,
 		convertedType,
@@ -443,7 +443,7 @@ func exportRestrictedType(
 		restrictions[i] = ExportType(gauge, restriction, results)
 	}
 
-	return cadence.NewRestrictedType(
+	return cadence.NewMeteredRestrictedType(
 		gauge,
 		"",
 		convertedType,
@@ -462,7 +462,7 @@ func exportCapabilityType(
 		borrowType = ExportType(gauge, t.BorrowType, results)
 	}
 
-	return cadence.NewCapabilityType(
+	return cadence.NewMeteredCapabilityType(
 		gauge,
 		borrowType,
 	)

--- a/runtime/convertTypes_test.go
+++ b/runtime/convertTypes_test.go
@@ -67,6 +67,6 @@ func TestExportRecursiveType(t *testing.T) {
 
 	assert.Equal(t,
 		expected,
-		ExportType(nil, ty, map[sema.TypeID]cadence.Type{}),
+		ExportType(ty, map[sema.TypeID]cadence.Type{}),
 	)
 }

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -605,7 +605,7 @@ func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) ca
 	}
 	return cadence.NewMeteredTypeValue(
 		inter,
-		ExportType(inter, typ, map[sema.TypeID]cadence.Type{}),
+		ExportMeteredType(inter, typ, map[sema.TypeID]cadence.Type{}),
 	)
 }
 
@@ -619,7 +619,7 @@ func exportCapabilityValue(v *interpreter.CapabilityValue, inter *interpreter.In
 		inter,
 		exportPathValue(inter, v.Path),
 		cadence.NewMeteredAddress(inter, v.Address),
-		ExportType(inter, borrowType, map[sema.TypeID]cadence.Type{}),
+		ExportMeteredType(inter, borrowType, map[sema.TypeID]cadence.Type{}),
 	)
 }
 
@@ -651,7 +651,7 @@ func exportEvent(
 		return cadence.Event{}, err
 	}
 
-	eventType := ExportType(gauge, event.Type, map[sema.TypeID]cadence.Type{}).(*cadence.EventType)
+	eventType := ExportMeteredType(gauge, event.Type, map[sema.TypeID]cadence.Type{}).(*cadence.EventType)
 
 	return exported.WithType(eventType), nil
 }

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1285,7 +1285,7 @@ func TestExportAddressValue(t *testing.T) {
     `
 
 	actual := exportValueFromScript(t, script)
-	expected := cadence.BytesToUnmeteredAddress(
+	expected := cadence.BytesToAddress(
 		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x42},
 	)
 

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -176,7 +176,6 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			},
 		)
 		exportedEventType := ExportType(
-			nil,
 			stdlib.AccountContractAddedEventType,
 			map[sema.TypeID]cadence.Type{},
 		)

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -49,7 +49,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 		event := events[0]
 
-		require.Equal(t, event.Type(nil), expectedEventType)
+		require.Equal(t, event.Type(), expectedEventType)
 
 		expectedEventCompositeType := expectedEventType.(*cadence.EventType)
 

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -615,9 +615,7 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
 	// Mint 1000 FLOW to sender
 
-	parsed, err := cadence.ParseUFix64("100000000000.0")
-	require.NoError(b, err)
-	mintAmount, err := cadence.NewUFix64(parsed)
+	mintAmount, err := cadence.NewUFix64("100000000000.0")
 	require.NoError(b, err)
 
 	mintAmountValue := interpreter.NewUnmeteredUFix64Value(uint64(mintAmount))
@@ -641,9 +639,7 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
 	// Benchmark sending tokens from sender to receiver
 
-	parsed, err = cadence.ParseUFix64("0.00000001")
-	require.NoError(b, err)
-	sendAmount, err := cadence.NewUFix64(parsed)
+	sendAmount, err := cadence.NewUFix64("0.00000001")
 	require.NoError(b, err)
 
 	signerAccount = senderAddress

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -347,7 +347,7 @@ func LiteralValue(inter *interpreter.Interpreter, expression ast.Expression, ty 
 			return nil, InvalidLiteralError
 		}
 
-		return cadence.BytesToUnmeteredAddress(expression.Value.Bytes()), nil
+		return cadence.BytesToAddress(expression.Value.Bytes()), nil
 	}
 
 	switch ty {

--- a/runtime/missingmember_test.go
+++ b/runtime/missingmember_test.go
@@ -3980,9 +3980,7 @@ transaction {
 }
 `
 
-	parsed, err := cadence.ParseUFix64("1000.0")
-	require.NoError(t, err)
-	mintAmount, err := cadence.NewUFix64(parsed)
+	mintAmount, err := cadence.NewUFix64("1000.0")
 	require.NoError(t, err)
 
 	const mintTransaction = `

--- a/runtime/resourcedictionary_test.go
+++ b/runtime/resourcedictionary_test.go
@@ -91,7 +91,7 @@ func TestRuntimeResourceDictionaryValues(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	addressValue := cadence.BytesToUnmeteredAddress([]byte{0xCA, 0xDE})
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -386,7 +386,7 @@ func TestRuntimeResourceDictionaryValues_Nested(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	addressValue := cadence.BytesToUnmeteredAddress([]byte{0xCA, 0xDE})
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
 	contract := []byte(`
      pub contract Test {
@@ -1301,7 +1301,7 @@ func BenchmarkRuntimeResourceDictionaryValues(b *testing.B) {
 
 	runtime := newTestInterpreterRuntime()
 
-	addressValue := cadence.BytesToUnmeteredAddress([]byte{0xCA, 0xDE})
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
 	contract := []byte(`
 	  pub contract Test {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -897,7 +897,7 @@ func validateArgumentParams(
 		parameterType := parameter.TypeAnnotation.Type
 		argument := arguments[i]
 
-		exportedParameterType := ExportType(inter, parameterType, map[sema.TypeID]cadence.Type{})
+		exportedParameterType := ExportMeteredType(inter, parameterType, map[sema.TypeID]cadence.Type{})
 		var value cadence.Value
 		var err error
 

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -117,7 +117,7 @@ func TestInterpreterElaborationImportMetering(t *testing.T) {
 		importExpressions[i] = fmt.Sprintf("import C%d from 0x1\n", i)
 	}
 
-	addressValue := cadence.BytesToUnmeteredAddress([]byte{byte(1)})
+	addressValue := cadence.BytesToAddress([]byte{byte(1)})
 
 	for imports := range contracts {
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3043,7 +3043,7 @@ func TestRuntimeTransaction_CreateAccount(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, events, 1)
-	assert.EqualValues(t, stdlib.AccountCreatedEventType.ID(), events[0].Type(nil).ID())
+	assert.EqualValues(t, stdlib.AccountCreatedEventType.ID(), events[0].Type().ID())
 }
 
 func TestRuntimeContractAccount(t *testing.T) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1023,7 +1023,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
             `,
 			args: [][]byte{
 				jsoncdc.MustEncode(
-					cadence.BytesToUnmeteredAddress(
+					cadence.BytesToAddress(
 						[]byte{
 							0x0, 0x0, 0x0, 0x0,
 							0x0, 0x0, 0x0, 0x1,
@@ -1318,7 +1318,7 @@ func TestRuntimeScriptArguments(t *testing.T) {
             `,
 			args: [][]byte{
 				jsoncdc.MustEncode(
-					cadence.BytesToUnmeteredAddress(
+					cadence.BytesToAddress(
 						[]byte{
 							0x0, 0x0, 0x0, 0x0,
 							0x0, 0x0, 0x0, 0x1,
@@ -3052,7 +3052,7 @@ func TestRuntimeContractAccount(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	addressValue := cadence.BytesToUnmeteredAddress([]byte{0xCA, 0xDE})
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
 	contract := []byte(`
       pub contract Test {
@@ -5399,7 +5399,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	addressValue := cadence.BytesToUnmeteredAddress([]byte{0xCA, 0xDE})
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
 	contract := []byte(`
       pub contract Test {
@@ -5555,7 +5555,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	addressValue := cadence.BytesToUnmeteredAddress([]byte{0xCA, 0xDE})
+	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
 	contract := []byte(`
       pub contract Test {
@@ -6777,7 +6777,7 @@ func TestRuntimeGetCapability(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Capability{
-				Address: cadence.BytesToUnmeteredAddress([]byte{0x1}),
+				Address: cadence.BytesToAddress([]byte{0x1}),
 				Path: cadence.Path{
 					Domain:     "public",
 					Identifier: "xxx",

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -209,8 +209,8 @@ func TestRuntimeBlockFieldTypes(t *testing.T) {
 		values := value.(cadence.Array).Values
 
 		require.Equal(t, 2, len(values))
-		assert.IsType(t, cadence.UFix64Type{}, values[0].Type(nil))
-		assert.IsType(t, cadence.UFix64Type{}, values[1].Type(nil))
+		assert.IsType(t, cadence.UFix64Type{}, values[0].Type())
+		assert.IsType(t, cadence.UFix64Type{}, values[1].Type())
 
 		assert.Equal(
 			t,

--- a/types.go
+++ b/types.go
@@ -33,9 +33,13 @@ type Type interface {
 
 type AnyType struct{}
 
-func NewAnyType(gauge common.MemoryGauge) AnyType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewAnyType() AnyType {
 	return AnyType{}
+}
+
+func NewMeteredAnyType(gauge common.MemoryGauge) AnyType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewAnyType()
 }
 
 func (AnyType) isType() {}
@@ -48,9 +52,13 @@ func (AnyType) ID() string {
 
 type AnyStructType struct{}
 
-func NewAnyStructType(gauge common.MemoryGauge) AnyStructType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewAnyStructType() AnyStructType {
 	return AnyStructType{}
+}
+
+func NewMeteredAnyStructType(gauge common.MemoryGauge) AnyStructType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewAnyStructType()
 }
 
 func (AnyStructType) isType() {}
@@ -63,9 +71,13 @@ func (AnyStructType) ID() string {
 
 type AnyResourceType struct{}
 
-func NewAnyResourceType(gauge common.MemoryGauge) AnyResourceType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewAnyResourceType() AnyResourceType {
 	return AnyResourceType{}
+}
+
+func NewMeteredAnyResourceType(gauge common.MemoryGauge) AnyResourceType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewAnyResourceType()
 }
 
 func (AnyResourceType) isType() {}
@@ -80,9 +92,13 @@ type OptionalType struct {
 	Type Type
 }
 
-func NewOptionalType(gauge common.MemoryGauge, typ Type) OptionalType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceOptionalType)
+func NewOptionalType(typ Type) OptionalType {
 	return OptionalType{Type: typ}
+}
+
+func NewMeteredOptionalType(gauge common.MemoryGauge, typ Type) OptionalType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceOptionalType)
+	return NewOptionalType(typ)
 }
 
 func (OptionalType) isType() {}
@@ -95,9 +111,13 @@ func (t OptionalType) ID() string {
 
 type MetaType struct{}
 
-func NewMetaType(gauge common.MemoryGauge) MetaType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewMetaType() MetaType {
 	return MetaType{}
+}
+
+func NewMeteredMetaType(gauge common.MemoryGauge) MetaType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewMetaType()
 }
 
 func (MetaType) isType() {}
@@ -110,9 +130,13 @@ func (MetaType) ID() string {
 
 type VoidType struct{}
 
-func NewVoidType(gauge common.MemoryGauge) VoidType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewVoidType() VoidType {
 	return VoidType{}
+}
+
+func NewMeteredVoidType(gauge common.MemoryGauge) VoidType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewVoidType()
 }
 
 func (VoidType) isType() {}
@@ -125,9 +149,13 @@ func (VoidType) ID() string {
 
 type NeverType struct{}
 
-func NewNeverType(gauge common.MemoryGauge) NeverType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewNeverType() NeverType {
 	return NeverType{}
+}
+
+func NewMeteredNeverType(gauge common.MemoryGauge) NeverType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewNeverType()
 }
 
 func (NeverType) isType() {}
@@ -140,9 +168,13 @@ func (NeverType) ID() string {
 
 type BoolType struct{}
 
-func NewBoolType(gauge common.MemoryGauge) BoolType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewBoolType() BoolType {
 	return BoolType{}
+}
+
+func NewMeteredBoolType(gauge common.MemoryGauge) BoolType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewBoolType()
 }
 
 func (BoolType) isType() {}
@@ -155,9 +187,13 @@ func (BoolType) ID() string {
 
 type StringType struct{}
 
-func NewStringType(gauge common.MemoryGauge) StringType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewStringType() StringType {
 	return StringType{}
+}
+
+func NewMeteredStringType(gauge common.MemoryGauge) StringType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewStringType()
 }
 
 func (StringType) isType() {}
@@ -170,9 +206,13 @@ func (StringType) ID() string {
 
 type CharacterType struct{}
 
-func NewCharacterType(gauge common.MemoryGauge) CharacterType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewCharacterType() CharacterType {
 	return CharacterType{}
+}
+
+func NewMeteredCharacterType(gauge common.MemoryGauge) CharacterType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewCharacterType()
 }
 
 func (CharacterType) isType() {}
@@ -185,9 +225,13 @@ func (CharacterType) ID() string {
 
 type BytesType struct{}
 
-func NewBytesType(gauge common.MemoryGauge) BytesType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewBytesType() BytesType {
 	return BytesType{}
+}
+
+func NewMeteredBytesType(gauge common.MemoryGauge) BytesType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewBytesType()
 }
 
 func (BytesType) isType() {}
@@ -200,9 +244,13 @@ func (BytesType) ID() string {
 
 type AddressType struct{}
 
-func NewAddressType(gauge common.MemoryGauge) AddressType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewAddressType() AddressType {
 	return AddressType{}
+}
+
+func NewMeteredAddressType(gauge common.MemoryGauge) AddressType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewAddressType()
 }
 
 func (AddressType) isType() {}
@@ -215,9 +263,13 @@ func (AddressType) ID() string {
 
 type NumberType struct{}
 
-func NewNumberType(gauge common.MemoryGauge) NumberType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewNumberType() NumberType {
 	return NumberType{}
+}
+
+func NewMeteredNumberType(gauge common.MemoryGauge) NumberType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewNumberType()
 }
 
 func (NumberType) isType() {}
@@ -230,9 +282,13 @@ func (NumberType) ID() string {
 
 type SignedNumberType struct{}
 
-func NewSignedNumberType(gauge common.MemoryGauge) SignedNumberType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewSignedNumberType() SignedNumberType {
 	return SignedNumberType{}
+}
+
+func NewMeteredSignedNumberType(gauge common.MemoryGauge) SignedNumberType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewSignedNumberType()
 }
 
 func (SignedNumberType) isType() {}
@@ -245,9 +301,13 @@ func (SignedNumberType) ID() string {
 
 type IntegerType struct{}
 
-func NewIntegerType(gauge common.MemoryGauge) IntegerType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewIntegerType() IntegerType {
 	return IntegerType{}
+}
+
+func NewMeteredIntegerType(gauge common.MemoryGauge) IntegerType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewIntegerType()
 }
 
 func (IntegerType) isType() {}
@@ -260,9 +320,13 @@ func (IntegerType) ID() string {
 
 type SignedIntegerType struct{}
 
-func NewSignedIntegerType(gauge common.MemoryGauge) SignedIntegerType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewSignedIntegerType() SignedIntegerType {
 	return SignedIntegerType{}
+}
+
+func NewMeteredSignedIntegerType(gauge common.MemoryGauge) SignedIntegerType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewSignedIntegerType()
 }
 
 func (SignedIntegerType) isType() {}
@@ -275,9 +339,13 @@ func (SignedIntegerType) ID() string {
 
 type FixedPointType struct{}
 
-func NewFixedPointType(gauge common.MemoryGauge) FixedPointType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewFixedPointType() FixedPointType {
 	return FixedPointType{}
+}
+
+func NewMeteredFixedPointType(gauge common.MemoryGauge) FixedPointType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewFixedPointType()
 }
 
 func (FixedPointType) isType() {}
@@ -290,9 +358,13 @@ func (FixedPointType) ID() string {
 
 type SignedFixedPointType struct{}
 
-func NewSignedFixedPointType(gauge common.MemoryGauge) SignedFixedPointType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewSignedFixedPointType() SignedFixedPointType {
 	return SignedFixedPointType{}
+}
+
+func NewMeteredSignedFixedPointType(gauge common.MemoryGauge) SignedFixedPointType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewSignedFixedPointType()
 }
 
 func (SignedFixedPointType) isType() {}
@@ -305,9 +377,13 @@ func (SignedFixedPointType) ID() string {
 
 type IntType struct{}
 
-func NewIntType(gauge common.MemoryGauge) IntType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewIntType() IntType {
 	return IntType{}
+}
+
+func NewMeteredIntType(gauge common.MemoryGauge) IntType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewIntType()
 }
 
 func (IntType) isType() {}
@@ -320,9 +396,13 @@ func (IntType) ID() string {
 
 type Int8Type struct{}
 
-func NewInt8Type(gauge common.MemoryGauge) Int8Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewInt8Type() Int8Type {
 	return Int8Type{}
+}
+
+func NewMeteredInt8Type(gauge common.MemoryGauge) Int8Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewInt8Type()
 }
 
 func (Int8Type) isType() {}
@@ -335,9 +415,13 @@ func (Int8Type) ID() string {
 
 type Int16Type struct{}
 
-func NewInt16Type(gauge common.MemoryGauge) Int16Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewInt16Type() Int16Type {
 	return Int16Type{}
+}
+
+func NewMeteredInt16Type(gauge common.MemoryGauge) Int16Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewInt16Type()
 }
 
 func (Int16Type) isType() {}
@@ -350,9 +434,13 @@ func (Int16Type) ID() string {
 
 type Int32Type struct{}
 
-func NewInt32Type(gauge common.MemoryGauge) Int32Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewInt32Type() Int32Type {
 	return Int32Type{}
+}
+
+func NewMeteredInt32Type(gauge common.MemoryGauge) Int32Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewInt32Type()
 }
 
 func (Int32Type) isType() {}
@@ -365,9 +453,13 @@ func (Int32Type) ID() string {
 
 type Int64Type struct{}
 
-func NewInt64Type(gauge common.MemoryGauge) Int64Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewInt64Type() Int64Type {
 	return Int64Type{}
+}
+
+func NewMeteredInt64Type(gauge common.MemoryGauge) Int64Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewInt64Type()
 }
 
 func (Int64Type) isType() {}
@@ -380,9 +472,13 @@ func (Int64Type) ID() string {
 
 type Int128Type struct{}
 
-func NewInt128Type(gauge common.MemoryGauge) Int128Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewInt128Type() Int128Type {
 	return Int128Type{}
+}
+
+func NewMeteredInt128Type(gauge common.MemoryGauge) Int128Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewInt128Type()
 }
 
 func (Int128Type) isType() {}
@@ -395,9 +491,13 @@ func (Int128Type) ID() string {
 
 type Int256Type struct{}
 
-func NewInt256Type(gauge common.MemoryGauge) Int256Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewInt256Type() Int256Type {
 	return Int256Type{}
+}
+
+func NewMeteredInt256Type(gauge common.MemoryGauge) Int256Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewInt256Type()
 }
 
 func (Int256Type) isType() {}
@@ -410,9 +510,13 @@ func (Int256Type) ID() string {
 
 type UIntType struct{}
 
-func NewUIntType(gauge common.MemoryGauge) UIntType {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUIntType() UIntType {
 	return UIntType{}
+}
+
+func NewMeteredUIntType(gauge common.MemoryGauge) UIntType {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUIntType()
 }
 
 func (UIntType) isType() {}
@@ -425,9 +529,13 @@ func (UIntType) ID() string {
 
 type UInt8Type struct{}
 
-func NewUInt8Type(gauge common.MemoryGauge) UInt8Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUInt8Type() UInt8Type {
 	return UInt8Type{}
+}
+
+func NewMeteredUInt8Type(gauge common.MemoryGauge) UInt8Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUInt8Type()
 }
 
 func (UInt8Type) isType() {}
@@ -440,9 +548,13 @@ func (UInt8Type) ID() string {
 
 type UInt16Type struct{}
 
-func NewUInt16Type(gauge common.MemoryGauge) UInt16Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUInt16Type() UInt16Type {
 	return UInt16Type{}
+}
+
+func NewMeteredUInt16Type(gauge common.MemoryGauge) UInt16Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUInt16Type()
 }
 
 func (UInt16Type) isType() {}
@@ -455,9 +567,13 @@ func (UInt16Type) ID() string {
 
 type UInt32Type struct{}
 
-func NewUInt32Type(gauge common.MemoryGauge) UInt32Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUInt32Type() UInt32Type {
 	return UInt32Type{}
+}
+
+func NewMeteredUInt32Type(gauge common.MemoryGauge) UInt32Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUInt32Type()
 }
 
 func (UInt32Type) isType() {}
@@ -470,9 +586,13 @@ func (UInt32Type) ID() string {
 
 type UInt64Type struct{}
 
-func NewUInt64Type(gauge common.MemoryGauge) UInt64Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUInt64Type() UInt64Type {
 	return UInt64Type{}
+}
+
+func NewMeteredUInt64Type(gauge common.MemoryGauge) UInt64Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUInt64Type()
 }
 
 func (UInt64Type) isType() {}
@@ -485,9 +605,13 @@ func (UInt64Type) ID() string {
 
 type UInt128Type struct{}
 
-func NewUInt128Type(gauge common.MemoryGauge) UInt128Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUInt128Type() UInt128Type {
 	return UInt128Type{}
+}
+
+func NewMeteredUInt128Type(gauge common.MemoryGauge) UInt128Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUInt128Type()
 }
 
 func (UInt128Type) isType() {}
@@ -500,9 +624,13 @@ func (UInt128Type) ID() string {
 
 type UInt256Type struct{}
 
-func NewUInt256Type(gauge common.MemoryGauge) UInt256Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUInt256Type() UInt256Type {
 	return UInt256Type{}
+}
+
+func NewMeteredUInt256Type(gauge common.MemoryGauge) UInt256Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUInt256Type()
 }
 
 func (UInt256Type) isType() {}
@@ -515,9 +643,13 @@ func (UInt256Type) ID() string {
 
 type Word8Type struct{}
 
-func NewWord8Type(gauge common.MemoryGauge) Word8Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewWord8Type() Word8Type {
 	return Word8Type{}
+}
+
+func NewMeteredWord8Type(gauge common.MemoryGauge) Word8Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewWord8Type()
 }
 
 func (Word8Type) isType() {}
@@ -530,9 +662,13 @@ func (Word8Type) ID() string {
 
 type Word16Type struct{}
 
-func NewWord16Type(gauge common.MemoryGauge) Word16Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewWord16Type() Word16Type {
 	return Word16Type{}
+}
+
+func NewMeteredWord16Type(gauge common.MemoryGauge) Word16Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewWord16Type()
 }
 
 func (Word16Type) isType() {}
@@ -545,9 +681,13 @@ func (Word16Type) ID() string {
 
 type Word32Type struct{}
 
-func NewWord32Type(gauge common.MemoryGauge) Word32Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewWord32Type() Word32Type {
 	return Word32Type{}
+}
+
+func NewMeteredWord32Type(gauge common.MemoryGauge) Word32Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewWord32Type()
 }
 
 func (Word32Type) isType() {}
@@ -560,9 +700,13 @@ func (Word32Type) ID() string {
 
 type Word64Type struct{}
 
-func NewWord64Type(gauge common.MemoryGauge) Word64Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewWord64Type() Word64Type {
 	return Word64Type{}
+}
+
+func NewMeteredWord64Type(gauge common.MemoryGauge) Word64Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewWord64Type()
 }
 
 func (Word64Type) isType() {}
@@ -575,9 +719,13 @@ func (Word64Type) ID() string {
 
 type Fix64Type struct{}
 
-func NewFix64Type(gauge common.MemoryGauge) Fix64Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewFix64Type() Fix64Type {
 	return Fix64Type{}
+}
+
+func NewMeteredFix64Type(gauge common.MemoryGauge) Fix64Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewFix64Type()
 }
 
 func (Fix64Type) isType() {}
@@ -590,9 +738,13 @@ func (Fix64Type) ID() string {
 
 type UFix64Type struct{}
 
-func NewUFix64Type(gauge common.MemoryGauge) UFix64Type {
-	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+func NewUFix64Type() UFix64Type {
 	return UFix64Type{}
+}
+
+func NewMeteredUFix64Type(gauge common.MemoryGauge) UFix64Type {
+	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
+	return NewUFix64Type()
 }
 
 func (UFix64Type) isType() {}
@@ -613,11 +765,17 @@ type VariableSizedArrayType struct {
 }
 
 func NewVariableSizedArrayType(
+	elementType Type,
+) VariableSizedArrayType {
+	return VariableSizedArrayType{ElementType: elementType}
+}
+
+func NewMeteredVariableSizedArrayType(
 	gauge common.MemoryGauge,
 	elementType Type,
 ) VariableSizedArrayType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceVariableSizedArrayType)
-	return VariableSizedArrayType{ElementType: elementType}
+	return NewVariableSizedArrayType(elementType)
 }
 
 func (VariableSizedArrayType) isType() {}
@@ -638,15 +796,22 @@ type ConstantSizedArrayType struct {
 }
 
 func NewConstantSizedArrayType(
+	size uint,
+	elementType Type,
+) ConstantSizedArrayType {
+	return ConstantSizedArrayType{
+		Size:        size,
+		ElementType: elementType,
+	}
+}
+
+func NewMeteredConstantSizedArrayType(
 	gauge common.MemoryGauge,
 	size uint,
 	elementType Type,
 ) ConstantSizedArrayType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceConstantSizedArrayType)
-	return ConstantSizedArrayType{
-		Size:        size,
-		ElementType: elementType,
-	}
+	return NewConstantSizedArrayType(size, elementType)
 }
 
 func (ConstantSizedArrayType) isType() {}
@@ -667,15 +832,22 @@ type DictionaryType struct {
 }
 
 func NewDictionaryType(
+	keyType Type,
+	elementType Type,
+) DictionaryType {
+	return DictionaryType{
+		KeyType:     keyType,
+		ElementType: elementType,
+	}
+}
+
+func NewMeteredDictionaryType(
 	gauge common.MemoryGauge,
 	keyType Type,
 	elementType Type,
 ) DictionaryType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceDictionaryType)
-	return DictionaryType{
-		KeyType:     keyType,
-		ElementType: elementType,
-	}
+	return NewDictionaryType(keyType, elementType)
 }
 
 func (DictionaryType) isType() {}
@@ -745,6 +917,20 @@ type StructType struct {
 }
 
 func NewStructType(
+	location common.Location,
+	qualifiedIdentifer string,
+	fields []Field,
+	initializers [][]Parameter,
+) *StructType {
+	return &StructType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifer,
+		Fields:              fields,
+		Initializers:        initializers,
+	}
+}
+
+func NewMeteredStructType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifer string,
@@ -752,12 +938,7 @@ func NewStructType(
 	initializers [][]Parameter,
 ) *StructType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceStructType)
-	return &StructType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
-		Fields:              fields,
-		Initializers:        initializers,
-	}
+	return NewStructType(location, qualifiedIdentifer, fields, initializers)
 }
 
 func (*StructType) isType() {}
@@ -798,6 +979,20 @@ type ResourceType struct {
 }
 
 func NewResourceType(
+	location common.Location,
+	qualifiedIdentifer string,
+	fields []Field,
+	initializers [][]Parameter,
+) *ResourceType {
+	return &ResourceType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifer,
+		Fields:              fields,
+		Initializers:        initializers,
+	}
+}
+
+func NewMeteredResourceType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifer string,
@@ -805,12 +1000,7 @@ func NewResourceType(
 	initializers [][]Parameter,
 ) *ResourceType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceResourceType)
-	return &ResourceType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
-		Fields:              fields,
-		Initializers:        initializers,
-	}
+	return NewResourceType(location, qualifiedIdentifer, fields, initializers)
 }
 
 func (*ResourceType) isType() {}
@@ -851,6 +1041,20 @@ type EventType struct {
 }
 
 func NewEventType(
+	location common.Location,
+	qualifiedIdentifer string,
+	fields []Field,
+	initializer []Parameter,
+) *EventType {
+	return &EventType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifer,
+		Fields:              fields,
+		Initializer:         initializer,
+	}
+}
+
+func NewMeteredEventType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifer string,
@@ -858,12 +1062,7 @@ func NewEventType(
 	initializer []Parameter,
 ) *EventType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceEventType)
-	return &EventType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
-		Fields:              fields,
-		Initializer:         initializer,
-	}
+	return NewEventType(location, qualifiedIdentifer, fields, initializer)
 }
 
 func (*EventType) isType() {}
@@ -904,6 +1103,20 @@ type ContractType struct {
 }
 
 func NewContractType(
+	location common.Location,
+	qualifiedIdentifer string,
+	fields []Field,
+	initializers [][]Parameter,
+) *ContractType {
+	return &ContractType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifer,
+		Fields:              fields,
+		Initializers:        initializers,
+	}
+}
+
+func NewMeteredContractType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifer string,
@@ -911,12 +1124,7 @@ func NewContractType(
 	initializers [][]Parameter,
 ) *ContractType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceContractType)
-	return &ContractType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
-		Fields:              fields,
-		Initializers:        initializers,
-	}
+	return NewContractType(location, qualifiedIdentifer, fields, initializers)
 }
 
 func (*ContractType) isType() {}
@@ -968,6 +1176,20 @@ type StructInterfaceType struct {
 }
 
 func NewStructInterfaceType(
+	location common.Location,
+	qualifiedIdentifer string,
+	fields []Field,
+	initializers [][]Parameter,
+) *StructInterfaceType {
+	return &StructInterfaceType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifer,
+		Fields:              fields,
+		Initializers:        initializers,
+	}
+}
+
+func NewMeteredStructInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifer string,
@@ -975,12 +1197,7 @@ func NewStructInterfaceType(
 	initializers [][]Parameter,
 ) *StructInterfaceType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceStructInterfaceType)
-	return &StructInterfaceType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
-		Fields:              fields,
-		Initializers:        initializers,
-	}
+	return NewStructInterfaceType(location, qualifiedIdentifer, fields, initializers)
 }
 
 func (*StructInterfaceType) isType() {}
@@ -1021,6 +1238,20 @@ type ResourceInterfaceType struct {
 }
 
 func NewResourceInterfaceType(
+	location common.Location,
+	qualifiedIdentifer string,
+	fields []Field,
+	initializers [][]Parameter,
+) *ResourceInterfaceType {
+	return &ResourceInterfaceType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifer,
+		Fields:              fields,
+		Initializers:        initializers,
+	}
+}
+
+func NewMeteredResourceInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifer string,
@@ -1028,12 +1259,7 @@ func NewResourceInterfaceType(
 	initializers [][]Parameter,
 ) *ResourceInterfaceType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceResourceInterfaceType)
-	return &ResourceInterfaceType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
-		Fields:              fields,
-		Initializers:        initializers,
-	}
+	return NewResourceInterfaceType(location, qualifiedIdentifer, fields, initializers)
 }
 
 func (*ResourceInterfaceType) isType() {}
@@ -1074,6 +1300,20 @@ type ContractInterfaceType struct {
 }
 
 func NewContractInterfaceType(
+	location common.Location,
+	qualifiedIdentifer string,
+	fields []Field,
+	initializers [][]Parameter,
+) *ContractInterfaceType {
+	return &ContractInterfaceType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifer,
+		Fields:              fields,
+		Initializers:        initializers,
+	}
+}
+
+func NewMeteredContractInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifer string,
@@ -1081,12 +1321,7 @@ func NewContractInterfaceType(
 	initializers [][]Parameter,
 ) *ContractInterfaceType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceContractInterfaceType)
-	return &ContractInterfaceType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
-		Fields:              fields,
-		Initializers:        initializers,
-	}
+	return NewContractInterfaceType(location, qualifiedIdentifer, fields, initializers)
 }
 
 func (*ContractInterfaceType) isType() {}
@@ -1126,17 +1361,25 @@ type FunctionType struct {
 }
 
 func NewFunctionType(
+	typeID string,
+	parameters []Parameter,
+	returnType Type,
+) FunctionType {
+	return FunctionType{
+		typeID:     typeID,
+		Parameters: parameters,
+		ReturnType: returnType,
+	}
+}
+
+func NewMeteredFunctionType(
 	gauge common.MemoryGauge,
 	typeID string,
 	parameters []Parameter,
 	returnType Type,
 ) FunctionType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceFunctionType)
-	return FunctionType{
-		typeID:     typeID,
-		Parameters: parameters,
-		ReturnType: returnType,
-	}
+	return NewFunctionType(typeID, parameters, returnType)
 }
 
 func (FunctionType) isType() {}
@@ -1158,15 +1401,22 @@ type ReferenceType struct {
 }
 
 func NewReferenceType(
+	authorized bool,
+	typ Type,
+) ReferenceType {
+	return ReferenceType{
+		Authorized: authorized,
+		Type:       typ,
+	}
+}
+
+func NewMeteredReferenceType(
 	gauge common.MemoryGauge,
 	authorized bool,
 	typ Type,
 ) ReferenceType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceReferenceType)
-	return ReferenceType{
-		Authorized: authorized,
-		Type:       typ,
-	}
+	return NewReferenceType(authorized, typ)
 }
 
 func (ReferenceType) isType() {}
@@ -1188,17 +1438,25 @@ type RestrictedType struct {
 }
 
 func NewRestrictedType(
+	typeID string,
+	typ Type,
+	restrictions []Type,
+) *RestrictedType {
+	return &RestrictedType{
+		typeID:       typeID,
+		Type:         typ,
+		Restrictions: restrictions,
+	}
+}
+
+func NewMeteredRestrictedType(
 	gauge common.MemoryGauge,
 	typeID string,
 	typ Type,
 	restrictions []Type,
 ) *RestrictedType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceRestrictedType)
-	return &RestrictedType{
-		typeID:       typeID,
-		Type:         typ,
-		Restrictions: restrictions,
-	}
+	return NewRestrictedType(typeID, typ, restrictions)
 }
 
 func (RestrictedType) isType() {}
@@ -1216,11 +1474,15 @@ func (t RestrictedType) WithID(id string) RestrictedType {
 
 type BlockType struct{}
 
-func NewBlockType(
+func NewBlockType() BlockType {
+	return BlockType{}
+}
+
+func NewMeteredBlockType(
 	gauge common.MemoryGauge,
 ) BlockType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return BlockType{}
+	return NewBlockType()
 }
 
 func (BlockType) isType() {}
@@ -1233,11 +1495,15 @@ func (BlockType) ID() string {
 
 type PathType struct{}
 
-func NewPathType(
+func NewPathType() PathType {
+	return PathType{}
+}
+
+func NewMeteredPathType(
 	gauge common.MemoryGauge,
 ) PathType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return PathType{}
+	return NewPathType()
 }
 
 func (PathType) isType() {}
@@ -1250,11 +1516,15 @@ func (PathType) ID() string {
 
 type CapabilityPathType struct{}
 
-func NewCapabilityPathType(
+func NewCapabilityPathType() CapabilityPathType {
+	return CapabilityPathType{}
+}
+
+func NewMeteredCapabilityPathType(
 	gauge common.MemoryGauge,
 ) CapabilityPathType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return CapabilityPathType{}
+	return NewCapabilityPathType()
 }
 
 func (CapabilityPathType) isType() {}
@@ -1267,11 +1537,15 @@ func (CapabilityPathType) ID() string {
 
 type StoragePathType struct{}
 
-func NewStoragePathType(
+func NewStoragePathType() StoragePathType {
+	return StoragePathType{}
+}
+
+func NewMeteredStoragePathType(
 	gauge common.MemoryGauge,
 ) StoragePathType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return StoragePathType{}
+	return NewStoragePathType()
 }
 
 func (StoragePathType) isType() {}
@@ -1284,11 +1558,15 @@ func (StoragePathType) ID() string {
 
 type PublicPathType struct{}
 
-func NewPublicPathType(
+func NewPublicPathType() PublicPathType {
+	return PublicPathType{}
+}
+
+func NewMeteredPublicPathType(
 	gauge common.MemoryGauge,
 ) PublicPathType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return PublicPathType{}
+	return NewPublicPathType()
 }
 
 func (PublicPathType) isType() {}
@@ -1301,11 +1579,15 @@ func (PublicPathType) ID() string {
 
 type PrivatePathType struct{}
 
-func NewPrivatePathType(
+func NewPrivatePathType() PrivatePathType {
+	return PrivatePathType{}
+}
+
+func NewMeteredPrivatePathType(
 	gauge common.MemoryGauge,
 ) PrivatePathType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return PrivatePathType{}
+	return NewPrivatePathType()
 }
 
 func (PrivatePathType) isType() {}
@@ -1320,12 +1602,16 @@ type CapabilityType struct {
 	BorrowType Type
 }
 
-func NewCapabilityType(
+func NewCapabilityType(borrowType Type) CapabilityType {
+	return CapabilityType{BorrowType: borrowType}
+}
+
+func NewMeteredCapabilityType(
 	gauge common.MemoryGauge,
 	borrowType Type,
 ) CapabilityType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceCapabilityType)
-	return CapabilityType{BorrowType: borrowType}
+	return NewCapabilityType(borrowType)
 }
 
 func (CapabilityType) isType() {}
@@ -1347,6 +1633,22 @@ type EnumType struct {
 }
 
 func NewEnumType(
+	location common.Location,
+	qualifiedIdentifier string,
+	rawType Type,
+	fields []Field,
+	initializers [][]Parameter,
+) *EnumType {
+	return &EnumType{
+		Location:            location,
+		QualifiedIdentifier: qualifiedIdentifier,
+		RawType:             rawType,
+		Fields:              fields,
+		Initializers:        initializers,
+	}
+}
+
+func NewMeteredEnumType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifier string,
@@ -1355,13 +1657,7 @@ func NewEnumType(
 	initializers [][]Parameter,
 ) *EnumType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceEnumType)
-	return &EnumType{
-		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifier,
-		RawType:             rawType,
-		Fields:              fields,
-		Initializers:        initializers,
-	}
+	return NewEnumType(location, qualifiedIdentifier, rawType, fields, initializers)
 }
 
 func (*EnumType) isType() {}
@@ -1395,11 +1691,15 @@ func (t *EnumType) CompositeInitializers() [][]Parameter {
 // AuthAccountType
 type AuthAccountType struct{}
 
-func NewAuthAccountType(
+func NewAuthAccountType() AuthAccountType {
+	return AuthAccountType{}
+}
+
+func NewMeteredAuthAccountType(
 	gauge common.MemoryGauge,
 ) AuthAccountType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return AuthAccountType{}
+	return NewAuthAccountType()
 }
 
 func (AuthAccountType) isType() {}
@@ -1411,11 +1711,15 @@ func (AuthAccountType) ID() string {
 // PublicAccountType
 type PublicAccountType struct{}
 
-func NewPublicAccountType(
+func NewPublicAccountType() PublicAccountType {
+	return PublicAccountType{}
+}
+
+func NewMeteredPublicAccountType(
 	gauge common.MemoryGauge,
 ) PublicAccountType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return PublicAccountType{}
+	return NewPublicAccountType()
 }
 
 func (PublicAccountType) isType() {}
@@ -1427,11 +1731,15 @@ func (PublicAccountType) ID() string {
 // DeployedContractType
 type DeployedContractType struct{}
 
-func NewDeployedContractType(
+func NewDeployedContractType() DeployedContractType {
+	return DeployedContractType{}
+}
+
+func NewMeteredDeployedContractType(
 	gauge common.MemoryGauge,
 ) DeployedContractType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return DeployedContractType{}
+	return NewDeployedContractType()
 }
 
 func (DeployedContractType) isType() {}
@@ -1443,11 +1751,15 @@ func (DeployedContractType) ID() string {
 // AuthAccountContractsType
 type AuthAccountContractsType struct{}
 
-func NewAuthAccountContractsType(
+func NewAuthAccountContractsType() AuthAccountContractsType {
+	return AuthAccountContractsType{}
+}
+
+func NewMeteredAuthAccountContractsType(
 	gauge common.MemoryGauge,
 ) AuthAccountContractsType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return AuthAccountContractsType{}
+	return NewAuthAccountContractsType()
 }
 
 func (AuthAccountContractsType) isType() {}
@@ -1459,11 +1771,15 @@ func (AuthAccountContractsType) ID() string {
 // PublicAccountContractsType
 type PublicAccountContractsType struct{}
 
-func NewPublicAccountContractsType(
+func NewPublicAccountContractsType() PublicAccountContractsType {
+	return PublicAccountContractsType{}
+}
+
+func NewMeteredPublicAccountContractsType(
 	gauge common.MemoryGauge,
 ) PublicAccountContractsType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return PublicAccountContractsType{}
+	return NewPublicAccountContractsType()
 }
 
 func (PublicAccountContractsType) isType() {}
@@ -1475,11 +1791,15 @@ func (PublicAccountContractsType) ID() string {
 // AuthAccountKeysType
 type AuthAccountKeysType struct{}
 
-func NewAuthAccountKeysType(
+func NewAuthAccountKeysType() AuthAccountKeysType {
+	return AuthAccountKeysType{}
+}
+
+func NewMeteredAuthAccountKeysType(
 	gauge common.MemoryGauge,
 ) AuthAccountKeysType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return AuthAccountKeysType{}
+	return NewAuthAccountKeysType()
 }
 
 func (AuthAccountKeysType) isType() {}
@@ -1491,11 +1811,15 @@ func (AuthAccountKeysType) ID() string {
 // PublicAccountContractsType
 type PublicAccountKeysType struct{}
 
-func NewPublicAccountKeysType(
+func NewPublicAccountKeysType() PublicAccountKeysType {
+	return PublicAccountKeysType{}
+}
+
+func NewMeteredPublicAccountKeysType(
 	gauge common.MemoryGauge,
 ) PublicAccountKeysType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return PublicAccountKeysType{}
+	return NewPublicAccountKeysType()
 }
 
 func (PublicAccountKeysType) isType() {}
@@ -1507,11 +1831,15 @@ func (PublicAccountKeysType) ID() string {
 // AccountKeyType
 type AccountKeyType struct{}
 
-func NewAccountKeyType(
+func NewAccountKeyType() AccountKeyType {
+	return AccountKeyType{}
+}
+
+func NewMeteredAccountKeyType(
 	gauge common.MemoryGauge,
 ) AccountKeyType {
 	common.UseConstantMemory(gauge, common.MemoryKindCadenceSimpleType)
-	return AccountKeyType{}
+	return NewAccountKeyType()
 }
 
 func (AccountKeyType) isType() {}

--- a/values.go
+++ b/values.go
@@ -634,6 +634,7 @@ func (v Int128) String() string {
 type Int256 struct {
 	Value *big.Int
 }
+
 var _ Value = Int256{}
 
 var Int256MemoryUsage = common.NewCadenceBigIntMemoryUsage(32)
@@ -1208,8 +1209,12 @@ var _ Value = Fix64(0)
 
 var fix64MemoryUsage = common.NewCadenceNumberMemoryUsage(int(unsafe.Sizeof(Fix64(0))))
 
-func NewFix64(value int64) (Fix64, error) {
-	return Fix64(value), nil
+func NewFix64(s string) (Fix64, error) {
+	v, err := fixedpoint.ParseFix64(s)
+	if err != nil {
+		return 0, err
+	}
+	return Fix64(v.Int64()), nil
 }
 
 func NewFix64FromParts(negative bool, integer int, fraction uint) (Fix64, error) {
@@ -1225,21 +1230,13 @@ func NewFix64FromParts(negative bool, integer int, fraction uint) (Fix64, error)
 	return Fix64(v.Int64()), nil
 }
 
-func NewMeteredFix64(gauge common.MemoryGauge, constructor func() (int64, error)) (Fix64, error) {
+func NewMeteredFix64(gauge common.MemoryGauge, constructor func() (string, error)) (Fix64, error) {
 	common.UseMemory(gauge, fix64MemoryUsage)
 	value, err := constructor()
 	if err != nil {
 		return 0, err
 	}
 	return NewFix64(value)
-}
-
-func ParseFix64(s string) (int64, error) {
-	v, err := fixedpoint.ParseFix64(s)
-	if err != nil {
-		return 0, err
-	}
-	return v.Int64(), nil
 }
 
 func (Fix64) isValue() {}
@@ -1274,8 +1271,12 @@ var _ Value = UFix64(0)
 
 var ufix64MemoryUsage = common.NewCadenceNumberMemoryUsage(int(unsafe.Sizeof(UFix64(0))))
 
-func NewUFix64(value uint64) (UFix64, error) {
-	return UFix64(value), nil
+func NewUFix64(s string) (UFix64, error) {
+	v, err := fixedpoint.ParseUFix64(s)
+	if err != nil {
+		return 0, err
+	}
+	return UFix64(v.Uint64()), nil
 }
 
 func NewUFix64FromParts(integer int, fraction uint) (UFix64, error) {
@@ -1290,7 +1291,7 @@ func NewUFix64FromParts(integer int, fraction uint) (UFix64, error) {
 	return UFix64(v.Uint64()), nil
 }
 
-func NewMeteredUFix64(gauge common.MemoryGauge, constructor func() (uint64, error)) (UFix64, error) {
+func NewMeteredUFix64(gauge common.MemoryGauge, constructor func() (string, error)) (UFix64, error) {
 	common.UseMemory(gauge, ufix64MemoryUsage)
 	value, err := constructor()
 	if err != nil {

--- a/values.go
+++ b/values.go
@@ -311,15 +311,15 @@ func NewMeteredAddress(memoryGauge common.MemoryGauge, b [AddressLength]byte) Ad
 	return NewAddress(b)
 }
 
-func BytesToUnmeteredAddress(b []byte) Address {
+func BytesToAddress(b []byte) Address {
 	var a Address
 	copy(a[AddressLength-len(b):AddressLength], b)
 	return a
 }
 
-func BytesToAddress(memoryGauge common.MemoryGauge, b []byte) Address {
+func BytesToMeteredAddress(memoryGauge common.MemoryGauge, b []byte) Address {
 	common.UseConstantMemory(memoryGauge, common.MemoryKindCadenceAddress)
-	return BytesToUnmeteredAddress(b)
+	return BytesToAddress(b)
 }
 
 func (Address) isValue() {}

--- a/values_test.go
+++ b/values_test.go
@@ -483,7 +483,7 @@ func TestOptional_Type(t *testing.T) {
 			OptionalType{
 				Type: NeverType{},
 			},
-			Optional{}.Type(nil),
+			Optional{}.Type(),
 		)
 	})
 
@@ -495,7 +495,7 @@ func TestOptional_Type(t *testing.T) {
 			},
 			Optional{
 				Value: Int8(2),
-			}.Type(nil),
+			}.Type(),
 		)
 	})
 }

--- a/values_test.go
+++ b/values_test.go
@@ -40,11 +40,8 @@ func TestStringer(t *testing.T) {
 		expected string
 	}
 
-	parsedU, _ := ParseUFix64("64.01")
-	ufix64, _ := NewUFix64(parsedU)
-
-	parsed, _ := ParseFix64("-32.11")
-	fix64, _ := NewFix64(parsed)
+	ufix64, _ := NewUFix64("64.01")
+	fix64, _ := NewFix64("-32.11")
 
 	stringerTests := map[string]testCase{
 		"UInt": {

--- a/values_test.go
+++ b/values_test.go
@@ -260,7 +260,7 @@ func TestStringer(t *testing.T) {
 		"Capability": {
 			value: Capability{
 				Path:       Path{Domain: "storage", Identifier: "foo"},
-				Address:    BytesToUnmeteredAddress([]byte{1, 2, 3, 4, 5}),
+				Address:    BytesToAddress([]byte{1, 2, 3, 4, 5}),
 				BorrowType: IntType{},
 			},
 			expected: "Capability<Int>(address: 0x0000000102030405, path: /storage/foo)",


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-private-issues/issues/46

## Description

The SDK etc use the cadence.Value and cadence.Type types. This PR undoes a change to the cadence.Value.Type method so the API will remain unchanged in the next Cadence release.

The cadence.Value.MeteredType method was added for when memory metering is needed.

Another change: I added compile-time interface type checking for the cadence.Value types. ex: `var _ Value = Void{}`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
