### PR TITLE
Disable flow-go sync

### DIFF
--- a/.github/workflows/sync-flow-go.yml.disabled
+++ b/.github/workflows/sync-flow-go.yml.disabled
@@ -1,6 +1,14 @@
+# Temporarily disabled, due to it not being useful
+# The reason it wasn't being useful is that flow-go master and cadence master are not usually connected.
+# both repositories use feature branches for deploy versions
+# 
+# With modifications this could still be useful in the future
+
+
 # Open a PR in flow-go when a PR in cadence is merged
 # The PR in flow-go is based on the last opened `auto-cadence-upgrade/*` if it exists.
 # Otherwise, it's based on the feature/secure-cadence branch.
+
 name: Sync flow-go
 
 # Only run on pull requests merged to master


### PR DESCRIPTION

## Description

The flow-go sync action has not been useful for a while now. The reason is that both cadence doesn't use the master branch as the one that is being actively worked on.

Let's disable this for now, and we can see if it can be fixed later.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
