### PR TITLE
Fail invalidated-resource use with a proper error

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -14327,11 +14327,11 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 
 	interpreter.ReportComputation(common.ComputationKindDestroyCompositeValue, 1)
 
-	storageID := v.StorageID()
-
 	if interpreter.invalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(getLocationRange)
 	}
+
+	storageID := v.StorageID()
 
 	if interpreter.tracingEnabled {
 		startTime := time.Now()

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -2545,3 +2545,48 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 		assert.Equal(t, 24, invalidatedResourceErr.StartPosition().Line)
 	})
 }
+
+func TestInterpretResourceDestroyedInPreCondition(t *testing.T) {
+
+	t.Parallel()
+
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+        resource interface I {
+             pub fun receiveResource(_ r: @Bar) {
+                pre {
+                    destroyResource(<-r)
+                }
+            }
+        }
+
+        fun destroyResource(_ r: @Bar): Bool {
+            destroy r
+            return true
+        }
+
+        resource Foo: I {
+             pub fun receiveResource(_ r: @Bar) {
+                destroy r
+            }
+        }
+
+        resource Bar  {}
+
+        fun test() {
+            let foo <- create Foo()
+            let bar <- create Bar()
+
+            foo.receiveResource(<- bar)
+            destroy foo
+        }`,
+
+		ParseCheckAndInterpretOptions{},
+	)
+
+	require.NoError(t, err)
+
+	_, err = inter.Invoke("test")
+	require.Error(t, err)
+	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+}


### PR DESCRIPTION
Closes #1781

## Description

Trying to get the `v.StorageID()` can cause nil-pointer dereference error if the resource is already invalidated. Hence move the `v.StorageID()` below the invalidated resource check, to give a proper error, instead of a nil-pointer.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
