### PR TITLE
[Test Framework] Provide a way to specify addresses for the imports

### DIFF
--- a/runtime/interpreter/test-framework.go
+++ b/runtime/interpreter/test-framework.go
@@ -55,6 +55,8 @@ type TestFramework interface {
 	) error
 
 	ReadFile(string) (string, error)
+
+	UseConfigs(configurations *Configurations)
 }
 
 type ScriptResult struct {
@@ -74,6 +76,10 @@ type Account struct {
 type PublicKey struct {
 	PublicKey []byte
 	SignAlgo  sema.SignatureAlgorithm
+}
+
+type Configurations struct {
+	AddressMapping map[string]common.Address
 }
 
 // TestFrameworkNotProvidedError is the error thrown if test-stdlib functionality is

--- a/runtime/interpreter/test-framework.go
+++ b/runtime/interpreter/test-framework.go
@@ -56,7 +56,7 @@ type TestFramework interface {
 
 	ReadFile(string) (string, error)
 
-	UseConfiguration(configurations *Configurations)
+	UseConfiguration(configuration *Configuration)
 }
 
 type ScriptResult struct {
@@ -78,7 +78,7 @@ type PublicKey struct {
 	SignAlgo  sema.SignatureAlgorithm
 }
 
-type Configurations struct {
+type Configuration struct {
 	Addresses map[string]common.Address
 }
 

--- a/runtime/interpreter/test-framework.go
+++ b/runtime/interpreter/test-framework.go
@@ -56,7 +56,7 @@ type TestFramework interface {
 
 	ReadFile(string) (string, error)
 
-	UseConfigs(configurations *Configurations)
+	UseConfiguration(configurations *Configurations)
 }
 
 type ScriptResult struct {
@@ -79,7 +79,7 @@ type PublicKey struct {
 }
 
 type Configurations struct {
-	AddressMapping map[string]common.Address
+	Addresses map[string]common.Address
 }
 
 // TestFrameworkNotProvidedError is the error thrown if test-stdlib functionality is

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -98,8 +98,8 @@ pub contract Test {
             )
         }
 
-        pub fun useConfiguration(_ confgiurations: Configurations) {
-            self.backend.useConfiguration(confgiurations)
+        pub fun useConfiguration(_ confgiuration: Configuration) {
+            self.backend.useConfiguration(confgiuration)
         }
     }
 
@@ -158,13 +158,13 @@ pub contract Test {
         }
     }
 
-    /// Configurations to be used by the blockchain.
+    /// Configuration to be used by the blockchain.
     /// Can be used to set the address mappings.
     ///
-    pub struct Configurations {
-        pub let addresses: { String: Address }
+    pub struct Configuration {
+        pub let addresses: {String: Address}
 
-        init(addresses: { String: Address }) {
+        init(addresses: {String: Address}) {
             self.addresses = addresses
         }
     }
@@ -206,6 +206,6 @@ pub contract Test {
             arguments: [AnyStruct]
         ): Error?
 
-        pub fun useConfiguration(_ confgiurations: Configurations)
+        pub fun useConfiguration(_ confgiuration: Configuration)
     }
 }

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -99,7 +99,7 @@ pub contract Test {
         }
 
         pub fun useConfiguration(_ confgiurations: Configurations) {
-            self.backend.useConfig(confgiurations)
+            self.backend.useConfiguration(confgiurations)
         }
     }
 
@@ -160,7 +160,7 @@ pub contract Test {
 
     /// Configurations to be used by the blockchain.
     /// Can be used to set the address mappings.
-    //'
+    ///
     pub struct Configurations {
         pub let addresses: { String: Address }
 
@@ -206,6 +206,6 @@ pub contract Test {
             arguments: [AnyStruct]
         ): Error?
 
-        pub fun useConfig(_ confgiurations: Configurations)
+        pub fun useConfiguration(_ confgiurations: Configurations)
     }
 }

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -4,6 +4,15 @@
 ///
 pub contract Test {
 
+    /// Convenient function to fail a test.
+    /// Is equivalent to calling `assert(false)`.
+    ///
+    pub fun fail() {
+        assert(false)
+    }
+
+    /// Blockchain emulates a real network.
+    ///
     pub struct Blockchain {
 
         pub let backend: AnyStruct{BlockchainBackend}

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -4,15 +4,6 @@
 ///
 pub contract Test {
 
-    /// Convenient function to fail a test.
-    /// Is equivalent to calling `assert(false)`.
-    ///
-    pub fun fail() {
-        assert(false)
-    }
-
-    /// Blockchain emulates a real network.
-    ///
     pub struct Blockchain {
 
         pub let backend: AnyStruct{BlockchainBackend}
@@ -97,6 +88,10 @@ pub contract Test {
                 arguments: arguments
             )
         }
+
+        pub fun useConfiguration(_ confgiurations: Configurations) {
+            self.backend.useConfig(confgiurations)
+        }
     }
 
     /// ResultStatus indicates status of a transaction or script execution.
@@ -154,6 +149,17 @@ pub contract Test {
         }
     }
 
+    /// Configurations to be used by the blockchain.
+    /// Can be used to set the address mappings.
+    //'
+    pub struct Configurations {
+        pub let addresses: { String: Address }
+
+        init(addresses: { String: Address }) {
+            self.addresses = addresses
+        }
+    }
+
     /// Transaction that can be submitted and executed on the blockchain.
     ///
     pub struct Transaction {
@@ -190,5 +196,7 @@ pub contract Test {
             account: Account,
             arguments: [AnyStruct]
         ): Error?
+
+        pub fun useConfig(_ confgiurations: Configurations)
     }
 }

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -634,9 +634,9 @@ var EmulatorBackendType = func() *sema.CompositeType {
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			emulatorBackendUseConfigsFunctionName,
-			emulatorBackendUseConfigsFunctionType,
-			emulatorBackendUseConfigsFunctionDocString,
+			emulatorBackendUseConfigFunctionName,
+			emulatorBackendUseConfigFunctionType,
+			emulatorBackendUseConfigFunctionDocString,
 		),
 	}
 
@@ -676,8 +676,8 @@ func newEmulatorBackend(
 			Value: emulatorBackendDeployContractFunction(testFramework),
 		},
 		{
-			Name:  emulatorBackendUseConfigsFunctionName,
-			Value: emulatorBackendUseConfigsFunction(testFramework),
+			Name:  emulatorBackendUseConfigFunctionName,
+			Value: emulatorBackendUseConfigFunction(testFramework),
 		},
 	}
 
@@ -1371,19 +1371,19 @@ func emulatorBackendDeployContractFunction(testFramework interpreter.TestFramewo
 
 // 'EmulatorBackend.useConfiguration' function
 
-const emulatorBackendUseConfigsFunctionName = "useConfiguration"
+const emulatorBackendUseConfigFunctionName = "useConfiguration"
 
-const emulatorBackendUseConfigsFunctionDocString = `Use configurations function`
+const emulatorBackendUseConfigFunctionDocString = `Use configurations function`
 
-var emulatorBackendUseConfigsFunctionType = func() *sema.FunctionType {
+var emulatorBackendUseConfigFunctionType = func() *sema.FunctionType {
 	// The type of the 'useConfiguration' function of 'EmulatorBackend' (interface-implementation)
 	// is same as that of 'BlockchainBackend' interface.
-	typ, ok := blockchainBackendInterfaceType.Members.Get(emulatorBackendUseConfigsFunctionName)
+	typ, ok := blockchainBackendInterfaceType.Members.Get(emulatorBackendUseConfigFunctionName)
 	if !ok {
 		panic(errors.NewUnexpectedError(
 			"cannot find member %s.%s",
 			blockchainBackendTypeName,
-			emulatorBackendUseConfigsFunctionName,
+			emulatorBackendUseConfigFunctionName,
 		))
 	}
 
@@ -1391,14 +1391,14 @@ var emulatorBackendUseConfigsFunctionType = func() *sema.FunctionType {
 	if !ok {
 		panic(errors.NewUnexpectedError(
 			"invalid type for %s. expected function",
-			emulatorBackendUseConfigsFunctionName,
+			emulatorBackendUseConfigFunctionName,
 		))
 	}
 
 	return functionType
 }()
 
-func emulatorBackendUseConfigsFunction(testFramework interpreter.TestFramework) *interpreter.HostFunctionValue {
+func emulatorBackendUseConfigFunction(testFramework interpreter.TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
 		func(invocation interpreter.Invocation) interpreter.Value {
 			inter := invocation.Interpreter
@@ -1436,13 +1436,13 @@ func emulatorBackendUseConfigsFunction(testFramework interpreter.TestFramework) 
 				return true
 			})
 
-			testFramework.UseConfiguration(&interpreter.Configurations{
+			testFramework.UseConfiguration(&interpreter.Configuration{
 				Addresses: mapping,
 			})
 
 			return interpreter.VoidValue{}
 		},
-		emulatorBackendUseConfigsFunctionType,
+		emulatorBackendUseConfigFunctionType,
 	)
 }
 

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1369,14 +1369,14 @@ func emulatorBackendDeployContractFunction(testFramework interpreter.TestFramewo
 	)
 }
 
-// 'EmulatorBackend.useConfig' function
+// 'EmulatorBackend.useConfiguration' function
 
-const emulatorBackendUseConfigsFunctionName = "useConfig"
+const emulatorBackendUseConfigsFunctionName = "useConfiguration"
 
 const emulatorBackendUseConfigsFunctionDocString = `Use configurations function`
 
 var emulatorBackendUseConfigsFunctionType = func() *sema.FunctionType {
-	// The type of the 'UseConfigs' function of 'EmulatorBackend' (interface-implementation)
+	// The type of the 'useConfiguration' function of 'EmulatorBackend' (interface-implementation)
 	// is same as that of 'BlockchainBackend' interface.
 	typ, ok := blockchainBackendInterfaceType.Members.Get(emulatorBackendUseConfigsFunctionName)
 	if !ok {
@@ -1436,8 +1436,8 @@ func emulatorBackendUseConfigsFunction(testFramework interpreter.TestFramework) 
 				return true
 			})
 
-			testFramework.UseConfigs(&interpreter.Configurations{
-				AddressMapping: mapping,
+			testFramework.UseConfiguration(&interpreter.Configurations{
+				Addresses: mapping,
 			})
 
 			return interpreter.VoidValue{}

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1381,7 +1381,7 @@ var emulatorBackendUseConfigsFunctionType = func() *sema.FunctionType {
 	typ, ok := blockchainBackendInterfaceType.Members.Get(emulatorBackendUseConfigsFunctionName)
 	if !ok {
 		panic(errors.NewUnexpectedError(
-			"cannot find type %s.%s",
+			"cannot find member %s.%s",
 			blockchainBackendTypeName,
 			emulatorBackendUseConfigsFunctionName,
 		))
@@ -1418,7 +1418,7 @@ func emulatorBackendUseConfigsFunction(testFramework interpreter.TestFramework) 
 				panic(errors.NewUnreachableError())
 			}
 
-			mapping := make(map[string]common.Address)
+			mapping := make(map[string]common.Address, addresses.Count())
 
 			addresses.Iterate(nil, func(locationValue, addressValue interpreter.Value) bool {
 				location, ok := locationValue.(*interpreter.StringValue)

--- a/test-framework/emulator_backend.go
+++ b/test-framework/emulator_backend.go
@@ -21,7 +21,6 @@ package test
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/onflow/cadence/runtime/parser"
 	"strings"
 
 	sdk "github.com/onflow/flow-go-sdk"
@@ -38,6 +37,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -58,11 +58,14 @@ type EmulatorBackend struct {
 	accountKeys map[common.Address]map[string]keyInfo
 
 	// Import resolver is used to resolve imports of the *test script*.
-	// Note: This doesn't resolve the imports for the codes that is being tested
+	//
+	// Note: This doesn't resolve the imports for the codes that is being tested.
 	// i.e: the code that is submitted to the blockchain.
 	// Use the configurations to set the import mapping to for the testing code.
 	importResolver ImportResolver
 
+	// A property bag to pass various configurations to the backend.
+	// Currently, supports passing address mapping for contracts.
 	configurations *interpreter.Configurations
 }
 
@@ -402,7 +405,7 @@ func newBlockchain(opts ...emulator.Option) *emulator.Blockchain {
 	return b
 }
 
-func (e *EmulatorBackend) UseConfigs(configurations *interpreter.Configurations) {
+func (e *EmulatorBackend) UseConfiguration(configurations *interpreter.Configurations) {
 	e.configurations = configurations
 }
 
@@ -465,7 +468,7 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 			continue
 		}
 
-		address := e.configurations.AddressMapping[location.String()]
+		address := e.configurations.Addresses[location.String()]
 
 		locationStr := fmt.Sprintf(`"%s"`, location)
 		addressStr := fmt.Sprintf("0x%s", address)

--- a/test-framework/emulator_backend.go
+++ b/test-framework/emulator_backend.go
@@ -462,6 +462,9 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 		panic(err)
 	}
 
+	sb := strings.Builder{}
+	prevLocationEnd := 0
+
 	for _, importDeclaration := range program.ImportDeclarations() {
 		location, ok := importDeclaration.Location.(common.StringLocation)
 		if !ok {
@@ -469,12 +472,17 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 		}
 
 		address := e.configurations.Addresses[location.String()]
-
-		locationStr := fmt.Sprintf(`"%s"`, location)
 		addressStr := fmt.Sprintf("0x%s", address)
 
-		code = strings.Replace(code, locationStr, addressStr, 1)
+		locationStart := importDeclaration.LocationPos.Offset
+
+		sb.WriteString(code[prevLocationEnd:locationStart])
+		sb.WriteString(addressStr)
+
+		prevLocationEnd = importDeclaration.EndPos.Offset + 1
 	}
 
-	return code
+	sb.WriteString(code[prevLocationEnd:])
+
+	return sb.String()
 }

--- a/test-framework/emulator_backend.go
+++ b/test-framework/emulator_backend.go
@@ -66,7 +66,7 @@ type EmulatorBackend struct {
 
 	// A property bag to pass various configurations to the backend.
 	// Currently, supports passing address mapping for contracts.
-	configurations *interpreter.Configurations
+	configuration *interpreter.Configuration
 }
 
 type keyInfo struct {
@@ -405,8 +405,8 @@ func newBlockchain(opts ...emulator.Option) *emulator.Blockchain {
 	return b
 }
 
-func (e *EmulatorBackend) UseConfiguration(configurations *interpreter.Configurations) {
-	e.configurations = configurations
+func (e *EmulatorBackend) UseConfiguration(configuration *interpreter.Configuration) {
+	e.configuration = configuration
 }
 
 // newInterpreter creates an interpreter instance needed for the value conversion.
@@ -453,7 +453,7 @@ func newInterpreter() (*interpreter.Interpreter, error) {
 }
 
 func (e *EmulatorBackend) replaceImports(code string) string {
-	if e.configurations == nil {
+	if e.configuration == nil {
 		return code
 	}
 
@@ -471,7 +471,7 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 			continue
 		}
 
-		address := e.configurations.Addresses[location.String()]
+		address := e.configuration.Addresses[location.String()]
 		addressStr := fmt.Sprintf("0x%s", address)
 
 		locationStart := importDeclaration.LocationPos.Offset

--- a/test-framework/emulator_backend.go
+++ b/test-framework/emulator_backend.go
@@ -21,6 +21,7 @@ package test
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/onflow/cadence/runtime/parser"
 	"strings"
 
 	sdk "github.com/onflow/flow-go-sdk"
@@ -56,7 +57,13 @@ type EmulatorBackend struct {
 	// accountKeys is a mapping of account addresses with their keys.
 	accountKeys map[common.Address]map[string]keyInfo
 
+	// Import resolver is used to resolve imports of the *test script*.
+	// Note: This doesn't resolve the imports for the codes that is being tested
+	// i.e: the code that is submitted to the blockchain.
+	// Use the configurations to set the import mapping to for the testing code.
 	importResolver ImportResolver
+
+	configurations *interpreter.Configurations
 }
 
 type keyInfo struct {
@@ -99,6 +106,8 @@ func (e *EmulatorBackend) RunScript(code string, args []interpreter.Value) *inte
 
 		arguments = append(arguments, encodedArg)
 	}
+
+	code = e.replaceImports(code)
 
 	result, err := e.blockchain.ExecuteScript([]byte(code), arguments)
 	if err != nil {
@@ -164,6 +173,8 @@ func (e *EmulatorBackend) AddTransaction(
 	signers []*interpreter.Account,
 	args []interpreter.Value,
 ) error {
+
+	code = e.replaceImports(code)
 
 	tx := e.newTransaction(code, authorizers)
 
@@ -299,6 +310,8 @@ func (e *EmulatorBackend) DeployContract(
 		    }
 	    }`
 
+	code = e.replaceImports(code)
+
 	hexEncodedCode := hex.EncodeToString([]byte(code))
 
 	inter, err := newInterpreter()
@@ -389,6 +402,10 @@ func newBlockchain(opts ...emulator.Option) *emulator.Blockchain {
 	return b
 }
 
+func (e *EmulatorBackend) UseConfigs(configurations *interpreter.Configurations) {
+	e.configurations = configurations
+}
+
 // newInterpreter creates an interpreter instance needed for the value conversion.
 //
 func newInterpreter() (*interpreter.Interpreter, error) {
@@ -430,4 +447,31 @@ func newInterpreter() (*interpreter.Interpreter, error) {
 			}
 		}),
 	)
+}
+
+func (e *EmulatorBackend) replaceImports(code string) string {
+	if e.configurations == nil {
+		return code
+	}
+
+	program, err := parser.ParseProgram(code, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, importDeclaration := range program.ImportDeclarations() {
+		location, ok := importDeclaration.Location.(common.StringLocation)
+		if !ok {
+			continue
+		}
+
+		address := e.configurations.AddressMapping[location.String()]
+
+		locationStr := fmt.Sprintf(`"%s"`, location)
+		addressStr := fmt.Sprintf("0x%s", address)
+
+		code = strings.Replace(code, locationStr, addressStr, 1)
+	}
+
+	return code
 }

--- a/test-framework/test_framework_test.go
+++ b/test-framework/test_framework_test.go
@@ -2279,7 +2279,7 @@ func TestReplaceImports(t *testing.T) {
 	t.Parallel()
 
 	emulatorBackend := NewEmulatorBackend(nil)
-	emulatorBackend.UseConfiguration(&interpreter.Configurations{
+	emulatorBackend.UseConfiguration(&interpreter.Configuration{
 		Addresses: map[string]common.Address{
 			"./sample/contract1.cdc": {0x1},
 			"./sample/contract2.cdc": {0x2},

--- a/test-framework/test_framework_test.go
+++ b/test-framework/test_framework_test.go
@@ -2060,7 +2060,7 @@ func TestReplacingImports(t *testing.T) {
 
                 // Set the configurations to use the address of the deployed contract.
 
-                blockchain.useConfiguration(Test.Configurations({
+                blockchain.useConfiguration(Test.Configuration({
                     "./FooContract": account.address
                 }))
             }
@@ -2139,7 +2139,7 @@ func TestReplacingImports(t *testing.T) {
 
                 // Address locations are not replaceable!
 
-                blockchain.useConfiguration(Test.Configurations({
+                blockchain.useConfiguration(Test.Configuration({
                     "0x01": account.address
                 }))
             }

--- a/test-framework/test_framework_test.go
+++ b/test-framework/test_framework_test.go
@@ -2044,6 +2044,7 @@ func TestReplacingImports(t *testing.T) {
             pub var account = blockchain.createAccount()
 
             pub fun setup() {
+                // Deploy the contract
                 var contractCode = Test.readFile("./sample/contract.cdc")
 
                 let err = blockchain.deployContract(
@@ -2057,7 +2058,7 @@ func TestReplacingImports(t *testing.T) {
                     panic(err!.message)
                 }
 
-                // The update the configurations to use address of the deployed contract.
+                // Set the configurations to use the address of the deployed contract.
 
                 blockchain.useConfiguration(Test.Configurations({
                     "./FooContract": account.address
@@ -2136,7 +2137,7 @@ func TestReplacingImports(t *testing.T) {
                     panic(err!.message)
                 }
 
-                // Address locations are not replacable!
+                // Address locations are not replaceable!
 
                 blockchain.useConfiguration(Test.Configurations({
                     "0x01": account.address
@@ -2269,6 +2270,7 @@ func TestReplacingImports(t *testing.T) {
 		assert.Contains(
 			t,
 			result.err.Error(),
-			"expecting an AddressLocation, but other location types are passed")
+			"expecting an AddressLocation, but other location types are passed",
+		)
 	})
 }

--- a/test-framework/test_framework_test.go
+++ b/test-framework/test_framework_test.go
@@ -2274,3 +2274,35 @@ func TestReplacingImports(t *testing.T) {
 		)
 	})
 }
+
+func TestReplaceImports(t *testing.T) {
+	t.Parallel()
+
+	emulatorBackend := NewEmulatorBackend(nil)
+	emulatorBackend.UseConfiguration(&interpreter.Configurations{
+		Addresses: map[string]common.Address{
+			"./sample/contract1.cdc": {0x1},
+			"./sample/contract2.cdc": {0x2},
+			"./sample/contract3.cdc": {0x3},
+		},
+	})
+
+	code := `
+        import C1 from "./sample/contract1.cdc"
+        import C2 from "./sample/contract2.cdc"
+        import C3 from "./sample/contract3.cdc"
+
+        pub fun main() {}
+    `
+	expected := `
+        import C1 from 0x0100000000000000
+        import C2 from 0x0200000000000000
+        import C3 from 0x0300000000000000
+
+        pub fun main() {}
+    `
+
+	replacedCode := emulatorBackend.replaceImports(code)
+
+	assert.Equal(t, expected, replacedCode)
+}


### PR DESCRIPTION
work towards https://github.com/onflow/cadence/issues/331

## Description

The last piece of the puzzle 🙏 

One common pattern in Cadence projects is to define the imports as file locations and specify the addresses corresponding to each network at the [config file](https://developers.flow.com/tools/flow-cli/configuration#contracts). It would make life easier for devs, if they can write tests for such projects, without having to change the imports.

This PR introduces an API to set a similar configuration dynamically to the blockchain during tests. So the devs can specify the accounts/addresses to which each import maps, at a single place. So they don't have to manually update the imports, which can be a real hassle.

(I couldn't think of a better approach. Suggestions are most welcome!)

API:

```cadence
blockchain.useConfiguration(_ configs: Test.Configurations)
``` 

Sample Usage:

```cadence
pub var blockchain = Test.newEmulatorBlockchain()
pub var accounts: [Test.Account] = []

pub fun setup() {
    // Create accounts in the blockchain.

    let acct1 = blockchain.createAccount()
    accounts.append(acct1)

    let acct2 = blockchain.createAccount()
    accounts.append(acct2)

    // Set the configurations with the addresses

    blockchain.useConfiguration(Test.Configurations({
        "./FooContract": acct1.address,
        "./BarContract": acct2.address
    }))
}

```

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
