### PR TITLE
Update incorrect example code

### DIFF
--- a/docs/tutorial/03-resources.mdx
+++ b/docs/tutorial/03-resources.mdx
@@ -304,7 +304,7 @@ This could be a headache for you, so choose unique path names to avoid this prob
 Finally, in the execute phase we log the phrase `"Saved Hello Resource to account."` to the console.
 
 ```cadence
-log(helloResource?.hello())
+log("Saved Hello Resource to account.")
 ```
 
 <Callout type="info">


### PR DESCRIPTION
Displayed code block shows `log(helloResource?.hello())`. However, expected to see `log("Saved Hello Resource to account.")` instead, because the log is supposed to be "Saved Hello Resource to account.".

Updated code block to display `log("Saved Hello Resource to account.")` instead.

Closes #1767 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
