### PR TITLE
Repair markdown for new site.

### DIFF
--- a/docs/language/functions.mdx
+++ b/docs/language/functions.mdx
@@ -515,4 +515,3 @@ fun incrementN() {
     n = n + 1
 }
 ```
-

--- a/docs/language/glossary.md
+++ b/docs/language/glossary.md
@@ -156,7 +156,7 @@ storagePath.toString()  // is "/storage/path"
 
 [More info](https://docs.onflow.org/cadence/language/accounts/#paths) on Paths
 
-## <- (lower than, hyphen) (Move operator)
+## `<-` (lower than, hyphen) (Move operator)
 
 The move operator `<-` replaces the assignment operator `=` in assignments that involve resources. To make assignment of resources explicit, the move operator `<-` must be used when:
 
@@ -186,7 +186,7 @@ let a <- [
 ]
 ```
 
-## <-! (lower than, hyphen, exclamation mark) (Force-assignment move operator)
+## `<-!` (lower than, hyphen, exclamation mark) (Force-assignment move operator)
 
 Assigns a resource value to an optional variable if the variable is `nil` (if it is not nil, it aborts)
 
@@ -199,7 +199,7 @@ var a: @R? <- nil
 a <-! create R()
 ```
 
-## <-> (lower than, hyphen, greater than) (Swap operator)
+## `<->` (lower than, hyphen, greater than) (Swap operator)
 
 `<->` is referred to as the Swap operator. It swaps values between the variables to the left and right of it. [More info](https://docs.onflow.org/cadence/language/operators/#swapping)
 
@@ -327,5 +327,4 @@ fun double(_ x: Int): Int {
     return x * 2
 }
 ```
-
 

--- a/docs/tutorial/01-first-steps.mdx
+++ b/docs/tutorial/01-first-steps.mdx
@@ -33,6 +33,8 @@ The Flow Playground should be compatible with any standard web browser,
 but we recommend that you use Google Chrome with it,
 because it has been tested and optimized for only the Chrome browser so far.
 
+<!-- If you encounter issues using the Flow Developer Playground, see the [Playground Manual](doc:playground-manual) or [Debugging](doc:debugging) for help. -->
+
 ## Getting to know the Playground
 
 The Playground contains everything you need to get familiar

--- a/docs/tutorial/05-non-fungible-tokens-1.mdx
+++ b/docs/tutorial/05-non-fungible-tokens-1.mdx
@@ -31,12 +31,9 @@ In this tutorial, we're going to deploy, store, and transfer **Non-Fungible Toke
 
 Open the starter code for this tutorial in the Flow Playground:
 
-<a
-  href="https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e"
-  target="_blank"
->
+<a href="https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e" target="_blank">
   https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e
-</a> <br />
+</a> <br/>
 The tutorial will ask you to take various actions to interact with this code.
 
 </Callout>
@@ -93,12 +90,12 @@ To get you comfortable using NFTs, this tutorial will teach you to:
   what any project should use in production. See the{" "}
   <a href="https://github.com/onflow/flow-nft" target="_blank">
     Flow Fungible Token standard
-  </a>{" "}
+  </a> 
   for the standard interface and example implementation. Additionally check out
-  the{" "}
+  the 
   <a href="https://github.com/onflow/kitty-items" target="_blank">
     Kitty Items Repo
-  </a>{" "}
+  </a> 
   for a production ready version!
 </Callout>
 
@@ -150,10 +147,7 @@ This contract relies on the [account storage API](/cadence/language/accounts/#au
 First, you'll need to follow this link to open a playground session
 with the Non-Fungible Token contracts, transactions, and scripts pre-loaded:
 
-<a
-  href="https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e"
-  target="_blank"
->
+<a href="https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e" target="_blank">
   https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e
 </a>
 

--- a/docs/tutorial/05-non-fungible-tokens-2.mdx
+++ b/docs/tutorial/05-non-fungible-tokens-2.mdx
@@ -32,12 +32,9 @@ a full implementation for **Non-Fungible Tokens (NFTs)**.
 
 Open the starter code for this tutorial in the Flow Playground:
 
-<a
-  href="https://play.onflow.org/af553a60-7b73-4e2e-b145-80a7c7e088dc"
-  target="_blank"
->
+<a href="https://play.onflow.org/af553a60-7b73-4e2e-b145-80a7c7e088dc" target="_blank">
   https://play.onflow.org/af553a60-7b73-4e2e-b145-80a7c7e088dc
-</a> <br />
+</a> <br/>
 The tutorial will ask you to take various actions to interact with this code.
 
 </Callout>
@@ -337,8 +334,6 @@ like a CryptoKitty owning a hat accessory,
 the Kitty literally stores the hat in its own storage and effectively owns it.
 The hat belongs to the CryptoKitty that it is stored in,
 and the hat can be transferred separately or along with the CryptoKitty that owns it,
-
-<!-- This feature is covered in more detail in [Composable Resources: Kitty Hats](doc:composable-resources-kitty-hats). -->
 
 ## Restricting Access to the NFT Collection
 

--- a/docs/tutorial/10-resources-compose.mdx
+++ b/docs/tutorial/10-resources-compose.mdx
@@ -132,6 +132,7 @@ These definitions show how a Kitty resource could own hats.
 
 The hats are stored in a variable in the Kitty resource.
 
+```cadence
     // place where the Kitty hats are stored
     `pub let items: <-{String: KittyHat}`
 

--- a/docs/tutorial/10-resources-compose.mdx
+++ b/docs/tutorial/10-resources-compose.mdx
@@ -134,8 +134,7 @@ The hats are stored in a variable in the Kitty resource.
 
 ```cadence
     // place where the Kitty hats are stored
-    `pub let items: <-{String: KittyHat}`
-
+    pub let items: <-{String: KittyHat}
 A Kitty owner can take the hats off the Kitty and transfer them individually. Or the owner can transfer a Kitty that owns a hat, and the hat will go along with the Kitty.
 
 Here is a transaction to create a `Kitty` and a `KittyHat`, store the hat in the Kitty, then store it in your account storage.

--- a/docs/tutorial/10-resources-compose.mdx
+++ b/docs/tutorial/10-resources-compose.mdx
@@ -135,6 +135,8 @@ The hats are stored in a variable in the Kitty resource.
 ```cadence
     // place where the Kitty hats are stored
     pub let items: <-{String: KittyHat}
+```
+
 A Kitty owner can take the hats off the Kitty and transfer them individually. Or the owner can transfer a Kitty that owns a hat, and the hat will go along with the Kitty.
 
 Here is a transaction to create a `Kitty` and a `KittyHat`, store the hat in the Kitty, then store it in your account storage.

--- a/docs/tutorial/10-resources-compose.mdx
+++ b/docs/tutorial/10-resources-compose.mdx
@@ -133,7 +133,7 @@ These definitions show how a Kitty resource could own hats.
 The hats are stored in a variable in the Kitty resource.
 
     // place where the Kitty hats are stored
-    pub let items: <-{String: KittyHat}
+    `pub let items: <-{String: KittyHat}`
 
 A Kitty owner can take the hats off the Kitty and transfer them individually. Or the owner can transfer a Kitty that owns a hat, and the hat will go along with the Kitty.
 


### PR DESCRIPTION
## Description

Fixes markdown rendering errors in docs as a result of upgrading the docs site from MDX v1 -> v2
Description of migration steps here: https://mdxjs.com/migrating/v2/

Original issue here: https://github.com/onflow/next-docs-v1/issues/292


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
