### PR TITLE
Include static types when exporting arrays and dictionaries

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -779,7 +779,10 @@ func newBytesValue(bytes []byte) cadence.Array {
 	for index, value := range bytes {
 		result[index] = cadence.NewUInt8(value)
 	}
-	return cadence.NewArray(result)
+	return cadence.NewArray(result).
+		WithType(cadence.VariableSizedArrayType{
+			ElementType: cadence.UInt8Type{},
+		})
 }
 
 func newSignAlgoValue(signAlgo sema.SignatureAlgorithm) cadence.Enum {
@@ -1527,7 +1530,9 @@ func TestPublicAccountContracts(t *testing.T) {
 					cadence.UInt8(1),
 					cadence.UInt8(2),
 				},
-			},
+			}.WithType(cadence.VariableSizedArrayType{
+				ElementType: cadence.UInt8Type{},
+			}),
 			array.Values[1],
 		)
 	})

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -231,7 +231,7 @@ func exportArrayValue(
 	cadence.Array,
 	error,
 ) {
-	return cadence.NewMeteredArray(
+	array, err := cadence.NewMeteredArray(
 		inter,
 		v.Count(),
 		func() ([]cadence.Value, error) {
@@ -257,6 +257,13 @@ func exportArrayValue(
 			return values, nil
 		},
 	)
+	if err != nil {
+		return cadence.Array{}, err
+	}
+
+	exportType := ExportType(v.SemaType(inter), map[sema.TypeID]cadence.Type{}).(cadence.ArrayType)
+
+	return array.WithType(exportType), err
 }
 
 func exportCompositeValue(
@@ -536,7 +543,7 @@ func exportDictionaryValue(
 	cadence.Dictionary,
 	error,
 ) {
-	return cadence.NewMeteredDictionary(
+	dictionary, err := cadence.NewMeteredDictionary(
 		inter,
 		v.Count(),
 		func() ([]cadence.KeyValuePair, error) {
@@ -575,6 +582,13 @@ func exportDictionaryValue(
 			return pairs, nil
 		},
 	)
+	if err != nil {
+		return cadence.Dictionary{}, err
+	}
+
+	exportType := ExportType(v.SemaType(inter), map[sema.TypeID]cadence.Type{}).(cadence.DictionaryType)
+
+	return dictionary.WithType(exportType), err
 }
 
 func exportLinkValue(v interpreter.LinkValue, inter *interpreter.Interpreter) cadence.Link {

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -581,6 +581,8 @@ func TestBLSAggregateSignatures(t *testing.T) {
 			cadence.UInt8(3),
 			cadence.UInt8(4),
 			cadence.UInt8(5),
+		}).WithType(cadence.VariableSizedArrayType{
+			ElementType: cadence.UInt8Type{},
 		}),
 		result,
 	)
@@ -651,6 +653,8 @@ func TestBLSAggregatePublicKeys(t *testing.T) {
 			cadence.UInt8(2),
 			cadence.UInt8(1),
 			cadence.UInt8(2),
+		}).WithType(cadence.VariableSizedArrayType{
+			ElementType: cadence.UInt8Type{},
 		}),
 		result.(cadence.Optional).Value.(cadence.Struct).Fields[0],
 	)

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -158,7 +158,9 @@ func TestRLPDecodeString(t *testing.T) {
 				assert.Equal(t,
 					cadence.Array{
 						Values: test.output,
-					},
+					}.WithType(cadence.VariableSizedArrayType{
+						ElementType: cadence.UInt8Type{},
+					}),
 					result,
 				)
 			}
@@ -314,13 +316,21 @@ func TestRLPDecodeList(t *testing.T) {
 
 				arrays := make([]cadence.Value, 0, len(test.output))
 				for _, values := range test.output {
-					arrays = append(arrays, cadence.Array{Values: values})
+					arrays = append(arrays,
+						cadence.Array{Values: values}.
+							WithType(cadence.VariableSizedArrayType{
+								ElementType: cadence.UInt8Type{},
+							}))
 				}
 
 				assert.Equal(t,
 					cadence.Array{
 						Values: arrays,
-					},
+					}.WithType(cadence.VariableSizedArrayType{
+						ElementType: cadence.VariableSizedArrayType{
+							ElementType: cadence.UInt8Type{},
+						},
+					}),
 					result,
 				)
 			}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2567,7 +2567,15 @@ func TestRuntimeScriptReturnTypeNotReturnableError(t *testing.T) {
 			cadence.NewArray([]cadence.Value{
 				cadence.NewArray([]cadence.Value{
 					nil,
+				}).WithType(cadence.VariableSizedArrayType{
+					ElementType: cadence.ReferenceType{
+						Type: cadence.AnyStructType{},
+					},
 				}),
+			}).WithType(cadence.VariableSizedArrayType{
+				ElementType: cadence.ReferenceType{
+					Type: cadence.AnyStructType{},
+				},
 			}),
 		)
 	})


### PR DESCRIPTION
Closes #1672 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
