### PR TITLE
Fix decoding of repeated/recursive encoded types

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -871,12 +871,7 @@ func (d *Decoder) decodeFieldTypes(fs []interface{}, results typeDecodingResults
 		Amount: uint64(len(fs)),
 	})
 
-	count := len(fs)
-	if count == 0 {
-		return nil
-	}
-
-	fields := make([]cadence.Field, 0, count)
+	fields := make([]cadence.Field, 0, len(fs))
 
 	for _, field := range fields {
 		fields = append(fields, d.decodeFieldType(field, results))
@@ -915,16 +910,12 @@ func (d *Decoder) decodeNominalType(
 	fields := d.decodeFieldTypes(fs, results)
 
 	// Unmetered because this is created as an array of nil arrays, not Parameter structs
-	var inits [][]cadence.Parameter
-	count := len(initializers)
-	if count > 0 {
-		inits = make([][]cadence.Parameter, 0, count)
-		for _, params := range initializers {
-			inits = append(
-				inits,
-				d.decodeParamTypes(toSlice(params), results),
-			)
-		}
+	inits := make([][]cadence.Parameter, 0, len(initializers))
+	for _, params := range initializers {
+		inits = append(
+			inits,
+			d.decodeParamTypes(toSlice(params), results),
+		)
 	}
 
 	location, qualifiedIdentifier, err := common.DecodeTypeID(d.gauge, typeID)

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -620,7 +620,7 @@ func preparePath(x cadence.Path) jsonValue {
 	}
 }
 
-func prepareParameterType(parameterType cadence.Parameter, results typeResults) jsonParameterType {
+func prepareParameterType(parameterType cadence.Parameter, results typePreparationResults) jsonParameterType {
 	return jsonParameterType{
 		Label: parameterType.Label,
 		Id:    parameterType.Identifier,
@@ -628,14 +628,14 @@ func prepareParameterType(parameterType cadence.Parameter, results typeResults) 
 	}
 }
 
-func prepareFieldType(fieldType cadence.Field, results typeResults) jsonFieldType {
+func prepareFieldType(fieldType cadence.Field, results typePreparationResults) jsonFieldType {
 	return jsonFieldType{
 		Id:   fieldType.Identifier,
 		Type: prepareType(fieldType.Type, results),
 	}
 }
 
-func prepareFields(fieldTypes []cadence.Field, results typeResults) []jsonFieldType {
+func prepareFields(fieldTypes []cadence.Field, results typePreparationResults) []jsonFieldType {
 	fields := make([]jsonFieldType, 0)
 	for _, field := range fieldTypes {
 		fields = append(fields, prepareFieldType(field, results))
@@ -643,7 +643,7 @@ func prepareFields(fieldTypes []cadence.Field, results typeResults) []jsonFieldT
 	return fields
 }
 
-func prepareParameters(parameterTypes []cadence.Parameter, results typeResults) []jsonParameterType {
+func prepareParameters(parameterTypes []cadence.Parameter, results typePreparationResults) []jsonParameterType {
 	parameters := make([]jsonParameterType, 0)
 	for _, param := range parameterTypes {
 		parameters = append(parameters, prepareParameterType(param, results))
@@ -651,7 +651,7 @@ func prepareParameters(parameterTypes []cadence.Parameter, results typeResults) 
 	return parameters
 }
 
-func prepareInitializers(initializerTypes [][]cadence.Parameter, results typeResults) [][]jsonParameterType {
+func prepareInitializers(initializerTypes [][]cadence.Parameter, results typePreparationResults) [][]jsonParameterType {
 	initializers := make([][]jsonParameterType, 0)
 	for _, params := range initializerTypes {
 		initializers = append(initializers, prepareParameters(params, results))
@@ -659,7 +659,7 @@ func prepareInitializers(initializerTypes [][]cadence.Parameter, results typeRes
 	return initializers
 }
 
-func prepareType(typ cadence.Type, results typeResults) jsonValue {
+func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 
 	var supportedRecursiveType bool
 	switch typ.(type) {
@@ -856,13 +856,13 @@ func prepareType(typ cadence.Type, results typeResults) jsonValue {
 	}
 }
 
-type typeResults map[cadence.Type]struct{}
+type typePreparationResults map[cadence.Type]struct{}
 
 func prepareTypeValue(typeValue cadence.TypeValue) jsonValue {
 	return jsonValueObject{
 		Type: typeTypeStr,
 		Value: jsonTypeValue{
-			StaticType: prepareType(typeValue.StaticType, typeResults{}),
+			StaticType: prepareType(typeValue.StaticType, typePreparationResults{}),
 		},
 	}
 }
@@ -873,7 +873,7 @@ func prepareCapability(capability cadence.Capability) jsonValue {
 		Value: jsonCapabilityValue{
 			Path:       preparePath(capability.Path),
 			Address:    encodeBytes(capability.Address.Bytes()),
-			BorrowType: prepareType(capability.BorrowType, typeResults{}),
+			BorrowType: prepareType(capability.BorrowType, typePreparationResults{}),
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1833,6 +1833,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 					Identifier: "foo",
 				},
 			},
+			Initializers: [][]cadence.Parameter{},
 		}
 
 		ty.Fields[0].Type = cadence.OptionalType{
@@ -1856,6 +1857,8 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 		fooTy := &cadence.ResourceType{
 			Location:            utils.TestLocation,
 			QualifiedIdentifier: "Foo",
+			Fields:              []cadence.Field{},
+			Initializers:        [][]cadence.Parameter{},
 		}
 
 		barTy := &cadence.ResourceType{
@@ -1871,6 +1874,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 					Type:       fooTy,
 				},
 			},
+			Initializers: [][]cadence.Parameter{},
 		}
 
 		testEncodeAndDecode(

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1839,7 +1839,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 			Type: ty,
 		}
 
-		testEncode(
+		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
 				StaticType: ty,
@@ -1873,7 +1873,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 			},
 		}
 
-		testEncode(
+		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
 				StaticType: barTy,

--- a/types.go
+++ b/types.go
@@ -904,6 +904,7 @@ type CompositeType interface {
 	CompositeTypeLocation() common.Location
 	CompositeTypeQualifiedIdentifier() string
 	CompositeFields() []Field
+	SetCompositeFields([]Field)
 	CompositeInitializers() [][]Parameter
 }
 
@@ -918,13 +919,13 @@ type StructType struct {
 
 func NewStructType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *StructType {
 	return &StructType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -963,6 +964,10 @@ func (t *StructType) CompositeTypeQualifiedIdentifier() string {
 
 func (t *StructType) CompositeFields() []Field {
 	return t.Fields
+}
+
+func (t *StructType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
 }
 
 func (t *StructType) CompositeInitializers() [][]Parameter {
@@ -1027,6 +1032,10 @@ func (t *ResourceType) CompositeFields() []Field {
 	return t.Fields
 }
 
+func (t *ResourceType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *ResourceType) CompositeInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1089,6 +1098,10 @@ func (t *EventType) CompositeFields() []Field {
 	return t.Fields
 }
 
+func (t *EventType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *EventType) CompositeInitializers() [][]Parameter {
 	return [][]Parameter{t.Initializer}
 }
@@ -1104,13 +1117,13 @@ type ContractType struct {
 
 func NewContractType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractType {
 	return &ContractType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1119,12 +1132,12 @@ func NewContractType(
 func NewMeteredContractType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractType {
 	common.UseMemory(gauge, common.CadenceContractTypeMemoryUsage)
-	return NewContractType(location, qualifiedIdentifer, fields, initializers)
+	return NewContractType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*ContractType) isType() {}
@@ -1151,6 +1164,10 @@ func (t *ContractType) CompositeFields() []Field {
 	return t.Fields
 }
 
+func (t *ContractType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *ContractType) CompositeInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1163,6 +1180,7 @@ type InterfaceType interface {
 	InterfaceTypeLocation() common.Location
 	InterfaceTypeQualifiedIdentifier() string
 	InterfaceFields() []Field
+	SetInterfaceFields(fields []Field)
 	InterfaceInitializers() [][]Parameter
 }
 
@@ -1177,13 +1195,13 @@ type StructInterfaceType struct {
 
 func NewStructInterfaceType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *StructInterfaceType {
 	return &StructInterfaceType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1192,12 +1210,12 @@ func NewStructInterfaceType(
 func NewMeteredStructInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *StructInterfaceType {
 	common.UseMemory(gauge, common.CadenceStructInterfaceTypeMemoryUsage)
-	return NewStructInterfaceType(location, qualifiedIdentifer, fields, initializers)
+	return NewStructInterfaceType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*StructInterfaceType) isType() {}
@@ -1224,6 +1242,10 @@ func (t *StructInterfaceType) InterfaceFields() []Field {
 	return t.Fields
 }
 
+func (t *StructInterfaceType) SetInterfaceFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *StructInterfaceType) InterfaceInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1239,13 +1261,13 @@ type ResourceInterfaceType struct {
 
 func NewResourceInterfaceType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ResourceInterfaceType {
 	return &ResourceInterfaceType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1254,12 +1276,12 @@ func NewResourceInterfaceType(
 func NewMeteredResourceInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ResourceInterfaceType {
 	common.UseMemory(gauge, common.CadenceResourceInterfaceTypeMemoryUsage)
-	return NewResourceInterfaceType(location, qualifiedIdentifer, fields, initializers)
+	return NewResourceInterfaceType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*ResourceInterfaceType) isType() {}
@@ -1286,6 +1308,10 @@ func (t *ResourceInterfaceType) InterfaceFields() []Field {
 	return t.Fields
 }
 
+func (t *ResourceInterfaceType) SetInterfaceFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *ResourceInterfaceType) InterfaceInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1301,13 +1327,13 @@ type ContractInterfaceType struct {
 
 func NewContractInterfaceType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractInterfaceType {
 	return &ContractInterfaceType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1316,12 +1342,12 @@ func NewContractInterfaceType(
 func NewMeteredContractInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractInterfaceType {
 	common.UseMemory(gauge, common.CadenceContractInterfaceTypeMemoryUsage)
-	return NewContractInterfaceType(location, qualifiedIdentifer, fields, initializers)
+	return NewContractInterfaceType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*ContractInterfaceType) isType() {}
@@ -1346,6 +1372,10 @@ func (t *ContractInterfaceType) InterfaceTypeQualifiedIdentifier() string {
 
 func (t *ContractInterfaceType) InterfaceFields() []Field {
 	return t.Fields
+}
+
+func (t *ContractInterfaceType) SetInterfaceFields(fields []Field) {
+	t.Fields = fields
 }
 
 func (t *ContractInterfaceType) InterfaceInitializers() [][]Parameter {
@@ -1682,6 +1712,10 @@ func (t *EnumType) CompositeTypeQualifiedIdentifier() string {
 
 func (t *EnumType) CompositeFields() []Field {
 	return t.Fields
+}
+
+func (t *EnumType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
 }
 
 func (t *EnumType) CompositeInitializers() [][]Parameter {


### PR DESCRIPTION
[Just like when encoding a type](https://github.com/onflow/cadence/blob/80f68a02b9942e5b6fa7517e3b2004c79a76a2fa/encoding/json/encode.go#L662-L662), keep track of the results of decoding a type.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
