### PR TITLE
Fix JSON encoding/decoding and test parallelization

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -1158,6 +1158,8 @@ func (d *Decoder) decodeType(valueJSON interface{}) cadence.Type {
 		return cadence.NewMeteredDeployedContractType(d.gauge)
 	case "AccountKey":
 		return cadence.NewMeteredAccountKeyType(d.gauge)
+	case "Block":
+		return cadence.NewMeteredBlockType(d.gauge)
 	default:
 		fieldsValue := obj.Get(fieldsKey)
 		typeIDValue := toString(obj.Get(typeIDKey))

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -683,6 +683,7 @@ func prepareType(typ cadence.Type, results typeResults) jsonValue {
 	case cadence.AnyType,
 		cadence.AnyStructType,
 		cadence.AnyResourceType,
+		cadence.AddressType,
 		cadence.MetaType,
 		cadence.VoidType,
 		cadence.NeverType,

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1057,9 +1057,12 @@ func TestEncodeLink(t *testing.T) {
 }
 
 func TestEncodeSimpleTypes(t *testing.T) {
+
 	t.Parallel()
 
-	tests := []cadence.Type{
+	var tests []encodeTest
+
+	for _, ty := range []cadence.Type{
 		cadence.AnyType{},
 		cadence.AnyResourceType{},
 		cadence.AnyResourceType{},
@@ -1109,23 +1112,17 @@ func TestEncodeSimpleTypes(t *testing.T) {
 		cadence.PublicAccountKeysType{},
 		cadence.PublicAccountType{},
 		cadence.DeployedContractType{},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("with static %s", test.ID()), func(t *testing.T) {
-
-			t.Parallel()
-
-			testEncodeAndDecode(
-				t,
-				cadence.TypeValue{
-					StaticType: test,
-				},
-				fmt.Sprintf(`{"type":"Type","value":{"staticType":{"kind":"%s"}}}`, test.ID()),
-			)
-
+	} {
+		tests = append(tests, encodeTest{
+			name: fmt.Sprintf("with static %s", ty.ID()),
+			val: cadence.TypeValue{
+				StaticType: ty,
+			},
+			expected: fmt.Sprintf(`{"type":"Type","value":{"staticType":{"kind":"%s"}}}`, ty.ID()),
 		})
 	}
+
+	testAllEncodeAndDecode(t, tests...)
 }
 
 func TestEncodeType(t *testing.T) {

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -120,8 +120,7 @@ func TestInterpreterElaborationImportMetering(t *testing.T) {
 
 	addressValue := cadence.BytesToAddress([]byte{byte(1)})
 
-	for imports := range contracts {
-
+	test := func(imports int) {
 		t.Run(fmt.Sprintf("import %d", imports), func(t *testing.T) {
 
 			t.Parallel()
@@ -204,6 +203,10 @@ func TestInterpreterElaborationImportMetering(t *testing.T) {
 			// one more for the script and one more for each contract imported
 			assert.Equal(t, uint64(3*imports+4), meter.getMemory(common.MemoryKindElaboration))
 		})
+	}
+
+	for imports := range contracts {
+		test(imports)
 	}
 }
 

--- a/runtime/tests/checker/nesting_test.go
+++ b/runtime/tests/checker/nesting_test.go
@@ -286,25 +286,30 @@ func TestCheckNestedTypeInvalidChildType(t *testing.T) {
 
 	t.Parallel()
 
-	test := func(t *testing.T, ty sema.Type) {
-		_, err := ParseAndCheckWithOptions(t,
-			`let u: T.U = nil`,
-			ParseAndCheckOptions{
-				Options: []sema.Option{
-					sema.WithPredeclaredTypes([]sema.TypeDeclaration{
-						stdlib.StandardLibraryType{
-							Name: "T",
-							Type: ty,
-							Kind: common.DeclarationKindType,
-						},
-					}),
+	test := func(t *testing.T, name string, ty sema.Type) {
+		t.Run(name, func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheckWithOptions(t,
+				`let u: T.U = nil`,
+				ParseAndCheckOptions{
+					Options: []sema.Option{
+						sema.WithPredeclaredTypes([]sema.TypeDeclaration{
+							stdlib.StandardLibraryType{
+								Name: "T",
+								Type: ty,
+								Kind: common.DeclarationKindType,
+							},
+						}),
+					},
 				},
-			},
-		)
+			)
 
-		errs := ExpectCheckerErrors(t, err, 1)
+			errs := ExpectCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.InvalidNestedTypeError{}, errs[0])
+			assert.IsType(t, &sema.InvalidNestedTypeError{}, errs[0])
+		})
 	}
 
 	testCases := map[string]sema.Type{
@@ -314,13 +319,7 @@ func TestCheckNestedTypeInvalidChildType(t *testing.T) {
 	}
 
 	for name, ty := range testCases {
-
-		t.Run(name, func(t *testing.T) {
-
-			t.Parallel()
-
-			test(t, ty)
-		})
+		test(t, name, ty)
 	}
 }
 


### PR DESCRIPTION
Port of https://github.com/dapperlabs/cadence-internal/pull/90

## Description

- Allow encoding of the Address type
- Allow decoding of the Block type
- Fix parallelization in tests. This is a [common gotcha](https://gist.github.com/kunwardeep/80c2e9f3d3256c894898bae82d9f75d0). I found the other problematic tests unrelated to the JSON encoding with https://github.com/kunwardeep/paralleltest

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
