### PR TITLE
Fix typo in nft-2 tutorial

### DIFF
--- a/docs/tutorial/05-non-fungible-tokens-2.mdx
+++ b/docs/tutorial/05-non-fungible-tokens-2.mdx
@@ -105,7 +105,7 @@ to enable more-sophisticated ways to interact with our NFTs.
 
 The next contract we look at is called `ExampleNFT`, it's stored in account `0x02`.
 This contract expands on the `BasicNFT` we looked at by adding:
-1. And `idCount` contract field that tracks unique NFT ids.
+1. An `idCount` contract field that tracks unique NFT ids.
 2. An `NFTReceiver` interface that exposes three functions for the collection
 3. Declares a resource called `Collection` that implements the `NFTReceiver` interface
 4. The `Collection` will declare fields and functions to interact with it,


### PR DESCRIPTION
No issue

## Description

One word typo in nft-2 tutorial
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
