### PR TITLE
Limit depth of expressions and types

### DIFF
--- a/runtime/parser2/errors.go
+++ b/runtime/parser2/errors.go
@@ -65,6 +65,8 @@ type SyntaxError struct {
 	Message string
 }
 
+var _ ParseError = &SyntaxError{}
+
 func (*SyntaxError) isParseError() {}
 
 func (e *SyntaxError) StartPosition() ast.Position {
@@ -84,6 +86,8 @@ func (e *SyntaxError) Error() string {
 type JuxtaposedUnaryOperatorsError struct {
 	Pos ast.Position
 }
+
+var _ ParseError = &JuxtaposedUnaryOperatorsError{}
 
 func (*JuxtaposedUnaryOperatorsError) isParseError() {}
 
@@ -107,6 +111,8 @@ type InvalidIntegerLiteralError struct {
 	InvalidIntegerLiteralKind InvalidNumberLiteralKind
 	ast.Range
 }
+
+var _ ParseError = &InvalidIntegerLiteralError{}
 
 func (*InvalidIntegerLiteralError) isParseError() {}
 
@@ -142,4 +148,55 @@ func (e *InvalidIntegerLiteralError) SecondaryError() string {
 	}
 
 	panic(errors.NewUnreachableError())
+}
+
+// ExpressionDepthLimitReachedError is reported when the expression depth limit was reached
+//
+type ExpressionDepthLimitReachedError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = ExpressionDepthLimitReachedError{}
+
+func (ExpressionDepthLimitReachedError) isParseError() {}
+
+func (e ExpressionDepthLimitReachedError) Error() string {
+	return fmt.Sprintf(
+		"program too complex, reached max expression depth limit %d",
+		expressionDepthLimit,
+	)
+}
+
+func (e ExpressionDepthLimitReachedError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e ExpressionDepthLimitReachedError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+// TypeDepthLimitReachedError is reported when the type depth limit was reached
+//
+
+type TypeDepthLimitReachedError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = TypeDepthLimitReachedError{}
+
+func (TypeDepthLimitReachedError) isParseError() {}
+
+func (e TypeDepthLimitReachedError) Error() string {
+	return fmt.Sprintf(
+		"program too complex, reached max type depth limit %d",
+		typeDepthLimit,
+	)
+}
+
+func (e TypeDepthLimitReachedError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e TypeDepthLimitReachedError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
 }

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -1252,6 +1252,17 @@ func exprLeftDenotationAllowsWhitespaceAfterToken(tokenType lexer.TokenType) boo
 //
 func parseExpression(p *parser, rightBindingPower int) ast.Expression {
 
+	if p.expressionDepth == expressionDepthLimit {
+		panic(ExpressionDepthLimitReachedError{
+			Pos: p.current.StartPos,
+		})
+	}
+
+	p.expressionDepth++
+	defer func() {
+		p.expressionDepth--
+	}()
+
 	p.skipSpaceAndComments(true)
 	t := p.current
 	p.next()

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -5865,13 +5865,13 @@ func TestParseReplayLimit(t *testing.T) {
 
 	var builder strings.Builder
 	builder.WriteString("let t = T")
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		builder.WriteString("<T")
 	}
 	builder.WriteString(">()")
 
 	code := builder.String()
-	_, errs := ParseProgram(code, nil)
+	_, err := ParseProgram(code, nil)
 	utils.AssertEqualWithDiff(t,
 		Error{
 			Code: code,
@@ -5879,13 +5879,13 @@ func TestParseReplayLimit(t *testing.T) {
 				&SyntaxError{
 					Message: fmt.Sprintf("program too ambiguous, replay limit of %d tokens exceeded", tokenReplayLimit),
 					Pos: ast.Position{
-						Offset: 210,
+						Offset: 282,
 						Line:   1,
-						Column: 210,
+						Column: 282,
 					},
 				},
 			},
 		},
-		errs,
+		err,
 	)
 }

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -30,10 +30,10 @@ import (
 )
 
 // expressionDepthLimit is the limit of how deeply nested an expression can get
-const expressionDepthLimit = 16
+const expressionDepthLimit = 1 << 4
 
 // typeDepthLimit is the limit of how deeply nested a type can get
-const typeDepthLimit = 16
+const typeDepthLimit = 1 << 4
 
 // lowestBindingPower is the lowest binding power.
 // The binding power controls operator precedence:

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -29,6 +29,12 @@ import (
 	"github.com/onflow/cadence/runtime/parser2/lexer"
 )
 
+// expressionDepthLimit is the limit of how deeply nested an expression can get
+const expressionDepthLimit = 16
+
+// typeDepthLimit is the limit of how deeply nested a type can get
+const typeDepthLimit = 16
+
 // lowestBindingPower is the lowest binding power.
 // The binding power controls operator precedence:
 // the higher the value, the tighter a token binds to the tokens that follow.
@@ -51,6 +57,10 @@ type parser struct {
 	// replayedTokensCount is the number of replayed tokens since starting the initial buffering.
 	// It is reset when the buffered tokens get accepted. This keeps errors local.
 	replayedTokensCount uint
+	// expressionDepth is the depth of the currently parsed expression (if >0)
+	expressionDepth int
+	// typeDepth is the depth of the type (if >0)
+	typeDepth int
 }
 
 // Parse creates a lexer to scan the given input string,

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -673,4 +673,3 @@ func TestParseTypeDepthLimit(t *testing.T) {
 		err.(Error).Errors,
 	)
 }
-

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -21,6 +21,7 @@ package parser2
 import (
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -607,3 +608,69 @@ func TestParseInvalidSingleQuoteImport(t *testing.T) {
 
 	require.EqualError(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n")
 }
+
+func TestParseExpressionDepthLimit(t *testing.T) {
+
+	t.Parallel()
+
+	var builder strings.Builder
+	builder.WriteString("let x = y")
+	for i := 0; i < 20; i++ {
+		builder.WriteString(" ?? z")
+	}
+
+	code := builder.String()
+
+	_, err := ParseProgram(code, nil)
+	require.Error(t, err)
+
+	utils.AssertEqualWithDiff(t,
+		[]error{
+			ExpressionDepthLimitReachedError{
+				Pos: ast.Position{
+					Offset: 88,
+					Line:   1,
+					Column: 88,
+				},
+			},
+		},
+		err.(Error).Errors,
+	)
+}
+
+func TestParseTypeDepthLimit(t *testing.T) {
+
+	t.Parallel()
+
+	const nesting = 20
+
+	var builder strings.Builder
+	builder.WriteString("let x: T<")
+	for i := 0; i < nesting; i++ {
+		builder.WriteString("T<")
+	}
+	builder.WriteString("U")
+	for i := 0; i < nesting; i++ {
+		builder.WriteString(">")
+	}
+	builder.WriteString(">? = nil")
+
+	code := builder.String()
+
+	_, err := ParseProgram(code, nil)
+	require.Error(t, err)
+
+	utils.AssertEqualWithDiff(t,
+		[]error{
+			TypeDepthLimitReachedError{
+				Pos: ast.Position{
+					Offset: 39,
+					Line:   1,
+					Column: 39,
+				},
+			},
+		},
+		err.(Error).Errors,
+	)
+}
+

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -680,6 +680,17 @@ func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnota
 
 func parseType(p *parser, rightBindingPower int) ast.Type {
 
+	if p.typeDepth == typeDepthLimit {
+		panic(TypeDepthLimitReachedError{
+			Pos: p.current.StartPos,
+		})
+	}
+
+	p.typeDepth++
+	defer func() {
+		p.typeDepth--
+	}()
+
 	p.skipSpaceAndComments(true)
 	t := p.current
 	p.next()


### PR DESCRIPTION
## Description

Don't allow expressions and types to be arbitrarily nested. Limit to sensible values.

I verified the limits currently do not affect existing contracts on Mainnet.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
