### PR TITLE
Use `any` in-place of `interface{}`

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -70,7 +70,7 @@ func NewDecoder(gauge common.MemoryGauge, r io.Reader) *Decoder {
 // This function returns an error if the bytes represent JSON that is malformed
 // or does not conform to the JSON Cadence specification.
 func (d *Decoder) Decode() (value cadence.Value, err error) {
-	jsonMap := make(map[string]interface{})
+	jsonMap := make(map[string]any)
 
 	err = d.dec.Decode(&jsonMap)
 	if err != nil {
@@ -120,7 +120,7 @@ const (
 
 var ErrInvalidJSONCadence = errors.New("invalid JSON Cadence structure")
 
-func (d *Decoder) decodeJSON(v interface{}) cadence.Value {
+func (d *Decoder) decodeJSON(v any) cadence.Value {
 	obj := toObject(v)
 
 	typeStr := obj.GetString(typeKey)
@@ -215,7 +215,7 @@ func (d *Decoder) decodeJSON(v interface{}) cadence.Value {
 	panic(ErrInvalidJSONCadence)
 }
 
-func (d *Decoder) decodeVoid(m map[string]interface{}) cadence.Void {
+func (d *Decoder) decodeVoid(m map[string]any) cadence.Void {
 	// object should not contain fields other than "type"
 	if len(m) != 1 {
 		// TODO: improve error message
@@ -225,7 +225,7 @@ func (d *Decoder) decodeVoid(m map[string]interface{}) cadence.Void {
 	return cadence.NewMeteredVoid(d.gauge)
 }
 
-func (d *Decoder) decodeOptional(valueJSON interface{}) cadence.Optional {
+func (d *Decoder) decodeOptional(valueJSON any) cadence.Optional {
 	if valueJSON == nil {
 		return cadence.NewMeteredOptional(d.gauge, nil)
 	}
@@ -233,11 +233,11 @@ func (d *Decoder) decodeOptional(valueJSON interface{}) cadence.Optional {
 	return cadence.NewMeteredOptional(d.gauge, d.decodeJSON(valueJSON))
 }
 
-func (d *Decoder) decodeBool(valueJSON interface{}) cadence.Bool {
+func (d *Decoder) decodeBool(valueJSON any) cadence.Bool {
 	return cadence.NewMeteredBool(d.gauge, toBool(valueJSON))
 }
 
-func (d *Decoder) decodeCharacter(valueJSON interface{}) cadence.Character {
+func (d *Decoder) decodeCharacter(valueJSON any) cadence.Character {
 	asString := toString(valueJSON)
 	char, err := cadence.NewMeteredCharacter(
 		d.gauge,
@@ -251,7 +251,7 @@ func (d *Decoder) decodeCharacter(valueJSON interface{}) cadence.Character {
 	return char
 }
 
-func (d *Decoder) decodeString(valueJSON interface{}) cadence.String {
+func (d *Decoder) decodeString(valueJSON any) cadence.String {
 	asString := toString(valueJSON)
 	str, err := cadence.NewMeteredString(
 		d.gauge,
@@ -266,7 +266,7 @@ func (d *Decoder) decodeString(valueJSON interface{}) cadence.String {
 	return str
 }
 
-func (d *Decoder) decodeAddress(valueJSON interface{}) cadence.Address {
+func (d *Decoder) decodeAddress(valueJSON any) cadence.Address {
 	v := toString(valueJSON)
 
 	// must include 0x prefix
@@ -284,7 +284,7 @@ func (d *Decoder) decodeAddress(valueJSON interface{}) cadence.Address {
 	return cadence.BytesToMeteredAddress(d.gauge, b)
 }
 
-func (d *Decoder) decodeBigInt(valueJSON interface{}) *big.Int {
+func (d *Decoder) decodeBigInt(valueJSON any) *big.Int {
 	v := toString(valueJSON)
 
 	i := new(big.Int)
@@ -297,7 +297,7 @@ func (d *Decoder) decodeBigInt(valueJSON interface{}) *big.Int {
 	return i
 }
 
-func (d *Decoder) decodeInt(valueJSON interface{}) cadence.Int {
+func (d *Decoder) decodeInt(valueJSON any) cadence.Int {
 	bigInt := d.decodeBigInt(valueJSON)
 	return cadence.NewMeteredIntFromBig(
 		d.gauge,
@@ -310,7 +310,7 @@ func (d *Decoder) decodeInt(valueJSON interface{}) cadence.Int {
 	)
 }
 
-func (d *Decoder) decodeInt8(valueJSON interface{}) cadence.Int8 {
+func (d *Decoder) decodeInt8(valueJSON any) cadence.Int8 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseInt(v, 10, 8)
@@ -322,7 +322,7 @@ func (d *Decoder) decodeInt8(valueJSON interface{}) cadence.Int8 {
 	return cadence.NewMeteredInt8(d.gauge, int8(i))
 }
 
-func (d *Decoder) decodeInt16(valueJSON interface{}) cadence.Int16 {
+func (d *Decoder) decodeInt16(valueJSON any) cadence.Int16 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseInt(v, 10, 16)
@@ -334,7 +334,7 @@ func (d *Decoder) decodeInt16(valueJSON interface{}) cadence.Int16 {
 	return cadence.NewMeteredInt16(d.gauge, int16(i))
 }
 
-func (d *Decoder) decodeInt32(valueJSON interface{}) cadence.Int32 {
+func (d *Decoder) decodeInt32(valueJSON any) cadence.Int32 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseInt(v, 10, 32)
@@ -346,7 +346,7 @@ func (d *Decoder) decodeInt32(valueJSON interface{}) cadence.Int32 {
 	return cadence.NewMeteredInt32(d.gauge, int32(i))
 }
 
-func (d *Decoder) decodeInt64(valueJSON interface{}) cadence.Int64 {
+func (d *Decoder) decodeInt64(valueJSON any) cadence.Int64 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseInt(v, 10, 64)
@@ -358,7 +358,7 @@ func (d *Decoder) decodeInt64(valueJSON interface{}) cadence.Int64 {
 	return cadence.NewMeteredInt64(d.gauge, i)
 }
 
-func (d *Decoder) decodeInt128(valueJSON interface{}) cadence.Int128 {
+func (d *Decoder) decodeInt128(valueJSON any) cadence.Int128 {
 	value, err := cadence.NewMeteredInt128FromBig(
 		d.gauge,
 		func() *big.Int {
@@ -373,7 +373,7 @@ func (d *Decoder) decodeInt128(valueJSON interface{}) cadence.Int128 {
 	return value
 }
 
-func (d *Decoder) decodeInt256(valueJSON interface{}) cadence.Int256 {
+func (d *Decoder) decodeInt256(valueJSON any) cadence.Int256 {
 	value, err := cadence.NewMeteredInt256FromBig(
 		d.gauge,
 		func() *big.Int {
@@ -388,7 +388,7 @@ func (d *Decoder) decodeInt256(valueJSON interface{}) cadence.Int256 {
 	return value
 }
 
-func (d *Decoder) decodeUInt(valueJSON interface{}) cadence.UInt {
+func (d *Decoder) decodeUInt(valueJSON any) cadence.UInt {
 	bigInt := d.decodeBigInt(valueJSON)
 	value, err := cadence.NewMeteredUIntFromBig(
 		d.gauge,
@@ -407,7 +407,7 @@ func (d *Decoder) decodeUInt(valueJSON interface{}) cadence.UInt {
 	return value
 }
 
-func (d *Decoder) decodeUInt8(valueJSON interface{}) cadence.UInt8 {
+func (d *Decoder) decodeUInt8(valueJSON any) cadence.UInt8 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 8)
@@ -419,7 +419,7 @@ func (d *Decoder) decodeUInt8(valueJSON interface{}) cadence.UInt8 {
 	return cadence.NewMeteredUInt8(d.gauge, uint8(i))
 }
 
-func (d *Decoder) decodeUInt16(valueJSON interface{}) cadence.UInt16 {
+func (d *Decoder) decodeUInt16(valueJSON any) cadence.UInt16 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 16)
@@ -431,7 +431,7 @@ func (d *Decoder) decodeUInt16(valueJSON interface{}) cadence.UInt16 {
 	return cadence.NewMeteredUInt16(d.gauge, uint16(i))
 }
 
-func (d *Decoder) decodeUInt32(valueJSON interface{}) cadence.UInt32 {
+func (d *Decoder) decodeUInt32(valueJSON any) cadence.UInt32 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 32)
@@ -443,7 +443,7 @@ func (d *Decoder) decodeUInt32(valueJSON interface{}) cadence.UInt32 {
 	return cadence.NewMeteredUInt32(d.gauge, uint32(i))
 }
 
-func (d *Decoder) decodeUInt64(valueJSON interface{}) cadence.UInt64 {
+func (d *Decoder) decodeUInt64(valueJSON any) cadence.UInt64 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 64)
@@ -455,7 +455,7 @@ func (d *Decoder) decodeUInt64(valueJSON interface{}) cadence.UInt64 {
 	return cadence.NewMeteredUInt64(d.gauge, i)
 }
 
-func (d *Decoder) decodeUInt128(valueJSON interface{}) cadence.UInt128 {
+func (d *Decoder) decodeUInt128(valueJSON any) cadence.UInt128 {
 	value, err := cadence.NewMeteredUInt128FromBig(
 		d.gauge,
 		func() *big.Int {
@@ -469,7 +469,7 @@ func (d *Decoder) decodeUInt128(valueJSON interface{}) cadence.UInt128 {
 	return value
 }
 
-func (d *Decoder) decodeUInt256(valueJSON interface{}) cadence.UInt256 {
+func (d *Decoder) decodeUInt256(valueJSON any) cadence.UInt256 {
 	value, err := cadence.NewMeteredUInt256FromBig(
 		d.gauge,
 		func() *big.Int {
@@ -483,7 +483,7 @@ func (d *Decoder) decodeUInt256(valueJSON interface{}) cadence.UInt256 {
 	return value
 }
 
-func (d *Decoder) decodeWord8(valueJSON interface{}) cadence.Word8 {
+func (d *Decoder) decodeWord8(valueJSON any) cadence.Word8 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 8)
@@ -495,7 +495,7 @@ func (d *Decoder) decodeWord8(valueJSON interface{}) cadence.Word8 {
 	return cadence.NewMeteredWord8(d.gauge, uint8(i))
 }
 
-func (d *Decoder) decodeWord16(valueJSON interface{}) cadence.Word16 {
+func (d *Decoder) decodeWord16(valueJSON any) cadence.Word16 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 16)
@@ -507,7 +507,7 @@ func (d *Decoder) decodeWord16(valueJSON interface{}) cadence.Word16 {
 	return cadence.NewMeteredWord16(d.gauge, uint16(i))
 }
 
-func (d *Decoder) decodeWord32(valueJSON interface{}) cadence.Word32 {
+func (d *Decoder) decodeWord32(valueJSON any) cadence.Word32 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 32)
@@ -519,7 +519,7 @@ func (d *Decoder) decodeWord32(valueJSON interface{}) cadence.Word32 {
 	return cadence.NewMeteredWord32(d.gauge, uint32(i))
 }
 
-func (d *Decoder) decodeWord64(valueJSON interface{}) cadence.Word64 {
+func (d *Decoder) decodeWord64(valueJSON any) cadence.Word64 {
 	v := toString(valueJSON)
 
 	i, err := strconv.ParseUint(v, 10, 64)
@@ -531,7 +531,7 @@ func (d *Decoder) decodeWord64(valueJSON interface{}) cadence.Word64 {
 	return cadence.NewMeteredWord64(d.gauge, i)
 }
 
-func (d *Decoder) decodeFix64(valueJSON interface{}) cadence.Fix64 {
+func (d *Decoder) decodeFix64(valueJSON any) cadence.Fix64 {
 	v, err := cadence.NewMeteredFix64(d.gauge, func() (string, error) {
 		return toString(valueJSON), nil
 	})
@@ -542,7 +542,7 @@ func (d *Decoder) decodeFix64(valueJSON interface{}) cadence.Fix64 {
 	return v
 }
 
-func (d *Decoder) decodeUFix64(valueJSON interface{}) cadence.UFix64 {
+func (d *Decoder) decodeUFix64(valueJSON any) cadence.UFix64 {
 	v, err := cadence.NewMeteredUFix64(d.gauge, func() (string, error) {
 		return toString(valueJSON), nil
 	})
@@ -553,7 +553,7 @@ func (d *Decoder) decodeUFix64(valueJSON interface{}) cadence.UFix64 {
 	return v
 }
 
-func (d *Decoder) decodeArray(valueJSON interface{}) cadence.Array {
+func (d *Decoder) decodeArray(valueJSON any) cadence.Array {
 	v := toSlice(valueJSON)
 
 	value, err := cadence.NewMeteredArray(
@@ -575,7 +575,7 @@ func (d *Decoder) decodeArray(valueJSON interface{}) cadence.Array {
 	return value
 }
 
-func (d *Decoder) decodeDictionary(valueJSON interface{}) cadence.Dictionary {
+func (d *Decoder) decodeDictionary(valueJSON any) cadence.Dictionary {
 	v := toSlice(valueJSON)
 
 	value, err := cadence.NewMeteredDictionary(
@@ -600,7 +600,7 @@ func (d *Decoder) decodeDictionary(valueJSON interface{}) cadence.Dictionary {
 	return value
 }
 
-func (d *Decoder) decodeKeyValuePair(valueJSON interface{}) cadence.KeyValuePair {
+func (d *Decoder) decodeKeyValuePair(valueJSON any) cadence.KeyValuePair {
 	obj := toObject(valueJSON)
 
 	key := obj.GetValue(d, keyKey)
@@ -620,7 +620,7 @@ type composite struct {
 	fieldTypes          []cadence.Field
 }
 
-func (d *Decoder) decodeComposite(valueJSON interface{}) composite {
+func (d *Decoder) decodeComposite(valueJSON any) composite {
 	obj := toObject(valueJSON)
 
 	typeID := obj.GetString(idKey)
@@ -659,7 +659,7 @@ func (d *Decoder) decodeComposite(valueJSON interface{}) composite {
 	}
 }
 
-func (d *Decoder) decodeCompositeField(valueJSON interface{}) (cadence.Value, cadence.Field) {
+func (d *Decoder) decodeCompositeField(valueJSON any) (cadence.Value, cadence.Field) {
 	obj := toObject(valueJSON)
 
 	name := obj.GetString(nameKey)
@@ -672,7 +672,7 @@ func (d *Decoder) decodeCompositeField(valueJSON interface{}) (cadence.Value, ca
 	return value, field
 }
 
-func (d *Decoder) decodeStruct(valueJSON interface{}) cadence.Struct {
+func (d *Decoder) decodeStruct(valueJSON any) cadence.Struct {
 	comp := d.decodeComposite(valueJSON)
 
 	structure, err := cadence.NewMeteredStruct(
@@ -696,7 +696,7 @@ func (d *Decoder) decodeStruct(valueJSON interface{}) cadence.Struct {
 	))
 }
 
-func (d *Decoder) decodeResource(valueJSON interface{}) cadence.Resource {
+func (d *Decoder) decodeResource(valueJSON any) cadence.Resource {
 	comp := d.decodeComposite(valueJSON)
 
 	resource, err := cadence.NewMeteredResource(
@@ -719,7 +719,7 @@ func (d *Decoder) decodeResource(valueJSON interface{}) cadence.Resource {
 	))
 }
 
-func (d *Decoder) decodeEvent(valueJSON interface{}) cadence.Event {
+func (d *Decoder) decodeEvent(valueJSON any) cadence.Event {
 	comp := d.decodeComposite(valueJSON)
 
 	event, err := cadence.NewMeteredEvent(
@@ -743,7 +743,7 @@ func (d *Decoder) decodeEvent(valueJSON interface{}) cadence.Event {
 	))
 }
 
-func (d *Decoder) decodeContract(valueJSON interface{}) cadence.Contract {
+func (d *Decoder) decodeContract(valueJSON any) cadence.Contract {
 	comp := d.decodeComposite(valueJSON)
 
 	contract, err := cadence.NewMeteredContract(
@@ -767,7 +767,7 @@ func (d *Decoder) decodeContract(valueJSON interface{}) cadence.Contract {
 	))
 }
 
-func (d *Decoder) decodeEnum(valueJSON interface{}) cadence.Enum {
+func (d *Decoder) decodeEnum(valueJSON any) cadence.Enum {
 	comp := d.decodeComposite(valueJSON)
 
 	enum, err := cadence.NewMeteredEnum(
@@ -792,7 +792,7 @@ func (d *Decoder) decodeEnum(valueJSON interface{}) cadence.Enum {
 	))
 }
 
-func (d *Decoder) decodeLink(valueJSON interface{}) cadence.Link {
+func (d *Decoder) decodeLink(valueJSON any) cadence.Link {
 	obj := toObject(valueJSON)
 
 	targetPath, ok := d.decodeJSON(obj.Get(targetPathKey)).(cadence.Path)
@@ -816,7 +816,7 @@ func (d *Decoder) decodeLink(valueJSON interface{}) cadence.Link {
 	)
 }
 
-func (d *Decoder) decodePath(valueJSON interface{}) cadence.Path {
+func (d *Decoder) decodePath(valueJSON any) cadence.Path {
 	obj := toObject(valueJSON)
 
 	domain := obj.GetString(domainKey)
@@ -841,7 +841,7 @@ func (d *Decoder) decodePath(valueJSON interface{}) cadence.Path {
 	)
 }
 
-func (d *Decoder) decodeParamType(valueJSON interface{}) cadence.Parameter {
+func (d *Decoder) decodeParamType(valueJSON any) cadence.Parameter {
 	obj := toObject(valueJSON)
 	// Unmetered because decodeParamType is metered in decodeParamTypes and called nowhere else
 	return cadence.NewParameter(
@@ -851,7 +851,7 @@ func (d *Decoder) decodeParamType(valueJSON interface{}) cadence.Parameter {
 	)
 }
 
-func (d *Decoder) decodeParamTypes(params []interface{}) []cadence.Parameter {
+func (d *Decoder) decodeParamTypes(params []any) []cadence.Parameter {
 	common.UseMemory(d.gauge, common.MemoryUsage{
 		Kind:   common.MemoryKindCadenceParameter,
 		Amount: uint64(len(params)),
@@ -865,7 +865,7 @@ func (d *Decoder) decodeParamTypes(params []interface{}) []cadence.Parameter {
 	return parameters
 }
 
-func (d *Decoder) decodeFieldTypes(fs []interface{}) []cadence.Field {
+func (d *Decoder) decodeFieldTypes(fs []any) []cadence.Field {
 	common.UseMemory(d.gauge, common.MemoryUsage{
 		Kind:   common.MemoryKindCadenceField,
 		Amount: uint64(len(fs)),
@@ -880,7 +880,7 @@ func (d *Decoder) decodeFieldTypes(fs []interface{}) []cadence.Field {
 	return fields
 }
 
-func (d *Decoder) decodeFieldType(valueJSON interface{}) cadence.Field {
+func (d *Decoder) decodeFieldType(valueJSON any) cadence.Field {
 	obj := toObject(valueJSON)
 	// Unmetered because decodeFieldType is metered in decodeFieldTypes and called nowhere else
 	return cadence.NewField(
@@ -889,7 +889,7 @@ func (d *Decoder) decodeFieldType(valueJSON interface{}) cadence.Field {
 	)
 }
 
-func (d *Decoder) decodeFunctionType(returnValue, parametersValue, id interface{}) cadence.Type {
+func (d *Decoder) decodeFunctionType(returnValue, parametersValue, id any) cadence.Type {
 	parameters := d.decodeParamTypes(toSlice(parametersValue))
 	returnType := d.decodeType(returnValue)
 
@@ -901,7 +901,7 @@ func (d *Decoder) decodeFunctionType(returnValue, parametersValue, id interface{
 	).WithID(toString(id))
 }
 
-func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, initializers []interface{}) cadence.Type {
+func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, initializers []any) cadence.Type {
 	fields := d.decodeFieldTypes(fs)
 
 	// Unmetered because this is created as an array of nil arrays, not Parameter structs
@@ -987,8 +987,8 @@ func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, ini
 }
 
 func (d *Decoder) decodeRestrictedType(
-	typeValue interface{},
-	restrictionsValue []interface{},
+	typeValue any,
+	restrictionsValue []any,
 	typeIDValue string,
 ) cadence.Type {
 	typ := d.decodeType(typeValue)
@@ -1005,7 +1005,7 @@ func (d *Decoder) decodeRestrictedType(
 	).WithID(typeIDValue)
 }
 
-func (d *Decoder) decodeType(valueJSON interface{}) cadence.Type {
+func (d *Decoder) decodeType(valueJSON any) cadence.Type {
 	if valueJSON == "" {
 		return nil
 	}
@@ -1166,7 +1166,7 @@ func (d *Decoder) decodeType(valueJSON interface{}) cadence.Type {
 	}
 }
 
-func (d *Decoder) decodeTypeValue(valueJSON interface{}) cadence.TypeValue {
+func (d *Decoder) decodeTypeValue(valueJSON any) cadence.TypeValue {
 	obj := toObject(valueJSON)
 
 	return cadence.NewMeteredTypeValue(
@@ -1175,7 +1175,7 @@ func (d *Decoder) decodeTypeValue(valueJSON interface{}) cadence.TypeValue {
 	)
 }
 
-func (d *Decoder) decodeCapability(valueJSON interface{}) cadence.Capability {
+func (d *Decoder) decodeCapability(valueJSON any) cadence.Capability {
 	obj := toObject(valueJSON)
 
 	path, ok := d.decodeJSON(obj.Get(pathKey)).(cadence.Path)
@@ -1194,9 +1194,9 @@ func (d *Decoder) decodeCapability(valueJSON interface{}) cadence.Capability {
 
 // JSON types
 
-type jsonObject map[string]interface{}
+type jsonObject map[string]any
 
-func (obj jsonObject) Get(key string) interface{} {
+func (obj jsonObject) Get(key string) any {
 	v, hasKey := obj[key]
 	if !hasKey {
 		// TODO: improve error message
@@ -1216,7 +1216,7 @@ func (obj jsonObject) GetString(key string) string {
 	return toString(v)
 }
 
-func (obj jsonObject) GetSlice(key string) []interface{} {
+func (obj jsonObject) GetSlice(key string) []any {
 	v := obj.Get(key)
 	return toSlice(v)
 }
@@ -1228,7 +1228,7 @@ func (obj jsonObject) GetValue(d *Decoder, key string) cadence.Value {
 
 // JSON conversion helpers
 
-func toBool(valueJSON interface{}) bool {
+func toBool(valueJSON any) bool {
 	v, isBool := valueJSON.(bool)
 	if !isBool {
 		// TODO: improve error message
@@ -1238,7 +1238,7 @@ func toBool(valueJSON interface{}) bool {
 	return v
 }
 
-func toUInt(valueJSON interface{}) uint {
+func toUInt(valueJSON any) uint {
 	v, isNum := valueJSON.(float64)
 	if !isNum {
 		// TODO: improve error message
@@ -1248,7 +1248,7 @@ func toUInt(valueJSON interface{}) uint {
 	return uint(v)
 }
 
-func toString(valueJSON interface{}) string {
+func toString(valueJSON any) string {
 	v, isString := valueJSON.(string)
 	if !isString {
 		// TODO: improve error message
@@ -1258,8 +1258,8 @@ func toString(valueJSON interface{}) string {
 	return v
 }
 
-func toSlice(valueJSON interface{}) []interface{} {
-	v, isSlice := valueJSON.([]interface{})
+func toSlice(valueJSON any) []any {
+	v, isSlice := valueJSON.([]any)
 	if !isSlice {
 		// TODO: improve error message
 		panic(ErrInvalidJSONCadence)
@@ -1268,8 +1268,8 @@ func toSlice(valueJSON interface{}) []interface{} {
 	return v
 }
 
-func toObject(valueJSON interface{}) jsonObject {
-	v, isMap := valueJSON.(map[string]interface{})
+func toObject(valueJSON any) jsonObject {
+	v, isMap := valueJSON.(map[string]any)
 	if !isMap {
 		// TODO: improve error message
 		panic(ErrInvalidJSONCadence)

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -99,7 +99,7 @@ func (e *Encoder) Encode(value cadence.Value) (err error) {
 
 // JSON struct definitions
 
-type jsonValue interface{}
+type jsonValue any
 
 type jsonValueObject struct {
 	Type  string    `json:"type"`
@@ -333,7 +333,7 @@ func prepareVoid() jsonValue {
 }
 
 func prepareOptional(v cadence.Optional) jsonValue {
-	var value interface{}
+	var value any
 
 	if v.Value != nil {
 		value = Prepare(v.Value)

--- a/helpers.go
+++ b/helpers.go
@@ -21,7 +21,7 @@ package cadence
 import "fmt"
 
 // Unmetered because this function is only used by the client.
-func NewValue(value interface{}) (Value, error) {
+func NewValue(value any) (Value, error) {
 	switch v := value.(type) {
 	case string:
 		return NewString(v)
@@ -43,7 +43,7 @@ func NewValue(value interface{}) (Value, error) {
 		return NewUInt32(v), nil
 	case uint64:
 		return NewUInt64(v), nil
-	case []interface{}:
+	case []any:
 		values := make([]Value, len(v))
 
 		for i, v := range v {
@@ -65,7 +65,7 @@ func NewValue(value interface{}) (Value, error) {
 
 // MustConvertValue converts a Go value to an ABI value or panics if the value
 // cannot be converted.
-func MustConvertValue(value interface{}) Value {
+func MustConvertValue(value any) Value {
 	ret, err := NewValue(value)
 	if err != nil {
 		panic(err)
@@ -119,7 +119,7 @@ func CastToUInt16(value Value) (uint16, error) {
 	return u, nil
 }
 
-func CastToArray(value Value) ([]interface{}, error) {
+func CastToArray(value Value) ([]any, error) {
 	casted, ok := value.(Array)
 	if !ok {
 		return nil, fmt.Errorf("%T is not a values.Array", value)
@@ -127,9 +127,9 @@ func CastToArray(value Value) ([]interface{}, error) {
 
 	goValue := casted.ToGoValue()
 
-	u, ok := goValue.([]interface{})
+	u, ok := goValue.([]any)
 	if !ok {
-		return nil, fmt.Errorf("%T is not a []interface{}]", value)
+		return nil, fmt.Errorf("%T is not a []any]", value)
 	}
 	return u, nil
 }

--- a/languageserver/cmd/languageserver/main_wasm.go
+++ b/languageserver/cmd/languageserver/main_wasm.go
@@ -46,7 +46,7 @@ func main() {
 
 	js.Global().Set(
 		startFunctionName,
-		js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		js.FuncOf(func(this js.Value, args []js.Value) any {
 			id += 1
 			go start(id)
 			return id
@@ -69,7 +69,7 @@ func start(id int) {
 
 	global := js.Global()
 
-	writeObject := func(obj interface{}) error {
+	writeObject := func(obj any) error {
 		// The object / message is sent to the JS environment
 		// by serializing it to JSON and calling a global function
 
@@ -86,7 +86,7 @@ func start(id int) {
 		return nil
 	}
 
-	readObject := func(v interface{}) (err error) {
+	readObject := func(v any) (err error) {
 		// Set up a wait group which allows blocking this function
 		// until the JS environment calls back
 
@@ -102,7 +102,7 @@ func start(id int) {
 		toServerFunctionName := globalFunctionName(id, "toServer")
 		global.Set(
 			toServerFunctionName,
-			js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+			js.FuncOf(func(this js.Value, args []js.Value) any {
 				defer func() {
 					global.Delete(toServerFunctionName)
 					wg.Done()
@@ -147,7 +147,7 @@ func start(id int) {
 
 	global.Set(
 		globalFunctionName(id, "onClientClose"),
-		js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		js.FuncOf(func(this js.Value, args []js.Value) any {
 			cancel()
 			return nil
 		}),

--- a/languageserver/integration/codelenses.go
+++ b/languageserver/integration/codelenses.go
@@ -209,7 +209,7 @@ func makeActionlessCodelens(title string, lensRange protocol.Range) *protocol.Co
 	}
 }
 
-func makeCodeLens(command string, title string, lensRange protocol.Range, arguments []interface{}) *protocol.CodeLens {
+func makeCodeLens(command string, title string, lensRange protocol.Range, arguments []any) *protocol.CodeLens {
 	return &protocol.CodeLens{
 		Range: lensRange,
 		Command: &protocol.Command{
@@ -294,7 +294,7 @@ func (i *FlowIntegration) scriptCodeLenses(
 	}
 
 	argsJSON, _ := json.Marshal(argumentList)
-	return makeCodeLens(CommandExecuteScript, title, codelensRange, []interface{}{uri, string(argsJSON)})
+	return makeCodeLens(CommandExecuteScript, title, codelensRange, []any{uri, string(argsJSON)})
 }
 
 func (i *FlowIntegration) transactionCodeLenses(
@@ -328,7 +328,7 @@ func (i *FlowIntegration) transactionCodeLenses(
 		CommandSendTransaction,
 		title,
 		codelensRange,
-		[]interface{}{uri, string(argsJSON), accounts},
+		[]any{uri, string(argsJSON), accounts},
 	)
 }
 
@@ -362,5 +362,5 @@ func (i *FlowIntegration) contractCodeLenses(
 		signer,
 	)
 
-	return makeCodeLens(CommandDeployContract, title, codelensRange, []interface{}{uri, name, resolvedAddress})
+	return makeCodeLens(CommandDeployContract, title, codelensRange, []any{uri, name, resolvedAddress})
 }

--- a/languageserver/integration/commands.go
+++ b/languageserver/integration/commands.go
@@ -119,7 +119,7 @@ func makeManagerCode(script string, serviceAddress string) []byte {
 // initAccountManager initializes Account manager on service account
 //
 // No arguments are expected
-func (i *FlowIntegration) initAccountManager(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) initAccountManager(conn protocol.Conn, args ...any) (any, error) {
 	serviceAccount, err := i.state.EmulatorServiceAccount()
 	if err != nil {
 		return nil, errorWithMessage(conn, ErrorMessageServiceAccount, err)
@@ -160,7 +160,7 @@ func (i *FlowIntegration) initAccountManager(conn protocol.Conn, args ...interfa
 // There should be exactly 2 arguments:
 //   * the DocumentURI of the file to submit
 //   * the arguments, encoded as JSON-CDC
-func (i *FlowIntegration) sendTransaction(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) sendTransaction(conn protocol.Conn, args ...any) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 3)
 	if err != nil {
 		return nil, errorWithMessage(conn, ErrorMessageArguments, err)
@@ -193,7 +193,7 @@ func (i *FlowIntegration) sendTransaction(conn protocol.Conn, args ...interface{
 		)
 	}
 
-	signerList := args[2].([]interface{})
+	signerList := args[2].([]any)
 	signers := make([]flow.Address, len(signerList))
 	for i, v := range signerList {
 		signers[i] = flow.HexToAddress(v.(string))
@@ -290,7 +290,7 @@ func (i *FlowIntegration) sendTransaction(conn protocol.Conn, args ...interface{
 // There should be exactly 2 arguments:
 //   * the DocumentURI of the file to submit
 //   * the arguments, encoded as JSON-CDC
-func (i *FlowIntegration) executeScript(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) executeScript(conn protocol.Conn, args ...any) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 2)
 	if err != nil {
 		return nil, errorWithMessage(conn, ErrorMessageArguments, err)
@@ -356,7 +356,7 @@ func (i *FlowIntegration) executeScript(conn protocol.Conn, args ...interface{})
 //
 // There should be exactly 1 argument:
 // * current state of the emulator represented as byte
-func (i *FlowIntegration) changeEmulatorState(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) changeEmulatorState(conn protocol.Conn, args ...any) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 1)
 	if err != nil {
 		return nil, errorWithMessage(conn, ErrorMessageArguments, err)
@@ -381,7 +381,7 @@ func (i *FlowIntegration) changeEmulatorState(conn protocol.Conn, args ...interf
 // There should be 2 arguments:
 //	 * name of the new active acount
 //   * address of the new active account
-func (i *FlowIntegration) switchActiveAccount(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) switchActiveAccount(conn protocol.Conn, args ...any) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 2)
 	if err != nil {
 		return nil, errorWithMessage(conn, ErrorMessageArguments, err)
@@ -406,7 +406,7 @@ func (i *FlowIntegration) switchActiveAccount(conn protocol.Conn, args ...interf
 }
 
 // createAccount creates a new account and returns its address.
-func (i *FlowIntegration) createAccount(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) createAccount(conn protocol.Conn, args ...any) (any, error) {
 	address, err := i.createAccountHelper(conn)
 	if err != nil {
 		return nil, errorWithMessage(conn, ErrorMessageAccountCreate, err)
@@ -424,7 +424,7 @@ func (i *FlowIntegration) createAccount(conn protocol.Conn, args ...interface{})
 //
 // There should be exactly 1 argument:
 // * number of accounts to be created
-func (i *FlowIntegration) createDefaultAccounts(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) createDefaultAccounts(conn protocol.Conn, args ...any) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 1)
 	if err != nil {
 		return nil, errorWithMessage(conn, ErrorMessageArguments, err)
@@ -476,7 +476,7 @@ func (i *FlowIntegration) createDefaultAccounts(conn protocol.Conn, args ...inte
 // There should be exactly 2 arguments:
 //   * the DocumentURI of the file to submit
 //   * the name of the contract
-func (i *FlowIntegration) deployContract(conn protocol.Conn, args ...interface{}) (interface{}, error) {
+func (i *FlowIntegration) deployContract(conn protocol.Conn, args ...any) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 3)
 	if err != nil {
 		return flow.Address{}, errorWithMessage(conn, ErrorMessageServiceAccount, err)

--- a/languageserver/integration/config.go
+++ b/languageserver/integration/config.go
@@ -55,8 +55,8 @@ type AccountPrivateKey struct {
 //
 // Returns an error if any fields are missing or malformed.
 //
-func configFromInitializationOptions(opts interface{}) (conf Config, err error) {
-	optsMap, ok := opts.(map[string]interface{})
+func configFromInitializationOptions(opts any) (conf Config, err error) {
+	optsMap, ok := opts.(map[string]any)
 	if !ok {
 		return Config{}, errors.New("invalid initialization options")
 	}

--- a/languageserver/integration/initialization.go
+++ b/languageserver/integration/initialization.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (i *FlowIntegration) initialize(initializationOptions interface{}) error {
+func (i *FlowIntegration) initialize(initializationOptions any) error {
 	// Parse the configuration options sent from the client
 	conf, err := configFromInitializationOptions(initializationOptions)
 	if err != nil {

--- a/languageserver/jsonrpc2/server.go
+++ b/languageserver/jsonrpc2/server.go
@@ -77,7 +77,7 @@ func (handler *handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *js
 	}
 }
 
-type Method func(*json.RawMessage) (interface{}, error)
+type Method func(*json.RawMessage) (any, error)
 
 type Server struct {
 	Methods map[string]Method
@@ -97,11 +97,11 @@ func (server *Server) Start(stream ObjectStream) <-chan struct{} {
 	return server.conn.DisconnectNotify()
 }
 
-func (server *Server) Notify(method string, params interface{}) error {
+func (server *Server) Notify(method string, params any) error {
 	return server.conn.Notify(context.Background(), method, params)
 }
 
-func (server *Server) Call(method string, params interface{}) error {
+func (server *Server) Call(method string, params any) error {
 	return server.conn.Call(context.Background(), method, params, nil)
 }
 

--- a/languageserver/protocol/methods.go
+++ b/languageserver/protocol/methods.go
@@ -20,7 +20,7 @@ package protocol
 
 import "encoding/json"
 
-func (s *Server) handleInitialize(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleInitialize(req *json.RawMessage) (any, error) {
 	var params InitializeParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (s *Server) handleInitialize(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.Initialize(s.conn, &params)
 }
 
-func (s *Server) handleDidOpenTextDocument(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleDidOpenTextDocument(req *json.RawMessage) (any, error) {
 	var params DidOpenTextDocumentParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (s *Server) handleDidOpenTextDocument(req *json.RawMessage) (interface{}, e
 	return nil, err
 }
 
-func (s *Server) handleDidChangeTextDocument(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleDidChangeTextDocument(req *json.RawMessage) (any, error) {
 	var params DidChangeTextDocumentParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (s *Server) handleDidChangeTextDocument(req *json.RawMessage) (interface{},
 	return nil, err
 }
 
-func (s *Server) handleHover(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleHover(req *json.RawMessage) (any, error) {
 	var params TextDocumentPositionParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (s *Server) handleHover(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.Hover(s.conn, &params)
 }
 
-func (s *Server) handleDefinition(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleDefinition(req *json.RawMessage) (any, error) {
 	var params TextDocumentPositionParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func (s *Server) handleDefinition(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.Definition(s.conn, &params)
 }
 
-func (s *Server) handleSignatureHelp(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleSignatureHelp(req *json.RawMessage) (any, error) {
 	var params TextDocumentPositionParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (s *Server) handleSignatureHelp(req *json.RawMessage) (interface{}, error) 
 	return s.Handler.SignatureHelp(s.conn, &params)
 }
 
-func (s *Server) handleDocumentHighlight(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleDocumentHighlight(req *json.RawMessage) (any, error) {
 	var params TextDocumentPositionParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (s *Server) handleDocumentHighlight(req *json.RawMessage) (interface{}, err
 	return s.Handler.DocumentHighlight(s.conn, &params)
 }
 
-func (s *Server) handleRename(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleRename(req *json.RawMessage) (any, error) {
 	var params RenameParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (s *Server) handleRename(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.Rename(s.conn, &params)
 }
 
-func (s *Server) handleCodeAction(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleCodeAction(req *json.RawMessage) (any, error) {
 	var params CodeActionParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -103,7 +103,7 @@ func (s *Server) handleCodeAction(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.CodeAction(s.conn, &params)
 }
 
-func (s *Server) handleCodeLens(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleCodeLens(req *json.RawMessage) (any, error) {
 	var params CodeLensParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func (s *Server) handleCodeLens(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.CodeLens(s.conn, &params)
 }
 
-func (s *Server) handleCompletion(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleCompletion(req *json.RawMessage) (any, error) {
 	var params CompletionParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (s *Server) handleCompletion(req *json.RawMessage) (interface{}, error) {
 	return s.Handler.Completion(s.conn, &params)
 }
 
-func (s *Server) handleCompletionItemResolve(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleCompletionItemResolve(req *json.RawMessage) (any, error) {
 	var completionItem CompletionItem
 	if err := json.Unmarshal(*req, &completionItem); err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func (s *Server) handleCompletionItemResolve(req *json.RawMessage) (interface{},
 	return s.Handler.ResolveCompletionItem(s.conn, &completionItem)
 }
 
-func (s *Server) handleExecuteCommand(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleExecuteCommand(req *json.RawMessage) (any, error) {
 	var params ExecuteCommandParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func (s *Server) handleExecuteCommand(req *json.RawMessage) (interface{}, error)
 	return s.Handler.ExecuteCommand(s.conn, &params)
 }
 
-func (s *Server) handleDocumentSymbol(req *json.RawMessage) (interface{}, error) {
+func (s *Server) handleDocumentSymbol(req *json.RawMessage) (any, error) {
 	var params DocumentSymbolParams
 	if err := json.Unmarshal(*req, &params); err != nil {
 		return nil, err
@@ -147,12 +147,12 @@ func (s *Server) handleDocumentSymbol(req *json.RawMessage) (interface{}, error)
 	return s.Handler.DocumentSymbol(s.conn, &params)
 }
 
-func (s *Server) handleShutdown(_ *json.RawMessage) (interface{}, error) {
+func (s *Server) handleShutdown(_ *json.RawMessage) (any, error) {
 	err := s.Handler.Shutdown(s.conn)
 	return nil, err
 }
 
-func (s *Server) handleExit(_ *json.RawMessage) (interface{}, error) {
+func (s *Server) handleExit(_ *json.RawMessage) (any, error) {
 	err := s.Handler.Exit(s.conn)
 	return nil, err
 }

--- a/languageserver/protocol/server.go
+++ b/languageserver/protocol/server.go
@@ -36,7 +36,7 @@ type Server struct {
 // the language server to push various types of messages to the client.
 // https://microsoft.github.io/language-server-protocol/specifications/specification-3-14
 type Conn interface {
-	Notify(method string, params interface{}) error
+	Notify(method string, params any) error
 	ShowMessage(params *ShowMessageParams)
 	LogMessage(params *LogMessageParams)
 	PublishDiagnostics(params *PublishDiagnosticsParams) error
@@ -66,7 +66,7 @@ func (conn *connection) PublishDiagnostics(params *PublishDiagnosticsParams) err
 }
 
 // Notify sends a notification to the client.
-func (conn *connection) Notify(method string, params interface{}) error {
+func (conn *connection) Notify(method string, params any) error {
 	return conn.jsonrpc2Server.Notify(method, params)
 }
 
@@ -90,7 +90,7 @@ type Handler interface {
 	CodeLens(conn Conn, params *CodeLensParams) ([]*CodeLens, error)
 	Completion(conn Conn, params *CompletionParams) ([]*CompletionItem, error)
 	ResolveCompletionItem(conn Conn, item *CompletionItem) (*CompletionItem, error)
-	ExecuteCommand(conn Conn, params *ExecuteCommandParams) (interface{}, error)
+	ExecuteCommand(conn Conn, params *ExecuteCommandParams) (any, error)
 	DocumentSymbol(conn Conn, params *DocumentSymbolParams) ([]*DocumentSymbol, error)
 	Shutdown(conn Conn) error
 	Exit(conn Conn) error

--- a/languageserver/protocol/types.go
+++ b/languageserver/protocol/types.go
@@ -212,7 +212,7 @@ type Registration struct {
 	/*RegisterOptions defined:
 	 * Options necessary for the registration.
 	 */
-	RegisterOptions interface{} `json:"registerOptions,omitempty"`
+	RegisterOptions any `json:"registerOptions,omitempty"`
 }
 
 // RegistrationParams is
@@ -1292,7 +1292,7 @@ type ClientCapabilities struct {
 	/*Experimental defined:
 	 * Experimental client capabilities.
 	 */
-	Experimental interface{} `json:"experimental,omitempty"`
+	Experimental any `json:"experimental,omitempty"`
 }
 
 /*StaticRegistrationOptions defined:
@@ -1489,7 +1489,7 @@ type ServerCapabilities struct {
 	 * Defines how text documents are synced. Is either a detailed structure defining each notification or
 	 * for backwards compatibility the TextDocumentSyncKind number.
 	 */
-	TextDocumentSync interface{} `json:"textDocumentSync,omitempty"` // TextDocumentSyncOptions | TextDocumentSyncKind
+	TextDocumentSync any `json:"textDocumentSync,omitempty"` // TextDocumentSyncOptions | TextDocumentSyncKind
 
 	/*HoverProvider defined:
 	 * The server provides hover support.
@@ -1574,7 +1574,7 @@ type ServerCapabilities struct {
 	 * specified if the client states that it supports
 	 * `prepareSupport` in its initial `initialize` request.
 	 */
-	RenameProvider interface{} `json:"renameProvider,omitempty"` // boolean | RenameOptions
+	RenameProvider any `json:"renameProvider,omitempty"` // boolean | RenameOptions
 
 	/*DocumentLinkProvider defined:
 	 * The server provides document link support.
@@ -1589,7 +1589,7 @@ type ServerCapabilities struct {
 	/*Experimental defined:
 	 * Experimental server capabilities.
 	 */
-	Experimental interface{} `json:"experimental,omitempty"`
+	Experimental any `json:"experimental,omitempty"`
 
 	/*ImplementationProvider defined:
 	 * The server provides Goto Implementation support.
@@ -1682,7 +1682,7 @@ type InitializeParams struct {
 	/*InitializationOptions defined:
 	 * User provided initialization options.
 	 */
-	InitializationOptions interface{} `json:"initializationOptions,omitempty"`
+	InitializationOptions any `json:"initializationOptions,omitempty"`
 
 	/*Trace defined:
 	 * The initial trace setting. If omitted trace is disabled ('off').
@@ -1708,7 +1708,7 @@ type InitializeResult struct {
 	/*Custom defined:
 	 * Custom initialization results.
 	 */
-	Custom map[string]interface{} `json:"custom"` // [custom: string]: any;
+	Custom map[string]any `json:"custom"` // [custom: string]: any;
 }
 
 // InitializedParams is
@@ -1730,7 +1730,7 @@ type DidChangeConfigurationParams struct {
 	/*Settings defined:
 	 * The actual changed settings
 	 */
-	Settings interface{} `json:"settings"`
+	Settings any `json:"settings"`
 }
 
 /*ShowMessageParams defined:
@@ -2195,7 +2195,7 @@ type ExecuteCommandParams struct {
 	/*Arguments defined:
 	 * Arguments that the command should be invoked with.
 	 */
-	Arguments []interface{} `json:"arguments,omitempty"`
+	Arguments []any `json:"arguments,omitempty"`
 }
 
 /*ExecuteCommandRegistrationOptions defined:
@@ -2455,7 +2455,7 @@ type Diagnostic struct {
 	/*Code defined:
 	 * The diagnostic's code, which usually appear in the user interface.
 	 */
-	Code interface{} `json:"code,omitempty"` // number | string
+	Code any `json:"code,omitempty"` // number | string
 
 	/*Source defined:
 	 * A human-readable string describing the source of this
@@ -2480,7 +2480,7 @@ type Diagnostic struct {
 	 */
 	RelatedInformation []DiagnosticRelatedInformation `json:"relatedInformation,omitempty"`
 
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 /*Command defined:
@@ -2505,7 +2505,7 @@ type Command struct {
 	 * Arguments that the command handler should be
 	 * invoked with.
 	 */
-	Arguments []interface{} `json:"arguments,omitempty"`
+	Arguments []any `json:"arguments,omitempty"`
 }
 
 /*TextEdit defined:
@@ -2818,7 +2818,7 @@ type CompletionItem struct {
 	/*Documentation defined:
 	 * A human-readable string that represents a doc-comment.
 	 */
-	Documentation interface{} `json:"documentation,omitempty"` // string | MarkupContent
+	Documentation any `json:"documentation,omitempty"` // string | MarkupContent
 
 	/*Deprecated defined:
 	 * Indicates if this item is deprecated.
@@ -2908,7 +2908,7 @@ type CompletionItem struct {
 	 * a [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest]
 	 * (#CompletionResolveRequest)
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 /*CompletionList defined:
@@ -3250,7 +3250,7 @@ type CodeLens struct {
 	 * a [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]
 	 * (#CodeLensResolveRequest)
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 /*FormattingOptions defined:
@@ -3309,7 +3309,7 @@ type DocumentLink struct {
 	 * A data entry field that is preserved on a document link between a
 	 * DocumentLinkRequest and a DocumentLinkResolveRequest.
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 /*SelectionRange defined:

--- a/languageserver/server/command.go
+++ b/languageserver/server/command.go
@@ -20,7 +20,7 @@ package server
 
 import "fmt"
 
-func CheckCommandArgumentCount(args []interface{}, expectedCount int) error {
+func CheckCommandArgumentCount(args []any, expectedCount int) error {
 	if len(args) != expectedCount {
 		return fmt.Errorf("expected %d arguments, got %d", expectedCount, len(args))
 	}

--- a/languageserver/server/objectstream.go
+++ b/languageserver/server/objectstream.go
@@ -19,14 +19,14 @@
 package server
 
 type ObjectStream struct {
-	writeObject func(obj interface{}) error
-	readObject  func(v interface{}) error
+	writeObject func(obj any) error
+	readObject  func(v any) error
 	close       func() error
 }
 
 func NewObjectStream(
-	writeObject func(obj interface{}) error,
-	readObject func(v interface{}) error,
+	writeObject func(obj any) error,
+	readObject func(v any) error,
 	close func() error,
 ) ObjectStream {
 	return ObjectStream{
@@ -36,11 +36,11 @@ func NewObjectStream(
 	}
 }
 
-func (o ObjectStream) WriteObject(obj interface{}) error {
+func (o ObjectStream) WriteObject(obj any) error {
 	return o.writeObject(obj)
 }
 
-func (o ObjectStream) ReadObject(v interface{}) (err error) {
+func (o ObjectStream) ReadObject(v any) (err error) {
 	return o.readObject(v)
 }
 

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -136,7 +136,7 @@ func (d Document) HasAnyPrecedingStringsAtPosition(options []string, line, colum
 
 // CommandHandler represents the form of functions that handle commands
 // submitted from the client using workspace/executeCommand.
-type CommandHandler func(conn protocol.Conn, args ...interface{}) (interface{}, error)
+type CommandHandler func(conn protocol.Conn, args ...any) (any, error)
 
 // AddressImportResolver is a function that is used to resolve address imports
 //
@@ -164,7 +164,7 @@ type DocumentSymbolProvider func(uri protocol.DocumentUri, version float64, chec
 
 // InitializationOptionsHandler is a function that is used to handle initialization options sent by the client
 //
-type InitializationOptionsHandler func(initializationOptions interface{}) error
+type InitializationOptionsHandler func(initializationOptions any) error
 
 type Server struct {
 	protocolServer       *protocol.Server
@@ -419,8 +419,8 @@ func accessCheckModeFromName(name string) sema.AccessCheckMode {
 	}
 }
 
-func (s *Server) configure(opts interface{}) {
-	optsMap, ok := opts.(map[string]interface{})
+func (s *Server) configure(opts any) {
+	optsMap, ok := opts.(map[string]any)
 	if !ok {
 		return
 	}
@@ -1619,7 +1619,7 @@ func (s *Server) maybeResolveRange(uri protocol.DocumentUri, id string, result *
 //
 // We register all the commands we support in registerCommands and populate
 // their corresponding handler at server initialization.
-func (s *Server) ExecuteCommand(conn protocol.Conn, params *protocol.ExecuteCommandParams) (interface{}, error) {
+func (s *Server) ExecuteCommand(conn protocol.Conn, params *protocol.ExecuteCommandParams) (any, error) {
 
 	conn.LogMessage(&protocol.LogMessageParams{
 		Type:    protocol.Log,
@@ -2025,7 +2025,7 @@ func (s *Server) defaultCommands() []Command {
 //
 // There should be exactly 1 argument:
 //   * the DocumentURI of the file to submit
-func (s *Server) getEntryPointParameters(_ protocol.Conn, args ...interface{}) (interface{}, error) {
+func (s *Server) getEntryPointParameters(_ protocol.Conn, args ...any) (any, error) {
 
 	err := CheckCommandArgumentCount(args, 1)
 	if err != nil {
@@ -2055,7 +2055,7 @@ func (s *Server) getEntryPointParameters(_ protocol.Conn, args ...interface{}) (
 //
 // There should be exactly 1 argument:
 //   * the DocumentURI of the file to submit
-func (s *Server) getContractInitializerParameters(_ protocol.Conn, args ...interface{}) (interface{}, error) {
+func (s *Server) getContractInitializerParameters(_ protocol.Conn, args ...any) (any, error) {
 
 	err := CheckCommandArgumentCount(args, 1)
 	if err != nil {
@@ -2097,7 +2097,7 @@ func (s *Server) getContractInitializerParameters(_ protocol.Conn, args ...inter
 // There should be exactly 2 arguments:
 //   * the DocumentURI of the file to submit
 //   * the array of arguments
-func (s *Server) parseEntryPointArguments(_ protocol.Conn, args ...interface{}) (interface{}, error) {
+func (s *Server) parseEntryPointArguments(_ protocol.Conn, args ...any) (any, error) {
 
 	err := CheckCommandArgumentCount(args, 2)
 	if err != nil {
@@ -2115,7 +2115,7 @@ func (s *Server) parseEntryPointArguments(_ protocol.Conn, args ...interface{}) 
 		return nil, fmt.Errorf("could not find document for URI %s", uri)
 	}
 
-	arguments, ok := args[1].([]interface{})
+	arguments, ok := args[1].([]any)
 	if !ok {
 		return nil, fmt.Errorf("invalid arguments argument: %#+v", args[1])
 	}
@@ -2132,7 +2132,7 @@ func (s *Server) parseEntryPointArguments(_ protocol.Conn, args ...interface{}) 
 		)
 	}
 
-	result := make([]interface{}, len(arguments))
+	result := make([]any, len(arguments))
 
 	for i, argument := range arguments {
 		parameter := parameters[i]

--- a/languageserver/test/util.go
+++ b/languageserver/test/util.go
@@ -72,7 +72,7 @@ func SetupDebugStdout() {
 // Log is a helper to log to a file during debugging or development.
 //
 // You can view logs by using the command `tail -f ./debug.log` in the root langauge server folder.
-func Log(msg ...interface{}) {
+func Log(msg ...any) {
 	SetupLogging()
 	log.Println(msg)
 }

--- a/runtime/ast/visitor.go
+++ b/runtime/ast/visitor.go
@@ -20,7 +20,7 @@ package ast
 
 import "github.com/onflow/cadence/runtime/common"
 
-type Repr interface{}
+type Repr any
 
 type Element interface {
 	HasPosition

--- a/runtime/cmd/parse/main_wasm.go
+++ b/runtime/cmd/parse/main_wasm.go
@@ -44,7 +44,7 @@ func main() {
 
 	js.Global().Set(
 		globalFunctionName("parse"),
-		js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		js.FuncOf(func(this js.Value, args []js.Value) any {
 			code := args[0].String()
 			return parse(code)
 		}),

--- a/runtime/common/compositekind.go
+++ b/runtime/common/compositekind.go
@@ -153,7 +153,7 @@ func (k CompositeKind) ConstructionKeyword() string {
 	return "create"
 }
 
-func (k CompositeKind) DestructionKeyword() interface{} {
+func (k CompositeKind) DestructionKeyword() any {
 	if k != CompositeKindResource {
 		return ""
 	}

--- a/runtime/common/intervalst/intervalst.go
+++ b/runtime/common/intervalst/intervalst.go
@@ -26,11 +26,11 @@ type IntervalST struct {
 	root *node
 }
 
-func (t *IntervalST) Get(interval Interval) interface{} {
+func (t *IntervalST) Get(interval Interval) any {
 	return t.get(t.root, interval)
 }
 
-func (t *IntervalST) get(x *node, interval Interval) interface{} {
+func (t *IntervalST) get(x *node, interval Interval) any {
 	if x == nil {
 		return nil
 	}
@@ -52,11 +52,11 @@ func (t *IntervalST) Contains(interval Interval) bool {
 //
 // NOTE: does *not* check if the interval already exists
 //
-func (t *IntervalST) Put(interval Interval, value interface{}) {
+func (t *IntervalST) Put(interval Interval, value any) {
 	t.root = t.randomizedInsert(t.root, interval, value)
 }
 
-func (t *IntervalST) randomizedInsert(x *node, interval Interval, value interface{}) *node {
+func (t *IntervalST) randomizedInsert(x *node, interval Interval, value any) *node {
 	if x == nil {
 		return newNode(interval, value)
 	}
@@ -77,7 +77,7 @@ func (t *IntervalST) randomizedInsert(x *node, interval Interval, value interfac
 	return x
 }
 
-func (t *IntervalST) rootInsert(x *node, interval Interval, value interface{}) *node {
+func (t *IntervalST) rootInsert(x *node, interval Interval, value any) *node {
 	if x == nil {
 		return newNode(interval, value)
 	}
@@ -94,11 +94,11 @@ func (t *IntervalST) rootInsert(x *node, interval Interval, value interface{}) *
 	return x
 }
 
-func (t *IntervalST) SearchInterval(interval Interval) (*Interval, interface{}) {
+func (t *IntervalST) SearchInterval(interval Interval) (*Interval, any) {
 	return t.searchInterval(t.root, interval)
 }
 
-func (t *IntervalST) searchInterval(x *node, interval Interval) (*Interval, interface{}) {
+func (t *IntervalST) searchInterval(x *node, interval Interval) (*Interval, any) {
 	for x != nil {
 		if x.interval.Intersects(interval) {
 			return &x.interval, x.value
@@ -111,11 +111,11 @@ func (t *IntervalST) searchInterval(x *node, interval Interval) (*Interval, inte
 	return nil, nil
 }
 
-func (t *IntervalST) Search(p Position) (*Interval, interface{}) {
+func (t *IntervalST) Search(p Position) (*Interval, any) {
 	return t.search(t.root, p)
 }
 
-func (t *IntervalST) search(x *node, p Position) (*Interval, interface{}) {
+func (t *IntervalST) search(x *node, p Position) (*Interval, any) {
 	for x != nil {
 		if x.interval.Contains(p) {
 			return &x.interval, x.value
@@ -130,7 +130,7 @@ func (t *IntervalST) search(x *node, p Position) (*Interval, interface{}) {
 
 type Entry struct {
 	Interval Interval
-	Value    interface{}
+	Value    any
 }
 
 func (t *IntervalST) SearchAll(p Position) []Entry {
@@ -170,7 +170,7 @@ func (t *IntervalST) searchAll(n *node, p Position, entries []Entry) (bool, []En
 	return found, entries
 }
 
-func (t *IntervalST) Values() []interface{} {
+func (t *IntervalST) Values() []any {
 	return t.root.Values()
 }
 

--- a/runtime/common/intervalst/node.go
+++ b/runtime/common/intervalst/node.go
@@ -20,7 +20,7 @@ package intervalst
 
 type node struct {
 	interval    Interval
-	value       interface{}
+	value       any
 	left, right *node
 	// size of subtree rooted at this node
 	n int
@@ -28,7 +28,7 @@ type node struct {
 	max Position
 }
 
-func newNode(interval Interval, value interface{}) *node {
+func newNode(interval Interval, value any) *node {
 	return &node{
 		interval: interval,
 		value:    value,
@@ -101,7 +101,7 @@ func (n *node) rotL() *node {
 	return x
 }
 
-func (n *node) Values() []interface{} {
+func (n *node) Values() []any {
 	if n == nil {
 		return nil
 	}

--- a/runtime/common/orderedmap/gen.go
+++ b/runtime/common/orderedmap/gen.go
@@ -22,5 +22,5 @@
 package orderedmap
 
 //go:generate go run github.com/cheekybits/genny -pkg=orderedmap -in=orderedmap.go -out=orderedmap_string_string.go gen "KeyType=string ValueType=string"
-//go:generate go run github.com/cheekybits/genny -pkg=orderedmap -in=orderedmap.go -out=orderedmap_string_interface.go gen "KeyType=string ValueType=interface{}"
+//go:generate go run github.com/cheekybits/genny -pkg=orderedmap -in=orderedmap.go -out=orderedmap_string_interface.go gen "KeyType=string ValueType=any"
 //go:generate go run github.com/cheekybits/genny -pkg=orderedmap -in=orderedmap.go -out=orderedmap_string_struct.go gen "KeyType=string ValueType=struct{}"

--- a/runtime/common/orderedmap/orderedmap_string_interface.go
+++ b/runtime/common/orderedmap/orderedmap_string_interface.go
@@ -54,7 +54,7 @@ func (om *StringInterfaceOrderedMap) Clear() {
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.
-func (om *StringInterfaceOrderedMap) Get(key string) (result interface{}, present bool) {
+func (om *StringInterfaceOrderedMap) Get(key string) (result any, present bool) {
 	var pair *StringInterfacePair
 	if pair, present = om.pairs[key]; present {
 		return pair.Value, present
@@ -70,7 +70,7 @@ func (om *StringInterfaceOrderedMap) GetPair(key string) *StringInterfacePair {
 
 // Set sets the key-value pair, and returns what `Get` would have returned
 // on that key prior to the call to `Set`.
-func (om *StringInterfaceOrderedMap) Set(key string, value interface{}) (oldValue interface{}, present bool) {
+func (om *StringInterfaceOrderedMap) Set(key string, value any) (oldValue any, present bool) {
 	var pair *StringInterfacePair
 	if pair, present = om.pairs[key]; present {
 		oldValue = pair.Value
@@ -90,7 +90,7 @@ func (om *StringInterfaceOrderedMap) Set(key string, value interface{}) (oldValu
 
 // Delete removes the key-value pair, and returns what `Get` would have returned
 // on that key prior to the call to `Delete`.
-func (om *StringInterfaceOrderedMap) Delete(key string) (oldValue interface{}, present bool) {
+func (om *StringInterfaceOrderedMap) Delete(key string) (oldValue any, present bool) {
 	var pair *StringInterfacePair
 	pair, present = om.pairs[key]
 	if !present {
@@ -121,7 +121,7 @@ func (om *StringInterfaceOrderedMap) Newest() *StringInterfacePair {
 
 // Foreach iterates over the entries of the map in the insertion order, and invokes
 // the provided function for each key-value pair.
-func (om *StringInterfaceOrderedMap) Foreach(f func(key string, value interface{})) {
+func (om *StringInterfaceOrderedMap) Foreach(f func(key string, value any)) {
 	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
 		f(pair.Key, pair.Value)
 	}
@@ -130,7 +130,7 @@ func (om *StringInterfaceOrderedMap) Foreach(f func(key string, value interface{
 // ForeachWithError iterates over the entries of the map in the insertion order,
 // and invokes the provided function for each key-value pair.
 // If the passed function returns an error, iteration breaks and the error is returned.
-func (om *StringInterfaceOrderedMap) ForeachWithError(f func(key string, value interface{}) error) error {
+func (om *StringInterfaceOrderedMap) ForeachWithError(f func(key string, value any) error) error {
 	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
 		err := f(pair.Key, pair.Value)
 		if err != nil {
@@ -144,7 +144,7 @@ func (om *StringInterfaceOrderedMap) ForeachWithError(f func(key string, value i
 //
 type StringInterfacePair struct {
 	Key   string
-	Value interface{}
+	Value any
 
 	element *list.Element
 }

--- a/runtime/compiler/ir/visitor.go
+++ b/runtime/compiler/ir/visitor.go
@@ -18,7 +18,7 @@
 
 package ir
 
-type Repr interface{}
+type Repr any
 
 type ConstVisitor interface {
 	VisitInt(Int) Repr

--- a/runtime/compiler/wasm/gen/main.go
+++ b/runtime/compiler/wasm/gen/main.go
@@ -430,7 +430,7 @@ func main() {
 
 	var generateSwitch func(group instructionGroup) (string, error)
 
-	templateFuncs := map[string]interface{}{
+	templateFuncs := map[string]any{
 		"goGenerateComment": func() string {
 			// NOTE: must be templated/injected, as otherwise
 			// it will be detected itself as a go generate invocation itself

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -801,7 +801,7 @@ func (d StorableDecoder) decodePath() (PathValue, error) {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			// No need to meter EmptyPathValue here or below because it's ignored for the error
 			return EmptyPathValue, fmt.Errorf(
-				"invalid path encoding: expected [%d]interface{}, got %s",
+				"invalid path encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -811,7 +811,7 @@ func (d StorableDecoder) decodePath() (PathValue, error) {
 
 	if size != expectedLength {
 		return EmptyPathValue, fmt.Errorf(
-			"invalid path encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid path encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			size,
 		)
@@ -856,7 +856,7 @@ func (d StorableDecoder) decodeCapability() (*CapabilityValue, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid capability encoding: expected [%d]interface{}, got %s",
+				"invalid capability encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -866,7 +866,7 @@ func (d StorableDecoder) decodeCapability() (*CapabilityValue, error) {
 
 	if size != expectedLength {
 		return nil, fmt.Errorf(
-			"invalid capability encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid capability encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			size,
 		)
@@ -942,7 +942,7 @@ func (d StorableDecoder) decodeLink() (LinkValue, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return EmptyLinkValue, fmt.Errorf(
-				"invalid link encoding: expected [%d]interface{}, got %s",
+				"invalid link encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -952,7 +952,7 @@ func (d StorableDecoder) decodeLink() (LinkValue, error) {
 
 	if size != expectedLength {
 		return EmptyLinkValue, fmt.Errorf(
-			"invalid link encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid link encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			size,
 		)
@@ -988,7 +988,7 @@ func (d StorableDecoder) decodeType() (TypeValue, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return EmptyTypeValue, fmt.Errorf(
-				"invalid type encoding: expected [%d]interface{}, got %s",
+				"invalid type encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -999,7 +999,7 @@ func (d StorableDecoder) decodeType() (TypeValue, error) {
 
 	if arraySize != expectedLength {
 		return EmptyTypeValue, fmt.Errorf(
-			"invalid type encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid type encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			arraySize,
 		)
@@ -1122,7 +1122,7 @@ func (d TypeDecoder) decodeCompositeStaticType() (StaticType, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid composite static type encoding: expected [%d]interface{}, got %s",
+				"invalid composite static type encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -1132,7 +1132,7 @@ func (d TypeDecoder) decodeCompositeStaticType() (StaticType, error) {
 
 	if size != expectedLength {
 		return nil, fmt.Errorf(
-			"invalid composite static type encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid composite static type encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			size,
 		)
@@ -1168,7 +1168,7 @@ func (d TypeDecoder) decodeInterfaceStaticType() (InterfaceStaticType, error) {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return InterfaceStaticType{},
 				fmt.Errorf(
-					"invalid interface static type encoding: expected [%d]interface{}, got %s",
+					"invalid interface static type encoding: expected [%d]any, got %s",
 					expectedLength,
 					e.ActualType.String(),
 				)
@@ -1179,7 +1179,7 @@ func (d TypeDecoder) decodeInterfaceStaticType() (InterfaceStaticType, error) {
 	if size != expectedLength {
 		return InterfaceStaticType{},
 			fmt.Errorf(
-				"invalid interface static type encoding: expected [%d]interface{}, got [%d]interface{}",
+				"invalid interface static type encoding: expected [%d]any, got [%d]any",
 				expectedLength,
 				size,
 			)
@@ -1229,7 +1229,7 @@ func (d TypeDecoder) decodeConstantSizedStaticType() (StaticType, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid constant-sized static type encoding: expected [%d]interface{}, got %s",
+				"invalid constant-sized static type encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -1239,7 +1239,7 @@ func (d TypeDecoder) decodeConstantSizedStaticType() (StaticType, error) {
 
 	if arraySize != expectedLength {
 		return nil, fmt.Errorf(
-			"invalid constant-sized static type encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid constant-sized static type encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			arraySize,
 		)
@@ -1290,7 +1290,7 @@ func (d TypeDecoder) decodeReferenceStaticType() (StaticType, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid reference static type encoding: expected [%d]interface{}, got %s",
+				"invalid reference static type encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -1300,7 +1300,7 @@ func (d TypeDecoder) decodeReferenceStaticType() (StaticType, error) {
 
 	if arraySize != expectedLength {
 		return nil, fmt.Errorf(
-			"invalid reference static type encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid reference static type encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			arraySize,
 		)
@@ -1343,7 +1343,7 @@ func (d TypeDecoder) decodeDictionaryStaticType() (StaticType, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid dictionary static type encoding: expected [%d]interface{}, got %s",
+				"invalid dictionary static type encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -1353,7 +1353,7 @@ func (d TypeDecoder) decodeDictionaryStaticType() (StaticType, error) {
 
 	if arraySize != expectedLength {
 		return nil, fmt.Errorf(
-			"invalid dictionary static type encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid dictionary static type encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			arraySize,
 		)
@@ -1388,7 +1388,7 @@ func (d TypeDecoder) decodeRestrictedStaticType() (StaticType, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid restricted static type encoding: expected [%d]interface{}, got %s",
+				"invalid restricted static type encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -1398,7 +1398,7 @@ func (d TypeDecoder) decodeRestrictedStaticType() (StaticType, error) {
 
 	if arraySize != expectedLength {
 		return nil, fmt.Errorf(
-			"invalid restricted static type encoding: expected [%d]interface{}, got [%d]interface{}",
+			"invalid restricted static type encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			arraySize,
 		)
@@ -1672,7 +1672,7 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
 			return nil, fmt.Errorf(
-				"invalid address location encoding: expected [%d]interface{}, got %s",
+				"invalid address location encoding: expected [%d]any, got %s",
 				expectedLength,
 				e.ActualType.String(),
 			)
@@ -1681,7 +1681,7 @@ func (d LocationDecoder) decodeAddressLocation() (common.Location, error) {
 	}
 
 	if size != expectedLength {
-		return nil, fmt.Errorf("invalid address location encoding: expected [%d]interface{}, got [%d]interface{}",
+		return nil, fmt.Errorf("invalid address location encoding: expected [%d]any, got [%d]any",
 			expectedLength,
 			size,
 		)

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -678,7 +678,7 @@ const (
 // Encode encodes PathValue as
 // cbor.Tag{
 //			Number: CBORTagPathValue,
-//			Content: []interface{}{
+//			Content: []any{
 //				encodedPathValueDomainFieldKey:     uint(v.Domain),
 //				encodedPathValueIdentifierFieldKey: string(v.Identifier),
 //			},
@@ -721,7 +721,7 @@ const (
 // Encode encodes CapabilityStorable as
 // cbor.Tag{
 //			Number: CBORTagCapabilityValue,
-//			Content: []interface{}{
+//			Content: []any{
 //					encodedCapabilityValueAddressFieldKey:    AddressValue(v.Address),
 // 					encodedCapabilityValuePathFieldKey:       PathValue(v.Path),
 // 					encodedCapabilityValueBorrowTypeFieldKey: StaticType(v.BorrowType),
@@ -810,7 +810,7 @@ func encodeLocation(e *cbor.StreamEncoder, l common.Location) error {
 		// common.AddressLocation is encoded as
 		// cbor.Tag{
 		//		Number: CBORTagAddressLocation,
-		//		Content: []interface{}{
+		//		Content: []any{
 		//			encodedAddressLocationAddressFieldKey: []byte{l.Address.Bytes()},
 		//			encodedAddressLocationNameFieldKey:    string(l.Name),
 		//		},
@@ -889,7 +889,7 @@ const (
 // Encode encodes LinkValue as
 // cbor.Tag{
 //			Number: CBORTagLinkValue,
-//			Content: []interface{}{
+//			Content: []any{
 //				encodedLinkValueTargetPathFieldKey: PathValue(v.TargetPath),
 //				encodedLinkValueTypeFieldKey:       StaticType(v.Type),
 //			},
@@ -1200,7 +1200,7 @@ const (
 // Encode encodes DictionaryStaticType as
 // cbor.Tag{
 //		Number: CBORTagDictionaryStaticType,
-// 		Content: []interface{}{
+// 		Content: []any{
 //				encodedDictionaryStaticTypeKeyTypeFieldKey:   StaticType(v.KeyType),
 //				encodedDictionaryStaticTypeValueTypeFieldKey: StaticType(v.ValueType),
 //		},
@@ -1242,7 +1242,7 @@ const (
 //		Number: CBORTagRestrictedStaticType,
 //		Content: cborArray{
 //				encodedRestrictedStaticTypeTypeFieldKey:         StaticType(v.Type),
-//				encodedRestrictedStaticTypeRestrictionsFieldKey: []interface{}(v.Restrictions),
+//				encodedRestrictedStaticTypeRestrictionsFieldKey: []any(v.Restrictions),
 //		},
 // }
 func (t *RestrictedStaticType) Encode(e *cbor.StreamEncoder) error {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -84,7 +84,7 @@ func (e PositionedError) Error() string {
 // It contains the recovered value.
 //
 type ExternalError struct {
-	Recovered interface{}
+	Recovered any
 }
 
 func (e ExternalError) Error() string {

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (interpreter *Interpreter) evalStatement(statement ast.Statement) interface{} {
+func (interpreter *Interpreter) evalStatement(statement ast.Statement) any {
 
 	// Recover and re-throw a panic, so that this interpreter's location and statement are used,
 	// instead of a potentially calling interpreter's location and statement
@@ -113,7 +113,7 @@ func (interpreter *Interpreter) visitIfStatementWithTestExpression(
 	if !ok {
 		panic(errors.NewUnreachableError())
 	}
-	var result interface{}
+	var result any
 	if value {
 		result = thenBlock.Accept(interpreter)
 	} else if elseBlock != nil {
@@ -164,7 +164,7 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 		)
 	}
 
-	var result interface{}
+	var result any
 	if someValue, ok := value.(*SomeValue); ok {
 
 		targetType := interpreter.Program.Elaboration.VariableDeclarationTargetTypes[declaration]

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3454,8 +3454,8 @@ func TestNumberValueIntegerConversion(t *testing.T) {
 	t.Parallel()
 
 	type converter struct {
-		convert func(NumberValue) (result interface{}, convertible bool)
-		check   func(t *testing.T, result interface{}) bool
+		convert func(NumberValue) (result any, convertible bool)
+		check   func(t *testing.T, result any) bool
 	}
 
 	test := func(
@@ -3506,22 +3506,22 @@ func TestNumberValueIntegerConversion(t *testing.T) {
 
 	converters := map[string]converter{
 		"ToInt": {
-			convert: func(value NumberValue) (interface{}, bool) {
+			convert: func(value NumberValue) (any, bool) {
 				return value.ToInt(), true
 			},
-			check: func(t *testing.T, result interface{}) bool {
+			check: func(t *testing.T, result any) bool {
 				return assert.Equal(t, 42, result)
 			},
 		},
 		"ToBigInt": {
-			convert: func(value NumberValue) (interface{}, bool) {
+			convert: func(value NumberValue) (any, bool) {
 				bigNumberValue, ok := value.(BigNumberValue)
 				if !ok {
 					return nil, false
 				}
 				return bigNumberValue.ToBigInt(nil), true
 			},
-			check: func(t *testing.T, result interface{}) bool {
+			check: func(t *testing.T, result any) bool {
 				return assert.Equal(t, big.NewInt(42), result)
 			},
 		},

--- a/runtime/parser2/declaration_test.go
+++ b/runtime/parser2/declaration_test.go
@@ -265,10 +265,10 @@ func TestParseParameterList(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string) (interface{}, []error) {
+	parse := func(input string) (any, []error) {
 		return Parse(
 			input,
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				return parseParameterList(p)
 			},
 			nil,
@@ -963,10 +963,10 @@ func TestParseAccess(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string) (interface{}, []error) {
+	parse := func(input string) (any, []error) {
 		return Parse(
 			input,
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				return parseAccess(p)
 			},
 			nil,
@@ -1649,10 +1649,10 @@ func TestParseFieldWithVariableKind(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string) (interface{}, []error) {
+	parse := func(input string) (any, []error) {
 		return Parse(
 			input,
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				return parseFieldWithVariableKind(p, ast.AccessNotSpecified, nil, "")
 			},
 			nil,

--- a/runtime/parser2/expression.go
+++ b/runtime/parser2/expression.go
@@ -109,7 +109,7 @@ var exprIdentifierLeftBindingPowers = map[string]int{}
 var exprLeftDenotations = [lexer.TokenMax]exprLeftDenotationFunc{}
 var exprMetaLeftDenotations = [lexer.TokenMax]exprMetaLeftDenotationFunc{}
 
-func defineExpr(def interface{}) {
+func defineExpr(def any) {
 	switch def := def.(type) {
 	case infixExpr:
 		tokenType := def.tokenType

--- a/runtime/parser2/expression_test.go
+++ b/runtime/parser2/expression_test.go
@@ -323,7 +323,7 @@ func TestParseAdvancedExpression(t *testing.T) {
 		gauge.debug = true
 		gauge.Limit(common.MemoryKindPosition, 11)
 
-		var panicMsg interface{}
+		var panicMsg any
 		(func() {
 			defer func() {
 				panicMsg = recover()
@@ -345,7 +345,7 @@ func TestParseAdvancedExpression(t *testing.T) {
 		gauge := makeLimitingMemoryGauge()
 		gauge.Limit(common.MemoryKindIntegerExpression, 1)
 
-		var panicMsg interface{}
+		var panicMsg any
 		(func() {
 			defer func() {
 				panicMsg = recover()

--- a/runtime/parser2/lexer/lexer.go
+++ b/runtime/parser2/lexer/lexer.go
@@ -133,7 +133,7 @@ func (l *lexer) Reclaim() {
 }
 
 var pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &lexer{
 			tokens: make([]Token, 0, 2048),
 		}
@@ -243,7 +243,7 @@ func (l *lexer) acceptOne(r rune) bool {
 }
 
 // emit writes a token to the channel.
-func (l *lexer) emit(ty TokenType, val interface{}, rangeStart ast.Position, consume bool) {
+func (l *lexer) emit(ty TokenType, val any, rangeStart ast.Position, consume bool) {
 
 	if len(l.tokens) >= tokenLimit {
 		panic(TokenLimitReachedError{})

--- a/runtime/parser2/lexer/token.go
+++ b/runtime/parser2/lexer/token.go
@@ -24,7 +24,7 @@ import (
 
 type Token struct {
 	Type  TokenType
-	Value interface{}
+	Value any
 	ast.Range
 }
 

--- a/runtime/parser2/parser.go
+++ b/runtime/parser2/parser.go
@@ -74,7 +74,7 @@ type parser struct {
 // It can be composed with different parse functions to parse the input string into different results.
 // See "ParseExpression", "ParseStatements" as examples.
 //
-func Parse(input string, parse func(*parser) interface{}, memoryGauge common.MemoryGauge) (result interface{}, errors []error) {
+func Parse(input string, parse func(*parser) any, memoryGauge common.MemoryGauge) (result any, errors []error) {
 	// create a lexer, which turns the input string into tokens
 	tokens := lexer.Lex(input, memoryGauge)
 	defer tokens.Reclaim()
@@ -84,9 +84,9 @@ func Parse(input string, parse func(*parser) interface{}, memoryGauge common.Mem
 func ParseTokenStream(
 	memoryGauge common.MemoryGauge,
 	tokens lexer.TokenStream,
-	parse func(*parser) interface{},
+	parse func(*parser) any,
 ) (
-	result interface{},
+	result any,
 	errors []error,
 ) {
 	p := &parser{
@@ -443,10 +443,10 @@ func (p *parser) endAmbiguity() {
 }
 
 func ParseExpression(input string, memoryGauge common.MemoryGauge) (expression ast.Expression, errs []error) {
-	var res interface{}
+	var res any
 	res, errs = Parse(
 		input,
-		func(p *parser) interface{} {
+		func(p *parser) any {
 			return parseExpression(p, lowestBindingPower)
 		},
 		memoryGauge,
@@ -463,10 +463,10 @@ func ParseExpression(input string, memoryGauge common.MemoryGauge) (expression a
 }
 
 func ParseStatements(input string, memoryGauge common.MemoryGauge) (statements []ast.Statement, errs []error) {
-	var res interface{}
+	var res any
 	res, errs = Parse(
 		input,
-		func(p *parser) interface{} {
+		func(p *parser) any {
 			return parseStatements(p, nil)
 		},
 		memoryGauge,
@@ -484,10 +484,10 @@ func ParseStatements(input string, memoryGauge common.MemoryGauge) (statements [
 }
 
 func ParseType(input string, memoryGauge common.MemoryGauge) (ty ast.Type, errs []error) {
-	var res interface{}
+	var res any
 	res, errs = Parse(
 		input,
-		func(p *parser) interface{} {
+		func(p *parser) any {
 			return parseType(p, lowestBindingPower)
 		},
 		memoryGauge,
@@ -505,10 +505,10 @@ func ParseType(input string, memoryGauge common.MemoryGauge) (ty ast.Type, errs 
 }
 
 func ParseDeclarations(input string, memoryGauge common.MemoryGauge) (declarations []ast.Declaration, errs []error) {
-	var res interface{}
+	var res any
 	res, errs = Parse(
 		input,
-		func(p *parser) interface{} {
+		func(p *parser) any {
 			return parseDeclarations(p, lexer.TokenEOF)
 		},
 		memoryGauge,
@@ -526,10 +526,10 @@ func ParseDeclarations(input string, memoryGauge common.MemoryGauge) (declaratio
 }
 
 func ParseArgumentList(input string, memoryGauge common.MemoryGauge) (arguments ast.Arguments, errs []error) {
-	var res interface{}
+	var res any
 	res, errs = Parse(
 		input,
-		func(p *parser) interface{} {
+		func(p *parser) any {
 			p.skipSpaceAndComments(true)
 			p.mustOne(lexer.TokenParenOpen)
 			arguments, _ := parseArgumentListRemainder(p)
@@ -563,12 +563,12 @@ func ParseProgramFromTokenStream(
 	program *ast.Program,
 	err error,
 ) {
-	var res interface{}
+	var res any
 	var errs []error
 	res, errs = ParseTokenStream(
 		memoryGauge,
 		input,
-		func(p *parser) interface{} {
+		func(p *parser) any {
 			return parseDeclarations(p, lexer.TokenEOF)
 		},
 	)

--- a/runtime/parser2/parser_test.go
+++ b/runtime/parser2/parser_test.go
@@ -73,7 +73,7 @@ func TestParseBuffering(t *testing.T) {
 
 		_, errs := Parse(
 			"a b c d",
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				p.mustOneString(lexer.TokenIdentifier, "a")
 				p.mustOne(lexer.TokenSpace)
 
@@ -102,7 +102,7 @@ func TestParseBuffering(t *testing.T) {
 
 		_, errs := Parse(
 			"a b x d",
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				p.mustOneString(lexer.TokenIdentifier, "a")
 				p.mustOne(lexer.TokenSpace)
 
@@ -139,7 +139,7 @@ func TestParseBuffering(t *testing.T) {
 
 		_, errs := Parse(
 			"a b c d",
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				p.mustOneString(lexer.TokenIdentifier, "a")
 				p.mustOne(lexer.TokenSpace)
 
@@ -171,7 +171,7 @@ func TestParseBuffering(t *testing.T) {
 
 		_, errs := Parse(
 			"a b c d",
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				p.mustOneString(lexer.TokenIdentifier, "a")
 				p.mustOne(lexer.TokenSpace)
 
@@ -219,7 +219,7 @@ func TestParseBuffering(t *testing.T) {
 
 		_, errs := Parse(
 			"a b c x",
-			func(p *parser) interface{} {
+			func(p *parser) any {
 				p.mustOneString(lexer.TokenIdentifier, "a")
 				p.mustOne(lexer.TokenSpace)
 
@@ -372,7 +372,7 @@ func TestParseEOF(t *testing.T) {
 
 	_, errs := Parse(
 		"a b",
-		func(p *parser) interface{} {
+		func(p *parser) any {
 			p.mustOneString(lexer.TokenIdentifier, "a")
 			p.skipSpaceAndComments(true)
 			p.mustOneString(lexer.TokenIdentifier, "b")
@@ -499,7 +499,7 @@ func TestParseArgumentList(t *testing.T) {
 		gauge := makeLimitingMemoryGauge()
 		gauge.Limit(common.MemoryKindSyntaxToken, 0)
 
-		var panicMsg interface{}
+		var panicMsg any
 		(func() {
 			defer func() {
 				panicMsg = recover()

--- a/runtime/parser2/type.go
+++ b/runtime/parser2/type.go
@@ -112,7 +112,7 @@ type postfixType struct {
 	leftDenotation postfixTypeFunc
 }
 
-func defineType(def interface{}) {
+func defineType(def any) {
 	switch def := def.(type) {
 	case prefixType:
 		tokenType := def.tokenType

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -77,7 +77,7 @@ type excerpt struct {
 	isError  bool
 }
 
-func newExcerpt(obj interface{}, message string, isError bool) excerpt {
+func newExcerpt(obj any, message string, isError bool) excerpt {
 	excerpt := excerpt{
 		message: message,
 		isError: isError,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6894,7 +6894,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		runtimeInterface := &testRuntimeInterface{
 			log: func(message string) {
 				// panic due to go-error in cadence implementation
-				var val interface{} = message
+				var val any = message
 				_ = val.(int)
 			},
 		}
@@ -6964,7 +6964,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		runtimeInterface := &testRuntimeInterface{
 			log: func(message string) {
 				// panic due to Cadence implementation error
-				var val interface{} = message
+				var val any = message
 				_ = val.(int)
 			},
 		}
@@ -7023,7 +7023,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 			log: func(message string) {
 				// panic due to Cadence implementation error
-				var val interface{} = message
+				var val any = message
 				_ = val.(int)
 			},
 		}

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -2109,7 +2109,7 @@ func (checker *Checker) checkResourceFieldsInvalidated(containerType Type, membe
 // checkResourceUseAfterInvalidation checks if a resource (variable or composite member)
 // is used after it was previously invalidated (moved or destroyed)
 //
-func (checker *Checker) checkResourceUseAfterInvalidation(resource interface{}, usePosition ast.HasPosition) {
+func (checker *Checker) checkResourceUseAfterInvalidation(resource any, usePosition ast.HasPosition) {
 	resourceInfo := checker.resources.Get(resource)
 	if resourceInfo.Invalidations.Size() == 0 {
 		return

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -47,7 +47,7 @@ func (checker *Checker) VisitWhileStatement(statement *ast.WhileStatement) ast.R
 
 func (checker *Checker) reportResourceUsesInLoop(startPos, endPos ast.Position) {
 
-	checker.resources.ForEach(func(resource interface{}, info ResourceInfo) {
+	checker.resources.ForEach(func(resource any, info ResourceInfo) {
 
 		// If the resource is a variable,
 		// only report an error if the variable was declared outside the loop

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1592,7 +1592,7 @@ func (checker *Checker) checkResourceLoss(depth int) {
 }
 
 type recordedResourceInvalidation struct {
-	resource     interface{}
+	resource     any
 	invalidation ResourceInvalidation
 }
 
@@ -2547,7 +2547,7 @@ func (checker *Checker) declareGlobalRanges() {
 	checker.Elaboration.GlobalValues.Foreach(addRange)
 }
 
-func (checker *Checker) maybeAddResourceInvalidation(resource interface{}, invalidation ResourceInvalidation) {
+func (checker *Checker) maybeAddResourceInvalidation(resource any, invalidation ResourceInvalidation) {
 	functionActivation := checker.functionActivations.Current()
 
 	if functionActivation.ReturnInfo.IsUnreachable() {

--- a/runtime/sema/gen.go
+++ b/runtime/sema/gen.go
@@ -26,7 +26,7 @@ package sema
 //go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_string_valuedeclaration.go gen "KeyType=string ValueType=ValueDeclaration"
 //go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_resourceinvalidation_struct.go gen "KeyType=ResourceInvalidation ValueType=struct{}"
 //go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_position_resourceuse.go gen "KeyType=ast.Position ValueType=ResourceUse"
-//go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_interface_resourceinfo.go gen "KeyType=interface{} ValueType=ResourceInfo"
+//go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_interface_resourceinfo.go gen "KeyType=any ValueType=ResourceInfo"
 //go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_string_importelement.go gen "KeyType=string ValueType=ImportElement"
 //go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_typeparameter_type.go gen "KeyType=*TypeParameter ValueType=Type"
 //go:generate go run github.com/cheekybits/genny -pkg=sema -in=../common/orderedmap/orderedmap.go -out=ordered_map_member_fielddeclaration.go gen "KeyType=*Member ValueType=*ast.FieldDeclaration"

--- a/runtime/sema/ordered_map_interface_resourceinfo.go
+++ b/runtime/sema/ordered_map_interface_resourceinfo.go
@@ -30,14 +30,14 @@ import "container/list"
 // InterfaceResourceInfoOrderedMap
 //
 type InterfaceResourceInfoOrderedMap struct {
-	pairs map[interface{}]*InterfaceResourceInfoPair
+	pairs map[any]*InterfaceResourceInfoPair
 	list  *list.List
 }
 
 // NewInterfaceResourceInfoOrderedMap creates a new InterfaceResourceInfoOrderedMap.
 func NewInterfaceResourceInfoOrderedMap() *InterfaceResourceInfoOrderedMap {
 	return &InterfaceResourceInfoOrderedMap{
-		pairs: make(map[interface{}]*InterfaceResourceInfoPair),
+		pairs: make(map[any]*InterfaceResourceInfoPair),
 		list:  list.New(),
 	}
 }
@@ -54,7 +54,7 @@ func (om *InterfaceResourceInfoOrderedMap) Clear() {
 // Get returns the value associated with the given key.
 // Returns nil if not found.
 // The second return value indicates if the key is present in the map.
-func (om *InterfaceResourceInfoOrderedMap) Get(key interface{}) (result ResourceInfo, present bool) {
+func (om *InterfaceResourceInfoOrderedMap) Get(key any) (result ResourceInfo, present bool) {
 	var pair *InterfaceResourceInfoPair
 	if pair, present = om.pairs[key]; present {
 		return pair.Value, present
@@ -64,13 +64,13 @@ func (om *InterfaceResourceInfoOrderedMap) Get(key interface{}) (result Resource
 
 // GetPair returns the key-value pair associated with the given key.
 // Returns nil if not found.
-func (om *InterfaceResourceInfoOrderedMap) GetPair(key interface{}) *InterfaceResourceInfoPair {
+func (om *InterfaceResourceInfoOrderedMap) GetPair(key any) *InterfaceResourceInfoPair {
 	return om.pairs[key]
 }
 
 // Set sets the key-value pair, and returns what `Get` would have returned
 // on that key prior to the call to `Set`.
-func (om *InterfaceResourceInfoOrderedMap) Set(key interface{}, value ResourceInfo) (oldValue ResourceInfo, present bool) {
+func (om *InterfaceResourceInfoOrderedMap) Set(key any, value ResourceInfo) (oldValue ResourceInfo, present bool) {
 	var pair *InterfaceResourceInfoPair
 	if pair, present = om.pairs[key]; present {
 		oldValue = pair.Value
@@ -90,7 +90,7 @@ func (om *InterfaceResourceInfoOrderedMap) Set(key interface{}, value ResourceIn
 
 // Delete removes the key-value pair, and returns what `Get` would have returned
 // on that key prior to the call to `Delete`.
-func (om *InterfaceResourceInfoOrderedMap) Delete(key interface{}) (oldValue ResourceInfo, present bool) {
+func (om *InterfaceResourceInfoOrderedMap) Delete(key any) (oldValue ResourceInfo, present bool) {
 	var pair *InterfaceResourceInfoPair
 	pair, present = om.pairs[key]
 	if !present {
@@ -121,7 +121,7 @@ func (om *InterfaceResourceInfoOrderedMap) Newest() *InterfaceResourceInfoPair {
 
 // Foreach iterates over the entries of the map in the insertion order, and invokes
 // the provided function for each key-value pair.
-func (om *InterfaceResourceInfoOrderedMap) Foreach(f func(key interface{}, value ResourceInfo)) {
+func (om *InterfaceResourceInfoOrderedMap) Foreach(f func(key any, value ResourceInfo)) {
 	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
 		f(pair.Key, pair.Value)
 	}
@@ -130,7 +130,7 @@ func (om *InterfaceResourceInfoOrderedMap) Foreach(f func(key interface{}, value
 // ForeachWithError iterates over the entries of the map in the insertion order,
 // and invokes the provided function for each key-value pair.
 // If the passed function returns an error, iteration breaks and the error is returned.
-func (om *InterfaceResourceInfoOrderedMap) ForeachWithError(f func(key interface{}, value ResourceInfo) error) error {
+func (om *InterfaceResourceInfoOrderedMap) ForeachWithError(f func(key any, value ResourceInfo) error) error {
 	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
 		err := f(pair.Key, pair.Value)
 		if err != nil {
@@ -143,7 +143,7 @@ func (om *InterfaceResourceInfoOrderedMap) ForeachWithError(f func(key interface
 // InterfaceResourceInfoPair
 //
 type InterfaceResourceInfoPair struct {
-	Key   interface{}
+	Key   any
 	Value ResourceInfo
 
 	element *list.Element

--- a/runtime/sema/resources_test.go
+++ b/runtime/sema/resources_test.go
@@ -172,7 +172,7 @@ func TestResourceResources_ForEach(t *testing.T) {
 
 	result := map[*Variable][]ResourceInvalidation{}
 
-	resources.ForEach(func(resource interface{}, info ResourceInfo) {
+	resources.ForEach(func(resource any, info ResourceInfo) {
 		variable := resource.(*Variable)
 		result[variable] = info.Invalidations.All()
 	})

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -129,7 +129,7 @@ func (a *VariableActivation) ForEach(cb func(string, *Variable) error) error {
 }
 
 var variableActivationPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &VariableActivation{}
 	},
 }

--- a/runtime/tests/checker/occurrences_test.go
+++ b/runtime/tests/checker/occurrences_test.go
@@ -210,7 +210,7 @@ func TestCheckOccurrencesFunction(t *testing.T) {
 		},
 	}
 
-	ms := make([]interface{}, len(matchers))
+	ms := make([]any, len(matchers))
 	for i := range matchers {
 		ms[i] = matchers[i]
 	}
@@ -338,7 +338,7 @@ func TestCheckOccurrencesStructAndInterface(t *testing.T) {
 		},
 	}
 
-	ms := make([]interface{}, len(matchers))
+	ms := make([]any, len(matchers))
 	for i := range matchers {
 		ms[i] = matchers[i]
 	}

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1013,7 +1013,7 @@ func newCompositeValue(
 
 	fields := make([]interpreter.CompositeField, fieldsCount)
 
-	fieldNames := make(map[string]interface{}, fieldsCount)
+	fieldNames := make(map[string]any, fieldsCount)
 
 	for i := 0; i < fieldsCount; {
 		fieldName := randomUTF8String()
@@ -1634,14 +1634,14 @@ const (
 )
 
 type valueMap struct {
-	values map[interface{}]interpreter.Value
-	keys   map[interface{}]interpreter.Value
+	values map[any]interpreter.Value
+	keys   map[any]interpreter.Value
 }
 
 func newValueMap(size int) *valueMap {
 	return &valueMap{
-		values: make(map[interface{}]interpreter.Value, size),
-		keys:   make(map[interface{}]interpreter.Value, size),
+		values: make(map[any]interpreter.Value, size),
+		keys:   make(map[any]interpreter.Value, size),
 	}
 }
 
@@ -1682,7 +1682,7 @@ func (m *valueMap) foreach(apply func(key, value interpreter.Value) (exit bool))
 	}
 }
 
-func (m *valueMap) internalKey(inter *interpreter.Interpreter, key interpreter.Value) interface{} {
+func (m *valueMap) internalKey(inter *interpreter.Interpreter, key interpreter.Value) any {
 	switch key := key.(type) {
 	case *interpreter.StringValue:
 		return *key

--- a/runtime/tests/utils/occurrence_matcher.go
+++ b/runtime/tests/utils/occurrence_matcher.go
@@ -31,7 +31,7 @@ type OccurrenceMatcher struct {
 	DeclarationKind common.DeclarationKind
 }
 
-func (matcher *OccurrenceMatcher) Match(actual interface{}) bool {
+func (matcher *OccurrenceMatcher) Match(actual any) bool {
 	occurrence, ok := actual.(sema.Occurrence)
 	if !ok {
 		return false

--- a/runtime/tests/utils/utils.go
+++ b/runtime/tests/utils/utils.go
@@ -41,7 +41,7 @@ const ImportedLocation = common.StringLocation("imported")
 // AssertEqualWithDiff asserts that two objects are equal.
 //
 // If the objects are not equal, this function prints a human-readable diff.
-func AssertEqualWithDiff(t *testing.T, expected, actual interface{}) {
+func AssertEqualWithDiff(t *testing.T, expected, actual any) {
 	if !assert.Equal(t, expected, actual) {
 		// the maximum levels of a struct to recurse into
 		// this prevents infinite recursion from circular references

--- a/tools/constructorcheck/analyzer.go
+++ b/tools/constructorcheck/analyzer.go
@@ -37,7 +37,7 @@ var Analyzer = &analysis.Analyzer{
 	Run:      run,
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	in, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	if !ok {
 		return nil, fmt.Errorf("failed to get result of inspect analysis")

--- a/tools/docgen/wasm/main.go
+++ b/tools/docgen/wasm/main.go
@@ -44,7 +44,7 @@ func main() {
 	js.Global().Set(
 		globalFunctionName("generate"),
 		js.FuncOf(
-			func(this js.Value, args []js.Value) interface{} {
+			func(this js.Value, args []js.Value) any {
 				return generateDocs(args)
 			},
 		),

--- a/tools/maprangecheck/analyzer.go
+++ b/tools/maprangecheck/analyzer.go
@@ -35,7 +35,7 @@ var Analyzer = &analysis.Analyzer{
 	Run:      run,
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	in, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	if !ok {
 		return nil, fmt.Errorf("failed to get result of inspect analysis")

--- a/values.go
+++ b/values.go
@@ -38,7 +38,7 @@ type Value interface {
 	isValue()
 	Type() Type
 	MeteredType(gauge common.MemoryGauge) Type
-	ToGoValue() interface{}
+	ToGoValue() any
 	fmt.Stringer
 }
 
@@ -74,7 +74,7 @@ func (Void) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredVoidType(gauge)
 }
 
-func (Void) ToGoValue() interface{} {
+func (Void) ToGoValue() any {
 	return nil
 }
 
@@ -128,7 +128,7 @@ func (o Optional) MeteredType(gauge common.MemoryGauge) Type {
 	)
 }
 
-func (o Optional) ToGoValue() interface{} {
+func (o Optional) ToGoValue() any {
 	if o.Value == nil {
 		return nil
 	}
@@ -170,7 +170,7 @@ func (Bool) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredBoolType(gauge)
 }
 
-func (v Bool) ToGoValue() interface{} {
+func (v Bool) ToGoValue() any {
 	return bool(v)
 }
 
@@ -212,7 +212,7 @@ func (String) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredStringType(gauge)
 }
 
-func (v String) ToGoValue() interface{} {
+func (v String) ToGoValue() any {
 	return string(v)
 }
 
@@ -241,7 +241,7 @@ func (Bytes) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredBytesType(gauge)
 }
 
-func (v Bytes) ToGoValue() interface{} {
+func (v Bytes) ToGoValue() any {
 	return []byte(v)
 }
 
@@ -286,7 +286,7 @@ func (Character) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredCharacterType(gauge)
 }
 
-func (v Character) ToGoValue() interface{} {
+func (v Character) ToGoValue() any {
 	return string(v)
 }
 
@@ -332,7 +332,7 @@ func (Address) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredAddressType(gauge)
 }
 
-func (v Address) ToGoValue() interface{} {
+func (v Address) ToGoValue() any {
 	return [AddressLength]byte(v)
 }
 
@@ -384,7 +384,7 @@ func (Int) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredIntType(gauge)
 }
 
-func (v Int) ToGoValue() interface{} {
+func (v Int) ToGoValue() any {
 	return v.Big()
 }
 
@@ -423,7 +423,7 @@ func NewMeteredInt8(memoryGauge common.MemoryGauge, v int8) Int8 {
 
 func (Int8) isValue() {}
 
-func (v Int8) ToGoValue() interface{} {
+func (v Int8) ToGoValue() any {
 	return int8(v)
 }
 
@@ -470,7 +470,7 @@ func (Int16) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredInt16Type(gauge)
 }
 
-func (v Int16) ToGoValue() interface{} {
+func (v Int16) ToGoValue() any {
 	return int16(v)
 }
 
@@ -511,7 +511,7 @@ func (Int32) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredInt32Type(gauge)
 }
 
-func (v Int32) ToGoValue() interface{} {
+func (v Int32) ToGoValue() any {
 	return int32(v)
 }
 
@@ -552,7 +552,7 @@ func (Int64) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredInt64Type(gauge)
 }
 
-func (v Int64) ToGoValue() interface{} {
+func (v Int64) ToGoValue() any {
 	return int64(v)
 }
 
@@ -609,7 +609,7 @@ func (Int128) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredInt128Type(gauge)
 }
 
-func (v Int128) ToGoValue() interface{} {
+func (v Int128) ToGoValue() any {
 	return v.Big()
 }
 
@@ -672,7 +672,7 @@ func (Int256) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredInt256Type(gauge)
 }
 
-func (v Int256) ToGoValue() interface{} {
+func (v Int256) ToGoValue() any {
 	return v.Big()
 }
 
@@ -731,7 +731,7 @@ func (UInt) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUIntType(gauge)
 }
 
-func (v UInt) ToGoValue() interface{} {
+func (v UInt) ToGoValue() any {
 	return v.Big()
 }
 
@@ -778,7 +778,7 @@ func (UInt8) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUInt8Type(gauge)
 }
 
-func (v UInt8) ToGoValue() interface{} {
+func (v UInt8) ToGoValue() any {
 	return uint8(v)
 }
 
@@ -817,7 +817,7 @@ func (UInt16) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUInt16Type(gauge)
 }
 
-func (v UInt16) ToGoValue() interface{} {
+func (v UInt16) ToGoValue() any {
 	return uint16(v)
 }
 
@@ -858,7 +858,7 @@ func (UInt32) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUInt32Type(gauge)
 }
 
-func (v UInt32) ToGoValue() interface{} {
+func (v UInt32) ToGoValue() any {
 	return uint32(v)
 }
 
@@ -899,7 +899,7 @@ func (UInt64) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUInt64Type(gauge)
 }
 
-func (v UInt64) ToGoValue() interface{} {
+func (v UInt64) ToGoValue() any {
 	return uint64(v)
 }
 
@@ -956,7 +956,7 @@ func (UInt128) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUInt128Type(gauge)
 }
 
-func (v UInt128) ToGoValue() interface{} {
+func (v UInt128) ToGoValue() any {
 	return v.Big()
 }
 
@@ -1019,7 +1019,7 @@ func (UInt256) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUInt256Type(gauge)
 }
 
-func (v UInt256) ToGoValue() interface{} {
+func (v UInt256) ToGoValue() any {
 	return v.Big()
 }
 
@@ -1066,7 +1066,7 @@ func (Word8) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredWord8Type(gauge)
 }
 
-func (v Word8) ToGoValue() interface{} {
+func (v Word8) ToGoValue() any {
 	return uint8(v)
 }
 
@@ -1105,7 +1105,7 @@ func (Word16) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredWord16Type(gauge)
 }
 
-func (v Word16) ToGoValue() interface{} {
+func (v Word16) ToGoValue() any {
 	return uint16(v)
 }
 
@@ -1146,7 +1146,7 @@ func (Word32) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredWord32Type(gauge)
 }
 
-func (v Word32) ToGoValue() interface{} {
+func (v Word32) ToGoValue() any {
 	return uint32(v)
 }
 
@@ -1187,7 +1187,7 @@ func (Word64) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredWord64Type(gauge)
 }
 
-func (v Word64) ToGoValue() interface{} {
+func (v Word64) ToGoValue() any {
 	return uint64(v)
 }
 
@@ -1249,7 +1249,7 @@ func (Fix64) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredFix64Type(gauge)
 }
 
-func (v Fix64) ToGoValue() interface{} {
+func (v Fix64) ToGoValue() any {
 	return int64(v)
 }
 
@@ -1318,7 +1318,7 @@ func (UFix64) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredUFix64Type(gauge)
 }
 
-func (v UFix64) ToGoValue() interface{} {
+func (v UFix64) ToGoValue() any {
 	return uint64(v)
 }
 
@@ -1377,8 +1377,8 @@ func (v Array) WithType(arrayType ArrayType) Array {
 	return v
 }
 
-func (v Array) ToGoValue() interface{} {
-	ret := make([]interface{}, len(v.Values))
+func (v Array) ToGoValue() any {
+	ret := make([]any, len(v.Values))
 
 	for i, e := range v.Values {
 		ret[i] = e.ToGoValue()
@@ -1437,8 +1437,8 @@ func (v Dictionary) WithType(dictionaryType DictionaryType) Dictionary {
 	return v
 }
 
-func (v Dictionary) ToGoValue() interface{} {
-	ret := map[interface{}]interface{}{}
+func (v Dictionary) ToGoValue() any {
+	ret := map[any]any{}
 
 	for _, p := range v.Pairs {
 		ret[p.Key.ToGoValue()] = p.Value.ToGoValue()
@@ -1525,8 +1525,8 @@ func (v Struct) WithType(typ *StructType) Struct {
 	return v
 }
 
-func (v Struct) ToGoValue() interface{} {
-	ret := make([]interface{}, len(v.Fields))
+func (v Struct) ToGoValue() any {
+	ret := make([]any, len(v.Fields))
 
 	for i, field := range v.Fields {
 		ret[i] = field.ToGoValue()
@@ -1603,8 +1603,8 @@ func (v Resource) WithType(typ *ResourceType) Resource {
 	return v
 }
 
-func (v Resource) ToGoValue() interface{} {
-	ret := make([]interface{}, len(v.Fields))
+func (v Resource) ToGoValue() any {
+	ret := make([]any, len(v.Fields))
 
 	for i, field := range v.Fields {
 		ret[i] = field.ToGoValue()
@@ -1660,8 +1660,8 @@ func (v Event) WithType(typ *EventType) Event {
 	return v
 }
 
-func (v Event) ToGoValue() interface{} {
-	ret := make([]interface{}, len(v.Fields))
+func (v Event) ToGoValue() any {
+	ret := make([]any, len(v.Fields))
 
 	for i, field := range v.Fields {
 		ret[i] = field.ToGoValue()
@@ -1716,8 +1716,8 @@ func (v Contract) WithType(typ *ContractType) Contract {
 	return v
 }
 
-func (v Contract) ToGoValue() interface{} {
-	ret := make([]interface{}, len(v.Fields))
+func (v Contract) ToGoValue() any {
+	ret := make([]any, len(v.Fields))
 
 	for i, field := range v.Fields {
 		ret[i] = field.ToGoValue()
@@ -1762,7 +1762,7 @@ func (v Link) MeteredType(_ common.MemoryGauge) Type {
 	return v.Type()
 }
 
-func (v Link) ToGoValue() interface{} {
+func (v Link) ToGoValue() any {
 	return nil
 }
 
@@ -1804,7 +1804,7 @@ func (Path) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredPathType(gauge)
 }
 
-func (Path) ToGoValue() interface{} {
+func (Path) ToGoValue() any {
 	return nil
 }
 
@@ -1844,7 +1844,7 @@ func (TypeValue) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredMetaType(gauge)
 }
 
-func (TypeValue) ToGoValue() interface{} {
+func (TypeValue) ToGoValue() any {
 	return nil
 }
 
@@ -1885,7 +1885,7 @@ func (v Capability) MeteredType(gauge common.MemoryGauge) Type {
 	return NewMeteredCapabilityType(gauge, v.BorrowType)
 }
 
-func (Capability) ToGoValue() interface{} {
+func (Capability) ToGoValue() any {
 	return nil
 }
 
@@ -1939,8 +1939,8 @@ func (v Enum) WithType(typ *EnumType) Enum {
 	return v
 }
 
-func (v Enum) ToGoValue() interface{} {
-	ret := make([]interface{}, len(v.Fields))
+func (v Enum) ToGoValue() any {
+	ret := make([]any, len(v.Fields))
 
 	for i, field := range v.Fields {
 		ret[i] = field.ToGoValue()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -43,7 +43,7 @@ type vm struct {
 func (m *vm) Invoke(name string, arguments ...interpreter.Value) (interpreter.Value, error) {
 	f := m.instance.GetExport(name).Func()
 
-	rawArguments := make([]interface{}, len(arguments))
+	rawArguments := make([]any, len(arguments))
 	for i, argument := range arguments {
 		rawArguments[i] = argument
 	}
@@ -76,7 +76,7 @@ func NewVM(wasm []byte) (VM, error) {
 
 	intFunc := wasmtime.WrapFunc(
 		store,
-		func(caller *wasmtime.Caller, offset int32, length int32) (interface{}, *wasmtime.Trap) {
+		func(caller *wasmtime.Caller, offset int32, length int32) (any, *wasmtime.Trap) {
 			if offset < 0 {
 				return nil, wasmtime.NewTrap(store, fmt.Sprintf("Int: invalid offset: %d", offset))
 			}
@@ -98,7 +98,7 @@ func NewVM(wasm []byte) (VM, error) {
 		},
 	)
 
-	stringFunc := wasmtime.WrapFunc(store, func(caller *wasmtime.Caller, offset int32, length int32) (interface{}, *wasmtime.Trap) {
+	stringFunc := wasmtime.WrapFunc(store, func(caller *wasmtime.Caller, offset int32, length int32) (any, *wasmtime.Trap) {
 		if offset < 0 {
 			return nil, wasmtime.NewTrap(store, fmt.Sprintf("String: invalid offset: %d", offset))
 		}
@@ -114,7 +114,7 @@ func NewVM(wasm []byte) (VM, error) {
 		return interpreter.NewStringValue(string(bytes)), nil
 	})
 
-	addFunc := wasmtime.WrapFunc(store, func(left, right interface{}) (interface{}, *wasmtime.Trap) {
+	addFunc := wasmtime.WrapFunc(store, func(left, right any) (any, *wasmtime.Trap) {
 		leftNumber, ok := left.(interpreter.NumberValue)
 		if !ok {
 			return nil, wasmtime.NewTrap(store, fmt.Sprintf("add: invalid left: %#+v", left))


### PR DESCRIPTION
## Description

`any` - an alias for `interface{}` was introduced with Go 1.18. This PR replaces all usages of `interface{}` with `any` for better readability and to potentially avoid mix use of the two.

More than anything else, `any` looks elegant 😉 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
