### PR TITLE
Take argument labels into account when declaring members for nested declarations

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -562,6 +562,7 @@ func (checker *Checker) declareCompositeMembersAndValue(
 					TypeAnnotation:        NewTypeAnnotation(nestedCompositeDeclarationVariable.Type),
 					DeclarationKind:       nestedCompositeDeclarationVariable.DeclarationKind,
 					VariableKind:          ast.VariableKindConstant,
+					ArgumentLabels:        nestedCompositeDeclarationVariable.ArgumentLabels,
 					IgnoreInSerialization: true,
 					DocString:             nestedCompositeDeclaration.DocString,
 				})

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -24,8 +24,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestCheckInvalidFunctionCallWithTooFewArguments(t *testing.T) {
@@ -342,4 +345,262 @@ func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
 	)
 
 	require.NoError(t, err)
+}
+
+func TestCheckArgumentLabels(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("function", func(t *testing.T) {
+
+		t.Run("", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              fun test(foo bar: Int, baz: String) {}
+
+	          let t = test(x: 1, "2")
+	        `)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+
+		t.Run("imported", func(t *testing.T) {
+
+			t.Parallel()
+
+			importedChecker, err := ParseAndCheckWithOptions(t,
+				`
+                  fun test(foo bar: Int, baz: String) {}
+                `,
+				ParseAndCheckOptions{
+					Location: utils.ImportedLocation,
+				},
+			)
+
+			require.NoError(t, err)
+
+			_, err = ParseAndCheckWithOptions(t,
+				`
+                  import "imported"
+
+                  let t = test(x: 1, "2")
+                `,
+				ParseAndCheckOptions{
+					Options: []sema.Option{
+						sema.WithImportHandler(
+							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+								return sema.ElaborationImport{
+									Elaboration: importedChecker.Elaboration,
+								}, nil
+							},
+						),
+					},
+				},
+			)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+	})
+
+	t.Run("composite function", func(t *testing.T) {
+
+		t.Run("", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+	          struct Test {
+                  fun test(foo bar: Int, baz: String) {}
+	          }
+
+	          let t = Test().test(x: 1, "2")
+	        `)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+
+		t.Run("imported", func(t *testing.T) {
+
+			t.Parallel()
+
+			importedChecker, err := ParseAndCheckWithOptions(t,
+				`
+	              struct Test {
+                      fun test(foo bar: Int, baz: String) {}
+	              }
+                `,
+				ParseAndCheckOptions{
+					Location: utils.ImportedLocation,
+				},
+			)
+
+			require.NoError(t, err)
+
+			_, err = ParseAndCheckWithOptions(t,
+				`
+                  import "imported"
+
+                  let t = Test().test(x: 1, "2")
+                `,
+				ParseAndCheckOptions{
+					Options: []sema.Option{
+						sema.WithImportHandler(
+							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+								return sema.ElaborationImport{
+									Elaboration: importedChecker.Elaboration,
+								}, nil
+							},
+						),
+					},
+				},
+			)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+	})
+
+	t.Run("constructor", func(t *testing.T) {
+
+		t.Run("", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              struct Test {
+                  init(foo bar: Int, baz: String) {}
+              }
+
+	          let t = Test(x: 1, "2")
+	        `)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+
+		t.Run("imported", func(t *testing.T) {
+
+			t.Parallel()
+
+			importedChecker, err := ParseAndCheckWithOptions(t,
+				`
+                  struct Test {
+                      init(foo bar: Int, baz: String) {}
+                  }
+                `,
+				ParseAndCheckOptions{
+					Location: utils.ImportedLocation,
+				},
+			)
+
+			require.NoError(t, err)
+
+			_, err = ParseAndCheckWithOptions(t,
+				`
+                  import "imported"
+
+                  let t = Test(x: 1, "2")
+                `,
+				ParseAndCheckOptions{
+					Options: []sema.Option{
+						sema.WithImportHandler(
+							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+								return sema.ElaborationImport{
+									Elaboration: importedChecker.Elaboration,
+								}, nil
+							},
+						),
+					},
+				},
+			)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+	})
+
+	t.Run("nested constructor", func(t *testing.T) {
+
+		t.Run("", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+	          contract C {
+                  struct S {
+                      init(foo bar: Int, baz: String) {}
+                  }
+	          }
+
+	          let t = C.S(x: 1, "2")
+	        `)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+
+		t.Run("imported", func(t *testing.T) {
+
+			t.Parallel()
+
+			importedChecker, err := ParseAndCheckWithOptions(t,
+				`
+	              contract C {
+                      struct S {
+                          init(foo bar: Int, baz: String) {}
+                      }
+	              }
+                `,
+				ParseAndCheckOptions{
+					Location: utils.ImportedLocation,
+				},
+			)
+
+			require.NoError(t, err)
+
+			_, err = ParseAndCheckWithOptions(t,
+				`
+                  import "imported"
+
+                  let t = C.S(x: 1, "2")
+                `,
+				ParseAndCheckOptions{
+					Options: []sema.Option{
+						sema.WithImportHandler(
+							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+								return sema.ElaborationImport{
+									Elaboration: importedChecker.Elaboration,
+								}, nil
+							},
+						),
+					},
+				},
+			)
+
+			errs := ExpectCheckerErrors(t, err, 2)
+
+			assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+			assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
+		})
+
+	})
 }


### PR DESCRIPTION
## Description

When declaring the members for nested declarations, e.g. a composite declaration inside a contract, also take the argument labels of the nested declaration into account.

This was reported by @justjoolz, who also provided a great reproduction in https://github.com/justjoolz/struct-test 🙏 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
