### PR TITLE
Separate type equality checker from contract update validator

### DIFF
--- a/runtime/contract_update_validation.go
+++ b/runtime/contract_update_validation.go
@@ -23,15 +23,15 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/sema"
 )
 
 type ContractUpdateValidator struct {
+	TypeEqualityChecker
+
 	location     Location
 	contractName string
 	oldProgram   *ast.Program
 	newProgram   *ast.Program
-	rootDecl     ast.Declaration
 	currentDecl  ast.Declaration
 	errors       []error
 }
@@ -68,7 +68,8 @@ func (validator *ContractUpdateValidator) Validate() error {
 		return validator.getContractUpdateError()
 	}
 
-	validator.rootDecl = newRootDecl
+	validator.TypeEqualityChecker.RootDeclIdentifier = newRootDecl.DeclarationIdentifier()
+
 	validator.checkDeclarationUpdatability(oldRootDecl, newRootDecl)
 
 	if validator.hasErrors() {
@@ -104,7 +105,6 @@ func getRootDeclaration(program *ast.Program) (ast.Declaration, error) {
 	return nil, &ContractNotFoundError{
 		Range: ast.NewUnmeteredRangeFromPositioned(program),
 	}
-
 }
 
 func (validator *ContractUpdateValidator) hasErrors() bool {
@@ -310,203 +310,6 @@ func (validator *ContractUpdateValidator) checkEnumCases(oldDeclaration ast.Decl
 	}
 }
 
-func (validator *ContractUpdateValidator) CheckNominalTypeEquality(expected *ast.NominalType, found ast.Type) error {
-	foundNominalType, ok := found.(*ast.NominalType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	// First check whether the names are equal.
-	ok = validator.checkNameEquality(expected, foundNominalType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	return nil
-}
-
-func (validator *ContractUpdateValidator) CheckOptionalTypeEquality(expected *ast.OptionalType, found ast.Type) error {
-	foundOptionalType, ok := found.(*ast.OptionalType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	return expected.Type.CheckEqual(foundOptionalType.Type, validator)
-}
-
-func (validator *ContractUpdateValidator) CheckVariableSizedTypeEquality(expected *ast.VariableSizedType, found ast.Type) error {
-	foundVarSizedType, ok := found.(*ast.VariableSizedType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	return expected.Type.CheckEqual(foundVarSizedType.Type, validator)
-}
-
-func (validator *ContractUpdateValidator) CheckConstantSizedTypeEquality(expected *ast.ConstantSizedType, found ast.Type) error {
-	foundConstSizedType, ok := found.(*ast.ConstantSizedType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	// Check size
-	if foundConstSizedType.Size.Value.Cmp(expected.Size.Value) != 0 ||
-		foundConstSizedType.Size.Base != expected.Size.Base {
-		return getTypeMismatchError(expected, found)
-	}
-
-	// Check type
-	return expected.Type.CheckEqual(foundConstSizedType.Type, validator)
-}
-
-func (validator *ContractUpdateValidator) CheckDictionaryTypeEquality(expected *ast.DictionaryType, found ast.Type) error {
-	foundDictionaryType, ok := found.(*ast.DictionaryType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	err := expected.KeyType.CheckEqual(foundDictionaryType.KeyType, validator)
-	if err != nil {
-		return err
-	}
-
-	return expected.ValueType.CheckEqual(foundDictionaryType.ValueType, validator)
-}
-
-func (validator *ContractUpdateValidator) CheckRestrictedTypeEquality(expected *ast.RestrictedType, found ast.Type) error {
-	foundRestrictedType, ok := found.(*ast.RestrictedType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	if expected.Type == nil {
-		if !isAnyStructOrAnyResourceType(foundRestrictedType.Type) {
-			return getTypeMismatchError(expected, found)
-		}
-		// else go on to check type restrictions
-	} else if foundRestrictedType.Type == nil {
-		if !isAnyStructOrAnyResourceType(expected.Type) {
-			return getTypeMismatchError(expected, found)
-		}
-		// else go on to check type restrictions
-	} else {
-		// both are not nil
-		err := expected.Type.CheckEqual(foundRestrictedType.Type, validator)
-		if err != nil {
-			return getTypeMismatchError(expected, found)
-		}
-	}
-
-	if len(expected.Restrictions) != len(foundRestrictedType.Restrictions) {
-		return getTypeMismatchError(expected, found)
-	}
-
-	for index, expectedRestriction := range expected.Restrictions {
-		foundRestriction := foundRestrictedType.Restrictions[index]
-		err := expectedRestriction.CheckEqual(foundRestriction, validator)
-		if err != nil {
-			return getTypeMismatchError(expected, found)
-		}
-	}
-
-	return nil
-}
-
-func (validator *ContractUpdateValidator) CheckInstantiationTypeEquality(expected *ast.InstantiationType, found ast.Type) error {
-	foundInstType, ok := found.(*ast.InstantiationType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	err := expected.Type.CheckEqual(foundInstType.Type, validator)
-	if err != nil || len(expected.TypeArguments) != len(foundInstType.TypeArguments) {
-		return getTypeMismatchError(expected, found)
-	}
-
-	for index, typeArgs := range expected.TypeArguments {
-		otherTypeArgs := foundInstType.TypeArguments[index]
-		err := typeArgs.Type.CheckEqual(otherTypeArgs.Type, validator)
-		if err != nil {
-			return getTypeMismatchError(expected, found)
-		}
-	}
-
-	return nil
-}
-
-func (validator *ContractUpdateValidator) CheckFunctionTypeEquality(expected *ast.FunctionType, found ast.Type) error {
-	foundFuncType, ok := found.(*ast.FunctionType)
-	if !ok || len(expected.ParameterTypeAnnotations) != len(foundFuncType.ParameterTypeAnnotations) {
-		return getTypeMismatchError(expected, found)
-	}
-
-	for index, expectedParamType := range expected.ParameterTypeAnnotations {
-		foundParamType := foundFuncType.ParameterTypeAnnotations[index]
-		err := expectedParamType.Type.CheckEqual(foundParamType.Type, validator)
-		if err != nil {
-			return getTypeMismatchError(expected, found)
-		}
-	}
-
-	return expected.ReturnTypeAnnotation.Type.CheckEqual(foundFuncType.ReturnTypeAnnotation.Type, validator)
-}
-
-func (validator *ContractUpdateValidator) CheckReferenceTypeEquality(expected *ast.ReferenceType, found ast.Type) error {
-	refType, ok := found.(*ast.ReferenceType)
-	if !ok {
-		return getTypeMismatchError(expected, found)
-	}
-
-	return expected.Type.CheckEqual(refType.Type, validator)
-}
-
-func (validator *ContractUpdateValidator) checkNameEquality(expectedType *ast.NominalType, foundType *ast.NominalType) bool {
-	isExpectedQualifiedName := expectedType.IsQualifiedName()
-	isFoundQualifiedName := foundType.IsQualifiedName()
-
-	// A field with a composite type can be defined in two ways:
-	// 	- Using type name (var x @ResourceName)
-	//	- Using qualified type name (var x @ContractName.ResourceName)
-
-	if isExpectedQualifiedName && !isFoundQualifiedName {
-		return validator.checkIdentifierEquality(expectedType, foundType)
-	}
-
-	if isFoundQualifiedName && !isExpectedQualifiedName {
-		return validator.checkIdentifierEquality(foundType, expectedType)
-	}
-
-	// At this point, either both are qualified names, or both are simple names.
-	// Thus, do a one-to-one match.
-	if expectedType.Identifier.Identifier != foundType.Identifier.Identifier {
-		return false
-	}
-
-	return identifiersEqual(expectedType.NestedIdentifiers, foundType.NestedIdentifiers)
-}
-
-func (validator *ContractUpdateValidator) checkIdentifierEquality(
-	qualifiedNominalType *ast.NominalType,
-	simpleNominalType *ast.NominalType,
-) bool {
-
-	// Situation:
-	// qualifiedNominalType -> identifier: A, nestedIdentifiers: [foo, bar, ...]
-	// simpleNominalType -> identifier: foo,  nestedIdentifiers: [bar, ...]
-
-	// If the first identifier (i.e: 'A') refers to a composite decl that is not the enclosing contract,
-	// then it must be referring to an imported contract. That means the two types are no longer the same.
-	if qualifiedNominalType.Identifier.Identifier != validator.rootDecl.DeclarationIdentifier().Identifier {
-		return false
-	}
-
-	if qualifiedNominalType.NestedIdentifiers[0].Identifier != simpleNominalType.Identifier.Identifier {
-		return false
-	}
-
-	return identifiersEqual(simpleNominalType.NestedIdentifiers, qualifiedNominalType.NestedIdentifiers[1:])
-}
-
 func (validator *ContractUpdateValidator) checkConformances(
 	oldDecl *ast.CompositeDeclaration,
 	newDecl *ast.CompositeDeclaration,
@@ -559,46 +362,6 @@ func (validator *ContractUpdateValidator) getContractUpdateError() error {
 		ContractName: validator.contractName,
 		Errors:       validator.errors,
 		Location:     validator.location,
-	}
-}
-
-func getTypeMismatchError(expectedType ast.Type, foundType ast.Type) *TypeMismatchError {
-	return &TypeMismatchError{
-		ExpectedType: expectedType,
-		FoundType:    foundType,
-		Range:        ast.NewUnmeteredRangeFromPositioned(foundType),
-	}
-}
-
-func identifiersEqual(expected []ast.Identifier, found []ast.Identifier) bool {
-	if len(expected) != len(found) {
-		return false
-	}
-
-	for index, element := range found {
-		if expected[index].Identifier != element.Identifier {
-			return false
-		}
-	}
-	return true
-}
-
-func isAnyStructOrAnyResourceType(astType ast.Type) bool {
-	// If the restricted type is not stated, then it is either AnyStruct or AnyResource
-	if astType == nil {
-		return true
-	}
-
-	nominalType, ok := astType.(*ast.NominalType)
-	if !ok {
-		return false
-	}
-
-	switch nominalType.Identifier.Identifier {
-	case sema.AnyStructType.Name, sema.AnyResourceType.Name:
-		return true
-	default:
-		return false
 	}
 }
 

--- a/runtime/contract_update_validation.go
+++ b/runtime/contract_update_validation.go
@@ -26,7 +26,7 @@ import (
 )
 
 type ContractUpdateValidator struct {
-	TypeEqualityChecker
+	TypeComparator
 
 	location     Location
 	contractName string
@@ -68,7 +68,7 @@ func (validator *ContractUpdateValidator) Validate() error {
 		return validator.getContractUpdateError()
 	}
 
-	validator.TypeEqualityChecker.RootDeclIdentifier = newRootDecl.DeclarationIdentifier()
+	validator.TypeComparator.RootDeclIdentifier = newRootDecl.DeclarationIdentifier()
 
 	validator.checkDeclarationUpdatability(oldRootDecl, newRootDecl)
 

--- a/runtime/type-comparator.go
+++ b/runtime/type-comparator.go
@@ -23,13 +23,13 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-var _ ast.TypeEqualityChecker = &TypeEqualityChecker{}
+var _ ast.TypeEqualityChecker = &TypeComparator{}
 
-type TypeEqualityChecker struct {
+type TypeComparator struct {
 	RootDeclIdentifier *Identifier
 }
 
-func (c *TypeEqualityChecker) CheckNominalTypeEquality(expected *ast.NominalType, found ast.Type) error {
+func (c *TypeComparator) CheckNominalTypeEquality(expected *ast.NominalType, found ast.Type) error {
 	foundNominalType, ok := found.(*ast.NominalType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -44,7 +44,7 @@ func (c *TypeEqualityChecker) CheckNominalTypeEquality(expected *ast.NominalType
 	return nil
 }
 
-func (c *TypeEqualityChecker) CheckOptionalTypeEquality(expected *ast.OptionalType, found ast.Type) error {
+func (c *TypeComparator) CheckOptionalTypeEquality(expected *ast.OptionalType, found ast.Type) error {
 	foundOptionalType, ok := found.(*ast.OptionalType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -53,7 +53,7 @@ func (c *TypeEqualityChecker) CheckOptionalTypeEquality(expected *ast.OptionalTy
 	return expected.Type.CheckEqual(foundOptionalType.Type, c)
 }
 
-func (c *TypeEqualityChecker) CheckVariableSizedTypeEquality(expected *ast.VariableSizedType, found ast.Type) error {
+func (c *TypeComparator) CheckVariableSizedTypeEquality(expected *ast.VariableSizedType, found ast.Type) error {
 	foundVarSizedType, ok := found.(*ast.VariableSizedType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -62,7 +62,7 @@ func (c *TypeEqualityChecker) CheckVariableSizedTypeEquality(expected *ast.Varia
 	return expected.Type.CheckEqual(foundVarSizedType.Type, c)
 }
 
-func (c *TypeEqualityChecker) CheckConstantSizedTypeEquality(expected *ast.ConstantSizedType, found ast.Type) error {
+func (c *TypeComparator) CheckConstantSizedTypeEquality(expected *ast.ConstantSizedType, found ast.Type) error {
 	foundConstSizedType, ok := found.(*ast.ConstantSizedType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -78,7 +78,7 @@ func (c *TypeEqualityChecker) CheckConstantSizedTypeEquality(expected *ast.Const
 	return expected.Type.CheckEqual(foundConstSizedType.Type, c)
 }
 
-func (c *TypeEqualityChecker) CheckDictionaryTypeEquality(expected *ast.DictionaryType, found ast.Type) error {
+func (c *TypeComparator) CheckDictionaryTypeEquality(expected *ast.DictionaryType, found ast.Type) error {
 	foundDictionaryType, ok := found.(*ast.DictionaryType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -92,7 +92,7 @@ func (c *TypeEqualityChecker) CheckDictionaryTypeEquality(expected *ast.Dictiona
 	return expected.ValueType.CheckEqual(foundDictionaryType.ValueType, c)
 }
 
-func (c *TypeEqualityChecker) CheckRestrictedTypeEquality(expected *ast.RestrictedType, found ast.Type) error {
+func (c *TypeComparator) CheckRestrictedTypeEquality(expected *ast.RestrictedType, found ast.Type) error {
 	foundRestrictedType, ok := found.(*ast.RestrictedType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -131,7 +131,7 @@ func (c *TypeEqualityChecker) CheckRestrictedTypeEquality(expected *ast.Restrict
 	return nil
 }
 
-func (c *TypeEqualityChecker) CheckInstantiationTypeEquality(expected *ast.InstantiationType, found ast.Type) error {
+func (c *TypeComparator) CheckInstantiationTypeEquality(expected *ast.InstantiationType, found ast.Type) error {
 	foundInstType, ok := found.(*ast.InstantiationType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -153,7 +153,7 @@ func (c *TypeEqualityChecker) CheckInstantiationTypeEquality(expected *ast.Insta
 	return nil
 }
 
-func (c *TypeEqualityChecker) CheckFunctionTypeEquality(expected *ast.FunctionType, found ast.Type) error {
+func (c *TypeComparator) CheckFunctionTypeEquality(expected *ast.FunctionType, found ast.Type) error {
 	foundFuncType, ok := found.(*ast.FunctionType)
 	if !ok || len(expected.ParameterTypeAnnotations) != len(foundFuncType.ParameterTypeAnnotations) {
 		return getTypeMismatchError(expected, found)
@@ -170,7 +170,7 @@ func (c *TypeEqualityChecker) CheckFunctionTypeEquality(expected *ast.FunctionTy
 	return expected.ReturnTypeAnnotation.Type.CheckEqual(foundFuncType.ReturnTypeAnnotation.Type, c)
 }
 
-func (c *TypeEqualityChecker) CheckReferenceTypeEquality(expected *ast.ReferenceType, found ast.Type) error {
+func (c *TypeComparator) CheckReferenceTypeEquality(expected *ast.ReferenceType, found ast.Type) error {
 	refType, ok := found.(*ast.ReferenceType)
 	if !ok {
 		return getTypeMismatchError(expected, found)
@@ -179,7 +179,7 @@ func (c *TypeEqualityChecker) CheckReferenceTypeEquality(expected *ast.Reference
 	return expected.Type.CheckEqual(refType.Type, c)
 }
 
-func (c *TypeEqualityChecker) checkNameEquality(expectedType *ast.NominalType, foundType *ast.NominalType) bool {
+func (c *TypeComparator) checkNameEquality(expectedType *ast.NominalType, foundType *ast.NominalType) bool {
 	isExpectedQualifiedName := expectedType.IsQualifiedName()
 	isFoundQualifiedName := foundType.IsQualifiedName()
 
@@ -204,7 +204,7 @@ func (c *TypeEqualityChecker) checkNameEquality(expectedType *ast.NominalType, f
 	return identifiersEqual(expectedType.NestedIdentifiers, foundType.NestedIdentifiers)
 }
 
-func (c *TypeEqualityChecker) checkIdentifierEquality(
+func (c *TypeComparator) checkIdentifierEquality(
 	qualifiedNominalType *ast.NominalType,
 	simpleNominalType *ast.NominalType,
 ) bool {

--- a/runtime/type-eqyality-checker.go
+++ b/runtime/type-eqyality-checker.go
@@ -1,0 +1,268 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+var _ ast.TypeEqualityChecker = &TypeEqualityChecker{}
+
+type TypeEqualityChecker struct {
+	RootDeclIdentifier *Identifier
+}
+
+func (c *TypeEqualityChecker) CheckNominalTypeEquality(expected *ast.NominalType, found ast.Type) error {
+	foundNominalType, ok := found.(*ast.NominalType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	// First check whether the names are equal.
+	ok = c.checkNameEquality(expected, foundNominalType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	return nil
+}
+
+func (c *TypeEqualityChecker) CheckOptionalTypeEquality(expected *ast.OptionalType, found ast.Type) error {
+	foundOptionalType, ok := found.(*ast.OptionalType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	return expected.Type.CheckEqual(foundOptionalType.Type, c)
+}
+
+func (c *TypeEqualityChecker) CheckVariableSizedTypeEquality(expected *ast.VariableSizedType, found ast.Type) error {
+	foundVarSizedType, ok := found.(*ast.VariableSizedType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	return expected.Type.CheckEqual(foundVarSizedType.Type, c)
+}
+
+func (c *TypeEqualityChecker) CheckConstantSizedTypeEquality(expected *ast.ConstantSizedType, found ast.Type) error {
+	foundConstSizedType, ok := found.(*ast.ConstantSizedType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	// Check size
+	if foundConstSizedType.Size.Value.Cmp(expected.Size.Value) != 0 ||
+		foundConstSizedType.Size.Base != expected.Size.Base {
+		return getTypeMismatchError(expected, found)
+	}
+
+	// Check type
+	return expected.Type.CheckEqual(foundConstSizedType.Type, c)
+}
+
+func (c *TypeEqualityChecker) CheckDictionaryTypeEquality(expected *ast.DictionaryType, found ast.Type) error {
+	foundDictionaryType, ok := found.(*ast.DictionaryType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	err := expected.KeyType.CheckEqual(foundDictionaryType.KeyType, c)
+	if err != nil {
+		return err
+	}
+
+	return expected.ValueType.CheckEqual(foundDictionaryType.ValueType, c)
+}
+
+func (c *TypeEqualityChecker) CheckRestrictedTypeEquality(expected *ast.RestrictedType, found ast.Type) error {
+	foundRestrictedType, ok := found.(*ast.RestrictedType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	if expected.Type == nil {
+		if !isAnyStructOrAnyResourceType(foundRestrictedType.Type) {
+			return getTypeMismatchError(expected, found)
+		}
+		// else go on to check type restrictions
+	} else if foundRestrictedType.Type == nil {
+		if !isAnyStructOrAnyResourceType(expected.Type) {
+			return getTypeMismatchError(expected, found)
+		}
+		// else go on to check type restrictions
+	} else {
+		// both are not nil
+		err := expected.Type.CheckEqual(foundRestrictedType.Type, c)
+		if err != nil {
+			return getTypeMismatchError(expected, found)
+		}
+	}
+
+	if len(expected.Restrictions) != len(foundRestrictedType.Restrictions) {
+		return getTypeMismatchError(expected, found)
+	}
+
+	for index, expectedRestriction := range expected.Restrictions {
+		foundRestriction := foundRestrictedType.Restrictions[index]
+		err := expectedRestriction.CheckEqual(foundRestriction, c)
+		if err != nil {
+			return getTypeMismatchError(expected, found)
+		}
+	}
+
+	return nil
+}
+
+func (c *TypeEqualityChecker) CheckInstantiationTypeEquality(expected *ast.InstantiationType, found ast.Type) error {
+	foundInstType, ok := found.(*ast.InstantiationType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	err := expected.Type.CheckEqual(foundInstType.Type, c)
+	if err != nil || len(expected.TypeArguments) != len(foundInstType.TypeArguments) {
+		return getTypeMismatchError(expected, found)
+	}
+
+	for index, typeArgs := range expected.TypeArguments {
+		otherTypeArgs := foundInstType.TypeArguments[index]
+		err := typeArgs.Type.CheckEqual(otherTypeArgs.Type, c)
+		if err != nil {
+			return getTypeMismatchError(expected, found)
+		}
+	}
+
+	return nil
+}
+
+func (c *TypeEqualityChecker) CheckFunctionTypeEquality(expected *ast.FunctionType, found ast.Type) error {
+	foundFuncType, ok := found.(*ast.FunctionType)
+	if !ok || len(expected.ParameterTypeAnnotations) != len(foundFuncType.ParameterTypeAnnotations) {
+		return getTypeMismatchError(expected, found)
+	}
+
+	for index, expectedParamType := range expected.ParameterTypeAnnotations {
+		foundParamType := foundFuncType.ParameterTypeAnnotations[index]
+		err := expectedParamType.Type.CheckEqual(foundParamType.Type, c)
+		if err != nil {
+			return getTypeMismatchError(expected, found)
+		}
+	}
+
+	return expected.ReturnTypeAnnotation.Type.CheckEqual(foundFuncType.ReturnTypeAnnotation.Type, c)
+}
+
+func (c *TypeEqualityChecker) CheckReferenceTypeEquality(expected *ast.ReferenceType, found ast.Type) error {
+	refType, ok := found.(*ast.ReferenceType)
+	if !ok {
+		return getTypeMismatchError(expected, found)
+	}
+
+	return expected.Type.CheckEqual(refType.Type, c)
+}
+
+func (c *TypeEqualityChecker) checkNameEquality(expectedType *ast.NominalType, foundType *ast.NominalType) bool {
+	isExpectedQualifiedName := expectedType.IsQualifiedName()
+	isFoundQualifiedName := foundType.IsQualifiedName()
+
+	// A field with a composite type can be defined in two ways:
+	// 	- Using type name (var x @ResourceName)
+	//	- Using qualified type name (var x @ContractName.ResourceName)
+
+	if isExpectedQualifiedName && !isFoundQualifiedName {
+		return c.checkIdentifierEquality(expectedType, foundType)
+	}
+
+	if isFoundQualifiedName && !isExpectedQualifiedName {
+		return c.checkIdentifierEquality(foundType, expectedType)
+	}
+
+	// At this point, either both are qualified names, or both are simple names.
+	// Thus, do a one-to-one match.
+	if expectedType.Identifier.Identifier != foundType.Identifier.Identifier {
+		return false
+	}
+
+	return identifiersEqual(expectedType.NestedIdentifiers, foundType.NestedIdentifiers)
+}
+
+func (c *TypeEqualityChecker) checkIdentifierEquality(
+	qualifiedNominalType *ast.NominalType,
+	simpleNominalType *ast.NominalType,
+) bool {
+
+	// Situation:
+	// qualifiedNominalType -> identifier: A, nestedIdentifiers: [foo, bar, ...]
+	// simpleNominalType -> identifier: foo,  nestedIdentifiers: [bar, ...]
+
+	// If the first identifier (i.e: 'A') refers to a composite decl that is not the enclosing contract,
+	// then it must be referring to an imported contract. That means the two types are no longer the same.
+	if c.RootDeclIdentifier != nil &&
+		qualifiedNominalType.Identifier.Identifier != c.RootDeclIdentifier.Identifier {
+		return false
+	}
+
+	if qualifiedNominalType.NestedIdentifiers[0].Identifier != simpleNominalType.Identifier.Identifier {
+		return false
+	}
+
+	return identifiersEqual(simpleNominalType.NestedIdentifiers, qualifiedNominalType.NestedIdentifiers[1:])
+}
+
+func identifiersEqual(expected []ast.Identifier, found []ast.Identifier) bool {
+	if len(expected) != len(found) {
+		return false
+	}
+
+	for index, element := range found {
+		if expected[index].Identifier != element.Identifier {
+			return false
+		}
+	}
+	return true
+}
+
+func isAnyStructOrAnyResourceType(astType ast.Type) bool {
+	// If the restricted type is not stated, then it is either AnyStruct or AnyResource
+	if astType == nil {
+		return true
+	}
+
+	nominalType, ok := astType.(*ast.NominalType)
+	if !ok {
+		return false
+	}
+
+	switch nominalType.Identifier.Identifier {
+	case sema.AnyStructType.Name, sema.AnyResourceType.Name:
+		return true
+	default:
+		return false
+	}
+}
+
+func getTypeMismatchError(expectedType ast.Type, foundType ast.Type) *TypeMismatchError {
+	return &TypeMismatchError{
+		ExpectedType: expectedType,
+		FoundType:    foundType,
+		Range:        ast.NewUnmeteredRangeFromPositioned(foundType),
+	}
+}


### PR DESCRIPTION
## Description

This PR separates the AST type equality checker from the contract update validator, so that type equality checking can be re-used. No change is done to the checker's logic.

This is needed for moving the [duplicate switch-case checking](https://github.com/onflow/cadence/pull/1307) to the linter repo. Because the switch-case checking currently depends on the type-checker to do the type equality check. But once it is moved out from the type-checker, it no longer can rely on the checker. Instead, the same 'type equality check' can be performed using the AST only, similar to how it is done in the contract update validator. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
