### PR TITLE
[LS] Use a hosted emulator from flowkit

### DIFF
--- a/languageserver/integration/codelenses.go
+++ b/languageserver/integration/codelenses.go
@@ -33,10 +33,8 @@ import (
 
 const (
 	// Codelens message prefixes
-	prefixOK       = "💡"
-	prefixStarting = "⏲"
-	prefixOffline  = "⚠️"
-	prefixError    = "🚫"
+	prefixOK    = "💡"
+	prefixError = "🚫"
 )
 
 func (i *FlowIntegration) codeLenses(
@@ -93,12 +91,6 @@ func (i *FlowIntegration) showDeployContractAction(
 	codelensRange := conversion.ASTToProtocolRange(position, position)
 	var codeLenses []*protocol.CodeLens
 
-	// Check emulator state
-	emulatorStateLens := i.checkEmulatorState(codelensRange)
-	if emulatorStateLens != nil {
-		return []*protocol.CodeLens{emulatorStateLens}, nil
-	}
-
 	if len(signersList) == 0 {
 		signersList = append(signersList, []string{i.activeAccount.Name})
 	}
@@ -137,13 +129,6 @@ func (i *FlowIntegration) entryPointActions(
 
 	codelensRange := conversion.ASTToProtocolRange(position, position)
 	var codeLenses []*protocol.CodeLens
-
-	// Check emulator state
-	emulatorStateLens := i.checkEmulatorState(codelensRange)
-	if emulatorStateLens != nil {
-		codeLenses = append(codeLenses, emulatorStateLens)
-		return codeLenses, nil
-	}
 
 	noParameters := len(entryPointInfo.parameters) == 0
 
@@ -248,29 +233,6 @@ func (i *FlowIntegration) showAbsentAccounts(accounts []string, codelensRange pr
 		common.EnumerateWords(accounts, "and"),
 	)
 	return makeActionlessCodelens(title, codelensRange)
-}
-
-func (i *FlowIntegration) checkEmulatorState(codelensRange protocol.Range) *protocol.CodeLens {
-	var title string
-	var codeLens *protocol.CodeLens
-
-	if i.emulatorState == EmulatorOffline {
-		title = fmt.Sprintf(
-			"%s Emulator is Offline. Click here to start it",
-			prefixOffline,
-		)
-		codeLens = makeCodeLens(ClientStartEmulator, title, codelensRange, nil)
-	}
-
-	if i.emulatorState == EmulatorStarting {
-		title = fmt.Sprintf(
-			"%s Emulator is starting up. Please wait \u2026",
-			prefixStarting,
-		)
-		codeLens = makeActionlessCodelens(title, codelensRange)
-	}
-
-	return codeLens
 }
 
 func (i *FlowIntegration) scriptCodeLenses(

--- a/languageserver/integration/commands.go
+++ b/languageserver/integration/commands.go
@@ -44,10 +44,7 @@ const (
 	CommandCreateAccount         = "cadence.server.flow.createAccount"
 	CommandCreateDefaultAccounts = "cadence.server.flow.createDefaultAccounts"
 	CommandSwitchActiveAccount   = "cadence.server.flow.switchActiveAccount"
-	CommandChangeEmulatorState   = "cadence.server.flow.changeEmulatorState"
 	CommandInitAccountManager    = "cadence.server.flow.initAccountManager"
-
-	ClientStartEmulator = "cadence.runEmulator"
 
 	ErrorMessageEmulator          = "emulator error"
 	ErrorMessageServiceAccount    = "service account error"
@@ -76,10 +73,6 @@ func (i *FlowIntegration) commands() []server.Command {
 		{
 			Name:    CommandDeployContract,
 			Handler: i.deployContract,
-		},
-		{
-			Name:    CommandChangeEmulatorState,
-			Handler: i.changeEmulatorState,
 		},
 		{
 			Name:    CommandSwitchActiveAccount,
@@ -363,30 +356,6 @@ func (i *FlowIntegration) executeScript(conn protocol.Conn, args ...json.RawMess
 	}
 
 	showMessage(conn, fmt.Sprintf("Result: %s", scriptResult.String()))
-	return nil, nil
-}
-
-// changeEmulatorState sets current state of the emulator as reported by LSP
-// used to update Code Lenses with proper title
-//
-// There should be exactly 1 argument:
-// * current state of the emulator represented as byte
-func (i *FlowIntegration) changeEmulatorState(conn protocol.Conn, args ...json.RawMessage) (interface{}, error) {
-	err := server.CheckCommandArgumentCount(args, 1)
-	if err != nil {
-		return nil, errorWithMessage(conn, ErrorMessageArguments, err)
-	}
-
-	var emulatorState float64
-	err = json.Unmarshal(args[0], &emulatorState)
-	if err != nil {
-		return nil, errorWithMessage(
-			conn,
-			ErrorMessageArguments,
-			fmt.Errorf("invalid emulator state argument: %#+v: %w", args[0], err),
-		)
-	}
-
 	return nil, nil
 }
 

--- a/languageserver/integration/commands.go
+++ b/languageserver/integration/commands.go
@@ -22,11 +22,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/onflow/cadence"
 	"io/ioutil"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/onflow/cadence"
 
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-go-sdk"
@@ -386,7 +387,6 @@ func (i *FlowIntegration) changeEmulatorState(conn protocol.Conn, args ...json.R
 		)
 	}
 
-	i.emulatorState = EmulatorState(emulatorState)
 	return nil, nil
 }
 

--- a/languageserver/integration/config.go
+++ b/languageserver/integration/config.go
@@ -34,9 +34,6 @@ type Config struct {
 	// The address where the emulator is running.
 	EmulatorAddr string
 
-	// Current emulator state
-	emulatorState EmulatorState
-
 	// Active account
 	activeAccount ClientAccount
 
@@ -60,12 +57,6 @@ func configFromInitializationOptions(opts any) (conf Config, err error) {
 	if !ok {
 		return Config{}, errors.New("invalid initialization options")
 	}
-
-	emulatorState, ok := optsMap["emulatorState"].(float64)
-	if !ok {
-		return Config{}, errors.New("initialization options: invalid emulator state")
-	}
-	conf.emulatorState = EmulatorState(emulatorState)
 
 	activeAccountName, ok := optsMap["activeAccountName"].(string)
 	if !ok {

--- a/languageserver/integration/initialization.go
+++ b/languageserver/integration/initialization.go
@@ -33,7 +33,6 @@ func (i *FlowIntegration) initialize(initializationOptions any) error {
 		return err
 	}
 	i.config = conf
-	i.emulatorState = conf.emulatorState
 	i.activeAccount = conf.activeAccount
 
 	configurationPaths := []string{conf.configPath}

--- a/languageserver/integration/initialization.go
+++ b/languageserver/integration/initialization.go
@@ -44,13 +44,14 @@ func (i *FlowIntegration) initialize(initializationOptions any) error {
 		return err
 	}
 
-	network, err := state.Networks().ByName("emulator")
+	logger := output.NewStdoutLogger(output.NoneLog)
+
+	serviceAccount, err := state.EmulatorServiceAccount()
 	if err != nil {
 		return err
 	}
-	logger := output.NewStdoutLogger(output.NoneLog)
 
-	grpcGateway, err := gateway.NewGrpcGateway(network.Host)
+	grpcGateway := gateway.NewEmulatorGateway(serviceAccount)
 	if err != nil {
 		return err
 	}

--- a/languageserver/integration/integration.go
+++ b/languageserver/integration/integration.go
@@ -42,7 +42,6 @@ type FlowIntegration struct {
 	contractInfo   map[protocol.DocumentURI]contractInfo
 
 	activeAccount ClientAccount
-	emulatorState EmulatorState
 
 	sharedServices *services.Services
 	state          *flowkit.State

--- a/languageserver/integration/integration.go
+++ b/languageserver/integration/integration.go
@@ -26,14 +26,6 @@ import (
 	"github.com/onflow/cadence/languageserver/server"
 )
 
-type EmulatorState int
-
-const (
-	EmulatorOffline EmulatorState = iota
-	EmulatorStarting
-	EmulatorStarted
-)
-
 type FlowIntegration struct {
 	server *server.Server
 	config Config

--- a/languageserver/test/flow.json
+++ b/languageserver/test/flow.json
@@ -1,0 +1,21 @@
+{
+	"emulators": {
+		"default": {
+			"port": 3569,
+			"serviceAccount": "emulator-account"
+		}
+	},
+	"contracts": {},
+	"networks": {
+		"emulator": "127.0.0.1:3569",
+		"mainnet": "access.mainnet.nodes.onflow.org:9000",
+		"testnet": "access.devnet.nodes.onflow.org:9000"
+	},
+	"accounts": {
+		"emulator-account": {
+			"address": "f8d6e0586b0a20c7",
+			"key": "c44604c862a3950ae82d56638929720f44875b2637054a1fdcb4e76b01b40881"
+		}
+	},
+	"deployments": {}
+}

--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -53,7 +53,6 @@ async function withConnection(f: (connection: ProtocolConnection) => Promise<voi
   if (enableFlowClient) {
     initOpts = {
       configPath: "./flow.json",
-      emulatorState: 1,
       activeAccountName: "service-account",
       activeAccountAddress: "0xf8d6e0586b0a20c7"
     }

--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -321,14 +321,13 @@ describe("script execution", () => {
 
   test("script executes and result is returned", async() => {
     await withConnection(async (connection) => {
-
       const resultPromise = new Promise<ShowMessageParams>(res =>
           connection.onNotification(ShowMessageNotification.type, res)
       )
 
       await connection.sendRequest(ExecuteCommandRequest.type, {
         command: "cadence.server.flow.executeScript",
-        arguments: ["file:///Users/dapper/Dev/cadence/languageserver/test/script.cdc", "[]"]
+        arguments: [`file://${__dirname}/script.cdc`, "[]"]
       })
 
       const result = await resultPromise

--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -51,10 +51,12 @@ async function withConnection(f: (connection: ProtocolConnection) => Promise<voi
 
   let initOpts = null
   if (enableFlowClient) {
+    // flow client initialization options where we pass the location of flow.json
+    // and service account name and its address
     initOpts = {
       configPath: "./flow.json",
-      activeAccountName: "service-account",
-      activeAccountAddress: "0xf8d6e0586b0a20c7"
+      activeAccountName: "service-account", // default service account name
+      activeAccountAddress: "0xf8d6e0586b0a20c7" // default service address for emulator network
     }
   }
 

--- a/languageserver/test/script.cdc
+++ b/languageserver/test/script.cdc
@@ -1,0 +1,3 @@
+pub fun main(): String {
+    return "HELLO WORLD"
+}


### PR DESCRIPTION
Closes #1691 

## Description
This PR changes the usage of the emulator. It now uses an emulator as a package programmatically leveraging the flowkit implementation instead of relaying on a separate emulator service being spawned. This makes the language server less complex and avoids emulator state synchronization. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
