### PR TITLE
Add token limit

### DIFF
--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -28,7 +28,7 @@ import (
 )
 
 // tokenLimit is a sensible limit for how many tokens may be emitted
-const tokenLimit = 2 << 18
+const tokenLimit = 1 << 19
 
 type TokenLimitReachedError struct {
 	ast.Position

--- a/runtime/parser2/lexer/lexer_test.go
+++ b/runtime/parser2/lexer/lexer_test.go
@@ -20,6 +20,7 @@ package lexer
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2142,4 +2143,23 @@ func TestEOFsAfterEmptyInput(t *testing.T) {
 			tokenStream.Next(),
 		)
 	}
+}
+
+func TestLimit(t *testing.T) {
+
+	t.Parallel()
+
+	var b strings.Builder
+	for i := 0; i < 300000; i++ {
+		b.WriteString("x ")
+	}
+
+	code := b.String()
+
+	assert.PanicsWithValue(t,
+		TokenLimitReachedError{},
+		func() {
+			_ = Lex(code, nil)
+		},
+	)
 }


### PR DESCRIPTION
## Description


Limit the amount of tokens that may be emitted during a lex.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
