### PR TITLE
Fix local token replay limit, add global replay limit

### DIFF
--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -579,6 +579,8 @@ func defineLessThanOrTypeArgumentsExpression() {
 			// was higher than the determined left binding power.
 
 			p.startBuffering()
+			p.startAmbiguity()
+			defer p.endAmbiguity()
 
 			// Skip the `<` token.
 			p.next()

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -5907,37 +5907,6 @@ func TestParseInvalidNegativeIntegerLiteralWithIncorrectPrefix(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestParseReplayLimit(t *testing.T) {
-
-	t.Parallel()
-
-	var builder strings.Builder
-	builder.WriteString("let t = T")
-	for i := 0; i < 1000; i++ {
-		builder.WriteString("<T")
-	}
-	builder.WriteString(">()")
-
-	code := builder.String()
-	_, err := ParseProgram(code, nil)
-	utils.AssertEqualWithDiff(t,
-		Error{
-			Code: code,
-			Errors: []error{
-				&SyntaxError{
-					Message: fmt.Sprintf("program too ambiguous, replay limit of %d tokens exceeded", tokenReplayLimit),
-					Pos: ast.Position{
-						Offset: 282,
-						Line:   1,
-						Column: 282,
-					},
-				},
-			},
-		},
-		err,
-	)
-}
-
 type limitingMemoryGauge struct {
 	limited map[common.MemoryKind]bool   // which kinds to limit
 	limits  map[common.MemoryKind]uint64 // limits of limited kinds

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -278,11 +278,11 @@ func (p *parser) acceptBuffered() {
 
 // localTokenReplayCountLimit is a sensible limit for how many tokens may be replayed
 // until the top-most ambiguity ends.
-const localTokenReplayCountLimit = 2 << 6
+const localTokenReplayCountLimit = 1 << 7
 
 // globalTokenReplayCountLimit is a sensible limit for how many tokens may be replayed
 // during a parse
-const globalTokenReplayCountLimit = 2 << 8
+const globalTokenReplayCountLimit = 1 << 9
 
 func checkReplayCount(total, additional, limit uint, kind string) uint {
 	newTotal := total + additional

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -54,9 +54,14 @@ type parser struct {
 	bufferedErrorsStack [][]error
 	// memoryGauge is used for metering memory usage
 	memoryGauge common.MemoryGauge
-	// replayedTokensCount is the number of replayed tokens since starting the initial buffering.
-	// It is reset when the buffered tokens get accepted. This keeps errors local.
-	replayedTokensCount uint
+	// localReplayedTokensCount is the number of replayed tokens since starting the top-most ambiguity.
+	// Reset when the top-most ambiguity starts and ends. This keeps errors local.
+	localReplayedTokensCount uint
+	// globalReplayedTokensCount is the number of replayed tokens since starting the parse.
+	// It is never reset.
+	globalReplayedTokensCount uint
+	// ambiguityLevel is the current level of ambiguity (nesting)
+	ambiguityLevel int
 	// expressionDepth is the depth of the currently parsed expression (if >0)
 	expressionDepth int
 	// typeDepth is the depth of the type (if >0)
@@ -269,14 +274,24 @@ func (p *parser) acceptBuffered() {
 			bufferedErrors...,
 		)
 	}
-
-	// Reset the replayed tokens count
-	p.replayedTokensCount = 0
 }
 
-// tokenReplayLimit is a sensible limit for how many tokens may be replayed
-// until the replay buffer is accepted.
-const tokenReplayLimit = 2 << 12
+// localTokenReplayCountLimit is a sensible limit for how many tokens may be replayed
+// until the top-most ambiguity ends.
+const localTokenReplayCountLimit = 2 << 6
+
+// globalTokenReplayCountLimit is a sensible limit for how many tokens may be replayed
+// during a parse
+const globalTokenReplayCountLimit = 2 << 8
+
+func checkReplayCount(total, additional, limit uint, kind string) uint {
+	newTotal := total + additional
+	// Check for overflow (uint) and for exceeding the limit
+	if newTotal < total || newTotal > limit {
+		panic(fmt.Errorf("program too ambiguous, %s replay limit of %d tokens exceeded", kind, limit))
+	}
+	return newTotal
+}
 
 func (p *parser) replayBuffered() {
 
@@ -288,12 +303,21 @@ func (p *parser) replayBuffered() {
 	lastIndex := len(p.backtrackingCursorStack) - 1
 	backtrackCursor := p.backtrackingCursorStack[lastIndex]
 
-	replayedCount := p.replayedTokensCount + uint(cursor-backtrackCursor)
-	// Check for overflow (uint) and for exceeding the limit
-	if replayedCount < p.replayedTokensCount || replayedCount > tokenReplayLimit {
-		panic(fmt.Errorf("program too ambiguous, replay limit of %d tokens exceeded", tokenReplayLimit))
-	}
-	p.replayedTokensCount = replayedCount
+	replayedCount := uint(cursor - backtrackCursor)
+
+	p.localReplayedTokensCount = checkReplayCount(
+		p.localReplayedTokensCount,
+		replayedCount,
+		localTokenReplayCountLimit,
+		"local",
+	)
+
+	p.globalReplayedTokensCount = checkReplayCount(
+		p.globalReplayedTokensCount,
+		replayedCount,
+		globalTokenReplayCountLimit,
+		"global",
+	)
 
 	p.tokens.Revert(backtrackCursor)
 	p.next()
@@ -402,6 +426,20 @@ func (p *parser) tokenToIdentifier(identifier lexer.Token) ast.Identifier {
 		identifier.Value.(string),
 		identifier.StartPos,
 	)
+}
+
+func (p *parser) startAmbiguity() {
+	if p.ambiguityLevel == 0 {
+		p.localReplayedTokensCount = 0
+	}
+	p.ambiguityLevel++
+}
+
+func (p *parser) endAmbiguity() {
+	p.ambiguityLevel--
+	if p.ambiguityLevel == 0 {
+		p.localReplayedTokensCount = 0
+	}
 }
 
 func ParseExpression(input string, memoryGauge common.MemoryGauge) (expression ast.Expression, errs []error) {

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -278,11 +278,11 @@ func (p *parser) acceptBuffered() {
 
 // localTokenReplayCountLimit is a sensible limit for how many tokens may be replayed
 // until the top-most ambiguity ends.
-const localTokenReplayCountLimit = 1 << 7
+const localTokenReplayCountLimit = 1 << 6
 
 // globalTokenReplayCountLimit is a sensible limit for how many tokens may be replayed
 // during a parse
-const globalTokenReplayCountLimit = 1 << 9
+const globalTokenReplayCountLimit = 1 << 10
 
 func checkReplayCount(total, additional, limit uint, kind string) uint {
 	newTotal := total + additional

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -53,7 +53,7 @@ func TestParseInvalid(t *testing.T) {
 	for _, test := range []test{
 		{unexpectedToken, "X"},
 		{unexpectedToken, "paste your code in here"},
-		{expectedExpression, "# a ( b > c > d > e > f > g > h > i > j > k > l > m > n > o > p > q > r > s > t > u > v > w > x > y > z > A > B > C > D > E > F>"},
+		{expectedExpression, "# a ( b > c > d > e > f > g > h > i > j > k > l > m > n > o > p > q > r >"},
 		{missingTypeAnnotation, "#0x0<{},>()"},
 	} {
 		t.Run(test.code, func(t *testing.T) {
@@ -700,7 +700,7 @@ func TestParseLocalReplayLimit(t *testing.T) {
 
 	var builder strings.Builder
 	builder.WriteString("let t = T")
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 30; i++ {
 		builder.WriteString("<T")
 	}
 	builder.WriteString(">()")
@@ -717,9 +717,9 @@ func TestParseLocalReplayLimit(t *testing.T) {
 						localTokenReplayCountLimit,
 					),
 					Pos: ast.Position{
-						Offset: 210,
+						Offset: 44,
 						Line:   1,
-						Column: 210,
+						Column: 44,
 					},
 				},
 			},
@@ -735,7 +735,7 @@ func TestParseGlobalReplayLimit(t *testing.T) {
 	var builder strings.Builder
 	for j := 0; j < 2; j++ {
 		builder.WriteString(";let t = T")
-		for i := 0; i < 30; i++ {
+		for i := 0; i < 16; i++ {
 			builder.WriteString("<T")
 		}
 	}
@@ -752,9 +752,9 @@ func TestParseGlobalReplayLimit(t *testing.T) {
 						globalTokenReplayCountLimit,
 					),
 					Pos: ast.Position{
-						Offset: 70,
+						Offset: 84,
 						Line:   1,
-						Column: 70,
+						Column: 84,
 					},
 				},
 			},

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -24,13 +24,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onflow/cadence/runtime/common"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser2/lexer"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )


### PR DESCRIPTION
## Description

The local replay was not correctly implemented: 
An ambiguity does not just end when the buffered tokens are accepted, it also ends after replaying the buffered tokens and re-parsing using a different rule. 
Explicitly state when an ambiguity starts and ends, and reset the local token replay limit.

In addition, add a global replay limit, as the local replay limit might not be sufficient in rejecting programs that are too ambiguous.

I parsed all Mainnet contracts using these changes and they all still parse.

TODO: Wrap errors in fatal errors, depends on #1660 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
