### PR TITLE
Add `type` function to list of functions in `AuthAccount` documentation

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -104,6 +104,7 @@ to the `prepare` phase of the transaction.
       // Account storage API (see the section below for documentation)
 
       fun save<T>(_ value: T, to: StoragePath)
+      fun type(at path: StoragePath): Type?
       fun load<T>(from: StoragePath): T?
       fun copy<T: AnyStruct>(from: StoragePath): T?
 


### PR DESCRIPTION
Closes #1654

https://github.com/onflow/cadence/pull/1254 missed a piece of documentation, leading to the docs not showing all the necessary information about the new `type` function. This fixes this documentation oversight. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
