### PR TITLE
Revert reference improvements

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1878,6 +1878,7 @@ func (*DestroyExpression) precedence() precedence {
 
 type ReferenceExpression struct {
 	Expression Expression
+	Type       Type     `json:"TargetType"`
 	StartPos   Position `json:"-"`
 }
 
@@ -1887,12 +1888,14 @@ var _ Expression = &ReferenceExpression{}
 func NewReferenceExpression(
 	gauge common.MemoryGauge,
 	expression Expression,
+	targetType Type,
 	startPos Position,
 ) *ReferenceExpression {
 	common.UseMemory(gauge, common.ReferenceExpressionMemoryUsage)
 
 	return &ReferenceExpression{
 		Expression: expression,
+		Type:       targetType,
 		StartPos:   startPos,
 	}
 }
@@ -1911,6 +1914,7 @@ func (e *ReferenceExpression) Accept(visitor Visitor) Repr {
 
 func (e *ReferenceExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Expression)
+	// TODO: walk type
 }
 
 func (e *ReferenceExpression) AcceptExp(visitor ExpressionVisitor) Repr {
@@ -1922,6 +1926,7 @@ func (e *ReferenceExpression) String() string {
 }
 
 var referenceExpressionRefOperatorDoc prettier.Doc = prettier.Text("&")
+var referenceExpressionAsOperatorDoc prettier.Doc = prettier.Text("as")
 
 func (e *ReferenceExpression) Doc() prettier.Doc {
 	doc := parenthesizedExpressionDoc(
@@ -1935,6 +1940,10 @@ func (e *ReferenceExpression) Doc() prettier.Doc {
 			prettier.Group{
 				Doc: doc,
 			},
+			prettier.Line{},
+			referenceExpressionAsOperatorDoc,
+			prettier.Line{},
+			e.Type.Doc(),
 		},
 	}
 }
@@ -1944,7 +1953,7 @@ func (e *ReferenceExpression) StartPosition() Position {
 }
 
 func (e *ReferenceExpression) EndPosition(memoryGauge common.MemoryGauge) Position {
-	return e.Expression.EndPosition(memoryGauge)
+	return e.Type.EndPosition(memoryGauge)
 }
 
 func (e *ReferenceExpression) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4091,6 +4091,12 @@ func TestReferenceExpression_MarshalJSON(t *testing.T) {
 				Pos:        Position{Offset: 1, Line: 2, Column: 3},
 			},
 		},
+		Type: &NominalType{
+			Identifier: Identifier{
+				Identifier: "AB",
+				Pos:        Position{Offset: 4, Line: 5, Column: 6},
+			},
+		},
 		StartPos: Position{Offset: 7, Line: 8, Column: 9},
 	}
 
@@ -4111,8 +4117,18 @@ func TestReferenceExpression_MarshalJSON(t *testing.T) {
                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
             },
+            "TargetType": {
+               "Type": "NominalType",
+               "Identifier": {
+                   "Identifier": "AB",
+                   "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+                   "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
+               },
+               "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
+               "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
+            },
             "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
-            "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
+            "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
         }
         `,
 		string(actual),
@@ -4133,6 +4149,14 @@ func TestReferenceExpression_Doc(t *testing.T) {
 				Value:           big.NewInt(42),
 				Base:            10,
 			},
+			Type: &ReferenceType{
+				Authorized: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "Int",
+					},
+				},
+			},
 		}
 
 		assert.Equal(t,
@@ -4141,6 +4165,14 @@ func TestReferenceExpression_Doc(t *testing.T) {
 					prettier.Text("&"),
 					prettier.Group{
 						Doc: prettier.Text("42"),
+					},
+					prettier.Line{},
+					prettier.Text("as"),
+					prettier.Line{},
+					prettier.Concat{
+						prettier.Text("auth "),
+						prettier.Text("&"),
+						prettier.Text("Int"),
 					},
 				},
 			},
@@ -4159,6 +4191,22 @@ func TestReferenceExpression_Doc(t *testing.T) {
 					Value:           big.NewInt(42),
 					Base:            10,
 				},
+				Type: &ReferenceType{
+					Authorized: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "AnyStruct",
+						},
+					},
+				},
+			},
+			Type: &ReferenceType{
+				Authorized: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "XYZ",
+					},
+				},
 			},
 		}
 
@@ -4173,8 +4221,24 @@ func TestReferenceExpression_Doc(t *testing.T) {
 								prettier.Group{
 									Doc: prettier.Text("42"),
 								},
+								prettier.Line{},
+								prettier.Text("as"),
+								prettier.Line{},
+								prettier.Concat{
+									prettier.Text("auth "),
+									prettier.Text("&"),
+									prettier.Text("AnyStruct"),
+								},
 							},
 						},
+					},
+					prettier.Line{},
+					prettier.Text("as"),
+					prettier.Line{},
+					prettier.Concat{
+						prettier.Text("auth "),
+						prettier.Text("&"),
+						prettier.Text("XYZ"),
 					},
 				},
 			},
@@ -4197,6 +4261,14 @@ func TestReferenceExpression_Doc(t *testing.T) {
 				Right: &IdentifierExpression{
 					Identifier: Identifier{
 						Identifier: "bar",
+					},
+				},
+			},
+			Type: &ReferenceType{
+				Authorized: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "Int",
 					},
 				},
 			},
@@ -4232,6 +4304,14 @@ func TestReferenceExpression_Doc(t *testing.T) {
 							},
 						},
 					},
+					prettier.Line{},
+					prettier.Text("as"),
+					prettier.Line{},
+					prettier.Concat{
+						prettier.Text("auth "),
+						prettier.Text("&"),
+						prettier.Text("Int"),
+					},
 				},
 			},
 			expr.Doc(),
@@ -4253,10 +4333,18 @@ func TestReferenceExpression_String(t *testing.T) {
 				Value:           big.NewInt(42),
 				Base:            10,
 			},
+			Type: &ReferenceType{
+				Authorized: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "Int",
+					},
+				},
+			},
 		}
 
 		assert.Equal(t,
-			"&42",
+			"&42 as auth &Int",
 			expr.String(),
 		)
 	})
@@ -4272,11 +4360,27 @@ func TestReferenceExpression_String(t *testing.T) {
 					Value:           big.NewInt(42),
 					Base:            10,
 				},
+				Type: &ReferenceType{
+					Authorized: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "AnyStruct",
+						},
+					},
+				},
+			},
+			Type: &ReferenceType{
+				Authorized: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "XYZ",
+					},
+				},
 			},
 		}
 
 		assert.Equal(t,
-			"&&42",
+			"&&42 as auth &AnyStruct as auth &XYZ",
 			expr.String(),
 		)
 	})
@@ -4299,10 +4403,18 @@ func TestReferenceExpression_String(t *testing.T) {
 					},
 				},
 			},
+			Type: &ReferenceType{
+				Authorized: true,
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "Int",
+					},
+				},
+			},
 		}
 
 		assert.Equal(t,
-			"&(foo - bar)",
+			"&(foo - bar) as auth &Int",
 			expr.String(),
 		)
 	})

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -19,6 +19,7 @@
 package parser
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 	"unicode/utf8"
@@ -1287,17 +1288,30 @@ func definePathExpression() {
 }
 
 func defineReferenceExpression() {
-	defineExpr(prefixExpr{
-		tokenType:    lexer.TokenAmpersand,
-		bindingPower: exprLeftBindingPowerUnaryPrefix,
-		nullDenotation: func(p *parser, right ast.Expression, tokenRange ast.Range) (ast.Expression, error) {
+	setExprNullDenotation(
+		lexer.TokenAmpersand,
+		func(p *parser, token lexer.Token) (ast.Expression, error) {
+			p.skipSpaceAndComments(true)
+			expression, err := parseExpression(p, exprLeftBindingPowerCasting-exprBindingPowerGap)
+			if err != nil {
+				return nil, err
+			}
+
+			p.skipSpaceAndComments(true)
+
+			castingExpression, ok := expression.(*ast.CastingExpression)
+			if !ok {
+				panic(fmt.Errorf("expected casting expression"))
+			}
+
 			return ast.NewReferenceExpression(
 				p.memoryGauge,
-				right,
-				tokenRange.StartPos,
+				castingExpression.Expression,
+				castingExpression.TypeAnnotation.Type,
+				token.StartPos,
 			), nil
 		},
-	})
+	)
 }
 
 func defineMemberExpression() {

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -1946,7 +1946,7 @@ func TestParseReference(t *testing.T) {
 
 	t.Parallel()
 
-	result, errs := ParseExpression("& t", nil)
+	result, errs := ParseExpression("& t as T", nil)
 	require.Empty(t, errs)
 
 	utils.AssertEqualWithDiff(t,
@@ -1955,6 +1955,12 @@ func TestParseReference(t *testing.T) {
 				Identifier: ast.Identifier{
 					Identifier: "t",
 					Pos:        ast.Position{Line: 1, Column: 2, Offset: 2},
+				},
+			},
+			Type: &ast.NominalType{
+				Identifier: ast.Identifier{
+					Identifier: "T",
+					Pos:        ast.Position{Line: 1, Column: 7, Offset: 7},
 				},
 			},
 			StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
@@ -1975,85 +1981,75 @@ func TestParseNilCoelesceReference(t *testing.T) {
 	utils.AssertEqualWithDiff(t,
 		&ast.BinaryExpression{
 			Operation: ast.OperationNilCoalesce,
-			Left: &ast.CastingExpression{
-				Expression: &ast.ReferenceExpression{
-					Expression: &ast.IndexExpression{
-						TargetExpression: &ast.IdentifierExpression{
-							Identifier: ast.Identifier{
-								Identifier: "xs",
-								Pos: ast.Position{
-									Offset: 12,
-									Line:   2,
-									Column: 11,
-								},
+			Left: &ast.ReferenceExpression{
+				Expression: &ast.IndexExpression{
+					TargetExpression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "xs",
+							Pos: ast.Position{
+								Offset: 12,
+								Line:   2,
+								Column: 11,
 							},
 						},
-						IndexingExpression: &ast.StringExpression{
-							Value: "a",
-							Range: ast.Range{
-								StartPos: ast.Position{
-									Offset: 15,
-									Line:   2,
-									Column: 14,
-								},
-								EndPos: ast.Position{
-									Offset: 17,
-									Line:   2,
-									Column: 16,
-								},
-							},
-						},
+					},
+					IndexingExpression: &ast.StringExpression{
+						Value: "a",
 						Range: ast.Range{
 							StartPos: ast.Position{
-								Offset: 14,
+								Offset: 15,
 								Line:   2,
-								Column: 13,
+								Column: 14,
 							},
 							EndPos: ast.Position{
-								Offset: 18,
+								Offset: 17,
 								Line:   2,
-								Column: 17,
+								Column: 16,
 							},
 						},
 					},
-					StartPos: ast.Position{
-						Offset: 11,
-						Line:   2,
-						Column: 10,
-					},
-				},
-				Operation: ast.OperationCast,
-				TypeAnnotation: &ast.TypeAnnotation{
-					Type: &ast.OptionalType{
-						Type: &ast.ReferenceType{
-							Authorized: false,
-							Type: &ast.NominalType{
-								Identifier: ast.Identifier{
-									Identifier: "Int",
-									Pos: ast.Position{
-										Offset: 24,
-										Line:   2,
-										Column: 23,
-									},
-								},
-							},
-							StartPos: ast.Position{
-								Offset: 23,
-								Line:   2,
-								Column: 22,
-							},
+					Range: ast.Range{
+						StartPos: ast.Position{
+							Offset: 14,
+							Line:   2,
+							Column: 13,
 						},
 						EndPos: ast.Position{
-							Offset: 27,
+							Offset: 18,
 							Line:   2,
-							Column: 26,
+							Column: 17,
 						},
 					},
-					StartPos: ast.Position{
-						Offset: 23,
-						Line:   2,
-						Column: 22,
+				},
+				Type: &ast.OptionalType{
+					Type: &ast.ReferenceType{
+						Authorized: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "Int",
+								Pos: ast.Position{
+									Offset: 24,
+									Line:   2,
+									Column: 23,
+								},
+							},
+						},
+						StartPos: ast.Position{
+							Offset: 23,
+							Line:   2,
+							Column: 22,
+						},
 					},
+					EndPos: ast.Position{
+						Offset: 27,
+						Line:   2,
+						Column: 26,
+					},
+				},
+				StartPos: ast.Position{
+					Offset: 11,
+					Line:   2,
+					Column: 10,
 				},
 			},
 			Right: &ast.IntegerExpression{
@@ -5628,67 +5624,57 @@ func TestParseReferenceInVariableDeclaration(t *testing.T) {
 	result, errs := ParseProgram(code, nil)
 	require.Empty(t, errs)
 
-	expected := &ast.VariableDeclaration{
-		IsConstant: true,
-		Identifier: ast.Identifier{
-			Identifier: "x",
-			Pos:        ast.Position{Offset: 12, Line: 2, Column: 11},
-		},
-		Value: &ast.CastingExpression{
-			Operation: ast.OperationCast,
-			Expression: &ast.ReferenceExpression{
-				Expression: &ast.IndexExpression{
-					TargetExpression: &ast.MemberExpression{
-						Expression: &ast.IdentifierExpression{
-							Identifier: ast.Identifier{
-								Identifier: "account",
-								Pos:        ast.Position{Offset: 17, Line: 2, Column: 16},
-							},
-						},
-						AccessPos: ast.Position{Offset: 24, Line: 2, Column: 23},
-						Identifier: ast.Identifier{
-							Identifier: "storage",
-							Pos:        ast.Position{Offset: 25, Line: 2, Column: 24},
-						},
-					},
-					IndexingExpression: &ast.IdentifierExpression{
-						Identifier: ast.Identifier{
-							Identifier: "R",
-							Pos:        ast.Position{Offset: 33, Line: 2, Column: 32},
-						},
-					},
-					Range: ast.Range{
-						StartPos: ast.Position{Offset: 32, Line: 2, Column: 31},
-						EndPos:   ast.Position{Offset: 34, Line: 2, Column: 33},
-					},
-				},
-				StartPos: ast.Position{Offset: 16, Line: 2, Column: 15},
-			},
-			TypeAnnotation: &ast.TypeAnnotation{
-				Type: &ast.ReferenceType{
-					Type: &ast.NominalType{
-						Identifier: ast.Identifier{
-							Identifier: "R",
-							Pos:        ast.Position{Offset: 40, Line: 2, Column: 39},
-						},
-					},
-					StartPos: ast.Position{Offset: 39, Line: 2, Column: 38},
-				},
-				StartPos: ast.Position{Offset: 39, Line: 2, Column: 38},
-			},
-		},
-		Transfer: &ast.Transfer{
-			Operation: ast.TransferOperationCopy,
-			Pos:       ast.Position{Offset: 14, Line: 2, Column: 13},
-		},
-		StartPos: ast.Position{Offset: 8, Line: 2, Column: 7},
-	}
-
-	expected.Value.(*ast.CastingExpression).ParentVariableDeclaration = expected
-
 	utils.AssertEqualWithDiff(t,
 		[]ast.Declaration{
-			expected,
+			&ast.VariableDeclaration{
+				IsConstant: true,
+				Identifier: ast.Identifier{
+					Identifier: "x",
+					Pos:        ast.Position{Offset: 12, Line: 2, Column: 11},
+				},
+				Value: &ast.ReferenceExpression{
+					Expression: &ast.IndexExpression{
+						TargetExpression: &ast.MemberExpression{
+							Expression: &ast.IdentifierExpression{
+								Identifier: ast.Identifier{
+									Identifier: "account",
+									Pos:        ast.Position{Offset: 17, Line: 2, Column: 16},
+								},
+							},
+							AccessPos: ast.Position{Offset: 24, Line: 2, Column: 23},
+							Identifier: ast.Identifier{
+								Identifier: "storage",
+								Pos:        ast.Position{Offset: 25, Line: 2, Column: 24},
+							},
+						},
+						IndexingExpression: &ast.IdentifierExpression{
+							Identifier: ast.Identifier{
+								Identifier: "R",
+								Pos:        ast.Position{Offset: 33, Line: 2, Column: 32},
+							},
+						},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 32, Line: 2, Column: 31},
+							EndPos:   ast.Position{Offset: 34, Line: 2, Column: 33},
+						},
+					},
+					Type: &ast.ReferenceType{
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "R",
+								Pos:        ast.Position{Offset: 40, Line: 2, Column: 39},
+							},
+						},
+						StartPos: ast.Position{Offset: 39, Line: 2, Column: 38},
+					},
+					StartPos: ast.Position{Offset: 16, Line: 2, Column: 15},
+				},
+				Transfer: &ast.Transfer{
+					Operation: ast.TransferOperationCopy,
+					Pos:       ast.Position{Offset: 14, Line: 2, Column: 13},
+				},
+				StartPos: ast.Position{Offset: 8, Line: 2, Column: 7},
+			},
 		},
 		result.Declarations(),
 	)

--- a/runtime/parser/statement_test.go
+++ b/runtime/parser/statement_test.go
@@ -52,7 +52,6 @@ func TestParseReplInput(t *testing.T) {
 	assert.IsType(t, &ast.VariableDeclaration{}, actual[1])
 	assert.IsType(t, &ast.ExpressionStatement{}, actual[2])
 }
-
 func TestParseReturnStatement(t *testing.T) {
 
 	t.Parallel()
@@ -2416,81 +2415,5 @@ func TestParseSwapStatementInFunctionDeclaration(t *testing.T) {
 			},
 		},
 		result.Declarations(),
-	)
-}
-
-func TestParseReferenceExpressionStatement(t *testing.T) {
-
-	t.Parallel()
-
-	result, errs := ParseStatements(
-		`
-           let x = &1 as &Int
-           (x!)
-	     `,
-		nil,
-	)
-	require.Empty(t, errs)
-
-	castingExpression := &ast.CastingExpression{
-		Expression: &ast.ReferenceExpression{
-			Expression: &ast.IntegerExpression{
-				PositiveLiteral: "1",
-				Value:           big.NewInt(1),
-				Base:            10,
-				Range: ast.Range{
-					StartPos: ast.Position{Offset: 21, Line: 2, Column: 20},
-					EndPos:   ast.Position{Offset: 21, Line: 2, Column: 20},
-				},
-			},
-			StartPos: ast.Position{Offset: 20, Line: 2, Column: 19},
-		},
-		Operation: ast.OperationCast,
-		TypeAnnotation: &ast.TypeAnnotation{
-			Type: &ast.ReferenceType{
-				Type: &ast.NominalType{
-					Identifier: ast.Identifier{
-						Identifier: "Int",
-						Pos:        ast.Position{Offset: 27, Line: 2, Column: 26},
-					},
-				},
-				StartPos: ast.Position{Offset: 26, Line: 2, Column: 25},
-			},
-			StartPos: ast.Position{Offset: 26, Line: 2, Column: 25},
-		},
-	}
-
-	expectedVariableDeclaration := &ast.VariableDeclaration{
-		IsConstant: true,
-		Identifier: ast.Identifier{
-			Identifier: "x",
-			Pos:        ast.Position{Offset: 16, Line: 2, Column: 15},
-		},
-		StartPos: ast.Position{Offset: 12, Line: 2, Column: 11},
-		Value:    castingExpression,
-		Transfer: &ast.Transfer{
-			Operation: ast.TransferOperationCopy,
-			Pos:       ast.Position{Offset: 18, Line: 2, Column: 17},
-		},
-	}
-
-	castingExpression.ParentVariableDeclaration = expectedVariableDeclaration
-
-	utils.AssertEqualWithDiff(t,
-		[]ast.Statement{
-			expectedVariableDeclaration,
-			&ast.ExpressionStatement{
-				Expression: &ast.ForceExpression{
-					Expression: &ast.IdentifierExpression{
-						Identifier: ast.Identifier{
-							Identifier: "x",
-							Pos:        ast.Position{Offset: 43, Line: 3, Column: 12},
-						},
-					},
-					EndPos: ast.Position{Offset: 44, Line: 3, Column: 13},
-				},
-			},
-		},
-		result,
 	)
 }

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -83,7 +83,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) as
 		if elementType == InvalidType {
 			checker.report(
 				&TypeAnnotationRequiredError{
-					Cause: "cannot infer type from array literal:",
+					Cause: "cannot infer type from array literal: ",
 					Pos:   expression.StartPos,
 				},
 			)

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -73,7 +73,7 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 			valueType == InvalidType {
 			checker.report(
 				&TypeAnnotationRequiredError{
-					Cause: "cannot infer type from dictionary literal:",
+					Cause: "cannot infer type from dictionary literal: ",
 					Pos:   expression.StartPos,
 				},
 			)

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -22,24 +22,15 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 )
 
-// VisitReferenceExpression checks a reference expression
+// VisitReferenceExpression checks a reference expression `&t as T`,
+// where `t` is the referenced expression, and `T` is the result type.
 //
 func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.ReferenceExpression) ast.Repr {
 
-	resultType := checker.expectedType
-
-	if resultType == nil {
-		checker.report(
-			&TypeAnnotationRequiredError{
-				Cause: "cannot infer type from reference expression:",
-				Pos:   referenceExpression.Expression.StartPosition(),
-			},
-		)
-
-		return InvalidType
-	}
-
 	// Check the result type and ensure it is a reference type
+
+	resultType := checker.ConvertType(referenceExpression.Type)
+	checker.checkInvalidInterfaceAsType(resultType, referenceExpression.Type)
 
 	var referenceType *ReferenceType
 	var targetType, returnType Type
@@ -64,7 +55,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 			checker.report(
 				&NonReferenceTypeReferenceError{
 					ActualType: resultType,
-					Range:      ast.NewRangeFromPositioned(checker.memoryGauge, referenceExpression),
+					Range:      ast.NewRangeFromPositioned(checker.memoryGauge, referenceExpression.Type),
 				},
 			)
 		} else {

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -6384,7 +6384,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 			}
 		})
 
-		t.Run("Reference, with cast", func(t *testing.T) {
+		t.Run("Reference, without type", func(t *testing.T) {
 			t.Parallel()
 
 			checker, err := ParseAndCheckWithAny(t, `
@@ -6394,7 +6394,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
+			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
 		})
 
 		t.Run("Reference, with type", func(t *testing.T) {
@@ -6407,7 +6407,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
+			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
 		})
 
 		t.Run("Conditional expr valid", func(t *testing.T) {

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -29,117 +29,6 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-func TestCheckReference(t *testing.T) {
-
-	t.Parallel()
-
-	t.Run("variable declaration type annotation", func(t *testing.T) {
-
-		t.Parallel()
-
-		t.Run("non-auth", func(t *testing.T) {
-
-			t.Parallel()
-
-			_, err := ParseAndCheck(t, `
-              let x: &Int = &1
-            `)
-
-			require.NoError(t, err)
-
-		})
-
-		t.Run("auth", func(t *testing.T) {
-
-			t.Parallel()
-
-			_, err := ParseAndCheck(t, `
-              let x: auth &Int = &1
-            `)
-
-			require.NoError(t, err)
-		})
-
-		t.Run("non-reference type", func(t *testing.T) {
-
-			t.Parallel()
-
-			_, err := ParseAndCheck(t, `
-              let x: Int = &1
-            `)
-
-			errs := ExpectCheckerErrors(t, err, 1)
-
-			assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[0])
-		})
-	})
-
-	t.Run("variable declaration type annotation", func(t *testing.T) {
-
-		t.Run("non-auth", func(t *testing.T) {
-
-			t.Parallel()
-
-			_, err := ParseAndCheck(t, `
-              let x = &1 as &Int
-            `)
-
-			require.NoError(t, err)
-		})
-
-		t.Run("non-auth", func(t *testing.T) {
-
-			t.Parallel()
-
-			_, err := ParseAndCheck(t, `
-              let x = &1 as auth &Int
-            `)
-
-			require.NoError(t, err)
-		})
-
-		t.Run("non-reference type", func(t *testing.T) {
-
-			t.Parallel()
-
-			_, err := ParseAndCheck(t, `
-              let x = &1 as Int
-            `)
-
-			errs := ExpectCheckerErrors(t, err, 1)
-
-			assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[0])
-		})
-	})
-
-	t.Run("invalid non-auth to auth cast", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, err := ParseAndCheck(t, `
-          let x = &1 as &Int as auth &Int
-        `)
-
-		errs := ExpectCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
-	})
-
-	t.Run("missing type", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, err := ParseAndCheck(t, `
-          let x = &1
-        `)
-
-		errs := ExpectCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.TypeAnnotationRequiredError{}, errs[0])
-	})
-
-}
-
 func TestCheckReferenceTypeOuter(t *testing.T) {
 
 	t.Parallel()
@@ -1224,12 +1113,10 @@ func TestCheckInvalidReferenceExpressionNonReferenceAnyResource(t *testing.T) {
       let y = &x as AnyResource{}
     `)
 
-	errs := ExpectCheckerErrors(t, err, 4)
+	errs := ExpectCheckerErrors(t, err, 2)
 
-	assert.IsType(t, &sema.MissingResourceAnnotationError{}, errs[0])
-	assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[1])
-	assert.IsType(t, &sema.NotDeclaredError{}, errs[2])
-	assert.IsType(t, &sema.IncorrectTransferOperationError{}, errs[3])
+	assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[0])
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
 }
 
 func TestCheckInvalidReferenceExpressionNonReferenceAnyStruct(t *testing.T) {


### PR DESCRIPTION
Revert #1661 

These improvements are only reverted, as they should have not been merged to master yet.
They will stay on `stable-cadence` and will eventually land on `master`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
