### PR TITLE
Improve type json docs

### DIFF
--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -506,7 +506,7 @@ These are basic types like `Int`, `String`, or `StoragePath`.
 
 ```json
 {
-  "kind": "Struct" | "Resource" | "Event" | "Constract" | "StructInterface" | "ResourceInterface" | "ContractInterface",
+  "kind": "Struct" | "Resource" | "Event" | "Contract" | "StructInterface" | "ResourceInterface" | "ContractInterface",
   "type": "", // this field exists only to keep parity with the enum structure below; the value must be the empty string
   "typeID": "<fully qualified type ID>",
   "initializers": [

--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -383,8 +383,19 @@ These are basic types like `Int`, `String`, or `StoragePath`.
 
 ```json
 {
-  "kind": "<type>"
-}
+  "kind": "Any" | "AnyStruct" | "AnyResource" | "Type" | 
+    "Void" | "Never" | "Bool" | "String" | "Character" | 
+    "Bytes" | "Address" | "Number" | "SignedNumber" | 
+    "Integer" | "SignedInteger" | "FixedPoint" | 
+    "SignedFixedPoint" | "Int" | "Int8" | "Int16" | 
+    "Int32" | "Int64" | "Int128" | "Int256" | "UInt" | 
+    "UInt8" | "UInt16" | "UInt32" | "UInt64" | "UInt128" | 
+    "UInt256" | "Word8" | "Word16" | "Word32" | "Word64" | 
+    "Fix64" | "UFix64" | "Path" | "CapabilityPath" | "StoragePath" |
+    "PublicPath" | "PrivatePath" | "AuthAccount" | "PublicAccount" | 
+    "AuthAccount.Keys" | "PublicAccount.Keys" | "AuthAccount.Contracts" | 
+    "PublicAccount.Contracts" | "DeployedContract" | "AccountKey" | "Block" 
+}"
 ```
 
 ### Example
@@ -496,7 +507,7 @@ These are basic types like `Int`, `String`, or `StoragePath`.
 ```json
 {
   "kind": "Struct" | "Resource" | "Event" | "Constract" | "StructInterface" | "ResourceInterface" | "ContractInterface",
-  "type": "",
+  "type": "", // this field exists only to keep parity with the enum structure below; the value must be the empty string
   "typeID": "<fully qualified type ID>",
   "initializers": [
     <initializer at index 0>,

--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -395,7 +395,7 @@ These are basic types like `Int`, `String`, or `StoragePath`.
     "PublicPath" | "PrivatePath" | "AuthAccount" | "PublicAccount" | 
     "AuthAccount.Keys" | "PublicAccount.Keys" | "AuthAccount.Contracts" | 
     "PublicAccount.Contracts" | "DeployedContract" | "AccountKey" | "Block" 
-}"
+}
 ```
 
 ### Example


### PR DESCRIPTION
Address follow-up comments in https://github.com/onflow/cadence/issues/1724

## Description

Adds a list of all simple type kinds, and a comment explaining why the composite type structure must contain an empty string.

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
