### PR TITLE
Fix JSON encoding of type values with recursive type

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -245,7 +245,7 @@ const (
 	enumTypeStr       = "Enum"
 )
 
-// prepare traverses the object graph of the provided value and constructs
+// Prepare traverses the object graph of the provided value and constructs
 // a struct representation that can be marshalled to JSON.
 func Prepare(v cadence.Value) jsonValue {
 	switch x := v.(type) {
@@ -661,10 +661,13 @@ func prepareInitializers(initializerTypes [][]cadence.Parameter, results typeRes
 
 func prepareType(typ cadence.Type, results typeResults) jsonValue {
 
-	if _, ok := results[typ]; ok {
-		return typ.ID()
+	switch typ := typ.(type) {
+	case cadence.CompositeType, cadence.InterfaceType:
+		if _, ok := results[typ]; ok {
+			return typ.ID()
+		}
+		results[typ] = struct{}{}
 	}
-	results[typ] = struct{}{}
 
 	switch typ := typ.(type) {
 	case cadence.AnyType,

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -620,46 +620,52 @@ func preparePath(x cadence.Path) jsonValue {
 	}
 }
 
-func prepareParameterType(parameterType cadence.Parameter) jsonParameterType {
+func prepareParameterType(parameterType cadence.Parameter, results typeResults) jsonParameterType {
 	return jsonParameterType{
 		Label: parameterType.Label,
 		Id:    parameterType.Identifier,
-		Type:  prepareType(parameterType.Type),
+		Type:  prepareType(parameterType.Type, results),
 	}
 }
 
-func prepareFieldType(fieldType cadence.Field) jsonFieldType {
+func prepareFieldType(fieldType cadence.Field, results typeResults) jsonFieldType {
 	return jsonFieldType{
 		Id:   fieldType.Identifier,
-		Type: prepareType(fieldType.Type),
+		Type: prepareType(fieldType.Type, results),
 	}
 }
 
-func prepareFields(fieldTypes []cadence.Field) []jsonFieldType {
+func prepareFields(fieldTypes []cadence.Field, results typeResults) []jsonFieldType {
 	fields := make([]jsonFieldType, 0)
 	for _, field := range fieldTypes {
-		fields = append(fields, prepareFieldType(field))
+		fields = append(fields, prepareFieldType(field, results))
 	}
 	return fields
 }
 
-func prepareParameters(parameterTypes []cadence.Parameter) []jsonParameterType {
+func prepareParameters(parameterTypes []cadence.Parameter, results typeResults) []jsonParameterType {
 	parameters := make([]jsonParameterType, 0)
 	for _, param := range parameterTypes {
-		parameters = append(parameters, prepareParameterType(param))
+		parameters = append(parameters, prepareParameterType(param, results))
 	}
 	return parameters
 }
 
-func prepareInitializers(initializerTypes [][]cadence.Parameter) [][]jsonParameterType {
+func prepareInitializers(initializerTypes [][]cadence.Parameter, results typeResults) [][]jsonParameterType {
 	initializers := make([][]jsonParameterType, 0)
 	for _, params := range initializerTypes {
-		initializers = append(initializers, prepareParameters(params))
+		initializers = append(initializers, prepareParameters(params, results))
 	}
 	return initializers
 }
 
-func prepareType(typ cadence.Type) jsonValue {
+func prepareType(typ cadence.Type, results typeResults) jsonValue {
+
+	if _, ok := results[typ]; ok {
+		return typ.ID()
+	}
+	results[typ] = struct{}{}
+
 	switch typ := typ.(type) {
 	case cadence.AnyType,
 		cadence.AnyStructType,
@@ -717,117 +723,117 @@ func prepareType(typ cadence.Type) jsonValue {
 	case cadence.OptionalType:
 		return jsonUnaryType{
 			Kind: "Optional",
-			Type: prepareType(typ.Type),
+			Type: prepareType(typ.Type, results),
 		}
 	case cadence.VariableSizedArrayType:
 		return jsonUnaryType{
 			Kind: "VariableSizedArray",
-			Type: prepareType(typ.ElementType),
+			Type: prepareType(typ.ElementType, results),
 		}
 	case cadence.ConstantSizedArrayType:
 		return jsonConstantSizedArrayType{
 			Kind: "ConstantSizedArray",
-			Type: prepareType(typ.ElementType),
+			Type: prepareType(typ.ElementType, results),
 			Size: typ.Size,
 		}
 	case cadence.DictionaryType:
 		return jsonDictionaryType{
 			Kind:      "Dictionary",
-			KeyType:   prepareType(typ.KeyType),
-			ValueType: prepareType(typ.ElementType),
+			KeyType:   prepareType(typ.KeyType, results),
+			ValueType: prepareType(typ.ElementType, results),
 		}
 	case *cadence.StructType:
 		return jsonNominalType{
 			Kind:         "Struct",
 			Type:         "",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: prepareInitializers(typ.Initializers),
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: prepareInitializers(typ.Initializers, results),
 		}
 	case *cadence.ResourceType:
 		return jsonNominalType{
 			Kind:         "Resource",
 			Type:         "",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: prepareInitializers(typ.Initializers),
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: prepareInitializers(typ.Initializers, results),
 		}
 	case *cadence.EventType:
 		return jsonNominalType{
 			Kind:         "Event",
 			Type:         "",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: [][]jsonParameterType{prepareParameters(typ.Initializer)},
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: [][]jsonParameterType{prepareParameters(typ.Initializer, results)},
 		}
 	case *cadence.ContractType:
 		return jsonNominalType{
 			Kind:         "Contract",
 			Type:         "",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: prepareInitializers(typ.Initializers),
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: prepareInitializers(typ.Initializers, results),
 		}
 	case *cadence.StructInterfaceType:
 		return jsonNominalType{
 			Kind:         "StructInterface",
 			Type:         "",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: prepareInitializers(typ.Initializers),
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: prepareInitializers(typ.Initializers, results),
 		}
 	case *cadence.ResourceInterfaceType:
 		return jsonNominalType{
 			Kind:         "ResourceInterface",
 			Type:         "",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: prepareInitializers(typ.Initializers),
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: prepareInitializers(typ.Initializers, results),
 		}
 	case *cadence.ContractInterfaceType:
 		return jsonNominalType{
 			Kind:         "ContractInterface",
 			Type:         "",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: prepareInitializers(typ.Initializers),
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: prepareInitializers(typ.Initializers, results),
 		}
 	case cadence.FunctionType:
 		return jsonFunctionType{
 			Kind:       "Function",
 			TypeID:     typ.ID(),
-			Return:     prepareType(typ.ReturnType),
-			Parameters: prepareParameters(typ.Parameters),
+			Return:     prepareType(typ.ReturnType, results),
+			Parameters: prepareParameters(typ.Parameters, results),
 		}
 	case cadence.ReferenceType:
 		return jsonReferenceType{
 			Kind:       "Reference",
 			Authorized: typ.Authorized,
-			Type:       prepareType(typ.Type),
+			Type:       prepareType(typ.Type, results),
 		}
 	case cadence.RestrictedType:
 		restrictions := make([]jsonValue, 0)
 		for _, restriction := range typ.Restrictions {
-			restrictions = append(restrictions, prepareType(restriction))
+			restrictions = append(restrictions, prepareType(restriction, results))
 		}
 		return jsonRestrictedType{
 			Kind:         "Restriction",
 			TypeID:       typ.ID(),
-			Type:         prepareType(typ.Type),
+			Type:         prepareType(typ.Type, results),
 			Restrictions: restrictions,
 		}
 	case cadence.CapabilityType:
 		return jsonUnaryType{
 			Kind: "Capability",
-			Type: prepareType(typ.BorrowType),
+			Type: prepareType(typ.BorrowType, results),
 		}
 	case *cadence.EnumType:
 		return jsonNominalType{
 			Kind:         "Enum",
 			TypeID:       string(typ.Location.TypeID(nil, typ.QualifiedIdentifier)),
-			Fields:       prepareFields(typ.Fields),
-			Initializers: prepareInitializers(typ.Initializers),
-			Type:         prepareType(typ.RawType),
+			Fields:       prepareFields(typ.Fields, results),
+			Initializers: prepareInitializers(typ.Initializers, results),
+			Type:         prepareType(typ.RawType, results),
 		}
 	case nil:
 		return ""
@@ -836,11 +842,13 @@ func prepareType(typ cadence.Type) jsonValue {
 	}
 }
 
+type typeResults map[cadence.Type]struct{}
+
 func prepareTypeValue(typeValue cadence.TypeValue) jsonValue {
 	return jsonValueObject{
 		Type: typeTypeStr,
 		Value: jsonTypeValue{
-			StaticType: prepareType(typeValue.StaticType),
+			StaticType: prepareType(typeValue.StaticType, typeResults{}),
 		},
 	}
 }
@@ -851,7 +859,7 @@ func prepareCapability(capability cadence.Capability) jsonValue {
 		Value: jsonCapabilityValue{
 			Path:       preparePath(capability.Path),
 			Address:    encodeBytes(capability.Address.Bytes()),
-			BorrowType: prepareType(capability.BorrowType),
+			BorrowType: prepareType(capability.BorrowType, typeResults{}),
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1843,8 +1843,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 		cadence.TypeValue{
 			StaticType: ty,
 		},
-		// TODO:
-		`{"type":"Type","staticType":null}`,
+		`{"type":"Type","value":{"staticType":{"kind":"Resource","typeID":"S.test.Foo","fields":[{"id":"foo","type":{"kind":"Optional","type":"S.test.Foo"}}],"initializers":[],"type":""}}}`,
 	)
 }
 
@@ -1943,7 +1942,7 @@ func testEncode(t *testing.T, val cadence.Value, expectedJSON string) (actualJSO
 
 	actualJSON = string(actualJSONBytes)
 
-	assert.JSONEq(t, expectedJSON, actualJSON)
+	assert.JSONEq(t, expectedJSON, actualJSON, fmt.Sprintf("actual: %s", actualJSON))
 
 	return actualJSON
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1481,12 +1481,12 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.FunctionType{
+				StaticType: (&cadence.FunctionType{
 					Parameters: []cadence.Parameter{
 						{Label: "qux", Identifier: "baz", Type: cadence.StringType{}},
 					},
 					ReturnType: cadence.IntType{},
-				}.WithID("Foo"),
+				}).WithID("Foo"),
 			},
 			`{"type":"Type","value":{"staticType":
 				{	
@@ -1521,12 +1521,12 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.RestrictedType{
+				StaticType: (&cadence.RestrictedType{
 					Restrictions: []cadence.Type{
 						cadence.StringType{},
 					},
 					Type: cadence.IntType{},
-				}.WithID("Int{String}"),
+				}).WithID("Int{String}"),
 			},
 			`{"type":"Type","value":{"staticType":
 				{	

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1820,6 +1820,34 @@ func TestExportRecursiveType(t *testing.T) {
 
 }
 
+func TestExportTypeValueRecursiveType(t *testing.T) {
+
+	t.Parallel()
+
+	ty := &cadence.ResourceType{
+		Location:            utils.TestLocation,
+		QualifiedIdentifier: "Foo",
+		Fields: []cadence.Field{
+			{
+				Identifier: "foo",
+			},
+		},
+	}
+
+	ty.Fields[0].Type = cadence.OptionalType{
+		Type: ty,
+	}
+
+	testEncode(
+		t,
+		cadence.TypeValue{
+			StaticType: ty,
+		},
+		// TODO:
+		`{"type":"Type","staticType":null}`,
+	)
+}
+
 func TestEncodePath(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -586,7 +586,7 @@ func exportRestrictedType(
 	gauge common.MemoryGauge,
 	t *sema.RestrictedType,
 	results map[sema.TypeID]cadence.Type,
-) cadence.RestrictedType {
+) *cadence.RestrictedType {
 
 	convertedType := ExportMeteredType(gauge, t.Type, results)
 
@@ -745,7 +745,7 @@ func ImportType(memoryGauge common.MemoryGauge, t cadence.Type) interpreter.Stat
 			ImportType(memoryGauge, t.Type),
 			nil,
 		)
-	case cadence.RestrictedType:
+	case *cadence.RestrictedType:
 		restrictions := make([]interpreter.InterfaceStaticType, 0, len(t.Restrictions))
 		for _, restriction := range t.Restrictions {
 			intf, ok := restriction.(cadence.InterfaceType)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1176,7 +1176,7 @@ func TestImportRuntimeType(t *testing.T) {
 		},
 		{
 			label: "RestrictedType",
-			actual: cadence.RestrictedType{
+			actual: &cadence.RestrictedType{
 				Type: &cadence.StructType{
 					Location:            TestLocation,
 					QualifiedIdentifier: "S",
@@ -1769,7 +1769,7 @@ func TestExportTypeValue(t *testing.T) {
 
 		assert.Equal(t,
 			cadence.TypeValue{
-				StaticType: cadence.RestrictedType{
+				StaticType: (&cadence.RestrictedType{
 					Type: &cadence.StructType{
 						QualifiedIdentifier: "S",
 						Location:            TestLocation,
@@ -1782,7 +1782,7 @@ func TestExportTypeValue(t *testing.T) {
 							Fields:              []cadence.Field{},
 						},
 					},
-				}.WithID("S.test.S{S.test.SI}"),
+				}).WithID("S.test.S{S.test.SI}"),
 			},
 			actual,
 		)

--- a/types.go
+++ b/types.go
@@ -1364,8 +1364,8 @@ func NewFunctionType(
 	typeID string,
 	parameters []Parameter,
 	returnType Type,
-) FunctionType {
-	return FunctionType{
+) *FunctionType {
+	return &FunctionType{
 		typeID:     typeID,
 		Parameters: parameters,
 		ReturnType: returnType,
@@ -1377,18 +1377,18 @@ func NewMeteredFunctionType(
 	typeID string,
 	parameters []Parameter,
 	returnType Type,
-) FunctionType {
+) *FunctionType {
 	common.UseMemory(gauge, common.CadenceFunctionTypeMemoryUsage)
 	return NewFunctionType(typeID, parameters, returnType)
 }
 
-func (FunctionType) isType() {}
+func (*FunctionType) isType() {}
 
-func (t FunctionType) ID() string {
+func (t *FunctionType) ID() string {
 	return t.typeID
 }
 
-func (t FunctionType) WithID(id string) FunctionType {
+func (t *FunctionType) WithID(id string) *FunctionType {
 	t.typeID = id
 	return t
 }
@@ -1459,13 +1459,13 @@ func NewMeteredRestrictedType(
 	return NewRestrictedType(typeID, typ, restrictions)
 }
 
-func (RestrictedType) isType() {}
+func (*RestrictedType) isType() {}
 
-func (t RestrictedType) ID() string {
+func (t *RestrictedType) ID() string {
 	return t.typeID
 }
 
-func (t RestrictedType) WithID(id string) RestrictedType {
+func (t *RestrictedType) WithID(id string) *RestrictedType {
 	t.typeID = id
 	return t
 }

--- a/types_test.go
+++ b/types_test.go
@@ -144,7 +144,7 @@ func TestType_ID(t *testing.T) {
 			"S.test.FooI",
 		},
 		{
-			RestrictedType{}.WithID("S.test.Foo{S.test.FooI}"),
+			(&RestrictedType{}).WithID("S.test.Foo{S.test.FooI}"),
 			"S.test.Foo{S.test.FooI}",
 		},
 	}


### PR DESCRIPTION
Closes #1704

## Description

Preparation of static types may run into a recursion. Track results and return the type ID in the recursive case.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
