### PR TITLE
Fixes tutorial callout and removes screenshot

### DIFF
--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -275,8 +275,6 @@ Click the `Send` button to submit the transaction
 
 </Callout>
 
-![Deploy Contract](Update Screenshot)
-
 You should see something like this in the transaction results at the bottom of the screen:
 
 ```

--- a/docs/tutorial/04-capabilities.mdx
+++ b/docs/tutorial/04-capabilities.mdx
@@ -67,12 +67,14 @@ In this tutorial, you will:
 Before following this tutorial, you should have the `HelloWorld` contract deployed in account `0x01`,
 just like in the [previous `Resource` contract tutorial](/cadence/tutorial/03-resources).
 
+<Callout type="info">
+
 Open the Account `0x01` tab with file named `HelloWorldResource.cdc`. <br />
 `HelloWorldResource.cdc` should contain the following code:
 
 </Callout>
 
-```cadence:title=HelloWorldResource.cdc
+```cadence:title=HelloWorldResource-2.cdc
 pub contract HelloWorld {
 
     // Declare a resource that only includes one function.


### PR DESCRIPTION
## Description

Fixes a missing callout line in the capabilities tutorial that was causing the docs site deployment to fail

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
