### PR TITLE
Fix typos and broken links on docs 

### DIFF
--- a/docs/anti-patterns.mdx
+++ b/docs/anti-patterns.mdx
@@ -129,7 +129,7 @@ let balanceRef = getAccount(account)
 let fullVaultRef = balanceRef as! &FlowToken.Vault
 
 // Withdraw the newly exposed funds
-let solenFunds <- fullVaultRef.withdraw(amount: 1000000)
+let stolenFunds <- fullVaultRef.withdraw(amount: 1000000)
 ```
 
 ## Events from resources may not be unique

--- a/docs/design-patterns.mdx
+++ b/docs/design-patterns.mdx
@@ -172,7 +172,7 @@ and deliver them to an address or `AuthAccount` specified as an argument.
 
 See how this is done in the LockedTokens contract init function:
 
-[LockedTokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/LockedTokens.cdc#L583)
+[LockedTokens.cdc](https://github.com/onflow/flow-core-contracts/blob/master/contracts/LockedTokens.cdc#L718)
 
 and in the transaction that is used to deploy it:
 

--- a/docs/language/transactions.md
+++ b/docs/language/transactions.md
@@ -201,7 +201,7 @@ transaction {
         //
         // Avoid logic that does not need access to signing accounts.
         //
-        // Signing accounts can't be accesed anywhere else in the transaction.
+        // Signing accounts can't be accessed anywhere else in the transaction.
     }
 
     pre {

--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -23,10 +23,10 @@ In this tutorial, we'll write and deploy our first smart contract!
 <Callout type="success">
   Open the starter code for this tutorial in the Flow Playground: <br />
   <a
-    href="https://play.onflow.org/8ae1a322-6e9d-4998-ae66-8e741fa81a5a"
+    href="https://play.onflow.org/dbc06b40-d0b1-42da-9e0d-686bc9972e65"
     target="_blank"
   >
-    https://play.onflow.org/8ae1a322-6e9d-4998-ae66-8e741fa81a5a
+    https://play.onflow.org/dbc06b40-d0b1-42da-9e0d-686bc9972e65
   </a>
   <br />
   The tutorial will ask you to take various actions to interact with this code.
@@ -106,10 +106,10 @@ Now let's look at the `HelloWorld` contract that you'll be working through in th
 If you haven't already, you'll need to follow this link to open a playground session with the Hello World contracts, transactions, and scripts pre-loaded:
 
   <a
-    href="https://play.onflow.org/8ae1a322-6e9d-4998-ae66-8e741fa81a5a"
+    href="https://play.onflow.org/dbc06b40-d0b1-42da-9e0d-686bc9972e65"
     target="_blank"
   >
-    https://play.onflow.org/8ae1a322-6e9d-4998-ae66-8e741fa81a5a?
+    https://play.onflow.org/dbc06b40-d0b1-42da-9e0d-686bc9972e65
   </a>
 
 </Callout>

--- a/docs/tutorial/04-capabilities.mdx
+++ b/docs/tutorial/04-capabilities.mdx
@@ -22,10 +22,10 @@ socialImageDescription: Capability smart contract image.
 <Callout type="success">
   Open the starter code for this tutorial in the Flow Playground. It is the same code that was in the previous tutorial: <br />
   <a
-    href="https://play.onflow.org/a26ec672-14c8-42cd-85ad-1409a8a23a84"
+    href="https://play.onflow.org/3a541312-a231-4f11-be79-23bcd2d94a6c"
     target="_blank"
   >
-    https://play.onflow.org/a26ec672-14c8-42cd-85ad-1409a8a23a84
+    https://play.onflow.org/3a541312-a231-4f11-be79-23bcd2d94a6c
   </a>
   <br />
   The tutorial will ask you to take various actions to interact with this code.

--- a/docs/tutorial/05-non-fungible-tokens-2.mdx
+++ b/docs/tutorial/05-non-fungible-tokens-2.mdx
@@ -678,4 +678,4 @@ Also check out the [Kitty Items Repo](https://github.com/onflow/kitty-items) for
 ---
 
 Now that you have a working NFT, you will probably want to be able to trade it. For that you are going to need to
-understand how fungible tokens works on Flow, so go ahead and move to the next tutorial!
+understand how fungible tokens work on Flow, so go ahead and move to the next tutorial!

--- a/docs/tutorial/05-non-fungible-tokens-2.mdx
+++ b/docs/tutorial/05-non-fungible-tokens-2.mdx
@@ -673,10 +673,9 @@ for information about the official Flow NFT standard and an example implementati
 
 Also check out the [Kitty Items Repo](https://github.com/onflow/kitty-items) for a production ready version!
 
-## Create a Flow Marketplace
+## Fungible Tokens
 
 ---
 
-Now that you have a working NFT, you can attempt to extend its functionality on your own,
-or you can learn how to create a marketplace that uses both fungible tokens and NFTs.
-Move on to the next tutorial to learn about Marketplaces in Cadence!
+Now that you have a working NFT, you will probably want to be able to trade it. For that you are going to need to
+understand how fungible tokens works on Flow, so go ahead and move to the next tutorial!

--- a/docs/tutorial/06-fungible-tokens.mdx
+++ b/docs/tutorial/06-fungible-tokens.mdx
@@ -10,10 +10,10 @@ In this tutorial, we're going to deploy, store, and transfer fungible tokens.
   Open the starter code for this tutorial in the Flow Playground:
   <br />
   <a
-    href="https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1"
+    href="https://play.onflow.org/adc24257-ccc6-4de8-aba4-e1bc33f5f029"
     target="_blank"
   >
-    https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1
+    https://play.onflow.org/adc24257-ccc6-4de8-aba4-e1bc33f5f029
   </a>
   <br />
   The tutorial will ask you to take various actions to interact with this code.
@@ -93,10 +93,10 @@ and [Hello, World!](02-hello-world) to learn the basics of the language and the 
   First, you'll need to follow this link to open a playground session with the
   Fungible Token contracts, transactions, and scripts pre-loaded:{" "}
   <a
-    href="https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1"
+    href="https://play.onflow.org/adc24257-ccc6-4de8-aba4-e1bc33f5f029"
     target="_blank"
   >
-    https://play.onflow.org/50745fb6-77d5-4510-adfc-cf448fb043e1
+    https://play.onflow.org/adc24257-ccc6-4de8-aba4-e1bc33f5f029
   </a>
 </Callout>
 <Callout type="info">
@@ -415,7 +415,7 @@ Click the `Deploy` button at the top right of the editor to deploy the code.
 
 </Callout>
 
-<img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-deploy" />
+<img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/playground-deploy.png" />
 
 This deployment stores the contract for the basic fungible token
 in your active account (account `0x01`) so that it can be imported into transactions.
@@ -602,7 +602,7 @@ fields private unless it is explicitly needed to be public.
 <Callout type="warning">
   This is especially important for array and dictionary types,
   which can have their contents maliciously mutated if they are made public.
-  This is one of THE MOST COMMON security mistake that Cadence developers make,
+  This is one of THE MOST COMMON security mistakes that Cadence developers make,
   so it is vitally important to be aware of this.
 
   See the [Cadence Best Practices document](/cadence/anti-patterns#array-or-dictionary-fields-should-be-private) for more details.
@@ -1111,8 +1111,8 @@ From here, you could try to extend the functionality of fungible tokens by makin
 - An escrow that can be deposited to (but only withdrawn when the balance reaches a certain point)
 - A function to the resource that mints new tokens!
 
-## Non-Fungible Tokens on Flow
+## Create a Flow Marketplace
 
 ---
-
-Now that you have an understanding of how fungible tokens work on Flow, you're ready to play with non-fungible tokens!
+Now that you have an understanding of how fungible tokens work on Flow and a working NFT, you can learn how to create 
+a marketplace that uses both fungible tokens and NFTs. Move on to the next tutorial to learn about Marketplaces in Cadence!

--- a/docs/tutorial/06-fungible-tokens.mdx
+++ b/docs/tutorial/06-fungible-tokens.mdx
@@ -1114,5 +1114,5 @@ From here, you could try to extend the functionality of fungible tokens by makin
 ## Create a Flow Marketplace
 
 ---
-Now that you have an understanding of how fungible tokens work on Flow and a working NFT, you can learn how to create 
+Now that you have an understanding of how fungible tokens work on Flow and have a working NFT, you can learn how to create 
 a marketplace that uses both fungible tokens and NFTs. Move on to the next tutorial to learn about Marketplaces in Cadence!

--- a/docs/tutorial/08-marketplace-compose.mdx
+++ b/docs/tutorial/08-marketplace-compose.mdx
@@ -410,7 +410,7 @@ External applications can monitor the blockchain to take action when certain eve
 
 ### Resource-Owned Capabilities
 
-[We have covered capabilities in previous tutorials(06-fungible-tokens#ensuring-security-in-public-capability-security)],
+We have covered capabilities in previous [tutorials](/cadence/tutorial/04-capabilities),
 but only the basics. Capabilities can be used for so much more!
 
 As you hopefully understand, [capabilites](/cadence/language/capability-based-access-control)

--- a/docs/tutorial/09-voting.mdx
+++ b/docs/tutorial/09-voting.mdx
@@ -137,7 +137,7 @@ pub contract ApprovalVoting {
             }
         }
 
-        // The admin calls this function to create a new Ballo
+        // The admin calls this function to create a new Ballot
         // that can be transferred to another user
         pub fun issueBallot(): @Ballot {
             return <-create Ballot()


### PR DESCRIPTION
Closes #1821

## Description

Fix some typos, outdated and broken images and broken links we knew about thanks to some feedback

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
