### PR TITLE
Change Runtime.InvokeContractFunction signature

### DIFF
--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -235,7 +235,9 @@ func (executor *interpreterContractFunctionExecutor) convertArgument(
 				inter,
 				interpreter.NewAddressValueFromConstructor(
 					inter,
-					func() common.Address { return common.MustBytesToAddress(addressValue.Bytes()) },
+					func() common.Address {
+						return common.Address(addressValue)
+					},
 				),
 				executor.context,
 				executor.storage,
@@ -250,19 +252,19 @@ func (executor *interpreterContractFunctionExecutor) convertArgument(
 				inter,
 				interpreter.NewAddressValueFromConstructor(
 					inter,
-					func() common.Address { return common.MustBytesToAddress(addressValue.Bytes()) },
+					func() common.Address {
+						return common.Address(addressValue)
+					},
 				),
 				executor.context.Interface,
 				executor.storage,
 			), nil
 		}
-	default:
-		return importValue(
-			inter,
-			getLocationRange,
-			argument,
-			argumentType,
-		)
 	}
-	return nil, nil
+	return importValue(
+		inter,
+		getLocationRange,
+		argument,
+		argumentType,
+	)
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3293,8 +3293,8 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Name:    "Test",
 			},
 			"helloArg",
-			[]interpreter.Value{
-				interpreter.NewUnmeteredStringValue("there!"),
+			[]cadence.Value{
+				cadence.String("there!"),
 			},
 			[]sema.Type{
 				sema.StringType,
@@ -3315,8 +3315,8 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Name:    "Test",
 			},
 			"helloReturn",
-			[]interpreter.Value{
-				interpreter.NewUnmeteredStringValue("there!"),
+			[]cadence.Value{
+				cadence.String("there!"),
 			},
 			[]sema.Type{
 				sema.StringType,
@@ -3338,10 +3338,10 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Name:    "Test",
 			},
 			"helloMultiArg",
-			[]interpreter.Value{
-				interpreter.NewUnmeteredStringValue("number"),
-				interpreter.NewUnmeteredIntValueFromInt64(42),
-				interpreter.AddressValue(addressValue),
+			[]cadence.Value{
+				cadence.String("number"),
+				cadence.NewInt(42),
+				cadence.BytesToAddress(addressValue.Bytes()),
 			},
 			[]sema.Type{
 				sema.StringType,
@@ -3365,9 +3365,9 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Name:    "Test",
 			},
 			"helloMultiArg",
-			[]interpreter.Value{
-				interpreter.NewUnmeteredStringValue("number"),
-				interpreter.NewUnmeteredIntValueFromInt64(42),
+			[]cadence.Value{
+				cadence.String("number"),
+				cadence.NewInt(42),
 			},
 			[]sema.Type{
 				sema.StringType,
@@ -3390,8 +3390,8 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Name:    "Test",
 			},
 			"helloArg",
-			[]interpreter.Value{
-				interpreter.NewUnmeteredIntValueFromInt64(42),
+			[]cadence.Value{
+				cadence.NewInt(42),
 			},
 			[]sema.Type{
 				sema.IntType,
@@ -3411,8 +3411,8 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Name:    "Test",
 			},
 			"helloAuthAcc",
-			[]interpreter.Value{
-				interpreter.AddressValue(addressValue),
+			[]cadence.Value{
+				cadence.BytesToAddress(addressValue.Bytes()),
 			},
 			[]sema.Type{
 				sema.AuthAccountType,
@@ -3433,8 +3433,8 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Name:    "Test",
 			},
 			"helloPublicAcc",
-			[]interpreter.Value{
-				interpreter.AddressValue(addressValue),
+			[]cadence.Value{
+				cadence.BytesToAddress(addressValue.Bytes()),
 			},
 			[]sema.Type{
 				sema.PublicAccountType,


### PR DESCRIPTION
References https://github.com/dapperlabs/flow-go/issues/6308

## Description

Changed Runtime.InvokeContractFunction signature so that the arguments are of type `cadence.Value` instead of `interpreter.Value`. 

This makes it possible to construct `cadence.Array`s  from the FVM side. Constructing interpreter arrays requires an interpreter instance.

It also makes more sense since `ExecuteTransaction` also accepts `cadence.Value`s (although in encoded form).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
