### PR TITLE
Wrap memory error in FatalError and check for it when parsing

### DIFF
--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"unsafe"
@@ -130,6 +131,22 @@ var (
 	StorageKeyMemoryUsage = NewConstantMemoryUsage(MemoryKindStorageKey)
 )
 
+
+// FatalError indicates an error that should end
+// the Cadence parsing, checking, or interpretation.
+type FatalError struct {
+	Err error
+}
+
+func (e FatalError) Unwrap() error {
+	return e.Err
+}
+
+func (e FatalError) Error() string {
+	return fmt.Sprintf("Fatal error: %s", e.Err.Error())
+}
+
+
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {
 	if gauge == nil {
 		return
@@ -137,7 +154,7 @@ func UseMemory(gauge MemoryGauge, usage MemoryUsage) {
 
 	err := gauge.MeterMemory(usage)
 	if err != nil {
-		panic(err)
+		panic(FatalError{Err: err})
 	}
 }
 

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -131,22 +131,6 @@ var (
 	StorageKeyMemoryUsage = NewConstantMemoryUsage(MemoryKindStorageKey)
 )
 
-
-// FatalError indicates an error that should end
-// the Cadence parsing, checking, or interpretation.
-type FatalError struct {
-	Err error
-}
-
-func (e FatalError) Unwrap() error {
-	return e.Err
-}
-
-func (e FatalError) Error() string {
-	return fmt.Sprintf("Fatal error: %s", e.Err.Error())
-}
-
-
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {
 	if gauge == nil {
 		return
@@ -754,4 +738,18 @@ func UseConstantMemory(memoryGauge MemoryGauge, kind MemoryKind) {
 		Kind:   kind,
 		Amount: 1,
 	})
+}
+
+// FatalError indicates an error that should end
+// the Cadence parsing, checking, or interpretation.
+type FatalError struct {
+	Err error
+}
+
+func (e FatalError) Unwrap() error {
+	return e.Err
+}
+
+func (e FatalError) Error() string {
+	return fmt.Sprintf("Fatal error: %s", e.Err.Error())
 }

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/parser2"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -441,13 +440,10 @@ func TestMemoryMeteringErrors(t *testing.T) {
 		require.IsType(t, Error{}, err)
 		runtimeError := err.(Error)
 
-		require.IsType(t, &ParsingCheckingError{}, runtimeError.Err)
-		parsingCheckingError := runtimeError.Err.(*ParsingCheckingError)
+		require.IsType(t, common.FatalError{}, runtimeError.Err)
+		fatalError := runtimeError.Err.(common.FatalError)
 
-		require.IsType(t, parser2.Error{}, parsingCheckingError.Err)
-		parserError := parsingCheckingError.Err.(parser2.Error)
-
-		assert.Contains(t, parserError.Error(), "memory limit exceeded")
+		assert.Contains(t, fatalError.Error(), "memory limit exceeded")
 	})
 
 	t.Run("at interpreter", func(t *testing.T) {

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -20,10 +20,11 @@ package parser2
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/runtime/common"
 	"math/big"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -20,6 +20,7 @@ package parser2
 
 import (
 	"fmt"
+	"github.com/onflow/cadence/runtime/common"
 	"math/big"
 	"strings"
 	"unicode/utf8"
@@ -582,17 +583,23 @@ func defineLessThanOrTypeArgumentsExpression() {
 			p.next()
 			p.skipSpaceAndComments(true)
 
-			// First, try to to parse zero or more comma-separated
-			// type arguments (type annotations), a closing greater token `>`,
-			// and start of an argument list, i.e. the open paren token `(`.
+			// First, try to parse zero or more comma-separated type
+			// arguments (type annotations), a closing greater token `>`,
+			// and the start of an argument list, i.e. the open paren token `(`.
 			//
-			// This parse may fail, in which case we just ignore the error.
+			// This parse may fail, in which case we just ignore the error,
+			// with the exception of fatal errors.
 
 			var argumentsStartPos ast.Position
 
 			(func() {
 				defer func() {
-					_ = recover()
+					err := recover()
+					// Fatal errors should abort parsing
+					_, ok := err.(common.FatalError)
+					if ok {
+						panic(err)
+					}
 				}()
 
 				typeArguments = parseCommaSeparatedTypeAnnotations(p, lexer.TokenGreater)

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -315,7 +315,30 @@ func TestParseAdvancedExpression(t *testing.T) {
 		)
 	})
 
-	t.Run("test FatalError in setExprMetaLeftDenotation", func(t *testing.T) {
+	t.Run("FatalError in setExprMetaLeftDenotation", func(t *testing.T) {
+
+		t.Parallel()
+
+		gauge := makeLimitingMemoryGauge()
+		gauge.debug = true
+		gauge.Limit(common.MemoryKindPosition, 11)
+
+		var panicMsg interface{}
+		(func() {
+			defer func() {
+				panicMsg = recover()
+			}()
+			ParseExpression("1 < 2", gauge)
+		})()
+
+		require.IsType(t, common.FatalError{}, panicMsg)
+
+		fatalError, _ := panicMsg.(common.FatalError)
+		var expectedError limitingMemoryGaugeError
+		assert.ErrorAs(t, fatalError, &expectedError)
+	})
+
+	t.Run("FatalError in parser.report", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -19,15 +19,15 @@
 package parser2
 
 import (
-	"errors"
 	"fmt"
-	"github.com/onflow/cadence/runtime/common"
 	"math"
 	"math/big"
 	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -5944,7 +5944,7 @@ func (g *limitingMemoryGauge) MeterMemory(usage common.MemoryUsage) error {
 	}
 
 	if g.limits[usage.Kind] < usage.Amount {
-		return errors.New(fmt.Sprintf(`Reached limit for "%s"`, usage.Kind.String()))
+		return fmt.Errorf(`reached limit for "%s"`, usage.Kind.String())
 	}
 
 	g.limits[usage.Kind] -= usage.Amount

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -153,6 +153,8 @@ func (l *lexer) run(state stateFn) {
 		if r := recover(); r != nil {
 			var err error
 			switch r := r.(type) {
+			case common.FatalError:
+				panic(r) // fatal error percolates up
 			case error:
 				err = r
 			default:

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -131,8 +131,15 @@ func (p *parser) report(errs ...error) {
 		// If the reported error is not yet a parse error,
 		// create a `SyntaxError` at the current position
 
-		var parseError ParseError
 		var ok bool
+
+		// Fatal errors should abort parsing
+		_, ok = err.(common.FatalError)
+		if ok {
+			panic(err)
+		}
+
+		var parseError ParseError
 		parseError, ok = err.(ParseError)
 		if !ok {
 			parseError = &SyntaxError{

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -20,6 +20,7 @@ package parser2
 
 import (
 	"fmt"
+	"github.com/onflow/cadence/runtime/common"
 	"math/big"
 	"testing"
 
@@ -491,6 +492,22 @@ func TestParseArgumentList(t *testing.T) {
 			expected,
 			result,
 		)
+	})
+
+	t.Run("fatal error from lack of memory", func(t *testing.T) {
+		gauge := makeLimitingMemoryGauge()
+		gauge.Limit(common.MemoryKindSyntaxToken, 0)
+
+		var panicMsg interface{}
+		(func() {
+			defer func() {
+				panicMsg = recover()
+			}()
+
+			ParseArgumentList(`(1, b: true)`, gauge)
+		})()
+
+		require.IsType(t, common.FatalError{}, panicMsg)
 	})
 
 	t.Run("valid", func(t *testing.T) {

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -20,9 +20,10 @@ package parser2
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/runtime/common"
 	"math/big"
 	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -509,6 +509,10 @@ func TestParseArgumentList(t *testing.T) {
 		})()
 
 		require.IsType(t, common.FatalError{}, panicMsg)
+
+		fatalError, _ := panicMsg.(common.FatalError)
+		var expectedError limitingMemoryGaugeError
+		assert.ErrorAs(t, fatalError, &expectedError)
 	})
 
 	t.Run("valid", func(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-private-issues/issues/52

## Description

Two related changes:
1. The errors returned from the FVM can have types that Cadence is unaware of. This is causing a problem when there's an error when metering memory usage (typically when out of memory). So here I wrap those errors inside a new error type, `FatalError`.
2. Parsing's error handling is a mishmash of strategies. Compounding this is that panicking is used to implement lookahead in the parser. Eventually we will explicitly wrap every parsing error as a parsing error and treat all other errors as fatal. But for this PR we do the inverse: wrap known-to-be-fatal errors in `FatalError` and check for them when handling errors while parsing. This relates to https://github.com/onflow/cadence/issues/1659.

______

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
