### PR TITLE
[0.24] Panic on duplicate key for resource-typed dictionary literal

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -622,3 +622,13 @@ type NonTransferableValueError struct {
 func (e NonTransferableValueError) Error() string {
 	return "cannot transfer non-transferable value"
 }
+
+// DuplicateKeyInResourceDictionaryError
+//
+type DuplicateKeyInResourceDictionaryError struct {
+	LocationRange
+}
+
+func (e DuplicateKeyInResourceDictionaryError) Error() string {
+	return "duplicate key in resource dictionary"
+}

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -699,8 +699,6 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 			locationRangeGetter(interpreter, interpreter.Location, entry.Value),
 		)
 
-		// TODO: panic for duplicate keys?
-
 		keyValuePairs = append(
 			keyValuePairs,
 			key,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -9884,3 +9884,50 @@ func TestInterpretNilCoalesceReference(t *testing.T) {
 		variable.GetValue(),
 	)
 }
+
+func TestInterpretDictionaryDuplicateKey(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("struct", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+
+          struct S {}
+
+          fun test() {
+              let s1 = S()
+              let s2 = S()
+              {"a": s1, "a": s2}
+          }
+        `)
+
+		_, err := inter.Invoke("test")
+		require.NoError(t, err)
+	})
+
+	t.Run("resource", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+
+          resource R {}
+
+          fun test() {
+              let r1 <- create R()
+              let r2 <- create R()
+              let rs <- {"a": <-r1, "a": <-r2}
+              destroy rs
+          }
+        `)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+
+		require.ErrorAs(t, err, &interpreter.DuplicateKeyInResourceDictionaryError{})
+
+	})
+}


### PR DESCRIPTION
## Description

Port of https://github.com/dapperlabs/cadence-internal/pull/96

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
