### PR TITLE
Preallocate ordered maps

### DIFF
--- a/runtime/common/list/list.go
+++ b/runtime/common/list/list.go
@@ -59,7 +59,9 @@ func (l *List[T]) Init() *List[T] {
 }
 
 // New returns an initialized list.
-func New[T any]() *List[T] { return new(List[T]).Init() }
+func New[T any]() *List[T] {
+	return new(List[T]).Init()
+}
 
 // Len returns the number of elements of list l.
 // The complexity is O(1).

--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -32,6 +32,14 @@ type OrderedMap[K comparable, V any] struct {
 	list  *list.List[*Pair[K, V]]
 }
 
+// New returns a new OrderedMap of the given size
+func New[T OrderedMap[K, V], K comparable, V any](size int) *T {
+	return &T{
+		pairs: make(map[K]*Pair[K, V], size),
+		list:  list.New[*Pair[K, V]](),
+	}
+}
+
 func (om *OrderedMap[K, V]) ensureInitialized() {
 	if om.pairs != nil {
 		return

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -21,6 +21,7 @@ package sema
 import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -82,9 +83,10 @@ func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDecl
 		// The initializer must initialize all members that are fields,
 		// e.g. not composite functions (which are by definition constant and "initialized")
 
-		fieldMembers := &MemberFieldDeclarationOrderedMap{}
+		fields := declaration.Members.Fields()
+		fieldMembers := orderedmap.New[MemberFieldDeclarationOrderedMap](len(fields))
 
-		for _, field := range declaration.Members.Fields() {
+		for _, field := range fields {
 			fieldName := field.Identifier.Identifier
 			member, ok := compositeType.Members.Get(fieldName)
 			if !ok {
@@ -504,7 +506,8 @@ func (checker *Checker) declareCompositeMembersAndValue(
 		panic(errors.NewUnreachableError())
 	}
 
-	declarationMembers := &StringMemberOrderedMap{}
+	nestedComposites := declaration.Members.Composites()
+	declarationMembers := orderedmap.New[StringMemberOrderedMap](len(nestedComposites))
 
 	(func() {
 		// Activate new scopes for nested types
@@ -542,7 +545,7 @@ func (checker *Checker) declareCompositeMembersAndValue(
 		//   }
 		// }
 		// ```
-		for _, nestedCompositeDeclaration := range declaration.Members.Composites() {
+		for _, nestedCompositeDeclaration := range nestedComposites {
 			checker.declareCompositeMembersAndValue(nestedCompositeDeclaration, kind)
 
 			// Declare nested composites' values (constructor/instance) as members of the containing composite

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -21,6 +21,7 @@ package sema
 import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -35,9 +36,10 @@ func (checker *Checker) VisitTransactionDeclaration(declaration *ast.Transaction
 		checker.containerTypes[transactionType] = false
 	}()
 
-	fieldMembers := &MemberFieldDeclarationOrderedMap{}
+	fields := declaration.Fields
+	fieldMembers := orderedmap.New[MemberFieldDeclarationOrderedMap](len(fields))
 
-	for _, field := range declaration.Fields {
+	for _, field := range fields {
 		fieldName := field.Identifier.Identifier
 		member, ok := transactionType.Members.Get(fieldName)
 


### PR DESCRIPTION
In some cases the final size of the ordered map is apparent at creation time. Preallocate the final size.
There might be more cases that could benefit from this
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
