### PR TITLE
[LS] Add inlay hints

### DIFF
--- a/languageserver/protocol/methods.go
+++ b/languageserver/protocol/methods.go
@@ -155,6 +155,14 @@ func (s *Server) handleDocumentLink(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.DocumentLink(s.conn, &params)
 }
 
+func (s *Server) handleInlayHint(req *json.RawMessage) (interface{}, error) {
+	var params InlayHintParams
+	if err := json.Unmarshal(*req, &params); err != nil {
+		return nil, err
+	}
+	return s.Handler.InlayHint(s.conn, &params)
+}
+
 func (s *Server) handleShutdown(_ *json.RawMessage) (interface{}, error) {
 	err := s.Handler.Shutdown(s.conn)
 	return nil, err

--- a/languageserver/protocol/server.go
+++ b/languageserver/protocol/server.go
@@ -93,6 +93,7 @@ type Handler interface {
 	ExecuteCommand(conn Conn, params *ExecuteCommandParams) (interface{}, error)
 	DocumentSymbol(conn Conn, params *DocumentSymbolParams) ([]*DocumentSymbol, error)
 	DocumentLink(conn Conn, params *DocumentLinkParams) ([]*DocumentLink, error)
+	InlayHint(conn Conn, params *InlayHintParams) ([]*InlayHint, error)
 	Shutdown(conn Conn) error
 	Exit(conn Conn) error
 }
@@ -154,6 +155,9 @@ func NewServer(handler Handler) *Server {
 
 	jsonrpc2Server.Methods["textDocument/documentLink"] =
 		server.handleDocumentLink
+
+	jsonrpc2Server.Methods["textDocument/inlayHint"] =
+		server.handleInlayHint
 
 	jsonrpc2Server.Methods["shutdown"] =
 		server.handleShutdown


### PR DESCRIPTION
## Description

Show inferred types of variable declarations as inlay hints.

<img width="460" src="https://user-images.githubusercontent.com/51661/172075376-a42a0014-8c1e-4694-9941-4e553928cb6b.png">

Requires https://github.com/onflow/vscode-cadence/pull/89 for the VS Code extension.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
