### PR TITLE
Robert/custom codec

### DIFF
--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -553,7 +553,7 @@ func TestSemaCodecBadTypes(t *testing.T) {
 	t.Run("unknown type", func(t *testing.T) {
 		_, decoder, buffer := NewTestCodec()
 
-		fakeType := byte(255)
+		fakeType := byte(0xff)
 		buffer.Write([]byte{fakeType})
 
 		_, err := decoder.Decode()

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/cadence/encoding/custom/sema_codec"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSemaCodecSimpleTypes(t *testing.T) {

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -1,0 +1,1643 @@
+package sema_codec_test
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/onflow/cadence/encoding/custom/sema_codec"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSemaCodecSimpleTypes(t *testing.T) {
+	t.Parallel()
+
+	type TestInfo struct {
+		SimpleType *sema.SimpleType
+		Type       sema_codec.EncodedSema
+	}
+
+	tests := []TestInfo{
+		{sema.AnyType, sema_codec.EncodedSemaSimpleTypeAnyType},
+		{sema.AnyResourceType, sema_codec.EncodedSemaSimpleTypeAnyResourceType},
+		{sema.AnyStructType, sema_codec.EncodedSemaSimpleTypeAnyStructType},
+		{sema.BlockType, sema_codec.EncodedSemaSimpleTypeBlockType},
+		{sema.BoolType, sema_codec.EncodedSemaSimpleTypeBoolType},
+		{sema.CharacterType, sema_codec.EncodedSemaSimpleTypeCharacterType},
+		{sema.DeployedContractType, sema_codec.EncodedSemaSimpleTypeDeployedContractType},
+		{sema.InvalidType, sema_codec.EncodedSemaSimpleTypeInvalidType},
+		{sema.MetaType, sema_codec.EncodedSemaSimpleTypeMetaType},
+		{sema.NeverType, sema_codec.EncodedSemaSimpleTypeNeverType},
+		{sema.PathType, sema_codec.EncodedSemaSimpleTypePathType},
+		{sema.StoragePathType, sema_codec.EncodedSemaSimpleTypeStoragePathType},
+		{sema.CapabilityPathType, sema_codec.EncodedSemaSimpleTypeCapabilityPathType},
+		{sema.PublicPathType, sema_codec.EncodedSemaSimpleTypePublicPathType},
+		{sema.PrivatePathType, sema_codec.EncodedSemaSimpleTypePrivatePathType},
+		{sema.StorableType, sema_codec.EncodedSemaSimpleTypeStorableType},
+		{sema.StringType, sema_codec.EncodedSemaSimpleTypeStringType},
+		{sema.VoidType, sema_codec.EncodedSemaSimpleTypeVoidType},
+	}
+
+	for _, typ := range tests {
+		t.Run(typ.SimpleType.Name, func(t *testing.T) {
+			testRootEncodeDecode(t, typ.SimpleType,
+				byte(typ.Type),
+			)
+		})
+	}
+}
+
+func TestSemaCodecNumericTypes(t *testing.T) {
+	t.Parallel()
+
+	type TestInfo struct {
+		SimpleType sema.Type
+		Type       sema_codec.EncodedSema
+	}
+
+	tests := []TestInfo{
+		{sema.NumberType, sema_codec.EncodedSemaNumericTypeNumberType},
+		{sema.SignedNumberType, sema_codec.EncodedSemaNumericTypeSignedNumberType},
+		{sema.IntegerType, sema_codec.EncodedSemaNumericTypeIntegerType},
+		{sema.SignedIntegerType, sema_codec.EncodedSemaNumericTypeSignedIntegerType},
+		{sema.IntType, sema_codec.EncodedSemaNumericTypeIntType},
+		{sema.Int8Type, sema_codec.EncodedSemaNumericTypeInt8Type},
+		{sema.Int16Type, sema_codec.EncodedSemaNumericTypeInt16Type},
+		{sema.Int32Type, sema_codec.EncodedSemaNumericTypeInt32Type},
+		{sema.Int64Type, sema_codec.EncodedSemaNumericTypeInt64Type},
+		{sema.Int128Type, sema_codec.EncodedSemaNumericTypeInt128Type},
+		{sema.Int256Type, sema_codec.EncodedSemaNumericTypeInt256Type},
+		{sema.UIntType, sema_codec.EncodedSemaNumericTypeUIntType},
+		{sema.UInt8Type, sema_codec.EncodedSemaNumericTypeUInt8Type},
+		{sema.UInt16Type, sema_codec.EncodedSemaNumericTypeUInt16Type},
+		{sema.UInt32Type, sema_codec.EncodedSemaNumericTypeUInt32Type},
+		{sema.UInt64Type, sema_codec.EncodedSemaNumericTypeUInt64Type},
+		{sema.UInt128Type, sema_codec.EncodedSemaNumericTypeUInt128Type},
+		{sema.UInt256Type, sema_codec.EncodedSemaNumericTypeUInt256Type},
+		{sema.Word8Type, sema_codec.EncodedSemaNumericTypeWord8Type},
+		{sema.Word16Type, sema_codec.EncodedSemaNumericTypeWord16Type},
+		{sema.Word32Type, sema_codec.EncodedSemaNumericTypeWord32Type},
+		{sema.Word64Type, sema_codec.EncodedSemaNumericTypeWord64Type},
+		{sema.FixedPointType, sema_codec.EncodedSemaNumericTypeFixedPointType},
+		{sema.SignedFixedPointType, sema_codec.EncodedSemaNumericTypeSignedFixedPointType},
+		{sema.Fix64Type, sema_codec.EncodedSemaFix64Type},
+		{sema.UFix64Type, sema_codec.EncodedSemaUFix64Type},
+	}
+
+	for _, typ := range tests {
+		t.Run(typ.SimpleType.String(), func(t *testing.T) {
+			t.Parallel()
+			testRootEncodeDecode(t, typ.SimpleType,
+				byte(typ.Type),
+			)
+		})
+	}
+}
+
+func TestSemaCodecMiscTypes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		testRootEncodeDecode(t, nil, byte(sema_codec.EncodedSemaNilType))
+	})
+
+	t.Run("AddressType", func(t *testing.T) {
+		t.Parallel()
+		testRootEncodeDecode(t, &sema.AddressType{}, byte(sema_codec.EncodedSemaAddressType))
+	})
+
+	t.Run("OptionalType", func(t *testing.T) {
+		t.Parallel()
+
+		testRootEncodeDecode(
+			t,
+			&sema.OptionalType{Type: sema.BoolType},
+			byte(sema_codec.EncodedSemaOptionalType),
+			byte(sema_codec.EncodedSemaSimpleTypeBoolType),
+		)
+	})
+
+	t.Run("ReferenceType", func(t *testing.T) {
+		t.Parallel()
+
+		testRootEncodeDecode(
+			t,
+			&sema.ReferenceType{
+				Authorized: false,
+				Type:       sema.AnyType,
+			},
+			byte(sema_codec.EncodedSemaReferenceType),
+			byte(sema_codec.EncodedBoolFalse),
+			byte(sema_codec.EncodedSemaSimpleTypeAnyType),
+		)
+	})
+
+	t.Run("CapabilityType", func(t *testing.T) {
+		t.Parallel()
+
+		testRootEncodeDecode(
+			t,
+			&sema.CapabilityType{BorrowType: sema.VoidType},
+			byte(sema_codec.EncodedSemaCapabilityType),
+			byte(sema_codec.EncodedSemaSimpleTypeVoidType),
+		)
+	})
+
+	t.Run("GenericType", func(t *testing.T) {
+		t.Parallel()
+
+		name := "could be anything"
+
+		testRootEncodeDecode(
+			t,
+			&sema.GenericType{TypeParameter: &sema.TypeParameter{
+				Name:      name,
+				TypeBound: sema.Int32Type,
+				Optional:  true,
+			}},
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaGenericType)},
+				[]byte{0, 0, 0, byte(len(name))},
+				[]byte(name),
+				[]byte{byte(sema_codec.EncodedSemaNumericTypeInt32Type)},
+				[]byte{byte(sema_codec.EncodedBoolTrue)},
+			)...,
+		)
+	})
+
+	t.Run("FunctionType", func(t *testing.T) {
+		t.Parallel()
+
+		const isConstructor = true
+		typeParameters := []*sema.TypeParameter{
+			{
+				Name:      "myriad",
+				TypeBound: sema.VoidType,
+				Optional:  false,
+			},
+		}
+		parameters := []*sema.Parameter{
+			{
+				Label:          "juno",
+				Identifier:     "fake0",
+				TypeAnnotation: sema.NewTypeAnnotation(sema.AnyResourceType),
+			},
+			{
+				Label:          "calipso",
+				Identifier:     "fake1",
+				TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
+			},
+		}
+		returnTypeAnnotation := sema.NewTypeAnnotation(sema.PathType)
+		requiredArgumentCount := 1
+
+		members := &sema.StringMemberOrderedMap{}
+		memberIdentifer := "someID"
+		memberDocString := "\"doctored\" string"
+		members.Set("yolo", sema.NewPublicConstantFieldMember(
+			nil,
+			sema.PrivatePathType,
+			memberIdentifer,
+			sema.Int8Type,
+			memberDocString,
+		))
+
+		functionType := &sema.FunctionType{
+			IsConstructor:            isConstructor,
+			TypeParameters:           typeParameters,
+			Parameters:               parameters,
+			ReturnTypeAnnotation:     returnTypeAnnotation,
+			RequiredArgumentCount:    &requiredArgumentCount,
+			ArgumentExpressionsCheck: nil,
+			Members:                  members,
+		}
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		err := encoder.Encode(functionType)
+		require.NoError(t, err, "encoding error")
+
+		expected := Concat(
+			[]byte{byte(sema_codec.EncodedSemaFunctionType)},
+
+			[]byte{byte(sema_codec.EncodedBoolTrue)}, // isConstructor
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeParameters array is non-nil
+			[]byte{0, 0, 0, byte(len(typeParameters))},
+			[]byte{0, 0, 0, byte(len(typeParameters[0].Name))},
+			[]byte(typeParameters[0].Name),
+			[]byte{byte(sema_codec.EncodedSemaSimpleTypeVoidType)},
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Parameters array is non-nil
+			[]byte{0, 0, 0, byte(len(parameters))},
+			[]byte{0, 0, 0, byte(len(parameters[0].Label))},
+			[]byte(parameters[0].Label),
+			[]byte{0, 0, 0, byte(len(parameters[0].Identifier))},
+			[]byte(parameters[0].Identifier),
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedBoolTrue)},
+			[]byte{byte(sema_codec.EncodedSemaSimpleTypeAnyResourceType)},
+			[]byte{0, 0, 0, byte(len(parameters[1].Label))},
+			[]byte(parameters[1].Label),
+			[]byte{0, 0, 0, byte(len(parameters[1].Identifier))},
+			[]byte(parameters[1].Identifier),
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedSemaSimpleTypeStringType)},
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeAnnotation is not nil
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeAnnotation: it is not a Resource
+			[]byte{byte(sema_codec.EncodedSemaSimpleTypePathType)},
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(requiredArgumentCount)},
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)},        // Members is not nil
+			[]byte{0, 0, 0, byte(members.Len())},             // Members length
+			[]byte{0, 0, 0, byte(len(members.Newest().Key))}, // Member key
+			[]byte(members.Newest().Key),
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.AccessPublic)}, // Member value
+			[]byte{0, 0, 0, byte(len(memberIdentifer))},         // Member AST identifier
+			[]byte(memberIdentifer),
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0}, // Member AST identifier position
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Member type annotation
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedSemaNumericTypeInt8Type)},
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(common.DeclarationKindField)}, // Member declaration kind
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.VariableKindConstant)},    // member variable kind
+			[]byte{byte(sema_codec.EncodedBoolTrue)},                       // Member has no argument labels
+			[]byte{byte(sema_codec.EncodedBoolFalse)},                      // Member is not predeclared
+			[]byte{0, 0, 0, byte(len(memberDocString))},                    // Member doc string
+			[]byte(memberDocString),
+		)
+
+		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
+
+		decoded, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		// Cannot simply check equality between original and decoded types because they are not shallowly equal.
+		// Specifically, RequiredArgumentCount and Members are not shallowly equal.
+		switch f := decoded.(type) {
+		case *sema.FunctionType:
+			assert.Equal(t, isConstructor, f.IsConstructor)
+
+			require.NotNil(t, f.TypeParameters, "TypeParameters")
+			require.Len(t, f.TypeParameters, 1, "TypeParameters")
+			assert.Equal(t, typeParameters[0], f.TypeParameters[0], "TypeParameters[0]")
+
+			require.NotNil(t, f.Parameters, "Parameters")
+			require.Len(t, f.Parameters, 2, "Parameters")
+			assert.Equal(t, parameters[0], f.Parameters[0], "Parameters[0]")
+			assert.Equal(t, parameters[1], f.Parameters[1], "Parameters[1]")
+
+			assert.Equal(t, returnTypeAnnotation, f.ReturnTypeAnnotation, "ReturnTypeAnnotation")
+
+			assert.Equal(t, requiredArgumentCount, *f.RequiredArgumentCount, "RequiredArgumentCount")
+
+			assert.Nil(t, f.ArgumentExpressionsCheck, "ArgumentExpressionsCheck")
+
+			// verify member equality
+			require.Equal(t, members.Len(), f.Members.Len(), "members length")
+			f.Members.Foreach(func(key string, actual *sema.Member) {
+				expected, present := f.Members.Get(key)
+				require.True(t, present, "extra member: %s", key)
+
+				assert.Equal(t, expected.ContainerType.ID(), actual.ContainerType.ID(), "container type for %s", key)
+				assert.Equal(t, expected.TypeAnnotation.QualifiedString(), actual.TypeAnnotation.QualifiedString(), "type annotation for %s", key)
+			})
+		default:
+			assert.Fail(t, "Decoded type is not *sema.FunctionTypre")
+		}
+	})
+
+	t.Run("DictionaryType", func(t *testing.T) {
+		t.Parallel()
+
+		testRootEncodeDecode(
+			t,
+			&sema.DictionaryType{
+				KeyType:   sema.StringType,
+				ValueType: sema.AnyStructType,
+			},
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaDictionaryType)},
+				[]byte{byte(sema_codec.EncodedSemaSimpleTypeStringType)},
+				[]byte{byte(sema_codec.EncodedSemaSimpleTypeAnyStructType)},
+			)...,
+		)
+	})
+
+	t.Run("TransactionType", func(t *testing.T) {
+		t.Parallel()
+
+		members := &sema.StringMemberOrderedMap{}
+		memberIdentifer := "someID"
+		memberDocString := "\"doctored\" string"
+		members.Set("yol2", sema.NewPublicConstantFieldMember(
+			nil,
+			sema.PrivatePathType,
+			memberIdentifer,
+			sema.Int8Type,
+			memberDocString,
+		))
+
+		fields := []string{
+			"twelve",
+			"twenty four",
+			"forty eight",
+			"ninety six",
+		}
+
+		prepareParameters := []*sema.Parameter{
+			{
+				Label:          "replay",
+				Identifier:     "fake6",
+				TypeAnnotation: sema.NewTypeAnnotation(sema.UInt16Type),
+			},
+		}
+
+		parameters := []*sema.Parameter{
+			{
+				Label:          "hadron",
+				Identifier:     "collision",
+				TypeAnnotation: sema.NewTypeAnnotation(sema.SignedFixedPointType),
+			},
+		}
+
+		transactionType := &sema.TransactionType{
+			Members:           members,
+			Fields:            fields,
+			PrepareParameters: prepareParameters,
+			Parameters:        parameters,
+		}
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		err := encoder.Encode(transactionType)
+		require.NoError(t, err, "encoding error")
+
+		expected := Concat(
+			[]byte{byte(sema_codec.EncodedSemaTransactionType)},
+			// members
+			[]byte{byte(sema_codec.EncodedBoolFalse)},        // Members is not nil
+			[]byte{0, 0, 0, byte(members.Len())},             // Members length
+			[]byte{0, 0, 0, byte(len(members.Newest().Key))}, // Member key
+			[]byte(members.Newest().Key),
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.AccessPublic)}, // Member value
+			[]byte{0, 0, 0, byte(len(memberIdentifer))},         // Member AST identifier
+			[]byte(memberIdentifer),
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0}, // Member AST identifier position
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Member type annotation
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedSemaNumericTypeInt8Type)},
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(common.DeclarationKindField)}, // Member declaration kind
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.VariableKindConstant)},    // member variable kind
+			[]byte{byte(sema_codec.EncodedBoolTrue)},                       // Member has no argument labels
+			[]byte{byte(sema_codec.EncodedBoolFalse)},                      // Member is not predeclared
+			[]byte{0, 0, 0, byte(len(memberDocString))},                    // Member doc string
+			[]byte(memberDocString),
+
+			// array of strings for fields
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{0, 0, 0, byte(len(fields))},
+			[]byte{0, 0, 0, byte(len(fields[0]))},
+			[]byte(fields[0]),
+			[]byte{0, 0, 0, byte(len(fields[1]))},
+			[]byte(fields[1]),
+			[]byte{0, 0, 0, byte(len(fields[2]))},
+			[]byte(fields[2]),
+			[]byte{0, 0, 0, byte(len(fields[3]))},
+			[]byte(fields[3]),
+
+			// array of parameters for prepareParameters
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{0, 0, 0, byte(len(prepareParameters))},
+			[]byte{0, 0, 0, byte(len(prepareParameters[0].Label))},
+			[]byte(prepareParameters[0].Label),
+			[]byte{0, 0, 0, byte(len(prepareParameters[0].Identifier))},
+			[]byte(prepareParameters[0].Identifier),
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedSemaNumericTypeUInt16Type)},
+
+			// array of parameters for parameters
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{0, 0, 0, byte(len(parameters))},
+			[]byte{0, 0, 0, byte(len(parameters[0].Label))},
+			[]byte(parameters[0].Label),
+			[]byte{0, 0, 0, byte(len(parameters[0].Identifier))},
+			[]byte(parameters[0].Identifier),
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedSemaNumericTypeSignedFixedPointType)},
+		)
+
+		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
+
+		decoded, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		// Cannot simply check equality between original and decoded types because they are not shallowly equal.
+		// Specifically, Members is not shallowly equal.
+		switch tx := decoded.(type) {
+		case *sema.TransactionType:
+			// verify member equality
+			require.Equal(t, members.Len(), tx.Members.Len(), "members length")
+			tx.Members.Foreach(func(key string, actual *sema.Member) {
+				expected, present := tx.Members.Get(key)
+				require.True(t, present, "extra member: %s", key)
+
+				assert.Equal(t, expected.ContainerType.ID(), actual.ContainerType.ID(), "container type for %s", key)
+				assert.Equal(t, expected.TypeAnnotation.QualifiedString(), actual.TypeAnnotation.QualifiedString(), "type annotation for %s", key)
+			})
+
+			assert.Equal(t, fields, tx.Fields, "fields")
+			assert.Equal(t, tx.Parameters, parameters, "parameters")
+			assert.Equal(t, tx.PrepareParameters, prepareParameters, "prepareParameters")
+		default:
+			assert.Fail(t, "Decoded type is not *sema.TransactionType")
+		}
+	})
+
+	t.Run("RestrictedType", func(t *testing.T) {
+		t.Parallel()
+
+		location := common.ScriptLocation{12, 24, 48, 96}
+		restrictedType := &sema.RestrictedType{
+			Type: sema.IntType,
+			Restrictions: []*sema.InterfaceType{{
+				Location:              location,
+				Identifier:            "peaked",
+				CompositeKind:         common.CompositeKindContract,
+				Members:               nil,
+				Fields:                nil,
+				InitializerParameters: nil,
+			}},
+		}
+		restrictedType.Restrictions[0].SetContainerType(restrictedType)
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		err := encoder.Encode(restrictedType)
+		require.NoError(t, err, "encoding error")
+
+		expected := Concat(
+			[]byte{byte(sema_codec.EncodedSemaRestrictedType)},
+			[]byte{byte(sema_codec.EncodedSemaNumericTypeIntType)},
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{0, 0, 0, 1},                      // array length
+			Concat([]byte{'s'}, location[:]),
+			[]byte{0, 0, 0, 6}, []byte("peaked"),    // identifier
+			[]byte{byte(common.CompositeKindContract)},
+			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // members is nil
+			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // fields is nil
+			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // initializer parameters is nil
+			[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // container type is root type
+			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // nested types is nil
+		)
+
+		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
+
+		decoded, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		// Cannot simply check equality between original and decoded types because they are not shallowly equal.
+		// Specifically, the elements of Restrictions are not shallowly equal.
+		switch r := decoded.(type) {
+		case *sema.RestrictedType:
+			assert.Equal(t, sema.IntType, r.Type, "Type")
+
+			require.Len(t, r.Restrictions, 1, "restrictions length")
+
+			// minimal verification
+			assert.Equal(t, restrictedType.Restrictions[0].Identifier, r.Restrictions[0].Identifier, "restriction identifier")
+		default:
+			assert.Fail(t, "Decoded type is not *sema.RestrictionType")
+		}
+	})
+}
+
+func TestSemaCodecBadTypes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown type", func(t *testing.T) {
+		_, decoder, buffer := NewTestCodec()
+
+		fakeType := byte(255)
+		buffer.Write([]byte{fakeType})
+
+		_, err := decoder.Decode()
+		assert.ErrorContains(t, err, "unknown type", "encoding unknown type succeeded when it shouldn't have")
+	})
+
+	t.Run("unknown simple type", func(t *testing.T) {
+		encoder, _, _ := NewTestCodec()
+
+		fakeSimpleType := &sema.SimpleType{}
+
+		err := encoder.Encode(fakeSimpleType)
+		assert.ErrorContains(t, err, "unknown simple type")
+	})
+
+	t.Run("unexpected numeric type", func(t *testing.T) {
+		encoder, _, _ := NewTestCodec()
+
+		fakeNumericType := &sema.NumericType{}
+
+		err := encoder.Encode(fakeNumericType)
+		assert.ErrorContains(t, err, "unexpected numeric type")
+	})
+
+	t.Run("unexpected fixed point numeric type", func(t *testing.T) {
+		encoder, _, _ := NewTestCodec()
+
+		fakeFixedPointNumericType := &sema.FixedPointNumericType{}
+
+		err := encoder.Encode(fakeFixedPointNumericType)
+		assert.ErrorContains(t, err, "unexpected fixed point numeric type")
+	})
+
+	t.Run("unexpected type", func(t *testing.T) {
+		t.Skip("TODO try to encode a fake sema.Type")
+	})
+
+	t.Run("unexpected location type", func(t *testing.T) {
+		t.Skip("TODO try to encode a fake common.Location")
+	})
+}
+
+func TestSemaCodecArrayTypes(t *testing.T) {
+	t.Run("variable", func(t *testing.T) {
+		t.Parallel()
+
+		testRootEncodeDecode(
+			t,
+			&sema.VariableSizedType{Type: sema.CharacterType},
+			byte(sema_codec.EncodedSemaVariableSizedType),
+			byte(sema_codec.EncodedSemaSimpleTypeCharacterType),
+		)
+	})
+
+	t.Run("constant", func(t *testing.T) {
+		t.Parallel()
+
+		testRootEncodeDecode(
+			t,
+			&sema.ConstantSizedType{
+				Type: sema.CharacterType,
+				Size: 90,
+			},
+			byte(sema_codec.EncodedSemaConstantSizedType),
+			byte(sema_codec.EncodedSemaSimpleTypeCharacterType),
+			0, 0, 0, 0, 0, 0, 0, byte(90),
+		)
+	})
+}
+
+func TestSemaCodecMiscValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("length", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		length := 10
+		testEncodeDecode(
+			t,
+			length,
+			buffer,
+			encoder.EncodeLength,
+			decoder.DecodeLength,
+			[]byte{0, 0, 0, byte(length)},
+		)
+	})
+
+	t.Run("length error: negative", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, _, _ := NewTestCodec()
+
+		err := encoder.EncodeLength(-1)
+		assert.ErrorContains(t, err, "cannot encode length below zero: -1")
+	})
+
+	t.Run("address", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		addressBytes := []byte{0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00}
+		address := common.MustBytesToAddress(addressBytes)
+
+		testEncodeDecode(
+			t,
+			address,
+			buffer,
+			encoder.EncodeAddress,
+			decoder.DecodeAddress,
+			addressBytes,
+		)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		s := "some string \x00 foo \t \n\r\n $ 5"
+
+		testEncodeDecode(
+			t,
+			s,
+			buffer,
+			encoder.EncodeString,
+			decoder.DecodeString,
+			append(
+				[]byte{0, 0, 0, byte(len(s))},
+				[]byte(s)...,
+			),
+		)
+	})
+
+	t.Run("string len=0", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		testEncodeDecode(
+			t,
+			"",
+			buffer,
+			encoder.EncodeString,
+			decoder.DecodeString,
+			[]byte{0, 0, 0, 0},
+		)
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		b := []byte("some bytes \x00 foo \t \n\r\n $ 5")
+
+		testEncodeDecode(
+			t,
+			b,
+			buffer,
+			encoder.EncodeBytes,
+			decoder.DecodeBytes,
+			append(
+				[]byte{0, 0, 0, byte(len(b))},
+				b...,
+			),
+		)
+	})
+
+	t.Run("bool true", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		testEncodeDecode(
+			t,
+			true,
+			buffer,
+			encoder.EncodeBool,
+			decoder.DecodeBool,
+			[]byte{byte(sema_codec.EncodedBoolTrue)},
+		)
+	})
+
+	t.Run("bool false", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		testEncodeDecode(
+			t,
+			false,
+			buffer,
+			encoder.EncodeBool,
+			decoder.DecodeBool,
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+		)
+	})
+
+	t.Run("uint64", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		i := uint64(1<<63) + 17
+
+		testEncodeDecode(
+			t,
+			i,
+			buffer,
+			encoder.EncodeUInt64,
+			decoder.DecodeUInt64,
+			[]byte{128, 0, 0, 0, 0, 0, 0, 17},
+		)
+	})
+
+	t.Run("int64 positive", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		i := int64(1<<62) + 17
+
+		testEncodeDecode(
+			t,
+			i,
+			buffer,
+			encoder.EncodeInt64,
+			decoder.DecodeInt64,
+			[]byte{64, 0, 0, 0, 0, 0, 0, 17},
+		)
+	})
+
+	t.Run("int64 negative", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		i := -(int64(1<<62) + 17)
+
+		testEncodeDecode(
+			t,
+			i,
+			buffer,
+			encoder.EncodeInt64,
+			decoder.DecodeInt64,
+			[]byte{0xff - 64, 0xff - 0, 0xff - 0, 0xff - 0, 0xff - 0, 0xff - 0, 0xff - 0, 0xff - 17 + 1},
+		)
+	})
+}
+
+func TestSemaCodecLocations(t *testing.T) {
+	t.Parallel()
+
+	for _, prefix := range []string{
+		common.AddressLocationPrefix,
+		common.IdentifierLocationPrefix,
+		common.ScriptLocationPrefix,
+		common.StringLocationPrefix,
+		common.TransactionLocationPrefix,
+		common.REPLLocationPrefix,
+		sema_codec.NilLocationPrefix,
+	} {
+		t.Run(fmt.Sprintf("prefix: %s", prefix), func(t *testing.T) {
+			t.Parallel()
+
+			encoder, decoder, buffer := NewTestCodec()
+
+			testEncodeDecode(
+				t,
+				sema_codec.NilLocationPrefix,
+				buffer,
+				encoder.EncodeLocationPrefix,
+				decoder.DecodeLocationPrefix,
+				[]byte{prefix[0]},
+			)
+		})
+	}
+
+	t.Run("EncodeLocation(nil)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		testEncodeDecode[common.Location](
+			t,
+			nil,
+			buffer,
+			encoder.EncodeLocation,
+			decoder.DecodeLocation,
+			[]byte{sema_codec.NilLocationPrefix[0]},
+		)
+	})
+
+	t.Run("EncodeLocation(Address)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		address := common.AddressLocation{
+			Address: common.Address{12, 13, 14},
+			Name:    "foo-bar",
+		}
+		testEncodeDecode[common.Location](
+			t,
+			address,
+			buffer,
+			encoder.EncodeLocation,
+			decoder.DecodeLocation,
+			Concat(
+				[]byte{common.AddressLocationPrefix[0]},
+				address.Address.Bytes(),
+				[]byte{0, 0, 0, byte(len(address.Name))},
+				[]byte(address.Name),
+			),
+		)
+	})
+
+	t.Run("EncodeLocation(Identifier)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		identifier := common.IdentifierLocation("id \x01 \x00\n\rsomeid\n")
+		testEncodeDecode[common.Location](
+			t,
+			identifier,
+			buffer,
+			encoder.EncodeLocation,
+			decoder.DecodeLocation,
+			Concat(
+				[]byte{common.IdentifierLocationPrefix[0]},
+				[]byte{0, 0, 0, byte(len(identifier))},
+				[]byte(identifier),
+			),
+		)
+	})
+
+	t.Run("EncodeLocation(Script)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		location := common.ScriptLocation{'i', 'd', ' ', 1, 0, '\n', '\r', 's', 'o', 'm', 'e', 'i', 'd', '\n'}
+		testEncodeDecode[common.Location](
+			t,
+			location,
+			buffer,
+			encoder.EncodeLocation,
+			decoder.DecodeLocation,
+			Concat(
+				[]byte{common.ScriptLocationPrefix[0]},
+				location[:],
+			),
+		)
+	})
+
+	t.Run("EncodeLocation(String)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		location := common.StringLocation("id \x01 \x00\n\rsomeid\n")
+		testEncodeDecode[common.Location](
+			t,
+			location,
+			buffer,
+			encoder.EncodeLocation,
+			decoder.DecodeLocation,
+			Concat(
+				[]byte{common.StringLocationPrefix[0]},
+				[]byte{0, 0, 0, byte(len(location))},
+				[]byte(location),
+			),
+		)
+	})
+
+	t.Run("EncodeLocation(Transaction)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		location := common.TransactionLocation{'i', 'd', ' ', 1, 0, '\n', '\r', 's', 'o', 'm', 'e', 'i', 'd', '\n'}
+		testEncodeDecode[common.Location](
+			t,
+			location,
+			buffer,
+			encoder.EncodeLocation,
+			decoder.DecodeLocation,
+			Concat(
+				[]byte{common.TransactionLocationPrefix[0]},
+				location[:],
+			),
+		)
+	})
+
+	t.Run("EncodeLocation(REPL)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		s := common.REPLLocation{}
+		testEncodeDecode[common.Location](
+			t,
+			s,
+			buffer,
+			encoder.EncodeLocation,
+			decoder.DecodeLocation,
+			[]byte{common.REPLLocationPrefix[0]},
+		)
+	})
+}
+
+func TestSemaCodecInterfaceType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom InterfaceType", func(t *testing.T) {
+		location := common.TransactionLocation{1, 3, 9, 27, 81}
+
+		identifier := "murakami"
+
+		members := &sema.StringMemberOrderedMap{}
+		memberIdentifer := "someID"
+		memberDocString := "\"doctored\" string"
+		members.Set("yolo", sema.NewPublicConstantFieldMember(
+			nil,
+			sema.PrivatePathType,
+			memberIdentifer,
+			sema.Int8Type,
+			memberDocString,
+		))
+
+		fields := []string{"dance"}
+
+		parameters := []*sema.Parameter{
+			{
+				Label:          "lol",
+				Identifier:     "haha",
+				TypeAnnotation: nil,
+			},
+		}
+
+		interfaceType := &sema.InterfaceType{
+			Location:              location,
+			Identifier:            identifier,
+			CompositeKind:         common.CompositeKindEnum,
+			Members:               members,
+			Fields:                fields,
+			InitializerParameters: parameters,
+		}
+
+		// TODO container type
+
+		// TODO nested types
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		err := encoder.Encode(interfaceType)
+		require.NoError(t, err, "encoding error")
+
+		expected := Concat(
+			[]byte{byte(sema_codec.EncodedSemaInterfaceType)},
+
+			[]byte{common.TransactionLocationPrefix[0]},
+			location[:],
+
+			[]byte{0, 0, 0, byte(len(identifier))},
+			[]byte(identifier),
+
+			[]byte{byte(common.CompositeKindEnum)},
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)},        // Members is not nil
+			[]byte{0, 0, 0, byte(members.Len())},             // Members length
+			[]byte{0, 0, 0, byte(len(members.Newest().Key))}, // Member key
+			[]byte(members.Newest().Key),
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.AccessPublic)}, // Member value
+			[]byte{0, 0, 0, byte(len(memberIdentifer))},         // Member AST identifier
+			[]byte(memberIdentifer),
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0}, // Member AST identifier position
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Member type annotation
+			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(sema_codec.EncodedSemaNumericTypeInt8Type)},
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(common.DeclarationKindField)}, // Member declaration kind
+			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.VariableKindConstant)},    // member variable kind
+			[]byte{byte(sema_codec.EncodedBoolTrue)},                       // Member has no argument labels
+			[]byte{byte(sema_codec.EncodedBoolFalse)},                      // Member is not predeclared
+			[]byte{0, 0, 0, byte(len(memberDocString))},                    // Member doc string
+			[]byte(memberDocString),
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Fields array is not nil
+			[]byte{0, 0, 0, byte(len(fields))},
+			[]byte{0, 0, 0, byte(len(fields[0]))},
+			[]byte(fields[0]),
+
+			[]byte{byte(sema_codec.EncodedBoolFalse)}, // InitializerParameters array is not nil
+			[]byte{0, 0, 0, byte(len(parameters))},
+			[]byte{0, 0, 0, byte(len(parameters[0].Label))},
+			[]byte(parameters[0].Label),
+			[]byte{0, 0, 0, byte(len(parameters[0].Identifier))},
+			[]byte(parameters[0].Identifier),
+			[]byte{byte(sema_codec.EncodedBoolTrue)},
+
+			[]byte{byte(sema_codec.EncodedSemaNilType)}, // no container type
+
+			[]byte{byte(sema_codec.EncodedBoolTrue)}, // no nested types
+		)
+
+		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
+
+		decoded, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		// Cannot simply check equality between original and decoded types because they are not shallowly equal.
+		// Specifically, RequiredArgumentCount and Members are not shallowly equal.
+		switch i := decoded.(type) {
+		case *sema.InterfaceType:
+			assert.Equal(t, location, i.Location, "location")
+
+			assert.Equal(t, identifier, i.Identifier, "identifier")
+
+			assert.Equal(t, common.CompositeKindEnum, i.CompositeKind, "composite kind")
+
+			// verify member equality
+			require.Equal(t, members.Len(), i.Members.Len(), "members length")
+			i.Members.Foreach(func(key string, actual *sema.Member) {
+				expected, present := i.Members.Get(key)
+				require.True(t, present, "extra member: %s", key)
+
+				assert.Equal(t, expected.ContainerType.ID(), actual.ContainerType.ID(), "container type for %s", key)
+				assert.Equal(t, expected.TypeAnnotation.QualifiedString(), actual.TypeAnnotation.QualifiedString(), "type annotation for %s", key)
+			})
+
+			assert.Equal(t, fields, i.Fields, "fields")
+
+			assert.Equal(t, parameters, i.InitializerParameters, "parameters")
+
+			assert.Nil(t, i.GetContainerType(), "container type")
+		default:
+			assert.Fail(t, "Decoded type is not *sema.InterfaceType")
+		}
+	})
+}
+
+func TestSemaCodecCompositeType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AuthAccountType (IsContainerType=true)", func(t *testing.T) {
+		ty := sema.AuthAccountType
+
+		encoder, decoder, _ := NewTestCodec()
+
+		err := encoder.Encode(ty)
+		require.NoError(t, err, "encoding error")
+
+		decoded, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		switch d := decoded.(type) {
+		case *sema.CompositeType:
+			assert.Equal(t, true, d.IsContainerType(), "IsContainerType")
+		default:
+			assert.Fail(t, "decoded type is not *sema.CompositeType")
+		}
+
+	})
+
+	t.Run("AccountKeyType", func(t *testing.T) {
+		theCompositeType := sema.AccountKeyType
+
+		encoder, buffer := NewTestEncoder()
+		err := encoder.Encode(theCompositeType)
+		require.NoError(t, err, "encoding error")
+
+		// verify the first few encoded bytes
+		expected := []byte{
+			// type of encoded sema type
+			byte(sema_codec.EncodedSemaCompositeType),
+
+			// location
+			sema_codec.NilLocationPrefix[0],
+
+			// length of identifier
+			0, 0, 0,
+			byte(len(sema.AccountKeyTypeName)),
+
+			// identifier
+			sema.AccountKeyTypeName[0],
+			sema.AccountKeyTypeName[1],
+			sema.AccountKeyTypeName[2],
+			sema.AccountKeyTypeName[3],
+			sema.AccountKeyTypeName[4],
+			sema.AccountKeyTypeName[5],
+			sema.AccountKeyTypeName[6],
+			sema.AccountKeyTypeName[7],
+			sema.AccountKeyTypeName[8],
+			sema.AccountKeyTypeName[9],
+
+			// composite kind
+			byte(common.CompositeKindStructure),
+
+			// ExplicitInterfaceConformances array is nil
+			byte(sema_codec.EncodedBoolTrue),
+
+			// ImplicitTypeRequirementConformances array is nil
+			byte(sema_codec.EncodedBoolTrue),
+		}
+		assert.Equal(t, expected, buffer.Bytes()[:len(expected)], "encoded bytes")
+
+		decoder := sema_codec.NewSemaDecoder(nil, buffer)
+		output, err := decoder.Decode()
+		require.NoError(t, err)
+
+		// populates `cachedIdentifiers` for top-level and its members
+		output.QualifiedString()
+		switch c := output.(type) {
+		case *sema.CompositeType:
+			c.Members.Foreach(func(key string, value *sema.Member) {
+				value.TypeAnnotation.QualifiedString()
+			})
+		}
+
+		// verify Equal(...) method equality... basically a smoke test
+		assert.True(t, output.Equal(theCompositeType), ".Equal(...) is false")
+
+		switch c := output.(type) {
+		case *sema.CompositeType:
+			// verify the easily verified
+			assert.Equal(t, theCompositeType.Fields, c.Fields)
+			assert.Equal(t, theCompositeType.Kind, c.Kind)
+			assert.Equal(t, theCompositeType.Location, c.Location)
+			assert.Equal(t, theCompositeType.EnumRawType, c.EnumRawType)
+			assert.Equal(t, theCompositeType.Identifier, c.Identifier)
+			assert.Equal(t, theCompositeType.ImportableWithoutLocation, c.ImportableWithoutLocation)
+			assert.Equal(t, theCompositeType.ConstructorParameters, c.ConstructorParameters)
+			assert.Equal(t, theCompositeType.ExplicitInterfaceConformances, c.ExplicitInterfaceConformances)
+			assert.Equal(t, theCompositeType.ImplicitTypeRequirementConformances, c.ImplicitTypeRequirementConformances)
+			assert.Equal(t, theCompositeType.GetContainerType(), c.GetContainerType())
+			assert.Equal(t, theCompositeType.GetNestedTypes(), c.GetNestedTypes())
+
+			// verify member equality
+			// note that only 3/5 of members are serializable so the encoded type has only 3 members
+			require.Equal(t, 3, c.Members.Len(), "members length")
+			c.Members.Foreach(func(key string, actual *sema.Member) {
+				expected, present := theCompositeType.Members.Get(key)
+				require.True(t, present, "extra member: %s", key)
+
+				assert.Equal(t, expected.ContainerType.ID(), actual.ContainerType.ID(), "container type for %s", key)
+				assert.Equal(t, expected.TypeAnnotation.QualifiedString(), actual.TypeAnnotation.QualifiedString(), "type annotation for %s", key)
+			})
+		default:
+			require.Fail(t, "decoded type is not CompositeType")
+		}
+	})
+}
+
+func TestSemaCodecRecursiveType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CompositeType", func(t *testing.T) {
+		c := &sema.CompositeType{}
+		c.SetContainerType(c)
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		err := encoder.Encode(c)
+		require.NoError(t, err, "encoding error")
+
+		expected := []byte{
+			byte(sema_codec.EncodedSemaCompositeType),
+			sema_codec.NilLocationPrefix[0],
+			0, 0, 0, 0, // identifier length
+			0,                                                   // composite kind
+			byte(sema_codec.EncodedBoolTrue),                    // ExplicitInterfaceConformances array is nil
+			byte(sema_codec.EncodedBoolTrue),                    // ImplicitTypeRequirementConformances array is nil
+			byte(sema_codec.EncodedBoolTrue),                    // no members
+			byte(sema_codec.EncodedBoolTrue),                    // Fields array is nil
+			byte(sema_codec.EncodedBoolTrue),                    // ConstructorParameters array is nil
+			byte(sema_codec.EncodedBoolTrue),                    // no nested types
+			byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1, // container type
+			byte(sema_codec.EncodedSemaNilType), // EnumRawType
+			byte(sema_codec.EncodedBoolFalse),   // hasComputedMembers
+			byte(sema_codec.EncodedBoolFalse),   // ImportableWithoutLocation
+		}
+
+		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
+
+		decoded, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		// Cannot simply check equality between original and decoded types because they are not shallowly equal.
+		switch cc := decoded.(type) {
+		case *sema.CompositeType:
+			assert.Equal(t, cc, cc.GetContainerType(), "container is self")
+		default:
+			assert.Fail(t, "Decoded type is not *sema.CompositeType")
+		}
+	})
+
+	t.Run("InterfaceType", func(t *testing.T) {
+		c := &sema.InterfaceType{}
+		c.SetContainerType(c)
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		err := encoder.Encode(c)
+		require.NoError(t, err, "encoding error")
+
+		expected := []byte{
+			byte(sema_codec.EncodedSemaInterfaceType),
+			sema_codec.NilLocationPrefix[0],
+			0, 0, 0, 0, // identifier length
+			0,                                                   // composite kind
+			byte(sema_codec.EncodedBoolTrue),                    // Members array is nil
+			byte(sema_codec.EncodedBoolTrue),                    // Fields array is nil
+			byte(sema_codec.EncodedBoolTrue),                    // InitializerParameters array is nil
+			byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1, // container type
+			byte(sema_codec.EncodedBoolTrue), // nestedTypes
+		}
+
+		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
+
+		decoded, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		// Cannot simply check equality between original and decoded types because they are not shallowly equal.
+		switch cc := decoded.(type) {
+		case *sema.InterfaceType:
+			assert.Equal(t, cc, cc.GetContainerType(), "container is self")
+		default:
+			assert.Fail(t, "Decoded type is not *sema.InterfaceType")
+		}
+	})
+
+	t.Run("GenericType", func(t *testing.T) {
+		parent := &sema.GenericType{} // extra layer to test non-zero pointer
+
+		g := &sema.GenericType{}
+		g.TypeParameter = &sema.TypeParameter{
+			Name:      "nomen",
+			TypeBound: g,
+			Optional:  true,
+		}
+
+		parent.TypeParameter = &sema.TypeParameter{
+			Name:      "parent",
+			TypeBound: g,
+			Optional:  false,
+		}
+
+		testRootEncodeDecode(
+			t,
+			parent,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaGenericType)},
+				[]byte{0, 0, 0, byte(len(parent.TypeParameter.Name))},
+				[]byte(parent.TypeParameter.Name),
+				[]byte{byte(sema_codec.EncodedSemaGenericType)},
+				[]byte{0, 0, 0, byte(len(g.TypeParameter.Name))},
+				[]byte(g.TypeParameter.Name),
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 12},
+				[]byte{byte(sema_codec.EncodedBoolTrue)},
+				[]byte{byte(sema_codec.EncodedBoolFalse)},
+			)...,
+		)
+	})
+
+	t.Run("FunctionType", func(t *testing.T) {
+		f := &sema.FunctionType{
+			IsConstructor:            false,
+			TypeParameters:           nil,
+			Parameters:               nil,
+			ReturnTypeAnnotation:     nil,
+			RequiredArgumentCount:    nil,
+			ArgumentExpressionsCheck: nil,
+			Members:                  nil,
+		}
+		f.TypeParameters = []*sema.TypeParameter{{
+			Name:      "nome",
+			TypeBound: f,
+			Optional:  false,
+		}}
+
+		testRootEncodeDecode(
+			t,
+			f,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaFunctionType)},
+				[]byte{byte(sema_codec.EncodedBoolFalse)}, // isConstructor
+				[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeParameters is not nil
+				[]byte{0, 0, 0, 1},
+				[]byte{0, 0, 0, byte(len(f.TypeParameters[0].Name))},
+				[]byte(f.TypeParameters[0].Name),
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // container type
+				[]byte{byte(sema_codec.EncodedBoolFalse)},
+				[]byte{byte(sema_codec.EncodedBoolTrue)}, // Parameters is nil
+				[]byte{byte(sema_codec.EncodedBoolTrue)}, // ReturnTypeAnnotation is nil
+				[]byte{byte(sema_codec.EncodedBoolTrue)}, // RequiredArgumentCount is nil
+				[]byte{byte(sema_codec.EncodedBoolTrue)}, // Members is nil
+			)...,
+		)
+	})
+
+	t.Run("DictionaryType", func(t *testing.T) {
+		d := &sema.DictionaryType{}
+		d.KeyType = d
+		d.ValueType = d
+
+		testRootEncodeDecode(
+			t,
+			d,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaDictionaryType)},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1},
+			)...,
+		)
+	})
+
+	t.Run("TransactionType", func(t *testing.T) {
+		tx := &sema.TransactionType{
+			Members:           nil,
+			Fields:            nil,
+			PrepareParameters: nil,
+			Parameters:        nil,
+		}
+		tx.Parameters = []*sema.Parameter{{
+			Label:      "momentary",
+			Identifier: "fade",
+		}}
+		tx.Parameters[0].TypeAnnotation = sema.NewTypeAnnotation(tx)
+
+		testRootEncodeDecode(
+			t,
+			tx,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaTransactionType)},
+				[]byte{byte(sema_codec.EncodedBoolTrue)},  // Members is nil
+				[]byte{byte(sema_codec.EncodedBoolTrue)},  // Fields is nil
+				[]byte{byte(sema_codec.EncodedBoolTrue)},  // PrepareParameters is nil
+				[]byte{byte(sema_codec.EncodedBoolFalse)}, // Parameters is not nil
+				[]byte{0, 0, 0, 1},                        // 1 Parameter
+				[]byte{0, 0, 0, byte(len(tx.Parameters[0].Label))},
+				[]byte(tx.Parameters[0].Label),
+				[]byte{0, 0, 0, byte(len(tx.Parameters[0].Identifier))},
+				[]byte(tx.Parameters[0].Identifier),
+				[]byte{byte(sema_codec.EncodedBoolFalse)},                   // TypeAnnotation is not nil
+				[]byte{byte(sema_codec.EncodedBoolFalse)},                   // TypeAnnotation is not a resource
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
+			)...,
+		)
+	})
+
+	t.Run("RestrictedType", func(t *testing.T) {
+		r := &sema.RestrictedType{}
+		r.Type = r
+
+		testRootEncodeDecode(
+			t,
+			r,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaRestrictedType)},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
+				[]byte{byte(sema_codec.EncodedBoolTrue)},                    // Restrictions is nil
+			)...,
+		)
+	})
+
+	t.Run("ConstantSizedType", func(t *testing.T) {
+		c := &sema.ConstantSizedType{}
+		c.Type = c
+
+		testRootEncodeDecode(
+			t,
+			c,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaConstantSizedType)},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
+				[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			)...,
+		)
+	})
+
+	t.Run("VariableSizedType", func(t *testing.T) {
+		v := &sema.VariableSizedType{}
+		v.Type = v
+
+		testRootEncodeDecode(
+			t,
+			v,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaVariableSizedType)},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
+			)...,
+		)
+	})
+
+	t.Run("OptionalType", func(t *testing.T) {
+		o := &sema.OptionalType{}
+		o.Type = o
+
+		testRootEncodeDecode(
+			t,
+			o,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaOptionalType)},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
+			)...,
+		)
+	})
+
+	t.Run("ReferenceType", func(t *testing.T) {
+		r := &sema.ReferenceType{}
+		r.Type = r
+
+		testRootEncodeDecode(
+			t,
+			r,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaReferenceType)},
+				[]byte{byte(sema_codec.EncodedBoolFalse)},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
+			)...,
+		)
+	})
+
+	t.Run("CapabilityType", func(t *testing.T) {
+		v := &sema.CapabilityType{}
+		v.BorrowType = v
+
+		testRootEncodeDecode(
+			t,
+			v,
+			Concat(
+				[]byte{byte(sema_codec.EncodedSemaCapabilityType)},
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
+			)...,
+		)
+	})
+}
+
+//
+// Elaboration
+//
+
+func TestSemaCodecElaboration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		el := sema.NewElaboration(nil, false)
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		testEncodeDecode(
+			t,
+			el,
+			buffer,
+			encoder.EncodeElaboration,
+			decoder.DecodeElaboration,
+			[]byte{
+				0, 0, 0, 0, // length of composite types
+				0, 0, 0, 0, // length of interface types
+			},
+		)
+	})
+
+	t.Run("full", func(t *testing.T) {
+		typeId := common.TypeID("houses")
+		location := common.ScriptLocation{9, 3, 1}
+		identifier := "valence"
+		kind := common.CompositeKindStructure
+
+		compType := &sema.CompositeType{
+			Location:   location,
+			Identifier: identifier,
+			Kind:       kind,
+		}
+		compType.SetContainerType(compType) // test recursive type
+
+		el := sema.NewElaboration(nil, false)
+		el.CompositeTypes[typeId] = compType
+		el.InterfaceTypes[typeId] = compType.InterfaceType()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		testEncodeDecode(
+			t,
+			el,
+			buffer,
+			encoder.EncodeElaboration,
+			decoder.DecodeElaboration,
+			Concat(
+				[]byte{0, 0, 0, 1},                 // length of CompositeTypes map
+				[]byte{0, 0, 0, byte(len(typeId))}, // TypeID aka map key
+				[]byte(typeId),
+				[]byte{common.ScriptLocationPrefix[0]}, // location
+				location[:],
+				[]byte{0, 0, 0, byte(len(identifier))}, // identifier
+				[]byte(identifier),
+				[]byte{byte(common.CompositeKindStructure)}, // composite kind
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil ExplicitInterfaceConformances
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil ImplicitTypeRequirementConformances
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Members
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Fields
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil ConstructorParameters
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil nestedTypes
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 14},
+				[]byte{byte(sema_codec.EncodedSemaNilType)}, // nil EnumRawType
+				[]byte{byte(sema_codec.EncodedBoolFalse)},   // hasComputedMembers
+				[]byte{byte(sema_codec.EncodedBoolFalse)},   // ImportableWithoutLocation
+
+				[]byte{0, 0, 0, 1},                 // length of InterfaceTypes map
+				[]byte{0, 0, 0, byte(len(typeId))}, // TypeID aka map key
+				[]byte(typeId),
+				[]byte{common.ScriptLocationPrefix[0]}, // location
+				location[:],
+				[]byte{0, 0, 0, byte(len(identifier))}, // identifier
+				[]byte(identifier),
+				[]byte{byte(common.CompositeKindStructure)}, // composite kind
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Members
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Fields
+				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil InitializerParameters
+				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 14},
+				[]byte{byte(sema_codec.EncodedBoolTrue)}, // nil nestedTypes
+
+			),
+		)
+	})
+}
+
+//
+// Helpers
+//
+
+func testRootEncodeDecode(
+	t *testing.T,
+	input sema.Type,
+	expectedEncoding ...byte,
+) ([]byte, sema.Type) {
+	blob, err := sema_codec.EncodeSema(input)
+	require.NoError(t, err, "encoding error")
+
+	if expectedEncoding != nil {
+		assert.Equal(t, expectedEncoding, blob)
+	}
+
+	output, err := sema_codec.DecodeSema(nil, blob)
+	require.NoError(t, err, "decoding error")
+
+	assert.Equal(t, input, output, "decoded message differs from input")
+
+	return blob, output
+}
+
+func testEncodeDecode[T any](
+	t *testing.T,
+	input T,
+	buffer *bytes.Buffer,
+	encode func(T) error,
+	decode func() (T, error),
+	expectedEncoding []byte,
+) {
+	err := encode(input)
+	require.NoError(t, err, "encoding error")
+
+	if expectedEncoding != nil {
+		assert.Equal(t, expectedEncoding, buffer.Bytes(), "encoded bytes differ from expectation")
+	}
+
+	output, err := decode()
+	require.NoError(t, err, "decoding error")
+
+	assert.Equal(t, input, output, "decoded data structure differs from expectation")
+}
+
+func NewTestEncoder() (*sema_codec.SemaEncoder, *bytes.Buffer) {
+	var w bytes.Buffer
+	encoder := sema_codec.NewSemaEncoder(&w)
+	return encoder, &w
+}
+
+func NewTestCodec() (encoder *sema_codec.SemaEncoder, decoder *sema_codec.SemaDecoder, buffer *bytes.Buffer) {
+	var w bytes.Buffer
+	buffer = &w
+	encoder = sema_codec.NewSemaEncoder(buffer)
+	decoder = sema_codec.NewSemaDecoder(nil, buffer)
+	return
+}
+
+func Concat(deep ...[]byte) []byte {
+	length := 0
+	for _, b := range deep {
+		length += len(b)
+	}
+
+	flat := make([]byte, 0, length)
+	for _, b := range deep {
+		flat = append(flat, b...)
+	}
+
+	return flat
+}
+
+// TODO test via fuzzing

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -495,9 +495,9 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 			[]byte{byte(sema_codec.EncodedSemaRestrictedType)},
 			[]byte{byte(sema_codec.EncodedSemaNumericTypeIntType)},
 			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
-			[]byte{0, 0, 0, 1},                      // array length
+			[]byte{0, 0, 0, 1}, // array length
 			Concat([]byte{'s'}, location[:]),
-			[]byte{0, 0, 0, 6}, []byte("peaked"),    // identifier
+			[]byte{0, 0, 0, 6}, []byte("peaked"), // identifier
 			[]byte{byte(common.CompositeKindContract)},
 			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // members is nil
 			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // fields is nil

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -3,13 +3,14 @@ package sema_codec_test
 import (
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/onflow/cadence/encoding/custom/sema_codec"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSemaCodecSimpleTypes(t *testing.T) {

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sema_codec_test
 
 import (

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
+// TODO add t.Parralel() to all of the tests
+
 func TestSemaCodecSimpleTypes(t *testing.T) {
 	t.Parallel()
 
@@ -544,6 +546,26 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 		default:
 			assert.Fail(t, "Decoded type is not *sema.RestrictionType")
 		}
+	})
+}
+
+func TestSemaCodecFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DecodeSema return error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := sema_codec.DecodeSema(nil, []byte{0xff})
+		assert.ErrorContains(t, err, "unknown type", "encoding unknown type succeeded when it shouldn't have")
+	})
+
+	t.Run("Go error panic when encoding", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Panics(t, func() {
+			var nilCompositeType *sema.CompositeType
+			_, _ = sema_codec.EncodeSema(nilCompositeType)
+		})
 	})
 }
 

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -701,7 +701,7 @@ func (d *SemaDecoder) DecodeStringTypeOrderedMap() (om *sema.StringTypeOrderedMa
 		return
 	}
 
-	om =  &sema.StringTypeOrderedMap{}
+	om = &sema.StringTypeOrderedMap{}
 
 	for i := 0; i < length; i++ {
 		var key string

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -602,6 +602,12 @@ func (d *SemaDecoder) DecodeInterfaceType() (t *sema.InterfaceType, err error) {
 	}
 	t.SetContainerType(containerType)
 
+	nestedTypes, err := d.DecodeStringTypeOrderedMap()
+	if err != nil {
+		return
+	}
+	t.SetNestedTypes(nestedTypes)
+
 	return
 }
 

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
+
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
-	"io"
 )
 
 //

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -77,7 +77,9 @@ func NewSemaDecoder(memoryGauge common.MemoryGauge, r io.Reader) *SemaDecoder {
 // an unknown composite type.
 func (d *SemaDecoder) Decode() (t sema.Type, err error) {
 	defer func() {
-		err = capturePanic("failed to decode sema type: %w")
+		if panicErr := capturePanic("failed to decode sema type: %w"); panicErr != nil {
+			err = panicErr
+		}
 	}()
 
 	return d.DecodeType()
@@ -85,7 +87,9 @@ func (d *SemaDecoder) Decode() (t sema.Type, err error) {
 
 func (d *SemaDecoder) DecodeElaboration() (el *sema.Elaboration, err error) {
 	defer func() {
-		err = capturePanic("failed to decode elaboration: %w")
+		if panicErr := capturePanic("failed to decode elaboration: %w"); panicErr != nil {
+			err = panicErr
+		}
 	}()
 
 	el = sema.NewElaboration(d.memoryGauge, false)

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -29,10 +29,6 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-//
-// Sema
-//
-
 // A SemaDecoder decodes custom-encoded representations of Cadence values.
 type SemaDecoder struct {
 	r           LocatedReader

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -75,22 +75,10 @@ func NewSemaDecoder(memoryGauge common.MemoryGauge, r io.Reader) *SemaDecoder {
 // is malformed, does not conform to the custom specification, or contains
 // an unknown composite type.
 func (d *SemaDecoder) Decode() (t sema.Type, err error) {
-	defer func() {
-		if panicErr := capturePanic("failed to decode sema type: %w"); panicErr != nil {
-			err = panicErr
-		}
-	}()
-
 	return d.DecodeType()
 }
 
 func (d *SemaDecoder) DecodeElaboration() (el *sema.Elaboration, err error) {
-	defer func() {
-		if panicErr := capturePanic("failed to decode elaboration: %w"); panicErr != nil {
-			err = panicErr
-		}
-	}()
-
 	el = sema.NewElaboration(d.memoryGauge, false)
 
 	err = DecodeMap(d, el.CompositeTypes, d.DecodeCompositeType)

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -1,0 +1,1060 @@
+package sema_codec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+	"io"
+)
+
+//
+// Sema
+//
+
+type LocatedReader struct {
+	r        io.Reader
+	location int
+}
+
+func (l *LocatedReader) Read(p []byte) (n int, err error) {
+	n, err = l.r.Read(p)
+	l.location += n
+	return
+}
+
+// A SemaDecoder decodes custom-encoded representations of Cadence values.
+type SemaDecoder struct {
+	r           LocatedReader
+	typeDefs    map[int]sema.Type
+	memoryGauge common.MemoryGauge
+}
+
+// Decode returns a Cadence value decoded from its custom-encoded representation.
+//
+// This function returns an error if the bytes represent a custom encoding that
+// is malformed, does not conform to the custom Cadence specification, or contains
+// an unknown composite type.
+func DecodeSema(gauge common.MemoryGauge, b []byte) (sema.Type, error) {
+	r := bytes.NewReader(b)
+	dec := NewSemaDecoder(gauge, r)
+
+	v, err := dec.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// NewSemaDecoder initializes a SemaDecoder that will decode custom-encoded bytes from the
+// given io.Reader.
+func NewSemaDecoder(memoryGauge common.MemoryGauge, r io.Reader) *SemaDecoder {
+	return &SemaDecoder{
+		r:           LocatedReader{r: r},
+		typeDefs:    map[int]sema.Type{},
+		memoryGauge: memoryGauge,
+	}
+}
+
+// Decode reads custom-encoded bytes from the io.Reader and decodes them to a
+// Sema type. There is no assumption about the top-level Sema type so the first
+// byte must specify the top-level type. Usually this will be a CompositeType.
+//
+// This function returns an error if the bytes represent a custom encoding that
+// is malformed, does not conform to the custom specification, or contains
+// an unknown composite type.
+func (d *SemaDecoder) Decode() (t sema.Type, err error) {
+	// capture panics that occur during decoding
+	defer func() {
+		if r := recover(); r != nil {
+			panicErr, isError := r.(error)
+			if !isError {
+				panic(r)
+			}
+
+			err = fmt.Errorf("failed to decode value: %w", panicErr)
+		}
+	}()
+
+	return d.DecodeType()
+}
+
+func (d *SemaDecoder) DecodeElaboration() (el *sema.Elaboration, err error) {
+	el = sema.NewElaboration(d.memoryGauge, false)
+
+	err = DecodeMap(d, el.CompositeTypes, d.DecodeCompositeType)
+	if err != nil {
+		return
+	}
+
+	err = DecodeMap(d, el.InterfaceTypes, d.DecodeInterfaceType)
+	return
+}
+
+func (d *SemaDecoder) DecodeType() (t sema.Type, err error) {
+	typeIdentifier, err := d.DecodeTypeIdentifier()
+	if err != nil {
+		return
+	}
+
+	if isSimpleType(typeIdentifier) {
+		t, err = EncodingToSimpleType(typeIdentifier)
+	} else if isNumericType(typeIdentifier) {
+		t, err = EncodingToNumericType(typeIdentifier)
+	} else if isFixedPointNumericType(typeIdentifier) {
+		t, err = EncodingToFixedPointNumericType(typeIdentifier)
+	} else {
+		switch typeIdentifier {
+		case EncodedSemaOptionalType:
+			t, err = d.DecodeOptionalType()
+		case EncodedSemaReferenceType:
+			t, err = d.DecodeReferenceType()
+		case EncodedSemaCapabilityType:
+			t, err = d.DecodeCapabilityType()
+		case EncodedSemaVariableSizedType:
+			t, err = d.DecodeVariableSizedType()
+		case EncodedSemaAddressType:
+			t = &sema.AddressType{}
+		case EncodedSemaNilType:
+			t = nil
+
+		case EncodedSemaCompositeType:
+			t, err = d.DecodeCompositeType()
+		case EncodedSemaInterfaceType:
+			t, err = d.DecodeInterfaceType()
+		case EncodedSemaGenericType:
+			t, err = d.DecodeGenericType()
+		case EncodedSemaFunctionType:
+			t, err = d.DecodeFunctionType()
+		case EncodedSemaDictionaryType:
+			t, err = d.DecodeDictionaryType()
+		case EncodedSemaTransactionType:
+			t, err = d.DecodeTransactionType()
+		case EncodedSemaRestrictedType:
+			t, err = d.DecodeRestrictedType()
+		case EncodedSemaConstantSizedType:
+			t, err = d.DecodeConstantSizedType()
+
+		case EncodedSemaPointerType:
+			t, err = d.EncodePointer()
+
+		default:
+			err = fmt.Errorf("unknown type identifier: %d", typeIdentifier)
+		}
+	}
+
+	return
+}
+
+func (d *SemaDecoder) EncodePointer() (t sema.Type, err error) {
+	bufferOffset, err := d.DecodeLength()
+	if err != nil {
+		return
+	}
+
+	if knownType, defined := d.typeDefs[bufferOffset]; defined {
+		t = knownType
+	} else {
+		err = fmt.Errorf(`pointer to unknown type: %d`, bufferOffset)
+	}
+	return
+}
+
+func (d *SemaDecoder) DecodeCapabilityType() (ct *sema.CapabilityType, err error) {
+	ct = &sema.CapabilityType{}
+
+	d.typeDefs[d.r.location] = ct
+
+	ct.BorrowType, err = d.DecodeType()
+	return
+}
+
+func (d *SemaDecoder) DecodeRestrictedType() (rt *sema.RestrictedType, err error) {
+	rt = &sema.RestrictedType{}
+
+	d.typeDefs[d.r.location] = rt
+
+	rt.Type, err = d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	rt.Restrictions, err = DecodeArray(d, d.DecodeInterfaceType)
+	return
+}
+
+func (d *SemaDecoder) DecodeTransactionType() (tx *sema.TransactionType, err error) {
+	tx = &sema.TransactionType{}
+
+	d.typeDefs[d.r.location] = tx
+
+	tx.Members, err = d.DecodeStringMemberOrderedMap(tx)
+	if err != nil {
+		return
+	}
+
+	tx.Fields, err = DecodeArray(d, d.DecodeString)
+	if err != nil {
+		return
+	}
+
+	tx.PrepareParameters, err = DecodeArray(d, d.DecodeParameter)
+	if err != nil {
+		return
+	}
+
+	tx.Parameters, err = DecodeArray(d, d.DecodeParameter)
+	return
+}
+
+func (d *SemaDecoder) DecodeReferenceType() (ref *sema.ReferenceType, err error) {
+	ref = &sema.ReferenceType{}
+
+	d.typeDefs[d.r.location] = ref
+
+	ref.Authorized, err = d.DecodeBool()
+	if err != nil {
+		return
+	}
+
+	ref.Type, err = d.DecodeType()
+	return
+}
+
+func (d *SemaDecoder) DecodeDictionaryType() (dict *sema.DictionaryType, err error) {
+	dict = &sema.DictionaryType{}
+
+	d.typeDefs[d.r.location] = dict
+
+	dict.KeyType, err = d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	dict.ValueType, err = d.DecodeType()
+	return
+}
+
+func (d *SemaDecoder) DecodeFunctionType() (ft *sema.FunctionType, err error) {
+	ft = &sema.FunctionType{}
+
+	d.typeDefs[d.r.location] = ft
+
+	ft.IsConstructor, err = d.DecodeBool()
+	if err != nil {
+		return
+	}
+
+	ft.TypeParameters, err = DecodeArray(d, d.DecodeTypeParameter)
+	if err != nil {
+		return
+	}
+
+	ft.Parameters, err = DecodeArray(d, d.DecodeParameter)
+	if err != nil {
+		return
+	}
+
+	ft.ReturnTypeAnnotation, err = d.DecodeTypeAnnotation()
+	if err != nil {
+		return
+	}
+
+	ft.RequiredArgumentCount, err = d.DecodeIntPointer()
+	if err != nil {
+		return
+	}
+
+	// TODO is ArgumentExpressionCheck needed?
+
+	ft.Members, err = d.DecodeStringMemberOrderedMap(ft)
+	return
+}
+
+// DecodeIntPointer always returns a new pointer.
+func (d *SemaDecoder) DecodeIntPointer() (ptr *int, err error) {
+	isNil, err := d.DecodeBool()
+	if isNil || err != nil {
+		return
+	}
+
+	i64, err := d.DecodeInt64()
+	if err != nil {
+		return
+	}
+
+	i := int(i64)
+	ptr = &i
+
+	return
+}
+
+func (d *SemaDecoder) DecodeVariableSizedType() (a *sema.VariableSizedType, err error) {
+	a = &sema.VariableSizedType{}
+
+	d.typeDefs[d.r.location] = a
+
+	t, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	a.Type = t
+	return
+}
+
+func (d *SemaDecoder) DecodeConstantSizedType() (a *sema.ConstantSizedType, err error) {
+	a = &sema.ConstantSizedType{}
+
+	d.typeDefs[d.r.location] = a
+
+	t, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	size, err := d.DecodeInt64()
+	if err != nil {
+		return
+	}
+
+	a.Type = t
+	a.Size = size
+	return
+}
+
+func EncodingToNumericType(b EncodedSema) (t *sema.NumericType, err error) {
+	switch b {
+	case EncodedSemaNumericTypeNumberType:
+		t = sema.NumberType
+	case EncodedSemaNumericTypeSignedNumberType:
+		t = sema.SignedNumberType
+	case EncodedSemaNumericTypeIntegerType:
+		t = sema.IntegerType
+	case EncodedSemaNumericTypeSignedIntegerType:
+		t = sema.SignedIntegerType
+	case EncodedSemaNumericTypeIntType:
+		t = sema.IntType
+	case EncodedSemaNumericTypeInt8Type:
+		t = sema.Int8Type
+	case EncodedSemaNumericTypeInt16Type:
+		t = sema.Int16Type
+	case EncodedSemaNumericTypeInt32Type:
+		t = sema.Int32Type
+	case EncodedSemaNumericTypeInt64Type:
+		t = sema.Int64Type
+	case EncodedSemaNumericTypeInt128Type:
+		t = sema.Int128Type
+	case EncodedSemaNumericTypeInt256Type:
+		t = sema.Int256Type
+	case EncodedSemaNumericTypeUIntType:
+		t = sema.UIntType
+	case EncodedSemaNumericTypeUInt8Type:
+		t = sema.UInt8Type
+	case EncodedSemaNumericTypeUInt16Type:
+		t = sema.UInt16Type
+	case EncodedSemaNumericTypeUInt32Type:
+		t = sema.UInt32Type
+	case EncodedSemaNumericTypeUInt64Type:
+		t = sema.UInt64Type
+	case EncodedSemaNumericTypeUInt128Type:
+		t = sema.UInt128Type
+	case EncodedSemaNumericTypeUInt256Type:
+		t = sema.UInt256Type
+	case EncodedSemaNumericTypeWord8Type:
+		t = sema.Word8Type
+	case EncodedSemaNumericTypeWord16Type:
+		t = sema.Word16Type
+	case EncodedSemaNumericTypeWord32Type:
+		t = sema.Word32Type
+	case EncodedSemaNumericTypeWord64Type:
+		t = sema.Word64Type
+	case EncodedSemaNumericTypeFixedPointType:
+		t = sema.FixedPointType
+	case EncodedSemaNumericTypeSignedFixedPointType:
+		t = sema.SignedFixedPointType
+	default:
+		err = fmt.Errorf("unknown numeric type: %d", b)
+	}
+
+	return
+}
+
+func EncodingToFixedPointNumericType(b EncodedSema) (t *sema.FixedPointNumericType, err error) {
+	switch b {
+	case EncodedSemaFix64Type:
+		t = sema.Fix64Type
+	case EncodedSemaUFix64Type:
+		t = sema.UFix64Type
+	default:
+		err = fmt.Errorf("unknown fixed point numeric type: %d", b)
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeGenericType() (t *sema.GenericType, err error) {
+	t = &sema.GenericType{}
+
+	d.typeDefs[d.r.location] = t
+
+	tp, err := d.DecodeTypeParameter()
+	if err != nil {
+		return
+	}
+
+	t.TypeParameter = tp
+	return
+}
+
+func (d *SemaDecoder) DecodeOptionalType() (opt *sema.OptionalType, err error) {
+	opt = &sema.OptionalType{}
+
+	d.typeDefs[d.r.location] = opt
+
+	t, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	opt.Type = t
+	return
+}
+
+func (d *SemaDecoder) DecodeTypeIdentifier() (id EncodedSema, err error) {
+	b, err := d.read(1)
+	if err != nil {
+		return
+	}
+
+	id = EncodedSema(b[0])
+	return
+}
+
+func (d *SemaDecoder) DecodeCompositeKind() (kind common.CompositeKind, err error) {
+	b, err := d.read(1)
+	if err != nil {
+		return
+	}
+
+	kind = common.CompositeKind(b[0])
+	return
+}
+
+func EncodingToSimpleType(b EncodedSema) (t *sema.SimpleType, err error) {
+	switch b {
+	case EncodedSemaSimpleTypeAnyType:
+		t = sema.AnyType
+	case EncodedSemaSimpleTypeAnyResourceType:
+		t = sema.AnyResourceType
+	case EncodedSemaSimpleTypeAnyStructType:
+		t = sema.AnyStructType
+	case EncodedSemaSimpleTypeBlockType:
+		t = sema.BlockType
+	case EncodedSemaSimpleTypeBoolType:
+		t = sema.BoolType
+	case EncodedSemaSimpleTypeCharacterType:
+		t = sema.CharacterType
+	case EncodedSemaSimpleTypeDeployedContractType:
+		t = sema.DeployedContractType
+	case EncodedSemaSimpleTypeInvalidType:
+		t = sema.InvalidType
+	case EncodedSemaSimpleTypeMetaType:
+		t = sema.MetaType
+	case EncodedSemaSimpleTypeNeverType:
+		t = sema.NeverType
+	case EncodedSemaSimpleTypePathType:
+		t = sema.PathType
+	case EncodedSemaSimpleTypeStoragePathType:
+		t = sema.StoragePathType
+	case EncodedSemaSimpleTypeCapabilityPathType:
+		t = sema.CapabilityPathType
+	case EncodedSemaSimpleTypePublicPathType:
+		t = sema.PublicPathType
+	case EncodedSemaSimpleTypePrivatePathType:
+		t = sema.PrivatePathType
+	case EncodedSemaSimpleTypeStorableType:
+		t = sema.StorableType
+	case EncodedSemaSimpleTypeStringType:
+		t = sema.StringType
+	case EncodedSemaSimpleTypeVoidType:
+		t = sema.VoidType
+	default:
+		err = fmt.Errorf("unknown simple subtype: %d", b)
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeCompositeType() (t *sema.CompositeType, err error) {
+	t = &sema.CompositeType{}
+
+	d.typeDefs[d.r.location] = t
+
+	t.Location, err = d.DecodeLocation()
+	if err != nil {
+		return
+	}
+
+	t.Identifier, err = d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	t.Kind, err = d.DecodeCompositeKind()
+	if err != nil {
+		return
+	}
+
+	t.ExplicitInterfaceConformances, err = DecodeArray(d, d.DecodeInterfaceType)
+	if err != nil {
+		return
+	}
+
+	t.ImplicitTypeRequirementConformances, err = DecodeArray(d, d.DecodeCompositeType)
+	if err != nil {
+		return
+	}
+
+	t.Members, err = d.DecodeStringMemberOrderedMap(t)
+	if err != nil {
+		return
+	}
+
+	t.Fields, err = DecodeArray(d, d.DecodeString)
+	if err != nil {
+		return
+	}
+
+	t.ConstructorParameters, err = DecodeArray(d, d.DecodeParameter)
+	if err != nil {
+		return
+	}
+
+	nestedTypes, err := d.DecodeStringTypeOrderedMap()
+	if err != nil {
+		return
+	}
+	t.SetNestedTypes(nestedTypes)
+
+	containerType, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+	t.SetContainerType(containerType)
+
+	t.EnumRawType, err = d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	hasComputedMembers, err := d.DecodeBool()
+	if err != nil {
+		return
+	}
+	t.SetHasComputedMembers(hasComputedMembers)
+
+	t.ImportableWithoutLocation, err = d.DecodeBool()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeInterfaceType() (t *sema.InterfaceType, err error) {
+	t = &sema.InterfaceType{}
+
+	d.typeDefs[d.r.location] = t
+
+	t.Location, err = d.DecodeLocation()
+	if err != nil {
+		return
+	}
+
+	t.Identifier, err = d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	t.CompositeKind, err = d.DecodeCompositeKind()
+	if err != nil {
+		return
+	}
+
+	t.Members, err = d.DecodeStringMemberOrderedMap(t)
+	if err != nil {
+		return
+	}
+
+	t.Fields, err = DecodeArray(d, d.DecodeString)
+	if err != nil {
+		return
+	}
+
+	t.InitializerParameters, err = DecodeArray(d, d.DecodeParameter)
+	if err != nil {
+		return
+	}
+
+	containerType, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+	t.SetContainerType(containerType)
+
+	return
+}
+
+func (d *SemaDecoder) DecodeTypeParameter() (p *sema.TypeParameter, err error) {
+	name, err := d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	bound, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	optional, err := d.DecodeBool()
+	if err != nil {
+		return
+	}
+
+	p = &sema.TypeParameter{
+		Name:      name,
+		TypeBound: bound,
+		Optional:  optional,
+	}
+	return
+}
+
+func (d *SemaDecoder) DecodeParameter() (parameter *sema.Parameter, err error) {
+	label, err := d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	id, err := d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	anno, err := d.DecodeTypeAnnotation()
+	if err != nil {
+		return
+	}
+
+	parameter = &sema.Parameter{
+		Label:          label,
+		Identifier:     id,
+		TypeAnnotation: anno,
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeStringMemberOrderedMap(containerType sema.Type) (om *sema.StringMemberOrderedMap, err error) {
+	isNil, err := d.DecodeBool()
+	if isNil || err != nil {
+		return
+	}
+
+	length, err := d.DecodeLength()
+	if err != nil {
+		return
+	}
+
+	om = &sema.StringMemberOrderedMap{}
+
+	for i := 0; i < length; i++ {
+		var key string
+		key, err = d.DecodeString()
+		if err != nil {
+			return
+		}
+
+		var member *sema.Member
+		member, err = d.DecodeMember(containerType)
+		if err != nil {
+			return
+		}
+
+		om.Set(key, member)
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeStringTypeOrderedMap() (om *sema.StringTypeOrderedMap, err error) {
+	isNil, err := d.DecodeBool()
+	if isNil || err != nil {
+		return
+	}
+
+	length, err := d.DecodeLength()
+	if err != nil {
+		return
+	}
+
+	om =  &sema.StringTypeOrderedMap{}
+
+	for i := 0; i < length; i++ {
+		var key string
+		key, err = d.DecodeString()
+		if err != nil {
+			return
+		}
+
+		var typ sema.Type
+		typ, err = d.DecodeType()
+		if err != nil {
+			return
+		}
+
+		om.Set(key, typ)
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeMember(containerType sema.Type) (member *sema.Member, err error) {
+	access, err := d.DecodeUInt64()
+	if err != nil {
+		return
+	}
+
+	identifier, err := d.DecodeAstIdentifier()
+	if err != nil {
+		return
+	}
+
+	typeAnnotation, err := d.DecodeTypeAnnotation()
+	if err != nil {
+		return
+	}
+
+	declarationKind, err := d.DecodeUInt64()
+	if err != nil {
+		return
+	}
+
+	variableKind, err := d.DecodeUInt64()
+	if err != nil {
+		return
+	}
+
+	argumentLabels, err := DecodeArray(d, d.DecodeString)
+	if err != nil {
+		return
+	}
+
+	predeclared, err := d.DecodeBool()
+	if err != nil {
+		return
+	}
+
+	docString, err := d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	member = &sema.Member{
+		ContainerType:         containerType,
+		Access:                ast.Access(access),
+		Identifier:            identifier,
+		TypeAnnotation:        typeAnnotation,
+		DeclarationKind:       common.DeclarationKind(declarationKind),
+		VariableKind:          ast.VariableKind(variableKind),
+		ArgumentLabels:        argumentLabels,
+		Predeclared:           predeclared,
+		IgnoreInSerialization: false, // wouldn't be encoded in the first place if true
+		DocString:             docString,
+	}
+	return
+}
+
+func (d *SemaDecoder) DecodeAstIdentifier() (id ast.Identifier, err error) {
+	identifier, err := d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	position, err := d.DecodeAstPosition()
+	if err != nil {
+		return
+	}
+
+	id = ast.Identifier{
+		Identifier: identifier,
+		Pos:        position,
+	}
+	return
+}
+
+func (d *SemaDecoder) DecodeAstPosition() (pos ast.Position, err error) {
+	offset, err := d.DecodeInt64()
+	if err != nil {
+		return
+	}
+
+	line, err := d.DecodeInt64()
+	if err != nil {
+		return
+	}
+
+	column, err := d.DecodeInt64()
+	if err != nil {
+		return
+	}
+
+	pos = ast.Position{
+		Offset: int(offset),
+		Line:   int(line),
+		Column: int(column),
+	}
+	return
+}
+
+func (d *SemaDecoder) DecodeTypeAnnotation() (anno *sema.TypeAnnotation, err error) {
+	isNil, err := d.DecodeBool()
+	if isNil || err != nil {
+		return
+	}
+
+	isResource, err := d.DecodeBool()
+	if err != nil {
+		return
+	}
+
+	t, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	anno = &sema.TypeAnnotation{
+		IsResource: isResource,
+		Type:       t,
+	}
+	return
+}
+
+func (d *SemaDecoder) DecodeLocation() (location common.Location, err error) {
+	prefix, err := d.DecodeLocationPrefix()
+
+	switch prefix {
+	case common.AddressLocationPrefix:
+		return d.DecodeAddressLocation()
+	case common.IdentifierLocationPrefix:
+		return d.DecodeIdentifierLocation()
+	case common.ScriptLocationPrefix:
+		return d.DecodeScriptLocation()
+	case common.StringLocationPrefix:
+		return d.DecodeStringLocation()
+	case common.TransactionLocationPrefix:
+		return d.DecodeTransactionLocation()
+	case string(common.REPLLocationPrefix[0]):
+		location = common.REPLLocation{}
+	case NilLocationPrefix:
+		return
+
+	// TODO more locations
+	default:
+		err = fmt.Errorf("unknown location prefix: %s", prefix)
+	}
+	return
+}
+
+func (d *SemaDecoder) DecodeLocationPrefix() (prefix string, err error) {
+	b, err := d.read(1)
+	prefix = string(b)
+	return
+}
+
+func (d *SemaDecoder) DecodeAddressLocation() (location common.AddressLocation, err error) {
+	address, err := d.DecodeAddress()
+	if err != nil {
+		return
+	}
+
+	name, err := d.DecodeString()
+	if err != nil {
+		return
+	}
+
+	location = common.NewAddressLocation(d.memoryGauge, address, name)
+
+	return
+}
+
+func (d *SemaDecoder) DecodeIdentifierLocation() (location common.IdentifierLocation, err error) {
+	s, err := d.DecodeString()
+	location = common.IdentifierLocation(s)
+	return
+}
+
+func (d *SemaDecoder) DecodeScriptLocation() (location common.ScriptLocation, err error) {
+	byteArray, err := d.read(len(location))
+	if err != nil {
+		return
+	}
+
+	for i, b := range byteArray {
+		location[i] = b
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeStringLocation() (location common.StringLocation, err error) {
+	s, err := d.DecodeString()
+	location = common.StringLocation(s)
+	return
+}
+
+func (d *SemaDecoder) DecodeTransactionLocation() (location common.TransactionLocation, err error) {
+	byteArray, err := d.read(len(location))
+	if err != nil {
+		return
+	}
+
+	for i, b := range byteArray {
+		location[i] = b
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeAddress() (address common.Address, err error) {
+	byteArray, err := d.read(common.AddressLength)
+	if err != nil {
+		return
+	}
+
+	for i, b := range byteArray {
+		address[i] = b
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeString() (s string, err error) {
+	b, err := d.DecodeBytes()
+	if err != nil {
+		return
+	}
+
+	s = string(b)
+	return
+}
+
+func (d *SemaDecoder) DecodeBytes() (bytes []byte, err error) {
+	length, err := d.DecodeLength()
+	if err != nil {
+		return
+	}
+
+	return d.read(length)
+}
+
+func (d *SemaDecoder) DecodeLength() (length int, err error) {
+	b, err := d.read(4)
+	if err != nil {
+		return
+	}
+
+	asUint32 := binary.BigEndian.Uint32(b)
+	length = int(asUint32)
+	return
+}
+
+func (d *SemaDecoder) DecodeBool() (boolean bool, err error) {
+	b, err := d.read(1)
+	if err != nil {
+		return
+	}
+
+	switch EncodedBool(b[0]) {
+	case EncodedBoolFalse:
+		boolean = false
+	case EncodedBoolTrue:
+		boolean = true
+	default:
+		err = fmt.Errorf("invalid boolean value: %d", b[0])
+	}
+
+	return
+}
+
+func (d *SemaDecoder) DecodeUInt64() (u uint64, err error) {
+	err = binary.Read(&d.r, binary.BigEndian, &u)
+	return
+}
+
+func (d *SemaDecoder) DecodeInt64() (i int64, err error) {
+	err = binary.Read(&d.r, binary.BigEndian, &i)
+	return
+}
+
+func (d *SemaDecoder) read(howManyBytes int) (b []byte, err error) {
+	b = make([]byte, howManyBytes)
+	_, err = d.r.Read(b)
+	return
+}
+
+func DecodeArray[T any](d *SemaDecoder, decodeFn func() (T, error)) (arr []T, err error) {
+	isNil, err := d.DecodeBool()
+	if isNil || err != nil {
+		return
+	}
+
+	length, err := d.DecodeLength()
+	if err != nil {
+		return
+	}
+
+	arr = make([]T, length)
+	for i := 0; i < length; i++ {
+		var element T
+		element, err = decodeFn()
+		if err != nil {
+			return
+		}
+
+		arr[i] = element
+	}
+
+	return
+}
+
+func DecodeMap[V sema.Type](d *SemaDecoder, mapToPopulate map[common.TypeID]V, decodeFn func() (V, error)) (err error) {
+	length, err := d.DecodeLength()
+	if err != nil {
+		return
+	}
+
+	for i := 0; i < length; i++ {
+		var (
+			k string
+			v V
+		)
+
+		k, err = d.DecodeString()
+		if err != nil {
+			return
+		}
+
+		v, err = decodeFn()
+		if err != nil {
+			return
+		}
+
+		mapToPopulate[common.TypeID(k)] = v
+	}
+
+	return
+}

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package sema_codec
 
 import (

--- a/encoding/custom/sema_codec/decode.go
+++ b/encoding/custom/sema_codec/decode.go
@@ -1,3 +1,22 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package sema_codec
 
 import (

--- a/encoding/custom/sema_codec/encode.go
+++ b/encoding/custom/sema_codec/encode.go
@@ -1,0 +1,1107 @@
+package sema_codec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+	"io"
+	"math/big"
+	goRuntime "runtime"
+)
+
+type LengthyWriter struct {
+	w      io.Writer
+	length int
+}
+
+func (l *LengthyWriter) Write(p []byte) (n int, err error) {
+	n, err = l.w.Write(p)
+	l.length += n
+	return
+}
+
+// A SemaEncoder converts Sema types into custom-encoded bytes.
+type SemaEncoder struct {
+	w        LengthyWriter
+	typeDefs map[sema.Type]int
+}
+
+// EncodeSema returns the custom-encoded representation of the given sema type.
+//
+// This function returns an error if the Cadence value cannot be represented in the custom format.
+func EncodeSema(t sema.Type) ([]byte, error) {
+	var w bytes.Buffer
+	enc := NewSemaEncoder(&w)
+
+	err := enc.Encode(t)
+	if err != nil {
+		return nil, err
+	}
+
+	return w.Bytes(), nil
+}
+
+// MustEncodeSema returns the custom-encoded representation of the given sema type, or panics
+// if the sema type cannot be represented in the custom format.
+func MustEncodeSema(value sema.Type) []byte {
+	b, err := EncodeSema(value)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// NewSemaEncoder initializes a SemaEncoder that will write custom-encoded bytes to the
+// given io.Writer.
+func NewSemaEncoder(w io.Writer) *SemaEncoder {
+	return &SemaEncoder{w: LengthyWriter{w: w}, typeDefs: map[sema.Type]int{}}
+}
+
+// Encode writes the custom-encoded representation of the given sema type to this
+// encoder's io.Writer.
+//
+// This function returns an error if the given sema type is not supported
+// by this encoder.
+func (e *SemaEncoder) Encode(t sema.Type) (err error) {
+	// capture panics that occur during struct preparation
+	defer func() {
+		if r := recover(); r != nil {
+			// don't recover Go errors
+			goErr, ok := r.(goRuntime.Error)
+			if ok {
+				panic(goErr)
+			}
+
+			panicErr, isError := r.(error)
+			if !isError {
+				panic(r)
+			}
+
+			err = fmt.Errorf("failed to encode value: %w", panicErr)
+		}
+	}()
+
+	return e.EncodeType(t)
+}
+
+// EncodeElaboration serializes the CompositeType and InterfaceType values in the Elaboration.
+// The rest of the Elaboration is NOT serialized because they are not needed for encoding external values.
+func (e *SemaEncoder) EncodeElaboration(el *sema.Elaboration) (err error) {
+	err = EncodeMap(e, el.CompositeTypes, e.EncodeCompositeType)
+	if err != nil {
+		return
+	}
+
+	return EncodeMap(e, el.InterfaceTypes, e.EncodeInterfaceType)
+}
+
+// EncodeType encodes any supported sema.Type.
+// Includes concrete type identifier because "Type" is an abstract type
+// ergo it can't be instantiated on decode.
+func (e *SemaEncoder) EncodeType(t sema.Type) (err error) {
+	// Non-recursable types
+	switch concreteType := t.(type) {
+	case *sema.SimpleType:
+		return e.EncodeSimpleType(concreteType)
+	case *sema.NumericType:
+		return e.EncodeNumericType(concreteType)
+	case *sema.FixedPointNumericType:
+		return e.EncodeFixedPointNumericType(concreteType)
+	case *sema.AddressType:
+		return e.EncodeTypeIdentifier(EncodedSemaAddressType)
+	case nil:
+		return e.EncodeTypeIdentifier(EncodedSemaNilType)
+	}
+
+	// Recursable types
+	if bufferOffset, usePointer := e.typeDefs[t]; usePointer {
+		return e.EncodePointer(bufferOffset)
+	}
+	e.typeDefs[t] = e.w.length + 1 // point to the encoded type, not its type identifier
+
+	switch concreteType := t.(type) {
+	case *sema.CompositeType:
+		err = e.EncodeTypeIdentifier(EncodedSemaCompositeType)
+		if err != nil {
+			return
+		}
+		return e.EncodeCompositeType(concreteType)
+	case *sema.InterfaceType:
+		err = e.EncodeTypeIdentifier(EncodedSemaInterfaceType)
+		if err != nil {
+			return
+		}
+		return e.EncodeInterfaceType(concreteType)
+	case *sema.GenericType:
+		err = e.EncodeTypeIdentifier(EncodedSemaGenericType)
+		if err != nil {
+			return
+		}
+		return e.EncodeGenericType(concreteType)
+	case *sema.FunctionType:
+		err = e.EncodeTypeIdentifier(EncodedSemaFunctionType)
+		if err != nil {
+			return
+		}
+		return e.EncodeFunctionType(concreteType)
+	case *sema.DictionaryType:
+		err = e.EncodeTypeIdentifier(EncodedSemaDictionaryType)
+		if err != nil {
+			return
+		}
+		return e.EncodeDictionaryType(concreteType)
+	case *sema.TransactionType:
+		err = e.EncodeTypeIdentifier(EncodedSemaTransactionType)
+		if err != nil {
+			return
+		}
+		return e.EncodeTransactionType(concreteType)
+	case *sema.RestrictedType:
+		err = e.EncodeTypeIdentifier(EncodedSemaRestrictedType)
+		if err != nil {
+			return
+		}
+		return e.EncodeRestrictedType(concreteType)
+	case *sema.VariableSizedType:
+		err = e.EncodeTypeIdentifier(EncodedSemaVariableSizedType)
+		if err != nil {
+			return
+		}
+		return e.EncodeVariableSizedType(concreteType)
+	case *sema.ConstantSizedType:
+		err = e.EncodeTypeIdentifier(EncodedSemaConstantSizedType)
+		if err != nil {
+			return
+		}
+		return e.EncodeConstantSizedType(concreteType)
+	case *sema.OptionalType:
+		err = e.EncodeTypeIdentifier(EncodedSemaOptionalType)
+		if err != nil {
+			return
+		}
+		return e.EncodeOptionalType(concreteType)
+	case *sema.ReferenceType:
+		err = e.EncodeTypeIdentifier(EncodedSemaReferenceType)
+		if err != nil {
+			return
+		}
+		return e.EncodeReferenceType(concreteType)
+	case *sema.CapabilityType:
+		err = e.EncodeTypeIdentifier(EncodedSemaCapabilityType)
+		if err != nil {
+			return
+		}
+		return e.EncodeCapabilityType(concreteType)
+
+	default:
+		return fmt.Errorf("unexpected type: %s", concreteType)
+	}
+}
+
+// TODO add protections against regressions from changes to enum
+// TODO consider putting simple and numeric types in a specific ranges (128+, 64-127)
+//      that turns certain bits into flags for the presence of those types, which can be calculated very fast
+//      (check the leftmost bit first, then the next bit, in that order, or there's overlap)
+type EncodedSema byte
+
+const (
+	EncodedSemaUnknown EncodedSema = iota // lacking type information; should not be encoded
+
+	// Simple Types
+
+	EncodedSemaSimpleTypeAnyType
+	EncodedSemaSimpleTypeAnyResourceType
+	EncodedSemaSimpleTypeAnyStructType
+	EncodedSemaSimpleTypeBlockType
+	EncodedSemaSimpleTypeBoolType
+	EncodedSemaSimpleTypeCharacterType
+	EncodedSemaSimpleTypeDeployedContractType
+	EncodedSemaSimpleTypeInvalidType
+	EncodedSemaSimpleTypeMetaType
+	EncodedSemaSimpleTypeNeverType
+	EncodedSemaSimpleTypePathType
+	EncodedSemaSimpleTypeStoragePathType
+	EncodedSemaSimpleTypeCapabilityPathType
+	EncodedSemaSimpleTypePublicPathType
+	EncodedSemaSimpleTypePrivatePathType
+	EncodedSemaSimpleTypeStorableType
+	EncodedSemaSimpleTypeStringType
+	EncodedSemaSimpleTypeVoidType
+
+	// Numeric Types
+
+	EncodedSemaNumericTypeNumberType
+	EncodedSemaNumericTypeSignedNumberType
+	EncodedSemaNumericTypeIntegerType
+	EncodedSemaNumericTypeSignedIntegerType
+	EncodedSemaNumericTypeIntType
+	EncodedSemaNumericTypeInt8Type
+	EncodedSemaNumericTypeInt16Type
+	EncodedSemaNumericTypeInt32Type
+	EncodedSemaNumericTypeInt64Type
+	EncodedSemaNumericTypeInt128Type
+	EncodedSemaNumericTypeInt256Type
+	EncodedSemaNumericTypeUIntType
+	EncodedSemaNumericTypeUInt8Type
+	EncodedSemaNumericTypeUInt16Type
+	EncodedSemaNumericTypeUInt32Type
+	EncodedSemaNumericTypeUInt64Type
+	EncodedSemaNumericTypeUInt128Type
+	EncodedSemaNumericTypeUInt256Type
+	EncodedSemaNumericTypeWord8Type
+	EncodedSemaNumericTypeWord16Type
+	EncodedSemaNumericTypeWord32Type
+	EncodedSemaNumericTypeWord64Type
+	EncodedSemaNumericTypeFixedPointType
+	EncodedSemaNumericTypeSignedFixedPointType
+
+	// Fixed Point Numeric Types
+
+	EncodedSemaFix64Type
+	EncodedSemaUFix64Type
+
+	// Pointable Types
+
+	EncodedSemaCompositeType
+	EncodedSemaInterfaceType
+	EncodedSemaGenericType
+	EncodedSemaTransactionType
+	EncodedSemaRestrictedType
+	EncodedSemaVariableSizedType
+	EncodedSemaConstantSizedType
+	EncodedSemaFunctionType
+	EncodedSemaDictionaryType
+
+	// Other Types
+
+	EncodedSemaNilType // no type is specified
+	EncodedSemaOptionalType
+
+	EncodedSemaReferenceType
+	EncodedSemaAddressType
+	EncodedSemaCapabilityType
+	EncodedSemaPointerType
+)
+
+func isSimpleType(encodedSema EncodedSema) bool {
+	return encodedSema >= EncodedSemaSimpleTypeAnyType &&
+		encodedSema <= EncodedSemaSimpleTypeVoidType
+}
+
+func isNumericType(encodedSema EncodedSema) bool {
+	return encodedSema >= EncodedSemaNumericTypeNumberType &&
+		encodedSema <= EncodedSemaNumericTypeSignedFixedPointType
+}
+
+func isFixedPointNumericType(encodedSema EncodedSema) bool {
+	return encodedSema == EncodedSemaFix64Type || encodedSema == EncodedSemaUFix64Type
+}
+
+func (e *SemaEncoder) EncodeSimpleType(t *sema.SimpleType) (err error) {
+	subType := EncodedSemaUnknown
+
+	switch t {
+	case sema.AnyType:
+		subType = EncodedSemaSimpleTypeAnyType
+	case sema.AnyResourceType:
+		subType = EncodedSemaSimpleTypeAnyResourceType
+	case sema.AnyStructType:
+		subType = EncodedSemaSimpleTypeAnyStructType
+	case sema.BlockType:
+		subType = EncodedSemaSimpleTypeBlockType
+	case sema.BoolType:
+		subType = EncodedSemaSimpleTypeBoolType
+	case sema.CharacterType:
+		subType = EncodedSemaSimpleTypeCharacterType
+	case sema.DeployedContractType:
+		subType = EncodedSemaSimpleTypeDeployedContractType
+	case sema.InvalidType:
+		subType = EncodedSemaSimpleTypeInvalidType
+	case sema.MetaType:
+		subType = EncodedSemaSimpleTypeMetaType
+	case sema.NeverType:
+		subType = EncodedSemaSimpleTypeNeverType
+	case sema.PathType:
+		subType = EncodedSemaSimpleTypePathType
+	case sema.StoragePathType:
+		subType = EncodedSemaSimpleTypeStoragePathType
+	case sema.CapabilityPathType:
+		subType = EncodedSemaSimpleTypeCapabilityPathType
+	case sema.PublicPathType:
+		subType = EncodedSemaSimpleTypePublicPathType
+	case sema.PrivatePathType:
+		subType = EncodedSemaSimpleTypePrivatePathType
+	case sema.StorableType:
+		subType = EncodedSemaSimpleTypeStorableType
+	case sema.StringType:
+		subType = EncodedSemaSimpleTypeStringType
+	case sema.VoidType:
+		subType = EncodedSemaSimpleTypeVoidType
+
+	default:
+		return fmt.Errorf("unknown simple type: %s", t)
+	}
+
+	return e.write([]byte{byte(subType)})
+}
+
+func (e *SemaEncoder) EncodeFunctionType(t *sema.FunctionType) (err error) {
+	err = e.EncodeBool(t.IsConstructor)
+	if err != nil {
+		return
+	}
+
+	err = EncodeArray(e, t.TypeParameters, e.EncodeTypeParameter)
+	if err != nil {
+		return
+	}
+
+	err = EncodeArray(e, t.Parameters, e.EncodeParameter)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeTypeAnnotation(t.ReturnTypeAnnotation)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeIntPointer(t.RequiredArgumentCount)
+	if err != nil {
+		return
+	}
+
+	// TODO Is it OK that ArgumentExpressionCheck is omitted?
+	//      I only see it set twice: AddressConversionFunctionType and NumberConversionFunctionType
+	//      It is likely that these should be encoded as enums instead, since they are Cadence globals.
+
+	return e.EncodeStringMemberOrderedMap(t.Members)
+}
+
+func (e *SemaEncoder) EncodeIntPointer(ptr *int) (err error) {
+	if ptr == nil {
+		return e.EncodeBool(true)
+	}
+
+	err = e.EncodeBool(false)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeInt64(int64(*ptr))
+}
+
+func (e *SemaEncoder) EncodeDictionaryType(t *sema.DictionaryType) (err error) {
+	err = e.EncodeType(t.KeyType)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeType(t.ValueType)
+}
+
+func (e *SemaEncoder) EncodeReferenceType(t *sema.ReferenceType) (err error) {
+	err = e.EncodeBool(t.Authorized)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeType(t.Type)
+}
+
+func (e *SemaEncoder) EncodeTransactionType(t *sema.TransactionType) (err error) {
+	err = e.EncodeStringMemberOrderedMap(t.Members)
+	if err != nil {
+		return
+	}
+
+	err = EncodeArray(e, t.Fields, e.EncodeString)
+	if err != nil {
+		return
+	}
+
+	err = EncodeArray(e, t.PrepareParameters, e.EncodeParameter)
+	if err != nil {
+		return
+	}
+
+	return EncodeArray(e, t.Parameters, e.EncodeParameter)
+}
+
+func (e *SemaEncoder) EncodeRestrictedType(t *sema.RestrictedType) (err error) {
+	err = e.EncodeType(t.Type)
+	if err != nil {
+		return
+	}
+
+	return EncodeArray(e, t.Restrictions, e.EncodeInterfaceType)
+}
+
+func (e *SemaEncoder) EncodeCapabilityType(t *sema.CapabilityType) (err error) {
+	return e.EncodeType(t.BorrowType)
+}
+
+func (e *SemaEncoder) EncodeOptionalType(t *sema.OptionalType) (err error) {
+	return e.EncodeType(t.Type)
+}
+
+func (e *SemaEncoder) EncodeVariableSizedType(t *sema.VariableSizedType) (err error) {
+	return e.EncodeType(t.Type)
+}
+
+func (e *SemaEncoder) EncodeConstantSizedType(t *sema.ConstantSizedType) (err error) {
+	err = e.EncodeType(t.Type)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeInt64(t.Size)
+}
+
+func (e *SemaEncoder) EncodeGenericType(t *sema.GenericType) (err error) {
+	return e.EncodeTypeParameter(t.TypeParameter)
+}
+
+func (e *SemaEncoder) EncodeNumericType(t *sema.NumericType) (err error) {
+	numericType := EncodedSemaUnknown
+
+	switch t {
+	case sema.NumberType:
+		numericType = EncodedSemaNumericTypeNumberType
+	case sema.SignedNumberType:
+		numericType = EncodedSemaNumericTypeSignedNumberType
+	case sema.IntegerType:
+		numericType = EncodedSemaNumericTypeIntegerType
+	case sema.SignedIntegerType:
+		numericType = EncodedSemaNumericTypeSignedIntegerType
+	case sema.IntType:
+		numericType = EncodedSemaNumericTypeIntType
+	case sema.Int8Type:
+		numericType = EncodedSemaNumericTypeInt8Type
+	case sema.Int16Type:
+		numericType = EncodedSemaNumericTypeInt16Type
+	case sema.Int32Type:
+		numericType = EncodedSemaNumericTypeInt32Type
+	case sema.Int64Type:
+		numericType = EncodedSemaNumericTypeInt64Type
+	case sema.Int128Type:
+		numericType = EncodedSemaNumericTypeInt128Type
+	case sema.Int256Type:
+		numericType = EncodedSemaNumericTypeInt256Type
+	case sema.UIntType:
+		numericType = EncodedSemaNumericTypeUIntType
+	case sema.UInt8Type:
+		numericType = EncodedSemaNumericTypeUInt8Type
+	case sema.UInt16Type:
+		numericType = EncodedSemaNumericTypeUInt16Type
+	case sema.UInt32Type:
+		numericType = EncodedSemaNumericTypeUInt32Type
+	case sema.UInt64Type:
+		numericType = EncodedSemaNumericTypeUInt64Type
+	case sema.UInt128Type:
+		numericType = EncodedSemaNumericTypeUInt128Type
+	case sema.UInt256Type:
+		numericType = EncodedSemaNumericTypeUInt256Type
+	case sema.Word8Type:
+		numericType = EncodedSemaNumericTypeWord8Type
+	case sema.Word16Type:
+		numericType = EncodedSemaNumericTypeWord16Type
+	case sema.Word32Type:
+		numericType = EncodedSemaNumericTypeWord32Type
+	case sema.Word64Type:
+		numericType = EncodedSemaNumericTypeWord64Type
+	case sema.FixedPointType:
+		numericType = EncodedSemaNumericTypeFixedPointType
+	case sema.SignedFixedPointType:
+		numericType = EncodedSemaNumericTypeSignedFixedPointType
+	default:
+		return fmt.Errorf("unexpected numeric type: %s", t)
+	}
+
+	return e.EncodeTypeIdentifier(numericType)
+}
+
+func (e *SemaEncoder) EncodeFixedPointNumericType(t *sema.FixedPointNumericType) (err error) {
+	fixedPointNumericType := EncodedSemaUnknown
+
+	switch t {
+	case sema.Fix64Type:
+		fixedPointNumericType = EncodedSemaFix64Type
+	case sema.UFix64Type:
+		fixedPointNumericType = EncodedSemaUFix64Type
+	default:
+		return fmt.Errorf("unexpected fixed point numeric type: %s", t)
+	}
+
+	return e.write([]byte{byte(fixedPointNumericType)})
+}
+
+func (e *SemaEncoder) EncodeBigInt(bi *big.Int) (err error) {
+	sign := bi.Sign()
+	neg := sign == -1
+	err = e.EncodeBool(neg)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeBytes(bi.Bytes())
+}
+
+func (e *SemaEncoder) EncodeTypeTag(tag sema.TypeTag) (err error) {
+	err = e.EncodeUInt64(tag.UpperMask())
+	if err != nil {
+		return
+	}
+
+	return e.EncodeUInt64(tag.LowerMask())
+}
+
+func (e *SemaEncoder) EncodeTypeIdentifier(id EncodedSema) (err error) {
+	return e.write([]byte{byte(id)})
+}
+
+// EncodeCompositeKind expects the CompositeKind to fit within a single byte.
+func (e *SemaEncoder) EncodeCompositeKind(kind common.CompositeKind) (err error) {
+	return e.write([]byte{byte(kind)})
+}
+
+func (e *SemaEncoder) EncodePointer(bufferOffset int) (err error) {
+	err = e.write([]byte{byte(EncodedSemaPointerType)})
+	if err != nil {
+		return
+	}
+
+	return e.EncodeLength(bufferOffset)
+}
+
+type EncodedSemaBuiltInCompositeType byte
+
+const (
+	EncodedSemaBuiltInCompositeTypeUnknown EncodedSemaBuiltInCompositeType = iota
+	EncodedSemaBuiltInCompositeTypePublicAccountType
+)
+
+// TODO encode built-in CompositeTypes as enums
+// TODO are composite types encodable is CompositeType.IsStorable() is false?
+// TODO if IsImportable is false then do we want to skip for execution state storage?
+func (e *SemaEncoder) EncodeCompositeType(compositeType *sema.CompositeType) (err error) {
+	// Location -> common.Location
+	err = e.EncodeLocation(compositeType.Location)
+	if err != nil {
+		return
+	}
+
+	// Identifier -> string
+	err = e.EncodeString(compositeType.Identifier)
+	if err != nil {
+		return
+	}
+
+	// Kind -> common.CompositeKind
+	err = e.EncodeCompositeKind(compositeType.Kind)
+	if err != nil {
+		return
+	}
+
+	// TODO does this handle recursive types correctly?
+	// ExplicitInterfaceConformances -> []*InterfaceType
+	err = EncodeArray(e, compositeType.ExplicitInterfaceConformances, e.EncodeInterfaceType)
+	if err != nil {
+		return
+	}
+
+	// TODO does this handle recursive types correctly?
+	// ImplicitTypeRequirementConformances -> []*CompositeType
+	err = EncodeArray(e, compositeType.ImplicitTypeRequirementConformances, e.EncodeCompositeType)
+	if err != nil {
+		return
+	}
+
+	// Members -> *StringMemberOrderedMap
+	err = e.EncodeStringMemberOrderedMap(compositeType.Members)
+	if err != nil {
+		return
+	}
+
+	// Fields -> []string
+	err = EncodeArray(e, compositeType.Fields, e.EncodeString)
+	if err != nil {
+		return
+	}
+
+	// ConstructorParameters -> []*Parameter
+	err = EncodeArray(e, compositeType.ConstructorParameters, e.EncodeParameter)
+	if err != nil {
+		return
+	}
+
+	// nestedTypes -> *StringTypeOrderedMap
+	err = e.EncodeStringTypeOrderedMap(compositeType.GetNestedTypes())
+	if err != nil {
+		return
+	}
+
+	// containerType -> Type
+	err = e.EncodeType(compositeType.GetContainerType())
+	if err != nil {
+		return
+	}
+
+	// EnumRawType -> Type
+	err = e.EncodeType(compositeType.EnumRawType)
+	if err != nil {
+		return
+	}
+
+	// hasComputedMembers -> bool
+	err = e.EncodeBool(compositeType.HasComputedMembers())
+	if err != nil {
+		return
+	}
+
+	// ImportableWithoutLocation -> bool
+	return e.EncodeBool(compositeType.ImportableWithoutLocation)
+}
+
+func (e *SemaEncoder) EncodeTypeParameter(p *sema.TypeParameter) (err error) {
+	err = e.EncodeString(p.Name)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeType(p.TypeBound)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeBool(p.Optional)
+}
+
+func (e *SemaEncoder) EncodeParameter(parameter *sema.Parameter) (err error) {
+	err = e.EncodeString(parameter.Label)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeString(parameter.Identifier)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeTypeAnnotation(parameter.TypeAnnotation)
+}
+
+func (e *SemaEncoder) EncodeStringMemberOrderedMap(om *sema.StringMemberOrderedMap) (err error) {
+	// TODO save a bit in the length for nil check?
+	err = e.EncodeBool(om == nil)
+	if om == nil || err != nil {
+		return
+	}
+
+	type StringMemberTuple struct {
+		String string
+		Member *sema.Member
+	}
+
+	serializables := make([]StringMemberTuple, 0, om.Len())
+
+	om.Foreach(func(key string, value *sema.Member) {
+		if value.IsStorable(make(map[*sema.Member]bool)) {
+			serializables = append(serializables, StringMemberTuple{
+				String: key,
+				Member: value,
+			})
+		}
+	})
+	err = e.EncodeLength(len(serializables))
+	if err != nil {
+		return
+	}
+
+	for _, tuple := range serializables {
+		err = e.EncodeString(tuple.String)
+		if err != nil {
+			return err
+		}
+
+		err = e.EncodeMember(tuple.Member)
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+func (e *SemaEncoder) EncodeStringTypeOrderedMap(om *sema.StringTypeOrderedMap) (err error) {
+	// TODO save a bit in the length for nil check?
+	err = e.EncodeBool(om == nil)
+	if om == nil || err != nil {
+		return
+	}
+
+	type StringTypeTuple struct {
+		String string
+		Type   sema.Type
+	}
+
+	serializables := make([]StringTypeTuple, 0, om.Len())
+
+	om.Foreach(func(key string, value sema.Type) {
+		if value.IsStorable(make(map[*sema.Member]bool)) {
+			serializables = append(serializables, StringTypeTuple{
+				String: key,
+				Type:   value,
+			})
+		}
+	})
+	err = e.EncodeLength(len(serializables))
+	if err != nil {
+		return
+	}
+
+	for _, tuple := range serializables {
+		err = e.EncodeString(tuple.String)
+		if err != nil {
+			return err
+		}
+
+		err = e.EncodeType(tuple.Type)
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+func (e *SemaEncoder) EncodeMember(member *sema.Member) (err error) {
+	err = e.EncodeUInt64(uint64(member.Access))
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeAstIdentifier(member.Identifier)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeTypeAnnotation(member.TypeAnnotation)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeUInt64(uint64(member.DeclarationKind))
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeUInt64(uint64(member.VariableKind))
+	if err != nil {
+		return
+	}
+
+	err = EncodeArray(e, member.ArgumentLabels, e.EncodeString)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeBool(member.Predeclared)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeString(member.DocString)
+}
+
+func (e *SemaEncoder) EncodeTypeAnnotation(anno *sema.TypeAnnotation) (err error) {
+	err = e.EncodeBool(anno == nil)
+	if anno == nil || err != nil {
+		return
+	}
+
+	err = e.EncodeBool(anno.IsResource)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeType(anno.Type)
+}
+
+func (e *SemaEncoder) EncodeAstIdentifier(id ast.Identifier) (err error) {
+	err = e.EncodeString(id.Identifier)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeAstPosition(id.Pos)
+}
+
+func (e *SemaEncoder) EncodeAstPosition(pos ast.Position) (err error) {
+	err = e.EncodeInt64(int64(pos.Offset))
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeInt64(int64(pos.Line))
+	if err != nil {
+		return
+	}
+
+	return e.EncodeInt64(int64(pos.Column))
+}
+
+func (e *SemaEncoder) EncodeInterfaceType(interfaceType *sema.InterfaceType) (err error) {
+	err = e.EncodeLocation(interfaceType.Location)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeString(interfaceType.Identifier)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeCompositeKind(interfaceType.CompositeKind)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeStringMemberOrderedMap(interfaceType.Members)
+	if err != nil {
+		return
+	}
+
+	err = EncodeArray(e, interfaceType.Fields, e.EncodeString)
+	if err != nil {
+		return
+	}
+
+	err = EncodeArray(e, interfaceType.InitializerParameters, e.EncodeParameter)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeType(interfaceType.GetContainerType())
+	if err != nil {
+		return
+	}
+
+	// TODO can I drop nested types if I encode built-in composite types as enums?
+	return e.EncodeStringTypeOrderedMap(interfaceType.GetNestedTypes())
+}
+
+type EncodedBool byte
+
+const (
+	EncodedBoolUnknown EncodedBool = iota
+	EncodedBoolFalse
+	EncodedBoolTrue
+)
+
+func (e *SemaEncoder) EncodeBool(boolean bool) (err error) {
+	b := EncodedBoolFalse
+	if boolean {
+		b = EncodedBoolTrue
+	}
+
+	return e.write([]byte{byte(b)})
+}
+
+// TODO use a more efficient encoder than `binary` (they say to in their top source comment)
+func (e *SemaEncoder) EncodeUInt64(i uint64) (err error) {
+	return binary.Write(&e.w, binary.BigEndian, i)
+}
+
+func (e *SemaEncoder) EncodeInt64(i int64) (err error) {
+	return binary.Write(&e.w, binary.BigEndian, i)
+}
+
+func (e *SemaEncoder) EncodeLocation(location common.Location) (err error) {
+	switch concreteType := location.(type) {
+	case common.AddressLocation:
+		return e.EncodeAddressLocation(concreteType)
+	case common.IdentifierLocation:
+		return e.EncodeIdentifierLocation(concreteType)
+	case common.ScriptLocation:
+		return e.EncodeScriptLocation(concreteType)
+	case common.StringLocation:
+		return e.EncodeStringLocation(concreteType)
+	case common.TransactionLocation:
+		return e.EncodeTransactionLocation(concreteType)
+	case common.REPLLocation:
+		return e.EncodeREPLLocation()
+	case nil:
+		return e.EncodeNilLocation()
+	default:
+		return fmt.Errorf("unexpected location type: %s", concreteType)
+	}
+}
+
+// The location prefixes are stored as strings but are always* a single ascii character,
+// so they can be stored in a single byte.
+// * The exception is the REPL location but its first ascii character is unique anyway.
+func (e *SemaEncoder) EncodeLocationPrefix(prefix string) (err error) {
+	char := prefix[0]
+	return e.write([]byte{char})
+}
+
+var NilLocationPrefix = "\x00"
+
+// EncodeNilLocation encodes a value that indicates that no location is specified
+func (e *SemaEncoder) EncodeNilLocation() (err error) {
+	return e.EncodeLocationPrefix(NilLocationPrefix)
+}
+
+func (e *SemaEncoder) EncodeAddressLocation(t common.AddressLocation) (err error) {
+	err = e.EncodeLocationPrefix(common.AddressLocationPrefix)
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeAddress(t.Address)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeString(t.Name)
+}
+
+func (e *SemaEncoder) EncodeIdentifierLocation(t common.IdentifierLocation) (err error) {
+	err = e.EncodeLocationPrefix(common.IdentifierLocationPrefix)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeString(string(t))
+}
+
+func (e *SemaEncoder) EncodeScriptLocation(t common.ScriptLocation) (err error) {
+	err = e.EncodeLocationPrefix(common.ScriptLocationPrefix)
+	if err != nil {
+		return
+	}
+
+	return e.write(t[:])
+}
+
+func (e *SemaEncoder) EncodeStringLocation(t common.StringLocation) (err error) {
+	err = e.EncodeLocationPrefix(common.StringLocationPrefix)
+	if err != nil {
+		return
+	}
+
+	return e.EncodeString(string(t))
+}
+
+func (e *SemaEncoder) EncodeTransactionLocation(t common.TransactionLocation) (err error) {
+	err = e.EncodeLocationPrefix(common.TransactionLocationPrefix)
+	if err != nil {
+		return
+	}
+
+	return e.write(t[:])
+}
+
+func (e *SemaEncoder) EncodeREPLLocation() (err error) {
+	return e.EncodeLocationPrefix(common.REPLLocationPrefix)
+}
+
+// EncodeString encodes a string as a byte array.
+func (e *SemaEncoder) EncodeString(s string) (err error) {
+	return e.EncodeBytes([]byte(s))
+}
+
+// EncodeBytes encodes a byte array.
+func (e *SemaEncoder) EncodeBytes(bytes []byte) (err error) {
+	err = e.EncodeLength(len(bytes))
+	if err != nil {
+		return
+	}
+
+	return e.write(bytes)
+}
+
+// TODO encode length with variable-sized encoding?
+//      e.g. first byte starting with `0` is the last byte in the length
+//      will usually save 3 bytes. the question is if it saves or costs encode and/or decode time
+
+// EncodeLength encodes a non-negative length as a uint32.
+// It uses 4 bytes.
+func (e *SemaEncoder) EncodeLength(length int) (err error) {
+	if length < 0 { // TODO is this safety check useful?
+		return fmt.Errorf("cannot encode length below zero: %d", length)
+	}
+
+	l := uint32(length)
+
+	return binary.Write(&e.w, binary.BigEndian, l)
+}
+
+func (e *SemaEncoder) EncodeAddress(address common.Address) (err error) {
+	return e.write(address[:])
+}
+
+func (e *SemaEncoder) write(b []byte) (err error) {
+	_, err = e.w.Write(b)
+	return
+}
+
+func EncodeArray[T any](e *SemaEncoder, arr []T, encodeFn func(T) error) (err error) {
+	// TODO save a bit in the array length for nil check?
+	err = e.EncodeBool(arr == nil)
+	if arr == nil || err != nil {
+		return
+	}
+
+	err = e.EncodeLength(len(arr))
+	if err != nil {
+		return
+	}
+
+	for _, element := range arr {
+		// TODO does this need to include pointer logic for recursive types in arrays to be handled correctly?
+		err = encodeFn(element)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// EncodeMap serializes a map from TypeID to sema.Type.
+func EncodeMap[V sema.Type](e *SemaEncoder, m map[common.TypeID]V, encodeFn func(V) error) (err error) {
+	// ASSUMPTION: map is never `nil`. WHY: EncodeMap only used for Elaboration, which is always fully instantiated.
+
+	err = e.EncodeLength(len(m))
+	if err != nil {
+		return
+	}
+
+	for k, v := range m {
+		err = e.EncodeString(string(k))
+		if err != nil {
+			return
+		}
+
+		if bufferOffset, usePointer := e.typeDefs[v]; usePointer {
+			err = e.EncodePointer(bufferOffset)
+			if err != nil {
+				return
+			}
+			continue
+		}
+		e.typeDefs[v] = e.w.length
+
+		err = encodeFn(v)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/encoding/custom/sema_codec/encode.go
+++ b/encoding/custom/sema_codec/encode.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/sema"
 	"io"
 	"math/big"
 	goRuntime "runtime"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 // A SemaEncoder converts Sema types into custom-encoded bytes.

--- a/encoding/custom/sema_codec/encode.go
+++ b/encoding/custom/sema_codec/encode.go
@@ -284,7 +284,7 @@ func isFixedPointNumericType(encodedSema EncodedSema) bool {
 }
 
 func (e *SemaEncoder) EncodeSimpleType(t *sema.SimpleType) (err error) {
-	subType := EncodedSemaUnknown
+	var subType EncodedSema
 
 	switch t {
 	case sema.AnyType:
@@ -449,7 +449,7 @@ func (e *SemaEncoder) EncodeGenericType(t *sema.GenericType) (err error) {
 }
 
 func (e *SemaEncoder) EncodeNumericType(t *sema.NumericType) (err error) {
-	numericType := EncodedSemaUnknown
+	var numericType EncodedSema
 
 	switch t {
 	case sema.NumberType:
@@ -508,7 +508,7 @@ func (e *SemaEncoder) EncodeNumericType(t *sema.NumericType) (err error) {
 }
 
 func (e *SemaEncoder) EncodeFixedPointNumericType(t *sema.FixedPointNumericType) (err error) {
-	fixedPointNumericType := EncodedSemaUnknown
+	var fixedPointNumericType EncodedSema
 
 	switch t {
 	case sema.Fix64Type:
@@ -1056,7 +1056,8 @@ func EncodeMap[V sema.Type](e *SemaEncoder, m map[common.TypeID]V, encodeFn func
 		return
 	}
 
-	for k, v := range m {
+	// The order of encoded key-value pairs does not matter so long as we don't rely on hashing encoded Elaborations.
+	for k, v := range m { //nolint:maprangecheck
 		err = e.EncodeString(string(k))
 		if err != nil {
 			return

--- a/encoding/custom/sema_codec/encode.go
+++ b/encoding/custom/sema_codec/encode.go
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package sema_codec
 
 import (

--- a/encoding/custom/sema_codec/encode.go
+++ b/encoding/custom/sema_codec/encode.go
@@ -79,7 +79,9 @@ func NewSemaEncoder(w io.Writer) *SemaEncoder {
 // by this encoder.
 func (e *SemaEncoder) Encode(t sema.Type) (err error) {
 	defer func() {
-		err = capturePanic("failed to encode sema type: %w")
+		if panicErr := capturePanic("failed to encode sema type: %w"); panicErr != nil {
+			err = panicErr
+		}
 	}()
 
 	return e.EncodeType(t)
@@ -89,7 +91,9 @@ func (e *SemaEncoder) Encode(t sema.Type) (err error) {
 // The rest of the Elaboration is NOT serialized because they are not needed for encoding external values.
 func (e *SemaEncoder) EncodeElaboration(el *sema.Elaboration) (err error) {
 	defer func() {
-		err = capturePanic("failed to encode elaboration: %w")
+		if panicErr := capturePanic("failed to encode elaboration: %w"); panicErr != nil {
+			err = panicErr
+		}
 	}()
 
 	err = EncodeMap(e, el.CompositeTypes, e.EncodeCompositeType)

--- a/encoding/custom/sema_codec/encode.go
+++ b/encoding/custom/sema_codec/encode.go
@@ -1,3 +1,22 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package sema_codec
 
 import (

--- a/encoding/custom/sema_codec/encode.go
+++ b/encoding/custom/sema_codec/encode.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	goRuntime "runtime"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -74,27 +73,14 @@ func NewSemaEncoder(w io.Writer) *SemaEncoder {
 // Encode writes the custom-encoded representation of the given sema type to this
 // encoder's io.Writer.
 //
-// This function returns an error if the given sema type is not supported
-// by this encoder.
+// This function returns an error if the given sema type is not supported by this encoder.
 func (e *SemaEncoder) Encode(t sema.Type) (err error) {
-	defer func() {
-		if panicErr := capturePanic("failed to encode sema type: %w"); panicErr != nil {
-			err = panicErr
-		}
-	}()
-
 	return e.EncodeType(t)
 }
 
 // EncodeElaboration serializes the CompositeType and InterfaceType values in the Elaboration.
 // The rest of the Elaboration is NOT serialized because they are not needed for encoding external values.
 func (e *SemaEncoder) EncodeElaboration(el *sema.Elaboration) (err error) {
-	defer func() {
-		if panicErr := capturePanic("failed to encode elaboration: %w"); panicErr != nil {
-			err = panicErr
-		}
-	}()
-
 	err = EncodeMap(e, el.CompositeTypes, e.EncodeCompositeType)
 	if err != nil {
 		return
@@ -1100,24 +1086,6 @@ func EncodeMap[V sema.Type](e *SemaEncoder, m map[common.TypeID]V, encodeFn func
 		}
 	}
 
-	return
-}
-
-func capturePanic(errorFormatting string) (err error) {
-	if r := recover(); r != nil {
-		// don't recover Go errors
-		goErr, ok := r.(goRuntime.Error)
-		if ok {
-			panic(goErr)
-		}
-
-		panicErr, isError := r.(error)
-		if !isError {
-			panic(r)
-		}
-
-		err = fmt.Errorf(errorFormatting, panicErr)
-	}
 	return
 }
 

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -34,9 +34,9 @@ const AuthAccountContractsTypeNamesField = "names"
 var AuthAccountContractsType = func() *CompositeType {
 
 	authAccountContractsType := &CompositeType{
-		Identifier: AuthAccountContractsTypeName,
-		Kind:       common.CompositeKindStructure,
-		importable: false,
+		Identifier:                AuthAccountContractsTypeName,
+		Kind:                      common.CompositeKindStructure,
+		ImportableWithoutLocation: false,
 	}
 
 	var members = []*Member{

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -49,10 +49,10 @@ const AuthAccountKeysField = "keys"
 var AuthAccountType = func() *CompositeType {
 
 	authAccountType := &CompositeType{
-		Identifier:         AuthAccountTypeName,
-		Kind:               common.CompositeKindStructure,
-		hasComputedMembers: true,
-		importable:         false,
+		Identifier:                AuthAccountTypeName,
+		Kind:                      common.CompositeKindStructure,
+		hasComputedMembers:        true,
+		ImportableWithoutLocation: false,
 		nestedTypes: func() *StringTypeOrderedMap {
 			nestedTypes := &StringTypeOrderedMap{}
 			nestedTypes.Set(AuthAccountContractsTypeName, AuthAccountContractsType)
@@ -524,9 +524,9 @@ var AccountTypeGetLinkTargetFunctionType = &FunctionType{
 var AuthAccountKeysType = func() *CompositeType {
 
 	accountKeys := &CompositeType{
-		Identifier: AccountKeysTypeName,
-		Kind:       common.CompositeKindStructure,
-		importable: false,
+		Identifier:                AccountKeysTypeName,
+		Kind:                      common.CompositeKindStructure,
+		ImportableWithoutLocation: false,
 	}
 
 	var members = []*Member{

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -260,10 +260,10 @@ func newNativeEnumType(
 	membersConstructor func(enumType *CompositeType) []*Member,
 ) *CompositeType {
 	ty := &CompositeType{
-		Identifier:  identifier,
-		EnumRawType: rawType,
-		Kind:        common.CompositeKindEnum,
-		importable:  true,
+		Identifier:                identifier,
+		EnumRawType:               rawType,
+		Kind:                      common.CompositeKindEnum,
+		ImportableWithoutLocation: true,
 	}
 
 	// Members of the enum type are *not* the enum cases!

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -31,9 +31,9 @@ const PublicAccountContractsTypeNamesField = "names"
 var PublicAccountContractsType = func() *CompositeType {
 
 	publicAccountContractsType := &CompositeType{
-		Identifier: PublicAccountContractsTypeName,
-		Kind:       common.CompositeKindStructure,
-		importable: false,
+		Identifier:                PublicAccountContractsTypeName,
+		Kind:                      common.CompositeKindStructure,
+		ImportableWithoutLocation: false,
 	}
 
 	var members = []*Member{

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -38,10 +38,10 @@ const PublicAccountContractsField = "contracts"
 var PublicAccountType = func() *CompositeType {
 
 	publicAccountType := &CompositeType{
-		Identifier:         PublicAccountTypeName,
-		Kind:               common.CompositeKindStructure,
-		hasComputedMembers: true,
-		importable:         false,
+		Identifier:                PublicAccountTypeName,
+		Kind:                      common.CompositeKindStructure,
+		hasComputedMembers:        true,
+		ImportableWithoutLocation: false,
 		nestedTypes: func() *StringTypeOrderedMap {
 			nestedTypes := &StringTypeOrderedMap{}
 			nestedTypes.Set(AccountKeysTypeName, PublicAccountKeysType)
@@ -116,9 +116,9 @@ var PublicAccountType = func() *CompositeType {
 var PublicAccountKeysType = func() *CompositeType {
 
 	accountKeys := &CompositeType{
-		Identifier: AccountKeysTypeName,
-		Kind:       common.CompositeKindStructure,
-		importable: false,
+		Identifier:                AccountKeysTypeName,
+		Kind:                      common.CompositeKindStructure,
+		ImportableWithoutLocation: false,
 	}
 
 	var members = []*Member{

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -52,6 +52,8 @@ type SimpleType struct {
 	ValueIndexingInfo    ValueIndexingInfo
 }
 
+var _ Type = &SimpleType{}
+
 func (*SimpleType) IsType() {}
 
 func (t *SimpleType) Tag() TypeTag {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3572,13 +3572,7 @@ func (t *CompositeType) QualifiedIdentifier() string {
 }
 
 func (t *CompositeType) ID() TypeID {
-	if t == nil {
-		panic("*CompositeType is nil")
-	}
 	t.initializeIdentifiers()
-	if t.cachedIdentifiers == nil {
-		panic("*CompositeType.cachedIdentifiers is nil")
-	}
 	return t.cachedIdentifiers.TypeID
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -659,7 +659,6 @@ type GenericType struct {
 
 var _ Type = &GenericType{}
 
-
 func (*GenericType) IsType() {}
 
 func (t *GenericType) Tag() TypeTag {

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -110,14 +110,6 @@ func (t TypeTag) BelongsTo(typeTag TypeTag) bool {
 	return t.And(typeTag).Equals(t)
 }
 
-func (t TypeTag) UpperMask() uint64 {
-	return t.upperMask
-}
-
-func (t TypeTag) LowerMask() uint64 {
-	return t.lowerMask
-}
-
 /*
  * Following defines the masks used to represent known types in Cadence.
  * Each of the numeric/simple type has a unique dedicated mask. All the derived

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -110,6 +110,14 @@ func (t TypeTag) BelongsTo(typeTag TypeTag) bool {
 	return t.And(typeTag).Equals(t)
 }
 
+func (t TypeTag) UpperMask() uint64 {
+	return t.upperMask
+}
+
+func (t TypeTag) LowerMask() uint64 {
+	return t.lowerMask
+}
+
 /*
  * Following defines the masks used to represent known types in Cadence.
  * Each of the numeric/simple type has a unique dedicated mask. All the derived


### PR DESCRIPTION
Closes #1636 

## Description

This is a custom codec for [de]serializing the sema types and the parts of the Elaboration needed for succinctly describing encoded Cadence values.

The goal for this PR is to have a codec in place to support the rest of the External Cadence Value Encoding epic rather than to have code that is ready for production in itself. The TODOs sprinkled throughout this PR reflect that goal: some of the TODOs point out potential bugs.

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
