### PR TITLE
chore(interpreter): improve error message

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -600,7 +600,7 @@ type InvalidPublicKeyError struct {
 }
 
 func (e InvalidPublicKeyError) Error() string {
-	return fmt.Sprintf("invalid public key: %s", e.PublicKey)
+	return fmt.Sprintf("invalid public key: %s, err: %s", e.PublicKey, e.Err)
 }
 
 func (e InvalidPublicKeyError) Unwrap() error {


### PR DESCRIPTION
## Description

This diff improves error message in the `InvalidPublicKeyError` to give more inside besides the "something went wrong":

before:
```
invalid public key: [248, 71, ..., 3, 232]
```

after:
```
invalid public key: [248, 71, ..., 3, 232], err: input has incorrect ECDSA_P256 key size
```