### PR TITLE
[Test Framework] Add helper function for contract deployment

### DIFF
--- a/runtime/interpreter/test-framework.go
+++ b/runtime/interpreter/test-framework.go
@@ -46,6 +46,14 @@ type TestFramework interface {
 	ExecuteNextTransaction() *TransactionResult
 
 	CommitBlock() error
+
+	DeployContract(
+		name string,
+		code string,
+		args []Value,
+		authorizer common.Address,
+		signers []*Account,
+	) error
 }
 
 type ScriptResult struct {

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -443,7 +443,7 @@ var emulatorBackendExecuteScriptFunction = interpreter.NewUnmeteredHostFunctionV
 
 		result := testFramework.RunScript(script, args)
 
-		return createScriptResult(invocation.Interpreter, result.Value, result)
+		return newScriptResult(invocation.Interpreter, result.Value, result)
 	},
 	emulatorBackendExecuteScriptFunctionType,
 )
@@ -464,9 +464,9 @@ func arrayValueToSlice(value interpreter.Value) ([]interpreter.Value, error) {
 	return result, nil
 }
 
-// createScriptResult Creates a "ScriptResult" using the return value of the executed script.
+// newScriptResult Creates a "ScriptResult" using the return value of the executed script.
 //
-func createScriptResult(
+func newScriptResult(
 	inter *interpreter.Interpreter,
 	returnValue interpreter.Value,
 	result *interpreter.ScriptResult,
@@ -488,11 +488,11 @@ func createScriptResult(
 		succeededVar := resultStatusConstructor.NestedVariables[succeededCaseName]
 		status = succeededVar.GetValue()
 	} else {
-		succeededVar := resultStatusConstructor.NestedVariables[failedCaseName]
-		status = succeededVar.GetValue()
+		failedVar := resultStatusConstructor.NestedVariables[failedCaseName]
+		status = failedVar.GetValue()
 	}
 
-	errValue := createError(inter, result.Error)
+	errValue := newErrorValue(inter, result.Error)
 
 	// Create a 'ScriptResult' by calling its constructor.
 
@@ -975,14 +975,14 @@ var emulatorBackendExecuteNextTransactionFunction = interpreter.NewUnmeteredHost
 			return interpreter.NilValue{}
 		}
 
-		return createTransactionResult(invocation.Interpreter, result)
+		return newTransactionResult(invocation.Interpreter, result)
 	},
 	emulatorBackendExecuteNextTransactionFunctionType,
 )
 
-// createTransactionResult Creates a "TransactionResult" indicating the status of the transaction execution.
+// newTransactionResult Creates a "TransactionResult" indicating the status of the transaction execution.
 //
-func createTransactionResult(inter *interpreter.Interpreter, result *interpreter.TransactionResult) interpreter.Value {
+func newTransactionResult(inter *interpreter.Interpreter, result *interpreter.TransactionResult) interpreter.Value {
 	// Lookup and get 'ResultStatus' enum value.
 	resultStatusConstructorVar := inter.Activations.Find(resultStatusTypeName)
 	resultStatusConstructor, ok := resultStatusConstructorVar.GetValue().(*interpreter.HostFunctionValue)
@@ -995,8 +995,8 @@ func createTransactionResult(inter *interpreter.Interpreter, result *interpreter
 		succeededVar := resultStatusConstructor.NestedVariables[succeededCaseName]
 		status = succeededVar.GetValue()
 	} else {
-		succeededVar := resultStatusConstructor.NestedVariables[failedCaseName]
-		status = succeededVar.GetValue()
+		failedVar := resultStatusConstructor.NestedVariables[failedCaseName]
+		status = failedVar.GetValue()
 	}
 
 	// Create a 'TransactionResult' by calling its constructor.
@@ -1006,7 +1006,7 @@ func createTransactionResult(inter *interpreter.Interpreter, result *interpreter
 		panic(errors.NewUnexpectedError("invalid type for constructor"))
 	}
 
-	errValue := createError(inter, result.Error)
+	errValue := newErrorValue(inter, result.Error)
 
 	transactionResult, err := inter.InvokeExternally(
 		transactionResultConstructor,
@@ -1024,7 +1024,7 @@ func createTransactionResult(inter *interpreter.Interpreter, result *interpreter
 	return transactionResult
 }
 
-func createError(inter *interpreter.Interpreter, err error) interpreter.Value {
+func newErrorValue(inter *interpreter.Interpreter, err error) interpreter.Value {
 	if err == nil {
 		return interpreter.NilValue{}
 	}
@@ -1180,7 +1180,7 @@ var emulatorBackendDeployContractFunction = interpreter.NewUnmeteredHostFunction
 			signers,
 		)
 
-		return createError(inter, err)
+		return newErrorValue(inter, err)
 	},
 	emulatorBackendDeployContractFunctionType,
 )

--- a/test-framework/emulator_backend.go
+++ b/test-framework/emulator_backend.go
@@ -19,6 +19,9 @@
 package test
 
 import (
+	"encoding/hex"
+	"fmt"
+	"github.com/onflow/cadence"
 	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/onflow/flow-go-sdk/test"
@@ -269,6 +272,86 @@ func (e *EmulatorBackend) CommitBlock() error {
 
 	_, err := e.blockchain.CommitBlock()
 	return err
+}
+
+func (e *EmulatorBackend) DeployContract(
+	name string,
+	code string,
+	args []interpreter.Value,
+	authorizer common.Address,
+	signers []*interpreter.Account,
+) error {
+
+	const deployContractTransactionTemplate = `
+	    transaction(%s) {
+		    prepare(signer: AuthAccount) {
+			    signer.contracts.add(name: "%s", code: "%s".decodeHex()%s)
+		    }
+	    }`
+
+	hexEncodedCode := hex.EncodeToString([]byte(code))
+
+	inter, err := newInterpreter()
+	if err != nil {
+		return err
+	}
+
+	cadenceArgs := make([]cadence.Value, 0, len(args))
+
+	txArgs, addArgs := "", ""
+
+	for i, arg := range args {
+		cadenceArg, err := runtime.ExportValue(arg, inter, interpreter.ReturnEmptyLocationRange)
+		if err != nil {
+			return err
+		}
+
+		if i > 0 {
+			txArgs += ", "
+		}
+
+		txArgs += fmt.Sprintf("arg%d: %s", i, cadenceArg.Type().ID())
+		addArgs += fmt.Sprintf(", arg%d", i)
+
+		cadenceArgs = append(cadenceArgs, cadenceArg)
+	}
+
+	script := fmt.Sprintf(
+		deployContractTransactionTemplate,
+		txArgs,
+		name,
+		hexEncodedCode,
+		addArgs,
+	)
+
+	tx := e.newTransaction(script, &authorizer)
+
+	for _, arg := range cadenceArgs {
+		err = tx.AddArgument(arg)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = e.signTransaction(tx, signers)
+	if err != nil {
+		return err
+	}
+
+	err = e.blockchain.AddTransaction(*tx)
+	if err != nil {
+		return err
+	}
+
+	// Increment the transaction sequence number offset for the current block.
+	e.blockOffset++
+
+	result := e.ExecuteNextTransaction()
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return e.CommitBlock()
 }
 
 // newBlockchain returns an emulator blockchain for testing.

--- a/test-framework/test_framework_test.go
+++ b/test-framework/test_framework_test.go
@@ -830,3 +830,73 @@ func TestExecutingTransactions(t *testing.T) {
 		assert.Contains(t, err.Error(), "is currently being executed")
 	})
 }
+
+func TestDeployingContracts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no args", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+            import Test
+
+            pub fun test() {
+                var blockchain = Test.newEmulatorBlockchain()
+                var account = blockchain.createAccount()
+
+                blockchain.deployContract(
+                    "Foo",
+                    "pub contract Foo{ init(){}  pub fun sayHello(): String { return \"hello from Foo\"} }",
+                    account.address,
+                    [account],
+                    [],
+                )
+
+                var script = "import Foo from ".concat(account.address.toString()).concat("\n")
+                script = script.concat("pub fun main(): String {  return Foo.sayHello() }")
+
+                var result = blockchain.executeScript(script, [])
+
+                assert(result.status == Test.ResultStatus.succeeded)
+                assert((result.returnValue! as! String) == "hello from Foo")
+            }
+        `
+
+		runner := NewTestRunner()
+		err := runner.RunTest(code, "test")
+		assert.NoError(t, err)
+	})
+
+	t.Run("no args", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+            import Test
+
+            pub fun test() {
+                var blockchain = Test.newEmulatorBlockchain()
+                var account = blockchain.createAccount()
+
+                blockchain.deployContract(
+                    "Foo",
+                    "pub contract Foo{ init(){}  pub fun sayHello(): String { return \"hello from Foo\"} }",
+                    account.address,
+                    [account],
+                    [],
+                )
+
+                var script = "import Foo from ".concat(account.address.toString()).concat("\n")
+                script = script.concat("pub fun main(): String {  return Foo.sayHello() }")
+
+                var result = blockchain.executeScript(script, [])
+
+                assert(result.status == Test.ResultStatus.succeeded)
+                assert((result.returnValue! as! String) == "hello from Foo")
+            }
+        `
+
+		runner := NewTestRunner()
+		err := runner.RunTest(code, "test")
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/331

## Description
Introduced a utility function to deploy a contract to the blockchain.

```cadence
let err = blockchain.deployContract(
    contractName,
    contractCode,
    authorizerAddress,
    signers,
    contractInitArgs,
)
```
Devs can also deploy contracts using a transaction. This is a utility method that does the same under the hood.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
