### PR TITLE
WIP looking for feedback on approach DO NOT MERGE

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -928,8 +928,8 @@ func HashTypeID(typeID common.TypeID) [HashedTypeIdLength]byte {
 }
 
 func bytesToHashedTypeIdLength(blob []byte) ([HashedTypeIdLength]byte, error) {
-	if len(blob) != 32 {
-		return [32]byte{}, errors.New("TODO")
+	if len(blob) != HashedTypeIdLength {
+		return [HashedTypeIdLength]byte{}, errors.New("TODO")
 	}
 
 	var rigid [HashedTypeIdLength]byte

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -933,9 +933,7 @@ func bytesToHashedTypeIdLength(blob []byte) ([HashedTypeIdLength]byte, error) {
 	}
 
 	var rigid [HashedTypeIdLength]byte
-	for i := 0; i < HashedTypeIdLength; i++ {
-		rigid[i] = blob[i]
-	}
+	copy(rigid[:], blob)
 
 	return rigid, nil
 }

--- a/runtime/common/addresslocation.go
+++ b/runtime/common/addresslocation.go
@@ -36,6 +36,8 @@ type AddressLocation struct {
 	Name    string
 }
 
+var _ Location = AddressLocation{}
+
 func (l AddressLocation) String() string {
 	if l.Name == "" {
 		return l.Address.String()

--- a/runtime/common/identifierlocation.go
+++ b/runtime/common/identifierlocation.go
@@ -30,6 +30,8 @@ const IdentifierLocationPrefix = "I"
 //
 type IdentifierLocation string
 
+var _ Location = IdentifierLocation("")
+
 func (l IdentifierLocation) ID() LocationID {
 	return NewLocationID(
 		IdentifierLocationPrefix,

--- a/runtime/common/scriptlocation.go
+++ b/runtime/common/scriptlocation.go
@@ -31,6 +31,8 @@ const ScriptLocationPrefix = "s"
 //
 type ScriptLocation []byte
 
+var _ Location = ScriptLocation{}
+
 func (l ScriptLocation) ID() LocationID {
 	return NewLocationID(
 		ScriptLocationPrefix,

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -30,6 +30,8 @@ const StringLocationPrefix = "S"
 //
 type StringLocation string
 
+var _ Location = StringLocation("")
+
 func (l StringLocation) ID() LocationID {
 	return NewLocationID(
 		StringLocationPrefix,

--- a/runtime/common/transactionlocation.go
+++ b/runtime/common/transactionlocation.go
@@ -31,6 +31,8 @@ const TransactionLocationPrefix = "t"
 //
 type TransactionLocation []byte
 
+var _ Location = TransactionLocation{}
+
 func (l TransactionLocation) ID() LocationID {
 	return NewLocationID(
 		TransactionLocationPrefix,

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -74,6 +74,7 @@ type Elaboration struct {
 	PostConditionsRewrite               map[*ast.Conditions]PostConditionsRewrite
 	EmitStatementEventTypes             map[*ast.EmitStatement]*CompositeType
 	CompositeTypes                      map[TypeID]*CompositeType
+	CompositeTypesEncoded               map[[32]byte]TypeID
 	InterfaceTypes                      map[TypeID]*InterfaceType
 	IdentifierInInvocationTypes         map[*ast.IdentifierExpression]Type
 	ImportDeclarationsResolvedLocations map[*ast.ImportDeclaration][]ResolvedLocation


### PR DESCRIPTION
This PR is just an easy way to get a good diff view with comments.

## Description

I wrote this code to work out a way to efficiently encode TypeID. This code definitely does not work. I just want to know if this approach is good in general.

My approach is to hash the TypeIDs so they will (hopefully) generally be smaller. This can be a security risk by allowing type spoofing so I use a long cryptographic hash instead of something simpler.

This only works if the TypeID is already loaded into the Elaboration struct so I encode the location as well.

QUESTION: What's a good way to load the location? I have two thoughts on approach:
1. Include the checker or whatever in the DecodeTypeID parameters.
2. Embrace lazy-loading by instead returning a struct with a method that takes a Checker (or w/e) that populates the Elaboration then returns the Type.

## Links

- https://github.com/onflow/cadence/issues/1636
- https://www.notion.so/dapperlabs/Compact-Cadence-Value-External-Encoding-fe380872bc84434b875489de1b0ad407#d23a081efd88465dbbb0e415b2fbbe06
- https://www.notion.so/dapperlabs/Cadence-External-Value-Encoding-9b4500fab33647cd851fe10d70285bc2
