### PR TITLE
Append special prefix to all internal error string messages

### DIFF
--- a/runtime/errors/errors.go
+++ b/runtime/errors/errors.go
@@ -145,7 +145,7 @@ func (e UnexpectedError) Unwrap() error {
 }
 
 func (e UnexpectedError) Error() string {
-	return fmt.Sprintf("%s\n%s", e.Err.Error(), e.Stack)
+	return fmt.Sprintf("internal error: %s\n%s", e.Err.Error(), e.Stack)
 }
 
 // DefaultUserError is the default implementation of UserError interface.

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -54,7 +54,7 @@ func (UnsupportedTagDecodingError) IsInternalError() {}
 
 func (e UnsupportedTagDecodingError) Error() string {
 	return fmt.Sprintf(
-		"unsupported decoded tag: %d",
+		"internal error: unsupported decoded tag: %d",
 		e.Tag,
 	)
 }
@@ -69,7 +69,7 @@ func (InvalidStringLengthError) IsInternalError() {}
 
 func (e InvalidStringLengthError) Error() string {
 	return fmt.Sprintf(
-		"invalid string length: got %d, expected max %d",
+		"internal error: invalid string length: got %d, expected max %d",
 		e.Length,
 		goMaxInt,
 	)

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -42,7 +42,7 @@ func (*unsupportedOperation) IsInternalError() {}
 
 func (e *unsupportedOperation) Error() string {
 	return fmt.Sprintf(
-		"cannot evaluate unsupported %s operation: %s",
+		"internal error: cannot evaluate unsupported %s operation: %s",
 		e.kind.Name(),
 		e.operation.Symbol(),
 	)


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/1686

## Description

Adds a special prefix `internal error:` to the error messages of all internal errors (errors that implements `InternalError`).

This has been already done for `InvalidatedResourceError`. https://github.com/onflow/cadence/blob/443ea529bed196b0ce0dc138246ee000ad4250fe/runtime/interpreter/errors.go#L292-L294

This PR adds the same for the remaining internal errors.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
