### PR TITLE
Add defensive check for member accesses

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -510,19 +510,17 @@ func (e InvocationArgumentTypeError) Error() string {
 	)
 }
 
-// InvocationReceiverTypeError
+// MemberAccessTypeError
 //
-type InvocationReceiverTypeError struct {
-	SelfType     sema.Type
-	ReceiverType sema.Type
+type MemberAccessTypeError struct {
+	ExpectedType sema.Type
 	LocationRange
 }
 
-func (e InvocationReceiverTypeError) Error() string {
+func (e MemberAccessTypeError) Error() string {
 	return fmt.Sprintf(
-		"invalid invocation on %s: expected %s",
-		e.SelfType.QualifiedString(),
-		e.ReceiverType.QualifiedString(),
+		"invalid member access: expected %s",
+		e.ExpectedType.QualifiedString(),
 	)
 }
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2123,17 +2123,8 @@ func (interpreter *Interpreter) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclarat
 	panic(errors.NewUnreachableError())
 }
 
-func (interpreter *Interpreter) CheckValueTransferTargetType(value Value, targetType sema.Type) bool {
-
-	if targetType == nil {
-		return true
-	}
-
-	if interpreter.IsSubTypeOfSemaType(value.StaticType(interpreter), targetType) {
-		return true
-	}
-
-	return false
+func (interpreter *Interpreter) ValueIsSubtypeOfSemaType(value Value, targetType sema.Type) bool {
+	return interpreter.IsSubTypeOfSemaType(value.StaticType(interpreter), targetType)
 }
 
 func (interpreter *Interpreter) transferAndConvert(
@@ -2157,7 +2148,10 @@ func (interpreter *Interpreter) transferAndConvert(
 		targetType,
 	)
 
-	if !interpreter.CheckValueTransferTargetType(result, targetType) {
+	// Defensively check the value's type matches the target type
+	if targetType != nil &&
+		!interpreter.ValueIsSubtypeOfSemaType(result, targetType) {
+
 		panic(ValueTransferTypeError{
 			TargetType:    targetType,
 			LocationRange: getLocationRange(),
@@ -4260,7 +4254,7 @@ func (interpreter *Interpreter) getUserCompositeType(location common.Location, t
 func (interpreter *Interpreter) getNativeCompositeType(qualifiedIdentifier string) (*sema.CompositeType, error) {
 	ty := sema.NativeCompositeTypes[qualifiedIdentifier]
 	if ty == nil {
-		return ty, TypeLoadingError{
+		return nil, TypeLoadingError{
 			TypeID: common.TypeID(qualifiedIdentifier),
 		}
 	}
@@ -4288,6 +4282,7 @@ func (interpreter *Interpreter) getInterfaceType(location common.Location, quali
 			TypeID: typeID,
 		}
 	}
+
 	return ty, nil
 }
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -133,10 +133,15 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 	target := interpreter.evalExpression(memberExpression.Expression)
 	identifier := memberExpression.Identifier.Identifier
 	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, memberExpression)
+
 	_, isNestedResourceMove := interpreter.Program.Elaboration.IsNestedResourceMoveExpression[memberExpression]
+
 	return getterSetter{
 		target: target,
 		get: func(allowMissing bool) Value {
+
+			interpreter.checkMemberAccess(memberExpression, target, getLocationRange)
+
 			isOptional := memberExpression.Optional
 
 			if isOptional {
@@ -177,8 +182,48 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 			return resultValue
 		},
 		set: func(value Value) {
+			interpreter.checkMemberAccess(memberExpression, target, getLocationRange)
+
 			interpreter.setMember(target, getLocationRange, identifier, value)
 		},
+	}
+}
+
+func (interpreter *Interpreter) checkMemberAccess(
+	memberExpression *ast.MemberExpression,
+	target Value,
+	getLocationRange func() LocationRange,
+) {
+	memberInfo := interpreter.Program.Elaboration.MemberExpressionMemberInfos[memberExpression]
+	expectedType := memberInfo.AccessedType
+
+	switch expectedType := expectedType.(type) {
+	case *sema.TransactionType:
+		// TODO: maybe also check transactions.
+		//   they are composites with a type ID which has an empty qualified ID, i.e. no type is available
+
+		return
+
+	case *sema.CompositeType:
+		// TODO: also check built-in values.
+		//   blocked by standard library values (RLP, BLS, etc.),
+		//   which are implemented as contracts, but currently do not have their type registered
+
+		if expectedType.Location == nil {
+			return
+		}
+	}
+
+	if _, ok := target.(*StorageReferenceValue); ok {
+		// NOTE: Storage reference value accesses are already checked in  StorageReferenceValue.dereference
+		return
+	}
+
+	if !interpreter.ValueIsSubtypeOfSemaType(target, expectedType) {
+		panic(MemberAccessTypeError{
+			ExpectedType:  expectedType,
+			LocationRange: getLocationRange(),
+		})
 	}
 }
 
@@ -751,12 +796,11 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 
 	arguments := interpreter.visitExpressionsNonCopying(argumentExpressions)
 
-	typeParameterTypes :=
-		interpreter.Program.Elaboration.InvocationExpressionTypeArguments[invocationExpression]
-	argumentTypes :=
-		interpreter.Program.Elaboration.InvocationExpressionArgumentTypes[invocationExpression]
-	parameterTypes :=
-		interpreter.Program.Elaboration.InvocationExpressionParameterTypes[invocationExpression]
+	elaboration := interpreter.Program.Elaboration
+
+	typeParameterTypes := elaboration.InvocationExpressionTypeArguments[invocationExpression]
+	argumentTypes := elaboration.InvocationExpressionArgumentTypes[invocationExpression]
+	parameterTypes := elaboration.InvocationExpressionParameterTypes[invocationExpression]
 
 	line := invocationExpression.StartPosition().Line
 

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -155,7 +155,7 @@ func TestInterpreterBoxing(t *testing.T) {
 	}
 }
 
-func BenchmarkTransfer(b *testing.B) {
+func BenchmarkValueIsSubtypeOfSemaType(b *testing.B) {
 
 	b.ReportAllocs()
 
@@ -184,7 +184,7 @@ func BenchmarkTransfer(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		ok := inter.CheckValueTransferTargetType(array, semaType)
+		ok := inter.ValueIsSubtypeOfSemaType(array, semaType)
 		assert.True(b, ok)
 	}
 }

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -177,7 +177,6 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 		t.Run("second save", func(t *testing.T) {
 
 			_, err := inter.Invoke("test")
-
 			require.Error(t, err)
 
 			require.ErrorAs(t, err, &interpreter.OverwriteError{})
@@ -224,7 +223,6 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 		t.Run("second save", func(t *testing.T) {
 
 			_, err := inter.Invoke("test")
-
 			require.Error(t, err)
 
 			require.ErrorAs(t, err, &interpreter.OverwriteError{})
@@ -400,6 +398,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 			// load
 
 			_, err = inter.Invoke("loadR2")
+			require.Error(t, err)
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
@@ -481,6 +480,8 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 			// load
 
 			_, err = inter.Invoke("loadS2")
+			require.Error(t, err)
+
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 			// NOTE: check loaded value was *not* removed from storage
@@ -575,6 +576,8 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 		// load
 
 		_, err = inter.Invoke("copyS2")
+		require.Error(t, err)
+
 		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 		// NOTE: check loaded value was *not* removed from storage
@@ -702,6 +705,8 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		t.Run("borrow R2", func(t *testing.T) {
 
 			_, err := inter.Invoke("borrowR2")
+			require.Error(t, err)
+
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 			// NOTE: check loaded value was *not* removed from storage
@@ -711,6 +716,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		t.Run("change after borrow", func(t *testing.T) {
 
 			_, err := inter.Invoke("changeAfterBorrow")
+			require.Error(t, err)
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
 		})
@@ -839,6 +845,8 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		t.Run("borrow S2", func(t *testing.T) {
 
 			_, err = inter.Invoke("borrowS2")
+			require.Error(t, err)
+
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 			// NOTE: check loaded value was *not* removed from storage
@@ -848,6 +856,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		t.Run("change after borrow", func(t *testing.T) {
 
 			_, err := inter.Invoke("changeAfterBorrow")
+			require.Error(t, err)
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
 		})
@@ -855,6 +864,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		t.Run("borrow as invalid type", func(t *testing.T) {
 			_, err = inter.Invoke("invalidBorrowS")
 			require.Error(t, err)
+
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 		})
 	})

--- a/runtime/tests/interpreter/member_test.go
+++ b/runtime/tests/interpreter/member_test.go
@@ -57,6 +57,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                     }
                 `)
 
+				// Construct an instance of type S
+				// by calling its constructor function of the same name
+
 				value, err := inter.Invoke("S")
 				require.NoError(t, err)
 
@@ -97,6 +100,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                     }
                 `)
 
+				// Construct an instance of type S2
+				// by calling its constructor function of the same name
+
 				value, err := inter.Invoke("S2")
 				require.NoError(t, err)
 
@@ -131,6 +137,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                         s?.foo
                     }
                 `)
+
+				// Construct an instance of type S
+				// by calling its constructor function of the same name
 
 				value, err := inter.Invoke("S")
 				require.NoError(t, err)
@@ -167,6 +176,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                         s?.foo
                     }
                 `)
+
+				// Construct an instance of type S2
+				// by calling its constructor function of the same name
 
 				value, err := inter.Invoke("S2")
 				require.NoError(t, err)
@@ -212,6 +224,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                     }
                 `)
 
+				// Construct an instance of type S
+				// by calling its constructor function of the same name
+
 				value, err := inter.Invoke("S")
 				require.NoError(t, err)
 
@@ -256,6 +271,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                     }
                 `)
 
+				// Construct an instance of type S2
+				// by calling its constructor function of the same name
+
 				value, err := inter.Invoke("S2")
 				require.NoError(t, err)
 
@@ -294,6 +312,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                         si?.foo
                     }
                 `)
+
+				// Construct an instance of type S
+				// by calling its constructor function of the same name
 
 				value, err := inter.Invoke("S")
 				require.NoError(t, err)
@@ -335,6 +356,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                     }
                 `)
 
+				// Construct an instance of type S2
+				// by calling its constructor function of the same name
+
 				value, err := inter.Invoke("S2")
 				require.NoError(t, err)
 
@@ -374,6 +398,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                         ref.foo = 2
                     }
                 `)
+
+				// Construct an instance of type S
+				// by calling its constructor function of the same name
 
 				value, err := inter.Invoke("S")
 				require.NoError(t, err)
@@ -419,6 +446,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                     }
                 `)
 
+				// Construct an instance of type S2
+				// by calling its constructor function of the same name
+
 				value, err := inter.Invoke("S2")
 				require.NoError(t, err)
 
@@ -457,6 +487,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                         ref?.foo
                     }
                 `)
+
+				// Construct an instance of type S
+				// by calling its constructor function of the same name
 
 				value, err := inter.Invoke("S")
 				require.NoError(t, err)
@@ -500,6 +533,9 @@ func TestInterpretMemberAccessType(t *testing.T) {
                     }
                 `)
 
+				// Construct an instance of type S2
+				// by calling its constructor function of the same name
+
 				value, err := inter.Invoke("S2")
 				require.NoError(t, err)
 
@@ -519,5 +555,4 @@ func TestInterpretMemberAccessType(t *testing.T) {
 			})
 		})
 	})
-
 }

--- a/runtime/tests/interpreter/member_test.go
+++ b/runtime/tests/interpreter/member_test.go
@@ -1,0 +1,523 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/tests/checker"
+)
+
+func TestInterpretMemberAccessType(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("direct", func(t *testing.T) {
+
+		t.Run("non-optional", func(t *testing.T) {
+
+			t.Run("valid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    fun get(s: S) {
+                        s.foo
+                    }
+
+                    fun set(s: S) {
+                        s.foo = 2
+                    }
+                `)
+
+				value, err := inter.Invoke("S")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("get", value)
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("set", value)
+				require.NoError(t, err)
+			})
+
+			t.Run("invalid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    struct S2 {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 2
+                        }
+                    }
+
+                    fun get(s: S) {
+                        s.foo
+                    }
+
+                    fun set(s: S) {
+                        s.foo = 3
+                    }
+                `)
+
+				value, err := inter.Invoke("S2")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("get", value)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+
+				_, err = inter.Invoke("set", value)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+			})
+		})
+
+		t.Run("optional", func(t *testing.T) {
+
+			t.Run("valid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    fun get(s: S?) {
+                        s?.foo
+                    }
+                `)
+
+				value, err := inter.Invoke("S")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke(
+					"get",
+					interpreter.NewUnmeteredSomeValueNonCopying(value),
+				)
+				require.NoError(t, err)
+			})
+
+			t.Run("invalid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    struct S2 {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 2
+                        }
+                    }
+
+                    fun get(s: S?) {
+                        s?.foo
+                    }
+                `)
+
+				value, err := inter.Invoke("S2")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke(
+					"get",
+					interpreter.NewUnmeteredSomeValueNonCopying(value),
+				)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+			})
+		})
+	})
+
+	t.Run("interface", func(t *testing.T) {
+
+		t.Run("non-optional", func(t *testing.T) {
+
+			t.Run("valid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct interface SI {
+                        var foo: Int
+                    }
+
+                    struct S: SI {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    fun get(si: AnyStruct{SI}) {
+                        si.foo
+                    }
+
+                    fun set(si: AnyStruct{SI}) {
+                        si.foo = 2
+                    }
+                `)
+
+				value, err := inter.Invoke("S")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("get", value)
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("set", value)
+				require.NoError(t, err)
+			})
+
+			t.Run("invalid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct interface SI {
+                        var foo: Int
+                    }
+
+                    struct S: SI {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    struct S2 {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 2
+                        }
+                    }
+
+                    fun get(si: AnyStruct{SI}) {
+                        si.foo
+                    }
+
+                    fun set(si: AnyStruct{SI}) {
+                        si.foo = 3
+                    }
+                `)
+
+				value, err := inter.Invoke("S2")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("get", value)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+
+				_, err = inter.Invoke("set", value)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+			})
+		})
+
+		t.Run("optional", func(t *testing.T) {
+
+			t.Run("valid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct interface SI {
+                        let foo: Int
+                    }
+
+                    struct S: SI {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    fun get(si: AnyStruct{SI}?) {
+                        si?.foo
+                    }
+                `)
+
+				value, err := inter.Invoke("S")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke(
+					"get",
+					interpreter.NewUnmeteredSomeValueNonCopying(value),
+				)
+				require.NoError(t, err)
+			})
+
+			t.Run("invalid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct interface SI {
+                        let foo: Int
+                    }
+
+                    struct S: SI {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    struct S2 {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 2
+                        }
+                    }
+
+                    fun get(si: AnyStruct{SI}?) {
+                        si?.foo
+                    }
+                `)
+
+				value, err := inter.Invoke("S2")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke(
+					"get",
+					interpreter.NewUnmeteredSomeValueNonCopying(value),
+				)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+			})
+		})
+	})
+
+	t.Run("reference", func(t *testing.T) {
+
+		t.Run("non-optional", func(t *testing.T) {
+
+			t.Run("valid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    fun get(ref: &S) {
+                        ref.foo
+                    }
+
+                    fun set(ref: &S) {
+                        ref.foo = 2
+                    }
+                `)
+
+				value, err := inter.Invoke("S")
+				require.NoError(t, err)
+
+				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
+
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(false, value, sType)
+
+				_, err = inter.Invoke("get", ref)
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("set", ref)
+				require.NoError(t, err)
+			})
+
+			t.Run("invalid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    struct S2 {
+                        var foo: Int
+
+                        init() {
+                            self.foo = 2
+                        }
+                    }
+
+                    fun get(ref: &S) {
+                        ref.foo
+                    }
+
+                    fun set(ref: &S) {
+                        ref.foo = 3
+                    }
+                `)
+
+				value, err := inter.Invoke("S2")
+				require.NoError(t, err)
+
+				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
+
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(false, value, sType)
+
+				_, err = inter.Invoke("get", ref)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+
+				_, err = inter.Invoke("set", ref)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+			})
+		})
+
+		t.Run("optional", func(t *testing.T) {
+
+			t.Run("valid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    fun get(ref: &S?) {
+                        ref?.foo
+                    }
+                `)
+
+				value, err := inter.Invoke("S")
+				require.NoError(t, err)
+
+				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
+
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(false, value, sType)
+
+				_, err = inter.Invoke(
+					"get",
+					interpreter.NewUnmeteredSomeValueNonCopying(
+						ref,
+					),
+				)
+				require.NoError(t, err)
+			})
+
+			t.Run("invalid", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndInterpret(t, `
+                    struct S {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 1
+                        }
+                    }
+
+                    struct S2 {
+                        let foo: Int
+
+                        init() {
+                            self.foo = 2
+                        }
+                    }
+
+                    fun get(ref: &S?) {
+                        ref?.foo
+                    }
+                `)
+
+				value, err := inter.Invoke("S2")
+				require.NoError(t, err)
+
+				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
+
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(false, value, sType)
+
+				_, err = inter.Invoke(
+					"get",
+					interpreter.NewUnmeteredSomeValueNonCopying(
+						ref,
+					),
+				)
+				require.Error(t, err)
+
+				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+			})
+		})
+	})
+
+}

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -8713,7 +8713,7 @@ func TestInterpretFunctionStaticType(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindFunctionStaticType))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindFunctionStaticType))
 	})
 }
 

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -472,9 +472,11 @@ func TestInterpretResourceReferenceAfterMove(t *testing.T) {
 		)
 
 		arrayRef := &interpreter.EphemeralReferenceValue{
-			Authorized:   false,
-			Value:        array,
-			BorrowedType: rType,
+			Authorized: false,
+			Value:      array,
+			BorrowedType: &sema.VariableSizedType{
+				Type: rType,
+			},
 		}
 
 		value, err := inter.Invoke("test", arrayRef)
@@ -524,9 +526,13 @@ func TestInterpretResourceReferenceAfterMove(t *testing.T) {
 		)
 
 		arrayRef := &interpreter.EphemeralReferenceValue{
-			Authorized:   false,
-			Value:        array,
-			BorrowedType: rType,
+			Authorized: false,
+			Value:      array,
+			BorrowedType: &sema.VariableSizedType{
+				Type: &sema.VariableSizedType{
+					Type: rType,
+				},
+			},
 		}
 
 		value, err := inter.Invoke("test", arrayRef)
@@ -577,9 +583,14 @@ func TestInterpretResourceReferenceAfterMove(t *testing.T) {
 		)
 
 		arrayRef := &interpreter.EphemeralReferenceValue{
-			Authorized:   false,
-			Value:        array,
-			BorrowedType: rType,
+			Authorized: false,
+			Value:      array,
+			BorrowedType: &sema.VariableSizedType{
+				Type: &sema.DictionaryType{
+					KeyType:   sema.IntType,
+					ValueType: rType,
+				},
+			},
 		}
 
 		value, err := inter.Invoke("test", arrayRef)


### PR DESCRIPTION
Closes #1757 

## Description

Defensively check if the value's type of a member access matches the expected static type.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
