### PR TITLE
Refactor intervalst to be generic

### DIFF
--- a/runtime/common/intervalst/intervalst_test.go
+++ b/runtime/common/intervalst/intervalst_test.go
@@ -59,7 +59,7 @@ func TestIntervalST_Search(t *testing.T) {
 
 	t.Parallel()
 
-	st := &IntervalST{}
+	st := &IntervalST[int]{}
 
 	st.Put(
 		NewInterval(
@@ -69,38 +69,44 @@ func TestIntervalST_Search(t *testing.T) {
 		100,
 	)
 
-	interval, value := st.Search(lineAndColumn{1, 3})
+	interval, value, present := st.Search(lineAndColumn{1, 3})
 	assert.Nil(t, interval)
-	assert.Nil(t, value)
+	assert.Zero(t, value)
+	assert.False(t, present)
 
-	interval, value = st.Search(lineAndColumn{2, 1})
+	interval, value, present = st.Search(lineAndColumn{2, 1})
 	assert.Nil(t, interval)
-	assert.Nil(t, value)
+	assert.Zero(t, value)
+	assert.False(t, present)
 
-	interval, value = st.Search(lineAndColumn{2, 2})
+	interval, value, present = st.Search(lineAndColumn{2, 2})
 	assert.Equal(t, interval, &Interval{
 		lineAndColumn{2, 2},
 		lineAndColumn{2, 4},
 	})
 	assert.Equal(t, value, 100)
+	assert.True(t, present)
 
-	interval, value = st.Search(lineAndColumn{2, 3})
+	interval, value, present = st.Search(lineAndColumn{2, 3})
 	assert.Equal(t, interval, &Interval{
 		lineAndColumn{2, 2},
 		lineAndColumn{2, 4},
 	})
 	assert.Equal(t, value, 100)
+	assert.True(t, present)
 
-	interval, value = st.Search(lineAndColumn{2, 4})
+	interval, value, present = st.Search(lineAndColumn{2, 4})
 	assert.Equal(t, interval, &Interval{
 		lineAndColumn{2, 2},
 		lineAndColumn{2, 4},
 	})
 	assert.Equal(t, value, 100)
+	assert.True(t, present)
 
-	interval, value = st.Search(lineAndColumn{2, 5})
+	interval, value, present = st.Search(lineAndColumn{2, 5})
 	assert.Nil(t, interval)
-	assert.Nil(t, value)
+	assert.Zero(t, value)
+	assert.False(t, present)
 
 	st.Put(
 		NewInterval(
@@ -110,28 +116,33 @@ func TestIntervalST_Search(t *testing.T) {
 		200,
 	)
 
-	interval, value = st.Search(lineAndColumn{2, 8})
+	interval, value, present = st.Search(lineAndColumn{2, 8})
 	assert.Nil(t, interval)
-	assert.Nil(t, value)
+	assert.Zero(t, value)
+	assert.False(t, present)
 
-	interval, value = st.Search(lineAndColumn{4, 8})
+	interval, value, present = st.Search(lineAndColumn{4, 8})
 	assert.Nil(t, interval)
-	assert.Nil(t, value)
+	assert.Zero(t, value)
+	assert.False(t, present)
 
-	interval, value = st.Search(lineAndColumn{3, 7})
+	interval, value, present = st.Search(lineAndColumn{3, 7})
 	assert.Nil(t, interval)
-	assert.Nil(t, value)
+	assert.Zero(t, value)
+	assert.False(t, present)
 
-	interval, value = st.Search(lineAndColumn{3, 8})
+	interval, value, present = st.Search(lineAndColumn{3, 8})
 	assert.Equal(t, interval, &Interval{
 		lineAndColumn{3, 8},
 		lineAndColumn{3, 8},
 	})
 	assert.Equal(t, value, 200)
+	assert.True(t, present)
 
-	interval, value = st.Search(lineAndColumn{3, 9})
+	interval, value, present = st.Search(lineAndColumn{3, 9})
 	assert.Nil(t, interval)
-	assert.Nil(t, value)
+	assert.Zero(t, value)
+	assert.False(t, present)
 
 	if !st.check() {
 		t.Fail()
@@ -213,7 +224,7 @@ func TestIntervalST_check(t *testing.T) {
 		},
 	}
 
-	st := &IntervalST{}
+	st := &IntervalST[Interval]{}
 
 	rand.Shuffle(len(intervals), func(i, j int) {
 		intervals[i], intervals[j] = intervals[j], intervals[i]
@@ -228,17 +239,16 @@ func TestIntervalST_check(t *testing.T) {
 	}
 
 	for _, interval := range intervals {
-		res, _ := st.Search(interval.Min)
+		res, _, _ := st.Search(interval.Min)
 		assert.NotNil(t, res)
-		res, _ = st.Search(interval.Max)
+		res, _, _ = st.Search(interval.Max)
 		assert.NotNil(t, res)
 	}
 
-	for _, value := range st.Values() {
-		interval := value.(Interval)
-		res, _ := st.Search(interval.Min)
+	for _, interval := range st.Values() {
+		res, _, _ := st.Search(interval.Min)
 		assert.NotNil(t, res)
-		res, _ = st.Search(interval.Max)
+		res, _, _ = st.Search(interval.Max)
 		assert.NotNil(t, res)
 	}
 }
@@ -247,7 +257,7 @@ func TestIntervalST_SearchAll(t *testing.T) {
 
 	t.Parallel()
 
-	st := &IntervalST{}
+	st := &IntervalST[int]{}
 
 	st.Put(
 		NewInterval(
@@ -291,7 +301,7 @@ func TestIntervalST_SearchAll(t *testing.T) {
 	for i := 4; i <= 5; i++ {
 		entries := st.SearchAll(lineAndColumn{2, i})
 		assert.Equal(t,
-			[]Entry{
+			[]Entry[int]{
 				{
 					Interval: NewInterval(
 						lineAndColumn{2, 4},
@@ -318,7 +328,7 @@ func TestIntervalST_SearchAll(t *testing.T) {
 
 	entries := st.SearchAll(lineAndColumn{3, 7})
 	assert.Equal(t,
-		[]Entry{
+		[]Entry[int]{
 			{
 				Interval: NewInterval(
 					lineAndColumn{3, 7},
@@ -333,7 +343,7 @@ func TestIntervalST_SearchAll(t *testing.T) {
 	for i := 8; i <= 9; i++ {
 		entries = st.SearchAll(lineAndColumn{3, i})
 		assert.ElementsMatch(t,
-			[]Entry{
+			[]Entry[int]{
 				{
 					Interval: NewInterval(
 						lineAndColumn{3, 8},
@@ -355,7 +365,7 @@ func TestIntervalST_SearchAll(t *testing.T) {
 
 	entries = st.SearchAll(lineAndColumn{3, 10})
 	assert.Equal(t,
-		[]Entry{
+		[]Entry[int]{
 			{
 				Interval: NewInterval(
 					lineAndColumn{3, 7},

--- a/runtime/common/intervalst/node.go
+++ b/runtime/common/intervalst/node.go
@@ -18,18 +18,18 @@
 
 package intervalst
 
-type node struct {
+type node[T any] struct {
 	interval    Interval
-	value       any
-	left, right *node
+	value       T
+	left, right *node[T]
 	// size of subtree rooted at this node
 	n int
 	// max endpoint in subtree rooted at this node
 	max Position
 }
 
-func newNode(interval Interval, value any) *node {
-	return &node{
+func newNode[T any](interval Interval, value T) *node[T] {
+	return &node[T]{
 		interval: interval,
 		value:    value,
 		n:        1,
@@ -37,7 +37,7 @@ func newNode(interval Interval, value any) *node {
 	}
 }
 
-func (n *node) size() int {
+func (n *node[T]) size() int {
 	if n == nil {
 		return 0
 	}
@@ -56,7 +56,7 @@ func (MinPosition) Compare(other Position) int {
 
 var minPosition = MinPosition{}
 
-func (n *node) Max() Position {
+func (n *node[T]) Max() Position {
 	if n == nil {
 		return minPosition
 	}
@@ -64,7 +64,7 @@ func (n *node) Max() Position {
 	return n.max
 }
 
-func (n *node) fix() {
+func (n *node[T]) fix() {
 	if n == nil {
 		return
 	}
@@ -83,7 +83,7 @@ func max3(a, b, c Position) Position {
 	return a
 }
 
-func (n *node) rotR() *node {
+func (n *node[T]) rotR() *node[T] {
 	x := n.left
 	n.left = x.right
 	x.right = n
@@ -92,7 +92,7 @@ func (n *node) rotR() *node {
 	return x
 }
 
-func (n *node) rotL() *node {
+func (n *node[T]) rotL() *node[T] {
 	x := n.right
 	n.right = x.left
 	x.left = n
@@ -101,7 +101,7 @@ func (n *node) rotL() *node {
 	return x
 }
 
-func (n *node) Values() []any {
+func (n *node[T]) Values() []T {
 	if n == nil {
 		return nil
 	}
@@ -112,13 +112,13 @@ func (n *node) Values() []any {
 	)
 }
 
-func (n *node) checkCount() bool {
+func (n *node[T]) checkCount() bool {
 	return n == nil ||
 		(n.left.checkCount() && n.right.checkCount() &&
 			(n.n == 1+n.left.size()+n.right.size()))
 }
 
-func (n *node) checkMax() bool {
+func (n *node[T]) checkMax() bool {
 	if n == nil {
 		return true
 	}

--- a/runtime/sema/function_invocations.go
+++ b/runtime/sema/function_invocations.go
@@ -31,12 +31,12 @@ type FunctionInvocation struct {
 }
 
 type FunctionInvocations struct {
-	tree *intervalst.IntervalST
+	tree *intervalst.IntervalST[FunctionInvocation]
 }
 
 func NewFunctionInvocations() *FunctionInvocations {
 	return &FunctionInvocations{
-		tree: &intervalst.IntervalST{},
+		tree: &intervalst.IntervalST[FunctionInvocation]{},
 	}
 }
 
@@ -59,12 +59,8 @@ func (f *FunctionInvocations) Put(
 }
 
 func (f *FunctionInvocations) Find(pos Position) *FunctionInvocation {
-	interval, value := f.tree.Search(pos)
-	if interval == nil {
-		return nil
-	}
-	invocation, ok := value.(FunctionInvocation)
-	if !ok {
+	_, invocation, present := f.tree.Search(pos)
+	if !present {
 		return nil
 	}
 	return &invocation

--- a/runtime/sema/member_accesses.go
+++ b/runtime/sema/member_accesses.go
@@ -30,12 +30,12 @@ type MemberAccess struct {
 }
 
 type MemberAccesses struct {
-	tree *intervalst.IntervalST
+	tree *intervalst.IntervalST[MemberAccess]
 }
 
 func NewMemberAccesses() *MemberAccesses {
 	return &MemberAccesses{
-		tree: &intervalst.IntervalST{},
+		tree: &intervalst.IntervalST[MemberAccess]{},
 	}
 }
 
@@ -53,12 +53,8 @@ func (m *MemberAccesses) Put(startPos, endPos ast.Position, accessedType Type) {
 }
 
 func (m *MemberAccesses) Find(pos Position) *MemberAccess {
-	interval, value := m.tree.Search(pos)
-	if interval == nil {
-		return nil
-	}
-	access, ok := value.(MemberAccess)
-	if !ok {
+	_, access, present := m.tree.Search(pos)
+	if !present {
 		return nil
 	}
 	return &access
@@ -67,11 +63,7 @@ func (m *MemberAccesses) Find(pos Position) *MemberAccess {
 func (m *MemberAccesses) All() []MemberAccess {
 	values := m.tree.Values()
 	accesses := make([]MemberAccess, len(values))
-	for i, value := range values {
-		access, ok := value.(MemberAccess)
-		if !ok {
-			continue
-		}
+	for i, access := range values {
 		accesses[i] = access
 	}
 	return accesses

--- a/runtime/sema/member_accesses.go
+++ b/runtime/sema/member_accesses.go
@@ -61,10 +61,5 @@ func (m *MemberAccesses) Find(pos Position) *MemberAccess {
 }
 
 func (m *MemberAccesses) All() []MemberAccess {
-	values := m.tree.Values()
-	accesses := make([]MemberAccess, len(values))
-	for i, access := range values {
-		accesses[i] = access
-	}
-	return accesses
+	return m.tree.Values()
 }

--- a/runtime/sema/occurrences.go
+++ b/runtime/sema/occurrences.go
@@ -71,12 +71,12 @@ type Origin struct {
 }
 
 type Occurrences struct {
-	tree *intervalst.IntervalST
+	tree *intervalst.IntervalST[Occurrence]
 }
 
 func NewOccurrences() *Occurrences {
 	return &Occurrences{
-		tree: &intervalst.IntervalST{},
+		tree: &intervalst.IntervalST[Occurrence]{},
 	}
 }
 
@@ -118,23 +118,15 @@ type Occurrence struct {
 func (o *Occurrences) All() []Occurrence {
 	values := o.tree.Values()
 	occurrences := make([]Occurrence, len(values))
-	for i, value := range values {
-		occurrence, ok := value.(Occurrence)
-		if !ok {
-			return nil
-		}
+	for i, occurrence := range values {
 		occurrences[i] = occurrence
 	}
 	return occurrences
 }
 
 func (o *Occurrences) Find(pos Position) *Occurrence {
-	interval, value := o.tree.Search(pos)
-	if interval == nil {
-		return nil
-	}
-	occurrence, ok := value.(Occurrence)
-	if !ok {
+	_, occurrence, present := o.tree.Search(pos)
+	if !present {
 		return nil
 	}
 	return &occurrence
@@ -144,11 +136,7 @@ func (o *Occurrences) FindAll(pos Position) []Occurrence {
 	entries := o.tree.SearchAll(pos)
 	occurrences := make([]Occurrence, len(entries))
 	for i, entry := range entries {
-		occurrence, ok := entry.Value.(Occurrence)
-		if !ok {
-			return nil
-		}
-		occurrences[i] = occurrence
+		occurrences[i] = entry.Value
 	}
 	return occurrences
 }

--- a/runtime/sema/occurrences.go
+++ b/runtime/sema/occurrences.go
@@ -116,12 +116,7 @@ type Occurrence struct {
 }
 
 func (o *Occurrences) All() []Occurrence {
-	values := o.tree.Values()
-	occurrences := make([]Occurrence, len(values))
-	for i, occurrence := range values {
-		occurrences[i] = occurrence
-	}
-	return occurrences
+	return o.tree.Values()
 }
 
 func (o *Occurrences) Find(pos Position) *Occurrence {

--- a/runtime/sema/ranges.go
+++ b/runtime/sema/ranges.go
@@ -50,12 +50,7 @@ func (r *Ranges) Put(startPos, endPos ast.Position, ra Range) {
 }
 
 func (r *Ranges) All() []Range {
-	values := r.tree.Values()
-	ranges := make([]Range, len(values))
-	for i, r := range values {
-		ranges[i] = r
-	}
-	return ranges
+	return r.tree.Values()
 }
 
 func (r *Ranges) FindAll(pos Position) []Range {

--- a/runtime/sema/ranges.go
+++ b/runtime/sema/ranges.go
@@ -32,12 +32,12 @@ type Range struct {
 }
 
 type Ranges struct {
-	tree *intervalst.IntervalST
+	tree *intervalst.IntervalST[Range]
 }
 
 func NewRanges() *Ranges {
 	return &Ranges{
-		tree: &intervalst.IntervalST{},
+		tree: &intervalst.IntervalST[Range]{},
 	}
 }
 
@@ -52,11 +52,7 @@ func (r *Ranges) Put(startPos, endPos ast.Position, ra Range) {
 func (r *Ranges) All() []Range {
 	values := r.tree.Values()
 	ranges := make([]Range, len(values))
-	for i, value := range values {
-		r, ok := value.(Range)
-		if !ok {
-			return nil
-		}
+	for i, r := range values {
 		ranges[i] = r
 	}
 	return ranges
@@ -66,11 +62,7 @@ func (r *Ranges) FindAll(pos Position) []Range {
 	entries := r.tree.SearchAll(pos)
 	ranges := make([]Range, len(entries))
 	for i, entry := range entries {
-		r, ok := entry.Value.(Range)
-		if !ok {
-			return nil
-		}
-		ranges[i] = r
+		ranges[i] = entry.Value
 	}
 	return ranges
 }


### PR DESCRIPTION
Uses 1.18 generics to get rid of unnecessary downcasting in this container
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
