### PR TITLE
Collape benchstat results

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,7 +83,14 @@ jobs:
             This branch with compared with the base branch ${{  github.event.pull_request.base.label }} commit ${{ github.event.pull_request.base.sha }}
             The command `for i in {1..N}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done` was used.
             Bench tests were run a total of ${{ steps.settings.outputs.benchmark_repetitions }} times on each branch.
-            ## Results
+            
+            <details>
+            <summary>Collapsed results for better readability</summary>
+            <p>
+
             ${{ env.BENCHSTAT }}
+            
+            </p>
+            </details>  
             
           edit-mode: replace


### PR DESCRIPTION
## Description

Related to: https://github.com/onflow/flow-go/pull/2748

Trying to see if the two CIs are in sync, the only difference I could find is that the `flow-go` CI collapses the results making them less spammy.