### PR TITLE
Fix decoding of repeated/recursive encoded types

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -873,7 +873,7 @@ func (d *Decoder) decodeFieldTypes(fs []any, results typeDecodingResults) []cade
 
 	fields := make([]cadence.Field, 0, len(fs))
 
-	for _, field := range fields {
+	for _, field := range fs {
 		fields = append(fields, d.decodeFieldType(field, results))
 	}
 
@@ -906,8 +906,7 @@ func (d *Decoder) decodeNominalType(
 	kind, typeID string,
 	fs, initializers []any,
 	results typeDecodingResults,
-) (ty cadence.Type) {
-	fields := d.decodeFieldTypes(fs, results)
+) cadence.Type {
 
 	// Unmetered because this is created as an array of nil arrays, not Parameter structs
 	inits := make([][]cadence.Parameter, 0, len(initializers))
@@ -923,79 +922,100 @@ func (d *Decoder) decodeNominalType(
 		panic(ErrInvalidJSONCadence)
 	}
 
+	var result cadence.Type
+	var interfaceType cadence.InterfaceType
+	var compositeType cadence.CompositeType
+
 	switch kind {
 	case "Struct":
-		ty = cadence.NewMeteredStructType(
+		compositeType = cadence.NewMeteredStructType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
-			fields,
+			nil,
 			inits,
 		)
+		result = compositeType
 	case "Resource":
-		ty = cadence.NewMeteredResourceType(
+		compositeType = cadence.NewMeteredResourceType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
-			fields,
+			nil,
 			inits,
 		)
+		result = compositeType
 	case "Event":
-		ty = cadence.NewMeteredEventType(
+		compositeType = cadence.NewMeteredEventType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
-			fields,
+			nil,
 			inits[0],
 		)
+		result = compositeType
 	case "Contract":
-		ty = cadence.NewMeteredContractType(
+		compositeType = cadence.NewMeteredContractType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
-			fields,
+			nil,
 			inits,
 		)
+		result = compositeType
 	case "StructInterface":
-		ty = cadence.NewMeteredStructInterfaceType(
+		interfaceType = cadence.NewMeteredStructInterfaceType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
-			fields,
+			nil,
 			inits,
 		)
+		result = interfaceType
 	case "ResourceInterface":
-		ty = cadence.NewMeteredResourceInterfaceType(
+		interfaceType = cadence.NewMeteredResourceInterfaceType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
-			fields,
+			nil,
 			inits,
 		)
+		result = interfaceType
 	case "ContractInterface":
-		ty = cadence.NewMeteredContractInterfaceType(
+		interfaceType = cadence.NewMeteredContractInterfaceType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
-			fields,
+			nil,
 			inits,
 		)
+		result = interfaceType
 	case "Enum":
-		ty = cadence.NewMeteredEnumType(
+		compositeType = cadence.NewMeteredEnumType(
 			d.gauge,
 			location,
 			qualifiedIdentifier,
 			d.decodeType(obj.Get(typeKey), results),
-			fields,
+			nil,
 			inits,
 		)
+		result = compositeType
 	default:
 		panic(ErrInvalidJSONCadence)
 	}
 
-	results[typeID] = ty
+	results[typeID] = result
 
-	return ty
+	fields := d.decodeFieldTypes(fs, results)
+
+	switch {
+	case compositeType != nil:
+		compositeType.SetCompositeFields(fields)
+	case interfaceType != nil:
+		interfaceType.SetInterfaceFields(fields)
+	}
+
+	return result
 }
 
 func (d *Decoder) decodeRestrictedType(

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -629,7 +629,7 @@ func (d *Decoder) decodeComposite(valueJSON any) composite {
 	if err != nil ||
 		location == nil && sema.NativeCompositeTypes[typeID] == nil {
 
-		// If the location is nil, and there is no native composite type with this ID, then its an invalid type.
+		// If the location is nil, and there is no native composite type with this ID, then it's an invalid type.
 		// Note: This is moved out from the common.DecodeTypeID() to avoid the circular dependency.
 		panic(fmt.Errorf("%s. invalid type ID: `%s`", ErrInvalidJSONCadence, typeID))
 	}
@@ -841,17 +841,17 @@ func (d *Decoder) decodePath(valueJSON any) cadence.Path {
 	)
 }
 
-func (d *Decoder) decodeParamType(valueJSON any) cadence.Parameter {
+func (d *Decoder) decodeParamType(valueJSON any, results typeDecodingResults) cadence.Parameter {
 	obj := toObject(valueJSON)
 	// Unmetered because decodeParamType is metered in decodeParamTypes and called nowhere else
 	return cadence.NewParameter(
 		toString(obj.Get(labelKey)),
 		toString(obj.Get(idKey)),
-		d.decodeType(obj.Get(typeKey)),
+		d.decodeType(obj.Get(typeKey), results),
 	)
 }
 
-func (d *Decoder) decodeParamTypes(params []any) []cadence.Parameter {
+func (d *Decoder) decodeParamTypes(params []any, results typeDecodingResults) []cadence.Parameter {
 	common.UseMemory(d.gauge, common.MemoryUsage{
 		Kind:   common.MemoryKindCadenceParameter,
 		Amount: uint64(len(params)),
@@ -859,39 +859,44 @@ func (d *Decoder) decodeParamTypes(params []any) []cadence.Parameter {
 	parameters := make([]cadence.Parameter, 0, len(params))
 
 	for _, param := range params {
-		parameters = append(parameters, d.decodeParamType(param))
+		parameters = append(parameters, d.decodeParamType(param, results))
 	}
 
 	return parameters
 }
 
-func (d *Decoder) decodeFieldTypes(fs []any) []cadence.Field {
+func (d *Decoder) decodeFieldTypes(fs []any, results typeDecodingResults) []cadence.Field {
 	common.UseMemory(d.gauge, common.MemoryUsage{
 		Kind:   common.MemoryKindCadenceField,
 		Amount: uint64(len(fs)),
 	})
 
-	fields := make([]cadence.Field, 0, len(fs))
+	count := len(fs)
+	if count == 0 {
+		return nil
+	}
 
-	for _, field := range fs {
-		fields = append(fields, d.decodeFieldType(field))
+	fields := make([]cadence.Field, 0, count)
+
+	for _, field := range fields {
+		fields = append(fields, d.decodeFieldType(field, results))
 	}
 
 	return fields
 }
 
-func (d *Decoder) decodeFieldType(valueJSON any) cadence.Field {
+func (d *Decoder) decodeFieldType(valueJSON any, results typeDecodingResults) cadence.Field {
 	obj := toObject(valueJSON)
 	// Unmetered because decodeFieldType is metered in decodeFieldTypes and called nowhere else
 	return cadence.NewField(
 		toString(obj.Get(idKey)),
-		d.decodeType(obj.Get(typeKey)),
+		d.decodeType(obj.Get(typeKey), results),
 	)
 }
 
-func (d *Decoder) decodeFunctionType(returnValue, parametersValue, id any) cadence.Type {
-	parameters := d.decodeParamTypes(toSlice(parametersValue))
-	returnType := d.decodeType(returnValue)
+func (d *Decoder) decodeFunctionType(returnValue, parametersValue, id any, results typeDecodingResults) cadence.Type {
+	parameters := d.decodeParamTypes(toSlice(parametersValue), results)
+	returnType := d.decodeType(returnValue, results)
 
 	return cadence.NewMeteredFunctionType(
 		d.gauge,
@@ -901,100 +906,117 @@ func (d *Decoder) decodeFunctionType(returnValue, parametersValue, id any) caden
 	).WithID(toString(id))
 }
 
-func (d *Decoder) decodeNominalType(obj jsonObject, kind, typeID string, fs, initializers []any) cadence.Type {
-	fields := d.decodeFieldTypes(fs)
+func (d *Decoder) decodeNominalType(
+	obj jsonObject,
+	kind, typeID string,
+	fs, initializers []any,
+	results typeDecodingResults,
+) (ty cadence.Type) {
+	fields := d.decodeFieldTypes(fs, results)
 
 	// Unmetered because this is created as an array of nil arrays, not Parameter structs
-	inits := make([][]cadence.Parameter, 0, len(initializers))
-	for _, params := range initializers {
-		inits = append(inits, d.decodeParamTypes(toSlice(params)))
+	var inits [][]cadence.Ω
+	count := len(initializers)
+	if count > 0 {
+		inits = make([][]cadence.Parameter, 0, count)
+		for _, params := range initializers {
+			inits = append(
+				inits,
+				d.decodeParamTypes(toSlice(params), results),
+			)
+		}
 	}
 
-	location, id, err := common.DecodeTypeID(d.gauge, typeID)
+	location, qualifiedIdentifier, err := common.DecodeTypeID(d.gauge, typeID)
 	if err != nil {
 		panic(ErrInvalidJSONCadence)
 	}
 
 	switch kind {
 	case "Struct":
-		return cadence.NewMeteredStructType(
+		ty = cadence.NewMeteredStructType(
 			d.gauge,
 			location,
-			id,
+			qualifiedIdentifier,
 			fields,
 			inits,
 		)
 	case "Resource":
-		return cadence.NewMeteredResourceType(
+		ty = cadence.NewMeteredResourceType(
 			d.gauge,
 			location,
-			id,
+			qualifiedIdentifier,
 			fields,
 			inits,
 		)
 	case "Event":
-		return cadence.NewMeteredEventType(
+		ty = cadence.NewMeteredEventType(
 			d.gauge,
 			location,
-			id,
+			qualifiedIdentifier,
 			fields,
 			inits[0],
 		)
 	case "Contract":
-		return cadence.NewMeteredContractType(
+		ty = cadence.NewMeteredContractType(
 			d.gauge,
 			location,
-			id,
+			qualifiedIdentifier,
 			fields,
 			inits,
 		)
 	case "StructInterface":
-		return cadence.NewMeteredStructInterfaceType(
+		ty = cadence.NewMeteredStructInterfaceType(
 			d.gauge,
 			location,
-			id,
+			qualifiedIdentifier,
 			fields,
 			inits,
 		)
 	case "ResourceInterface":
-		return cadence.NewMeteredResourceInterfaceType(
+		ty = cadence.NewMeteredResourceInterfaceType(
 			d.gauge,
 			location,
-			id,
+			qualifiedIdentifier,
 			fields,
 			inits,
 		)
 	case "ContractInterface":
-		return cadence.NewMeteredContractInterfaceType(
+		ty = cadence.NewMeteredContractInterfaceType(
 			d.gauge,
 			location,
-			id,
+			qualifiedIdentifier,
 			fields,
 			inits,
 		)
 	case "Enum":
-		return cadence.NewMeteredEnumType(
+		ty = cadence.NewMeteredEnumType(
 			d.gauge,
 			location,
-			id,
-			d.decodeType(obj.Get(typeKey)),
+			qualifiedIdentifier,
+			d.decodeType(obj.Get(typeKey), results),
 			fields,
 			inits,
 		)
+	default:
+		panic(ErrInvalidJSONCadence)
 	}
 
-	panic(ErrInvalidJSONCadence)
+	results[typeID] = ty
+
+	return ty
 }
 
 func (d *Decoder) decodeRestrictedType(
 	typeValue any,
 	restrictionsValue []any,
 	typeIDValue string,
+	results typeDecodingResults,
 ) cadence.Type {
-	typ := d.decodeType(typeValue)
+	typ := d.decodeType(typeValue, results)
 	restrictions := make([]cadence.Type, 0, len(restrictionsValue))
 	for _, restriction := range restrictionsValue {
-		restrictions = append(restrictions, d.decodeType(restriction))
+		restrictions = append(restrictions, d.decodeType(restriction, results))
 	}
 
 	return cadence.NewMeteredRestrictedType(
@@ -1005,10 +1027,20 @@ func (d *Decoder) decodeRestrictedType(
 	).WithID(typeIDValue)
 }
 
-func (d *Decoder) decodeType(valueJSON any) cadence.Type {
+type typeDecodingResults map[string]cadence.Type
+
+func (d *Decoder) decodeType(valueJSON any, results typeDecodingResults) cadence.Type {
 	if valueJSON == "" {
 		return nil
 	}
+
+	typeID, ok := valueJSON.(string)
+	if ok {
+		if result, ok := results[typeID]; ok {
+			return result
+		}
+	}
+
 	obj := toObject(valueJSON)
 	kindValue := toString(obj.Get(kindKey))
 
@@ -1017,46 +1049,51 @@ func (d *Decoder) decodeType(valueJSON any) cadence.Type {
 		returnValue := obj.Get(returnKey)
 		parametersValue := obj.Get(parametersKey)
 		idValue := obj.Get(typeIDKey)
-		return d.decodeFunctionType(returnValue, parametersValue, idValue)
+		return d.decodeFunctionType(returnValue, parametersValue, idValue, results)
 	case "Restriction":
 		restrictionsValue := obj.Get(restrictionsKey)
 		typeIDValue := toString(obj.Get(typeIDKey))
 		typeValue := obj.Get(typeKey)
-		return d.decodeRestrictedType(typeValue, toSlice(restrictionsValue), typeIDValue)
+		return d.decodeRestrictedType(
+			typeValue,
+			toSlice(restrictionsValue),
+			typeIDValue,
+			results,
+		)
 	case "Optional":
 		return cadence.NewMeteredOptionalType(
 			d.gauge,
-			d.decodeType(obj.Get(typeKey)),
+			d.decodeType(obj.Get(typeKey), results),
 		)
 	case "VariableSizedArray":
 		return cadence.NewMeteredVariableSizedArrayType(
 			d.gauge,
-			d.decodeType(obj.Get(typeKey)),
+			d.decodeType(obj.Get(typeKey), results),
 		)
 	case "Capability":
 		return cadence.NewMeteredCapabilityType(
 			d.gauge,
-			d.decodeType(obj.Get(typeKey)),
+			d.decodeType(obj.Get(typeKey), results),
 		)
 	case "Dictionary":
 		return cadence.NewMeteredDictionaryType(
 			d.gauge,
-			d.decodeType(obj.Get(keyKey)),
-			d.decodeType(obj.Get(valueKey)),
+			d.decodeType(obj.Get(keyKey), results),
+			d.decodeType(obj.Get(valueKey), results),
 		)
 	case "ConstantSizedArray":
 		size := toUInt(obj.Get(sizeKey))
 		return cadence.NewMeteredConstantSizedArrayType(
 			d.gauge,
 			size,
-			d.decodeType(obj.Get(typeKey)),
+			d.decodeType(obj.Get(typeKey), results),
 		)
 	case "Reference":
 		auth := toBool(obj.Get(authorizedKey))
 		return cadence.NewMeteredReferenceType(
 			d.gauge,
 			auth,
-			d.decodeType(obj.Get(typeKey)),
+			d.decodeType(obj.Get(typeKey), results),
 		)
 	case "Any":
 		return cadence.NewMeteredAnyType(d.gauge)
@@ -1164,7 +1201,14 @@ func (d *Decoder) decodeType(valueJSON any) cadence.Type {
 		fieldsValue := obj.Get(fieldsKey)
 		typeIDValue := toString(obj.Get(typeIDKey))
 		initValue := obj.Get(initializersKey)
-		return d.decodeNominalType(obj, kindValue, typeIDValue, toSlice(fieldsValue), toSlice(initValue))
+		return d.decodeNominalType(
+			obj,
+			kindValue,
+			typeIDValue,
+			toSlice(fieldsValue),
+			toSlice(initValue),
+			results,
+		)
 	}
 }
 
@@ -1173,7 +1217,7 @@ func (d *Decoder) decodeTypeValue(valueJSON any) cadence.TypeValue {
 
 	return cadence.NewMeteredTypeValue(
 		d.gauge,
-		d.decodeType(obj.Get(staticTypeKey)),
+		d.decodeType(obj.Get(staticTypeKey), typeDecodingResults{}),
 	)
 }
 
@@ -1190,7 +1234,7 @@ func (d *Decoder) decodeCapability(valueJSON any) cadence.Capability {
 		d.gauge,
 		path,
 		d.decodeAddress(obj.Get(addressKey)),
-		d.decodeType(obj.Get(borrowTypeKey)),
+		d.decodeType(obj.Get(borrowTypeKey), typeDecodingResults{}),
 	)
 }
 

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -871,12 +871,7 @@ func (d *Decoder) decodeFieldTypes(fs []any, results typeDecodingResults) []cade
 		Amount: uint64(len(fs)),
 	})
 
-	count := len(fs)
-	if count == 0 {
-		return nil
-	}
-
-	fields := make([]cadence.Field, 0, count)
+	fields := make([]cadence.Field, 0, len(fs))
 
 	for _, field := range fields {
 		fields = append(fields, d.decodeFieldType(field, results))
@@ -915,16 +910,12 @@ func (d *Decoder) decodeNominalType(
 	fields := d.decodeFieldTypes(fs, results)
 
 	// Unmetered because this is created as an array of nil arrays, not Parameter structs
-	var inits [][]cadence.Ω
-	count := len(initializers)
-	if count > 0 {
-		inits = make([][]cadence.Parameter, 0, count)
-		for _, params := range initializers {
-			inits = append(
-				inits,
-				d.decodeParamTypes(toSlice(params), results),
-			)
-		}
+	inits := make([][]cadence.Parameter, 0, len(initializers))
+	for _, params := range initializers {
+		inits = append(
+			inits,
+			d.decodeParamTypes(toSlice(params), results),
+		)
 	}
 
 	location, qualifiedIdentifier, err := common.DecodeTypeID(d.gauge, typeID)

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -620,7 +620,7 @@ func preparePath(x cadence.Path) jsonValue {
 	}
 }
 
-func prepareParameterType(parameterType cadence.Parameter, results typeResults) jsonParameterType {
+func prepareParameterType(parameterType cadence.Parameter, results typePreparationResults) jsonParameterType {
 	return jsonParameterType{
 		Label: parameterType.Label,
 		Id:    parameterType.Identifier,
@@ -628,14 +628,14 @@ func prepareParameterType(parameterType cadence.Parameter, results typeResults) 
 	}
 }
 
-func prepareFieldType(fieldType cadence.Field, results typeResults) jsonFieldType {
+func prepareFieldType(fieldType cadence.Field, results typePreparationResults) jsonFieldType {
 	return jsonFieldType{
 		Id:   fieldType.Identifier,
 		Type: prepareType(fieldType.Type, results),
 	}
 }
 
-func prepareFields(fieldTypes []cadence.Field, results typeResults) []jsonFieldType {
+func prepareFields(fieldTypes []cadence.Field, results typePreparationResults) []jsonFieldType {
 	fields := make([]jsonFieldType, 0)
 	for _, field := range fieldTypes {
 		fields = append(fields, prepareFieldType(field, results))
@@ -643,7 +643,7 @@ func prepareFields(fieldTypes []cadence.Field, results typeResults) []jsonFieldT
 	return fields
 }
 
-func prepareParameters(parameterTypes []cadence.Parameter, results typeResults) []jsonParameterType {
+func prepareParameters(parameterTypes []cadence.Parameter, results typePreparationResults) []jsonParameterType {
 	parameters := make([]jsonParameterType, 0)
 	for _, param := range parameterTypes {
 		parameters = append(parameters, prepareParameterType(param, results))
@@ -651,7 +651,7 @@ func prepareParameters(parameterTypes []cadence.Parameter, results typeResults) 
 	return parameters
 }
 
-func prepareInitializers(initializerTypes [][]cadence.Parameter, results typeResults) [][]jsonParameterType {
+func prepareInitializers(initializerTypes [][]cadence.Parameter, results typePreparationResults) [][]jsonParameterType {
 	initializers := make([][]jsonParameterType, 0)
 	for _, params := range initializerTypes {
 		initializers = append(initializers, prepareParameters(params, results))
@@ -659,7 +659,7 @@ func prepareInitializers(initializerTypes [][]cadence.Parameter, results typeRes
 	return initializers
 }
 
-func prepareType(typ cadence.Type, results typeResults) jsonValue {
+func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 
 	var supportedRecursiveType bool
 	switch typ.(type) {
@@ -856,13 +856,13 @@ func prepareType(typ cadence.Type, results typeResults) jsonValue {
 	}
 }
 
-type typeResults map[cadence.Type]struct{}
+type typePreparationResults map[cadence.Type]struct{}
 
 func prepareTypeValue(typeValue cadence.TypeValue) jsonValue {
 	return jsonValueObject{
 		Type: typeTypeStr,
 		Value: jsonTypeValue{
-			StaticType: prepareType(typeValue.StaticType, typeResults{}),
+			StaticType: prepareType(typeValue.StaticType, typePreparationResults{}),
 		},
 	}
 }
@@ -873,7 +873,7 @@ func prepareCapability(capability cadence.Capability) jsonValue {
 		Value: jsonCapabilityValue{
 			Path:       preparePath(capability.Path),
 			Address:    encodeBytes(capability.Address.Bytes()),
-			BorrowType: prepareType(capability.BorrowType, typeResults{}),
+			BorrowType: prepareType(capability.BorrowType, typePreparationResults{}),
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1833,6 +1833,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 					Identifier: "foo",
 				},
 			},
+			Initializers: [][]cadence.Parameter{},
 		}
 
 		ty.Fields[0].Type = cadence.OptionalType{
@@ -1856,6 +1857,8 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 		fooTy := &cadence.ResourceType{
 			Location:            utils.TestLocation,
 			QualifiedIdentifier: "Foo",
+			Fields:              []cadence.Field{},
+			Initializers:        [][]cadence.Parameter{},
 		}
 
 		barTy := &cadence.ResourceType{
@@ -1871,6 +1874,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 					Type:       fooTy,
 				},
 			},
+			Initializers: [][]cadence.Parameter{},
 		}
 
 		testEncodeAndDecode(

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1839,7 +1839,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 			Type: ty,
 		}
 
-		testEncode(
+		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
 				StaticType: ty,
@@ -1873,7 +1873,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 			},
 		}
 
-		testEncode(
+		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
 				StaticType: barTy,

--- a/npm-packages/cadence-docgen/package.json
+++ b/npm-packages/cadence-docgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-docgen",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "The Cadence Dcoument Generator",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/types.go
+++ b/types.go
@@ -904,6 +904,7 @@ type CompositeType interface {
 	CompositeTypeLocation() common.Location
 	CompositeTypeQualifiedIdentifier() string
 	CompositeFields() []Field
+	SetCompositeFields([]Field)
 	CompositeInitializers() [][]Parameter
 }
 
@@ -918,13 +919,13 @@ type StructType struct {
 
 func NewStructType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *StructType {
 	return &StructType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -963,6 +964,10 @@ func (t *StructType) CompositeTypeQualifiedIdentifier() string {
 
 func (t *StructType) CompositeFields() []Field {
 	return t.Fields
+}
+
+func (t *StructType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
 }
 
 func (t *StructType) CompositeInitializers() [][]Parameter {
@@ -1027,6 +1032,10 @@ func (t *ResourceType) CompositeFields() []Field {
 	return t.Fields
 }
 
+func (t *ResourceType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *ResourceType) CompositeInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1089,6 +1098,10 @@ func (t *EventType) CompositeFields() []Field {
 	return t.Fields
 }
 
+func (t *EventType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *EventType) CompositeInitializers() [][]Parameter {
 	return [][]Parameter{t.Initializer}
 }
@@ -1104,13 +1117,13 @@ type ContractType struct {
 
 func NewContractType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractType {
 	return &ContractType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1119,12 +1132,12 @@ func NewContractType(
 func NewMeteredContractType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractType {
 	common.UseMemory(gauge, common.CadenceContractTypeMemoryUsage)
-	return NewContractType(location, qualifiedIdentifer, fields, initializers)
+	return NewContractType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*ContractType) isType() {}
@@ -1151,6 +1164,10 @@ func (t *ContractType) CompositeFields() []Field {
 	return t.Fields
 }
 
+func (t *ContractType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *ContractType) CompositeInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1163,6 +1180,7 @@ type InterfaceType interface {
 	InterfaceTypeLocation() common.Location
 	InterfaceTypeQualifiedIdentifier() string
 	InterfaceFields() []Field
+	SetInterfaceFields(fields []Field)
 	InterfaceInitializers() [][]Parameter
 }
 
@@ -1177,13 +1195,13 @@ type StructInterfaceType struct {
 
 func NewStructInterfaceType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *StructInterfaceType {
 	return &StructInterfaceType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1192,12 +1210,12 @@ func NewStructInterfaceType(
 func NewMeteredStructInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *StructInterfaceType {
 	common.UseMemory(gauge, common.CadenceStructInterfaceTypeMemoryUsage)
-	return NewStructInterfaceType(location, qualifiedIdentifer, fields, initializers)
+	return NewStructInterfaceType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*StructInterfaceType) isType() {}
@@ -1224,6 +1242,10 @@ func (t *StructInterfaceType) InterfaceFields() []Field {
 	return t.Fields
 }
 
+func (t *StructInterfaceType) SetInterfaceFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *StructInterfaceType) InterfaceInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1239,13 +1261,13 @@ type ResourceInterfaceType struct {
 
 func NewResourceInterfaceType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ResourceInterfaceType {
 	return &ResourceInterfaceType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1254,12 +1276,12 @@ func NewResourceInterfaceType(
 func NewMeteredResourceInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ResourceInterfaceType {
 	common.UseMemory(gauge, common.CadenceResourceInterfaceTypeMemoryUsage)
-	return NewResourceInterfaceType(location, qualifiedIdentifer, fields, initializers)
+	return NewResourceInterfaceType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*ResourceInterfaceType) isType() {}
@@ -1286,6 +1308,10 @@ func (t *ResourceInterfaceType) InterfaceFields() []Field {
 	return t.Fields
 }
 
+func (t *ResourceInterfaceType) SetInterfaceFields(fields []Field) {
+	t.Fields = fields
+}
+
 func (t *ResourceInterfaceType) InterfaceInitializers() [][]Parameter {
 	return t.Initializers
 }
@@ -1301,13 +1327,13 @@ type ContractInterfaceType struct {
 
 func NewContractInterfaceType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractInterfaceType {
 	return &ContractInterfaceType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1316,12 +1342,12 @@ func NewContractInterfaceType(
 func NewMeteredContractInterfaceType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ContractInterfaceType {
 	common.UseMemory(gauge, common.CadenceContractInterfaceTypeMemoryUsage)
-	return NewContractInterfaceType(location, qualifiedIdentifer, fields, initializers)
+	return NewContractInterfaceType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*ContractInterfaceType) isType() {}
@@ -1346,6 +1372,10 @@ func (t *ContractInterfaceType) InterfaceTypeQualifiedIdentifier() string {
 
 func (t *ContractInterfaceType) InterfaceFields() []Field {
 	return t.Fields
+}
+
+func (t *ContractInterfaceType) SetInterfaceFields(fields []Field) {
+	t.Fields = fields
 }
 
 func (t *ContractInterfaceType) InterfaceInitializers() [][]Parameter {
@@ -1682,6 +1712,10 @@ func (t *EnumType) CompositeTypeQualifiedIdentifier() string {
 
 func (t *EnumType) CompositeFields() []Field {
 	return t.Fields
+}
+
+func (t *EnumType) SetCompositeFields(fields []Field) {
+	t.Fields = fields
 }
 
 func (t *EnumType) CompositeInitializers() [][]Parameter {

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.24.1"
+const Version = "v0.24.2"


### PR DESCRIPTION
Port of #1720

## Description

[Just like when encoding a type](https://github.com/onflow/cadence/blob/80f68a02b9942e5b6fa7517e3b2004c79a76a2fa/encoding/json/encode.go#L662-L662), keep track of the results of decoding a type.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
