### PR TITLE
[0.23] Reads of missing storage maps should not cause creation

### DIFF
--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -200,7 +200,7 @@ type interpreterStorage struct {
 
 var _ interpreter.Storage = &interpreterStorage{}
 
-func (i interpreterStorage) GetStorageMap(_ common.Address, _ string) *interpreter.StorageMap {
+func (i interpreterStorage) GetStorageMap(_ common.Address, _ string, _ bool) *interpreter.StorageMap {
 	panic("unexpected GetStorageMap call")
 }
 

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -218,9 +218,12 @@ func TestRuntimeContract(t *testing.T) {
 		// so getting the storage map here once upfront would result in outdated data
 
 		getContractValueExists := func() bool {
-			return NewStorage(storage).
-				GetStorageMap(signerAddress, StorageDomainContract).
-				ValueExists("Test")
+			storageMap := NewStorage(storage).
+				GetStorageMap(signerAddress, StorageDomainContract, false)
+			if storageMap == nil {
+				return false
+			}
+			return storageMap.ValueExists("Test")
 		}
 
 		t.Run("add", func(t *testing.T) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -306,7 +306,7 @@ func (c TypeCodes) Merge(codes TypeCodes) {
 
 type Storage interface {
 	atree.SlabStorage
-	GetStorageMap(address common.Address, domain string) *StorageMap
+	GetStorageMap(address common.Address, domain string, createIfNotExists bool) *StorageMap
 	CheckHealth() error
 }
 
@@ -2565,7 +2565,10 @@ func (interpreter *Interpreter) storedValueExists(
 	domain string,
 	identifier string,
 ) bool {
-	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain)
+	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain, false)
+	if accountStorage == nil {
+		return false
+	}
 	return accountStorage.ValueExists(identifier)
 }
 
@@ -2574,7 +2577,10 @@ func (interpreter *Interpreter) ReadStored(
 	domain string,
 	identifier string,
 ) Value {
-	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain)
+	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain, false)
+	if accountStorage == nil {
+		return nil
+	}
 	return accountStorage.ReadValue(identifier)
 }
 
@@ -2584,7 +2590,7 @@ func (interpreter *Interpreter) writeStored(
 	identifier string,
 	value Value,
 ) {
-	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain)
+	accountStorage := interpreter.Storage.GetStorageMap(storageAddress, domain, true)
 	accountStorage.WriteValue(interpreter, identifier, value)
 }
 

--- a/runtime/interpreter/storage.go
+++ b/runtime/interpreter/storage.go
@@ -167,10 +167,16 @@ func NewInMemoryStorage() InMemoryStorage {
 	}
 }
 
-func (i InMemoryStorage) GetStorageMap(address common.Address, domain string) (storageMap *StorageMap) {
+func (i InMemoryStorage) GetStorageMap(
+	address common.Address,
+	domain string,
+	createIfNotExists bool,
+) (
+	storageMap *StorageMap,
+) {
 	key := StorageKey{address, domain}
 	storageMap = i.StorageMaps[key]
-	if storageMap == nil {
+	if storageMap == nil && createIfNotExists {
 		storageMap = NewStorageMap(i, atree.Address(address))
 		i.StorageMaps[key] = storageMap
 	}

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -448,8 +448,7 @@ func TestStorageOverwriteAndRemove(t *testing.T) {
 
 	const identifier = "test"
 
-	storageMap := storage.GetStorageMap(address, "storage")
-
+	storageMap := storage.GetStorageMap(address, "storage", true)
 	storageMap.WriteValue(inter, identifier, array1)
 
 	// Overwriting delete any existing child slabs

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1916,8 +1916,11 @@ func (r *interpreterRuntime) loadContract(
 			storageMap := storage.GetStorageMap(
 				location.Address,
 				StorageDomainContract,
+				false,
 			)
-			storedValue = storageMap.ReadValue(location.Name)
+			if storageMap != nil {
+				storedValue = storageMap.ReadValue(location.Name)
+			}
 		}
 
 		if storedValue == nil {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -5491,17 +5491,6 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	deploy := utils.DeploymentTransaction("Test", contract)
 
-	setupTx := []byte(`
-      import Test from 0xCADE
-
-       transaction {
-
-          prepare(signer: AuthAccount) {
-              signer.save(<-Test.createR(), to: /storage/r)
-          }
-       }
-    `)
-
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
@@ -5579,7 +5568,16 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	err = runtime.ExecuteTransaction(
 		Script{
-			Source: setupTx,
+			Source: []byte(`
+              import Test from 0xCADE
+
+               transaction {
+
+                  prepare(signer: AuthAccount) {
+                      signer.save(<-Test.createR(), to: /storage/r)
+                  }
+               }
+            `),
 		},
 		Context{
 			Interface: runtimeInterface,
@@ -5595,12 +5593,12 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 				addressValue[:],
 				[]byte("storage"),
 			},
-			// storage domain storage map
+			// resource value
 			{
 				addressValue[:],
 				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3},
 			},
-			// resource value
+			// storage domain storage map
 			{
 				addressValue[:],
 				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4},
@@ -5665,7 +5663,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 			// resource value
 			{
 				addressValue[:],
-				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4},
+				[]byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3},
 			},
 		},
 		writes,

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -2929,3 +2929,42 @@ func TestRuntimeStorageEnumCase(t *testing.T) {
 		loggedMessages,
 	)
 }
+
+func TestStorageReadNoImplicitWrite(t *testing.T) {
+
+	t.Parallel()
+
+	rt := newTestInterpreterRuntime()
+
+	address, err := common.HexToAddress("0x1")
+	require.NoError(t, err)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestLedger(nil, func(_, _, _ []byte) {
+			assert.FailNow(t, "unexpected write")
+		}),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{address}, nil
+		},
+	}
+
+	err = rt.ExecuteTransaction(
+		Script{
+			Source: []byte((`
+              transaction {
+			    prepare(signer: AuthAccount) {
+			        let ref = getAccount(0x2)
+			            .getCapability(/public/test)
+			            .borrow<&AnyStruct>()
+                    assert(ref == nil)
+			    }
+              }
+            `)),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  common.TransactionLocation{},
+		},
+	)
+	require.NoError(t, err)
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4565,7 +4565,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 			nil,
 		)
 
-		storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier())
+		storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier(), true)
 		storageMap.WriteValue(inter, storagePath.Identifier, r)
 
 		result, err := inter.Invoke("testInvalidUnauthorized")

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -727,7 +727,7 @@ func TestInterpretGetType(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier())
+			storageMap := storage.GetStorageMap(storageAddress, storagePath.Domain.Identifier(), true)
 			storageMap.WriteValue(
 				inter,
 				storagePath.Identifier,


### PR DESCRIPTION
Port of #1557 to v0.23

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
