### PR TITLE
[LS] NPM release v0.24.0 crash reporting

### DIFF
--- a/languageserver/jsonrpc2/server.go
+++ b/languageserver/jsonrpc2/server.go
@@ -34,6 +34,9 @@ type handler struct {
 }
 
 func (handler *handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	defer sentry.Flush(2 * time.Second)
+	defer sentry.Recover()
+
 	method, ok := handler.server.Methods[req.Method]
 
 	if !ok {
@@ -53,8 +56,6 @@ func (handler *handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *js
 		return
 	}
 
-	defer sentry.Flush(2 * time.Second)
-	defer sentry.Recover()
 	result, err := method(req.Params)
 
 	if req.Notif {

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1718,7 +1718,6 @@ func (s *Server) getDiagnostics(
 			diagnostics = append(diagnostics, parserDiagnostics...)
 		}
 	}
-	panic("CRASH TEST 2")
 	// If there is a parse result succeeded proceed with resolving imports and checking the parsed program,
 	// even if there there might have been parsing errors.
 

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/onflow/cadence/languageserver/test"
+
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -292,6 +294,8 @@ func NewServer() (*Server, error) {
 	server.protocolServer = protocol.NewServer(server)
 
 	// init crash reporting
+	defer sentry.Flush(2 * time.Second)
+	defer sentry.Recover()
 	initCrashReporting(server)
 
 	// Set default commands
@@ -385,6 +389,7 @@ func initCrashReporting(server *Server) {
 		Transport:        sentrySyncTransport,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			if server.reportCrashes {
+				test.Log("crash report", event)
 				return event
 			}
 
@@ -1713,7 +1718,7 @@ func (s *Server) getDiagnostics(
 			diagnostics = append(diagnostics, parserDiagnostics...)
 		}
 	}
-
+	panic("CRASH TEST 2")
 	// If there is a parse result succeeded proceed with resolving imports and checking the parsed program,
 	// even if there there might have been parsing errors.
 

--- a/npm-packages/cadence-language-server/package.json
+++ b/npm-packages/cadence-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-language-server",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "The Cadence Language Server",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {


### PR DESCRIPTION
Closes: #1639 

This PR updates the released version on npm that includes the crash reporting. It also improves crash reporting by covering the server init too.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
