### PR TITLE
[LS] Add stdlib builtin value declarations

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -44,10 +44,15 @@ import (
 	"github.com/onflow/cadence/languageserver/protocol"
 )
 
-var valueDeclarations = append(
+var functionDeclarations = append(
 	stdlib.FlowBuiltInFunctions(stdlib.FlowBuiltinImpls{}),
 	stdlib.BuiltinFunctions...,
 ).ToSemaValueDeclarations()
+
+var valueDeclarations = append(
+	functionDeclarations,
+	stdlib.BuiltinValues.ToSemaValueDeclarations()...,
+)
 
 var typeDeclarations = append(
 	stdlib.FlowBuiltInTypes,


### PR DESCRIPTION
Closes #1140

## Description

Add the missing standard library value declarations (hash and signature algorithm, RLP and BLS functions, etc)

<img width="560" src="https://user-images.githubusercontent.com/51661/172076009-4b6c5da0-688a-41fc-aea0-4732c1c06f44.png"/>


Thanks to @bluesign to figuring out the problem and developing this fix!

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
