### PR TITLE
Handle and wrap non-error type panics in interpreterRuntime

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -236,6 +236,9 @@ func (r *interpreterRuntime) Recover(onError func(error), context Context) {
 		err = recovered
 	case error:
 		err = newError(recovered, context)
+	default:
+		err = fmt.Errorf("%s", recovered)
+		err = newError(err, context)
 	}
 
 	onError(err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7146,6 +7146,36 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorAs(t, err, &Error{})
 	})
+
+	t.Run("panic with non error", func(t *testing.T) {
+
+		t.Parallel()
+
+		script := []byte(`pub fun main() {}`)
+
+		runtimeInterface := &testRuntimeInterface{
+			meterMemory: func(usage common.MemoryUsage) error {
+				// panic with a non-error type
+				panic("crasher")
+			},
+		}
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.Error(t, err)
+		require.ErrorAs(t, err, &Error{})
+	})
+
 }
 
 func TestRuntimeComputationMetring(t *testing.T) {


### PR DESCRIPTION
## Description

Handle and wrap the non-error type panics at the runtime-interface.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
