### PR TITLE
[Test Framework] Remove test-framework field from interpreter

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -363,7 +363,6 @@ type Interpreter struct {
 	resourceVariables                    map[ResourceKindedValue]*Variable
 	memoryGauge                          common.MemoryGauge
 	CallStack                            *CallStack
-	TestFramework                        TestFramework
 }
 
 var _ common.MemoryGauge = &Interpreter{}
@@ -686,15 +685,6 @@ func WithDebugger(debugger *Debugger) Option {
 	}
 }
 
-// WithTestFramework returns an interpreter option which sets the given test framework
-//
-func WithTestFramework(testFramework TestFramework) Option {
-	return func(interpreter *Interpreter) error {
-		interpreter.SetTestFramework(testFramework)
-		return nil
-	}
-}
-
 // Create a base-activation so that it can be reused across all interpreters.
 //
 var baseActivation = func() *VariableActivation {
@@ -921,12 +911,6 @@ func (interpreter *Interpreter) setTypeCodes(typeCodes TypeCodes) {
 //
 func (interpreter *Interpreter) SetDebugger(debugger *Debugger) {
 	interpreter.debugger = debugger
-}
-
-// SetTestFramework sets the test framework to be used for running tests.
-//
-func (interpreter *Interpreter) SetTestFramework(testFramework TestFramework) {
-	interpreter.TestFramework = testFramework
 }
 
 // locationRangeGetter returns a function that returns the location range
@@ -2747,7 +2731,6 @@ func (interpreter *Interpreter) NewSubInterpreter(
 		WithOnResourceOwnerChangeHandler(interpreter.onResourceOwnerChange),
 		WithOnMeterComputationFuncHandler(interpreter.onMeterComputation),
 		WithMemoryGauge(interpreter.memoryGauge),
-		WithTestFramework(interpreter.TestFramework),
 	}
 
 	return NewInterpreter(

--- a/test-framework/test_framework.go
+++ b/test-framework/test_framework.go
@@ -305,13 +305,13 @@ func contractVariableHandler(
 }
 
 func (r *TestRunner) interpreterOptions(ctx runtime.Context) []interpreter.Option {
+
 	return []interpreter.Option{
 		// TODO: The default injected fields handler only supports 'address' locations.
 		//   However, during tests, it is possible to get non-address locations. e.g: file paths.
 		//   Thus, need to properly handle them. Make this nil for now.
 		interpreter.WithInjectedCompositeFieldsHandler(nil),
 
-		interpreter.WithTestFramework(NewEmulatorBackend(r.importResolver)),
 		interpreter.WithImportLocationHandler(
 			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				switch location {
@@ -377,8 +377,10 @@ func (r *TestRunner) interpreterOptions(ctx runtime.Context) []interpreter.Optio
 				return contract
 
 			case stdlib.TestContractLocation:
+				testFramework := NewEmulatorBackend(r.importResolver)
 				contract, err := stdlib.NewTestContract(
 					inter,
+					testFramework,
 					constructorGenerator(common.Address{}),
 					invocationRange,
 				)


### PR DESCRIPTION
## Description

Removes the test-framework field from the interpreter. Instead, pass it as an argument where necessary.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
