### PR TITLE
Fix typo in how to run docgen tool

### DIFF
--- a/tools/docgen/README.md
+++ b/tools/docgen/README.md
@@ -11,7 +11,7 @@ Supports generating documentation for following declarations:
 The tool currently supports generating documentation in Markdown format.
 
 ## How To Run
-Navigate to `<cadence_dir>/tools/docgen` directory and run:
+Navigate to `<cadence_dir>/tools/docgen/cmd` directory and run:
 ```
 go run main.go <path_to_cadence_file> <output_dir>
 ```


### PR DESCRIPTION
## Description

The path from the docgen tool has to be executed is missing the `/cmd` folder

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
