### PR TITLE
Differentate invalidated resource use errors

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -208,13 +208,23 @@ func (e DivisionByZeroError) Error() string {
 }
 
 // InvalidatedResourceError
-
+//
 type InvalidatedResourceError struct {
 	LocationRange
 }
 
 func (e InvalidatedResourceError) Error() string {
-	return "resource is invalidated and cannot be used anymore"
+	return "internal error: resource is invalidated and cannot be used anymore"
+}
+
+// DestroyedResourceError
+//
+type DestroyedResourceError struct {
+	LocationRange
+}
+
+func (e DestroyedResourceError) Error() string {
+	return "resource was destroyed and cannot be used anymore"
 }
 
 // ForceAssignmentToNonNilResourceError

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -217,7 +217,8 @@ func (e InvalidatedResourceError) Error() string {
 	return "internal error: resource is invalidated and cannot be used anymore"
 }
 
-// DestroyedResourceError
+// DestroyedResourceError is the error which is reported
+// when a user uses a destroyed resource through a reference
 //
 type DestroyedResourceError struct {
 	LocationRange

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4429,7 +4429,7 @@ func (interpreter *Interpreter) checkResourceNotDestroyed(value Value, getLocati
 		return
 	}
 
-	panic(InvalidatedResourceError{
+	panic(DestroyedResourceError{
 		LocationRange: getLocationRange(),
 	})
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4423,7 +4423,7 @@ func (interpreter *Interpreter) checkContainerMutation(
 	}
 }
 
-func (interpreter *Interpreter) checkResourceNotDestroyed(value Value, getLocationRange func() LocationRange) {
+func (interpreter *Interpreter) checkReferencedResourceNotDestroyed(value Value, getLocationRange func() LocationRange) {
 	resourceKindedValue, ok := value.(ResourceKindedValue)
 	if !ok || !resourceKindedValue.IsDestroyed() {
 		return

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1486,13 +1486,15 @@ func (v *ArrayValue) IsImportable(inter *Interpreter) bool {
 	return importable
 }
 
-func (v *ArrayValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *ArrayValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
 	if v.isDestroyed {
 		panic(DestroyedResourceError{
 			LocationRange: getLocationRange(),
 		})
 	}
+}
 
+func (v *ArrayValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
 	if v.array == nil && v.IsResourceKinded(interpreter) {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
@@ -1507,6 +1509,8 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -1609,6 +1613,8 @@ func (v *ArrayValue) GetKey(interpreter *Interpreter, getLocationRange func() Lo
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	index := key.(NumberValue).ToInt()
 	return v.Get(interpreter, getLocationRange, index)
 }
@@ -1651,6 +1657,8 @@ func (v *ArrayValue) SetKey(interpreter *Interpreter, getLocationRange func() Lo
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	index := key.(NumberValue).ToInt()
 	v.Set(interpreter, getLocationRange, index, value)
@@ -1769,6 +1777,8 @@ func (v *ArrayValue) InsertKey(interpreter *Interpreter, getLocationRange func()
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	index := key.(NumberValue).ToInt()
 	v.Insert(interpreter, getLocationRange, index, value)
 }
@@ -1820,6 +1830,8 @@ func (v *ArrayValue) RemoveKey(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	index := key.(NumberValue).ToInt()
 	return v.Remove(interpreter, getLocationRange, index)
@@ -1926,6 +1938,9 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	switch name {
 	case "length":
 		return NewIntValueFromInt64(interpreter, int64(v.Count()))
@@ -2125,6 +2140,8 @@ func (v *ArrayValue) RemoveMember(interpreter *Interpreter, getLocationRange fun
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	// Arrays have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -2134,6 +2151,8 @@ func (v *ArrayValue) SetMember(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	// Arrays have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
@@ -2258,6 +2277,8 @@ func (v *ArrayValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	interpreter.ReportComputation(common.ComputationKindTransferArrayValue, uint(v.Count()))
 
@@ -14336,6 +14357,8 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 
@@ -14387,6 +14410,8 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -14470,13 +14495,15 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	return nil
 }
 
-func (v *CompositeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
+func (v *CompositeValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
 	if v.isDestroyed {
 		panic(DestroyedResourceError{
 			LocationRange: getLocationRange(),
 		})
 	}
+}
 
+func (v *CompositeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
 	if v.dictionary == nil && v.Kind == common.CompositeKindResource {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
@@ -14530,6 +14557,8 @@ func (v *CompositeValue) RemoveMember(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -14591,6 +14620,8 @@ func (v *CompositeValue) SetMember(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -14720,6 +14751,8 @@ func (v *CompositeValue) GetField(interpreter *Interpreter, getLocationRange fun
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	storable, err := v.dictionary.Get(
 		StringAtreeComparator,
@@ -14961,6 +14994,8 @@ func (v *CompositeValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -15490,13 +15525,15 @@ func (v *DictionaryValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *DictionaryValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *DictionaryValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
 	if v.isDestroyed {
 		panic(DestroyedResourceError{
 			LocationRange: getLocationRange(),
 		})
 	}
+}
 
+func (v *DictionaryValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
 	if v.dictionary == nil && v.IsResourceKinded(interpreter) {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
@@ -15510,6 +15547,8 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -15599,6 +15638,8 @@ func (v *DictionaryValue) GetKey(interpreter *Interpreter, getLocationRange func
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	value, ok := v.Get(interpreter, getLocationRange, keyValue)
 	if ok {
 		return NewSomeValueNonCopying(interpreter, value)
@@ -15617,6 +15658,8 @@ func (v *DictionaryValue) SetKey(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, getLocationRange)
 	interpreter.checkContainerMutation(
@@ -15695,6 +15738,8 @@ func (v *DictionaryValue) GetMember(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -15831,6 +15876,8 @@ func (v *DictionaryValue) RemoveMember(interpreter *Interpreter, getLocationRang
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	// Dictionaries have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -15840,6 +15887,8 @@ func (v *DictionaryValue) SetMember(interpreter *Interpreter, getLocationRange f
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	// Dictionaries have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
@@ -15858,6 +15907,8 @@ func (v *DictionaryValue) RemoveKey(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	return v.Remove(interpreter, getLocationRange, key)
 }
@@ -16137,6 +16188,8 @@ func (v *DictionaryValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -16612,6 +16665,8 @@ func (v *SomeValue) Destroy(interpreter *Interpreter, getLocationRange func() Lo
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	innerValue := v.InnerValue(interpreter, getLocationRange)
 
 	maybeDestroy(interpreter, getLocationRange, innerValue)
@@ -16639,6 +16694,9 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, getLocationRange func() 
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	switch name {
 	case "map":
 		return NewHostFunctionValue(
@@ -16687,6 +16745,8 @@ func (v *SomeValue) RemoveMember(interpreter *Interpreter, getLocationRange func
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
 
+	v.checkDestroyedResourceUse(getLocationRange)
+
 	panic(errors.NewUnreachableError())
 }
 
@@ -16695,6 +16755,8 @@ func (v *SomeValue) SetMember(interpreter *Interpreter, getLocationRange func() 
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	panic(errors.NewUnreachableError())
 }
@@ -16772,13 +16834,15 @@ func (v *SomeValue) IsResourceKinded(interpreter *Interpreter) bool {
 	return v.value.IsResourceKinded(interpreter)
 }
 
-func (v *SomeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
+func (v *SomeValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
 	if v.isDestroyed {
 		panic(DestroyedResourceError{
 			LocationRange: getLocationRange(),
 		})
 	}
+}
 
+func (v *SomeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
 	if v.value == nil {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
@@ -16797,6 +16861,8 @@ func (v *SomeValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	innerValue := v.value
 
@@ -16861,6 +16927,8 @@ func (v *SomeValue) InnerValue(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	v.checkDestroyedResourceUse(getLocationRange)
 
 	return v.value
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1486,16 +1486,8 @@ func (v *ArrayValue) IsImportable(inter *Interpreter) bool {
 	return importable
 }
 
-func (v *ArrayValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
-	if v.isDestroyed {
-		panic(DestroyedResourceError{
-			LocationRange: getLocationRange(),
-		})
-	}
-}
-
 func (v *ArrayValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
-	if v.array == nil && v.IsResourceKinded(interpreter) {
+	if v.isDestroyed || (v.array == nil && v.IsResourceKinded(interpreter)) {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})
@@ -1509,8 +1501,6 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -1613,8 +1603,6 @@ func (v *ArrayValue) GetKey(interpreter *Interpreter, getLocationRange func() Lo
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	index := key.(NumberValue).ToInt()
 	return v.Get(interpreter, getLocationRange, index)
 }
@@ -1657,8 +1645,6 @@ func (v *ArrayValue) SetKey(interpreter *Interpreter, getLocationRange func() Lo
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	index := key.(NumberValue).ToInt()
 	v.Set(interpreter, getLocationRange, index, value)
@@ -1777,8 +1763,6 @@ func (v *ArrayValue) InsertKey(interpreter *Interpreter, getLocationRange func()
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	index := key.(NumberValue).ToInt()
 	v.Insert(interpreter, getLocationRange, index, value)
 }
@@ -1830,8 +1814,6 @@ func (v *ArrayValue) RemoveKey(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	index := key.(NumberValue).ToInt()
 	return v.Remove(interpreter, getLocationRange, index)
@@ -1938,9 +1920,6 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	switch name {
 	case "length":
 		return NewIntValueFromInt64(interpreter, int64(v.Count()))
@@ -2140,8 +2119,6 @@ func (v *ArrayValue) RemoveMember(interpreter *Interpreter, getLocationRange fun
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	// Arrays have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -2151,8 +2128,6 @@ func (v *ArrayValue) SetMember(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	// Arrays have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
@@ -2277,8 +2252,6 @@ func (v *ArrayValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	interpreter.ReportComputation(common.ComputationKindTransferArrayValue, uint(v.Count()))
 
@@ -14357,8 +14330,6 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 
@@ -14410,8 +14381,6 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -14495,16 +14464,8 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	return nil
 }
 
-func (v *CompositeValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
-	if v.isDestroyed {
-		panic(DestroyedResourceError{
-			LocationRange: getLocationRange(),
-		})
-	}
-}
-
 func (v *CompositeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
-	if v.dictionary == nil && v.Kind == common.CompositeKindResource {
+	if v.isDestroyed || (v.dictionary == nil && v.Kind == common.CompositeKindResource) {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})
@@ -14557,8 +14518,6 @@ func (v *CompositeValue) RemoveMember(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -14620,8 +14579,6 @@ func (v *CompositeValue) SetMember(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -14751,8 +14708,6 @@ func (v *CompositeValue) GetField(interpreter *Interpreter, getLocationRange fun
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	storable, err := v.dictionary.Get(
 		StringAtreeComparator,
@@ -14994,8 +14949,6 @@ func (v *CompositeValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -15525,16 +15478,8 @@ func (v *DictionaryValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *DictionaryValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
-	if v.isDestroyed {
-		panic(DestroyedResourceError{
-			LocationRange: getLocationRange(),
-		})
-	}
-}
-
 func (v *DictionaryValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
-	if v.dictionary == nil && v.IsResourceKinded(interpreter) {
+	if v.isDestroyed || (v.dictionary == nil && v.IsResourceKinded(interpreter)) {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})
@@ -15547,8 +15492,6 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -15638,8 +15581,6 @@ func (v *DictionaryValue) GetKey(interpreter *Interpreter, getLocationRange func
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	value, ok := v.Get(interpreter, getLocationRange, keyValue)
 	if ok {
 		return NewSomeValueNonCopying(interpreter, value)
@@ -15658,8 +15599,6 @@ func (v *DictionaryValue) SetKey(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, getLocationRange)
 	interpreter.checkContainerMutation(
@@ -15738,8 +15677,6 @@ func (v *DictionaryValue) GetMember(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -15876,8 +15813,6 @@ func (v *DictionaryValue) RemoveMember(interpreter *Interpreter, getLocationRang
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	// Dictionaries have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -15887,8 +15822,6 @@ func (v *DictionaryValue) SetMember(interpreter *Interpreter, getLocationRange f
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	// Dictionaries have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
@@ -15907,8 +15840,6 @@ func (v *DictionaryValue) RemoveKey(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	return v.Remove(interpreter, getLocationRange, key)
 }
@@ -16188,8 +16119,6 @@ func (v *DictionaryValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -16665,8 +16594,6 @@ func (v *SomeValue) Destroy(interpreter *Interpreter, getLocationRange func() Lo
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	innerValue := v.InnerValue(interpreter, getLocationRange)
 
 	maybeDestroy(interpreter, getLocationRange, innerValue)
@@ -16694,9 +16621,6 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, getLocationRange func() 
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	switch name {
 	case "map":
 		return NewHostFunctionValue(
@@ -16745,8 +16669,6 @@ func (v *SomeValue) RemoveMember(interpreter *Interpreter, getLocationRange func
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
 
-	v.checkDestroyedResourceUse(getLocationRange)
-
 	panic(errors.NewUnreachableError())
 }
 
@@ -16755,8 +16677,6 @@ func (v *SomeValue) SetMember(interpreter *Interpreter, getLocationRange func() 
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	panic(errors.NewUnreachableError())
 }
@@ -16834,16 +16754,8 @@ func (v *SomeValue) IsResourceKinded(interpreter *Interpreter) bool {
 	return v.value.IsResourceKinded(interpreter)
 }
 
-func (v *SomeValue) checkDestroyedResourceUse(getLocationRange func() LocationRange) {
-	if v.isDestroyed {
-		panic(DestroyedResourceError{
-			LocationRange: getLocationRange(),
-		})
-	}
-}
-
 func (v *SomeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
-	if v.value == nil {
+	if v.isDestroyed || v.value == nil {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})
@@ -16861,8 +16773,6 @@ func (v *SomeValue) Transfer(
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	innerValue := v.value
 
@@ -16927,8 +16837,6 @@ func (v *SomeValue) InnerValue(interpreter *Interpreter, getLocationRange func()
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
-
-	v.checkDestroyedResourceUse(getLocationRange)
 
 	return v.value
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1487,7 +1487,13 @@ func (v *ArrayValue) IsImportable(inter *Interpreter) bool {
 }
 
 func (v *ArrayValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
-	if v.isDestroyed || (v.array == nil && v.IsResourceKinded(interpreter)) {
+	if v.isDestroyed {
+		panic(DestroyedResourceError{
+			LocationRange: getLocationRange(),
+		})
+	}
+
+	if v.array == nil && v.IsResourceKinded(interpreter) {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})
@@ -14465,7 +14471,13 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 }
 
 func (v *CompositeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
-	if v.isDestroyed || (v.dictionary == nil && v.Kind == common.CompositeKindResource) {
+	if v.isDestroyed {
+		panic(DestroyedResourceError{
+			LocationRange: getLocationRange(),
+		})
+	}
+
+	if v.dictionary == nil && v.Kind == common.CompositeKindResource {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})
@@ -15479,7 +15491,13 @@ func (v *DictionaryValue) IsDestroyed() bool {
 }
 
 func (v *DictionaryValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
-	if v.isDestroyed || (v.dictionary == nil && v.IsResourceKinded(interpreter)) {
+	if v.isDestroyed {
+		panic(DestroyedResourceError{
+			LocationRange: getLocationRange(),
+		})
+	}
+
+	if v.dictionary == nil && v.IsResourceKinded(interpreter) {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})
@@ -16755,7 +16773,13 @@ func (v *SomeValue) IsResourceKinded(interpreter *Interpreter) bool {
 }
 
 func (v *SomeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
-	if v.isDestroyed || v.value == nil {
+	if v.isDestroyed {
+		panic(DestroyedResourceError{
+			LocationRange: getLocationRange(),
+		})
+	}
+
+	if v.value == nil {
 		panic(InvalidatedResourceError{
 			LocationRange: getLocationRange(),
 		})

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16998,7 +16998,7 @@ func (v *StorageReferenceValue) GetMember(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	return interpreter.getMember(self, getLocationRange, name)
 }
@@ -17017,7 +17017,7 @@ func (v *StorageReferenceValue) RemoveMember(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	return self.(MemberAccessibleValue).RemoveMember(interpreter, getLocationRange, name)
 }
@@ -17037,7 +17037,7 @@ func (v *StorageReferenceValue) SetMember(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	interpreter.setMember(self, getLocationRange, name, value)
 }
@@ -17056,7 +17056,7 @@ func (v *StorageReferenceValue) GetKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	return self.(ValueIndexableValue).
 		GetKey(interpreter, getLocationRange, key)
@@ -17077,7 +17077,7 @@ func (v *StorageReferenceValue) SetKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	self.(ValueIndexableValue).
 		SetKey(interpreter, getLocationRange, key, value)
@@ -17098,7 +17098,7 @@ func (v *StorageReferenceValue) InsertKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	self.(ValueIndexableValue).
 		InsertKey(interpreter, getLocationRange, key, value)
@@ -17118,7 +17118,7 @@ func (v *StorageReferenceValue) RemoveKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	return self.(ValueIndexableValue).
 		RemoveKey(interpreter, getLocationRange, key)
@@ -17334,7 +17334,7 @@ func (v *EphemeralReferenceValue) GetMember(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	return interpreter.getMember(self, getLocationRange, name)
 }
@@ -17353,7 +17353,7 @@ func (v *EphemeralReferenceValue) RemoveMember(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	if memberAccessibleValue, ok := self.(MemberAccessibleValue); ok {
 		return memberAccessibleValue.RemoveMember(interpreter, getLocationRange, identifier)
@@ -17377,7 +17377,7 @@ func (v *EphemeralReferenceValue) SetMember(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	interpreter.setMember(self, getLocationRange, name, value)
 }
@@ -17396,7 +17396,7 @@ func (v *EphemeralReferenceValue) GetKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	return self.(ValueIndexableValue).
 		GetKey(interpreter, getLocationRange, key)
@@ -17417,7 +17417,7 @@ func (v *EphemeralReferenceValue) SetKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	self.(ValueIndexableValue).
 		SetKey(interpreter, getLocationRange, key, value)
@@ -17438,7 +17438,7 @@ func (v *EphemeralReferenceValue) InsertKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	self.(ValueIndexableValue).
 		InsertKey(interpreter, getLocationRange, key, value)
@@ -17458,7 +17458,7 @@ func (v *EphemeralReferenceValue) RemoveKey(
 
 	self := *referencedValue
 
-	interpreter.checkResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
 
 	return self.(ValueIndexableValue).
 		RemoveKey(interpreter, getLocationRange, key)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7214,7 +7214,7 @@ func TestInterpretReferenceDereferenceFailure(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	require.ErrorAs(t, err, &interpreter.DestroyedResourceError{})
 }
 
 func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
@@ -8192,7 +8192,7 @@ func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	require.ErrorAs(t, err, &interpreter.DestroyedResourceError{})
 }
 
 func TestInterpretNonStorageReferenceToOptional(t *testing.T) {


### PR DESCRIPTION
Closes dapperlabs/cadence-private-issues#55

## Description

Differentiate between use after destruction (user error) and use after invalidation (internal error)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
