### PR TITLE
Fix minor typo: language docs - consts & vars

### DIFF
--- a/docs/language/constants-and-variables.md
+++ b/docs/language/constants-and-variables.md
@@ -10,7 +10,7 @@ Declarations can be created in any scope, including the global scope.
 
 Constant means that the *identifier's* association is constant,
 not the *value* itself –
-the value may still be changed if is mutable.
+the value may still be changed if it is mutable.
 
 Constants are declared using the `let` keyword. Variables are declared
 using the `var` keyword.


### PR DESCRIPTION
Closes #N/A

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Minor edit correcting typo on language docs.
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
