### PR TITLE
Panic on duplicate key for resource-typed dictionary literal

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -811,3 +811,17 @@ func (NonTransferableValueError) IsUserError() {}
 func (e NonTransferableValueError) Error() string {
 	return "cannot transfer non-transferable value"
 }
+
+// DuplicateKeyInResourceDictionaryError
+//
+type DuplicateKeyInResourceDictionaryError struct {
+	LocationRange
+}
+
+var _ errors.UserError = DuplicateKeyInResourceDictionaryError{}
+
+func (DuplicateKeyInResourceDictionaryError) IsUserError() {}
+
+func (e DuplicateKeyInResourceDictionaryError) Error() string {
+	return "duplicate key in resource dictionary"
+}

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -702,8 +702,6 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 			locationRangeGetter(interpreter, interpreter.Location, entry.Value),
 		)
 
-		// TODO: panic for duplicate keys?
-
 		keyValuePairs = append(
 			keyValuePairs,
 			key,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -15397,11 +15397,28 @@ func NewDictionaryValueWithAddress(
 	// values are added to the dictionary after creation, not here
 	v = newDictionaryValueFromConstructor(interpreter, dictionaryType, 0, constructor)
 
+	// NOTE: lazily initialized when needed for performance reasons
+	var lazyIsResourceTyped *bool
+
 	for i := 0; i < keysAndValuesCount; i += 2 {
 		key := keysAndValues[i]
 		value := keysAndValues[i+1]
-		// TODO: handle existing value
-		_ = v.Insert(interpreter, getLocationRange, key, value)
+		existingValue := v.Insert(interpreter, getLocationRange, key, value)
+		// If the dictionary already contained a value for the key,
+		// and the dictionary is resource-typed,
+		// then we need to prevent a resource loss
+		if _, ok := existingValue.(*SomeValue); ok {
+			// Lazily determine if the dictionary is resource-typed, once
+			if lazyIsResourceTyped == nil {
+				isResourceTyped := v.SemaType(interpreter).IsResourceType()
+				lazyIsResourceTyped = &isResourceTyped
+			}
+			if *lazyIsResourceTyped {
+				panic(DuplicateKeyInResourceDictionaryError{
+					LocationRange: getLocationRange(),
+				})
+			}
+		}
 	}
 
 	return v


### PR DESCRIPTION
## Description

Port of https://github.com/dapperlabs/cadence-internal/pull/96

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
