### PR TITLE
Resource destruction should also invalidate references

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1508,6 +1508,8 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
 
+	storageID := v.StorageID()
+
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
 
@@ -1528,9 +1530,27 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 	})
 
 	v.isDestroyed = true
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.array = nil
 	}
+
+	interpreter.updateReferencedResource(
+		storageID,
+		storageID,
+		func(value ReferenceTrackedResourceKindedValue) {
+			arrayValue, ok := value.(*ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			arrayValue.isDestroyed = true
+
+			if interpreter.invalidatedResourceValidationEnabled {
+				arrayValue.array = nil
+			}
+		},
+	)
 }
 
 func (v *ArrayValue) IsDestroyed() bool {
@@ -14307,6 +14327,8 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 
 	interpreter.ReportComputation(common.ComputationKindDestroyCompositeValue, 1)
 
+	storageID := v.StorageID()
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
@@ -14352,9 +14374,27 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 	}
 
 	v.isDestroyed = true
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.dictionary = nil
 	}
+
+	interpreter.updateReferencedResource(
+		storageID,
+		storageID,
+		func(value ReferenceTrackedResourceKindedValue) {
+			compositeValue, ok := value.(*CompositeValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			compositeValue.isDestroyed = true
+
+			if interpreter.invalidatedResourceValidationEnabled {
+				compositeValue.dictionary = nil
+			}
+		},
+	)
 }
 
 func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
@@ -15472,9 +15512,12 @@ func (v *DictionaryValue) checkInvalidatedResourceUse(interpreter *Interpreter, 
 func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange func() LocationRange) {
 
 	interpreter.ReportComputation(common.ComputationKindDestroyDictionaryValue, 1)
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
 	}
+
+	storageID := v.StorageID()
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()
@@ -15499,9 +15542,27 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 	})
 
 	v.isDestroyed = true
+
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.dictionary = nil
 	}
+
+	interpreter.updateReferencedResource(
+		storageID,
+		storageID,
+		func(value ReferenceTrackedResourceKindedValue) {
+			dictionaryValue, ok := value.(*DictionaryValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			dictionaryValue.isDestroyed = true
+
+			if interpreter.invalidatedResourceValidationEnabled {
+				dictionaryValue.dictionary = nil
+			}
+		},
+	)
 }
 
 func (v *DictionaryValue) ContainsKey(

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -2407,3 +2407,141 @@ func TestInterpretArrayOptionalResourceReference(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 }
+
+func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
+
+	t.Parallel()
+
+	const resourceCode = `
+	  resource R {
+          var value: Int
+
+          init() {
+              self.value = 0
+          }
+
+          fun increment() {
+              self.value = self.value + 1
+          }
+      }
+	`
+
+	t.Run("composite", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, resourceCode+`
+
+          fun test(): Int {
+
+              let resources <- {
+                  "r": <-create R()
+              }
+
+              let ref = &resources["r"] as &R?
+              let r <-resources.remove(key: "r")
+	          destroy r
+              destroy resources
+
+              ref!.increment()
+              return ref!.value
+          }
+        `)
+
+		_, err := inter.Invoke("test")
+
+		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceErr)
+
+		assert.Equal(t, 26, invalidatedResourceErr.StartPosition().Line)
+	})
+
+	t.Run("dictionary", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, resourceCode+`
+
+          fun test(): Int {
+
+              let resources <- {
+                  "nested": <-{"r": <-create R()}
+              }
+
+              let ref = &resources["nested"] as &{String: R}?
+              let nested <-resources.remove(key: "nested")
+	          destroy nested
+              destroy resources
+
+              return ref!.length
+          }
+        `)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+
+		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceErr)
+
+		assert.Equal(t, 26, invalidatedResourceErr.StartPosition().Line)
+	})
+
+	t.Run("array", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, resourceCode+`
+
+          fun test(): Int {
+
+              let resources <- {
+                  "nested": <-[<-create R()]
+              }
+
+              let ref = &resources["nested"] as &[R]?
+              let nested <-resources.remove(key: "nested")
+	          destroy nested
+              destroy resources
+
+              return ref!.length
+          }
+        `)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+
+		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceErr)
+
+		assert.Equal(t, 26, invalidatedResourceErr.StartPosition().Line)
+	})
+
+	t.Run("optional", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, resourceCode+`
+
+          fun test(): Int {
+
+              let resources: @[R?] <- [<-create R()]
+
+              let ref = &resources[0] as &R?
+              let r <-resources.remove(at: 0)
+		      destroy r
+              destroy resources
+
+              ref!.increment()
+              return ref!.value
+          }
+        `)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+
+		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceErr)
+
+		assert.Equal(t, 24, invalidatedResourceErr.StartPosition().Line)
+	})
+}

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -2450,7 +2450,7 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 
 		assert.Equal(t, 26, invalidatedResourceErr.StartPosition().Line)
@@ -2480,7 +2480,7 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 
 		assert.Equal(t, 26, invalidatedResourceErr.StartPosition().Line)
@@ -2510,7 +2510,7 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 
 		assert.Equal(t, 26, invalidatedResourceErr.StartPosition().Line)
@@ -2539,7 +2539,7 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
 
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 
 		assert.Equal(t, 24, invalidatedResourceErr.StartPosition().Line)


### PR DESCRIPTION
Port of dapperlabs/cadence-internal#85

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
