### PR TITLE
Refactor checker config and position info

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -42,8 +42,9 @@ func Fuzz(data []byte) int {
 		program,
 		utils.TestLocation,
 		nil,
-		false,
-		sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
+		&sema.Config{
+			AccessCheckMode: sema.AccessCheckModeNotSpecifiedUnrestricted,
+		},
 	)
 	if err != nil {
 		return 0

--- a/runtime/cmd/execute/repl.go
+++ b/runtime/cmd/execute/repl.go
@@ -51,7 +51,6 @@ func RunREPL() {
 		func(value interpreter.Value) {
 			fmt.Println(formatValue(value))
 		},
-		nil,
 	)
 
 	if err != nil {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1862,7 +1862,14 @@ func TestExportTypeValue(t *testing.T) {
 		program, err := parser.ParseProgram(code, nil)
 		require.NoError(t, err)
 
-		checker, err := sema.NewChecker(program, TestLocation, nil, false)
+		checker, err := sema.NewChecker(
+			program,
+			TestLocation,
+			nil,
+			&sema.Config{
+				AccessCheckMode: sema.AccessCheckModeStrict,
+			},
+		)
 		require.NoError(t, err)
 
 		err = checker.Check()
@@ -1948,12 +1955,19 @@ func TestExportCapabilityValue(t *testing.T) {
 	t.Run("Struct", func(t *testing.T) {
 
 		const code = `
-          pub struct S {}
+          struct S {}
         `
 		program, err := parser.ParseProgram(code, nil)
 		require.NoError(t, err)
 
-		checker, err := sema.NewChecker(program, TestLocation, nil, false)
+		checker, err := sema.NewChecker(
+			program,
+			TestLocation,
+			nil,
+			&sema.Config{
+				AccessCheckMode: sema.AccessCheckModeNotSpecifiedUnrestricted,
+			},
+		)
 		require.NoError(t, err)
 
 		err = checker.Check()
@@ -2061,12 +2075,19 @@ func TestExportLinkValue(t *testing.T) {
 	t.Run("Struct", func(t *testing.T) {
 
 		const code = `
-          pub struct S {}
+          struct S {}
         `
 		program, err := parser.ParseProgram(code, nil)
 		require.NoError(t, err)
 
-		checker, err := sema.NewChecker(program, TestLocation, nil, false)
+		checker, err := sema.NewChecker(
+			program,
+			TestLocation,
+			nil,
+			&sema.Config{
+				AccessCheckMode: sema.AccessCheckModeNotSpecifiedUnrestricted,
+			},
+		)
 		require.NoError(t, err)
 
 		err = checker.Check()

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -41,30 +41,19 @@ type REPL struct {
 func NewREPL(
 	onError func(err error, location Location, codes map[Location]string),
 	onResult func(interpreter.Value),
-	checkerOptions []sema.Option,
 ) (*REPL, error) {
 
 	checkers := map[Location]*sema.Checker{}
 	codes := map[Location]string{}
 
-	defaultCheckerOptions := cmd.DefaultCheckerOptions(checkers, codes)
-
-	defaultCheckerOptions = append(
-		defaultCheckerOptions,
-		sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
-	)
-
-	checkerOptions = append(
-		defaultCheckerOptions,
-		checkerOptions...,
-	)
+	checkerConfig := cmd.DefaultCheckerConfig(checkers, codes)
+	checkerConfig.AccessCheckMode = sema.AccessCheckModeNotSpecifiedUnrestricted
 
 	checker, err := sema.NewChecker(
 		nil,
 		common.REPLLocation{},
 		nil,
-		false,
-		checkerOptions...,
+		checkerConfig,
 	)
 	if err != nil {
 		return nil, err
@@ -77,7 +66,7 @@ func NewREPL(
 	// NOTE: storage option must be provided *before* the predeclared values option,
 	// as predeclared values may rely on storage
 
-	config := &interpreter.Config{
+	interpreterConfig := &interpreter.Config{
 		Storage: storage,
 		UUIDHandler: func() (uint64, error) {
 			defer func() { uuid++ }()
@@ -88,7 +77,7 @@ func NewREPL(
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
-		config,
+		interpreterConfig,
 	)
 	if err != nil {
 		return nil, err

--- a/runtime/sema/accesscheckmode.go
+++ b/runtime/sema/accesscheckmode.go
@@ -23,16 +23,18 @@ package sema
 type AccessCheckMode uint
 
 const (
+	// AccessCheckModeDefault indicates the default access check mode should be used.
+	AccessCheckModeDefault AccessCheckMode = iota
 	// AccessCheckModeStrict indicates that access modifiers are required
-	// and access checks are always enforced
-	AccessCheckModeStrict AccessCheckMode = iota
+	// and access checks are always enforced.
+	AccessCheckModeStrict
 	// AccessCheckModeNotSpecifiedRestricted indicates modifiers are optional.
 	// Access is assumed private if not specified
 	AccessCheckModeNotSpecifiedRestricted
 	// AccessCheckModeNotSpecifiedUnrestricted indicates access modifiers are optional.
 	// Access is assumed public if not specified
 	AccessCheckModeNotSpecifiedUnrestricted
-	// AccessCheckModeNone indicates access modifiers are optional and ignored
+	// AccessCheckModeNone indicates access modifiers are optional and ignored.
 	AccessCheckModeNone
 )
 

--- a/runtime/sema/accesscheckmode_string.go
+++ b/runtime/sema/accesscheckmode_string.go
@@ -8,15 +8,16 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[AccessCheckModeStrict-0]
-	_ = x[AccessCheckModeNotSpecifiedRestricted-1]
-	_ = x[AccessCheckModeNotSpecifiedUnrestricted-2]
-	_ = x[AccessCheckModeNone-3]
+	_ = x[AccessCheckModeDefault-0]
+	_ = x[AccessCheckModeStrict-1]
+	_ = x[AccessCheckModeNotSpecifiedRestricted-2]
+	_ = x[AccessCheckModeNotSpecifiedUnrestricted-3]
+	_ = x[AccessCheckModeNone-4]
 }
 
-const _AccessCheckMode_name = "AccessCheckModeStrictAccessCheckModeNotSpecifiedRestrictedAccessCheckModeNotSpecifiedUnrestrictedAccessCheckModeNone"
+const _AccessCheckMode_name = "AccessCheckModeDefaultAccessCheckModeStrictAccessCheckModeNotSpecifiedRestrictedAccessCheckModeNotSpecifiedUnrestrictedAccessCheckModeNone"
 
-var _AccessCheckMode_index = [...]uint8{0, 21, 58, 97, 116}
+var _AccessCheckMode_index = [...]uint8{0, 22, 43, 80, 119, 138}
 
 func (i AccessCheckMode) String() string {
 	if i >= AccessCheckMode(len(_AccessCheckMode_index)-1) {

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -124,7 +124,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 						Range:        ast.NewRangeFromPositioned(checker.memoryGauge, leftHandExpression),
 					},
 				)
-			} else if checker.extendedElaboration {
+			} else if checker.Config.ExtendedElaborationEnabled {
 				checker.Elaboration.RuntimeCastTypes[expression] =
 					RuntimeCastTypes{
 						Left:  leftHandType,
@@ -144,7 +144,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 		// the inferred-type of the expression. i.e: exprActualType == rightHandType
 		// Then, it is not possible to determine whether the target type is redundant.
 		// Therefore, don't check for redundant casts, if there are errors.
-		if checker.extendedElaboration && !hasErrors {
+		if checker.Config.ExtendedElaborationEnabled && !hasErrors {
 			checker.Elaboration.StaticCastTypes[expression] =
 				CastTypes{
 					ExprActualType: exprActualType,

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -441,7 +441,7 @@ func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclarati
 	})
 	checker.report(err)
 
-	if checker.positionInfoEnabled {
+	if checker.PositionInfo != nil {
 		checker.recordVariableDeclarationOccurrence(
 			identifier.Identifier,
 			variable,
@@ -693,8 +693,8 @@ func (checker *Checker) declareCompositeMembersAndValue(
 
 		compositeType.Members = members
 		compositeType.Fields = fields
-		if checker.positionInfoEnabled {
-			checker.memberOrigins[compositeType] = origins
+		if checker.PositionInfo != nil {
+			checker.PositionInfo.recordMemberOrigins(compositeType, origins)
 		}
 	})()
 
@@ -801,7 +801,8 @@ func (checker *Checker) declareEnumConstructor(
 	enumCases := declaration.Members.EnumCases()
 
 	var constructorOrigins map[string]*Origin
-	if checker.positionInfoEnabled {
+
+	if checker.PositionInfo != nil {
 		constructorOrigins = make(map[string]*Origin, len(enumCases))
 	}
 
@@ -829,7 +830,7 @@ func (checker *Checker) declareEnumConstructor(
 				DocString:       enumCase.DocString,
 			})
 
-		if checker.positionInfoEnabled && constructorOrigins != nil {
+		if checker.PositionInfo != nil && constructorOrigins != nil {
 			constructorOrigins[caseName] =
 				checker.recordFieldDeclarationOrigin(
 					enumCase.Identifier,
@@ -839,8 +840,8 @@ func (checker *Checker) declareEnumConstructor(
 		}
 	}
 
-	if checker.positionInfoEnabled {
-		checker.memberOrigins[constructorType] = constructorOrigins
+	if checker.PositionInfo != nil {
+		checker.PositionInfo.recordMemberOrigins(constructorType, constructorOrigins)
 	}
 
 	_, err := checker.valueActivations.Declare(variableDeclaration{
@@ -1490,7 +1491,7 @@ func (checker *Checker) defaultMembersAndOrigins(
 
 	memberCount := len(fields) + len(functions)
 	members = &StringMemberOrderedMap{}
-	if checker.positionInfoEnabled {
+	if checker.PositionInfo != nil {
 		origins = make(map[string]*Origin, memberCount)
 	}
 
@@ -1567,7 +1568,7 @@ func (checker *Checker) defaultMembersAndOrigins(
 				DocString:       field.DocString,
 			})
 
-		if checker.positionInfoEnabled && origins != nil {
+		if checker.PositionInfo != nil && origins != nil {
 			origins[identifier] =
 				checker.recordFieldDeclarationOrigin(
 					field.Identifier,
@@ -1635,9 +1636,8 @@ func (checker *Checker) defaultMembersAndOrigins(
 				HasImplementation: hasImplementation,
 			})
 
-		if checker.positionInfoEnabled && origins != nil {
-			origins[identifier] =
-				checker.recordFunctionDeclarationOrigin(function, functionType)
+		if checker.PositionInfo != nil && origins != nil {
+			origins[identifier] = checker.recordFunctionDeclarationOrigin(function, functionType)
 		}
 	}
 
@@ -1655,7 +1655,8 @@ func (checker *Checker) eventMembersAndOrigins(
 	parameters := initializer.FunctionDeclaration.ParameterList.Parameters
 
 	members = &StringMemberOrderedMap{}
-	if checker.positionInfoEnabled {
+
+	if checker.PositionInfo != nil {
 		origins = make(map[string]*Origin, len(parameters))
 	}
 
@@ -1677,7 +1678,7 @@ func (checker *Checker) eventMembersAndOrigins(
 				VariableKind:    ast.VariableKindConstant,
 			})
 
-		if checker.positionInfoEnabled && origins != nil {
+		if checker.PositionInfo != nil && origins != nil {
 			origins[identifier.Identifier] =
 				checker.recordFieldDeclarationOrigin(
 					identifier,
@@ -1952,7 +1953,7 @@ func (checker *Checker) declareSelfValue(selfType Type, selfDocString string) {
 		DocString:       selfDocString,
 	}
 	checker.valueActivations.Set(SelfIdentifier, self)
-	if checker.positionInfoEnabled {
+	if checker.PositionInfo != nil {
 		checker.recordVariableDeclarationOccurrence(SelfIdentifier, self)
 	}
 }

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -83,7 +83,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr 
 		allowOuterScopeShadowing: false,
 	})
 	checker.report(err)
-	if checker.positionInfoEnabled {
+	if checker.PositionInfo != nil {
 		checker.recordVariableDeclarationOccurrence(identifier, variable)
 	}
 
@@ -99,7 +99,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr 
 			allowOuterScopeShadowing: false,
 		})
 		checker.report(err)
-		if checker.positionInfoEnabled {
+		if checker.PositionInfo != nil {
 			checker.recordVariableDeclarationOccurrence(index, indexVariable)
 		}
 	}

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -40,7 +40,7 @@ func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) as
 		ResourceInvalidationKindMoveDefinite,
 	)
 
-	if checker.extendedElaboration {
+	if checker.Config.ExtendedElaborationEnabled {
 		checker.Elaboration.ForceExpressionTypes[expression] = valueType
 	}
 

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -110,7 +110,7 @@ func (checker *Checker) declareFunctionDeclaration(
 	})
 	checker.report(err)
 
-	if checker.positionInfoEnabled {
+	if checker.PositionInfo != nil {
 		checker.recordFunctionDeclarationOrigin(declaration, functionType)
 	}
 }
@@ -191,20 +191,12 @@ func (checker *Checker) checkFunction(
 		},
 	)
 
-	if checker.positionInfoEnabled && functionBlock != nil {
+	if checker.PositionInfo != nil && functionBlock != nil {
 		startPos := functionBlock.StartPosition()
 		endPos := functionBlock.EndPosition(checker.memoryGauge)
 
 		for _, parameter := range functionType.Parameters {
-			checker.Ranges.Put(
-				startPos,
-				endPos,
-				Range{
-					Identifier:      parameter.Identifier,
-					Type:            parameter.TypeAnnotation.Type,
-					DeclarationKind: common.DeclarationKindParameter,
-				},
-			)
+			checker.PositionInfo.recordParameterRange(startPos, endPos, parameter)
 		}
 	}
 }
@@ -315,7 +307,7 @@ func (checker *Checker) declareParameters(
 			Pos:             &identifier.Pos,
 		}
 		checker.valueActivations.Set(identifier.Identifier, variable)
-		if checker.positionInfoEnabled {
+		if checker.PositionInfo != nil {
 			checker.recordVariableDeclarationOccurrence(identifier.Identifier, variable)
 		}
 	}

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -71,7 +71,8 @@ func (checker *Checker) resolveLocation(identifiers []ast.Identifier, location c
 	// If no location handler is available,
 	// default to resolving to a single location that declares all identifiers
 
-	if checker.locationHandler == nil {
+	locationHandler := checker.Config.LocationHandler
+	if locationHandler == nil {
 		return []ResolvedLocation{
 			{
 				Location:    location,
@@ -82,7 +83,7 @@ func (checker *Checker) resolveLocation(identifiers []ast.Identifier, location c
 
 	// A location handler is available,
 	// use it to resolve the location / identifiers
-	return checker.locationHandler(identifiers, location)
+	return locationHandler(identifiers, location)
 }
 
 func (checker *Checker) importResolvedLocation(resolvedLocation ResolvedLocation, locationRange ast.Range) {
@@ -93,9 +94,10 @@ func (checker *Checker) importResolvedLocation(resolvedLocation ResolvedLocation
 
 	var imp Import
 
-	if checker.importHandler != nil {
+	importHandler := checker.Config.ImportHandler
+	if importHandler != nil {
 		var err error
-		imp, err = checker.importHandler(checker, location, locationRange)
+		imp, err = importHandler(checker, location, locationRange)
 		if err != nil {
 
 			// The import handler may return CyclicImportsError specifically

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -244,10 +244,12 @@ func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclarati
 		allowOuterScopeShadowing: false,
 	})
 	checker.report(err)
-	checker.recordVariableDeclarationOccurrence(
-		identifier.Identifier,
-		variable,
-	)
+	if checker.PositionInfo != nil {
+		checker.recordVariableDeclarationOccurrence(
+			identifier.Identifier,
+			variable,
+		)
+	}
 
 	checker.Elaboration.InterfaceDeclarationTypes[declaration] = interfaceType
 	checker.Elaboration.InterfaceTypeDeclarations[interfaceType] = declaration
@@ -335,8 +337,8 @@ func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclar
 
 	interfaceType.Members = members
 	interfaceType.Fields = fields
-	if checker.positionInfoEnabled {
-		checker.memberOrigins[interfaceType] = origins
+	if checker.PositionInfo != nil {
+		checker.PositionInfo.recordMemberOrigins(interfaceType, origins)
 	}
 
 	// NOTE: determine initializer parameter types while nested types are in scope,

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -134,22 +134,10 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 
 	arguments := invocationExpression.Arguments
 
-	if checker.positionInfoEnabled && len(arguments) > 0 {
-
-		trailingSeparatorPositions := make([]ast.Position, 0, len(arguments))
-
-		for _, argument := range arguments {
-			trailingSeparatorPositions = append(
-				trailingSeparatorPositions,
-				argument.TrailingSeparatorPos,
-			)
-		}
-
-		checker.FunctionInvocations.Put(
-			invocationExpression.ArgumentsStartPos,
-			invocationExpression.EndPos,
+	if checker.PositionInfo != nil && len(arguments) > 0 {
+		checker.PositionInfo.recordFunctionInvocation(
+			invocationExpression,
 			functionType,
-			trailingSeparatorPositions,
 		)
 	}
 

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -37,10 +37,10 @@ func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) 
 			}
 		}
 
-		if checker.positionInfoEnabled {
-			checker.MemberAccesses.Put(
-				expression.AccessPos,
-				expression.EndPosition(checker.memoryGauge),
+		if checker.PositionInfo != nil {
+			checker.PositionInfo.recordMemberAccess(
+				checker.memoryGauge,
+				expression,
 				memberAccessType,
 			)
 		}
@@ -244,13 +244,12 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 		}
 	} else {
 
-		if checker.positionInfoEnabled {
-			origins := checker.memberOrigins[accessedType]
-			origin := origins[identifier]
-			checker.Occurrences.Put(
+		if checker.PositionInfo != nil {
+			checker.PositionInfo.recordMemberOccurrence(
+				accessedType,
+				identifier,
 				identifierStartPosition,
 				identifierEndPosition,
-				origin,
 			)
 		}
 
@@ -317,8 +316,9 @@ func (checker *Checker) isReadableMember(member *Member) bool {
 			return true
 		}
 
-		if checker.memberAccountAccessHandler != nil {
-			return checker.memberAccountAccessHandler(checker, location)
+		memberAccountAccessHandler := checker.Config.MemberAccountAccessHandler
+		if memberAccountAccessHandler != nil {
+			return memberAccountAccessHandler(checker, location)
 		}
 	}
 

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -266,8 +266,8 @@ func (checker *Checker) declareTransactionDeclaration(declaration *ast.Transacti
 
 	transactionType.Members = members
 	transactionType.Fields = fields
-	if checker.positionInfoEnabled {
-		checker.memberOrigins[transactionType] = origins
+	if checker.PositionInfo != nil {
+		checker.PositionInfo.recordMemberOrigins(transactionType, origins)
 	}
 
 	if declaration.Prepare != nil {

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -81,11 +81,11 @@ type MemberAccountAccessHandlerFunc func(checker *Checker, memberLocation common
 // Checker
 
 type Checker struct {
-	Program                            *ast.Program
-	Location                           common.Location
-	baseTypeActivation                 *VariableActivation
-	baseValueActivation                *VariableActivation
-	accessCheckMode                    AccessCheckMode
+	Program     *ast.Program
+	Location    common.Location
+	Elaboration *Elaboration
+	Config      *Config
+
 	errors                             []error
 	valueActivations                   *VariableActivations
 	resources                          *Resources
@@ -93,155 +93,34 @@ type Checker struct {
 	containerTypes                     map[Type]bool
 	functionActivations                *FunctionActivations
 	inCondition                        bool
-	positionInfoEnabled                bool
-	Occurrences                        *Occurrences
-	variableOrigins                    map[*Variable]*Origin
-	memberOrigins                      map[Type]map[string]*Origin
-	MemberAccesses                     *MemberAccesses
-	Ranges                             *Ranges
-	FunctionInvocations                *FunctionInvocations
 	isChecked                          bool
 	inCreate                           bool
 	inInvocation                       bool
 	inAssignment                       bool
 	allowSelfResourceFieldInvalidation bool
-	Elaboration                        *Elaboration
 	currentMemberExpression            *ast.MemberExpression
-	validTopLevelDeclarationsHandler   ValidTopLevelDeclarationsHandlerFunc
-	beforeExtractor                    *BeforeExtractor
-	locationHandler                    LocationHandlerFunc
-	importHandler                      ImportHandlerFunc
-	checkHandler                       CheckHandlerFunc
-	expectedType                       Type
-	memberAccountAccessHandler         MemberAccountAccessHandlerFunc
-	extendedElaboration                bool
-	errorShortCircuitingEnabled        bool
+	// initialized lazily. use beforeExtractor()
+	_beforeExtractor *BeforeExtractor
+	expectedType     Type
+
 	// memoryGauge is used for metering memory usage
-	memoryGauge common.MemoryGauge
-}
-
-type Option func(*Checker) error
-
-func WithBaseValueActivation(baseValueActivation *VariableActivation) Option {
-	return func(checker *Checker) error {
-		checker.baseValueActivation = baseValueActivation
-		return nil
-	}
-}
-
-func WithBaseTypeActivation(baseTypeActivation *VariableActivation) Option {
-	return func(checker *Checker) error {
-		checker.baseTypeActivation = baseTypeActivation
-		return nil
-	}
-}
-
-// WithAccessCheckMode returns a checker option which sets
-// the given mode for access control checks.
-//
-func WithAccessCheckMode(mode AccessCheckMode) Option {
-	return func(checker *Checker) error {
-		checker.accessCheckMode = mode
-		return nil
-	}
-}
-
-// WithValidTopLevelDeclarationsHandler returns a checker option which sets
-// the given handler as function which is used to determine
-// the slice of declaration kinds which are valid at the top-level
-// for a given location.
-//
-func WithValidTopLevelDeclarationsHandler(handler ValidTopLevelDeclarationsHandlerFunc) Option {
-	return func(checker *Checker) error {
-		checker.validTopLevelDeclarationsHandler = handler
-		return nil
-	}
-}
-
-// WithCheckHandler returns a checker option which sets
-// the given function as the handler for the checking of the program.
-//
-func WithCheckHandler(handler CheckHandlerFunc) Option {
-	return func(checker *Checker) error {
-		checker.checkHandler = handler
-		return nil
-	}
-}
-
-// WithLocationHandler returns a checker option which sets
-// the given handler as function which is used to resolve locations.
-//
-func WithLocationHandler(handler LocationHandlerFunc) Option {
-	return func(checker *Checker) error {
-		checker.locationHandler = handler
-		return nil
-	}
-}
-
-// WithImportHandler returns a checker option which sets
-// the given handler as function which is used to resolve unresolved imports.
-//
-func WithImportHandler(handler ImportHandlerFunc) Option {
-	return func(checker *Checker) error {
-		checker.importHandler = handler
-		return nil
-	}
-}
-
-// WithMemberAccountAccessHandler returns a checker option which sets
-// the given handler as function which is used to determine
-// if the access of a member with account access modifier is valid.
-//
-func WithMemberAccountAccessHandler(handler MemberAccountAccessHandlerFunc) Option {
-	return func(checker *Checker) error {
-		checker.memberAccountAccessHandler = handler
-		return nil
-	}
-}
-
-// WithPositionInfoEnabled returns a checker option which enables/disables
-// if position info recoding is enabled.
-//
-// Position info includes origins, occurrences, member accesses, and ranges.
-//
-func WithPositionInfoEnabled(enabled bool) Option {
-	return func(checker *Checker) error {
-		checker.positionInfoEnabled = enabled
-		if enabled {
-			checker.memberOrigins = map[Type]map[string]*Origin{}
-			checker.variableOrigins = map[*Variable]*Origin{}
-			checker.Occurrences = NewOccurrences()
-			checker.MemberAccesses = NewMemberAccesses()
-			checker.Ranges = NewRanges()
-			checker.FunctionInvocations = NewFunctionInvocations()
-		}
-
-		return nil
-	}
-}
-
-// WithErrorShortCircuitingEnabled returns a checker option which enables/disables
-// error short-circuiting in the checker.
-// When enabled, the checker will stop running once it encounters an error.
-// When disabled (the default), the checker reports the error then continues checking.
-//
-func WithErrorShortCircuitingEnabled(enabled bool) Option {
-	return func(checker *Checker) error {
-		checker.errorShortCircuitingEnabled = enabled
-		return nil
-	}
+	memoryGauge  common.MemoryGauge
+	PositionInfo *PositionInfo
 }
 
 func NewChecker(
 	program *ast.Program,
 	location common.Location,
 	memoryGauge common.MemoryGauge,
-	extendedElaboration bool,
-	options ...Option,
+	config *Config,
 ) (*Checker, error) {
 
 	if location == nil {
-		return nil, &MissingLocationError{}
+		return nil, errors.NewDefaultUserError("missing location")
+	}
+
+	if config.AccessCheckMode == AccessCheckModeDefault {
+		return nil, errors.NewDefaultUserError("invalid default access check mode")
 	}
 
 	functionActivations := &FunctionActivations{}
@@ -250,36 +129,41 @@ func NewChecker(
 		0,
 	)
 
+	elaboration := NewElaboration(
+		memoryGauge,
+		config.ExtendedElaborationEnabled,
+	)
+
 	checker := &Checker{
 		Program:             program,
 		Location:            location,
-		baseValueActivation: BaseValueActivation,
-		baseTypeActivation:  BaseTypeActivation,
+		Config:              config,
+		Elaboration:         elaboration,
 		resources:           NewResources(),
 		functionActivations: functionActivations,
 		containerTypes:      map[Type]bool{},
-		Elaboration:         NewElaboration(memoryGauge, extendedElaboration),
-		extendedElaboration: extendedElaboration,
 		memoryGauge:         memoryGauge,
 	}
 
-	for _, option := range options {
-		err := option(checker)
-		if err != nil {
-			return nil, err
-		}
+	// Initialize value activations
+
+	baseValueActivation := config.BaseValueActivation
+	if baseValueActivation == nil {
+		baseValueActivation = BaseValueActivation
 	}
+	checker.valueActivations = NewVariableActivations(baseValueActivation)
 
-	// Should be done after setting checker options, since base activations might get set in options.
-	checker.valueActivations = NewVariableActivations(checker.baseValueActivation)
-	checker.typeActivations = NewVariableActivations(checker.baseTypeActivation)
+	// Initialize type activations
 
-	// Should be done after setting checker options, since memory-gauge is set via options.
-	checker.beforeExtractor = NewBeforeExtractor(checker.memoryGauge, checker.report)
+	baseTypeActivation := config.BaseTypeActivation
+	if baseTypeActivation == nil {
+		baseTypeActivation = BaseTypeActivation
+	}
+	checker.typeActivations = NewVariableActivations(baseTypeActivation)
 
-	err := checker.CheckerError()
-	if err != nil {
-		return nil, err
+	// Initialize position info, if enabled
+	if checker.Config.PositionInfoEnabled {
+		checker.PositionInfo = NewPositionInfo()
 	}
 
 	return checker, nil
@@ -290,16 +174,7 @@ func (checker *Checker) SubChecker(program *ast.Program, location common.Locatio
 		program,
 		location,
 		checker.memoryGauge,
-		checker.extendedElaboration,
-		WithBaseValueActivation(checker.baseValueActivation),
-		WithBaseTypeActivation(checker.baseTypeActivation),
-		WithAccessCheckMode(checker.accessCheckMode),
-		WithValidTopLevelDeclarationsHandler(checker.validTopLevelDeclarationsHandler),
-		WithCheckHandler(checker.checkHandler),
-		WithLocationHandler(checker.locationHandler),
-		WithImportHandler(checker.importHandler),
-		WithPositionInfoEnabled(checker.positionInfoEnabled),
-		WithErrorShortCircuitingEnabled(checker.errorShortCircuitingEnabled),
+		checker.Config,
 	)
 }
 
@@ -318,7 +193,7 @@ func (checker *Checker) Check() error {
 		checker.Elaboration.setIsChecking(true)
 		checker.errors = nil
 		check := func() {
-			if checker.errorShortCircuitingEnabled {
+			if checker.Config.ErrorShortCircuitingEnabled {
 				defer func() {
 					switch recovered := recover().(type) {
 					case stopChecking:
@@ -336,13 +211,15 @@ func (checker *Checker) Check() error {
 
 			checker.Program.Accept(checker)
 		}
-		if checker.checkHandler != nil {
-			checker.checkHandler(checker, check)
+		if checker.Config.CheckHandler != nil {
+			checker.Config.CheckHandler(checker, check)
 		} else {
 			check()
 		}
 
-		checker.declareGlobalRanges()
+		if checker.PositionInfo != nil {
+			checker.declareGlobalRanges()
+		}
 
 		checker.Elaboration.setIsChecking(false)
 		checker.isChecked = true
@@ -369,7 +246,7 @@ func (checker *Checker) report(err error) {
 		return
 	}
 	checker.errors = append(checker.errors, err)
-	if checker.errorShortCircuitingEnabled {
+	if checker.Config.ErrorShortCircuitingEnabled {
 		panic(stopChecking{})
 	}
 }
@@ -452,13 +329,15 @@ func (checker *Checker) VisitProgram(program *ast.Program) ast.Repr {
 }
 
 func (checker *Checker) checkTopLevelDeclarationValidity(declarations []ast.Declaration) {
-	if checker.validTopLevelDeclarationsHandler == nil {
+	validTopLevelDeclarationsHandler := checker.Config.ValidTopLevelDeclarationsHandler
+
+	if validTopLevelDeclarationsHandler == nil {
 		return
 	}
 
 	validDeclarationKinds := map[common.DeclarationKind]bool{}
 
-	validTopLevelDeclarations := checker.validTopLevelDeclarationsHandler(checker.Location)
+	validTopLevelDeclarations := validTopLevelDeclarationsHandler(checker.Location)
 	if validTopLevelDeclarations == nil {
 		return
 	}
@@ -828,7 +707,7 @@ func (checker *Checker) findAndCheckValueVariable(identifierExpression *ast.Iden
 		return nil
 	}
 
-	if checker.positionInfoEnabled && recordOccurrence && identifier.Identifier != "" {
+	if checker.PositionInfo != nil && recordOccurrence && identifier.Identifier != "" {
 		checker.recordVariableReferenceOccurrence(
 			identifier.StartPosition(),
 			identifier.EndPosition(checker.memoryGauge),
@@ -1235,7 +1114,7 @@ func (checker *Checker) findAndCheckTypeVariable(identifier ast.Identifier, reco
 		return nil
 	}
 
-	if checker.positionInfoEnabled && recordOccurrence && identifier.Identifier != "" {
+	if checker.PositionInfo != nil && recordOccurrence && identifier.Identifier != "" {
 		checker.recordVariableReferenceOccurrence(
 			identifier.StartPosition(),
 			identifier.EndPosition(checker.memoryGauge),
@@ -1349,37 +1228,20 @@ func (checker *Checker) parameters(parameterList *ast.ParameterList) []*Paramete
 }
 
 func (checker *Checker) recordVariableReferenceOccurrence(startPos, endPos ast.Position, variable *Variable) {
-	if !checker.positionInfoEnabled {
-		return
-	}
-
-	origin, ok := checker.variableOrigins[variable]
-	if !ok {
-		startPos2 := variable.Pos
-		var endPos2 *ast.Position
-		if startPos2 != nil {
-			pos := startPos2.Shifted(checker.memoryGauge, len(variable.Identifier)-1)
-			endPos2 = &pos
-		}
-		origin = &Origin{
-			Type:            variable.Type,
-			DeclarationKind: variable.DeclarationKind,
-			StartPos:        startPos2,
-			EndPos:          endPos2,
-			DocString:       variable.DocString,
-		}
-		checker.variableOrigins[variable] = origin
-	}
-	checker.Occurrences.Put(startPos, endPos, origin)
+	checker.PositionInfo.recordVariableReferenceOccurrence(
+		checker.memoryGauge,
+		startPos,
+		endPos,
+		variable,
+	)
 }
 
 func (checker *Checker) recordVariableDeclarationOccurrence(name string, variable *Variable) {
-	if variable.Pos == nil {
-		return
-	}
-	startPos := *variable.Pos
-	endPos := variable.Pos.Shifted(checker.memoryGauge, len(name)-1)
-	checker.recordVariableReferenceOccurrence(startPos, endPos, variable)
+	checker.PositionInfo.recordVariableDeclarationOccurrence(
+		checker.memoryGauge,
+		name,
+		variable,
+	)
 }
 
 func (checker *Checker) recordFieldDeclarationOrigin(
@@ -1387,55 +1249,23 @@ func (checker *Checker) recordFieldDeclarationOrigin(
 	fieldType Type,
 	docString string,
 ) *Origin {
-	if !checker.positionInfoEnabled {
-		return nil
-	}
-
-	startPosition := identifier.StartPosition()
-	endPosition := identifier.EndPosition(checker.memoryGauge)
-
-	origin := &Origin{
-		Type:            fieldType,
-		DeclarationKind: common.DeclarationKindField,
-		StartPos:        &startPosition,
-		EndPos:          &endPosition,
-		DocString:       docString,
-	}
-
-	checker.Occurrences.Put(
-		startPosition,
-		endPosition,
-		origin,
+	return checker.PositionInfo.recordFieldDeclarationOrigin(
+		checker.memoryGauge,
+		identifier,
+		fieldType,
+		docString,
 	)
-
-	return origin
 }
 
 func (checker *Checker) recordFunctionDeclarationOrigin(
 	function *ast.FunctionDeclaration,
 	functionType *FunctionType,
 ) *Origin {
-	if !checker.positionInfoEnabled {
-		return nil
-	}
-
-	startPosition := function.Identifier.StartPosition()
-	endPosition := function.Identifier.EndPosition(checker.memoryGauge)
-
-	origin := &Origin{
-		Type:            functionType,
-		DeclarationKind: common.DeclarationKindFunction,
-		StartPos:        &startPosition,
-		EndPos:          &endPosition,
-		DocString:       function.DocString,
-	}
-
-	checker.Occurrences.Put(
-		startPosition,
-		endPosition,
-		origin,
+	return checker.PositionInfo.recordFunctionDeclarationOrigin(
+		checker.memoryGauge,
+		function,
+		functionType,
 	)
-	return origin
 }
 
 func (checker *Checker) enterValueScope() {
@@ -1839,7 +1669,7 @@ func (checker *Checker) checkDeclarationAccessModifier(
 			// Type declarations cannot be effectively private for now
 
 			if isTypeDeclaration &&
-				checker.accessCheckMode == AccessCheckModeNotSpecifiedRestricted {
+				checker.Config.AccessCheckMode == AccessCheckModeNotSpecifiedRestricted {
 
 				checker.report(
 					&MissingAccessModifierError{
@@ -1852,7 +1682,7 @@ func (checker *Checker) checkDeclarationAccessModifier(
 
 			// In strict mode, access modifiers must be given
 
-			if checker.accessCheckMode == AccessCheckModeStrict {
+			if checker.Config.AccessCheckMode == AccessCheckModeStrict {
 				checker.report(
 					&MissingAccessModifierError{
 						DeclarationKind: declarationKind,
@@ -1894,7 +1724,7 @@ func (checker *Checker) checkCharacterLiteral(expression *ast.StringExpression) 
 }
 
 func (checker *Checker) isReadableAccess(access ast.Access) bool {
-	switch checker.accessCheckMode {
+	switch checker.Config.AccessCheckMode {
 	case AccessCheckModeStrict,
 		AccessCheckModeNotSpecifiedRestricted:
 
@@ -1916,7 +1746,7 @@ func (checker *Checker) isReadableAccess(access ast.Access) bool {
 }
 
 func (checker *Checker) isWriteableAccess(access ast.Access) bool {
-	switch checker.accessCheckMode {
+	switch checker.Config.AccessCheckMode {
 	case AccessCheckModeStrict,
 		AccessCheckModeNotSpecifiedRestricted:
 
@@ -2098,19 +1928,21 @@ func (checker *Checker) rewritePostConditions(postConditions []*ast.Condition) P
 	var beforeStatements []ast.Statement
 	rewrittenPostConditions := make([]*ast.Condition, len(postConditions))
 
+	beforeExtractor := checker.beforeExtractor()
+
 	for i, postCondition := range postConditions {
 
 		// copy condition and set expression to rewritten one
 		newPostCondition := *postCondition
 
-		testExtraction := checker.beforeExtractor.ExtractBefore(postCondition.Test)
+		testExtraction := beforeExtractor.ExtractBefore(postCondition.Test)
 
 		extractedExpressions := testExtraction.ExtractedExpressions
 
 		newPostCondition.Test = testExtraction.RewrittenExpression
 
 		if postCondition.Message != nil {
-			messageExtraction := checker.beforeExtractor.ExtractBefore(postCondition.Message)
+			messageExtraction := beforeExtractor.ExtractBefore(postCondition.Message)
 
 			newPostCondition.Message = messageExtraction.RewrittenExpression
 
@@ -2217,7 +2049,7 @@ func (checker *Checker) effectiveCompositeMemberAccess(access ast.Access) ast.Ac
 		return access
 	}
 
-	switch checker.accessCheckMode {
+	switch checker.Config.AccessCheckMode {
 	case AccessCheckModeStrict, AccessCheckModeNotSpecifiedRestricted:
 		return ast.AccessPrivate
 
@@ -2399,36 +2231,25 @@ func (checker *Checker) expressionRange(expression ast.Expression) ast.Range {
 }
 
 func (checker *Checker) declareGlobalRanges() {
-	if !checker.positionInfoEnabled {
-		return
-	}
-
-	addRange := func(name string, variable *Variable) {
-		checker.Ranges.Put(
-			ast.NewPosition(checker.memoryGauge, 0, 1, 0),
-			ast.NewPosition(checker.memoryGauge, 0, math.MaxInt32, 0),
-			Range{
-				Identifier:      name,
-				Type:            variable.Type,
-				DeclarationKind: variable.DeclarationKind,
-				DocString:       variable.DocString,
-			},
-		)
-	}
+	memoryGauge := checker.memoryGauge
 
 	_ = BaseTypeActivation.ForEach(func(name string, variable *Variable) error {
-		addRange(name, variable)
+		checker.PositionInfo.recordGlobalRange(memoryGauge, name, variable)
 		return nil
 	})
 
 	_ = BaseValueActivation.ForEach(func(name string, variable *Variable) error {
-		addRange(name, variable)
+		checker.PositionInfo.recordGlobalRange(memoryGauge, name, variable)
 		return nil
 	})
 
-	checker.Elaboration.GlobalTypes.Foreach(addRange)
+	checker.Elaboration.GlobalTypes.Foreach(func(name string, variable *Variable) {
+		checker.PositionInfo.recordGlobalRange(memoryGauge, name, variable)
+	})
 
-	checker.Elaboration.GlobalValues.Foreach(addRange)
+	checker.Elaboration.GlobalValues.Foreach(func(name string, variable *Variable) {
+		checker.PositionInfo.recordGlobalRange(memoryGauge, name, variable)
+	})
 }
 
 func (checker *Checker) maybeAddResourceInvalidation(resource Resource, invalidation ResourceInvalidation) {
@@ -2439,6 +2260,13 @@ func (checker *Checker) maybeAddResourceInvalidation(resource Resource, invalida
 	}
 
 	checker.resources.AddInvalidation(resource, invalidation)
+}
+
+func (checker *Checker) beforeExtractor() *BeforeExtractor {
+	if checker._beforeExtractor == nil {
+		checker._beforeExtractor = NewBeforeExtractor(checker.memoryGauge, checker.report)
+	}
+	return checker._beforeExtractor
 }
 
 func wrapWithOptionalIfNotNil(typ Type) Type {

--- a/runtime/sema/config.go
+++ b/runtime/sema/config.go
@@ -1,0 +1,47 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+type Config struct {
+	BaseTypeActivation  *VariableActivation
+	BaseValueActivation *VariableActivation
+	// AccessCheckMode is the mode for access control checks.
+	// It determines how access modifiers how existing and missing acess modifiers are treated.
+	AccessCheckMode AccessCheckMode
+	// ValidTopLevelDeclarationsHandler is used to determine the kinds of declarations
+	// which are valid at the top-level for a given location.
+	ValidTopLevelDeclarationsHandler ValidTopLevelDeclarationsHandlerFunc
+	// LocationHandler is used to resolve locations.
+	LocationHandler LocationHandlerFunc
+	// ImportHandler is used to resolve unresolved imports.
+	ImportHandler ImportHandlerFunc
+	// CheckHandler is the function which is used for the checking of a program.
+	CheckHandler CheckHandlerFunc
+	// PositionInfoEnabled determines if position information is generated.
+	// Position info includes origins, occurrences, member accesses, ranges, and function invocations.
+	PositionInfoEnabled bool
+	// ExtendedElaborationEnabled determines if extended elaboration information is generated.
+	ExtendedElaborationEnabled bool
+	// ErrorShortCircuitingEnabled determines if error short-circuiting is enabled.
+	// When enabled, the checker will stop running once it encounters an error.
+	// When disabled (the default), the checker reports the error then continues checking.
+	ErrorShortCircuitingEnabled bool
+	// MemberAccountAccessHandler is used to determine if the access of a member with account access modifier is valid.
+	MemberAccountAccessHandler MemberAccountAccessHandlerFunc
+}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -73,14 +73,6 @@ func (e *InvalidPragmaError) Error() string {
 	return fmt.Sprintf("invalid pragma %s", e.Message)
 }
 
-// MissingLocationError
-
-type MissingLocationError struct{}
-
-func (e *MissingLocationError) Error() string {
-	return "missing location"
-}
-
 // CheckerError
 
 type CheckerError struct {

--- a/runtime/sema/positioninfo.go
+++ b/runtime/sema/positioninfo.go
@@ -52,17 +52,17 @@ func (i *PositionInfo) recordVariableReferenceOccurrence(
 ) {
 	origin, ok := i.VariableOrigins[variable]
 	if !ok {
-		startPos2 := variable.Pos
-		var endPos2 *ast.Position
-		if startPos2 != nil {
-			pos := startPos2.Shifted(memoryGauge, len(variable.Identifier)-1)
-			endPos2 = &pos
+		originStartPos := variable.Pos
+		var originEndPos *ast.Position
+		if originStartPos != nil {
+			pos := originStartPos.Shifted(memoryGauge, len(variable.Identifier)-1)
+			originEndPos = &pos
 		}
 		origin = &Origin{
 			Type:            variable.Type,
 			DeclarationKind: variable.DeclarationKind,
-			StartPos:        startPos2,
-			EndPos:          endPos2,
+			StartPos:        originStartPos,
+			EndPos:          originEndPos,
 			DocString:       variable.DocString,
 		}
 		i.VariableOrigins[variable] = origin

--- a/runtime/sema/positioninfo.go
+++ b/runtime/sema/positioninfo.go
@@ -1,0 +1,251 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"math"
+)
+
+type PositionInfo struct {
+	Occurrences         *Occurrences
+	VariableOrigins     map[*Variable]*Origin
+	MemberOrigins       map[Type]map[string]*Origin
+	MemberAccesses      *MemberAccesses
+	Ranges              *Ranges
+	FunctionInvocations *FunctionInvocations
+}
+
+func NewPositionInfo() *PositionInfo {
+	return &PositionInfo{
+		MemberOrigins:       map[Type]map[string]*Origin{},
+		VariableOrigins:     map[*Variable]*Origin{},
+		Occurrences:         NewOccurrences(),
+		MemberAccesses:      NewMemberAccesses(),
+		Ranges:              NewRanges(),
+		FunctionInvocations: NewFunctionInvocations(),
+	}
+}
+
+func (i *PositionInfo) recordVariableReferenceOccurrence(
+	memoryGauge common.MemoryGauge,
+	startPos ast.Position,
+	endPos ast.Position,
+	variable *Variable,
+) {
+	origin, ok := i.VariableOrigins[variable]
+	if !ok {
+		startPos2 := variable.Pos
+		var endPos2 *ast.Position
+		if startPos2 != nil {
+			pos := startPos2.Shifted(memoryGauge, len(variable.Identifier)-1)
+			endPos2 = &pos
+		}
+		origin = &Origin{
+			Type:            variable.Type,
+			DeclarationKind: variable.DeclarationKind,
+			StartPos:        startPos2,
+			EndPos:          endPos2,
+			DocString:       variable.DocString,
+		}
+		i.VariableOrigins[variable] = origin
+	}
+	i.Occurrences.Put(startPos, endPos, origin)
+}
+
+func (i *PositionInfo) recordFieldDeclarationOrigin(
+	memoryGauge common.MemoryGauge,
+	identifier ast.Identifier,
+	fieldType Type,
+	docString string,
+) *Origin {
+	startPosition := identifier.StartPosition()
+	endPosition := identifier.EndPosition(memoryGauge)
+
+	origin := &Origin{
+		Type:            fieldType,
+		DeclarationKind: common.DeclarationKindField,
+		StartPos:        &startPosition,
+		EndPos:          &endPosition,
+		DocString:       docString,
+	}
+
+	i.Occurrences.Put(
+		startPosition,
+		endPosition,
+		origin,
+	)
+
+	return origin
+}
+
+func (i *PositionInfo) recordFunctionDeclarationOrigin(
+	memoryGauge common.MemoryGauge,
+	function *ast.FunctionDeclaration,
+	functionType *FunctionType,
+) *Origin {
+
+	startPosition := function.Identifier.StartPosition()
+	endPosition := function.Identifier.EndPosition(memoryGauge)
+
+	origin := &Origin{
+		Type:            functionType,
+		DeclarationKind: common.DeclarationKindFunction,
+		StartPos:        &startPosition,
+		EndPos:          &endPosition,
+		DocString:       function.DocString,
+	}
+
+	i.Occurrences.Put(
+		startPosition,
+		endPosition,
+		origin,
+	)
+	return origin
+}
+
+func (i *PositionInfo) recordVariableDeclarationOccurrence(
+	memoryGauge common.MemoryGauge,
+	name string,
+	variable *Variable,
+) {
+	if variable.Pos == nil {
+		return
+	}
+	startPos := *variable.Pos
+	endPos := variable.Pos.Shifted(memoryGauge, len(name)-1)
+	i.recordVariableReferenceOccurrence(memoryGauge, startPos, endPos, variable)
+}
+
+func (i *PositionInfo) recordMemberOrigins(ty Type, origins map[string]*Origin) {
+	i.MemberOrigins[ty] = origins
+}
+
+func (i *PositionInfo) recordGlobalRange(
+	memoryGauge common.MemoryGauge,
+	name string,
+	variable *Variable,
+) {
+	i.Ranges.Put(
+		ast.NewPosition(memoryGauge, 0, 1, 0),
+		ast.NewPosition(memoryGauge, 0, math.MaxInt32, 0),
+		Range{
+			Identifier:      name,
+			Type:            variable.Type,
+			DeclarationKind: variable.DeclarationKind,
+			DocString:       variable.DocString,
+		},
+	)
+}
+
+func (i *PositionInfo) recordParameterRange(
+	startPos ast.Position,
+	endPos ast.Position,
+	parameter *Parameter,
+) {
+	i.Ranges.Put(
+		startPos,
+		endPos,
+		Range{
+			Identifier:      parameter.Identifier,
+			Type:            parameter.TypeAnnotation.Type,
+			DeclarationKind: common.DeclarationKindParameter,
+		},
+	)
+}
+
+func (i *PositionInfo) recordFunctionInvocation(
+	invocationExpression *ast.InvocationExpression,
+	functionType *FunctionType,
+) {
+	arguments := invocationExpression.Arguments
+
+	trailingSeparatorPositions := make([]ast.Position, 0, len(arguments))
+
+	for _, argument := range arguments {
+		trailingSeparatorPositions = append(
+			trailingSeparatorPositions,
+			argument.TrailingSeparatorPos,
+		)
+	}
+
+	i.FunctionInvocations.Put(
+		invocationExpression.ArgumentsStartPos,
+		invocationExpression.EndPos,
+		functionType,
+		trailingSeparatorPositions,
+	)
+}
+
+func (i *PositionInfo) recordMemberAccess(
+	memoryGauge common.MemoryGauge,
+	expression *ast.MemberExpression,
+	memberAccessType Type,
+) {
+	i.MemberAccesses.Put(
+		expression.AccessPos,
+		expression.EndPosition(memoryGauge),
+		memberAccessType,
+	)
+}
+
+func (i *PositionInfo) recordMemberOccurrence(
+	accessedType Type,
+	identifier string,
+	identifierStartPosition ast.Position,
+	identifierEndPosition ast.Position,
+) {
+	origins := i.MemberOrigins[accessedType]
+	origin := origins[identifier]
+	i.Occurrences.Put(
+		identifierStartPosition,
+		identifierEndPosition,
+		origin,
+	)
+}
+
+func (i *PositionInfo) recordVariableDeclarationRange(
+	memoryGauge common.MemoryGauge,
+	declaration *ast.VariableDeclaration,
+	endPosition ast.Position,
+	identifier string,
+	declarationType Type,
+) {
+	// TODO: use the start position of the next statement
+	//   after this variable declaration instead
+
+	var startPosition ast.Position
+	if declaration.SecondValue != nil {
+		startPosition = declaration.SecondValue.EndPosition(memoryGauge)
+	} else {
+		startPosition = declaration.Value.EndPosition(memoryGauge)
+	}
+
+	i.Ranges.Put(
+		startPosition,
+		endPosition,
+		Range{
+			Identifier:      identifier,
+			DeclarationKind: declaration.DeclarationKind(),
+			Type:            declarationType,
+			DocString:       declaration.DocString,
+		},
+	)
+}

--- a/runtime/sema/positioninfo.go
+++ b/runtime/sema/positioninfo.go
@@ -19,9 +19,10 @@
 package sema
 
 import (
+	"math"
+
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"math"
 )
 
 type PositionInfo struct {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3273,7 +3273,7 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 		switch argument := argument.(type) {
 		case *ast.IntegerExpression:
 			if CheckIntegerLiteral(nil, argument, targetType, checker.report) {
-				if checker.extendedElaboration {
+				if checker.Config.ExtendedElaborationEnabled {
 					checker.Elaboration.NumberConversionArgumentTypes[argument] = struct {
 						Type  Type
 						Range ast.Range
@@ -3283,7 +3283,7 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 
 		case *ast.FixedPointExpression:
 			if CheckFixedPointLiteral(nil, argument, targetType, checker.report) {
-				if checker.extendedElaboration {
+				if checker.Config.ExtendedElaborationEnabled {
 					checker.Elaboration.NumberConversionArgumentTypes[argument] = struct {
 						Type  Type
 						Range ast.Range
@@ -3297,7 +3297,7 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 func init() {
 
 	// Declare a function for the string type.
-	// For now it has no parameters and creates an empty string
+	// For now, it has no parameters and creates an empty string
 
 	typeName := StringType.String()
 

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -539,7 +539,11 @@ func TestBeforeType_Strings(t *testing.T) {
 
 func TestQualifiedIdentifierCreation(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("with containers", func(t *testing.T) {
+
+		t.Parallel()
 
 		a := &CompositeType{
 			Kind:       common.CompositeKindStructure,
@@ -572,11 +576,15 @@ func TestQualifiedIdentifierCreation(t *testing.T) {
 	})
 
 	t.Run("without containers", func(t *testing.T) {
+		t.Parallel()
+
 		identifier := qualifiedIdentifier("foo", nil)
 		assert.Equal(t, "foo", identifier)
 	})
 
 	t.Run("public account container", func(t *testing.T) {
+		t.Parallel()
+
 		identifier := qualifiedIdentifier("foo", PublicAccountType)
 		assert.Equal(t, "PublicAccount.foo", identifier)
 	})
@@ -620,6 +628,8 @@ func BenchmarkQualifiedIdentifierCreation(b *testing.B) {
 
 func TestIdentifierCacheUpdate(t *testing.T) {
 
+	t.Parallel()
+
 	code := `
           pub contract interface Test {
 
@@ -647,7 +657,9 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 		program,
 		common.StringLocation("test"),
 		nil,
-		false,
+		&Config{
+			AccessCheckMode: AccessCheckModeStrict,
+		},
 	)
 	require.NoError(t, err)
 
@@ -1660,7 +1672,6 @@ func TestTypeInclusions(t *testing.T) {
 
 		for _, typ := range AllNumberTypes {
 			t.Run(typ.String(), func(t *testing.T) {
-				t.Parallel()
 				assert.True(t, NumberTypeTag.ContainsAny(typ.Tag()))
 			})
 		}
@@ -1671,7 +1682,6 @@ func TestTypeInclusions(t *testing.T) {
 
 		for _, typ := range AllIntegerTypes {
 			t.Run(typ.String(), func(t *testing.T) {
-				t.Parallel()
 				assert.True(t, IntegerTypeTag.ContainsAny(typ.Tag()))
 			})
 		}
@@ -1682,7 +1692,6 @@ func TestTypeInclusions(t *testing.T) {
 
 		for _, typ := range AllSignedIntegerTypes {
 			t.Run(typ.String(), func(t *testing.T) {
-				t.Parallel()
 				assert.True(t, SignedIntegerTypeTag.ContainsAny(typ.Tag()))
 			})
 		}
@@ -1693,7 +1702,6 @@ func TestTypeInclusions(t *testing.T) {
 
 		for _, typ := range AllUnsignedIntegerTypes {
 			t.Run(typ.String(), func(t *testing.T) {
-				t.Parallel()
 				assert.True(t, UnsignedIntegerTypeTag.ContainsAny(typ.Tag()))
 			})
 		}
@@ -1704,7 +1712,6 @@ func TestTypeInclusions(t *testing.T) {
 
 		for _, typ := range AllFixedPointTypes {
 			t.Run(typ.String(), func(t *testing.T) {
-				t.Parallel()
 				assert.True(t, FixedPointTypeTag.ContainsAny(typ.Tag()))
 			})
 		}
@@ -1715,16 +1722,16 @@ func TestTypeInclusions(t *testing.T) {
 
 		for _, typ := range AllSignedFixedPointTypes {
 			t.Run(typ.String(), func(t *testing.T) {
-				t.Parallel()
 				assert.True(t, SignedFixedPointTypeTag.ContainsAny(typ.Tag()))
 			})
 		}
 	})
 
 	t.Run("UnsignedFixedPoint", func(t *testing.T) {
+		t.Parallel()
+
 		for _, typ := range AllUnsignedFixedPointTypes {
 			t.Run(typ.String(), func(t *testing.T) {
-				t.Parallel()
 				assert.True(t, UnsignedFixedPointTypeTag.ContainsAny(typ.Tag()))
 			})
 		}
@@ -1736,7 +1743,6 @@ func TestTypeInclusions(t *testing.T) {
 
 		err := BaseTypeActivation.ForEach(func(name string, variable *Variable) error {
 			t.Run(name, func(t *testing.T) {
-				t.Parallel()
 
 				typ := variable.Type
 				if _, ok := typ.(*CompositeType); ok {
@@ -1757,7 +1763,6 @@ func TestTypeInclusions(t *testing.T) {
 
 		err := BaseTypeActivation.ForEach(func(name string, variable *Variable) error {
 			t.Run(name, func(t *testing.T) {
-				t.Parallel()
 
 				typ := variable.Type
 

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -49,8 +49,10 @@ func testInterpreter(t *testing.T, code string, valueDeclaration StandardLibrary
 		program,
 		utils.TestLocation,
 		nil,
-		false,
-		sema.WithBaseValueActivation(baseValueActivation),
+		&sema.Config{
+			BaseValueActivation: baseValueActivation,
+			AccessCheckMode:     sema.AccessCheckModeStrict,
+		},
 	)
 	require.NoError(t, err)
 

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -42,7 +42,9 @@ var CryptoChecker = func() *sema.Checker {
 		program,
 		location,
 		nil,
-		false,
+		&sema.Config{
+			AccessCheckMode: sema.AccessCheckModeStrict,
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -201,8 +201,8 @@ func TestCheckAccessModifierInterfaceFunctionDeclaration(t *testing.T) {
 							access.Keyword(),
 						),
 						ParseAndCheckOptions{
-							Options: []sema.Option{
-								sema.WithAccessCheckMode(checkMode),
+							Config: &sema.Config{
+								AccessCheckMode: checkMode,
 							},
 						},
 					)
@@ -614,8 +614,8 @@ func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
 								body,
 							),
 							ParseAndCheckOptions{
-								Options: []sema.Option{
-									sema.WithAccessCheckMode(checkMode),
+								Config: &sema.Config{
+									AccessCheckMode: checkMode,
 								},
 							},
 						)
@@ -722,8 +722,8 @@ func TestCheckAccessCompositeFunction(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Options: []sema.Option{
-								sema.WithAccessCheckMode(checkMode),
+							Config: &sema.Config{
+								AccessCheckMode: checkMode,
 							},
 						},
 					)
@@ -837,8 +837,8 @@ func TestCheckAccessInterfaceFunction(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Options: []sema.Option{
-								sema.WithAccessCheckMode(checkMode),
+							Config: &sema.Config{
+								AccessCheckMode: checkMode,
 							},
 						},
 					)
@@ -948,8 +948,8 @@ func TestCheckAccessCompositeFieldRead(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Options: []sema.Option{
-								sema.WithAccessCheckMode(checkMode),
+							Config: &sema.Config{
+								AccessCheckMode: checkMode,
 							},
 						},
 					)
@@ -1067,8 +1067,8 @@ func TestCheckAccessInterfaceFieldRead(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Options: []sema.Option{
-								sema.WithAccessCheckMode(checkMode),
+							Config: &sema.Config{
+								AccessCheckMode: checkMode,
 							},
 						},
 					)
@@ -1183,8 +1183,8 @@ func TestCheckAccessCompositeFieldAssignmentAndSwap(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Options: []sema.Option{
-								sema.WithAccessCheckMode(checkMode),
+							Config: &sema.Config{
+								AccessCheckMode: checkMode,
 							},
 						},
 					)
@@ -1326,8 +1326,8 @@ func TestCheckAccessInterfaceFieldWrite(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Options: []sema.Option{
-								sema.WithAccessCheckMode(checkMode),
+							Config: &sema.Config{
+								AccessCheckMode: checkMode,
 							},
 						},
 					)
@@ -1421,8 +1421,8 @@ func TestCheckAccessCompositeFieldVariableDeclarationWithSecondValue(t *testing.
 						access.Keyword(),
 					),
 					ParseAndCheckOptions{
-						Options: []sema.Option{
-							sema.WithAccessCheckMode(checkMode),
+						Config: &sema.Config{
+							AccessCheckMode: checkMode,
 						},
 					},
 				)
@@ -1533,8 +1533,8 @@ func TestCheckAccessInterfaceFieldVariableDeclarationWithSecondValue(t *testing.
 						access.Keyword(),
 					),
 					ParseAndCheckOptions{
-						Options: []sema.Option{
-							sema.WithAccessCheckMode(checkMode),
+						Config: &sema.Config{
+							AccessCheckMode: checkMode,
 						},
 					},
 				)
@@ -1639,15 +1639,14 @@ func TestCheckAccessImportGlobalValue(t *testing.T) {
                        import a, b, c from "imported"
                     `,
 					ParseAndCheckOptions{
-						Options: []sema.Option{
-							sema.WithAccessCheckMode(checkMode),
-							sema.WithImportHandler(
-								func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-									return sema.ElaborationImport{
-										Elaboration: importedChecker.Elaboration,
-									}, nil
-								},
-							),
+
+						Config: &sema.Config{
+							AccessCheckMode: checkMode,
+							ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+								return sema.ElaborationImport{
+									Elaboration: importedChecker.Elaboration,
+								}, nil
+							},
 						},
 					},
 				)
@@ -1846,15 +1845,13 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
                   }
                 `,
 				ParseAndCheckOptions{
-					Options: []sema.Option{
-						sema.WithAccessCheckMode(checkMode),
-						sema.WithImportHandler(
-							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-								return sema.ElaborationImport{
-									Elaboration: imported.Elaboration,
-								}, nil
-							},
-						),
+					Config: &sema.Config{
+						AccessCheckMode: checkMode,
+						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+							return sema.ElaborationImport{
+								Elaboration: imported.Elaboration,
+							}, nil
+						},
 					},
 				},
 			)
@@ -1893,14 +1890,12 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
            }
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: imported.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: imported.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -2379,15 +2374,13 @@ func TestCheckAccountAccess(t *testing.T) {
 								importingCode,
 								ParseAndCheckOptions{
 									Location: test.location,
-									Options: []sema.Option{
-										sema.WithAccessCheckMode(checkMode),
-										sema.WithImportHandler(
-											func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-												return sema.ElaborationImport{
-													Elaboration: importedChecker.Elaboration,
-												}, nil
-											},
-										),
+									Config: &sema.Config{
+										AccessCheckMode: checkMode,
+										ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+											return sema.ElaborationImport{
+												Elaboration: importedChecker.Elaboration,
+											}, nil
+										},
 									},
 								},
 							)

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -46,8 +46,8 @@ func ParseAndCheckAccount(t *testing.T, code string) (*sema.Checker, error) {
 	return ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/assert_test.go
+++ b/runtime/tests/checker/assert_test.go
@@ -41,8 +41,8 @@ func TestCheckAssertWithoutMessage(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -64,8 +64,8 @@ func TestCheckAssertWithMessage(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/contract_test.go
+++ b/runtime/tests/checker/contract_test.go
@@ -417,7 +417,6 @@ func TestCheckContractNestedDeclarationOrderInsideOutside(t *testing.T) {
 // - Using inner types in functions outside (both type in parameter and constructor)
 // - Using outer functions in inner types' functions
 // - Mutually using sibling types
-//
 func TestCheckContractNestedDeclarationsComplex(t *testing.T) {
 
 	t.Parallel()
@@ -737,8 +736,8 @@ func TestCheckContractEnumAccessRestricted(t *testing.T) {
 
 	_, err := ParseAndCheckWithOptions(t, "contract enum{}let x = enum!",
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithAccessCheckMode(sema.AccessCheckModeStrict),
+			Config: &sema.Config{
+				AccessCheckMode: sema.AccessCheckModeStrict,
 			},
 		},
 	)

--- a/runtime/tests/checker/crypto_test.go
+++ b/runtime/tests/checker/crypto_test.go
@@ -47,8 +47,8 @@ func TestCheckHashAlgorithmCases(t *testing.T) {
 				algorithm.Name(),
 			),
 			ParseAndCheckOptions{
-				Options: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				Config: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 			},
 		)
@@ -73,8 +73,8 @@ func TestCheckHashAlgorithmConstructor(t *testing.T) {
            let algo = HashAlgorithm(rawValue: 0)
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -96,8 +96,8 @@ func TestCheckHashAlgorithmHashFunctions(t *testing.T) {
            let result2: [UInt8] = HashAlgorithm.SHA2_256.hashWithTag(data, tag: "tag")
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -122,8 +122,8 @@ func TestCheckSignatureAlgorithmCases(t *testing.T) {
 				algorithm.Name(),
 			),
 			ParseAndCheckOptions{
-				Options: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				Config: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 			},
 		)
@@ -148,8 +148,8 @@ func TestCheckSignatureAlgorithmConstructor(t *testing.T) {
            let algo = SignatureAlgorithm(rawValue: 0)
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -175,8 +175,8 @@ func TestCheckVerifyPoP(t *testing.T) {
            let x: Bool = key.verifyPoP([1, 2, 3])
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -202,8 +202,8 @@ func TestCheckVerifyPoPInvalidArgument(t *testing.T) {
            let x: Int = key.verifyPoP([1 as Int32, 2, 3])
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -226,8 +226,8 @@ func TestCheckBLSAggregateSignatures(t *testing.T) {
            let r: [UInt8] = BLS.aggregateSignatures([[1 as UInt8, 2, 3], []])!
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -247,8 +247,8 @@ func TestCheckInvalidBLSAggregateSignatures(t *testing.T) {
            let r: [UInt16] = BLS.aggregateSignatures([[1 as UInt32, 2, 3], []])!
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -278,8 +278,8 @@ func TestCheckBLSAggregatePublicKeys(t *testing.T) {
            ])!
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -301,8 +301,8 @@ func TestCheckInvalidBLSAggregatePublicKeys(t *testing.T) {
            let r: [PublicKey] = BLS.aggregatePublicKeys([1])!
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/declaration_test.go
+++ b/runtime/tests/checker/declaration_test.go
@@ -472,15 +472,13 @@ func TestCheckTopLevelContractRestriction(t *testing.T) {
           contract C {}
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithValidTopLevelDeclarationsHandler(
-					func(_ common.Location) []common.DeclarationKind {
-						return []common.DeclarationKind{
-							common.DeclarationKindContract,
-							common.DeclarationKindImport,
-						}
-					},
-				),
+			Config: &sema.Config{
+				ValidTopLevelDeclarationsHandler: func(_ common.Location) []common.DeclarationKind {
+					return []common.DeclarationKind{
+						common.DeclarationKindContract,
+						common.DeclarationKindImport,
+					}
+				},
 			},
 		},
 	)
@@ -509,16 +507,14 @@ func TestCheckInvalidTopLevelContractRestriction(t *testing.T) {
 			_, err := ParseAndCheckWithOptions(t,
 				code,
 				ParseAndCheckOptions{
-					Options: []sema.Option{
-						sema.WithValidTopLevelDeclarationsHandler(
-							func(_ common.Location) []common.DeclarationKind {
-								return []common.DeclarationKind{
-									common.DeclarationKindContractInterface,
-									common.DeclarationKindContract,
-									common.DeclarationKindImport,
-								}
-							},
-						),
+					Config: &sema.Config{
+						ValidTopLevelDeclarationsHandler: func(_ common.Location) []common.DeclarationKind {
+							return []common.DeclarationKind{
+								common.DeclarationKindContractInterface,
+								common.DeclarationKindContract,
+								common.DeclarationKindImport,
+							}
+						},
 					},
 				},
 			)

--- a/runtime/tests/checker/errors_test.go
+++ b/runtime/tests/checker/errors_test.go
@@ -43,8 +43,8 @@ func TestCheckErrorShortCircuiting(t *testing.T) {
               let x: Type<X<X<X>>>? = nil
             `,
 			ParseAndCheckOptions{
-				Options: []sema.Option{
-					sema.WithErrorShortCircuitingEnabled(true),
+				Config: &sema.Config{
+					ErrorShortCircuitingEnabled: true,
 				},
 			},
 		)
@@ -71,28 +71,26 @@ func TestCheckErrorShortCircuiting(t *testing.T) {
                let b = B
             `,
 			ParseAndCheckOptions{
-				Options: []sema.Option{
-					sema.WithErrorShortCircuitingEnabled(true),
-					sema.WithImportHandler(
-						func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+				Config: &sema.Config{
+					ErrorShortCircuitingEnabled: true,
+					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 
-							_, err := ParseAndCheckWithOptions(t,
-								`
-                                  pub let x = X
-                                  pub let y = Y
-                                `,
-								ParseAndCheckOptions{
-									Location: utils.ImportedLocation,
-									Options: []sema.Option{
-										sema.WithErrorShortCircuitingEnabled(true),
-									},
+						_, err := ParseAndCheckWithOptions(t,
+							`
+                              pub let x = X
+                              pub let y = Y
+                            `,
+							ParseAndCheckOptions{
+								Location: utils.ImportedLocation,
+								Config: &sema.Config{
+									ErrorShortCircuitingEnabled: true,
 								},
-							)
-							require.Error(t, err)
+							},
+						)
+						require.Error(t, err)
 
-							return nil, err
-						},
-					),
+						return nil, err
+					},
 				},
 			},
 		)

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -265,14 +265,12 @@ func TestCheckEmitEvent(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Options: []sema.Option{
-					sema.WithImportHandler(
-						func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-							return sema.ElaborationImport{
-								Elaboration: importedChecker.Elaboration,
-							}, nil
-						},
-					),
+				Config: &sema.Config{
+					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
+						}, nil
+					},
 				},
 			},
 		)

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -43,8 +43,8 @@ func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.
 	return ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -67,14 +67,12 @@ func TestCheckRepeatedImport(t *testing.T) {
            import y from "imported"
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -127,38 +125,34 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
            import y from 0x1
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithLocationHandler(
-					func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-						for _, identifier := range identifiers {
-							result = append(result, sema.ResolvedLocation{
-								Location: common.AddressLocation{
-									Address: importedAddress,
-									Name:    identifier.Identifier,
-								},
-								Identifiers: []ast.Identifier{
-									identifier,
-								},
-							})
-						}
-						return
-					},
-				),
-				sema.WithImportHandler(
-					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						addressLocation := importedLocation.(common.AddressLocation)
-						var importedChecker *sema.Checker
-						switch addressLocation.Name {
-						case "x":
-							importedChecker = importedCheckerX
-						case "y":
-							importedChecker = importedCheckerY
-						}
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
+					for _, identifier := range identifiers {
+						result = append(result, sema.ResolvedLocation{
+							Location: common.AddressLocation{
+								Address: importedAddress,
+								Name:    identifier.Identifier,
+							},
+							Identifiers: []ast.Identifier{
+								identifier,
+							},
+						})
+					}
+					return
+				},
+				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+					addressLocation := importedLocation.(common.AddressLocation)
+					var importedChecker *sema.Checker
+					switch addressLocation.Name {
+					case "x":
+						importedChecker = importedCheckerX
+					case "y":
+						importedChecker = importedCheckerY
+					}
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -187,14 +181,12 @@ func TestCheckInvalidRepeatedImport(t *testing.T) {
            import x from "imported"
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -249,38 +241,34 @@ func TestCheckImportResolutionSplit(t *testing.T) {
            import x, y from 0x1
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithLocationHandler(
-					func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-						for _, identifier := range identifiers {
-							result = append(result, sema.ResolvedLocation{
-								Location: common.AddressLocation{
-									Address: importedAddress,
-									Name:    identifier.Identifier,
-								},
-								Identifiers: []ast.Identifier{
-									identifier,
-								},
-							})
-						}
-						return
-					},
-				),
-				sema.WithImportHandler(
-					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						addressLocation := importedLocation.(common.AddressLocation)
-						var importedChecker *sema.Checker
-						switch addressLocation.Name {
-						case "x":
-							importedChecker = importedCheckerX
-						case "y":
-							importedChecker = importedCheckerY
-						}
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
+					for _, identifier := range identifiers {
+						result = append(result, sema.ResolvedLocation{
+							Location: common.AddressLocation{
+								Address: importedAddress,
+								Name:    identifier.Identifier,
+							},
+							Identifiers: []ast.Identifier{
+								identifier,
+							},
+						})
+					}
+					return
+				},
+				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+					addressLocation := importedLocation.(common.AddressLocation)
+					var importedChecker *sema.Checker
+					switch addressLocation.Name {
+					case "x":
+						importedChecker = importedCheckerX
+					case "y":
+						importedChecker = importedCheckerY
+					}
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -312,14 +300,12 @@ func TestCheckImportAll(t *testing.T) {
           pub let x = answer()
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -349,14 +335,12 @@ func TestCheckInvalidImportUnexported(t *testing.T) {
            pub let x = answer()
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -392,14 +376,12 @@ func TestCheckImportSome(t *testing.T) {
           pub let x = answer()
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -421,12 +403,10 @@ func TestCheckInvalidImportedError(t *testing.T) {
            import x from "imported"
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return nil, importedErr
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return nil, importedErr
+				},
 			},
 		},
 	)
@@ -494,14 +474,12 @@ func TestCheckImportTypes(t *testing.T) {
 					useCode,
 				),
 				ParseAndCheckOptions{
-					Options: []sema.Option{
-						sema.WithImportHandler(
-							func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-								return sema.ElaborationImport{
-									Elaboration: importedChecker.Elaboration,
-								}, nil
-							},
-						),
+					Config: &sema.Config{
+						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+							return sema.ElaborationImport{
+								Elaboration: importedChecker.Elaboration,
+							}, nil
+						},
 					},
 				},
 			)
@@ -541,29 +519,27 @@ func TestCheckInvalidImportCycleSelf(t *testing.T) {
 			code,
 			ParseAndCheckOptions{
 				Location: location,
-				Options: []sema.Option{
-					sema.WithImportHandler(
-						func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+				Config: &sema.Config{
+					ImportHandler: func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 
-							elaboration, ok := elaborations[importedLocation]
-							if !ok {
-								subChecker, err := checker.SubChecker(importedProgram, importedLocation)
-								if err != nil {
-									return nil, err
-								}
-								elaborations[importedLocation] = subChecker.Elaboration
-								err = subChecker.Check()
-								if err != nil {
-									return nil, err
-								}
-								elaboration = subChecker.Elaboration
+						elaboration, ok := elaborations[importedLocation]
+						if !ok {
+							subChecker, err := checker.SubChecker(importedProgram, importedLocation)
+							if err != nil {
+								return nil, err
 							}
+							elaborations[importedLocation] = subChecker.Elaboration
+							err = subChecker.Check()
+							if err != nil {
+								return nil, err
+							}
+							elaboration = subChecker.Elaboration
+						}
 
-							return sema.ElaborationImport{
-								Elaboration: elaboration,
-							}, nil
-						},
-					),
+						return sema.ElaborationImport{
+							Elaboration: elaboration,
+						}, nil
+					},
 				},
 			},
 		)
@@ -634,30 +610,28 @@ func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
 		codeEven,
 		ParseAndCheckOptions{
 			Location: common.StringLocation("even"),
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						importedProgram := getProgram(importedLocation)
+			Config: &sema.Config{
+				ImportHandler: func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+					importedProgram := getProgram(importedLocation)
 
-						elaboration, ok := elaborations[importedLocation]
-						if !ok {
-							subChecker, err := checker.SubChecker(importedProgram, importedLocation)
-							if err != nil {
-								return nil, err
-							}
-							elaborations[importedLocation] = subChecker.Elaboration
-							err = subChecker.Check()
-							if err != nil {
-								return nil, err
-							}
-							elaboration = subChecker.Elaboration
+					elaboration, ok := elaborations[importedLocation]
+					if !ok {
+						subChecker, err := checker.SubChecker(importedProgram, importedLocation)
+						if err != nil {
+							return nil, err
 						}
+						elaborations[importedLocation] = subChecker.Elaboration
+						err = subChecker.Check()
+						if err != nil {
+							return nil, err
+						}
+						elaboration = subChecker.Elaboration
+					}
 
-						return sema.ElaborationImport{
-							Elaboration: elaboration,
-						}, nil
-					},
-				),
+					return sema.ElaborationImport{
+						Elaboration: elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -722,14 +696,12 @@ func TestCheckImportVirtual(t *testing.T) {
 	_, err := ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.VirtualImport{
-							ValueElements: valueElements,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.VirtualImport{
+						ValueElements: valueElements,
+					}, nil
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -1869,8 +1869,9 @@ func BenchmarkContractInterfaceFungibleToken(b *testing.B) {
 			program,
 			TestLocation,
 			nil,
-			false,
-			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
+			&sema.Config{
+				AccessCheckMode: sema.AccessCheckModeNotSpecifiedUnrestricted,
+			},
 		)
 		if err != nil {
 			b.Fatal(err)
@@ -1902,9 +1903,10 @@ func BenchmarkCheckContractInterfaceFungibleTokenConformance(b *testing.B) {
 			program,
 			TestLocation,
 			nil,
-			false,
-			sema.WithAccessCheckMode(sema.AccessCheckModeNotSpecifiedUnrestricted),
-			sema.WithBaseValueActivation(baseValueActivation),
+			&sema.Config{
+				AccessCheckMode:     sema.AccessCheckModeNotSpecifiedUnrestricted,
+				BaseValueActivation: baseValueActivation,
+			},
 		)
 		if err != nil {
 			b.Fatal(err)

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -336,8 +336,8 @@ func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/nesting_test.go
+++ b/runtime/tests/checker/nesting_test.go
@@ -301,8 +301,8 @@ func TestCheckNestedTypeInvalidChildType(t *testing.T) {
 			_, err := ParseAndCheckWithOptions(t,
 				`let u: T.U = nil`,
 				ParseAndCheckOptions{
-					Options: []sema.Option{
-						sema.WithBaseTypeActivation(baseTypeActivation),
+					Config: &sema.Config{
+						BaseTypeActivation: baseTypeActivation,
 					},
 				},
 			)

--- a/runtime/tests/checker/nft_test.go
+++ b/runtime/tests/checker/nft_test.go
@@ -997,15 +997,13 @@ func TestCheckTopShotContract(t *testing.T) {
 				Address: common.MustBytesToAddress([]byte{0x2}),
 				Name:    "TopShot",
 			},
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: nftChecker.Elaboration,
-						}, nil
-					},
-				),
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: nftChecker.Elaboration,
+					}, nil
+				},
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/occurrences_test.go
+++ b/runtime/tests/checker/occurrences_test.go
@@ -41,15 +41,15 @@ func TestCheckOccurrencesVariableDeclarations(t *testing.T) {
         var y = x
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithPositionInfoEnabled(true),
+			Config: &sema.Config{
+				PositionInfoEnabled: true,
 			},
 		},
 	)
 
 	require.NoError(t, err)
 
-	occurrences := checker.Occurrences.All()
+	occurrences := checker.PositionInfo.Occurrences.All()
 
 	matchers := []*OccurrenceMatcher{
 		{
@@ -87,8 +87,8 @@ nextMatcher:
 	}
 
 	for _, matcher := range matchers {
-		assert.NotNil(t, checker.Occurrences.Find(matcher.StartPos))
-		assert.NotNil(t, checker.Occurrences.Find(matcher.EndPos))
+		assert.NotNil(t, checker.PositionInfo.Occurrences.Find(matcher.StartPos))
+		assert.NotNil(t, checker.PositionInfo.Occurrences.Find(matcher.EndPos))
 	}
 }
 
@@ -113,15 +113,15 @@ func TestCheckOccurrencesFunction(t *testing.T) {
         }
 		`,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithPositionInfoEnabled(true),
+			Config: &sema.Config{
+				PositionInfoEnabled: true,
 			},
 		},
 	)
 
 	require.NoError(t, err)
 
-	occurrences := checker.Occurrences.All()
+	occurrences := checker.PositionInfo.Occurrences.All()
 
 	matchers := []*OccurrenceMatcher{
 		{
@@ -227,8 +227,8 @@ nextMatcher:
 	}
 
 	for _, matcher := range matchers {
-		assert.NotNil(t, checker.Occurrences.Find(matcher.StartPos))
-		assert.NotNil(t, checker.Occurrences.Find(matcher.EndPos))
+		assert.NotNil(t, checker.PositionInfo.Occurrences.Find(matcher.StartPos))
+		assert.NotNil(t, checker.PositionInfo.Occurrences.Find(matcher.EndPos))
 	}
 }
 
@@ -254,15 +254,15 @@ func TestCheckOccurrencesStructAndInterface(t *testing.T) {
 	    }
 		`,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithPositionInfoEnabled(true),
+			Config: &sema.Config{
+				PositionInfoEnabled: true,
 			},
 		},
 	)
 
 	require.NoError(t, err)
 
-	occurrences := checker.Occurrences.All()
+	occurrences := checker.PositionInfo.Occurrences.All()
 
 	matchers := []*OccurrenceMatcher{
 		{
@@ -355,7 +355,7 @@ nextMatcher:
 	}
 
 	for _, matcher := range matchers {
-		assert.NotNil(t, checker.Occurrences.Find(matcher.StartPos))
-		assert.NotNil(t, checker.Occurrences.Find(matcher.EndPos))
+		assert.NotNil(t, checker.PositionInfo.Occurrences.Find(matcher.StartPos))
+		assert.NotNil(t, checker.PositionInfo.Occurrences.Find(matcher.EndPos))
 	}
 }

--- a/runtime/tests/checker/predeclaredvalues_test.go
+++ b/runtime/tests/checker/predeclaredvalues_test.go
@@ -52,8 +52,8 @@ func TestCheckPredeclaredValues(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/range_test.go
+++ b/runtime/tests/checker/range_test.go
@@ -63,8 +63,8 @@ func TestCheckRange(t *testing.T) {
           resource _TEST_Baz {}
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithPositionInfoEnabled(true),
+			Config: &sema.Config{
+				PositionInfoEnabled: true,
 			},
 		},
 	)
@@ -107,7 +107,7 @@ func TestCheckRange(t *testing.T) {
 		})
 	}
 
-	ranges = checker.Ranges.All()
+	ranges = checker.PositionInfo.Ranges.All()
 	sortAndFilterRanges()
 
 	barTypeVariable, ok := checker.Elaboration.GlobalTypes.Get("_TEST_Bar")
@@ -181,7 +181,7 @@ func TestCheckRange(t *testing.T) {
 		ranges,
 	)
 
-	ranges = checker.Ranges.FindAll(sema.Position{Line: 8, Column: 0})
+	ranges = checker.PositionInfo.Ranges.FindAll(sema.Position{Line: 8, Column: 0})
 	sortAndFilterRanges()
 	assert.Equal(t,
 		[]sema.Range{
@@ -229,7 +229,7 @@ func TestCheckRange(t *testing.T) {
 		ranges,
 	)
 
-	ranges = checker.Ranges.FindAll(sema.Position{Line: 8, Column: 100})
+	ranges = checker.PositionInfo.Ranges.FindAll(sema.Position{Line: 8, Column: 100})
 	sortAndFilterRanges()
 	assert.Equal(t,
 		[]sema.Range{

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -1466,14 +1466,12 @@ func TestCheckInvalidCreateImportedResource(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -3114,7 +3112,6 @@ func TestCheckInvalidEnumResourceField(t *testing.T) {
 
 // TestCheckResourceInterfaceConformance tests the check
 // of conformance of resources to resource interfaces.
-//
 func TestCheckResourceInterfaceConformance(t *testing.T) {
 
 	t.Parallel()
@@ -3134,7 +3131,6 @@ func TestCheckResourceInterfaceConformance(t *testing.T) {
 
 // TestCheckInvalidResourceInterfaceConformance tests the check
 // of conformance of resources to resource interfaces.
-//
 func TestCheckInvalidResourceInterfaceConformance(t *testing.T) {
 
 	t.Parallel()
@@ -3154,7 +3150,6 @@ func TestCheckInvalidResourceInterfaceConformance(t *testing.T) {
 
 // TestCheckInvalidResourceInterfaceUseAsType tests that a resource interface
 // can not be used as a type
-//
 func TestCheckInvalidResourceInterfaceUseAsType(t *testing.T) {
 
 	t.Parallel()
@@ -3174,7 +3169,6 @@ func TestCheckInvalidResourceInterfaceUseAsType(t *testing.T) {
 
 // TestCheckResourceInterfaceUseAsType test if a resource
 // is a subtype of a restricted AnyResource type.
-//
 func TestCheckResourceInterfaceUseAsType(t *testing.T) {
 
 	t.Parallel()
@@ -3292,7 +3286,6 @@ func TestCheckInvalidResourceLossThroughFunctionResultAccess(t *testing.T) {
 // TestCheckAnyResourceDestruction tests if resources
 // can be passed to restricted AnyResources parameters,
 // and if the argument can be destroyed.
-//
 func TestCheckAnyResourceDestruction(t *testing.T) {
 
 	t.Parallel()
@@ -3317,7 +3310,6 @@ func TestCheckAnyResourceDestruction(t *testing.T) {
 // TestCheckInvalidResourceFieldMoveThroughVariableDeclaration tests if resources nested
 // as a field in another resource cannot be moved out of the containing resource through
 // a variable declaration. This would partially invalidate the containing resource
-//
 func TestCheckInvalidResourceFieldMoveThroughVariableDeclaration(t *testing.T) {
 
 	t.Parallel()
@@ -3357,7 +3349,6 @@ func TestCheckInvalidResourceFieldMoveThroughVariableDeclaration(t *testing.T) {
 // as a field in another resource cannot be moved out of the containing resource
 // by passing the field as an argument to a function. This would partially invalidate
 // the containing resource
-//
 func TestCheckInvalidResourceFieldMoveThroughParameter(t *testing.T) {
 
 	t.Parallel()
@@ -4773,7 +4764,6 @@ func TestCheckInvalidOptionalResourceCoalescingRightSide(t *testing.T) {
 //
 // Check that an function's return information
 // does not influence another function's return information.
-//
 func TestCheckInvalidResourceLossInNestedContractResource(t *testing.T) {
 
 	t.Parallel()
@@ -4803,7 +4793,6 @@ func TestCheckInvalidResourceLossInNestedContractResource(t *testing.T) {
 }
 
 // https://github.com/onflow/cadence/issues/73
-//
 func TestCheckResourceMoveMemberInvocation(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -208,8 +208,8 @@ func testExits(t *testing.T, test exitTest) {
 		t,
 		code,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -462,7 +462,6 @@ func TestCheckNeverInvocationExits(t *testing.T) {
 
 // TestCheckNestedFunctionExits tests if a function with a return statement
 // nested inside another function does not influence the containing function
-//
 func TestCheckNestedFunctionExits(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/rlp_test.go
+++ b/runtime/tests/checker/rlp_test.go
@@ -39,8 +39,8 @@ func TestCheckRLPDecodeString(t *testing.T) {
            let l: [UInt8] = RLP.decodeString([0, 1, 2])
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -59,8 +59,8 @@ func TestCheckInvalidRLPDecodeString(t *testing.T) {
            let l: String = RLP.decodeString("string")
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -83,8 +83,8 @@ func TestCheckRLPDecodeList(t *testing.T) {
            let l: [[UInt8]] = RLP.decodeList([0, 1, 2])
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -103,8 +103,8 @@ func TestCheckInvalidRLPDecodeList(t *testing.T) {
            let l: String = RLP.decodeList("string")
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)

--- a/runtime/tests/checker/transactions_test.go
+++ b/runtime/tests/checker/transactions_test.go
@@ -368,8 +368,8 @@ func TestCheckTransactionExecuteScope(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithAccessCheckMode(sema.AccessCheckModeStrict),
+			Config: &sema.Config{
+				AccessCheckMode: sema.AccessCheckModeStrict,
 			},
 		},
 	)

--- a/runtime/tests/checker/utils_test.go
+++ b/runtime/tests/checker/utils_test.go
@@ -34,8 +34,8 @@ func ParseAndCheckWithPanic(t *testing.T, code string) (*sema.Checker, error) {
 	return ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 		},
 	)
@@ -53,8 +53,8 @@ func ParseAndCheckWithAny(t *testing.T, code string) (*sema.Checker, error) {
 	return ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithBaseTypeActivation(baseTypeActivation),
+			Config: &sema.Config{
+				BaseTypeActivation: baseTypeActivation,
 			},
 		},
 	)

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -2894,8 +2894,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 						Address: address,
 						Name:    "foo",
 					},
-					Options: []sema.Option{
-						sema.WithBaseValueActivation(baseValueActivation),
+					Config: &sema.Config{
+						BaseValueActivation: baseValueActivation,
 					},
 				},
 			)
@@ -2920,40 +2920,42 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 					})
 				}`, continueAfterMutation),
 				ParseCheckAndInterpretOptions{
-					CheckerOptions: []sema.Option{
-						sema.WithBaseValueActivation(baseValueActivation),
-						sema.WithLocationHandler(
-							func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
+					CheckerConfig: &sema.Config{
+						BaseValueActivation: baseValueActivation,
+						LocationHandler: func(
+							identifiers []ast.Identifier,
+							location common.Location,
+						) (result []sema.ResolvedLocation, err error) {
+							require.Equal(t,
+								common.AddressLocation{
+									Address: address,
+									Name:    "",
+								},
+								location,
+							)
 
-								require.Equal(t,
-									common.AddressLocation{
-										Address: address,
-										Name:    "",
+							for _, identifier := range identifiers {
+								result = append(result, sema.ResolvedLocation{
+									Location: common.AddressLocation{
+										Address: location.(common.AddressLocation).Address,
+										Name:    identifier.Identifier,
 									},
-									location,
-								)
-
-								for _, identifier := range identifiers {
-									result = append(result, sema.ResolvedLocation{
-										Location: common.AddressLocation{
-											Address: location.(common.AddressLocation).Address,
-											Name:    identifier.Identifier,
-										},
-										Identifiers: []ast.Identifier{
-											identifier,
-										},
-									})
-								}
-								return
-							},
-						),
-						sema.WithImportHandler(
-							func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-								return sema.ElaborationImport{
-									Elaboration: importedChecker.Elaboration,
-								}, nil
-							},
-						),
+									Identifiers: []ast.Identifier{
+										identifier,
+									},
+								})
+							}
+							return
+						},
+						ImportHandler: func(
+							checker *sema.Checker,
+							importedLocation common.Location,
+							_ ast.Range,
+						) (sema.Import, error) {
+							return sema.ElaborationImport{
+								Elaboration: importedChecker.Elaboration,
+							}, nil
+						},
 					},
 					Config: &interpreter.Config{
 						BaseActivation:       baseActivation,

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -99,8 +99,8 @@ func testAccount(
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
-			CheckerOptions: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			CheckerConfig: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 			Config: &interpreter.Config{
 				BaseActivation:       baseActivation,

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -140,15 +140,15 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
-			CheckerOptions: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
-				sema.WithBaseTypeActivation(baseTypeActivation),
-				sema.WithCheckHandler(func(checker *sema.Checker, check func()) {
+			CheckerConfig: &sema.Config{
+				BaseValueActivation: baseValueActivation,
+				BaseTypeActivation:  baseTypeActivation,
+				CheckHandler: func(checker *sema.Checker, check func()) {
 					if checker.Location == TestLocation {
 						checker.Elaboration.CompositeTypes[fruitType.ID()] = fruitType
 					}
 					check()
-				}),
+				},
 			},
 			Config: &interpreter.Config{
 				Storage:        storage,

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -1155,8 +1155,8 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerOptions: []sema.Option{
-				sema.WithBaseValueActivation(baseValueActivation),
+			CheckerConfig: &sema.Config{
+				BaseValueActivation: baseValueActivation,
 			},
 			Config: &interpreter.Config{
 				BaseActivation: baseActivation,

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -333,8 +333,8 @@ func TestArrayMutation(t *testing.T) {
                 logger("hello")
             }`,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -472,8 +472,8 @@ func TestArrayMutation(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -723,8 +723,8 @@ func TestDictionaryMutation(t *testing.T) {
                 logger("hello")
             }`,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -862,8 +862,8 @@ func TestDictionaryMutation(t *testing.T) {
                }
            `,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3507,8 +3507,8 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 	baseActivation.Declare(capabilityValueDeclaration)
 
 	options := ParseCheckAndInterpretOptions{
-		CheckerOptions: []sema.Option{
-			sema.WithBaseValueActivation(baseValueActivation),
+		CheckerConfig: &sema.Config{
+			BaseValueActivation: baseValueActivation,
 		},
 		Config: &interpreter.Config{
 			BaseActivation: baseActivation,

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -72,8 +72,8 @@ func TestInterpretEquality(t *testing.T) {
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
 				},
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 			},
 		)

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -1062,8 +1062,8 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -1107,12 +1107,16 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
-					PublicKeyValidationHandler: func(_ *interpreter.Interpreter, _ func() interpreter.LocationRange, _ *interpreter.CompositeValue) error {
+					PublicKeyValidationHandler: func(
+						_ *interpreter.Interpreter,
+						_ func() interpreter.LocationRange,
+						_ *interpreter.CompositeValue,
+					) error {
 						return nil
 					},
 				},
@@ -1161,12 +1165,16 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
-					PublicKeyValidationHandler: func(_ *interpreter.Interpreter, _ func() interpreter.LocationRange, _ *interpreter.CompositeValue) error {
+					PublicKeyValidationHandler: func(
+						_ *interpreter.Interpreter,
+						_ func() interpreter.LocationRange,
+						_ *interpreter.CompositeValue,
+					) error {
 						return nil
 					},
 				},
@@ -8835,14 +8843,12 @@ func TestInterpretASTMetering(t *testing.T) {
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithImportHandler(
-						func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-							return sema.ElaborationImport{
-								Elaboration: importedChecker.Elaboration,
-							}, nil
-						},
-					),
+				CheckerConfig: &sema.Config{
+					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
+						}, nil
+					},
 				},
 				Config: &interpreter.Config{
 					ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
@@ -9109,7 +9115,7 @@ func TestInterpretASTMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(232), meter.getMemory(common.MemoryKindPosition))
+		assert.Equal(t, uint64(231), meter.getMemory(common.MemoryKindPosition))
 		assert.Equal(t, uint64(126), meter.getMemory(common.MemoryKindRange))
 	})
 
@@ -9135,14 +9141,12 @@ func TestInterpretASTMetering(t *testing.T) {
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithImportHandler(
-						func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-							return sema.ElaborationImport{
-								Elaboration: importedChecker.Elaboration,
-							}, nil
-						},
-					),
+				CheckerConfig: &sema.Config{
+					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
+						}, nil
+					},
 				},
 				Config: &interpreter.Config{
 					ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
@@ -9337,8 +9341,8 @@ func TestInterpretValueStringConversion(t *testing.T) {
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
 				},
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 			},
 			meter,
@@ -9681,8 +9685,8 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
 				},
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 			},
 			meter,

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -139,8 +139,8 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
               let result = Type<Int>() == unknownType
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -195,8 +195,8 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
               let result = unknownType1 == unknownType2
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -284,8 +284,8 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
               let identifier = unknownType.identifier
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -410,8 +410,8 @@ func TestInterpretIsInstance(t *testing.T) {
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			inter, err := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -550,8 +550,8 @@ func TestInterpretIsSubtype(t *testing.T) {
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			inter, err := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,
@@ -718,8 +718,8 @@ func TestInterpretGetType(t *testing.T) {
 			inter, err := parseCheckAndInterpretWithOptions(t,
 				testCase.code,
 				ParseCheckAndInterpretOptions{
-					CheckerOptions: []sema.Option{
-						sema.WithBaseValueActivation(baseValueActivation),
+					CheckerConfig: &sema.Config{
+						BaseValueActivation: baseValueActivation,
 					},
 					Config: &interpreter.Config{
 						Storage:        storage,

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -70,19 +70,17 @@ func TestInterpretStatementHandler(t *testing.T) {
           }
         `,
 		checker.ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						assert.Equal(t,
-							utils.ImportedLocation,
-							importedLocation,
-						)
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+					assert.Equal(t,
+						utils.ImportedLocation,
+						importedLocation,
+					)
 
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -196,19 +194,17 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
           }
         `,
 		checker.ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						assert.Equal(t,
-							utils.ImportedLocation,
-							importedLocation,
-						)
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+					assert.Equal(t,
+						utils.ImportedLocation,
+						importedLocation,
+					)
 
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
@@ -333,28 +329,21 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
           }
         `,
 		checker.ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						assert.Equal(t,
-							utils.ImportedLocation,
-							importedLocation,
-						)
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+					assert.Equal(t,
+						utils.ImportedLocation,
+						importedLocation,
+					)
 
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)
 	require.NoError(t, err)
-
-	type occurrence struct {
-		interpreterID int
-		line          int
-	}
 
 	var occurrences []int
 	var nextInterpreterID int

--- a/runtime/tests/interpreter/transfer_test.go
+++ b/runtime/tests/interpreter/transfer_test.go
@@ -73,9 +73,9 @@ func TestInterpretTransferCheck(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerOptions: []sema.Option{
-					sema.WithBaseTypeActivation(baseTypeActivation),
-					sema.WithBaseValueActivation(baseValueActivation),
+				CheckerConfig: &sema.Config{
+					BaseTypeActivation:  baseTypeActivation,
+					BaseValueActivation: baseValueActivation,
 				},
 				Config: &interpreter.Config{
 					BaseActivation: baseActivation,

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -64,19 +64,17 @@ func TestInterpretResourceUUID(t *testing.T) {
           }
         `,
 		checker.ParseAndCheckOptions{
-			Options: []sema.Option{
-				sema.WithImportHandler(
-					func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-						assert.Equal(t,
-							ImportedLocation,
-							importedLocation,
-						)
+			Config: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+					assert.Equal(t,
+						ImportedLocation,
+						importedLocation,
+					)
 
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
-					},
-				),
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
 			},
 		},
 	)

--- a/tools/analysis/loadmode.go
+++ b/tools/analysis/loadmode.go
@@ -32,4 +32,7 @@ const (
 
 	// NeedPositionInfo provides position information (e.g. occurrences).
 	NeedPositionInfo
+
+	// NeedExtendedElaboration provides an extended elaboration.
+	NeedExtendedElaboration
 )

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -91,15 +91,18 @@ func (programs Programs) check(
 		program,
 		location,
 		nil,
-		true,
-		sema.WithLocationHandler(
-			sema.AddressLocationHandlerFunc(
+		&sema.Config{
+			AccessCheckMode: sema.AccessCheckModeStrict,
+			LocationHandler: sema.AddressLocationHandlerFunc(
 				config.ResolveAddressContractNames,
 			),
-		),
-		sema.WithPositionInfoEnabled(config.Mode&NeedPositionInfo != 0),
-		sema.WithImportHandler(
-			func(checker *sema.Checker, importedLocation common.Location, importRange ast.Range) (sema.Import, error) {
+			PositionInfoEnabled:        config.Mode&NeedPositionInfo != 0,
+			ExtendedElaborationEnabled: config.Mode&NeedExtendedElaboration != 0,
+			ImportHandler: func(
+				checker *sema.Checker,
+				importedLocation common.Location,
+				importRange ast.Range,
+			) (sema.Import, error) {
 
 				var elaboration *sema.Elaboration
 				switch importedLocation {
@@ -119,7 +122,7 @@ func (programs Programs) check(
 					Elaboration: elaboration,
 				}, nil
 			},
-		),
+		},
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

[Just like for the interpreter](https://github.com/onflow/cadence/pull/1831), refactor the functional checker options to a struct.
While at it, also refactor the position info code out into a separate type.

Best viewed with whitespace disabled.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
