### PR TITLE
Allow decoding of types in pre-0.3.0 format (just type ID)

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -35,17 +35,30 @@ import (
 
 // A Decoder decodes JSON-encoded representations of Cadence values.
 type Decoder struct {
-	dec   *json.Decoder
-	gauge common.MemoryGauge
+	dec                          *json.Decoder
+	gauge                        common.MemoryGauge
+	allowUnstructuredStaticTypes bool
+}
+
+type Option func(*Decoder)
+
+func WithAllowUnstructuredStaticTypes(allow bool) Option {
+	return func(decoder *Decoder) {
+		decoder.allowUnstructuredStaticTypes = allow
+	}
 }
 
 // Decode returns a Cadence value decoded from its JSON-encoded representation.
 //
 // This function returns an error if the bytes represent JSON that is malformed
 // or does not conform to the JSON Cadence specification.
-func Decode(gauge common.MemoryGauge, b []byte) (cadence.Value, error) {
+func Decode(gauge common.MemoryGauge, b []byte, options ...Option) (cadence.Value, error) {
 	r := bytes.NewReader(b)
 	dec := NewDecoder(gauge, r)
+
+	for _, option := range options {
+		option(dec)
+	}
 
 	v, err := dec.Decode()
 	if err != nil {
@@ -1050,8 +1063,11 @@ func (d *Decoder) decodeType(valueJSON interface{}, results typeDecodingResults)
 			return result
 		}
 
-		// Backwards-compatibility for format <0.3.0
-		return cadence.TypeID(typeID)
+		// Backwards-compatibility for format <0.3.0:
+		// static types were encoded as
+		if d.allowUnstructuredStaticTypes {
+			return cadence.TypeID(typeID)
+		}
 	}
 
 	obj := toObject(valueJSON)

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -35,13 +35,19 @@ import (
 
 // A Decoder decodes JSON-encoded representations of Cadence values.
 type Decoder struct {
-	dec                          *json.Decoder
-	gauge                        common.MemoryGauge
+	dec   *json.Decoder
+	gauge common.MemoryGauge
+	// allowUnstructuredStaticTypes controls if the decoding
+	// of a static type as a type ID (cadence.TypeID) is allowed
 	allowUnstructuredStaticTypes bool
 }
 
 type Option func(*Decoder)
 
+// WithAllowUnstructuredStaticTypes returns a new Decoder Option
+// which enables or disables if the decoding of a static type
+// as a type ID (cadence.TypeID) is allowed
+//
 func WithAllowUnstructuredStaticTypes(allow bool) Option {
 	return func(decoder *Decoder) {
 		decoder.allowUnstructuredStaticTypes = allow

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -1045,11 +1045,13 @@ func (d *Decoder) decodeType(valueJSON interface{}, results typeDecodingResults)
 		return nil
 	}
 
-	typeID, ok := valueJSON.(string)
-	if ok {
+	if typeID, ok := valueJSON.(string); ok {
 		if result, ok := results[typeID]; ok {
 			return result
 		}
+
+		// Backwards-compatibility for format <0.3.0
+		return cadence.TypeID(typeID)
 	}
 
 	obj := toObject(valueJSON)

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -2029,13 +2029,28 @@ func TestDecodeBackwardsCompatibilityTypeID(t *testing.T) {
 
 	t.Parallel()
 
-	testDecode(
-		t,
-		`{"type":"Type","value":{"staticType":"&Int"}}}`,
+	const encoded = `{"type":"Type","value":{"staticType":"&Int"}}}`
 
-		cadence.TypeValue{
-			StaticType: cadence.TypeID("&Int"),
-		},
-		json.WithAllowUnstructuredStaticTypes(true),
-	)
+	t.Run("unstructured static types allowed", func(t *testing.T) {
+
+		t.Parallel()
+
+		testDecode(
+			t,
+			encoded,
+
+			cadence.TypeValue{
+				StaticType: cadence.TypeID("&Int"),
+			},
+			json.WithAllowUnstructuredStaticTypes(true),
+		)
+	})
+
+	t.Run("unstructured static types disallowed", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := json.Decode(nil, []byte(encoded))
+		require.Error(t, err)
+	})
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -2024,3 +2024,17 @@ func TestNonUTF8StringEncoding(t *testing.T) {
 	assert.IsType(t, cadence.String(""), decodedValue)
 	assert.True(t, utf8.ValidString(decodedValue.String()))
 }
+
+func TestDecodeBackwardsCompatibilityTypeID(t *testing.T) {
+
+	t.Parallel()
+
+	testDecode(
+		t,
+		`{"type":"Type","value":{"staticType":"&Int"}}}`,
+
+		cadence.TypeValue{
+			StaticType: cadence.TypeID("&Int"),
+		},
+	)
+}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1987,8 +1987,8 @@ func testEncode(t *testing.T, val cadence.Value, expectedJSON string) (actualJSO
 	return actualJSON
 }
 
-func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value) {
-	decodedVal, err := json.Decode(nil, []byte(actualJSON))
+func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value, options ...json.Option) {
+	decodedVal, err := json.Decode(nil, []byte(actualJSON), options...)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedVal, decodedVal)
@@ -2036,5 +2036,6 @@ func TestDecodeBackwardsCompatibilityTypeID(t *testing.T) {
 		cadence.TypeValue{
 			StaticType: cadence.TypeID("&Int"),
 		},
+		json.WithAllowUnstructuredStaticTypes(true),
 	)
 }

--- a/types.go
+++ b/types.go
@@ -29,6 +29,19 @@ type Type interface {
 	ID() string
 }
 
+// TypeID is a type which is only known by its type ID.
+// This type should not be used when encoding values,
+// and should only be used for decoding values that were encoded
+// using an older format of the JSON encoding (<v0.3.0)
+//
+type TypeID string
+
+func (TypeID) isType() {}
+
+func (t TypeID) ID() string {
+	return string(t)
+}
+
 // AnyType
 
 type AnyType struct{}


### PR DESCRIPTION
## Description

Make it possible to use the current decoder for values that were encoded in the pre-0.3.0 format, where static types were encoded as a type ID.

For example, this allows off-chain consumers to decode older events.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
