### PR TITLE
Properly support super types in ConformsToStaticType implementations

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -1036,7 +1036,6 @@ func importCapability(
 ) {
 
 	_, ok := borrowType.(cadence.ReferenceType)
-
 	if !ok {
 		return nil, fmt.Errorf(
 			"cannot import capability: expected reference, got '%s'",

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -103,7 +103,7 @@ func TestImportedValueMemoryMetering(t *testing.T) {
 		)
 
 		assert.Equal(t, uint64(1), meter[common.MemoryKindOptionalValue])
-		assert.Equal(t, uint64(3), meter[common.MemoryKindOptionalStaticType])
+		assert.Equal(t, uint64(2), meter[common.MemoryKindOptionalStaticType])
 	})
 
 	t.Run("UInt", func(t *testing.T) {
@@ -501,7 +501,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 		{
 			TypeName:     "String?",
 			MemoryKind:   common.MemoryKindOptionalStaticType,
-			Weight:       3,
+			Weight:       2,
 			TypeInstance: cadence.NewOptional(cadence.String("hello")),
 		},
 		{

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -166,7 +166,7 @@ func (f *InterpretedFunctionValue) ConformsToStaticType(
 		return f.Type.Equal(targetType.Type)
 	}
 
-	return primitiveValueConformsToStaticType(inter, f, staticType)
+	return valueStaticTypeIsSubType(inter, f, staticType)
 }
 
 func (f *InterpretedFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -316,7 +316,7 @@ func (f *HostFunctionValue) ConformsToStaticType(
 		return f.Type.Equal(targetType.Type)
 	}
 
-	return primitiveValueConformsToStaticType(inter, f, staticType)
+	return valueStaticTypeIsSubType(inter, f, staticType)
 }
 
 func (f *HostFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -156,17 +156,17 @@ func (f *InterpretedFunctionValue) invoke(invocation Invocation) Value {
 }
 
 func (f *InterpretedFunctionValue) ConformsToStaticType(
-	_ *Interpreter,
+	inter *Interpreter,
 	_ func() LocationRange,
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
 	targetType, ok := staticType.(FunctionStaticType)
-	if !ok {
-		return false
+	if ok {
+		return f.Type.Equal(targetType.Type)
 	}
 
-	return f.Type.Equal(targetType.Type)
+	return primitiveValueConformsToStaticType(inter, f, staticType)
 }
 
 func (f *InterpretedFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -306,17 +306,17 @@ func (*HostFunctionValue) SetMember(_ *Interpreter, _ func() LocationRange, _ st
 }
 
 func (f *HostFunctionValue) ConformsToStaticType(
-	_ *Interpreter,
+	inter *Interpreter,
 	_ func() LocationRange,
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
 	targetType, ok := staticType.(FunctionStaticType)
-	if !ok {
-		return false
+	if ok {
+		return f.Type.Equal(targetType.Type)
 	}
 
-	return f.Type.Equal(targetType.Type)
+	return primitiveValueConformsToStaticType(inter, f, staticType)
 }
 
 func (f *HostFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -156,17 +156,11 @@ func (f *InterpretedFunctionValue) invoke(invocation Invocation) Value {
 }
 
 func (f *InterpretedFunctionValue) ConformsToStaticType(
-	inter *Interpreter,
+	_ *Interpreter,
 	_ func() LocationRange,
-	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	targetType, ok := staticType.(FunctionStaticType)
-	if ok {
-		return f.Type.Equal(targetType.Type)
-	}
-
-	return valueStaticTypeIsSubType(inter, f, staticType)
+	return true
 }
 
 func (f *InterpretedFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -306,17 +300,11 @@ func (*HostFunctionValue) SetMember(_ *Interpreter, _ func() LocationRange, _ st
 }
 
 func (f *HostFunctionValue) ConformsToStaticType(
-	inter *Interpreter,
+	_ *Interpreter,
 	_ func() LocationRange,
-	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	targetType, ok := staticType.(FunctionStaticType)
-	if ok {
-		return f.Type.Equal(targetType.Type)
-	}
-
-	return valueStaticTypeIsSubType(inter, f, staticType)
+	return true
 }
 
 func (f *HostFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -416,13 +404,11 @@ func (f BoundFunctionValue) invoke(invocation Invocation) Value {
 func (f BoundFunctionValue) ConformsToStaticType(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
-	staticType StaticType,
 	results TypeConformanceResults,
 ) bool {
 	return f.Function.ConformsToStaticType(
 		interpreter,
 		getLocationRange,
-		staticType,
 		results,
 	)
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3850,7 +3850,6 @@ func (interpreter *Interpreter) authAccountLinkFunction(addressValue AddressValu
 			}
 
 			borrowType, ok := typeParameterPair.Value.(*sema.ReferenceType)
-
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -206,6 +206,7 @@ func (v *SimpleCompositeValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
+	// TODO: handle e.g. AnyStruct. Use  primitiveValueConformsToStaticType?
 	return staticType.Equal(v.StaticType(inter))
 }
 

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -201,13 +201,22 @@ func (v *SimpleCompositeValue) MeteredString(memoryGauge common.MemoryGauge, see
 }
 
 func (v *SimpleCompositeValue) ConformsToStaticType(
-	inter *Interpreter,
-	_ func() LocationRange,
-	staticType StaticType,
-	_ TypeConformanceResults,
+	interpreter *Interpreter,
+	getLocationRange func() LocationRange,
+	results TypeConformanceResults,
 ) bool {
-	// TODO: handle e.g. AnyStruct. Use  primitiveValueConformsToStaticType?
-	return staticType.Equal(v.StaticType(inter))
+
+	for _, value := range v.Fields {
+		if !value.ConformsToStaticType(
+			interpreter,
+			getLocationRange,
+			results,
+		) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (v *SimpleCompositeValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -206,7 +206,11 @@ func (v *SimpleCompositeValue) ConformsToStaticType(
 	results TypeConformanceResults,
 ) bool {
 
-	for _, value := range v.Fields {
+	for _, fieldName := range v.FieldNames {
+		value, ok := v.Fields[fieldName]
+		if !ok {
+			continue
+		}
 		if !value.ConformsToStaticType(
 			interpreter,
 			getLocationRange,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -96,6 +96,14 @@ type Value interface {
 	Accept(interpreter *Interpreter, visitor Visitor)
 	Walk(interpreter *Interpreter, walkChild func(Value))
 	StaticType(interpreter *Interpreter) StaticType
+	// ConformsToStaticType returns true if the value (i.e. its dynamic type)
+	// conforms to its own static type.
+	// Non-container values trivially always conform to their own static type.
+	// Container values conform to their own static type,
+	// and this function recursively checks conformance for nested values.
+	// If the container contains static type information about nested values,
+	// e.g. the element type of an array, it also ensures the nested values'
+	// static types are subtypes.
 	ConformsToStaticType(
 		interpreter *Interpreter,
 		getLocationRange func() LocationRange,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17159,11 +17159,12 @@ func (v *StorageReferenceValue) ConformsToStaticType(
 	results TypeConformanceResults,
 ) bool {
 
-	// TODO: handle AnyStruct/AnyResource
-
 	refType, ok := staticType.(ReferenceStaticType)
-	if !ok ||
-		refType.Authorized != v.Authorized {
+	if !ok {
+		return primitiveValueConformsToStaticType(interpreter, v, staticType)
+	}
+
+	if refType.Authorized != v.Authorized {
 
 		return false
 	}
@@ -17499,13 +17500,12 @@ func (v *EphemeralReferenceValue) ConformsToStaticType(
 	staticType StaticType,
 	results TypeConformanceResults,
 ) bool {
-
-	// TODO: handle AnyStruct/AnyResource
-
 	refType, ok := staticType.(ReferenceStaticType)
-	if !ok ||
-		refType.Authorized != v.Authorized {
+	if !ok {
+		return primitiveValueConformsToStaticType(interpreter, v, staticType)
+	}
 
+	if refType.Authorized != v.Authorized {
 		return false
 	}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2144,6 +2144,8 @@ func (v *ArrayValue) ConformsToStaticType(
 	results TypeConformanceResults,
 ) bool {
 
+	// TODO: handle AnyStruct/AnyResource
+
 	count := v.Count()
 
 	if interpreter.tracingEnabled {
@@ -14816,6 +14818,8 @@ func (v *CompositeValue) ConformsToStaticType(
 	results TypeConformanceResults,
 ) bool {
 
+	// TODO: handle AnyStruct/AnyResource
+
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 
@@ -15975,6 +15979,8 @@ func (v *DictionaryValue) ConformsToStaticType(
 	results TypeConformanceResults,
 ) bool {
 
+	// TODO: handle AnyStruct/AnyResource
+
 	count := v.Count()
 
 	if interpreter.tracingEnabled {
@@ -16687,6 +16693,9 @@ func (v SomeValue) ConformsToStaticType(
 	staticType StaticType,
 	results TypeConformanceResults,
 ) bool {
+
+	// TODO: handle AnyStruct/AnyResource
+
 	optionalType, ok := staticType.(OptionalStaticType)
 	if !ok {
 		return false
@@ -17148,6 +17157,8 @@ func (v *StorageReferenceValue) ConformsToStaticType(
 	results TypeConformanceResults,
 ) bool {
 
+	// TODO: handle AnyStruct/AnyResource
+
 	refType, ok := staticType.(ReferenceStaticType)
 	if !ok ||
 		refType.Authorized != v.Authorized {
@@ -17486,6 +17497,8 @@ func (v *EphemeralReferenceValue) ConformsToStaticType(
 	staticType StaticType,
 	results TypeConformanceResults,
 ) bool {
+
+	// TODO: handle AnyStruct/AnyResource
 
 	refType, ok := staticType.(ReferenceStaticType)
 	if !ok ||
@@ -17963,7 +17976,7 @@ func (PathValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ V
 }
 
 func (v PathValue) ConformsToStaticType(
-	_ *Interpreter,
+	inter *Interpreter,
 	_ func() LocationRange,
 	staticType StaticType,
 	_ TypeConformanceResults,
@@ -17976,7 +17989,7 @@ func (v PathValue) ConformsToStaticType(
 	case PrimitiveStaticTypeStoragePath:
 		return v.Domain == common.PathDomainStorage
 	default:
-		return false
+		return primitiveValueConformsToStaticType(inter, v, staticType)
 	}
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -371,7 +371,7 @@ func (v TypeValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v TypeValue) Storable(
@@ -501,7 +501,7 @@ func (v VoidValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v VoidValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -644,7 +644,7 @@ func (v BoolValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -786,7 +786,7 @@ func (v CharacterValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v CharacterValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -1290,7 +1290,7 @@ func (v *StringValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 // ArrayValue
@@ -2143,9 +2143,6 @@ func (v *ArrayValue) ConformsToStaticType(
 	staticType StaticType,
 	results TypeConformanceResults,
 ) bool {
-
-	// TODO: handle AnyStruct/AnyResource
-
 	count := v.Count()
 
 	if interpreter.tracingEnabled {
@@ -2172,7 +2169,7 @@ func (v *ArrayValue) ConformsToStaticType(
 	case VariableSizedStaticType:
 		elementType = typedStaticType.ElementType()
 	default:
-		return false
+		return valueStaticTypeIsSubType(interpreter, v, staticType)
 	}
 
 	result := true
@@ -3251,7 +3248,7 @@ func (v IntValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v IntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
@@ -3858,7 +3855,7 @@ func (v Int8Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v Int8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -4467,7 +4464,7 @@ func (v Int16Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v Int16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -5076,7 +5073,7 @@ func (v Int32Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v Int32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -5680,7 +5677,7 @@ func (v Int64Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v Int64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -6389,7 +6386,7 @@ func (v Int128Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v Int128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -7095,7 +7092,7 @@ func (v Int256Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v Int256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -7705,7 +7702,7 @@ func (v UIntValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v UIntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
@@ -8242,7 +8239,7 @@ func (v UInt8Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v UInt8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
@@ -8785,7 +8782,7 @@ func (v UInt16Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (UInt16Value) IsStorable() bool {
@@ -9333,7 +9330,7 @@ func (v UInt32Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (UInt32Value) IsStorable() bool {
@@ -9909,7 +9906,7 @@ func (v UInt64Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 func (UInt64Value) IsStorable() bool {
 	return true
@@ -10560,7 +10557,7 @@ func (v UInt128Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (UInt128Value) IsStorable() bool {
@@ -11212,7 +11209,7 @@ func (v UInt256Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (UInt256Value) IsStorable() bool {
@@ -11647,7 +11644,7 @@ func (v Word8Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (Word8Value) IsStorable() bool {
@@ -12084,7 +12081,7 @@ func (v Word16Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (Word16Value) IsStorable() bool {
@@ -12522,7 +12519,7 @@ func (v Word32Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (Word32Value) IsStorable() bool {
@@ -12986,7 +12983,7 @@ func (v Word64Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (Word64Value) IsStorable() bool {
@@ -13546,7 +13543,7 @@ func (v Fix64Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (Fix64Value) IsStorable() bool {
@@ -14071,7 +14068,7 @@ func (v UFix64Value) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (UFix64Value) IsStorable() bool {
@@ -15980,9 +15977,6 @@ func (v *DictionaryValue) ConformsToStaticType(
 	staticType StaticType,
 	results TypeConformanceResults,
 ) bool {
-
-	// TODO: handle AnyStruct/AnyResource
-
 	count := v.Count()
 
 	if interpreter.tracingEnabled {
@@ -16001,7 +15995,7 @@ func (v *DictionaryValue) ConformsToStaticType(
 
 	dictionaryType, ok := staticType.(DictionaryStaticType)
 	if !ok {
-		return false
+		return valueStaticTypeIsSubType(interpreter, v, staticType)
 	}
 
 	iterator, err := v.dictionary.Iterator()
@@ -16479,7 +16473,7 @@ func (v NilValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v NilValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
@@ -16695,9 +16689,6 @@ func (v *SomeValue) ConformsToStaticType(
 	staticType StaticType,
 	results TypeConformanceResults,
 ) bool {
-
-	// TODO: handle AnyStruct/AnyResource
-
 	optionalType, ok := staticType.(OptionalStaticType)
 	if ok {
 		innerValue := v.InnerValue(interpreter, getLocationRange)
@@ -16710,7 +16701,7 @@ func (v *SomeValue) ConformsToStaticType(
 		)
 	}
 
-	return primitiveValueConformsToStaticType(interpreter, v, staticType)
+	return valueStaticTypeIsSubType(interpreter, v, staticType)
 }
 
 func (v *SomeValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
@@ -17161,7 +17152,7 @@ func (v *StorageReferenceValue) ConformsToStaticType(
 
 	refType, ok := staticType.(ReferenceStaticType)
 	if !ok {
-		return primitiveValueConformsToStaticType(interpreter, v, staticType)
+		return valueStaticTypeIsSubType(interpreter, v, staticType)
 	}
 
 	if refType.Authorized != v.Authorized {
@@ -17502,7 +17493,7 @@ func (v *EphemeralReferenceValue) ConformsToStaticType(
 ) bool {
 	refType, ok := staticType.(ReferenceStaticType)
 	if !ok {
-		return primitiveValueConformsToStaticType(interpreter, v, staticType)
+		return valueStaticTypeIsSubType(interpreter, v, staticType)
 	}
 
 	if refType.Authorized != v.Authorized {
@@ -17760,7 +17751,7 @@ func (v AddressValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (AddressValue) IsStorable() bool {
@@ -17991,7 +17982,7 @@ func (v PathValue) ConformsToStaticType(
 	case PrimitiveStaticTypeStoragePath:
 		return v.Domain == common.PathDomainStorage
 	default:
-		return primitiveValueConformsToStaticType(inter, v, staticType)
+		return valueStaticTypeIsSubType(inter, v, staticType)
 	}
 }
 
@@ -18243,7 +18234,7 @@ func (v *CapabilityValue) ConformsToStaticType(
 	staticType StaticType,
 	_ TypeConformanceResults,
 ) bool {
-	return primitiveValueConformsToStaticType(inter, v, staticType)
+	return valueStaticTypeIsSubType(inter, v, staticType)
 }
 
 func (v *CapabilityValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
@@ -18624,7 +18615,7 @@ var publicKeyVerifyPoPFunction = NewUnmeteredHostFunctionValue(
 	sema.PublicKeyVerifyPoPFunctionType,
 )
 
-func primitiveValueConformsToStaticType(inter *Interpreter, v Value, targetStaticType StaticType) bool {
+func valueStaticTypeIsSubType(inter *Interpreter, v Value, targetStaticType StaticType) bool {
 	staticType := v.StaticType(inter)
 	return inter.IsSubType(staticType, targetStaticType)
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -4019,5 +4019,41 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		)
 	})
 
-	// TODO: simple composite
+	t.Run("SimplCompositeValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		test(
+			NewSimpleCompositeValue(
+				inter,
+				PrimitiveStaticTypeBlock.SemaType().ID(),
+				PrimitiveStaticTypeBlock,
+				[]string{"height"},
+				map[string]Value{
+					"height": NewUnmeteredInt64Value(1),
+				},
+				nil,
+				nil,
+				nil,
+			),
+			true,
+		)
+
+		test(
+			NewSimpleCompositeValue(
+				inter,
+				PrimitiveStaticTypeBlock.SemaType().ID(),
+				PrimitiveStaticTypeBlock,
+				[]string{"foo"},
+				map[string]Value{
+					"foo": invalidCompositeValue,
+				},
+				nil,
+				nil,
+				nil,
+			),
+			false,
+		)
+	})
+
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -4202,5 +4202,90 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		test(v, false, PrimitiveStaticTypeBool)
 	})
 
-	// TODO: array, dictionary, composite, simple composite
+	t.Run("ArrayValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewArrayValue(
+			inter,
+			VariableSizedStaticType{
+				Type: PrimitiveStaticTypeNumber,
+			},
+			testAddress,
+			NewUnmeteredInt8Value(2),
+			NewUnmeteredFix64Value(3),
+		)
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, VariableSizedStaticType{
+			Type: PrimitiveStaticTypeAnyStruct,
+		})
+		test(v, true, VariableSizedStaticType{
+			Type: PrimitiveStaticTypeNumber,
+		})
+		test(v, true, OptionalStaticType{
+			Type: VariableSizedStaticType{
+				Type: PrimitiveStaticTypeNumber,
+			},
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, VariableSizedStaticType{
+			Type: PrimitiveStaticTypeInteger,
+		})
+	})
+
+	t.Run("DictionaryValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewDictionaryValueWithAddress(
+			inter,
+			DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeString,
+				ValueType: PrimitiveStaticTypeNumber,
+			},
+			testAddress,
+			NewUnmeteredStringValue("a"),
+			NewUnmeteredInt8Value(2),
+			NewUnmeteredStringValue("b"),
+			NewUnmeteredFix64Value(3),
+		)
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, DictionaryStaticType{
+			KeyType:   PrimitiveStaticTypeAnyStruct,
+			ValueType: PrimitiveStaticTypeAnyStruct,
+		})
+		test(v, true, DictionaryStaticType{
+			KeyType:   PrimitiveStaticTypeAnyStruct,
+			ValueType: PrimitiveStaticTypeNumber,
+		})
+		test(v, true, DictionaryStaticType{
+			KeyType:   PrimitiveStaticTypeString,
+			ValueType: PrimitiveStaticTypeAnyStruct,
+		})
+		test(v, true, OptionalStaticType{
+			Type: DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeString,
+				ValueType: PrimitiveStaticTypeNumber,
+			},
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, DictionaryStaticType{
+			KeyType:   PrimitiveStaticTypeString,
+			ValueType: PrimitiveStaticTypeInteger,
+		})
+		test(v, false, DictionaryStaticType{
+			KeyType:   PrimitiveStaticTypeInteger,
+			ValueType: PrimitiveStaticTypeNumber,
+		})
+	})
+
+	// TODO: composite, simple composite
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -4165,5 +4165,42 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		})
 	})
 
+	t.Run("CapabilityValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredCapabilityValue(
+			NewUnmeteredAddressValueFromBytes(testAddress.Bytes()),
+			NewUnmeteredPathValue(common.PathDomainStorage, "test"),
+			ReferenceStaticType{
+				Authorized:     false,
+				BorrowedType:   PrimitiveStaticTypeBool,
+				ReferencedType: PrimitiveStaticTypeBool,
+			},
+		)
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, CapabilityStaticType{
+			BorrowType: ReferenceStaticType{
+				Authorized:     false,
+				BorrowedType:   PrimitiveStaticTypeBool,
+				ReferencedType: PrimitiveStaticTypeBool,
+			},
+		})
+		test(v, true, OptionalStaticType{
+			Type: CapabilityStaticType{
+				BorrowType: ReferenceStaticType{
+					Authorized:     false,
+					BorrowedType:   PrimitiveStaticTypeBool,
+					ReferencedType: PrimitiveStaticTypeBool,
+				},
+			},
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeBool)
+	})
+
 	// TODO: array, dictionary, composite, simple composite
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3764,8 +3764,6 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		})
 	})
 
-	// TODO: number types
-
 	t.Run("NilValue", func(t *testing.T) {
 
 		t.Parallel()
@@ -3778,7 +3776,6 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		test(v, true, OptionalStaticType{
 			Type: PrimitiveStaticTypeNever,
 		})
-
 	})
 
 	t.Run("SomeValue", func(t *testing.T) {
@@ -3803,7 +3800,6 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		test(v, false, PrimitiveStaticTypeAnyResource)
 		test(v, false, PrimitiveStaticTypeBool)
 		test(v, false, PrimitiveStaticTypeString)
-
 	})
 
 	t.Run("PathValue, storage domain", func(t *testing.T) {
@@ -3893,4 +3889,169 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		})
 	})
 
+	t.Run("integer values", func(t *testing.T) {
+
+		t.Parallel()
+
+		type testCase struct {
+			Value  NumberValue
+			Signed bool
+		}
+
+		testCases := map[*sema.NumericType]testCase{
+			sema.IntType: {
+				Value:  NewUnmeteredIntValueFromInt64(42),
+				Signed: true,
+			},
+			sema.UIntType: {
+				Value: NewUnmeteredUIntValueFromUint64(42),
+			},
+			sema.UInt8Type: {
+				Value: NewUnmeteredUInt8Value(42),
+			},
+			sema.UInt16Type: {
+				Value: NewUnmeteredUInt16Value(42),
+			},
+			sema.UInt32Type: {
+				Value: NewUnmeteredUInt32Value(42),
+			},
+			sema.UInt64Type: {
+				Value: NewUnmeteredUInt64Value(42),
+			},
+			sema.UInt128Type: {
+				Value: NewUnmeteredUInt128ValueFromUint64(42),
+			},
+			sema.UInt256Type: {
+				Value: NewUnmeteredUInt256ValueFromUint64(42),
+			},
+			sema.Word8Type: {
+				Value: NewUnmeteredWord8Value(42),
+			},
+			sema.Word16Type: {
+				Value: NewUnmeteredWord16Value(42),
+			},
+			sema.Word32Type: {
+				Value: NewUnmeteredWord32Value(42),
+			},
+			sema.Word64Type: {
+				Value: NewUnmeteredWord64Value(42),
+			},
+			sema.Int8Type: {
+				Value:  NewUnmeteredInt8Value(42),
+				Signed: true,
+			},
+			sema.Int16Type: {
+				Value:  NewUnmeteredInt16Value(42),
+				Signed: true,
+			},
+			sema.Int32Type: {
+				Value:  NewUnmeteredInt32Value(42),
+				Signed: true,
+			},
+			sema.Int64Type: {
+				Value:  NewUnmeteredInt64Value(42),
+				Signed: true,
+			},
+			sema.Int128Type: {
+				Value:  NewUnmeteredInt128ValueFromInt64(42),
+				Signed: true,
+			},
+			sema.Int256Type: {
+				Value:  NewUnmeteredInt256ValueFromInt64(42),
+				Signed: true,
+			},
+		}
+
+		for _, ty := range sema.AllIntegerTypes {
+			// Only test leaf types
+			switch ty {
+			case sema.IntegerType, sema.SignedIntegerType:
+				continue
+			}
+
+			_, ok := testCases[ty.(*sema.NumericType)]
+			require.True(t, ok, "missing case for type %s", ty.String())
+		}
+
+		for semaType, testCase := range testCases {
+
+			v := testCase.Value
+			staticType := ConvertSemaToStaticType(nil, semaType)
+
+			test(v, true, PrimitiveStaticTypeAny)
+			test(v, true, PrimitiveStaticTypeAnyStruct)
+			test(v, true, PrimitiveStaticTypeNumber)
+			test(v, true, PrimitiveStaticTypeInteger)
+			test(v, testCase.Signed, PrimitiveStaticTypeSignedInteger)
+			test(v, true, staticType)
+			test(v, true, OptionalStaticType{
+				Type: PrimitiveStaticTypeInteger,
+			})
+
+			test(v, false, PrimitiveStaticTypeAnyResource)
+			test(v, false, PrimitiveStaticTypeBool)
+			test(v, false, PrimitiveStaticTypeFixedPoint)
+			test(v, false, PrimitiveStaticTypeSignedFixedPoint)
+			test(v, false, VariableSizedStaticType{
+				Type: staticType,
+			})
+		}
+	})
+
+	t.Run("fixed-point values", func(t *testing.T) {
+
+		t.Parallel()
+
+		type testCase struct {
+			Value  FixedPointValue
+			Signed bool
+		}
+
+		testCases := map[*sema.FixedPointNumericType]testCase{
+			sema.UFix64Type: {
+				Value: NewUnmeteredUFix64ValueWithInteger(42),
+			},
+			sema.Fix64Type: {
+				Value:  NewUnmeteredFix64ValueWithInteger(42),
+				Signed: true,
+			},
+		}
+
+		for _, ty := range sema.AllFixedPointTypes {
+			// Only test leaf types
+			switch ty {
+			case sema.FixedPointType, sema.SignedFixedPointType:
+				continue
+			}
+
+			_, ok := testCases[ty.(*sema.FixedPointNumericType)]
+			require.True(t, ok, "missing case for type %s", ty.String())
+		}
+
+		for semaType, testCase := range testCases {
+
+			v := testCase.Value
+			staticType := ConvertSemaToStaticType(nil, semaType)
+
+			test(v, true, PrimitiveStaticTypeAny)
+			test(v, true, PrimitiveStaticTypeAnyStruct)
+			test(v, true, PrimitiveStaticTypeNumber)
+			test(v, true, PrimitiveStaticTypeFixedPoint)
+			test(v, testCase.Signed, PrimitiveStaticTypeSignedFixedPoint)
+			test(v, true, staticType)
+			test(v, true, OptionalStaticType{
+				Type: PrimitiveStaticTypeFixedPoint,
+			})
+
+			test(v, false, PrimitiveStaticTypeAnyResource)
+			test(v, false, PrimitiveStaticTypeBool)
+			test(v, false, PrimitiveStaticTypeInteger)
+			test(v, false, PrimitiveStaticTypeSignedInteger)
+			test(v, false, VariableSizedStaticType{
+				Type: staticType,
+			})
+		}
+	})
+
+	// TODO: array, dictionary, composite, simple composite, ephemeral reference, storage reference
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3642,7 +3642,6 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				})
 			})
 		}
-
 	})
 
 	t.Run("BoolValue", func(t *testing.T) {
@@ -3663,7 +3662,6 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		test(v, false, VariableSizedStaticType{
 			Type: PrimitiveStaticTypeBool,
 		})
-
 	})
 
 	t.Run("StringValue", func(t *testing.T) {
@@ -3684,7 +3682,6 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		test(v, false, VariableSizedStaticType{
 			Type: PrimitiveStaticTypeString,
 		})
-
 	})
 
 	t.Run("AddressValue", func(t *testing.T) {
@@ -3705,7 +3702,195 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		test(v, false, VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAddress,
 		})
+	})
 
+	t.Run("TypeValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredTypeValue(PrimitiveStaticTypeInt)
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, PrimitiveStaticTypeMetaType)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeMetaType,
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, VariableSizedStaticType{
+			Type: PrimitiveStaticTypeMetaType,
+		})
+	})
+
+	t.Run("VoidValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredVoidValue()
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, PrimitiveStaticTypeVoid)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeVoid,
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, VariableSizedStaticType{
+			Type: PrimitiveStaticTypeVoid,
+		})
+	})
+
+	t.Run("CharacterValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredCharacterValue("t")
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, PrimitiveStaticTypeCharacter)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeCharacter,
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, VariableSizedStaticType{
+			Type: PrimitiveStaticTypeCharacter,
+		})
+	})
+
+	// TODO: number types
+
+	t.Run("NilValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredNilValue()
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, PrimitiveStaticTypeAnyResource)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeNever,
+		})
+
+	})
+
+	t.Run("SomeValue", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredSomeValueNonCopying(
+			NewUnmeteredBoolValue(true),
+		)
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeBool,
+		})
+		test(v, true, OptionalStaticType{
+			Type: OptionalStaticType{
+				Type: PrimitiveStaticTypeBool,
+			},
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, PrimitiveStaticTypeString)
+
+	})
+
+	t.Run("PathValue, storage domain", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredPathValue(common.PathDomainStorage, "test")
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, PrimitiveStaticTypePath)
+		test(v, true, PrimitiveStaticTypeStoragePath)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypePath,
+		})
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeStoragePath,
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeCapabilityPath)
+		test(v, false, PrimitiveStaticTypePrivatePath)
+		test(v, false, PrimitiveStaticTypePublicPath)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, VariableSizedStaticType{
+			Type: PrimitiveStaticTypePath,
+		})
+	})
+
+	t.Run("PathValue, public domain", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredPathValue(common.PathDomainPublic, "test")
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, PrimitiveStaticTypePath)
+		test(v, true, PrimitiveStaticTypeCapabilityPath)
+		test(v, true, PrimitiveStaticTypePublicPath)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypePath,
+		})
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeCapabilityPath,
+		})
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypePublicPath,
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeStoragePath)
+		test(v, false, PrimitiveStaticTypePrivatePath)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, VariableSizedStaticType{
+			Type: PrimitiveStaticTypePath,
+		})
+	})
+
+	t.Run("PathValue, private domain", func(t *testing.T) {
+
+		t.Parallel()
+
+		v := NewUnmeteredPathValue(common.PathDomainPrivate, "test")
+
+		test(v, true, PrimitiveStaticTypeAny)
+		test(v, true, PrimitiveStaticTypeAnyStruct)
+		test(v, true, PrimitiveStaticTypePath)
+		test(v, true, PrimitiveStaticTypeCapabilityPath)
+		test(v, true, PrimitiveStaticTypePrivatePath)
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypePath,
+		})
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypeCapabilityPath,
+		})
+		test(v, true, OptionalStaticType{
+			Type: PrimitiveStaticTypePrivatePath,
+		})
+
+		test(v, false, PrimitiveStaticTypeAnyResource)
+		test(v, false, PrimitiveStaticTypeStoragePath)
+		test(v, false, PrimitiveStaticTypePublicPath)
+		test(v, false, PrimitiveStaticTypeBool)
+		test(v, false, VariableSizedStaticType{
+			Type: PrimitiveStaticTypePath,
+		})
 	})
 
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -1618,19 +1618,9 @@ func TestEphemeralReferenceTypeConformance(t *testing.T) {
 	conforms := value.ConformsToStaticType(
 		inter,
 		ReturnEmptyLocationRange,
-		value.StaticType(inter),
 		TypeConformanceResults{},
 	)
 	assert.True(t, conforms)
-
-	// Check against a non-conforming type
-	conforms = value.ConformsToStaticType(
-		inter,
-		ReturnEmptyLocationRange,
-		ReferenceStaticType{},
-		TypeConformanceResults{},
-	)
-	assert.False(t, conforms)
 }
 
 func TestCapabilityValue_Equal(t *testing.T) {
@@ -3560,11 +3550,10 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 	storageMap := storage.GetStorageMap(testAddress, "storage", true)
 	storageMap.WriteValue(inter, "test", NewUnmeteredBoolValue(true))
 
-	test := func(value Value, expected bool, staticType StaticType) {
+	test := func(value Value, expected bool) {
 		result := value.ConformsToStaticType(
 			inter,
 			ReturnEmptyLocationRange,
-			staticType,
 			TypeConformanceResults{},
 		)
 		if expected {
@@ -3601,56 +3590,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			},
 		} {
 			t.Run(name, func(t *testing.T) {
-
-				test(f, true, PrimitiveStaticTypeAny)
-				test(f, true, PrimitiveStaticTypeAnyStruct)
-				test(f, true, FunctionStaticType{
-					Type: &sema.FunctionType{
-						Parameters: []*sema.Parameter{
-							{
-								TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
-							},
-						},
-						ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
-					},
-				})
-
-				test(f, false, PrimitiveStaticTypeAnyResource)
-				test(f, false, FunctionStaticType{
-					Type: &sema.FunctionType{
-						ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
-					},
-				})
-				test(f, false, FunctionStaticType{
-					Type: &sema.FunctionType{
-						Parameters: []*sema.Parameter{
-							{
-								TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
-							},
-						},
-						ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
-					},
-				})
-				test(f, false, FunctionStaticType{
-					Type: &sema.FunctionType{
-						Parameters: []*sema.Parameter{
-							{
-								TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
-							},
-						},
-						ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
-					},
-				})
-				test(f, false, FunctionStaticType{
-					Type: &sema.FunctionType{
-						Parameters: []*sema.Parameter{
-							{
-								TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
-							},
-						},
-						ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
-					},
-				})
+				test(f, true)
 			})
 		}
 	})
@@ -3659,134 +3599,49 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 
 		t.Parallel()
 
-		v := BoolValue(true)
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypeBool)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeBool,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeString)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeBool,
-		})
+		test(NewUnmeteredBoolValue(true), true)
 	})
 
 	t.Run("StringValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredStringValue("test")
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypeString)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeString,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeString,
-		})
+		test(NewUnmeteredStringValue("test"), true)
 	})
 
 	t.Run("AddressValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredAddressValueFromBytes([]byte{0x1})
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypeAddress)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeAddress,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeAddress,
-		})
+		test(NewUnmeteredAddressValueFromBytes([]byte{0x1}), true)
 	})
 
 	t.Run("TypeValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredTypeValue(PrimitiveStaticTypeInt)
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypeMetaType)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeMetaType,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeMetaType,
-		})
+		test(NewUnmeteredTypeValue(PrimitiveStaticTypeInt), true)
 	})
 
 	t.Run("VoidValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredVoidValue()
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypeVoid)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeVoid,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeVoid,
-		})
+		test(NewUnmeteredVoidValue(), true)
 	})
 
 	t.Run("CharacterValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredCharacterValue("t")
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypeCharacter)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeCharacter,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeCharacter,
-		})
+		test(NewUnmeteredCharacterValue("t"), true)
 	})
 
 	t.Run("NilValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredNilValue()
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypeAnyResource)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeNever,
-		})
+		test(NewUnmeteredNilValue(), true)
 	})
 
 	t.Run("SomeValue", func(t *testing.T) {
@@ -3797,180 +3652,41 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			NewUnmeteredBoolValue(true),
 		)
 
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeBool,
-		})
-		test(v, true, OptionalStaticType{
-			Type: OptionalStaticType{
-				Type: PrimitiveStaticTypeBool,
-			},
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, PrimitiveStaticTypeString)
+		test(v, true)
 	})
 
-	t.Run("PathValue, storage domain", func(t *testing.T) {
+	t.Run("PathValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredPathValue(common.PathDomainStorage, "test")
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypePath)
-		test(v, true, PrimitiveStaticTypeStoragePath)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypePath,
-		})
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeStoragePath,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeCapabilityPath)
-		test(v, false, PrimitiveStaticTypePrivatePath)
-		test(v, false, PrimitiveStaticTypePublicPath)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypePath,
-		})
-	})
-
-	t.Run("PathValue, public domain", func(t *testing.T) {
-
-		t.Parallel()
-
-		v := NewUnmeteredPathValue(common.PathDomainPublic, "test")
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypePath)
-		test(v, true, PrimitiveStaticTypeCapabilityPath)
-		test(v, true, PrimitiveStaticTypePublicPath)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypePath,
-		})
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeCapabilityPath,
-		})
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypePublicPath,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeStoragePath)
-		test(v, false, PrimitiveStaticTypePrivatePath)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypePath,
-		})
-	})
-
-	t.Run("PathValue, private domain", func(t *testing.T) {
-
-		t.Parallel()
-
-		v := NewUnmeteredPathValue(common.PathDomainPrivate, "test")
-
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, PrimitiveStaticTypePath)
-		test(v, true, PrimitiveStaticTypeCapabilityPath)
-		test(v, true, PrimitiveStaticTypePrivatePath)
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypePath,
-		})
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypeCapabilityPath,
-		})
-		test(v, true, OptionalStaticType{
-			Type: PrimitiveStaticTypePrivatePath,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeStoragePath)
-		test(v, false, PrimitiveStaticTypePublicPath)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypePath,
-		})
+		for _, domain := range common.AllPathDomains {
+			test(NewUnmeteredPathValue(domain, "test"), true)
+		}
 	})
 
 	t.Run("integer values", func(t *testing.T) {
 
 		t.Parallel()
 
-		type testCase struct {
-			Value  NumberValue
-			Signed bool
-		}
-
-		testCases := map[*sema.NumericType]testCase{
-			sema.IntType: {
-				Value:  NewUnmeteredIntValueFromInt64(42),
-				Signed: true,
-			},
-			sema.UIntType: {
-				Value: NewUnmeteredUIntValueFromUint64(42),
-			},
-			sema.UInt8Type: {
-				Value: NewUnmeteredUInt8Value(42),
-			},
-			sema.UInt16Type: {
-				Value: NewUnmeteredUInt16Value(42),
-			},
-			sema.UInt32Type: {
-				Value: NewUnmeteredUInt32Value(42),
-			},
-			sema.UInt64Type: {
-				Value: NewUnmeteredUInt64Value(42),
-			},
-			sema.UInt128Type: {
-				Value: NewUnmeteredUInt128ValueFromUint64(42),
-			},
-			sema.UInt256Type: {
-				Value: NewUnmeteredUInt256ValueFromUint64(42),
-			},
-			sema.Word8Type: {
-				Value: NewUnmeteredWord8Value(42),
-			},
-			sema.Word16Type: {
-				Value: NewUnmeteredWord16Value(42),
-			},
-			sema.Word32Type: {
-				Value: NewUnmeteredWord32Value(42),
-			},
-			sema.Word64Type: {
-				Value: NewUnmeteredWord64Value(42),
-			},
-			sema.Int8Type: {
-				Value:  NewUnmeteredInt8Value(42),
-				Signed: true,
-			},
-			sema.Int16Type: {
-				Value:  NewUnmeteredInt16Value(42),
-				Signed: true,
-			},
-			sema.Int32Type: {
-				Value:  NewUnmeteredInt32Value(42),
-				Signed: true,
-			},
-			sema.Int64Type: {
-				Value:  NewUnmeteredInt64Value(42),
-				Signed: true,
-			},
-			sema.Int128Type: {
-				Value:  NewUnmeteredInt128ValueFromInt64(42),
-				Signed: true,
-			},
-			sema.Int256Type: {
-				Value:  NewUnmeteredInt256ValueFromInt64(42),
-				Signed: true,
-			},
+		testCases := map[*sema.NumericType]NumberValue{
+			sema.IntType:     NewUnmeteredIntValueFromInt64(42),
+			sema.UIntType:    NewUnmeteredUIntValueFromUint64(42),
+			sema.UInt8Type:   NewUnmeteredUInt8Value(42),
+			sema.UInt16Type:  NewUnmeteredUInt16Value(42),
+			sema.UInt32Type:  NewUnmeteredUInt32Value(42),
+			sema.UInt64Type:  NewUnmeteredUInt64Value(42),
+			sema.UInt128Type: NewUnmeteredUInt128ValueFromUint64(42),
+			sema.UInt256Type: NewUnmeteredUInt256ValueFromUint64(42),
+			sema.Word8Type:   NewUnmeteredWord8Value(42),
+			sema.Word16Type:  NewUnmeteredWord16Value(42),
+			sema.Word32Type:  NewUnmeteredWord32Value(42),
+			sema.Word64Type:  NewUnmeteredWord64Value(42),
+			sema.Int8Type:    NewUnmeteredInt8Value(42),
+			sema.Int16Type:   NewUnmeteredInt16Value(42),
+			sema.Int32Type:   NewUnmeteredInt32Value(42),
+			sema.Int64Type:   NewUnmeteredInt64Value(42),
+			sema.Int128Type:  NewUnmeteredInt128ValueFromInt64(42),
+			sema.Int256Type:  NewUnmeteredInt256ValueFromInt64(42),
 		}
 
 		for _, ty := range sema.AllIntegerTypes {
@@ -3984,28 +3700,8 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			require.True(t, ok, "missing case for type %s", ty.String())
 		}
 
-		for semaType, testCase := range testCases {
-
-			v := testCase.Value
-			staticType := ConvertSemaToStaticType(nil, semaType)
-
-			test(v, true, PrimitiveStaticTypeAny)
-			test(v, true, PrimitiveStaticTypeAnyStruct)
-			test(v, true, PrimitiveStaticTypeNumber)
-			test(v, true, PrimitiveStaticTypeInteger)
-			test(v, testCase.Signed, PrimitiveStaticTypeSignedInteger)
-			test(v, true, staticType)
-			test(v, true, OptionalStaticType{
-				Type: PrimitiveStaticTypeInteger,
-			})
-
-			test(v, false, PrimitiveStaticTypeAnyResource)
-			test(v, false, PrimitiveStaticTypeBool)
-			test(v, false, PrimitiveStaticTypeFixedPoint)
-			test(v, false, PrimitiveStaticTypeSignedFixedPoint)
-			test(v, false, VariableSizedStaticType{
-				Type: staticType,
-			})
+		for _, v := range testCases {
+			test(v, true)
 		}
 	})
 
@@ -4013,19 +3709,9 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 
 		t.Parallel()
 
-		type testCase struct {
-			Value  FixedPointValue
-			Signed bool
-		}
-
-		testCases := map[*sema.FixedPointNumericType]testCase{
-			sema.UFix64Type: {
-				Value: NewUnmeteredUFix64ValueWithInteger(42),
-			},
-			sema.Fix64Type: {
-				Value:  NewUnmeteredFix64ValueWithInteger(42),
-				Signed: true,
-			},
+		testCases := map[*sema.FixedPointNumericType]NumberValue{
+			sema.UFix64Type: NewUnmeteredUFix64ValueWithInteger(42),
+			sema.Fix64Type:  NewUnmeteredFix64ValueWithInteger(42),
 		}
 
 		for _, ty := range sema.AllFixedPointTypes {
@@ -4039,28 +3725,8 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			require.True(t, ok, "missing case for type %s", ty.String())
 		}
 
-		for semaType, testCase := range testCases {
-
-			v := testCase.Value
-			staticType := ConvertSemaToStaticType(nil, semaType)
-
-			test(v, true, PrimitiveStaticTypeAny)
-			test(v, true, PrimitiveStaticTypeAnyStruct)
-			test(v, true, PrimitiveStaticTypeNumber)
-			test(v, true, PrimitiveStaticTypeFixedPoint)
-			test(v, testCase.Signed, PrimitiveStaticTypeSignedFixedPoint)
-			test(v, true, staticType)
-			test(v, true, OptionalStaticType{
-				Type: PrimitiveStaticTypeFixedPoint,
-			})
-
-			test(v, false, PrimitiveStaticTypeAnyResource)
-			test(v, false, PrimitiveStaticTypeBool)
-			test(v, false, PrimitiveStaticTypeInteger)
-			test(v, false, PrimitiveStaticTypeSignedInteger)
-			test(v, false, VariableSizedStaticType{
-				Type: staticType,
-			})
+		for _, v := range testCases {
+			test(v, true)
 		}
 	})
 
@@ -4068,101 +3734,48 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredEphemeralReferenceValue(
-			false,
-			NewUnmeteredBoolValue(true),
-			sema.BoolType,
+		test(
+			NewUnmeteredEphemeralReferenceValue(
+				false,
+				NewUnmeteredBoolValue(true),
+				sema.BoolType,
+			),
+			true,
 		)
 
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, ReferenceStaticType{
-			Authorized:     false,
-			BorrowedType:   PrimitiveStaticTypeBool,
-			ReferencedType: PrimitiveStaticTypeBool,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     false,
-				BorrowedType:   PrimitiveStaticTypeBool,
-				ReferencedType: PrimitiveStaticTypeBool,
-			},
-		})
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     true,
-				BorrowedType:   PrimitiveStaticTypeBool,
-				ReferencedType: PrimitiveStaticTypeBool,
-			},
-		})
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     false,
-				BorrowedType:   PrimitiveStaticTypeString,
-				ReferencedType: PrimitiveStaticTypeString,
-			},
-		})
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     false,
-				BorrowedType:   PrimitiveStaticTypeBool,
-				ReferencedType: PrimitiveStaticTypeString,
-			},
-		})
+		test(
+			NewUnmeteredEphemeralReferenceValue(
+				false,
+				NewUnmeteredBoolValue(true),
+				sema.StringType,
+			),
+			false,
+		)
 	})
 
 	t.Run("StorageReferenceValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewUnmeteredStorageReferenceValue(
-			false,
-			testAddress,
-			NewUnmeteredPathValue(common.PathDomainStorage, "test"),
-			sema.BoolType,
+		test(
+			NewUnmeteredStorageReferenceValue(
+				false,
+				testAddress,
+				NewUnmeteredPathValue(common.PathDomainStorage, "test"),
+				sema.BoolType,
+			),
+			true,
 		)
 
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, ReferenceStaticType{
-			Authorized:     false,
-			BorrowedType:   PrimitiveStaticTypeBool,
-			ReferencedType: PrimitiveStaticTypeBool,
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     false,
-				BorrowedType:   PrimitiveStaticTypeBool,
-				ReferencedType: PrimitiveStaticTypeBool,
-			},
-		})
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     true,
-				BorrowedType:   PrimitiveStaticTypeBool,
-				ReferencedType: PrimitiveStaticTypeBool,
-			},
-		})
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     false,
-				BorrowedType:   PrimitiveStaticTypeString,
-				ReferencedType: PrimitiveStaticTypeString,
-			},
-		})
-		test(v, false, VariableSizedStaticType{
-			Type: ReferenceStaticType{
-				Authorized:     false,
-				BorrowedType:   PrimitiveStaticTypeBool,
-				ReferencedType: PrimitiveStaticTypeString,
-			},
-		})
+		test(
+			NewUnmeteredStorageReferenceValue(
+				false,
+				testAddress,
+				NewUnmeteredPathValue(common.PathDomainStorage, "test"),
+				sema.StringType,
+			),
+			false,
+		)
 	})
 
 	t.Run("CapabilityValue", func(t *testing.T) {
@@ -4179,112 +3792,142 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			},
 		)
 
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, CapabilityStaticType{
-			BorrowType: ReferenceStaticType{
-				Authorized:     false,
-				BorrowedType:   PrimitiveStaticTypeBool,
-				ReferencedType: PrimitiveStaticTypeBool,
-			},
-		})
-		test(v, true, OptionalStaticType{
-			Type: CapabilityStaticType{
-				BorrowType: ReferenceStaticType{
-					Authorized:     false,
-					BorrowedType:   PrimitiveStaticTypeBool,
-					ReferencedType: PrimitiveStaticTypeBool,
-				},
-			},
-		})
-
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
+		test(v, true)
 	})
 
 	t.Run("ArrayValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewArrayValue(
-			inter,
-			VariableSizedStaticType{
-				Type: PrimitiveStaticTypeNumber,
-			},
-			testAddress,
-			NewUnmeteredInt8Value(2),
-			NewUnmeteredFix64Value(3),
+		test(
+			NewArrayValue(
+				inter,
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeNumber,
+				},
+				testAddress,
+				NewUnmeteredInt8Value(2),
+				NewUnmeteredFix64Value(3),
+			),
+			true,
 		)
 
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeAnyStruct,
-		})
-		test(v, true, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeNumber,
-		})
-		test(v, true, OptionalStaticType{
-			Type: VariableSizedStaticType{
-				Type: PrimitiveStaticTypeNumber,
-			},
-		})
+		test(
+			NewArrayValue(
+				inter,
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeAnyStruct,
+				},
+				testAddress,
+				NewUnmeteredInt8Value(2),
+				NewUnmeteredFix64Value(3),
+			),
+			true,
+		)
 
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, VariableSizedStaticType{
-			Type: PrimitiveStaticTypeInteger,
-		})
+		test(
+			NewArrayValue(
+				inter,
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeInteger,
+				},
+				testAddress,
+				NewUnmeteredInt8Value(2),
+				NewUnmeteredFix64Value(3),
+			),
+			false,
+		)
+
+		// TODO: add case with composite mismatch
 	})
 
 	t.Run("DictionaryValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		v := NewDictionaryValueWithAddress(
-			inter,
-			DictionaryStaticType{
-				KeyType:   PrimitiveStaticTypeString,
-				ValueType: PrimitiveStaticTypeNumber,
-			},
-			testAddress,
-			NewUnmeteredStringValue("a"),
-			NewUnmeteredInt8Value(2),
-			NewUnmeteredStringValue("b"),
-			NewUnmeteredFix64Value(3),
+		test(
+			NewDictionaryValueWithAddress(
+				inter,
+				DictionaryStaticType{
+					KeyType:   PrimitiveStaticTypeString,
+					ValueType: PrimitiveStaticTypeNumber,
+				},
+				testAddress,
+				NewUnmeteredStringValue("a"),
+				NewUnmeteredInt8Value(2),
+				NewUnmeteredStringValue("b"),
+				NewUnmeteredFix64Value(3),
+			),
+			true,
 		)
 
-		test(v, true, PrimitiveStaticTypeAny)
-		test(v, true, PrimitiveStaticTypeAnyStruct)
-		test(v, true, DictionaryStaticType{
-			KeyType:   PrimitiveStaticTypeAnyStruct,
-			ValueType: PrimitiveStaticTypeAnyStruct,
-		})
-		test(v, true, DictionaryStaticType{
-			KeyType:   PrimitiveStaticTypeAnyStruct,
-			ValueType: PrimitiveStaticTypeNumber,
-		})
-		test(v, true, DictionaryStaticType{
-			KeyType:   PrimitiveStaticTypeString,
-			ValueType: PrimitiveStaticTypeAnyStruct,
-		})
-		test(v, true, OptionalStaticType{
-			Type: DictionaryStaticType{
-				KeyType:   PrimitiveStaticTypeString,
-				ValueType: PrimitiveStaticTypeNumber,
-			},
-		})
+		test(
+			NewDictionaryValueWithAddress(
+				inter,
+				DictionaryStaticType{
+					KeyType:   PrimitiveStaticTypeString,
+					ValueType: PrimitiveStaticTypeAnyStruct,
+				},
+				testAddress,
+				NewUnmeteredStringValue("a"),
+				NewUnmeteredInt8Value(2),
+				NewUnmeteredStringValue("b"),
+				NewUnmeteredFix64Value(3),
+			),
+			true,
+		)
 
-		test(v, false, PrimitiveStaticTypeAnyResource)
-		test(v, false, PrimitiveStaticTypeBool)
-		test(v, false, DictionaryStaticType{
-			KeyType:   PrimitiveStaticTypeString,
-			ValueType: PrimitiveStaticTypeInteger,
-		})
-		test(v, false, DictionaryStaticType{
-			KeyType:   PrimitiveStaticTypeInteger,
-			ValueType: PrimitiveStaticTypeNumber,
-		})
+		test(
+			NewDictionaryValueWithAddress(
+				inter,
+				DictionaryStaticType{
+					KeyType:   PrimitiveStaticTypeAnyStruct,
+					ValueType: PrimitiveStaticTypeNumber,
+				},
+				testAddress,
+				NewUnmeteredStringValue("a"),
+				NewUnmeteredInt8Value(2),
+				NewUnmeteredStringValue("b"),
+				NewUnmeteredFix64Value(3),
+			),
+			true,
+		)
+
+		// TODO: cannot test due to container mutation check. import instead?
+
+		//test(
+		//	NewDictionaryValueWithAddress(
+		//		inter,
+		//		DictionaryStaticType{
+		//			KeyType:   PrimitiveStaticTypeInt,
+		//			ValueType: PrimitiveStaticTypeNumber,
+		//		},
+		//		testAddress,
+		//		NewUnmeteredStringValue("a"),
+		//		NewUnmeteredInt8Value(2),
+		//		NewUnmeteredStringValue("b"),
+		//		NewUnmeteredFix64Value(3),
+		//	),
+		//	false,
+		//)
+		//
+		//test(
+		//	NewDictionaryValueWithAddress(
+		//		inter,
+		//		DictionaryStaticType{
+		//			KeyType:   PrimitiveStaticTypeAnyStruct,
+		//			ValueType: PrimitiveStaticTypeInteger,
+		//		},
+		//		testAddress,
+		//		NewUnmeteredStringValue("a"),
+		//		NewUnmeteredInt8Value(2),
+		//		NewUnmeteredStringValue("b"),
+		//		NewUnmeteredFix64Value(3),
+		//	),
+		//	false,
+		//)
+
+		// TODO: add case with composite mismatch
 	})
 
 	// TODO: composite, simple composite

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3574,6 +3574,17 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 	storageMap := storage.GetStorageMap(testAddress, "storage", true)
 	storageMap.WriteValue(inter, "test", NewUnmeteredBoolValue(true))
 
+	newCompositeValue := func(fields []CompositeField) *CompositeValue {
+		return NewCompositeValue(
+			inter,
+			utils.TestLocation,
+			"Test",
+			common.CompositeKindStructure,
+			fields,
+			testAddress,
+		)
+	}
+
 	test := func(value Value, expected bool) {
 		result := value.ConformsToStaticType(
 			inter,
@@ -3819,6 +3830,8 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		test(v, true)
 	})
 
+	invalidCompositeValue := newCompositeValue([]CompositeField{})
+
 	t.Run("ArrayValue", func(t *testing.T) {
 
 		t.Parallel()
@@ -3862,7 +3875,17 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			false,
 		)
 
-		// TODO: add case with composite mismatch
+		test(
+			NewArrayValue(
+				inter,
+				VariableSizedStaticType{
+					Type: PrimitiveStaticTypeAnyStruct,
+				},
+				testAddress,
+				invalidCompositeValue,
+			),
+			false,
+		)
 	})
 
 	t.Run("DictionaryValue", func(t *testing.T) {
@@ -3951,26 +3974,27 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		//	false,
 		//)
 
-		// TODO: add case with composite mismatch
+		test(
+			NewDictionaryValueWithAddress(
+				inter,
+				DictionaryStaticType{
+					KeyType:   PrimitiveStaticTypeAnyStruct,
+					ValueType: PrimitiveStaticTypeAnyStruct,
+				},
+				testAddress,
+				NewUnmeteredStringValue("a"),
+				invalidCompositeValue,
+			),
+			false,
+		)
 	})
 
 	t.Run("CompositeValue", func(t *testing.T) {
 
 		t.Parallel()
 
-		newTestCompositeValue := func(fields []CompositeField) *CompositeValue {
-			return NewCompositeValue(
-				inter,
-				utils.TestLocation,
-				"Test",
-				common.CompositeKindStructure,
-				fields,
-				testAddress,
-			)
-		}
-
 		test(
-			newTestCompositeValue([]CompositeField{
+			newCompositeValue([]CompositeField{
 				{
 					Name:  "foo",
 					Value: NewUnmeteredBoolValue(true),
@@ -3980,7 +4004,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		)
 
 		test(
-			newTestCompositeValue([]CompositeField{
+			newCompositeValue([]CompositeField{
 				{
 					Name:  "foo",
 					Value: NewUnmeteredStringValue("test"),
@@ -3990,7 +4014,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		)
 
 		test(
-			newTestCompositeValue([]CompositeField{}),
+			invalidCompositeValue,
 			false,
 		)
 	})

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -967,12 +967,10 @@ func validateArgumentParams(
 		}
 
 		// Check whether the decoded value conforms to the type associated with the value
-		conformanceResults := interpreter.TypeConformanceResults{}
 		if !arg.ConformsToStaticType(
 			inter,
 			interpreter.ReturnEmptyLocationRange,
-			argType,
-			conformanceResults,
+			interpreter.TypeConformanceResults{},
 		) {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: i,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -948,14 +948,16 @@ func validateArgumentParams(
 		}
 
 		// Ensure the argument is of an importable type
+		argType := arg.StaticType(inter)
+
 		if !arg.IsImportable(inter) {
 			return nil, &ArgumentNotImportableError{
-				Type: arg.StaticType(inter),
+				Type: argType,
 			}
 		}
 
 		// Check that decoded value is a subtype of static parameter type
-		if !inter.IsSubTypeOfSemaType(arg.StaticType(inter), parameterType) {
+		if !inter.IsSubTypeOfSemaType(argType, parameterType) {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: i,
 				Err: &InvalidValueTypeError{
@@ -969,7 +971,7 @@ func validateArgumentParams(
 		if !arg.ConformsToStaticType(
 			inter,
 			interpreter.ReturnEmptyLocationRange,
-			arg.StaticType(inter),
+			argType,
 			conformanceResults,
 		) {
 			return nil, &InvalidEntryPointArgumentError{


### PR DESCRIPTION
Closes #1693

## Description

Change `ConformsToStaticType` so it only determines if the value conforms to its own static type, recursively.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
