### PR TITLE
codec cadence.value cadence.type

### DIFF
--- a/encoding/custom/common_codec/common.go
+++ b/encoding/custom/common_codec/common.go
@@ -1,0 +1,95 @@
+package common_codec
+
+import (
+	"fmt"
+	"io"
+)
+
+type LengthyWriter struct {
+	w      io.Writer
+	length int
+}
+
+func NewLengthyWriter(w io.Writer) LengthyWriter {
+	return LengthyWriter{w: w}
+}
+
+func (l *LengthyWriter) Write(p []byte) (n int, err error) {
+	n, err = l.w.Write(p)
+	l.length += n
+	return
+}
+
+func (l *LengthyWriter) Len() int {
+	return l.length
+}
+
+type LocatedReader struct {
+	r        io.Reader
+	location int
+}
+
+func NewLocatedReader(r io.Reader) LocatedReader {
+	return LocatedReader{r: r}
+}
+
+func (l *LocatedReader) Read(p []byte) (n int, err error) {
+	n, err = l.r.Read(p)
+	l.location += n
+	return
+}
+
+func (l *LocatedReader) Location() int {
+	return l.location
+}
+
+func Concat(deep ...[]byte) []byte {
+	length := 0
+	for _, b := range deep {
+		length += len(b)
+	}
+
+	flat := make([]byte, 0, length)
+	for _, b := range deep {
+		flat = append(flat, b...)
+	}
+
+	return flat
+}
+
+type EncodedBool byte
+
+const (
+	EncodedBoolUnknown EncodedBool = iota
+	EncodedBoolFalse
+	EncodedBoolTrue
+)
+
+func EncodeBool(w io.Writer, boolean bool) (err error) {
+	b := EncodedBoolFalse
+	if boolean {
+		b = EncodedBoolTrue
+	}
+
+	_, err = w.Write([]byte{byte(b)})
+	return
+}
+
+func DecodeBool(r io.Reader) (boolean bool, err error) {
+	b := make([]byte, 1)
+	_, err = r.Read(b)
+	if err != nil {
+		return
+	}
+
+	switch EncodedBool(b[0]) {
+	case EncodedBoolFalse:
+		boolean = false
+	case EncodedBoolTrue:
+		boolean = true
+	default:
+		err = fmt.Errorf("invalid boolean value: %d", b[0])
+	}
+
+	return
+}

--- a/encoding/custom/common_codec/common.go
+++ b/encoding/custom/common_codec/common.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package common_codec
 
 import (

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onflow/cadence/encoding/custom/common_codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -153,7 +154,7 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 				Type:       sema.AnyType,
 			},
 			byte(sema_codec.EncodedSemaReferenceType),
-			byte(sema_codec.EncodedBoolFalse),
+			byte(common_codec.EncodedBoolFalse),
 			byte(sema_codec.EncodedSemaSimpleTypeAnyType),
 		)
 	})
@@ -181,12 +182,12 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 				TypeBound: sema.Int32Type,
 				Optional:  true,
 			}},
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaGenericType)},
 				[]byte{0, 0, 0, byte(len(name))},
 				[]byte(name),
 				[]byte{byte(sema_codec.EncodedSemaNumericTypeInt32Type)},
-				[]byte{byte(sema_codec.EncodedBoolTrue)},
+				[]byte{byte(common_codec.EncodedBoolTrue)},
 			)...,
 		)
 	})
@@ -243,43 +244,43 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 		err := encoder.Encode(functionType)
 		require.NoError(t, err, "encoding error")
 
-		expected := Concat(
+		expected := common_codec.Concat(
 			[]byte{byte(sema_codec.EncodedSemaFunctionType)},
 
-			[]byte{byte(sema_codec.EncodedBoolTrue)}, // isConstructor
+			[]byte{byte(common_codec.EncodedBoolTrue)}, // isConstructor
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeParameters array is non-nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // TypeParameters array is non-nil
 			[]byte{0, 0, 0, byte(len(typeParameters))},
 			[]byte{0, 0, 0, byte(len(typeParameters[0].Name))},
 			[]byte(typeParameters[0].Name),
 			[]byte{byte(sema_codec.EncodedSemaSimpleTypeVoidType)},
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Parameters array is non-nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // Parameters array is non-nil
 			[]byte{0, 0, 0, byte(len(parameters))},
 			[]byte{0, 0, 0, byte(len(parameters[0].Label))},
 			[]byte(parameters[0].Label),
 			[]byte{0, 0, 0, byte(len(parameters[0].Identifier))},
 			[]byte(parameters[0].Identifier),
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
-			[]byte{byte(sema_codec.EncodedBoolTrue)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolTrue)},
 			[]byte{byte(sema_codec.EncodedSemaSimpleTypeAnyResourceType)},
 			[]byte{0, 0, 0, byte(len(parameters[1].Label))},
 			[]byte(parameters[1].Label),
 			[]byte{0, 0, 0, byte(len(parameters[1].Identifier))},
 			[]byte(parameters[1].Identifier),
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{byte(sema_codec.EncodedSemaSimpleTypeStringType)},
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeAnnotation is not nil
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeAnnotation: it is not a Resource
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // TypeAnnotation is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // TypeAnnotation: it is not a Resource
 			[]byte{byte(sema_codec.EncodedSemaSimpleTypePathType)},
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{0, 0, 0, 0, 0, 0, 0, byte(requiredArgumentCount)},
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)},        // Members is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)},      // Members is not nil
 			[]byte{0, 0, 0, byte(members.Len())},             // Members length
 			[]byte{0, 0, 0, byte(len(members.Newest().Key))}, // Member key
 			[]byte(members.Newest().Key),
@@ -289,13 +290,13 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0}, // Member AST identifier position
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Member type annotation
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // Member type annotation
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{byte(sema_codec.EncodedSemaNumericTypeInt8Type)},
 			[]byte{0, 0, 0, 0, 0, 0, 0, byte(common.DeclarationKindField)}, // Member declaration kind
 			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.VariableKindConstant)},    // member variable kind
-			[]byte{byte(sema_codec.EncodedBoolTrue)},                       // Member has no argument labels
-			[]byte{byte(sema_codec.EncodedBoolFalse)},                      // Member is not predeclared
+			[]byte{byte(common_codec.EncodedBoolTrue)},                     // Member has no argument labels
+			[]byte{byte(common_codec.EncodedBoolFalse)},                    // Member is not predeclared
 			[]byte{0, 0, 0, byte(len(memberDocString))},                    // Member doc string
 			[]byte(memberDocString),
 		)
@@ -349,7 +350,7 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 				KeyType:   sema.StringType,
 				ValueType: sema.AnyStructType,
 			},
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaDictionaryType)},
 				[]byte{byte(sema_codec.EncodedSemaSimpleTypeStringType)},
 				[]byte{byte(sema_codec.EncodedSemaSimpleTypeAnyStructType)},
@@ -406,10 +407,10 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 		err := encoder.Encode(transactionType)
 		require.NoError(t, err, "encoding error")
 
-		expected := Concat(
+		expected := common_codec.Concat(
 			[]byte{byte(sema_codec.EncodedSemaTransactionType)},
 			// members
-			[]byte{byte(sema_codec.EncodedBoolFalse)},        // Members is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)},      // Members is not nil
 			[]byte{0, 0, 0, byte(members.Len())},             // Members length
 			[]byte{0, 0, 0, byte(len(members.Newest().Key))}, // Member key
 			[]byte(members.Newest().Key),
@@ -419,18 +420,18 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0}, // Member AST identifier position
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Member type annotation
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // Member type annotation
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{byte(sema_codec.EncodedSemaNumericTypeInt8Type)},
 			[]byte{0, 0, 0, 0, 0, 0, 0, byte(common.DeclarationKindField)}, // Member declaration kind
 			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.VariableKindConstant)},    // member variable kind
-			[]byte{byte(sema_codec.EncodedBoolTrue)},                       // Member has no argument labels
-			[]byte{byte(sema_codec.EncodedBoolFalse)},                      // Member is not predeclared
+			[]byte{byte(common_codec.EncodedBoolTrue)},                     // Member has no argument labels
+			[]byte{byte(common_codec.EncodedBoolFalse)},                    // Member is not predeclared
 			[]byte{0, 0, 0, byte(len(memberDocString))},                    // Member doc string
 			[]byte(memberDocString),
 
 			// array of strings for fields
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // array is not nil
 			[]byte{0, 0, 0, byte(len(fields))},
 			[]byte{0, 0, 0, byte(len(fields[0]))},
 			[]byte(fields[0]),
@@ -442,25 +443,25 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 			[]byte(fields[3]),
 
 			// array of parameters for prepareParameters
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // array is not nil
 			[]byte{0, 0, 0, byte(len(prepareParameters))},
 			[]byte{0, 0, 0, byte(len(prepareParameters[0].Label))},
 			[]byte(prepareParameters[0].Label),
 			[]byte{0, 0, 0, byte(len(prepareParameters[0].Identifier))},
 			[]byte(prepareParameters[0].Identifier),
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{byte(sema_codec.EncodedSemaNumericTypeUInt16Type)},
 
 			// array of parameters for parameters
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // array is not nil
 			[]byte{0, 0, 0, byte(len(parameters))},
 			[]byte{0, 0, 0, byte(len(parameters[0].Label))},
 			[]byte(parameters[0].Label),
 			[]byte{0, 0, 0, byte(len(parameters[0].Identifier))},
 			[]byte(parameters[0].Identifier),
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{byte(sema_codec.EncodedSemaNumericTypeSignedFixedPointType)},
 		)
 
@@ -513,19 +514,19 @@ func TestSemaCodecMiscTypes(t *testing.T) {
 		err := encoder.Encode(restrictedType)
 		require.NoError(t, err, "encoding error")
 
-		expected := Concat(
+		expected := common_codec.Concat(
 			[]byte{byte(sema_codec.EncodedSemaRestrictedType)},
 			[]byte{byte(sema_codec.EncodedSemaNumericTypeIntType)},
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // array is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // array is not nil
 			[]byte{0, 0, 0, 1}, // array length
-			Concat([]byte{'s'}, location[:]),
+			common_codec.Concat([]byte{'s'}, location[:]),
 			[]byte{0, 0, 0, 6}, []byte("peaked"), // identifier
 			[]byte{byte(common.CompositeKindContract)},
-			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // members is nil
-			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // fields is nil
-			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // initializer parameters is nil
+			[]byte{byte(common_codec.EncodedBoolTrue)},                  // members is nil
+			[]byte{byte(common_codec.EncodedBoolTrue)},                  // fields is nil
+			[]byte{byte(common_codec.EncodedBoolTrue)},                  // initializer parameters is nil
 			[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // container type is root type
-			[]byte{byte(sema_codec.EncodedBoolTrue)},                    // nested types is nil
+			[]byte{byte(common_codec.EncodedBoolTrue)},                  // nested types is nil
 		)
 
 		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
@@ -646,6 +647,7 @@ func TestSemaCodecArrayTypes(t *testing.T) {
 	})
 }
 
+// TODO move these tests to common_codec
 func TestSemaCodecMiscValues(t *testing.T) {
 	t.Parallel()
 
@@ -750,30 +752,38 @@ func TestSemaCodecMiscValues(t *testing.T) {
 	t.Run("bool true", func(t *testing.T) {
 		t.Parallel()
 
-		encoder, decoder, buffer := NewTestCodec()
+		_, _, buffer := NewTestCodec()
 
 		testEncodeDecode(
 			t,
 			true,
 			buffer,
-			encoder.EncodeBool,
-			decoder.DecodeBool,
-			[]byte{byte(sema_codec.EncodedBoolTrue)},
+			func(b bool) error {
+				return common_codec.EncodeBool(buffer, b)
+			},
+			func() (bool, error) {
+				return common_codec.DecodeBool(buffer)
+			},
+			[]byte{byte(common_codec.EncodedBoolTrue)},
 		)
 	})
 
 	t.Run("bool false", func(t *testing.T) {
 		t.Parallel()
 
-		encoder, decoder, buffer := NewTestCodec()
+		_, _, buffer := NewTestCodec()
 
 		testEncodeDecode(
 			t,
 			false,
 			buffer,
-			encoder.EncodeBool,
-			decoder.DecodeBool,
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			func(b bool) error {
+				return common_codec.EncodeBool(buffer, b)
+			},
+			func() (bool, error) {
+				return common_codec.DecodeBool(buffer)
+			},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 		)
 	})
 
@@ -887,7 +897,7 @@ func TestSemaCodecLocations(t *testing.T) {
 			buffer,
 			encoder.EncodeLocation,
 			decoder.DecodeLocation,
-			Concat(
+			common_codec.Concat(
 				[]byte{common.AddressLocationPrefix[0]},
 				address.Address.Bytes(),
 				[]byte{0, 0, 0, byte(len(address.Name))},
@@ -908,7 +918,7 @@ func TestSemaCodecLocations(t *testing.T) {
 			buffer,
 			encoder.EncodeLocation,
 			decoder.DecodeLocation,
-			Concat(
+			common_codec.Concat(
 				[]byte{common.IdentifierLocationPrefix[0]},
 				[]byte{0, 0, 0, byte(len(identifier))},
 				[]byte(identifier),
@@ -928,7 +938,7 @@ func TestSemaCodecLocations(t *testing.T) {
 			buffer,
 			encoder.EncodeLocation,
 			decoder.DecodeLocation,
-			Concat(
+			common_codec.Concat(
 				[]byte{common.ScriptLocationPrefix[0]},
 				location[:],
 			),
@@ -947,7 +957,7 @@ func TestSemaCodecLocations(t *testing.T) {
 			buffer,
 			encoder.EncodeLocation,
 			decoder.DecodeLocation,
-			Concat(
+			common_codec.Concat(
 				[]byte{common.StringLocationPrefix[0]},
 				[]byte{0, 0, 0, byte(len(location))},
 				[]byte(location),
@@ -967,7 +977,7 @@ func TestSemaCodecLocations(t *testing.T) {
 			buffer,
 			encoder.EncodeLocation,
 			decoder.DecodeLocation,
-			Concat(
+			common_codec.Concat(
 				[]byte{common.TransactionLocationPrefix[0]},
 				location[:],
 			),
@@ -1044,7 +1054,7 @@ func TestSemaCodecInterfaceType(t *testing.T) {
 		err := encoder.Encode(interfaceType)
 		require.NoError(t, err, "encoding error")
 
-		expected := Concat(
+		expected := common_codec.Concat(
 			[]byte{byte(sema_codec.EncodedSemaInterfaceType)},
 
 			[]byte{common.TransactionLocationPrefix[0]},
@@ -1055,7 +1065,7 @@ func TestSemaCodecInterfaceType(t *testing.T) {
 
 			[]byte{byte(common.CompositeKindEnum)},
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)},        // Members is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)},      // Members is not nil
 			[]byte{0, 0, 0, byte(members.Len())},             // Members length
 			[]byte{0, 0, 0, byte(len(members.Newest().Key))}, // Member key
 			[]byte(members.Newest().Key),
@@ -1065,41 +1075,41 @@ func TestSemaCodecInterfaceType(t *testing.T) {
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0}, // Member AST identifier position
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Member type annotation
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // Member type annotation
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{byte(sema_codec.EncodedSemaNumericTypeInt8Type)},
 			[]byte{0, 0, 0, 0, 0, 0, 0, byte(common.DeclarationKindField)}, // Member declaration kind
 			[]byte{0, 0, 0, 0, 0, 0, 0, byte(ast.VariableKindConstant)},    // member variable kind
-			[]byte{byte(sema_codec.EncodedBoolTrue)},                       // Member has no argument labels
-			[]byte{byte(sema_codec.EncodedBoolFalse)},                      // Member is not predeclared
+			[]byte{byte(common_codec.EncodedBoolTrue)},                     // Member has no argument labels
+			[]byte{byte(common_codec.EncodedBoolFalse)},                    // Member is not predeclared
 			[]byte{0, 0, 0, byte(len(memberDocString))},                    // Member doc string
 			[]byte(memberDocString),
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // Fields array is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // Fields array is not nil
 			[]byte{0, 0, 0, byte(len(fields))},
 			[]byte{0, 0, 0, byte(len(fields[0]))},
 			[]byte(fields[0]),
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // InitializerParameters array is not nil
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // InitializerParameters array is not nil
 			[]byte{0, 0, 0, byte(len(parameters))},
 			[]byte{0, 0, 0, byte(len(parameters[0].Label))},
 			[]byte(parameters[0].Label),
 			[]byte{0, 0, 0, byte(len(parameters[0].Identifier))},
 			[]byte(parameters[0].Identifier),
-			[]byte{byte(sema_codec.EncodedBoolTrue)},
+			[]byte{byte(common_codec.EncodedBoolTrue)},
 
 			[]byte{byte(sema_codec.EncodedSemaInterfaceType)}, // container type is empty interface
 			[]byte{sema_codec.NilLocationPrefix[0]},
 			[]byte{0, 0, 0, 0},
 			[]byte{byte(common.CompositeKindUnknown)},
-			[]byte{byte(sema_codec.EncodedBoolFalse)},
+			[]byte{byte(common_codec.EncodedBoolFalse)},
 			[]byte{0, 0, 0, 0},
-			[]byte{byte(sema_codec.EncodedBoolTrue)},
-			[]byte{byte(sema_codec.EncodedBoolTrue)},
+			[]byte{byte(common_codec.EncodedBoolTrue)},
+			[]byte{byte(common_codec.EncodedBoolTrue)},
 			[]byte{byte(sema_codec.EncodedSemaNilType)},
-			[]byte{byte(sema_codec.EncodedBoolTrue)},
+			[]byte{byte(common_codec.EncodedBoolTrue)},
 
-			[]byte{byte(sema_codec.EncodedBoolFalse)}, // nested type
+			[]byte{byte(common_codec.EncodedBoolFalse)}, // nested type
 			[]byte{0, 0, 0, 1},
 			[]byte{0, 0, 0, 4},
 			[]byte("none"),
@@ -1201,10 +1211,10 @@ func TestSemaCodecCompositeType(t *testing.T) {
 			byte(common.CompositeKindStructure),
 
 			// ExplicitInterfaceConformances array is nil
-			byte(sema_codec.EncodedBoolTrue),
+			byte(common_codec.EncodedBoolTrue),
 
 			// ImplicitTypeRequirementConformances array is nil
-			byte(sema_codec.EncodedBoolTrue),
+			byte(common_codec.EncodedBoolTrue),
 		}
 		assert.Equal(t, expected, buffer.Bytes()[:len(expected)], "encoded bytes")
 
@@ -1272,16 +1282,16 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 			sema_codec.NilLocationPrefix[0],
 			0, 0, 0, 0, // identifier length
 			0,                                                   // composite kind
-			byte(sema_codec.EncodedBoolTrue),                    // ExplicitInterfaceConformances array is nil
-			byte(sema_codec.EncodedBoolTrue),                    // ImplicitTypeRequirementConformances array is nil
-			byte(sema_codec.EncodedBoolTrue),                    // no members
-			byte(sema_codec.EncodedBoolTrue),                    // Fields array is nil
-			byte(sema_codec.EncodedBoolTrue),                    // ConstructorParameters array is nil
-			byte(sema_codec.EncodedBoolTrue),                    // no nested types
+			byte(common_codec.EncodedBoolTrue),                  // ExplicitInterfaceConformances array is nil
+			byte(common_codec.EncodedBoolTrue),                  // ImplicitTypeRequirementConformances array is nil
+			byte(common_codec.EncodedBoolTrue),                  // no members
+			byte(common_codec.EncodedBoolTrue),                  // Fields array is nil
+			byte(common_codec.EncodedBoolTrue),                  // ConstructorParameters array is nil
+			byte(common_codec.EncodedBoolTrue),                  // no nested types
 			byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1, // container type
 			byte(sema_codec.EncodedSemaNilType), // EnumRawType
-			byte(sema_codec.EncodedBoolFalse),   // hasComputedMembers
-			byte(sema_codec.EncodedBoolFalse),   // ImportableWithoutLocation
+			byte(common_codec.EncodedBoolFalse), // hasComputedMembers
+			byte(common_codec.EncodedBoolFalse), // ImportableWithoutLocation
 		}
 
 		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
@@ -1312,11 +1322,11 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 			sema_codec.NilLocationPrefix[0],
 			0, 0, 0, 0, // identifier length
 			0,                                                   // composite kind
-			byte(sema_codec.EncodedBoolTrue),                    // Members array is nil
-			byte(sema_codec.EncodedBoolTrue),                    // Fields array is nil
-			byte(sema_codec.EncodedBoolTrue),                    // InitializerParameters array is nil
+			byte(common_codec.EncodedBoolTrue),                  // Members array is nil
+			byte(common_codec.EncodedBoolTrue),                  // Fields array is nil
+			byte(common_codec.EncodedBoolTrue),                  // InitializerParameters array is nil
 			byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1, // container type
-			byte(sema_codec.EncodedBoolTrue), // nestedTypes
+			byte(common_codec.EncodedBoolTrue), // nestedTypes
 		}
 
 		assert.Equal(t, expected, buffer.Bytes(), "encoded bytes differ")
@@ -1352,7 +1362,7 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			parent,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaGenericType)},
 				[]byte{0, 0, 0, byte(len(parent.TypeParameter.Name))},
 				[]byte(parent.TypeParameter.Name),
@@ -1360,8 +1370,8 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 				[]byte{0, 0, 0, byte(len(g.TypeParameter.Name))},
 				[]byte(g.TypeParameter.Name),
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 12},
-				[]byte{byte(sema_codec.EncodedBoolTrue)},
-				[]byte{byte(sema_codec.EncodedBoolFalse)},
+				[]byte{byte(common_codec.EncodedBoolTrue)},
+				[]byte{byte(common_codec.EncodedBoolFalse)},
 			)...,
 		)
 	})
@@ -1385,19 +1395,19 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			f,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaFunctionType)},
-				[]byte{byte(sema_codec.EncodedBoolFalse)}, // isConstructor
-				[]byte{byte(sema_codec.EncodedBoolFalse)}, // TypeParameters is not nil
+				[]byte{byte(common_codec.EncodedBoolFalse)}, // isConstructor
+				[]byte{byte(common_codec.EncodedBoolFalse)}, // TypeParameters is not nil
 				[]byte{0, 0, 0, 1},
 				[]byte{0, 0, 0, byte(len(f.TypeParameters[0].Name))},
 				[]byte(f.TypeParameters[0].Name),
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // container type
-				[]byte{byte(sema_codec.EncodedBoolFalse)},
-				[]byte{byte(sema_codec.EncodedBoolTrue)}, // Parameters is nil
-				[]byte{byte(sema_codec.EncodedBoolTrue)}, // ReturnTypeAnnotation is nil
-				[]byte{byte(sema_codec.EncodedBoolTrue)}, // RequiredArgumentCount is nil
-				[]byte{byte(sema_codec.EncodedBoolTrue)}, // Members is nil
+				[]byte{byte(common_codec.EncodedBoolFalse)},
+				[]byte{byte(common_codec.EncodedBoolTrue)}, // Parameters is nil
+				[]byte{byte(common_codec.EncodedBoolTrue)}, // ReturnTypeAnnotation is nil
+				[]byte{byte(common_codec.EncodedBoolTrue)}, // RequiredArgumentCount is nil
+				[]byte{byte(common_codec.EncodedBoolTrue)}, // Members is nil
 			)...,
 		)
 	})
@@ -1410,7 +1420,7 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			d,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaDictionaryType)},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1},
@@ -1434,19 +1444,19 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			tx,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaTransactionType)},
-				[]byte{byte(sema_codec.EncodedBoolTrue)},  // Members is nil
-				[]byte{byte(sema_codec.EncodedBoolTrue)},  // Fields is nil
-				[]byte{byte(sema_codec.EncodedBoolTrue)},  // PrepareParameters is nil
-				[]byte{byte(sema_codec.EncodedBoolFalse)}, // Parameters is not nil
-				[]byte{0, 0, 0, 1},                        // 1 Parameter
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // Members is nil
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // Fields is nil
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // PrepareParameters is nil
+				[]byte{byte(common_codec.EncodedBoolFalse)}, // Parameters is not nil
+				[]byte{0, 0, 0, 1},                          // 1 Parameter
 				[]byte{0, 0, 0, byte(len(tx.Parameters[0].Label))},
 				[]byte(tx.Parameters[0].Label),
 				[]byte{0, 0, 0, byte(len(tx.Parameters[0].Identifier))},
 				[]byte(tx.Parameters[0].Identifier),
-				[]byte{byte(sema_codec.EncodedBoolFalse)},                   // TypeAnnotation is not nil
-				[]byte{byte(sema_codec.EncodedBoolFalse)},                   // TypeAnnotation is not a resource
+				[]byte{byte(common_codec.EncodedBoolFalse)},                 // TypeAnnotation is not nil
+				[]byte{byte(common_codec.EncodedBoolFalse)},                 // TypeAnnotation is not a resource
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
 			)...,
 		)
@@ -1459,10 +1469,10 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			r,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaRestrictedType)},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
-				[]byte{byte(sema_codec.EncodedBoolTrue)},                    // Restrictions is nil
+				[]byte{byte(common_codec.EncodedBoolTrue)},                  // Restrictions is nil
 			)...,
 		)
 	})
@@ -1474,7 +1484,7 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			c,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaConstantSizedType)},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
 				[]byte{0, 0, 0, 0, 0, 0, 0, 0},
@@ -1489,7 +1499,7 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			v,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaVariableSizedType)},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
 			)...,
@@ -1503,7 +1513,7 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			o,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaOptionalType)},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
 			)...,
@@ -1517,9 +1527,9 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			r,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaReferenceType)},
-				[]byte{byte(sema_codec.EncodedBoolFalse)},
+				[]byte{byte(common_codec.EncodedBoolFalse)},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
 			)...,
 		)
@@ -1532,7 +1542,7 @@ func TestSemaCodecRecursiveType(t *testing.T) {
 		testRootEncodeDecode(
 			t,
 			v,
-			Concat(
+			common_codec.Concat(
 				[]byte{byte(sema_codec.EncodedSemaCapabilityType)},
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 1}, // type is recursive
 			)...,
@@ -1590,7 +1600,7 @@ func TestSemaCodecElaboration(t *testing.T) {
 			buffer,
 			encoder.EncodeElaboration,
 			decoder.DecodeElaboration,
-			Concat(
+			common_codec.Concat(
 				[]byte{0, 0, 0, 1},                 // length of CompositeTypes map
 				[]byte{0, 0, 0, byte(len(typeId))}, // TypeID aka map key
 				[]byte(typeId),
@@ -1599,16 +1609,16 @@ func TestSemaCodecElaboration(t *testing.T) {
 				[]byte{0, 0, 0, byte(len(identifier))}, // identifier
 				[]byte(identifier),
 				[]byte{byte(common.CompositeKindStructure)}, // composite kind
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil ExplicitInterfaceConformances
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil ImplicitTypeRequirementConformances
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Members
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Fields
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil ConstructorParameters
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil nestedTypes
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil ExplicitInterfaceConformances
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil ImplicitTypeRequirementConformances
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil Members
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil Fields
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil ConstructorParameters
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil nestedTypes
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 14},
 				[]byte{byte(sema_codec.EncodedSemaNilType)}, // nil EnumRawType
-				[]byte{byte(sema_codec.EncodedBoolFalse)},   // hasComputedMembers
-				[]byte{byte(sema_codec.EncodedBoolFalse)},   // ImportableWithoutLocation
+				[]byte{byte(common_codec.EncodedBoolFalse)}, // hasComputedMembers
+				[]byte{byte(common_codec.EncodedBoolFalse)}, // ImportableWithoutLocation
 
 				[]byte{0, 0, 0, 1},                 // length of InterfaceTypes map
 				[]byte{0, 0, 0, byte(len(typeId))}, // TypeID aka map key
@@ -1618,11 +1628,11 @@ func TestSemaCodecElaboration(t *testing.T) {
 				[]byte{0, 0, 0, byte(len(identifier))}, // identifier
 				[]byte(identifier),
 				[]byte{byte(common.CompositeKindStructure)}, // composite kind
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Members
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil Fields
-				[]byte{byte(sema_codec.EncodedBoolTrue)},    // nil InitializerParameters
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil Members
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil Fields
+				[]byte{byte(common_codec.EncodedBoolTrue)},  // nil InitializerParameters
 				[]byte{byte(sema_codec.EncodedSemaPointerType), 0, 0, 0, 14},
-				[]byte{byte(sema_codec.EncodedBoolTrue)}, // nil nestedTypes
+				[]byte{byte(common_codec.EncodedBoolTrue)}, // nil nestedTypes
 
 			),
 		)
@@ -1686,20 +1696,6 @@ func NewTestCodec() (encoder *sema_codec.SemaEncoder, decoder *sema_codec.SemaDe
 	encoder = sema_codec.NewSemaEncoder(buffer)
 	decoder = sema_codec.NewSemaDecoder(nil, buffer)
 	return
-}
-
-func Concat(deep ...[]byte) []byte {
-	length := 0
-	for _, b := range deep {
-		length += len(b)
-	}
-
-	flat := make([]byte, 0, length)
-	for _, b := range deep {
-		flat = append(flat, b...)
-	}
-
-	return flat
 }
 
 // TODO test via fuzzing

--- a/encoding/custom/sema_codec/codec_test.go
+++ b/encoding/custom/sema_codec/codec_test.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onflow/cadence/encoding/custom/common_codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/encoding/custom/common_codec"
 
 	"github.com/onflow/cadence/encoding/custom/sema_codec"
 	"github.com/onflow/cadence/runtime/ast"

--- a/encoding/custom/value_codec/codec_test.go
+++ b/encoding/custom/value_codec/codec_test.go
@@ -1,0 +1,329 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package value_codec_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/custom/common_codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/encoding/custom/value_codec"
+)
+
+func TestValueCodecVoid(t *testing.T) {
+	t.Parallel()
+
+	encoder, decoder, buffer := NewTestCodec()
+
+	value := cadence.NewVoid()
+
+	err := encoder.Encode(value)
+	require.NoError(t, err, "encoding error")
+
+	assert.Equal(
+		t,
+		[]byte{byte(value_codec.EncodedValueVoid)},
+		buffer.Bytes(), "encoded bytes differ")
+
+	output, err := decoder.Decode()
+	require.NoError(t, err, "decoding error")
+
+	assert.Equal(t, value, output, "decoded value differs")
+}
+
+func TestValueCodecBool(t *testing.T) {
+	t.Parallel()
+
+	t.Run("false", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		value := cadence.NewBool(false)
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueBool),
+				byte(common_codec.EncodedBoolFalse),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+
+	t.Run("true", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		value := cadence.NewBool(true)
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueBool),
+				byte(common_codec.EncodedBoolTrue),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+}
+
+func TestValueCodecOptional(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Optional(Void)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		innerValue := cadence.NewVoid()
+		value := cadence.NewOptional(innerValue)
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueOptional),
+				byte(common_codec.EncodedBoolFalse),
+				byte(value_codec.EncodedValueVoid),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+
+	t.Run("Optional(bool)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		innerValue := cadence.NewBool(true)
+		value := cadence.NewOptional(innerValue)
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueOptional),
+				byte(common_codec.EncodedBoolFalse),
+				byte(value_codec.EncodedValueBool),
+				byte(common_codec.EncodedBoolTrue),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+
+	t.Run("Optional(nil)", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		value := cadence.NewOptional(nil)
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueOptional),
+				byte(common_codec.EncodedBoolTrue),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+}
+
+func TestValueCodecArray(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Variable Array, len=0", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		elements := make([]cadence.Value, 0)
+
+		value := cadence.NewArray(elements).
+			WithType(cadence.NewVariableSizedArrayType(cadence.NewAnyType()))
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueArray),
+				byte(value_codec.EncodedArrayTypeVariable),
+				byte(value_codec.EncodedTypeAnyType),
+				0, 0, 0, byte(len(elements)),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+
+	t.Run("Variable Array, len=2", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		elements := []cadence.Value{
+			cadence.NewVoid(),
+			cadence.NewBool(true),
+		}
+
+		value := cadence.NewArray(elements).
+			WithType(cadence.NewVariableSizedArrayType(cadence.NewAnyType()))
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueArray),
+				byte(value_codec.EncodedArrayTypeVariable),
+				byte(value_codec.EncodedTypeAnyType),
+				0, 0, 0, byte(len(elements)),
+
+				byte(value_codec.EncodedValueVoid),
+
+				byte(value_codec.EncodedValueBool),
+				byte(common_codec.EncodedBoolTrue),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+
+	t.Run("Constant Array, len=0", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		elements := make([]cadence.Value, 0)
+
+		value := cadence.NewArray(elements).
+			WithType(cadence.NewConstantSizedArrayType(uint(len(elements)), cadence.NewAnyStructType()))
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueArray),
+				byte(value_codec.EncodedArrayTypeConstant),
+				byte(value_codec.EncodedTypeAnyStructType),
+				0, 0, 0, byte(len(elements)),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+
+	t.Run("Constant Array, len=2", func(t *testing.T) {
+		t.Parallel()
+
+		encoder, decoder, buffer := NewTestCodec()
+
+		elements := []cadence.Value{
+			cadence.NewVoid(),
+			cadence.NewBool(true),
+		}
+
+		value := cadence.NewArray(elements).
+			WithType(cadence.NewConstantSizedArrayType(uint(len(elements)), cadence.NewAnyStructType()))
+
+		err := encoder.Encode(value)
+		require.NoError(t, err, "encoding error")
+
+		assert.Equal(
+			t,
+			[]byte{
+				byte(value_codec.EncodedValueArray),
+				byte(value_codec.EncodedArrayTypeConstant),
+				byte(value_codec.EncodedTypeAnyStructType),
+				0, 0, 0, byte(len(elements)),
+
+				byte(value_codec.EncodedValueVoid),
+
+				byte(value_codec.EncodedValueBool),
+				byte(common_codec.EncodedBoolTrue),
+			},
+			buffer.Bytes(), "encoded bytes differ")
+
+		output, err := decoder.Decode()
+		require.NoError(t, err, "decoding error")
+
+		assert.Equal(t, value, output, "decoded value differs")
+	})
+}
+
+func NewTestCodec() (encoder *value_codec.Encoder, decoder *value_codec.Decoder, buffer *bytes.Buffer) {
+	var w bytes.Buffer
+	buffer = &w
+	encoder = value_codec.NewEncoder(buffer)
+	decoder = value_codec.NewDecoder(nil, buffer)
+	return
+}

--- a/encoding/custom/value_codec/codec_test.go
+++ b/encoding/custom/value_codec/codec_test.go
@@ -22,10 +22,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/onflow/cadence"
-	"github.com/onflow/cadence/encoding/custom/common_codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/custom/common_codec"
 
 	"github.com/onflow/cadence/encoding/custom/value_codec"
 )

--- a/encoding/custom/value_codec/decode.go
+++ b/encoding/custom/value_codec/decode.go
@@ -1,0 +1,277 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package value_codec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/custom/common_codec"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+// A Decoder decodes custom-encoded representations of Cadence values.
+type Decoder struct {
+	r           common_codec.LocatedReader
+	buf         []byte
+	memoryGauge common.MemoryGauge
+	types       map[common.TypeID]*cadence.CompositeType
+	// abi any // TODO abi for cutting down on what needs to be transferred
+}
+
+// Decode returns a Cadence value decoded from its custom-encoded representation.
+//
+// This function returns an error if the bytes represent a custom encoding that
+// is malformed, does not conform to the custom Cadence specification, or contains
+// an unknown composite type.
+func Decode(gauge common.MemoryGauge, b []byte) (cadence.Value, error) {
+	r := bytes.NewReader(b)
+	dec := NewDecoder(gauge, r)
+
+	v, err := dec.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// NewDecoder initializes a Decoder that will decode custom-encoded bytes from the
+// given io.Reader.
+func NewDecoder(memoryGauge common.MemoryGauge, r io.Reader) *Decoder {
+	return &Decoder{
+		r:           common_codec.NewLocatedReader(r),
+		memoryGauge: memoryGauge,
+	}
+}
+
+// Decode reads custom-encoded bytes from the io.Reader and decodes them to a
+// Cadence value.
+//
+// This function returns an error if the bytes represent a custom encoding that
+// is malformed, does not conform to the custom Cadence specification, or contains
+// an unknown composite type.
+func (d *Decoder) Decode() (value cadence.Value, err error) {
+	return d.DecodeValue()
+}
+
+// TODO need a way to decode values with known type vs values with unknown type
+//      if type is known then no identifier is needed, such as for elements in constant sized array
+func (d *Decoder) DecodeValue() (value cadence.Value, err error) {
+	identifier, err := d.DecodeIdentifier()
+	if err != nil {
+		return
+	}
+
+	switch identifier {
+	case EncodedValueVoid:
+		value = cadence.NewMeteredVoid(d.memoryGauge)
+	}
+
+	switch identifier {
+	case EncodedValueVoid:
+		value = cadence.NewMeteredVoid(d.memoryGauge)
+	case EncodedValueBool:
+		value, err = d.DecodeBool()
+	case EncodedValueOptional:
+		value, err = d.DecodeOptional()
+	case EncodedValueArray:
+		value, err = d.DecodeArray()
+	}
+
+	return
+}
+
+func (d *Decoder) DecodeIdentifier() (id EncodedValue, err error) {
+	b, err := d.read(1)
+	if err != nil {
+		return
+	}
+
+	id = EncodedValue(b[0])
+	return
+}
+
+func (d *Decoder) DecodeVoid() (value cadence.Void, err error) {
+	_, err = d.read(1)
+	value = cadence.NewMeteredVoid(d.memoryGauge)
+	return
+}
+
+func (d *Decoder) DecodeOptional() (value cadence.Optional, err error) {
+	isNil, err := d.DecodeBool()
+	if isNil || err != nil {
+		return
+	}
+
+	innerValue, err := d.DecodeValue()
+	value = cadence.NewMeteredOptional(d.memoryGauge, innerValue)
+	return
+}
+
+func (d *Decoder) DecodeBool() (value cadence.Bool, err error) {
+	boolean, err := common_codec.DecodeBool(&d.r)
+	if err != nil {
+		return
+	}
+
+	value = cadence.NewMeteredBool(d.memoryGauge, boolean)
+	return
+}
+
+// TODO how am I to represent complex types?
+//      like a CompositeValue has a type... do I put it inside the CompositeValue encoding?
+//      what I want to do is put it early enough that the CompositeValue encoding can be very light
+//      maybe do it like: identifier type value
+//      have it so the identifier tells you the baset type
+
+func (d *Decoder) DecodeArray() (array cadence.Array, err error) {
+	arrayType, err := d.DecodeArrayType()
+	if err != nil {
+		return
+	}
+
+	var size int
+	switch t := arrayType.(type) {
+	case cadence.ConstantSizedArrayType:
+		size = int(t.Size)
+	case cadence.VariableSizedArrayType:
+		size, err = d.DecodeLength()
+		if err != nil {
+			return
+		}
+	}
+	array, err = cadence.NewMeteredArray(d.memoryGauge, size, func() (elements []cadence.Value, err error) {
+		elements = make([]cadence.Value, 0, size)
+		for i := 0; i < size; i++ {
+			// TODO if `elementType` is concrete then each element needn't encode its type
+			var elementValue cadence.Value
+			elementValue, err = d.DecodeValue()
+			if err != nil {
+				return
+			}
+			elements = append(elements, elementValue)
+		}
+
+		return elements, nil
+	})
+
+	array = array.WithType(arrayType)
+
+	return
+}
+
+func (d *Decoder) DecodeArrayType() (t cadence.ArrayType, err error) {
+	b, err := d.read(1)
+	if err != nil {
+		return
+	}
+
+	elementType, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	switch EncodedArrayType(b[0]) {
+	case EncodedArrayTypeVariable:
+		t = cadence.NewMeteredVariableSizedArrayType(d.memoryGauge, elementType)
+	case EncodedArrayTypeConstant:
+		var size int
+		size, err = d.DecodeLength()
+		if err != nil {
+			return
+		}
+		t = cadence.NewMeteredConstantSizedArrayType(d.memoryGauge, uint(size), elementType)
+	default:
+		err = fmt.Errorf("invalid array type encoding: %d", b[0])
+	}
+	return
+}
+
+//
+// Types
+//
+
+func (d *Decoder) DecodeType() (t cadence.Type, err error) {
+	typeIdentifer, err := d.DecodeTypeIdentifier()
+
+	switch typeIdentifer {
+	case EncodedTypeVoid:
+		t = cadence.NewMeteredVoidType(d.memoryGauge)
+	case EncodedTypeOptional:
+		t, err = d.DecodeOptionalType()
+	case EncodedTypeBool:
+		t = cadence.NewMeteredBoolType(d.memoryGauge)
+	case EncodedTypeArray:
+		t, err = d.DecodeArrayType()
+	case EncodedTypeAnyType:
+		t = cadence.NewMeteredAnyType(d.memoryGauge)
+	case EncodedTypeAnyStructType:
+		t = cadence.NewMeteredAnyStructType(d.memoryGauge)
+	default:
+		err = fmt.Errorf("unknown type identifier: %d", typeIdentifer)
+	}
+	return
+}
+
+func (d *Decoder) DecodeTypeIdentifier() (t EncodedType, err error) {
+	b, err := d.read(1)
+	t = EncodedType(b[0])
+	return
+}
+
+func (d *Decoder) DecodeOptionalType() (t cadence.OptionalType, err error) {
+	isNil, err := common_codec.DecodeBool(&d.r)
+	if isNil || err != nil {
+		return
+	}
+
+	elementType, err := d.DecodeType()
+	if err != nil {
+		return
+	}
+
+	t = cadence.NewMeteredOptionalType(d.memoryGauge, elementType)
+	return
+}
+
+//
+// Other
+//
+
+func (d *Decoder) DecodeLength() (length int, err error) {
+	b, err := d.read(4)
+	if err != nil {
+		return
+	}
+
+	asUint32 := binary.BigEndian.Uint32(b)
+
+	length = int(asUint32)
+	return
+}
+
+func (d *Decoder) read(howManyBytes int) (b []byte, err error) {
+	b = make([]byte, howManyBytes)
+	_, err = d.r.Read(b)
+	return
+}

--- a/encoding/custom/value_codec/encode.go
+++ b/encoding/custom/value_codec/encode.go
@@ -1,0 +1,308 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package value_codec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/custom/common_codec"
+)
+
+// An Encoder converts Cadence values into custom-encoded bytes.
+type Encoder struct {
+	w        common_codec.LengthyWriter
+	typeDefs map[cadence.Type]int
+}
+
+// EncodeValue returns the custom-encoded representation of the given value.
+//
+// This function returns an error if the Cadence value cannot be represented in the custom format.
+func EncodeValue(value cadence.Value) ([]byte, error) {
+	var w bytes.Buffer
+	enc := NewEncoder(&w)
+
+	err := enc.Encode(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return w.Bytes(), nil
+}
+
+// MustEncode returns the custom-encoded representation of the given value, or panics
+// if the value cannot be represented in the custom format.
+func MustEncodeValue(value cadence.Value) []byte {
+	b, err := EncodeValue(value)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// NewEncoder initializes an Encoder that will write custom-encoded bytes to the
+// given io.Writer.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{
+		w:        common_codec.NewLengthyWriter(w),
+		typeDefs: map[cadence.Type]int{},
+	}
+}
+
+// TODO include leading byte with version information
+//      maybe include other metadata too, like the size the decoder's typeDefs map will be
+
+// Encode writes the custom-encoded representation of the given value to this
+// encoder's io.Writer.
+//
+// This function returns an error if the given value's type is not supported
+// by this encoder.
+func (e *Encoder) Encode(value cadence.Value) (err error) {
+	return e.EncodeValue(value)
+}
+
+//
+// Values
+//
+
+// EncodeValue encodes any supported cadence.Value.
+func (e *Encoder) EncodeValue(value cadence.Value) (err error) {
+	// Non-recursable types
+	switch v := value.(type) {
+	case cadence.Void:
+		return e.EncodeValueIdentifier(EncodedValueVoid)
+	case cadence.Bool:
+		err = e.EncodeValueIdentifier(EncodedValueBool)
+		if err != nil {
+			return
+		}
+		return common_codec.EncodeBool(&e.w, bool(v))
+	}
+
+	switch v := value.(type) {
+	case cadence.Optional:
+		err = e.EncodeValueIdentifier(EncodedValueOptional)
+		if err != nil {
+			return
+		}
+		return e.EncodeOptional(v)
+	case cadence.Array:
+		// TODO if an array type is known ahead of time, what needs to be encoded and what can be excluded?
+		//      specifically, how much of ArrayType is needed? Just constant vs variable?
+		//		aka is Size part of what's known ahead of time? it's certainly encoded in the sema type
+		err = e.EncodeValueIdentifier(EncodedValueArray)
+		if err != nil {
+			return
+		}
+		return e.EncodeArray(v)
+	}
+
+	return fmt.Errorf("unexpected value: ${value}")
+}
+
+type EncodedValue byte
+
+const (
+	EncodedValueUnknown EncodedValue = iota
+
+	EncodedValueVoid
+	EncodedValueBool
+	EncodedValueArray
+	EncodedValueOptional
+)
+
+func (e *Encoder) EncodeValueIdentifier(id EncodedValue) (err error) {
+	return e.write([]byte{byte(id)})
+}
+
+func (e *Encoder) EncodeOptional(value cadence.Optional) (err error) {
+	isNil := value.Value == nil
+	err = common_codec.EncodeBool(&e.w, isNil)
+	if isNil || err != nil {
+		return
+	}
+
+	return e.EncodeValue(value.Value)
+}
+
+// TODO handle encode/decode of the two array types in a cleaner way
+func (e *Encoder) EncodeArray(value cadence.Array) (err error) {
+	err = e.EncodeArrayType(value.ArrayType)
+	if err != nil {
+		return
+	}
+
+	switch v := value.ArrayType.(type) {
+	case cadence.VariableSizedArrayType:
+		err = e.EncodeLength(len(value.Values))
+		if err != nil {
+			return
+		}
+	case cadence.ConstantSizedArrayType:
+		if len(value.Values) != int(v.Size) {
+			return fmt.Errorf("constant size array size=%d but has %d elements", v.Size, len(value.Values))
+		}
+	}
+
+	for _, element := range value.Values {
+		err = e.EncodeValue(element)
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+//
+// Types
+//
+
+func (e *Encoder) EncodeType(t cadence.Type) (err error) {
+	switch actualType := t.(type) {
+	case cadence.VoidType:
+		return e.EncodeTypeIdentifier(EncodedTypeVoid)
+	case cadence.BoolType:
+		return e.EncodeTypeIdentifier(EncodedTypeBool)
+	case cadence.OptionalType:
+		err = e.EncodeTypeIdentifier(EncodedTypeVoid)
+		if err != nil {
+			return
+		}
+		return e.EncodeOptionalType(actualType)
+	case cadence.AnyType:
+		return e.EncodeTypeIdentifier(EncodedTypeAnyType)
+	case cadence.AnyStructType:
+		return e.EncodeTypeIdentifier(EncodedTypeAnyStructType)
+	}
+
+	if bufferOffset, usePointer := e.typeDefs[t]; usePointer {
+		return e.EncodePointer(bufferOffset)
+	}
+	e.typeDefs[t] = e.w.Len() + 1 // point to encoded type, not its identifier
+
+	switch actualType := t.(type) {
+	case cadence.ArrayType:
+		return e.EncodeArrayType(actualType)
+	}
+
+	return fmt.Errorf("unknown type: %s", t)
+}
+
+func (e *Encoder) EncodeTypeIdentifier(id EncodedType) (err error) {
+	return e.write([]byte{byte(id)})
+}
+
+type EncodedType byte
+
+const (
+	EncodedTypeUnknown EncodedType = iota
+
+	// Concrete Types
+
+	EncodedTypeVoid
+	EncodedTypeBool
+
+	// Abstract Types
+
+	EncodedTypeAnyType
+	EncodedTypeAnyStructType
+
+	// Pointable Types
+
+	EncodedTypeArray
+	EncodedTypeOptional
+
+	// Other Types
+
+	EncodedTypePointer
+)
+
+func (e *Encoder) EncodePointer(bufferOffset int) (err error) {
+	err = e.write([]byte{byte(EncodedTypePointer)})
+	if err != nil {
+		return
+	}
+
+	return e.EncodeLength(bufferOffset)
+}
+
+func (e *Encoder) EncodeOptionalType(t cadence.OptionalType) (err error) {
+	return e.EncodeType(t.Type)
+}
+
+type EncodedArrayType byte
+
+const (
+	EncodedArrayTypeUnknown EncodedArrayType = iota
+	EncodedArrayTypeVariable
+	EncodedArrayTypeConstant
+)
+
+func (e *Encoder) EncodeArrayType(t cadence.ArrayType) (err error) {
+	var b EncodedArrayType
+	switch t.(type) {
+	case cadence.VariableSizedArrayType:
+		b = EncodedArrayTypeVariable
+	case cadence.ConstantSizedArrayType:
+		b = EncodedArrayTypeConstant
+	default:
+		return fmt.Errorf("unknown array type: %s", t)
+	}
+	err = e.write([]byte{byte(b)})
+	if err != nil {
+		return
+	}
+
+	err = e.EncodeType(t.Element())
+	if err != nil {
+		return
+	}
+
+	switch concreteType := t.(type) {
+	case cadence.ConstantSizedArrayType:
+		err = e.EncodeLength(int(concreteType.Size))
+	}
+
+	return
+}
+
+//
+// Other
+//
+
+// EncodeLength encodes a non-negative length as a uint32.
+// It uses 4 bytes.
+func (e *Encoder) EncodeLength(length int) (err error) {
+	if length < 0 { // TODO is this safety check useful?
+		return fmt.Errorf("cannot encode length below zero: %d", length)
+	}
+
+	l := uint32(length)
+
+	return binary.Write(&e.w, binary.BigEndian, l)
+}
+
+func (e *Encoder) write(b []byte) (err error) {
+	_, err = e.w.Write(b)
+	return
+}

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -221,11 +221,6 @@ func exportValueWithInterpreter(
 	case *interpreter.CapabilityValue:
 		return exportCapabilityValue(v, inter), nil
 	case *interpreter.EphemeralReferenceValue:
-		// TODO (robert) this strategy is very inefficient, right?
-		//      it looks like it exports the referenced value except for its ephemeral references...
-		//      even if the references value is a parent value too,
-		//      so it could almost double the eventual encoding size
-
 		// Break recursion through ephemeral references
 		if _, ok := seenReferences[v]; ok {
 			return nil, nil

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -65,7 +65,7 @@ type seenReferences map[*interpreter.EphemeralReferenceValue]struct{}
 
 // exportValueWithInterpreter exports the given internal (interpreter) value to an external value.
 //
-// The export is recursive, the results parameter prevents cycles:
+// The export is recursive, the seenReferences parameter prevents cycles:
 // it is checked at the start of the recursively called function,
 // and pre-set before a recursive call.
 //
@@ -221,6 +221,11 @@ func exportValueWithInterpreter(
 	case *interpreter.CapabilityValue:
 		return exportCapabilityValue(v, inter), nil
 	case *interpreter.EphemeralReferenceValue:
+		// TODO (robert) this strategy is very inefficient, right?
+		//      it looks like it exports the referenced value except for its ephemeral references...
+		//      even if the references value is a parent value too,
+		//      so it could almost double the eventual encoding size
+
 		// Break recursion through ephemeral references
 		if _, ok := seenReferences[v]; ok {
 			return nil, nil

--- a/types.go
+++ b/types.go
@@ -777,6 +777,8 @@ type VariableSizedArrayType struct {
 	ElementType Type
 }
 
+var _ ArrayType = VariableSizedArrayType{}
+
 func NewVariableSizedArrayType(
 	elementType Type,
 ) VariableSizedArrayType {
@@ -807,6 +809,8 @@ type ConstantSizedArrayType struct {
 	Size        uint
 	ElementType Type
 }
+
+var _ ArrayType = ConstantSizedArrayType{}
 
 func NewConstantSizedArrayType(
 	size uint,
@@ -930,6 +934,8 @@ type StructType struct {
 	Initializers        [][]Parameter
 }
 
+var _ CompositeType = &StructType{}
+
 func NewStructType(
 	location common.Location,
 	qualifiedIdentifier string,
@@ -995,6 +1001,8 @@ type ResourceType struct {
 	Fields              []Field
 	Initializers        [][]Parameter
 }
+
+var _ CompositeType = &ResourceType{}
 
 func NewResourceType(
 	location common.Location,
@@ -1062,6 +1070,8 @@ type EventType struct {
 	Initializer         []Parameter
 }
 
+var _ CompositeType = &EventType{}
+
 func NewEventType(
 	location common.Location,
 	qualifiedIdentifer string,
@@ -1127,6 +1137,8 @@ type ContractType struct {
 	Fields              []Field
 	Initializers        [][]Parameter
 }
+
+var _ CompositeType = &ContractType{}
 
 func NewContractType(
 	location common.Location,
@@ -1206,6 +1218,8 @@ type StructInterfaceType struct {
 	Initializers        [][]Parameter
 }
 
+var _ InterfaceType = &StructInterfaceType{}
+
 func NewStructInterfaceType(
 	location common.Location,
 	qualifiedIdentifier string,
@@ -1272,6 +1286,8 @@ type ResourceInterfaceType struct {
 	Initializers        [][]Parameter
 }
 
+var _ InterfaceType = &ResourceInterfaceType{}
+
 func NewResourceInterfaceType(
 	location common.Location,
 	qualifiedIdentifier string,
@@ -1337,6 +1353,8 @@ type ContractInterfaceType struct {
 	Fields              []Field
 	Initializers        [][]Parameter
 }
+
+var _ InterfaceType = &ContractInterfaceType{}
 
 func NewContractInterfaceType(
 	location common.Location,


### PR DESCRIPTION
Progress towards https://github.com/onflow/cadence/issues/1715

## Description

This is the first pass at encoding/decoding cadence.Value and cadence.Type in a performant format. This PR in particular emulates the same work done for the sema types. The sema codec is also affected because common code has been refactored out.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
