### PR TITLE
Remove invalid markdown in docs.

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -363,7 +363,7 @@ Both `StoragePath` and `CapabilityPath` are subtypes of `Path`.
 
 #### Path Functions
 
-- `cadence•fun toString(): String`
+- `fun toString(): String`
 
   Returns the string representation of the path.
 
@@ -394,7 +394,7 @@ Account storage is accessed through the following functions of `AuthAccount`.
 This means that any code that has access to the authorized account has access
 to all its stored objects.
 
-- `cadence•fun save<T>(_ value: T, to: StoragePath)`
+- `fun save<T>(_ value: T, to: StoragePath)`
 
   Saves an object to account storage.
   Resources are moved into storage, and structures are copied.
@@ -406,7 +406,7 @@ to all its stored objects.
 
   The path must be a storage path, i.e., only the domain `storage` is allowed.
 
-- `cadence•fun type(at path: StoragePath): Type?`
+- `fun type(at path: StoragePath): Type?`
 
   Reads the type of an object from the account's storage which is stored under the given path, or nil if no object is stored under the given path.
 
@@ -414,7 +414,7 @@ to all its stored objects.
 
   The path must be a storage path, i.e., only the domain `storage` is allowed
 
-- `cadence•fun load<T>(from: StoragePath): T?`
+- `fun load<T>(from: StoragePath): T?`
 
   Loads an object from account storage.
   If no object is stored under the given path, the function returns `nil`.
@@ -432,7 +432,7 @@ to all its stored objects.
 
   The path must be a storage path, i.e., only the domain `storage` is allowed.
 
-- `cadence•fun copy<T: AnyStruct>(from: StoragePath): T?`
+- `fun copy<T: AnyStruct>(from: StoragePath): T?`
 
   Returns a copy of a structure stored in account storage, without removing it from storage.
 
@@ -539,7 +539,7 @@ as it is necessary for resources,
 it is also possible to create references to objects in storage:
 This is possible using the `borrow` function of an `AuthAccount`:
 
-- `cadence•fun borrow<T: &Any>(from: StoragePath): T?`
+- `fun borrow<T: &Any>(from: StoragePath): T?`
 
   Returns a reference to an object in storage without removing it from storage.
   If no object is stored under the given path, the function returns `nil`.

--- a/docs/language/built-in-functions.mdx
+++ b/docs/language/built-in-functions.mdx
@@ -3,7 +3,7 @@ title: Built-in Functions
 ---
 
 ## panic
-`cadence•fun panic(_ message: String): Never`
+`fun panic(_ message: String): Never`
 
   Terminates the program unconditionally
   and reports a message which explains why the unrecoverable error occurred.
@@ -15,7 +15,7 @@ title: Built-in Functions
 
 ## assert
 
-`cadence•fun assert(_ condition: Bool, message: String)`
+`fun assert(_ condition: Bool, message: String)`
 
   Terminates the program if the given condition is false,
   and reports a message which explains how the condition is false.
@@ -25,7 +25,7 @@ title: Built-in Functions
 
 ## unsafeRandom
 
-`cadence•fun unsafeRandom(): UInt64`
+`fun unsafeRandom(): UInt64`
 
   Returns a pseudo-random number.
 
@@ -40,14 +40,14 @@ RLP (Recursive Length Prefix) serialization allows the encoding of arbitrarily n
 
 Cadence provides RLP decoding functions in the built-in `RLP` contract, which does not need to be imported.
 
-- `cadence•fun decodeString(_ input: [UInt8]): [UInt8]`
+- `fun decodeString(_ input: [UInt8]): [UInt8]`
 
   Decodes an RLP-encoded byte array (called string in the context of RLP).
   The byte array should only contain of a single encoded value for a string; if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
   If any error is encountered while decoding, the program aborts.
 
 
-- `cadence•fun decodeList(_ input: [UInt8]): [[UInt8]]`
+- `fun decodeList(_ input: [UInt8]): [[UInt8]]`
 
   Decodes an RLP-encoded list into an array of RLP-encoded items.
   Note that this function does not recursively decode, so each element of the resulting array is RLP-encoded data.

--- a/docs/language/capability-based-access-control.md
+++ b/docs/language/capability-based-access-control.md
@@ -31,7 +31,7 @@ This allows exposing and hiding certain functionality of a stored object.
 
 Capabilities are created using the `link` function of an authorized account (`AuthAccount`):
 
-- `cadence•fun link<T: &Any>(_ newCapabilityPath: CapabilityPath, target: Path): Capability<T>?`
+- `fun link<T: &Any>(_ newCapabilityPath: CapabilityPath, target: Path): Capability<T>?`
 
   `newCapabilityPath` is the public or private path identifying the new capability.
 
@@ -60,14 +60,14 @@ Capabilities are created using the `link` function of an authorized account (`Au
 
 Capabilities can be removed using the `unlink` function of an authorized account (`AuthAccount`):
 
-- `cadence•fun unlink(_ path: CapabilityPath)`
+- `fun unlink(_ path: CapabilityPath)`
 
   `path` is the public or private path identifying the capability that should be removed.
 
 To get the target path for a capability, the `getLinkTarget` function
 of an authorized account (`AuthAccount`) or public account (`PublicAccount`) can be used:
 
-- `cadence•fun getLinkTarget(_ path: CapabilityPath): Path?`
+- `fun getLinkTarget(_ path: CapabilityPath): Path?`
 
   `path` is the public or private path identifying the capability.
   The function returns the link target path,
@@ -77,7 +77,7 @@ of an authorized account (`AuthAccount`) or public account (`PublicAccount`) can
 Existing capabilities can be obtained by using the `getCapability` function
 of authorized accounts (`AuthAccount`) and public accounts (`PublicAccount`):
 
-- `cadence•fun getCapability<T>(_ at: CapabilityPath): Capability<T>`
+- `fun getCapability<T>(_ at: CapabilityPath): Capability<T>`
 
   For public accounts, the function returns a capability
   if the given path is public.
@@ -95,7 +95,7 @@ The `getCapability` function does **not** check if the target exists.
 The link is latent.
 The `check` function of the capability can be used to check if the target currently exists and could be borrowed,
 
-- `cadence•fun check<T: &Any>(): Bool`
+- `fun check<T: &Any>(): Bool`
 
   `T` is the type parameter for the reference type.
   A type argument for the parameter must be provided explicitly.
@@ -106,7 +106,7 @@ The `check` function of the capability can be used to check if the target curren
 Finally, the capability can be borrowed to get a reference to the stored object.
 This can be done using the `borrow` function of the capability:
 
-- `cadence•fun borrow<T: &Any>(): T?`
+- `fun borrow<T: &Any>(): T?`
 
   The function returns a reference to the object targeted by the capability,
   provided it can be borrowed using the given type.
@@ -229,6 +229,6 @@ let counterRef2 = publicAccount.borrow<&Counter>(from: /storage/counter)
 
 The address of a capability can be obtained from the `address` field of the capability:
 
-- `cadence•let address: Address`
+- `let address: Address`
 
   The address of the capability.

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -261,7 +261,7 @@ The PoP can only be verified using the `PublicKey` method `verifyPoP`.
 
 ### BLS signature aggregation
 
-`cadence•fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?`
+`fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?`
 
 Aggregates multiple BLS signatures into one. 
 Signatures could be generated from the same or distinct messages, they
@@ -276,7 +276,7 @@ verfiy multiple signatures of the same message.
 
 ### BLS public key aggregation
 
-`cadence•fun aggregatePublicKeys(_ publicKeys: [PublicKey]): PublicKey?`
+`fun aggregatePublicKeys(_ publicKeys: [PublicKey]): PublicKey?`
 
 Aggregates multiple BLS public keys into one.
 

--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -15,11 +15,11 @@ Please let us know if your use-case demands it by request this feature in an iss
 
 To get information about a block, the functions `getCurrentBlock` and `getBlock` can be used:
 
-- `cadence•fun getCurrentBlock(): Block`
+- `fun getCurrentBlock(): Block`
 
   Returns the current block, i.e. the block which contains the currently executed transaction.
 
-- `cadence•fun getBlock(at height: UInt64): Block?`
+- `fun getBlock(at height: UInt64): Block?`
 
   Returns the block at the given height.
   If the given block does not exist the function returns `nil`.

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -158,7 +158,7 @@ let b = x + 1000000000000000000000000
 
 Integers have multiple built-in functions you can use.
 
-- `cadence•fun toString(): String`
+- `fun toString(): String`
 
   Returns the string representation of the integer.
 
@@ -168,7 +168,7 @@ Integers have multiple built-in functions you can use.
   answer.toString()  // is "42"
   ```
 
-- `cadence•fun toBigEndianBytes(): [UInt8]`
+- `fun toBigEndianBytes(): [UInt8]`
 
   Returns the byte array representation (`[UInt8]`) in big-endian order of the integer.
 
@@ -212,7 +212,7 @@ have the following factors, and can represent values in the following ranges:
 
 Fixed-Point numbers have multiple built-in functions you can use.
 
-- `cadence•fun toString(): String`
+- `fun toString(): String`
 
   Returns the string representation of the fixed-point number.
 
@@ -222,7 +222,7 @@ Fixed-Point numbers have multiple built-in functions you can use.
   fix.toString()  // is "1.23000000"
   ```
 
-- `cadence•fun toBigEndianBytes(): [UInt8]`
+- `fun toBigEndianBytes(): [UInt8]`
 
   Returns the byte array representation (`[UInt8]`) in big-endian order of the fixed-point number.
 
@@ -331,7 +331,7 @@ let aNumber = 0x436164656E636521
 
 Addresses have multiple built-in functions you can use.
 
-- `cadence•fun toString(): String`
+- `fun toString(): String`
 
   Returns the string representation of the address.
   The result has a `0x` prefix and is zero-padded.
@@ -344,7 +344,7 @@ Addresses have multiple built-in functions you can use.
   shortAddress.toString()  // is "0x0000000000000001"
   ```
 
-- `cadence•fun toBytes(): [UInt8]`
+- `fun toBytes(): [UInt8]`
 
   Returns the byte array representation (`[UInt8]`) of the address.
 
@@ -629,7 +629,7 @@ let canadianFlag: Character = "\u{1F1E8}\u{1F1E6}"
 
 Strings have multiple built-in functions you can use:
 
-- `cadence•let length: Int`
+- `let length: Int`
 
   Returns the number of characters in the string as an integer.
 
@@ -641,7 +641,7 @@ Strings have multiple built-in functions you can use:
   // `length` is `5`
   ```
 
-- `cadence•let utf8: [UInt8]`
+- `let utf8: [UInt8]`
 
   The byte array of the UTF-8 encoding
 
@@ -651,7 +651,7 @@ Strings have multiple built-in functions you can use:
   // `bytes` is `[70, 108, 111, 119, 101, 114, 115, 32, 240, 159, 146, 144]`
   ```
 
-- `cadence•fun concat(_ other: String): String`
+- `fun concat(_ other: String): String`
 
   Concatenates the string `other` to the end of the original string,
   but does not modify the original string.
@@ -667,7 +667,7 @@ Strings have multiple built-in functions you can use:
   // `helloWorld` is now `"helloworld"`
   ```
 
-- `cadence•fun slice(from: Int, upTo: Int): String`
+- `fun slice(from: Int, upTo: Int): String`
 
   Returns a string slice of the characters
   in the given string from start index `from` up to,
@@ -691,7 +691,7 @@ Strings have multiple built-in functions you can use:
   let invalidIndices = example.slice(from: 2, upTo: 1)
   ```
 
-- `cadence•fun decodeHex(): [UInt8]`
+- `fun decodeHex(): [UInt8]`
 
   Returns an array containing the bytes represented by the given hexadecimal string.
 
@@ -704,7 +704,7 @@ Strings have multiple built-in functions you can use:
   example.decodeHex()  // is `[67, 97, 100, 101, 110, 99, 101, 33]`
   ```
 
-- `cadence•fun toLower(): String`
+- `fun toLower(): String`
   Returns a string where all upper case letters are replaced with lowercase characters
 
   ```cadence
@@ -715,7 +715,7 @@ Strings have multiple built-in functions you can use:
 
 The `String` type also provides the following functions:
 
-- `cadence•fun String.encodeHex(_ data: [UInt8]): String`
+- `fun String.encodeHex(_ data: [UInt8]): String`
 
   Returns a hexadecimal string for the given byte array
 
@@ -736,7 +736,7 @@ let c = str[0] // is the Character "a"
 
 `Character` values can be converted into `String` values using the `toString` function:
 
-- `cadence•fun toString(): String`
+- `fun toString(): String`
 
   Returns the string representation of the character.
 
@@ -877,7 +877,7 @@ that can be used to get information about and manipulate the contents of the arr
 The field `length`, and the functions `concat`, and `contains`
 are available for both variable-sized and fixed-sized or variable-sized arrays.
 
-- `cadence•let length: Int`
+- `let length: Int`
 
   The number of elements in the array.
 
@@ -891,7 +891,7 @@ are available for both variable-sized and fixed-sized or variable-sized arrays.
   // `length` is `4`
   ```
 
-- `cadence•fun concat(_ array: T): T`
+- `fun concat(_ array: T): T`
 
   Concatenates the parameter `array` to the end
   of the array the function is called on,
@@ -917,7 +917,7 @@ are available for both variable-sized and fixed-sized or variable-sized arrays.
   // `moreNumbers` is still `[11, 27]`
   ```
 
-- `cadence•fun contains(_ element: T): Bool`
+- `fun contains(_ element: T): Bool`
 
   Returns true if the given element of type `T` is in the array.
 
@@ -939,7 +939,7 @@ are available for both variable-sized and fixed-sized or variable-sized arrays.
   let containsKitty = numbers.contains("Kitty")
   ```
 
-- `cadence•fun firstIndex(of: T): Int?`
+- `fun firstIndex(of: T): Int?`
   Returns the index of the first element matching the given object in the array, nil if no match.
   Available if `T` is not resource-kinded and equatable.
 
@@ -956,7 +956,7 @@ are available for both variable-sized and fixed-sized or variable-sized arrays.
  // `index` is nil
 ```
 
-- `cadence•fun slice(from: Int, upTo: Int): [T]`
+- `fun slice(from: Int, upTo: Int): [T]`
 
   Returns an array slice of the elements
   in the given array from start index `from` up to,
@@ -985,7 +985,7 @@ are available for both variable-sized and fixed-sized or variable-sized arrays.
 The following functions can only be used on variable-sized arrays.
 It is invalid to use one of these functions on a fixed-sized array.
 
-- `cadence•fun append(_ element: T): Void`
+- `fun append(_ element: T): Void`
 
   Adds the new element `element` of type `T` to the end of the array.
 
@@ -1005,7 +1005,7 @@ It is invalid to use one of these functions on a fixed-sized array.
   numbers.append("SneakyString")
   ```
 
-- `cadence•fun appendAll(_ array: T): Void`
+- `fun appendAll(_ array: T): Void`
 
   Adds all the elements from `array` to the end of the array
   the function is called on.
@@ -1026,7 +1026,7 @@ It is invalid to use one of these functions on a fixed-sized array.
   numbers.appendAll(["Sneaky", "String"])
   ```
 
-- `cadence•fun insert(at index: Int, _ element: T): Void`
+- `fun insert(at index: Int, _ element: T): Void`
 
   Inserts the new element `element` of type `T`
   at the given `index` of the array.
@@ -1055,7 +1055,7 @@ It is invalid to use one of these functions on a fixed-sized array.
   numbers.insert(at: 12, 39)
   ```
 
-- `cadence•fun remove(at index: Int): T`
+- `fun remove(at index: Int): T`
 
   Removes the element at the given `index` from the array and returns it.
 
@@ -1077,7 +1077,7 @@ It is invalid to use one of these functions on a fixed-sized array.
   numbers.remove(at: 19)
   ```
 
-- `cadence•fun removeFirst(): T`
+- `fun removeFirst(): T`
 
   Removes the first element from the array and returns it.
 
@@ -1104,7 +1104,7 @@ It is invalid to use one of these functions on a fixed-sized array.
   numbers.removeFirst()
   ```
 
-- `cadence•fun removeLast(): T`
+- `fun removeLast(): T`
 
   Removes the last element from the array and returns it.
 
@@ -1265,7 +1265,7 @@ booleans[0] = true
 
 ### Dictionary Fields and Functions
 
-- `cadence•let length: Int`
+- `let length: Int`
 
   The number of entries in the dictionary.
 
@@ -1279,7 +1279,7 @@ booleans[0] = true
   // `length` is `2`
   ```
 
-- `cadence•fun insert(key: K, _ value: V): V?`
+- `fun insert(key: K, _ value: V): V?`
 
   Inserts the given value of type `V` into the dictionary under the given `key` of type `K`.
   
@@ -1307,7 +1307,7 @@ booleans[0] = true
   // `numbers` is `{"twentyThree": 23, "fortyTwo": 42}`
   ```
 
-- `cadence•fun remove(key: K): V?`
+- `fun remove(key: K): V?`
 
   Removes the value for the given `key` of type `K` from the dictionary.
 
@@ -1339,7 +1339,7 @@ booleans[0] = true
   // `numbers` is `{"twentyThree": 23}`
   ```
 
-- `cadence•let keys: [K]`
+- `let keys: [K]`
 
   Returns an array of the keys of type `K` in the dictionary. This does not
   modify the dictionary, just returns a copy of the keys as an array.
@@ -1355,7 +1355,7 @@ booleans[0] = true
   // `keys` has type `[String]` and is `["fortyTwo","twentyThree"]`
   ```
 
-- `cadence•let values: [V]`
+- `let values: [V]`
 
   Returns an array of the values of type `V` in the dictionary. This does not
   modify the dictionary, just returns a copy of the values as an array.
@@ -1373,7 +1373,7 @@ booleans[0] = true
   // `values` has type [Int] and is `[42, 23]`
   ```
 
-- `cadence•fun containsKey(key: K): Bool`
+- `fun containsKey(key: K): Bool`
 
   Returns true if the given key of type `K` is in the dictionary.
 


### PR DESCRIPTION
For your consideration:

Closes https://github.com/onflow/next-docs-v1/issues/597

## Description

A user in Discord reported that inline Cadence snippets were rendering with some artifacts (See image below):


![](https://user-images.githubusercontent.com/901466/185446870-3611808b-b75f-42f1-ab50-59c3f1372f50.png)

The new docs site has changed how inline snippets are handled, making this notation invalid.
This pr removes the artifacts. 

This might make updating these inline snippets later, if we decide to add support for inline highlighing of Cadence. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
