### PR TITLE
Optimize and make visitor generic

### DIFF
--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -50,10 +50,6 @@ func (b *Block) IsEmpty() bool {
 	return len(b.Statements) == 0
 }
 
-func (b *Block) Accept(visitor Visitor) Repr {
-	return visitor.VisitBlock(b)
-}
-
 func (b *Block) Walk(walkChild func(Element)) {
 	walkStatements(walkChild, b.Statements)
 }
@@ -139,10 +135,6 @@ func (b *FunctionBlock) IsEmpty() bool {
 
 func (*FunctionBlock) ElementType() ElementType {
 	return ElementTypeFunctionBlock
-}
-
-func (b *FunctionBlock) Accept(visitor Visitor) Repr {
-	return visitor.VisitFunctionBlock(b)
 }
 
 func (b *FunctionBlock) Walk(walkChild func(Element)) {

--- a/runtime/ast/composite.go
+++ b/runtime/ast/composite.go
@@ -72,10 +72,6 @@ func (*CompositeDeclaration) ElementType() ElementType {
 	return ElementTypeCompositeDeclaration
 }
 
-func (d *CompositeDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitCompositeDeclaration(d)
-}
-
 func (d *CompositeDeclaration) Walk(walkChild func(Element)) {
 	walkDeclarations(walkChild, d.Members.declarations)
 }
@@ -301,10 +297,6 @@ func (*FieldDeclaration) ElementType() ElementType {
 	return ElementTypeFieldDeclaration
 }
 
-func (d *FieldDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitFieldDeclaration(d)
-}
-
 func (d *FieldDeclaration) Walk(_ func(Element)) {
 	// NO-OP
 	// TODO: walk type
@@ -442,10 +434,6 @@ func NewEnumCaseDeclaration(
 
 func (*EnumCaseDeclaration) ElementType() ElementType {
 	return ElementTypeEnumCaseDeclaration
-}
-
-func (d *EnumCaseDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitEnumCaseDeclaration(d)
 }
 
 func (*EnumCaseDeclaration) Walk(_ func(Element)) {

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -38,7 +38,6 @@ type Expression interface {
 	fmt.Stringer
 	IfStatementTest
 	isExpression()
-	AcceptExp(ExpressionVisitor) Repr
 	Doc() prettier.Doc
 	precedence() precedence
 }
@@ -69,16 +68,8 @@ func (*BoolExpression) isExpression() {}
 
 func (*BoolExpression) isIfStatementTest() {}
 
-func (e *BoolExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (*BoolExpression) Walk(_ func(Element)) {
 	// NO-OP
-}
-
-func (e *BoolExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitBoolExpression(e)
 }
 
 func (e *BoolExpression) String() string {
@@ -135,16 +126,8 @@ func (*NilExpression) isExpression() {}
 
 func (*NilExpression) isIfStatementTest() {}
 
-func (e *NilExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (*NilExpression) Walk(_ func(Element)) {
 	// NO-OP
-}
-
-func (e *NilExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitNilExpression(e)
 }
 
 func (e *NilExpression) String() string {
@@ -210,16 +193,8 @@ func (*StringExpression) isExpression() {}
 
 func (*StringExpression) isIfStatementTest() {}
 
-func (e *StringExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (*StringExpression) Walk(_ func(Element)) {
 	// NO-OP
-}
-
-func (e *StringExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitStringExpression(e)
 }
 
 func (e *StringExpression) String() string {
@@ -282,16 +257,8 @@ func (*IntegerExpression) isExpression() {}
 
 func (*IntegerExpression) isIfStatementTest() {}
 
-func (e *IntegerExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (*IntegerExpression) Walk(_ func(Element)) {
 	// NO-OP
-}
-
-func (e *IntegerExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitIntegerExpression(e)
 }
 
 func (e *IntegerExpression) String() string {
@@ -366,16 +333,8 @@ func (*FixedPointExpression) isExpression() {}
 
 func (*FixedPointExpression) isIfStatementTest() {}
 
-func (e *FixedPointExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (*FixedPointExpression) Walk(_ func(Element)) {
 	// NO-OP
-}
-
-func (e *FixedPointExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitFixedPointExpression(e)
 }
 
 func (e *FixedPointExpression) String() string {
@@ -456,16 +415,8 @@ func (*ArrayExpression) isExpression() {}
 
 func (*ArrayExpression) isIfStatementTest() {}
 
-func (e *ArrayExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *ArrayExpression) Walk(walkChild func(Element)) {
 	walkExpressions(walkChild, e.Values)
-}
-
-func (e *ArrayExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitArrayExpression(e)
 }
 
 func (e *ArrayExpression) String() string {
@@ -538,19 +489,11 @@ func (*DictionaryExpression) isExpression() {}
 
 func (*DictionaryExpression) isIfStatementTest() {}
 
-func (e *DictionaryExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *DictionaryExpression) Walk(walkChild func(Element)) {
 	for _, entry := range e.Entries {
 		walkChild(entry.Key)
 		walkChild(entry.Value)
 	}
-}
-
-func (e *DictionaryExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitDictionaryExpression(e)
 }
 
 func (e *DictionaryExpression) String() string {
@@ -668,16 +611,8 @@ func (*IdentifierExpression) isExpression() {}
 
 func (*IdentifierExpression) isIfStatementTest() {}
 
-func (e *IdentifierExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (*IdentifierExpression) Walk(_ func(Element)) {
 	// NO-OP
-}
-
-func (e *IdentifierExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitIdentifierExpression(e)
 }
 
 func (e *IdentifierExpression) String() string {
@@ -784,19 +719,11 @@ func (*InvocationExpression) isExpression() {}
 
 func (*InvocationExpression) isIfStatementTest() {}
 
-func (e *InvocationExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *InvocationExpression) Walk(walkChild func(Element)) {
 	walkChild(e.InvokedExpression)
 	for _, argument := range e.Arguments {
 		walkChild(argument.Expression)
 	}
-}
-
-func (e *InvocationExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitInvocationExpression(e)
 }
 
 func (e *InvocationExpression) String() string {
@@ -911,16 +838,8 @@ func (e *MemberExpression) AccessedExpression() Expression {
 	return e.Expression
 }
 
-func (e *MemberExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *MemberExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Expression)
-}
-
-func (e *MemberExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitMemberExpression(e)
 }
 
 func (e *MemberExpression) String() string {
@@ -1024,18 +943,11 @@ func (e *IndexExpression) AccessedExpression() Expression {
 	return e.TargetExpression
 }
 
-func (e *IndexExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *IndexExpression) Walk(walkChild func(Element)) {
 	walkChild(e.TargetExpression)
 	walkChild(e.IndexingExpression)
 }
 
-func (e *IndexExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitIndexExpression(e)
-}
 func (e *IndexExpression) String() string {
 	return Prettier(e)
 }
@@ -1102,10 +1014,6 @@ func (*ConditionalExpression) isExpression() {}
 
 func (*ConditionalExpression) isIfStatementTest() {}
 
-func (e *ConditionalExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *ConditionalExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Test)
 	walkChild(e.Then)
@@ -1114,9 +1022,6 @@ func (e *ConditionalExpression) Walk(walkChild func(Element)) {
 	}
 }
 
-func (e *ConditionalExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitConditionalExpression(e)
-}
 func (e *ConditionalExpression) String() string {
 	return Prettier(e)
 }
@@ -1234,16 +1139,8 @@ func (*UnaryExpression) isExpression() {}
 
 func (*UnaryExpression) isIfStatementTest() {}
 
-func (e *UnaryExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *UnaryExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Expression)
-}
-
-func (e *UnaryExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitUnaryExpression(e)
 }
 
 func (e *UnaryExpression) String() string {
@@ -1331,17 +1228,9 @@ func (*BinaryExpression) isExpression() {}
 
 func (*BinaryExpression) isIfStatementTest() {}
 
-func (e *BinaryExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *BinaryExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Left)
 	walkChild(e.Right)
-}
-
-func (e *BinaryExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitBinaryExpression(e)
 }
 
 func (e *BinaryExpression) String() string {
@@ -1481,18 +1370,10 @@ func (*FunctionExpression) isExpression() {}
 
 func (*FunctionExpression) isIfStatementTest() {}
 
-func (e *FunctionExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *FunctionExpression) Walk(walkChild func(Element)) {
 	// TODO: walk parameters
 	// TODO: walk return type
 	walkChild(e.FunctionBlock)
-}
-
-func (e *FunctionExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitFunctionExpression(e)
 }
 
 func (e *FunctionExpression) String() string {
@@ -1649,16 +1530,9 @@ func (*CastingExpression) isExpression() {}
 
 func (*CastingExpression) isIfStatementTest() {}
 
-func (e *CastingExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
 func (e *CastingExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Expression)
 	// TODO: also walk type
-}
-
-func (e *CastingExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitCastingExpression(e)
 }
 
 func (e *CastingExpression) String() string {
@@ -1740,16 +1614,8 @@ func (*CreateExpression) isExpression() {}
 
 func (*CreateExpression) isIfStatementTest() {}
 
-func (e *CreateExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *CreateExpression) Walk(walkChild func(Element)) {
 	walkChild(e.InvocationExpression)
-}
-
-func (e *CreateExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitCreateExpression(e)
 }
 
 func (e *CreateExpression) String() string {
@@ -1821,16 +1687,8 @@ func (*DestroyExpression) isExpression() {}
 
 func (*DestroyExpression) isIfStatementTest() {}
 
-func (e *DestroyExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *DestroyExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Expression)
-}
-
-func (e *DestroyExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitDestroyExpression(e)
 }
 
 func (e *DestroyExpression) String() string {
@@ -1908,17 +1766,9 @@ func (*ReferenceExpression) isExpression() {}
 
 func (*ReferenceExpression) isIfStatementTest() {}
 
-func (e *ReferenceExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *ReferenceExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Expression)
 	// TODO: walk type
-}
-
-func (e *ReferenceExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitReferenceExpression(e)
 }
 
 func (e *ReferenceExpression) String() string {
@@ -2004,16 +1854,8 @@ func (*ForceExpression) isExpression() {}
 
 func (*ForceExpression) isIfStatementTest() {}
 
-func (e *ForceExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (e *ForceExpression) Walk(walkChild func(Element)) {
 	walkChild(e.Expression)
-}
-
-func (e *ForceExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitForceExpression(e)
 }
 
 func (e *ForceExpression) String() string {
@@ -2091,16 +1933,8 @@ func (*PathExpression) isExpression() {}
 
 func (*PathExpression) isIfStatementTest() {}
 
-func (e *PathExpression) Accept(visitor Visitor) Repr {
-	return e.AcceptExp(visitor)
-}
-
 func (*PathExpression) Walk(_ func(Element)) {
 	// NO-OP
-}
-
-func (e *PathExpression) AcceptExp(visitor ExpressionVisitor) Repr {
-	return visitor.VisitPathExpression(e)
 }
 
 func (e *PathExpression) String() string {

--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -135,8 +135,10 @@ type ExpressionExtractor struct {
 	MemoryGauge          common.MemoryGauge
 }
 
+var _ ExpressionVisitor[ExpressionExtraction] = &ExpressionExtractor{}
+
 func (extractor *ExpressionExtractor) Extract(expression Expression) ExpressionExtraction {
-	return expression.AcceptExp(extractor).(ExpressionExtraction)
+	return AcceptExpression[ExpressionExtraction](expression, extractor)
 }
 
 func (extractor *ExpressionExtractor) FreshIdentifier() string {
@@ -165,7 +167,7 @@ type ExpressionExtraction struct {
 	ExtractedExpressions []ExtractedExpression
 }
 
-func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpression) Repr {
+func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -186,7 +188,7 @@ func (extractor *ExpressionExtractor) ExtractBool(expression *BoolExpression) Ex
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpression) Repr {
+func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -207,7 +209,7 @@ func (extractor *ExpressionExtractor) ExtractNil(expression *NilExpression) Expr
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *IntegerExpression) Repr {
+func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *IntegerExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -228,7 +230,7 @@ func (extractor *ExpressionExtractor) ExtractInteger(expression *IntegerExpressi
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *FixedPointExpression) Repr {
+func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *FixedPointExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -249,7 +251,7 @@ func (extractor *ExpressionExtractor) ExtractFixedPoint(expression *FixedPointEx
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringExpression) Repr {
+func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -270,7 +272,7 @@ func (extractor *ExpressionExtractor) ExtractString(expression *StringExpression
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitArrayExpression(expression *ArrayExpression) Repr {
+func (extractor *ExpressionExtractor) VisitArrayExpression(expression *ArrayExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -324,7 +326,7 @@ func (extractor *ExpressionExtractor) VisitExpressions(
 	return rewrittenExpressions, extractedExpressions
 }
 
-func (extractor *ExpressionExtractor) VisitDictionaryExpression(expression *DictionaryExpression) Repr {
+func (extractor *ExpressionExtractor) VisitDictionaryExpression(expression *DictionaryExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -368,7 +370,7 @@ func (extractor *ExpressionExtractor) ExtractDictionary(expression *DictionaryEx
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitIdentifierExpression(expression *IdentifierExpression) Repr {
+func (extractor *ExpressionExtractor) VisitIdentifierExpression(expression *IdentifierExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -388,7 +390,7 @@ func (extractor *ExpressionExtractor) ExtractIdentifier(expression *IdentifierEx
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitInvocationExpression(expression *InvocationExpression) Repr {
+func (extractor *ExpressionExtractor) VisitInvocationExpression(expression *InvocationExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -457,7 +459,7 @@ func (extractor *ExpressionExtractor) extractArguments(
 	return newArguments, extractedExpressions
 }
 
-func (extractor *ExpressionExtractor) VisitMemberExpression(expression *MemberExpression) Repr {
+func (extractor *ExpressionExtractor) VisitMemberExpression(expression *MemberExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -485,7 +487,7 @@ func (extractor *ExpressionExtractor) ExtractMember(expression *MemberExpression
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitIndexExpression(expression *IndexExpression) Repr {
+func (extractor *ExpressionExtractor) VisitIndexExpression(expression *IndexExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -513,7 +515,7 @@ func (extractor *ExpressionExtractor) ExtractIndex(expression *IndexExpression) 
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitConditionalExpression(expression *ConditionalExpression) Repr {
+func (extractor *ExpressionExtractor) VisitConditionalExpression(expression *ConditionalExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -548,7 +550,7 @@ func (extractor *ExpressionExtractor) ExtractConditional(expression *Conditional
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitUnaryExpression(expression *UnaryExpression) Repr {
+func (extractor *ExpressionExtractor) VisitUnaryExpression(expression *UnaryExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -576,7 +578,7 @@ func (extractor *ExpressionExtractor) ExtractUnary(expression *UnaryExpression) 
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitBinaryExpression(expression *BinaryExpression) Repr {
+func (extractor *ExpressionExtractor) VisitBinaryExpression(expression *BinaryExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -609,7 +611,7 @@ func (extractor *ExpressionExtractor) ExtractBinary(expression *BinaryExpression
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitFunctionExpression(expression *FunctionExpression) Repr {
+func (extractor *ExpressionExtractor) VisitFunctionExpression(expression *FunctionExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -625,7 +627,7 @@ func (extractor *ExpressionExtractor) ExtractFunction(_ *FunctionExpression) Exp
 	panic(errors.NewUnreachableError())
 }
 
-func (extractor *ExpressionExtractor) VisitCastingExpression(expression *CastingExpression) Repr {
+func (extractor *ExpressionExtractor) VisitCastingExpression(expression *CastingExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation
@@ -654,7 +656,7 @@ func (extractor *ExpressionExtractor) ExtractCast(expression *CastingExpression)
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitCreateExpression(expression *CreateExpression) Repr {
+func (extractor *ExpressionExtractor) VisitCreateExpression(expression *CreateExpression) ExpressionExtraction {
 	// delegate to child extractor, if any,
 	// or call default implementation
 
@@ -695,7 +697,7 @@ func (extractor *ExpressionExtractor) ExtractCreate(expression *CreateExpression
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitDestroyExpression(expression *DestroyExpression) Repr {
+func (extractor *ExpressionExtractor) VisitDestroyExpression(expression *DestroyExpression) ExpressionExtraction {
 	// delegate to child extractor, if any,
 	// or call default implementation
 
@@ -722,7 +724,7 @@ func (extractor *ExpressionExtractor) ExtractDestroy(expression *DestroyExpressi
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitReferenceExpression(expression *ReferenceExpression) Repr {
+func (extractor *ExpressionExtractor) VisitReferenceExpression(expression *ReferenceExpression) ExpressionExtraction {
 	// delegate to child extractor, if any,
 	// or call default implementation
 
@@ -749,7 +751,7 @@ func (extractor *ExpressionExtractor) ExtractReference(expression *ReferenceExpr
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitForceExpression(expression *ForceExpression) Repr {
+func (extractor *ExpressionExtractor) VisitForceExpression(expression *ForceExpression) ExpressionExtraction {
 	// delegate to child extractor, if any,
 	// or call default implementation
 
@@ -776,7 +778,7 @@ func (extractor *ExpressionExtractor) ExtractForce(expression *ForceExpression) 
 	}
 }
 
-func (extractor *ExpressionExtractor) VisitPathExpression(expression *PathExpression) Repr {
+func (extractor *ExpressionExtractor) VisitPathExpression(expression *PathExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
 	// or call default implementation

--- a/runtime/ast/function_declaration.go
+++ b/runtime/ast/function_declaration.go
@@ -85,10 +85,6 @@ func (d *FunctionDeclaration) EndPosition(memoryGauge common.MemoryGauge) Positi
 	return d.ParameterList.EndPosition(memoryGauge)
 }
 
-func (d *FunctionDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitFunctionDeclaration(d)
-}
-
 func (d *FunctionDeclaration) Walk(walkChild func(Element)) {
 	// TODO: walk parameters
 	// TODO: walk return type
@@ -193,10 +189,6 @@ func (d *SpecialFunctionDeclaration) StartPosition() Position {
 
 func (d *SpecialFunctionDeclaration) EndPosition(memoryGauge common.MemoryGauge) Position {
 	return d.FunctionDeclaration.EndPosition(memoryGauge)
-}
-
-func (d *SpecialFunctionDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitSpecialFunctionDeclaration(d)
 }
 
 func (d *SpecialFunctionDeclaration) Walk(walkChild func(Element)) {

--- a/runtime/ast/import.go
+++ b/runtime/ast/import.go
@@ -63,10 +63,6 @@ func (*ImportDeclaration) isDeclaration() {}
 
 func (*ImportDeclaration) isStatement() {}
 
-func (d *ImportDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitImportDeclaration(d)
-}
-
 func (*ImportDeclaration) Walk(_ func(Element)) {
 	// NO-OP
 }

--- a/runtime/ast/interface.go
+++ b/runtime/ast/interface.go
@@ -66,10 +66,6 @@ func (*InterfaceDeclaration) ElementType() ElementType {
 	return ElementTypeInterfaceDeclaration
 }
 
-func (d *InterfaceDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitInterfaceDeclaration(d)
-}
-
 func (d *InterfaceDeclaration) Walk(walkChild func(Element)) {
 	walkDeclarations(walkChild, d.Members.declarations)
 }

--- a/runtime/ast/pragma.go
+++ b/runtime/ast/pragma.go
@@ -53,10 +53,6 @@ func (*PragmaDeclaration) isDeclaration() {}
 
 func (*PragmaDeclaration) isStatement() {}
 
-func (d *PragmaDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitPragmaDeclaration(d)
-}
-
 func (d *PragmaDeclaration) Walk(walkChild func(Element)) {
 	walkChild(d.Expression)
 }

--- a/runtime/ast/program.go
+++ b/runtime/ast/program.go
@@ -66,10 +66,6 @@ func (p *Program) EndPosition(memoryGauge common.MemoryGauge) Position {
 	return lastDeclaration.EndPosition(memoryGauge)
 }
 
-func (p *Program) Accept(visitor Visitor) Repr {
-	return visitor.VisitProgram(p)
-}
-
 func (p *Program) Walk(walkChild func(Element)) {
 	walkDeclarations(walkChild, p.declarations)
 }

--- a/runtime/ast/statement.go
+++ b/runtime/ast/statement.go
@@ -58,10 +58,6 @@ func (*ReturnStatement) ElementType() ElementType {
 
 func (*ReturnStatement) isStatement() {}
 
-func (s *ReturnStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitReturnStatement(s)
-}
-
 func (s *ReturnStatement) Walk(walkChild func(Element)) {
 	if s.Expression != nil {
 		walkChild(s.Expression)
@@ -119,10 +115,6 @@ func (*BreakStatement) ElementType() ElementType {
 
 func (*BreakStatement) isStatement() {}
 
-func (s *BreakStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitBreakStatement(s)
-}
-
 func (*BreakStatement) Walk(_ func(Element)) {
 	// NO-OP
 }
@@ -169,10 +161,6 @@ func (*ContinueStatement) ElementType() ElementType {
 }
 
 func (*ContinueStatement) isStatement() {}
-
-func (s *ContinueStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitContinueStatement(s)
-}
 
 func (*ContinueStatement) Walk(_ func(Element)) {
 	// NO-OP
@@ -250,10 +238,6 @@ func (s *IfStatement) EndPosition(memoryGauge common.MemoryGauge) Position {
 		return s.Else.EndPosition(memoryGauge)
 	}
 	return s.Then.EndPosition(memoryGauge)
-}
-
-func (s *IfStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitIfStatement(s)
 }
 
 func (s *IfStatement) Walk(walkChild func(Element)) {
@@ -350,10 +334,6 @@ func (*WhileStatement) ElementType() ElementType {
 
 func (*WhileStatement) isStatement() {}
 
-func (s *WhileStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitWhileStatement(s)
-}
-
 func (s *WhileStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Test)
 	walkChild(s.Block)
@@ -434,10 +414,6 @@ func (*ForStatement) ElementType() ElementType {
 }
 
 func (*ForStatement) isStatement() {}
-
-func (s *ForStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitForStatement(s)
-}
 
 func (s *ForStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Value)
@@ -535,10 +511,6 @@ func (s *EmitStatement) EndPosition(memoryGauge common.MemoryGauge) Position {
 	return s.InvocationExpression.EndPosition(memoryGauge)
 }
 
-func (s *EmitStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitEmitStatement(s)
-}
-
 func (s *EmitStatement) Walk(walkChild func(Element)) {
 	walkChild(s.InvocationExpression)
 }
@@ -600,10 +572,6 @@ func (*AssignmentStatement) ElementType() ElementType {
 }
 
 func (*AssignmentStatement) isStatement() {}
-
-func (s *AssignmentStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitAssignmentStatement(s)
-}
 
 func (s *AssignmentStatement) StartPosition() Position {
 	return s.Target.StartPosition()
@@ -683,10 +651,6 @@ func (s *SwapStatement) EndPosition(memoryGauge common.MemoryGauge) Position {
 	return s.Right.EndPosition(memoryGauge)
 }
 
-func (s *SwapStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitSwapStatement(s)
-}
-
 func (s *SwapStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Left)
 	walkChild(s.Right)
@@ -751,10 +715,6 @@ func (s *ExpressionStatement) EndPosition(memoryGauge common.MemoryGauge) Positi
 	return s.Expression.EndPosition(memoryGauge)
 }
 
-func (s *ExpressionStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitExpressionStatement(s)
-}
-
 func (s *ExpressionStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Expression)
 }
@@ -810,10 +770,6 @@ func (*SwitchStatement) ElementType() ElementType {
 }
 
 func (*SwitchStatement) isStatement() {}
-
-func (s *SwitchStatement) Accept(visitor Visitor) Repr {
-	return visitor.VisitSwitchStatement(s)
-}
 
 func (s *SwitchStatement) Walk(walkChild func(Element)) {
 	walkChild(s.Expression)

--- a/runtime/ast/transaction_declaration.go
+++ b/runtime/ast/transaction_declaration.go
@@ -70,10 +70,6 @@ func (*TransactionDeclaration) ElementType() ElementType {
 	return ElementTypeTransactionDeclaration
 }
 
-func (d *TransactionDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitTransactionDeclaration(d)
-}
-
 func (d *TransactionDeclaration) Walk(walkChild func(Element)) {
 	// TODO: walk parameters
 	for _, declaration := range d.Fields {

--- a/runtime/ast/variable_declaration.go
+++ b/runtime/ast/variable_declaration.go
@@ -99,10 +99,6 @@ func (d *VariableDeclaration) EndPosition(memoryGauge common.MemoryGauge) Positi
 
 func (*VariableDeclaration) isIfStatementTest() {}
 
-func (d *VariableDeclaration) Accept(visitor Visitor) Repr {
-	return visitor.VisitVariableDeclaration(d)
-}
-
 func (d *VariableDeclaration) Walk(walkChild func(Element)) {
 	// TODO: walk type
 	walkChild(d.Value)

--- a/runtime/ast/visitor.go
+++ b/runtime/ast/visitor.go
@@ -18,14 +18,14 @@
 
 package ast
 
-import "github.com/onflow/cadence/runtime/common"
-
-type Repr any
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+)
 
 type Element interface {
 	HasPosition
 	ElementType() ElementType
-	Accept(Visitor) Repr
 	Walk(walkChild func(Element))
 }
 
@@ -35,11 +35,6 @@ var _ Element = NotAnElement{}
 
 func (NotAnElement) ElementType() ElementType {
 	return ElementTypeUnknown
-}
-
-func (NotAnElement) Accept(Visitor) Repr {
-	// NO-OP
-	return nil
 }
 
 func (NotAnElement) StartPosition() Position {
@@ -54,67 +49,286 @@ func (NotAnElement) Walk(_ func(Element)) {
 	// NO-OP
 }
 
-type StatementDeclarationVisitor interface {
-	VisitVariableDeclaration(*VariableDeclaration) Repr
-	VisitFunctionDeclaration(*FunctionDeclaration) Repr
-	VisitSpecialFunctionDeclaration(*SpecialFunctionDeclaration) Repr
-	VisitCompositeDeclaration(*CompositeDeclaration) Repr
-	VisitInterfaceDeclaration(*InterfaceDeclaration) Repr
-	VisitTransactionDeclaration(*TransactionDeclaration) Repr
+type StatementDeclarationVisitor[T any] interface {
+	VisitVariableDeclaration(*VariableDeclaration) T
+	VisitFunctionDeclaration(*FunctionDeclaration) T
+	VisitSpecialFunctionDeclaration(*SpecialFunctionDeclaration) T
+	VisitCompositeDeclaration(*CompositeDeclaration) T
+	VisitInterfaceDeclaration(*InterfaceDeclaration) T
+	VisitTransactionDeclaration(*TransactionDeclaration) T
 }
 
-type DeclarationVisitor interface {
-	StatementDeclarationVisitor
-	VisitFieldDeclaration(*FieldDeclaration) Repr
-	VisitEnumCaseDeclaration(*EnumCaseDeclaration) Repr
-	VisitPragmaDeclaration(*PragmaDeclaration) Repr
-	VisitImportDeclaration(*ImportDeclaration) Repr
+type DeclarationVisitor[T any] interface {
+	StatementDeclarationVisitor[T]
+	VisitFieldDeclaration(*FieldDeclaration) T
+	VisitEnumCaseDeclaration(*EnumCaseDeclaration) T
+	VisitPragmaDeclaration(*PragmaDeclaration) T
+	VisitImportDeclaration(*ImportDeclaration) T
 }
 
-type StatementVisitor interface {
-	StatementDeclarationVisitor
-	VisitReturnStatement(*ReturnStatement) Repr
-	VisitBreakStatement(*BreakStatement) Repr
-	VisitContinueStatement(*ContinueStatement) Repr
-	VisitIfStatement(*IfStatement) Repr
-	VisitSwitchStatement(*SwitchStatement) Repr
-	VisitWhileStatement(*WhileStatement) Repr
-	VisitForStatement(*ForStatement) Repr
-	VisitEmitStatement(*EmitStatement) Repr
-	VisitAssignmentStatement(*AssignmentStatement) Repr
-	VisitSwapStatement(*SwapStatement) Repr
-	VisitExpressionStatement(*ExpressionStatement) Repr
+type StatementVisitor[T any] interface {
+	StatementDeclarationVisitor[T]
+	VisitReturnStatement(*ReturnStatement) T
+	VisitBreakStatement(*BreakStatement) T
+	VisitContinueStatement(*ContinueStatement) T
+	VisitIfStatement(*IfStatement) T
+	VisitSwitchStatement(*SwitchStatement) T
+	VisitWhileStatement(*WhileStatement) T
+	VisitForStatement(*ForStatement) T
+	VisitEmitStatement(*EmitStatement) T
+	VisitAssignmentStatement(*AssignmentStatement) T
+	VisitSwapStatement(*SwapStatement) T
+	VisitExpressionStatement(*ExpressionStatement) T
 }
 
-type ExpressionVisitor interface {
-	VisitBoolExpression(*BoolExpression) Repr
-	VisitNilExpression(*NilExpression) Repr
-	VisitIntegerExpression(*IntegerExpression) Repr
-	VisitFixedPointExpression(*FixedPointExpression) Repr
-	VisitArrayExpression(*ArrayExpression) Repr
-	VisitDictionaryExpression(*DictionaryExpression) Repr
-	VisitIdentifierExpression(*IdentifierExpression) Repr
-	VisitInvocationExpression(*InvocationExpression) Repr
-	VisitMemberExpression(*MemberExpression) Repr
-	VisitIndexExpression(*IndexExpression) Repr
-	VisitConditionalExpression(*ConditionalExpression) Repr
-	VisitUnaryExpression(*UnaryExpression) Repr
-	VisitBinaryExpression(*BinaryExpression) Repr
-	VisitFunctionExpression(*FunctionExpression) Repr
-	VisitStringExpression(*StringExpression) Repr
-	VisitCastingExpression(*CastingExpression) Repr
-	VisitCreateExpression(*CreateExpression) Repr
-	VisitDestroyExpression(*DestroyExpression) Repr
-	VisitReferenceExpression(*ReferenceExpression) Repr
-	VisitForceExpression(*ForceExpression) Repr
-	VisitPathExpression(*PathExpression) Repr
+type ExpressionVisitor[T any] interface {
+	VisitBoolExpression(*BoolExpression) T
+	VisitNilExpression(*NilExpression) T
+	VisitIntegerExpression(*IntegerExpression) T
+	VisitFixedPointExpression(*FixedPointExpression) T
+	VisitArrayExpression(*ArrayExpression) T
+	VisitDictionaryExpression(*DictionaryExpression) T
+	VisitIdentifierExpression(*IdentifierExpression) T
+	VisitInvocationExpression(*InvocationExpression) T
+	VisitMemberExpression(*MemberExpression) T
+	VisitIndexExpression(*IndexExpression) T
+	VisitConditionalExpression(*ConditionalExpression) T
+	VisitUnaryExpression(*UnaryExpression) T
+	VisitBinaryExpression(*BinaryExpression) T
+	VisitFunctionExpression(*FunctionExpression) T
+	VisitStringExpression(*StringExpression) T
+	VisitCastingExpression(*CastingExpression) T
+	VisitCreateExpression(*CreateExpression) T
+	VisitDestroyExpression(*DestroyExpression) T
+	VisitReferenceExpression(*ReferenceExpression) T
+	VisitForceExpression(*ForceExpression) T
+	VisitPathExpression(*PathExpression) T
 }
 
-type Visitor interface {
-	StatementVisitor
-	ExpressionVisitor
-	DeclarationVisitor
-	VisitProgram(*Program) Repr
-	VisitBlock(*Block) Repr
-	VisitFunctionBlock(*FunctionBlock) Repr
+type Visitor[T any] interface {
+	StatementVisitor[T]
+	ExpressionVisitor[T]
+	DeclarationVisitor[T]
+	VisitProgram(*Program) T
+	VisitBlock(*Block) T
+	VisitFunctionBlock(*FunctionBlock) T
+}
+
+func Accept[T any](element Element, visitor Visitor[T]) (_ T) {
+
+	switch element.ElementType() {
+	case ElementTypePragmaDeclaration:
+		return visitor.VisitPragmaDeclaration(element.(*PragmaDeclaration))
+
+	case ElementTypeUnknown:
+		// NO-OP
+		return
+
+	case ElementTypeBlock:
+		return visitor.VisitBlock(element.(*Block))
+
+	case ElementTypeFunctionBlock:
+		return visitor.VisitFunctionBlock(element.(*FunctionBlock))
+
+	case ElementTypeCompositeDeclaration:
+		return visitor.VisitCompositeDeclaration(element.(*CompositeDeclaration))
+
+	case ElementTypeInterfaceDeclaration:
+		return visitor.VisitInterfaceDeclaration(element.(*InterfaceDeclaration))
+
+	case ElementTypeFieldDeclaration:
+		return visitor.VisitFieldDeclaration(element.(*FieldDeclaration))
+
+	case ElementTypeReturnStatement:
+		return visitor.VisitReturnStatement(element.(*ReturnStatement))
+
+	case ElementTypeEnumCaseDeclaration:
+		return visitor.VisitEnumCaseDeclaration(element.(*EnumCaseDeclaration))
+
+	case ElementTypeFunctionDeclaration:
+		return visitor.VisitFunctionDeclaration(element.(*FunctionDeclaration))
+
+	case ElementTypeSpecialFunctionDeclaration:
+		return visitor.VisitSpecialFunctionDeclaration(element.(*SpecialFunctionDeclaration))
+
+	case ElementTypeVariableDeclaration:
+		return visitor.VisitVariableDeclaration(element.(*VariableDeclaration))
+
+	case ElementTypeTransactionDeclaration:
+		return visitor.VisitTransactionDeclaration(element.(*TransactionDeclaration))
+
+	case ElementTypeImportDeclaration:
+		return visitor.VisitImportDeclaration(element.(*ImportDeclaration))
+
+	case ElementTypeProgram:
+		return visitor.VisitProgram(element.(*Program))
+
+	case ElementTypeContinueStatement:
+		return visitor.VisitContinueStatement(element.(*ContinueStatement))
+
+	case ElementTypeBreakStatement:
+		return visitor.VisitBreakStatement(element.(*BreakStatement))
+
+	case ElementTypeIfStatement:
+		return visitor.VisitIfStatement(element.(*IfStatement))
+
+	case ElementTypeForStatement:
+		return visitor.VisitForStatement(element.(*ForStatement))
+
+	case ElementTypeAssignmentStatement:
+		return visitor.VisitAssignmentStatement(element.(*AssignmentStatement))
+
+	case ElementTypeWhileStatement:
+		return visitor.VisitWhileStatement(element.(*WhileStatement))
+
+	case ElementTypeSwapStatement:
+		return visitor.VisitSwapStatement(element.(*SwapStatement))
+
+	case ElementTypeSwitchStatement:
+		return visitor.VisitSwitchStatement(element.(*SwitchStatement))
+
+	case ElementTypeEmitStatement:
+		return visitor.VisitEmitStatement(element.(*EmitStatement))
+
+	case ElementTypeExpressionStatement:
+		return visitor.VisitExpressionStatement(element.(*ExpressionStatement))
+
+	case ElementTypeNilExpression:
+		return visitor.VisitNilExpression(element.(*NilExpression))
+
+	case ElementTypeBoolExpression:
+		return visitor.VisitBoolExpression(element.(*BoolExpression))
+
+	case ElementTypeStringExpression:
+		return visitor.VisitStringExpression(element.(*StringExpression))
+
+	case ElementTypeIntegerExpression:
+		return visitor.VisitIntegerExpression(element.(*IntegerExpression))
+
+	case ElementTypeFixedPointExpression:
+		return visitor.VisitFixedPointExpression(element.(*FixedPointExpression))
+
+	case ElementTypeDictionaryExpression:
+		return visitor.VisitDictionaryExpression(element.(*DictionaryExpression))
+
+	case ElementTypePathExpression:
+		return visitor.VisitPathExpression(element.(*PathExpression))
+
+	case ElementTypeForceExpression:
+		return visitor.VisitForceExpression(element.(*ForceExpression))
+
+	case ElementTypeArrayExpression:
+		return visitor.VisitArrayExpression(element.(*ArrayExpression))
+
+	case ElementTypeInvocationExpression:
+		return visitor.VisitInvocationExpression(element.(*InvocationExpression))
+
+	case ElementTypeIdentifierExpression:
+		return visitor.VisitIdentifierExpression(element.(*IdentifierExpression))
+
+	case ElementTypeIndexExpression:
+		return visitor.VisitIndexExpression(element.(*IndexExpression))
+
+	case ElementTypeUnaryExpression:
+		return visitor.VisitUnaryExpression(element.(*UnaryExpression))
+
+	case ElementTypeFunctionExpression:
+		return visitor.VisitFunctionExpression(element.(*FunctionExpression))
+
+	case ElementTypeCreateExpression:
+		return visitor.VisitCreateExpression(element.(*CreateExpression))
+
+	case ElementTypeMemberExpression:
+		return visitor.VisitMemberExpression(element.(*MemberExpression))
+
+	case ElementTypeReferenceExpression:
+		return visitor.VisitReferenceExpression(element.(*ReferenceExpression))
+
+	case ElementTypeDestroyExpression:
+		return visitor.VisitDestroyExpression(element.(*DestroyExpression))
+
+	case ElementTypeCastingExpression:
+		return visitor.VisitCastingExpression(element.(*CastingExpression))
+
+	case ElementTypeBinaryExpression:
+		return visitor.VisitBinaryExpression(element.(*BinaryExpression))
+
+	case ElementTypeConditionalExpression:
+		return visitor.VisitConditionalExpression(element.(*ConditionalExpression))
+
+	}
+
+	panic(errors.NewUnreachableError())
+}
+
+func AcceptExpression[T any](expression Expression, visitor ExpressionVisitor[T]) (_ T) {
+
+	switch expression.ElementType() {
+
+	case ElementTypeNilExpression:
+		return visitor.VisitNilExpression(expression.(*NilExpression))
+
+	case ElementTypeBoolExpression:
+		return visitor.VisitBoolExpression(expression.(*BoolExpression))
+
+	case ElementTypeStringExpression:
+		return visitor.VisitStringExpression(expression.(*StringExpression))
+
+	case ElementTypeIntegerExpression:
+		return visitor.VisitIntegerExpression(expression.(*IntegerExpression))
+
+	case ElementTypeFixedPointExpression:
+		return visitor.VisitFixedPointExpression(expression.(*FixedPointExpression))
+
+	case ElementTypeDictionaryExpression:
+		return visitor.VisitDictionaryExpression(expression.(*DictionaryExpression))
+
+	case ElementTypePathExpression:
+		return visitor.VisitPathExpression(expression.(*PathExpression))
+
+	case ElementTypeForceExpression:
+		return visitor.VisitForceExpression(expression.(*ForceExpression))
+
+	case ElementTypeArrayExpression:
+		return visitor.VisitArrayExpression(expression.(*ArrayExpression))
+
+	case ElementTypeInvocationExpression:
+		return visitor.VisitInvocationExpression(expression.(*InvocationExpression))
+
+	case ElementTypeIdentifierExpression:
+		return visitor.VisitIdentifierExpression(expression.(*IdentifierExpression))
+
+	case ElementTypeIndexExpression:
+		return visitor.VisitIndexExpression(expression.(*IndexExpression))
+
+	case ElementTypeUnaryExpression:
+		return visitor.VisitUnaryExpression(expression.(*UnaryExpression))
+
+	case ElementTypeFunctionExpression:
+		return visitor.VisitFunctionExpression(expression.(*FunctionExpression))
+
+	case ElementTypeCreateExpression:
+		return visitor.VisitCreateExpression(expression.(*CreateExpression))
+
+	case ElementTypeMemberExpression:
+		return visitor.VisitMemberExpression(expression.(*MemberExpression))
+
+	case ElementTypeReferenceExpression:
+		return visitor.VisitReferenceExpression(expression.(*ReferenceExpression))
+
+	case ElementTypeDestroyExpression:
+		return visitor.VisitDestroyExpression(expression.(*DestroyExpression))
+
+	case ElementTypeCastingExpression:
+		return visitor.VisitCastingExpression(expression.(*CastingExpression))
+
+	case ElementTypeBinaryExpression:
+		return visitor.VisitBinaryExpression(expression.(*BinaryExpression))
+
+	case ElementTypeConditionalExpression:
+		return visitor.VisitConditionalExpression(expression.(*ConditionalExpression))
+
+	}
+
+	panic(errors.NewUnreachableError())
 }

--- a/runtime/cmd/compile/main.go
+++ b/runtime/cmd/compile/main.go
@@ -57,7 +57,7 @@ func main() {
 	funcs := make([]*ir.Func, len(functionDeclarations))
 
 	for i, functionDeclaration := range functionDeclarations {
-		funcs[i] = functionDeclaration.Accept(comp).(*ir.Func)
+		funcs[i] = ast.Accept[ir.Repr](functionDeclaration, comp).(*ir.Func)
 	}
 
 	// Generate a WebAssembly module for the functions

--- a/runtime/compiler/compiler.go
+++ b/runtime/compiler/compiler.go
@@ -56,49 +56,49 @@ func (compiler *Compiler) setLocal(name string, variable *Local) {
 	compiler.activations.Set(name, variable)
 }
 
-func (compiler *Compiler) VisitReturnStatement(statement *ast.ReturnStatement) ast.Repr {
-	exp := statement.Expression.Accept(compiler).(ir.Expr)
+func (compiler *Compiler) VisitReturnStatement(statement *ast.ReturnStatement) ir.Repr {
+	exp := ast.Accept[ir.Repr](statement.Expression, compiler).(ir.Expr)
 	return &ir.Return{
 		Exp: exp,
 	}
 }
 
-func (compiler *Compiler) VisitBreakStatement(_ *ast.BreakStatement) ast.Repr {
+func (compiler *Compiler) VisitBreakStatement(_ *ast.BreakStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitContinueStatement(_ *ast.ContinueStatement) ast.Repr {
+func (compiler *Compiler) VisitContinueStatement(_ *ast.ContinueStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitIfStatement(_ *ast.IfStatement) ast.Repr {
+func (compiler *Compiler) VisitIfStatement(_ *ast.IfStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitWhileStatement(_ *ast.WhileStatement) ast.Repr {
+func (compiler *Compiler) VisitWhileStatement(_ *ast.WhileStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitForStatement(_ *ast.ForStatement) ast.Repr {
+func (compiler *Compiler) VisitForStatement(_ *ast.ForStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitEmitStatement(_ *ast.EmitStatement) ast.Repr {
+func (compiler *Compiler) VisitEmitStatement(_ *ast.EmitStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitSwitchStatement(_ *ast.SwitchStatement) ast.Repr {
+func (compiler *Compiler) VisitSwitchStatement(_ *ast.SwitchStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitVariableDeclaration(declaration *ast.VariableDeclaration) ast.Repr {
+func (compiler *Compiler) VisitVariableDeclaration(declaration *ast.VariableDeclaration) ir.Repr {
 
 	// TODO: potential storage removal
 	// TODO: copy and convert
@@ -108,7 +108,7 @@ func (compiler *Compiler) VisitVariableDeclaration(declaration *ast.VariableDecl
 	targetType := compiler.Checker.Elaboration.VariableDeclarationTypes[declaration].TargetType
 	valType := compileValueType(targetType)
 	local := compiler.declareLocal(identifier, valType)
-	exp := declaration.Value.Accept(compiler).(ir.Expr)
+	exp := ast.Accept[ir.Repr](declaration.Value, compiler).(ir.Expr)
 
 	return &ir.StoreLocal{
 		LocalIndex: local.Index,
@@ -116,32 +116,32 @@ func (compiler *Compiler) VisitVariableDeclaration(declaration *ast.VariableDecl
 	}
 }
 
-func (compiler *Compiler) VisitAssignmentStatement(_ *ast.AssignmentStatement) ast.Repr {
+func (compiler *Compiler) VisitAssignmentStatement(_ *ast.AssignmentStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitSwapStatement(_ *ast.SwapStatement) ast.Repr {
+func (compiler *Compiler) VisitSwapStatement(_ *ast.SwapStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitExpressionStatement(_ *ast.ExpressionStatement) ast.Repr {
+func (compiler *Compiler) VisitExpressionStatement(_ *ast.ExpressionStatement) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitBoolExpression(_ *ast.BoolExpression) ast.Repr {
+func (compiler *Compiler) VisitBoolExpression(_ *ast.BoolExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitNilExpression(_ *ast.NilExpression) ast.Repr {
+func (compiler *Compiler) VisitNilExpression(_ *ast.NilExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitIntegerExpression(expression *ast.IntegerExpression) ast.Repr {
+func (compiler *Compiler) VisitIntegerExpression(expression *ast.IntegerExpression) ir.Repr {
 	var value []byte
 
 	if expression.Value.Sign() < 0 {
@@ -161,22 +161,22 @@ func (compiler *Compiler) VisitIntegerExpression(expression *ast.IntegerExpressi
 	}
 }
 
-func (compiler *Compiler) VisitFixedPointExpression(_ *ast.FixedPointExpression) ast.Repr {
+func (compiler *Compiler) VisitFixedPointExpression(_ *ast.FixedPointExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitArrayExpression(_ *ast.ArrayExpression) ast.Repr {
+func (compiler *Compiler) VisitArrayExpression(_ *ast.ArrayExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitDictionaryExpression(_ *ast.DictionaryExpression) ast.Repr {
+func (compiler *Compiler) VisitDictionaryExpression(_ *ast.DictionaryExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitIdentifierExpression(expression *ast.IdentifierExpression) ast.Repr {
+func (compiler *Compiler) VisitIdentifierExpression(expression *ast.IdentifierExpression) ir.Repr {
 	// TODO
 	local := compiler.findLocal(expression.Identifier.Identifier)
 	// TODO: moves
@@ -185,35 +185,35 @@ func (compiler *Compiler) VisitIdentifierExpression(expression *ast.IdentifierEx
 	}
 }
 
-func (compiler *Compiler) VisitInvocationExpression(_ *ast.InvocationExpression) ast.Repr {
+func (compiler *Compiler) VisitInvocationExpression(_ *ast.InvocationExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitMemberExpression(_ *ast.MemberExpression) ast.Repr {
+func (compiler *Compiler) VisitMemberExpression(_ *ast.MemberExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitIndexExpression(_ *ast.IndexExpression) ast.Repr {
+func (compiler *Compiler) VisitIndexExpression(_ *ast.IndexExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitConditionalExpression(_ *ast.ConditionalExpression) ast.Repr {
+func (compiler *Compiler) VisitConditionalExpression(_ *ast.ConditionalExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitUnaryExpression(_ *ast.UnaryExpression) ast.Repr {
+func (compiler *Compiler) VisitUnaryExpression(_ *ast.UnaryExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitBinaryExpression(expression *ast.BinaryExpression) ast.Repr {
+func (compiler *Compiler) VisitBinaryExpression(expression *ast.BinaryExpression) ir.Repr {
 	op := compileBinaryOperation(expression.Operation)
-	left := expression.Left.Accept(compiler).(ir.Expr)
-	right := expression.Right.Accept(compiler).(ir.Expr)
+	left := ast.Accept[ir.Repr](expression.Left, compiler).(ir.Expr)
+	right := ast.Accept[ir.Repr](expression.Right, compiler).(ir.Expr)
 
 	return &ir.BinOpExpr{
 		Op:    op,
@@ -222,12 +222,12 @@ func (compiler *Compiler) VisitBinaryExpression(expression *ast.BinaryExpression
 	}
 }
 
-func (compiler *Compiler) VisitFunctionExpression(_ *ast.FunctionExpression) ast.Repr {
+func (compiler *Compiler) VisitFunctionExpression(_ *ast.FunctionExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitStringExpression(e *ast.StringExpression) ast.Repr {
+func (compiler *Compiler) VisitStringExpression(e *ast.StringExpression) ir.Repr {
 	return &ir.Const{
 		Constant: ir.String{
 			Value: e.Value,
@@ -235,46 +235,46 @@ func (compiler *Compiler) VisitStringExpression(e *ast.StringExpression) ast.Rep
 	}
 }
 
-func (compiler *Compiler) VisitCastingExpression(_ *ast.CastingExpression) ast.Repr {
+func (compiler *Compiler) VisitCastingExpression(_ *ast.CastingExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitCreateExpression(_ *ast.CreateExpression) ast.Repr {
+func (compiler *Compiler) VisitCreateExpression(_ *ast.CreateExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitDestroyExpression(_ *ast.DestroyExpression) ast.Repr {
+func (compiler *Compiler) VisitDestroyExpression(_ *ast.DestroyExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitReferenceExpression(_ *ast.ReferenceExpression) ast.Repr {
+func (compiler *Compiler) VisitReferenceExpression(_ *ast.ReferenceExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitForceExpression(_ *ast.ForceExpression) ast.Repr {
+func (compiler *Compiler) VisitForceExpression(_ *ast.ForceExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitPathExpression(_ *ast.PathExpression) ast.Repr {
+func (compiler *Compiler) VisitPathExpression(_ *ast.PathExpression) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitProgram(_ *ast.Program) ast.Repr {
+func (compiler *Compiler) VisitProgram(_ *ast.Program) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) ast.Repr {
+func (compiler *Compiler) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) ir.Repr {
 	return compiler.VisitFunctionDeclaration(declaration.FunctionDeclaration)
 }
 
-func (compiler *Compiler) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration) ast.Repr {
+func (compiler *Compiler) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration) ir.Repr {
 
 	// TODO: declare function in current scope, use current scope in function
 	// TODO: conditions
@@ -298,7 +298,7 @@ func (compiler *Compiler) VisitFunctionDeclaration(declaration *ast.FunctionDecl
 
 	// Compile the function block
 
-	stmt := block.Accept(compiler).(ir.Stmt)
+	stmt := ast.Accept[ir.Repr](block, compiler).(ir.Stmt)
 
 	// Important: compile locals after compiling function block,
 	// and don't include parameters in locals
@@ -315,7 +315,7 @@ func (compiler *Compiler) VisitFunctionDeclaration(declaration *ast.FunctionDecl
 	}
 }
 
-func (compiler *Compiler) VisitBlock(block *ast.Block) ast.Repr {
+func (compiler *Compiler) VisitBlock(block *ast.Block) ir.Repr {
 
 	// Block scope: each block gets an activation record
 
@@ -326,7 +326,7 @@ func (compiler *Compiler) VisitBlock(block *ast.Block) ast.Repr {
 
 	stmts := make([]ir.Stmt, len(block.Statements))
 	for i, statement := range block.Statements {
-		stmts[i] = statement.Accept(compiler).(ir.Stmt)
+		stmts[i] = ast.Accept[ir.Repr](statement, compiler).(ir.Stmt)
 	}
 
 	// NOTE: just return an IR statement sequence,
@@ -336,47 +336,47 @@ func (compiler *Compiler) VisitBlock(block *ast.Block) ast.Repr {
 	}
 }
 
-func (compiler *Compiler) VisitFunctionBlock(_ *ast.FunctionBlock) ast.Repr {
+func (compiler *Compiler) VisitFunctionBlock(_ *ast.FunctionBlock) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitCompositeDeclaration(_ *ast.CompositeDeclaration) ast.Repr {
+func (compiler *Compiler) VisitCompositeDeclaration(_ *ast.CompositeDeclaration) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitInterfaceDeclaration(_ *ast.InterfaceDeclaration) ast.Repr {
+func (compiler *Compiler) VisitInterfaceDeclaration(_ *ast.InterfaceDeclaration) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitFieldDeclaration(_ *ast.FieldDeclaration) ast.Repr {
+func (compiler *Compiler) VisitFieldDeclaration(_ *ast.FieldDeclaration) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitCondition(_ *ast.Condition) ast.Repr {
+func (compiler *Compiler) VisitCondition(_ *ast.Condition) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitPragmaDeclaration(_ *ast.PragmaDeclaration) ast.Repr {
+func (compiler *Compiler) VisitPragmaDeclaration(_ *ast.PragmaDeclaration) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitImportDeclaration(_ *ast.ImportDeclaration) ast.Repr {
+func (compiler *Compiler) VisitImportDeclaration(_ *ast.ImportDeclaration) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitTransactionDeclaration(_ *ast.TransactionDeclaration) ast.Repr {
+func (compiler *Compiler) VisitTransactionDeclaration(_ *ast.TransactionDeclaration) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (compiler *Compiler) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) ast.Repr {
+func (compiler *Compiler) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) ir.Repr {
 	// TODO
 	panic(errors.NewUnreachableError())
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -424,7 +424,7 @@ func (interpreter *Interpreter) Interpret() (err error) {
 	})
 
 	if interpreter.Program != nil {
-		interpreter.Program.Program.Accept(interpreter)
+		ast.Accept[any](interpreter.Program.Program, interpreter)
 	}
 
 	interpreter.interpreted = true
@@ -436,7 +436,7 @@ func (interpreter *Interpreter) Interpret() (err error) {
 // then finds the declaration and adds it to the globals
 //
 func (interpreter *Interpreter) visitGlobalDeclaration(declaration ast.Declaration) {
-	declaration.Accept(interpreter)
+	ast.Accept[any](declaration, interpreter)
 	interpreter.declareGlobal(declaration)
 }
 
@@ -637,7 +637,7 @@ func (interpreter *Interpreter) RecoverErrors(onError func(error)) {
 	}
 }
 
-func (interpreter *Interpreter) VisitProgram(program *ast.Program) ast.Repr {
+func (interpreter *Interpreter) VisitProgram(program *ast.Program) any {
 
 	for _, declaration := range program.ImportDeclarations() {
 		interpreter.visitGlobalDeclaration(declaration)
@@ -737,11 +737,11 @@ func (interpreter *Interpreter) VisitProgram(program *ast.Program) ast.Repr {
 	return nil
 }
 
-func (interpreter *Interpreter) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) any {
 	return interpreter.VisitFunctionDeclaration(declaration.FunctionDeclaration)
 }
 
-func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration) any {
 
 	identifier := declaration.Identifier.Identifier
 
@@ -801,7 +801,7 @@ func (interpreter *Interpreter) functionDeclarationValue(
 	)
 }
 
-func (interpreter *Interpreter) VisitBlock(block *ast.Block) ast.Repr {
+func (interpreter *Interpreter) VisitBlock(block *ast.Block) any {
 	// block scope: each block gets an activation record
 	interpreter.activations.PushNewWithCurrent()
 	defer interpreter.activations.Pop()
@@ -809,7 +809,7 @@ func (interpreter *Interpreter) VisitBlock(block *ast.Block) ast.Repr {
 	return interpreter.visitStatements(block.Statements)
 }
 
-func (interpreter *Interpreter) VisitFunctionBlock(_ *ast.FunctionBlock) ast.Repr {
+func (interpreter *Interpreter) VisitFunctionBlock(_ *ast.FunctionBlock) any {
 	// NOTE: see visitBlock
 	panic(errors.NewUnreachableError())
 }
@@ -955,7 +955,7 @@ func (interpreter *Interpreter) visitAssignment(
 }
 
 // NOTE: only called for top-level composite declarations
-func (interpreter *Interpreter) VisitCompositeDeclaration(declaration *ast.CompositeDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitCompositeDeclaration(declaration *ast.CompositeDeclaration) any {
 
 	// lexical scope: variables in functions are bound to what is visible at declaration time
 	lexicalScope := interpreter.activations.CurrentOrNew()
@@ -1633,12 +1633,12 @@ func (interpreter *Interpreter) compositeFunction(
 	)
 }
 
-func (interpreter *Interpreter) VisitFieldDeclaration(_ *ast.FieldDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitFieldDeclaration(_ *ast.FieldDeclaration) any {
 	// fields aren't interpreted
 	panic(errors.NewUnreachableError())
 }
 
-func (interpreter *Interpreter) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) any {
 	// enum cases aren't interpreted
 	panic(errors.NewUnreachableError())
 }
@@ -1863,7 +1863,7 @@ func (interpreter *Interpreter) Unbox(getLocationRange func() LocationRange, val
 }
 
 // NOTE: only called for top-level interface declarations
-func (interpreter *Interpreter) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) any {
 
 	// lexical scope: variables in functions are bound to what is visible at declaration time
 	lexicalScope := interpreter.activations.CurrentOrNew()

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDeclaration) any {
 
 	resolvedLocations := interpreter.Program.Elaboration.ImportDeclarationsResolvedLocations[declaration]
 

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-func (interpreter *Interpreter) VisitTransactionDeclaration(declaration *ast.TransactionDeclaration) ast.Repr {
+func (interpreter *Interpreter) VisitTransactionDeclaration(declaration *ast.TransactionDeclaration) any {
 	interpreter.declareTransactionEntryPoint(declaration)
 
 	return nil

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -105,7 +105,7 @@ func (r *REPL) handleCheckerError() bool {
 }
 
 func (r *REPL) execute(element ast.Element) {
-	result := element.Accept(r.inter)
+	result := ast.Accept[any](element, r.inter)
 	expStatementRes, ok := result.(interpreter.ExpressionStatementResult)
 	if !ok {
 		return
@@ -117,7 +117,7 @@ func (r *REPL) execute(element ast.Element) {
 }
 
 func (r *REPL) check(element ast.Element, code string) bool {
-	element.Accept(r.checker)
+	ast.Accept[sema.Type](element, r.checker)
 	r.codes[r.checker.Location] = code
 	return r.handleCheckerError()
 }

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -20,7 +20,7 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
-func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) ast.Repr {
+func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Type {
 
 	// visit all elements, ensure they are all the same type
 

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitAssignmentStatement(assignment *ast.AssignmentStatement) ast.Repr {
+func (checker *Checker) VisitAssignmentStatement(assignment *ast.AssignmentStatement) Type {
 	targetType, valueType := checker.checkAssignment(
 		assignment.Target,
 		assignment.Value,

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) ast.Repr {
+func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) Type {
 
 	var leftType, rightType, resultType Type
 	defer func() {

--- a/runtime/sema/check_block.go
+++ b/runtime/sema/check_block.go
@@ -20,7 +20,7 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
-func (checker *Checker) VisitBlock(block *ast.Block) ast.Repr {
+func (checker *Checker) VisitBlock(block *ast.Block) Type {
 	checker.enterValueScope()
 	defer checker.leaveValueScope(block.EndPosition, true)
 
@@ -62,7 +62,7 @@ func (checker *Checker) visitStatements(statements []ast.Statement) {
 
 		// check statement
 
-		statement.Accept(checker)
+		ast.Accept[Type](statement, checker)
 	}
 }
 

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression) ast.Repr {
+func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression) Type {
 
 	// Visit type annotation
 

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitCompositeDeclaration(declaration *ast.CompositeDeclaration) ast.Repr {
+func (checker *Checker) VisitCompositeDeclaration(declaration *ast.CompositeDeclaration) Type {
 	checker.visitCompositeDeclaration(declaration, ContainerKindComposite)
 
 	return nil
@@ -200,11 +200,11 @@ func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDecl
 	// DON'T use `nestedDeclarations`, because of non-deterministic order
 
 	for _, nestedInterface := range declaration.Members.Interfaces() {
-		nestedInterface.Accept(checker)
+		ast.Accept[Type](nestedInterface, checker)
 	}
 
 	for _, nestedComposite := range declaration.Members.Composites() {
-		nestedComposite.Accept(checker)
+		ast.Accept[Type](nestedComposite, checker)
 	}
 }
 
@@ -2025,13 +2025,13 @@ func (checker *Checker) checkNestedIdentifier(
 	}
 }
 
-func (checker *Checker) VisitFieldDeclaration(_ *ast.FieldDeclaration) ast.Repr {
+func (checker *Checker) VisitFieldDeclaration(_ *ast.FieldDeclaration) Type {
 	// NOTE: field type is already checked when determining composite function in `compositeType`
 
 	panic(errors.NewUnreachableError())
 }
 
-func (checker *Checker) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) ast.Repr {
+func (checker *Checker) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) Type {
 	// NOTE: already checked when checking the composite
 
 	panic(errors.NewUnreachableError())

--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitIfStatement(statement *ast.IfStatement) ast.Repr {
+func (checker *Checker) VisitIfStatement(statement *ast.IfStatement) Type {
 
 	thenElement := statement.Then
 
@@ -43,12 +43,12 @@ func (checker *Checker) VisitIfStatement(statement *ast.IfStatement) ast.Repr {
 				defer checker.leaveValueScope(thenElement.EndPosition, true)
 
 				checker.visitVariableDeclaration(test, true)
-				thenElement.Accept(checker)
+				ast.Accept[Type](thenElement, checker)
 
 				return nil
 			},
 			func() Type {
-				elseElement.Accept(checker)
+				ast.Accept[Type](elseElement, checker)
 				return nil
 			},
 		)
@@ -60,7 +60,7 @@ func (checker *Checker) VisitIfStatement(statement *ast.IfStatement) ast.Repr {
 	return nil
 }
 
-func (checker *Checker) VisitConditionalExpression(expression *ast.ConditionalExpression) ast.Repr {
+func (checker *Checker) VisitConditionalExpression(expression *ast.ConditionalExpression) Type {
 
 	expectedType := checker.expectedType
 
@@ -121,18 +121,10 @@ func (checker *Checker) visitConditional(
 
 	return checker.checkConditionalBranches(
 		func() Type {
-			thenResult, ok := thenElement.Accept(checker).(Type)
-			if !ok || thenResult == nil {
-				return nil
-			}
-			return thenResult
+			return ast.Accept[Type](thenElement, checker)
 		},
 		func() Type {
-			elseResult, ok := elseElement.Accept(checker).(Type)
-			if !ok || elseResult == nil {
-				return nil
-			}
-			return elseResult
+			return ast.Accept[Type](elseElement, checker)
 		},
 	)
 }

--- a/runtime/sema/check_conditions.go
+++ b/runtime/sema/check_conditions.go
@@ -40,7 +40,7 @@ func (checker *Checker) visitConditions(conditions []*ast.Condition) {
 	}
 }
 
-func (checker *Checker) checkCondition(condition *ast.Condition) ast.Repr {
+func (checker *Checker) checkCondition(condition *ast.Condition) Type {
 
 	// check test expression is boolean
 	checker.VisitExpression(condition.Test, BoolType)

--- a/runtime/sema/check_create_expression.go
+++ b/runtime/sema/check_create_expression.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitCreateExpression(expression *ast.CreateExpression) ast.Repr {
+func (checker *Checker) VisitCreateExpression(expression *ast.CreateExpression) Type {
 	inCreate := checker.inCreate
 	checker.inCreate = true
 	defer func() {

--- a/runtime/sema/check_destroy_expression.go
+++ b/runtime/sema/check_destroy_expression.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 )
 
-func (checker *Checker) VisitDestroyExpression(expression *ast.DestroyExpression) (resultType ast.Repr) {
+func (checker *Checker) VisitDestroyExpression(expression *ast.DestroyExpression) (resultType Type) {
 	resultType = VoidType
 
 	valueType := checker.VisitExpression(expression.Expression, nil)

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpression) ast.Repr {
+func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpression) Type {
 
 	// visit all entries, ensure key are all the same type,
 	// and values are all the same type

--- a/runtime/sema/check_emit_statement.go
+++ b/runtime/sema/check_emit_statement.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitEmitStatement(statement *ast.EmitStatement) ast.Repr {
+func (checker *Checker) VisitEmitStatement(statement *ast.EmitStatement) Type {
 	invocation := statement.InvocationExpression
 
 	ty := checker.checkInvocationExpression(invocation)

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpression) ast.Repr {
+func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpression) Type {
 	identifier := expression.Identifier
 	variable := checker.findAndCheckValueVariable(expression, true)
 	if variable == nil {
@@ -136,7 +136,7 @@ func (checker *Checker) checkResourceVariableCapturingInFunction(variable *Varia
 	)
 }
 
-func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatement) ast.Repr {
+func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatement) Type {
 	expression := statement.Expression
 
 	ty := checker.VisitExpression(expression, nil)
@@ -152,7 +152,7 @@ func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatem
 	return nil
 }
 
-func (checker *Checker) VisitBoolExpression(_ *ast.BoolExpression) ast.Repr {
+func (checker *Checker) VisitBoolExpression(_ *ast.BoolExpression) Type {
 	return BoolType
 }
 
@@ -160,11 +160,11 @@ var NilType = &OptionalType{
 	Type: NeverType,
 }
 
-func (checker *Checker) VisitNilExpression(_ *ast.NilExpression) ast.Repr {
+func (checker *Checker) VisitNilExpression(_ *ast.NilExpression) Type {
 	return NilType
 }
 
-func (checker *Checker) VisitIntegerExpression(expression *ast.IntegerExpression) ast.Repr {
+func (checker *Checker) VisitIntegerExpression(expression *ast.IntegerExpression) Type {
 	expectedType := UnwrapOptionalType(checker.expectedType)
 
 	var actualType Type
@@ -191,7 +191,7 @@ func (checker *Checker) VisitIntegerExpression(expression *ast.IntegerExpression
 	return actualType
 }
 
-func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpression) ast.Repr {
+func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpression) Type {
 	// TODO: adjust once/if we support more fixed point types
 
 	// If the contextually expected type is a subtype of FixedPoint, then take that.
@@ -216,7 +216,7 @@ func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpr
 	return actualType
 }
 
-func (checker *Checker) VisitStringExpression(expression *ast.StringExpression) ast.Repr {
+func (checker *Checker) VisitStringExpression(expression *ast.StringExpression) Type {
 	expectedType := UnwrapOptionalType(checker.expectedType)
 
 	var actualType Type = StringType
@@ -231,7 +231,7 @@ func (checker *Checker) VisitStringExpression(expression *ast.StringExpression) 
 	return actualType
 }
 
-func (checker *Checker) VisitIndexExpression(expression *ast.IndexExpression) ast.Repr {
+func (checker *Checker) VisitIndexExpression(expression *ast.IndexExpression) Type {
 	return checker.visitIndexExpression(expression, false)
 }
 

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr {
+func (checker *Checker) VisitForStatement(statement *ast.ForStatement) Type {
 
 	checker.enterValueScope()
 	defer checker.leaveValueScope(statement.EndPosition, true)
@@ -110,7 +110,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) ast.Repr 
 
 	_ = checker.checkPotentiallyUnevaluated(func() Type {
 		checker.functionActivations.WithLoop(func() {
-			statement.Block.Accept(checker)
+			ast.Accept[Type](statement.Block, checker)
 		})
 
 		// ignored

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 )
 
-func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) ast.Repr {
+func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) Type {
 
 	// Expected type of the `expression.Expression` is the optional of expected type of current context.
 	// i.e: if `x!` is `String`, then `x` is expected to be `String?`.

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration) ast.Repr {
+func (checker *Checker) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration) Type {
 	return checker.visitFunctionDeclaration(
 		declaration,
 		functionDeclarationOptions{
@@ -35,7 +35,7 @@ func (checker *Checker) VisitFunctionDeclaration(declaration *ast.FunctionDeclar
 	)
 }
 
-func (checker *Checker) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) ast.Repr {
+func (checker *Checker) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) Type {
 	return checker.VisitFunctionDeclaration(declaration.FunctionDeclaration)
 }
 
@@ -56,7 +56,7 @@ type functionDeclarationOptions struct {
 func (checker *Checker) visitFunctionDeclaration(
 	declaration *ast.FunctionDeclaration,
 	options functionDeclarationOptions,
-) ast.Repr {
+) Type {
 
 	checker.checkDeclarationAccessModifier(
 		declaration.Access,
@@ -313,7 +313,7 @@ func (checker *Checker) declareParameters(
 	}
 }
 
-func (checker *Checker) VisitFunctionBlock(functionBlock *ast.FunctionBlock) ast.Repr {
+func (checker *Checker) VisitFunctionBlock(functionBlock *ast.FunctionBlock) Type {
 	// NOTE: see visitFunctionBlock
 	panic(errors.NewUnreachableError())
 }
@@ -412,7 +412,7 @@ func (checker *Checker) declareBefore() {
 	// TODO: record occurrence – but what position?
 }
 
-func (checker *Checker) VisitFunctionExpression(expression *ast.FunctionExpression) ast.Repr {
+func (checker *Checker) VisitFunctionExpression(expression *ast.FunctionExpression) Type {
 
 	// TODO: infer
 	functionType := checker.functionType(expression.ParameterList, expression.ReturnTypeAnnotation)

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -38,12 +38,12 @@ import (
 // 2. Acquiring the programs for the resolved imports. For each resolved import a separate program can be returned.
 //
 
-func (checker *Checker) VisitImportDeclaration(_ *ast.ImportDeclaration) ast.Repr {
+func (checker *Checker) VisitImportDeclaration(_ *ast.ImportDeclaration) Type {
 	// Handled in `declareImportDeclaration`
 	panic(&UnreachableStatementError{})
 }
 
-func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclaration) ast.Repr {
+func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclaration) Type {
 	locationRange := ast.NewRange(
 		checker.memoryGauge,
 		declaration.LocationPos,

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -31,7 +31,7 @@ import (
 // and that the members and nested declarations for the interface type were declared
 // through `declareInterfaceMembers`.
 //
-func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) ast.Repr {
+func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) Type {
 
 	const kind = ContainerKindInterface
 
@@ -114,7 +114,7 @@ func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDecl
 	// DON'T use `nestedDeclarations`, because of non-deterministic order
 
 	for _, nestedInterface := range declaration.Members.Interfaces() {
-		nestedInterface.Accept(checker)
+		ast.Accept[Type](nestedInterface, checker)
 	}
 
 	for _, nestedComposite := range declaration.Members.Composites() {

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitInvocationExpression(invocationExpression *ast.InvocationExpression) ast.Repr {
+func (checker *Checker) VisitInvocationExpression(invocationExpression *ast.InvocationExpression) Type {
 	ty := checker.checkInvocationExpression(invocationExpression)
 
 	// Events cannot be invoked without an emit statement

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -25,7 +25,7 @@ import (
 
 // NOTE: only called if the member expression is *not* an assignment
 //
-func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) ast.Repr {
+func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) Type {
 	accessedType, member, isOptional := checker.visitMember(expression)
 
 	if !accessedType.IsInvalidType() {

--- a/runtime/sema/check_path_expression.go
+++ b/runtime/sema/check_path_expression.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitPathExpression(expression *ast.PathExpression) ast.Repr {
+func (checker *Checker) VisitPathExpression(expression *ast.PathExpression) Type {
 
 	ty, err := CheckPathLiteral(
 		expression.Domain.Identifier,

--- a/runtime/sema/check_pragma.go
+++ b/runtime/sema/check_pragma.go
@@ -20,7 +20,7 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
-func (checker *Checker) VisitPragmaDeclaration(p *ast.PragmaDeclaration) ast.Repr {
+func (checker *Checker) VisitPragmaDeclaration(p *ast.PragmaDeclaration) Type {
 
 	invocPragma, isInvocPragma := p.Expression.(*ast.InvocationExpression)
 	var isIdentPragma bool

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -25,7 +25,7 @@ import (
 // VisitReferenceExpression checks a reference expression `&t as T`,
 // where `t` is the referenced expression, and `T` is the result type.
 //
-func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.ReferenceExpression) ast.Repr {
+func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.ReferenceExpression) Type {
 
 	// Check the result type and ensure it is a reference type
 

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -20,7 +20,7 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
-func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) ast.Repr {
+func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) Type {
 	functionActivation := checker.functionActivations.Current()
 
 	defer func() {

--- a/runtime/sema/check_swap.go
+++ b/runtime/sema/check_swap.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitSwapStatement(swap *ast.SwapStatement) ast.Repr {
+func (checker *Checker) VisitSwapStatement(swap *ast.SwapStatement) Type {
 
 	leftType := checker.VisitExpression(swap.Left, nil)
 	rightType := checker.VisitExpression(swap.Right, nil)

--- a/runtime/sema/check_switch.go
+++ b/runtime/sema/check_switch.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 )
 
-func (checker *Checker) VisitSwitchStatement(statement *ast.SwitchStatement) ast.Repr {
+func (checker *Checker) VisitSwitchStatement(statement *ast.SwitchStatement) Type {
 
 	testType := checker.VisitExpression(statement.Expression, nil)
 
@@ -180,5 +180,5 @@ func (checker *Checker) checkSwitchCaseStatements(switchCase *ast.SwitchCase) {
 			switchCase.EndPos,
 		),
 	)
-	block.Accept(checker)
+	ast.Accept[Type](block, checker)
 }

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitTransactionDeclaration(declaration *ast.TransactionDeclaration) ast.Repr {
+func (checker *Checker) VisitTransactionDeclaration(declaration *ast.TransactionDeclaration) Type {
 	transactionType := checker.Elaboration.TransactionDeclarationTypes[declaration]
 	if transactionType == nil {
 		panic(errors.NewUnreachableError())

--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) ast.Repr {
+func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) Type {
 
 	var expectedType Type
 	if expression.Operation == ast.OperationMove {

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
-func (checker *Checker) VisitVariableDeclaration(declaration *ast.VariableDeclaration) ast.Repr {
+func (checker *Checker) VisitVariableDeclaration(declaration *ast.VariableDeclaration) Type {
 	checker.visitVariableDeclaration(declaration, false)
 	return nil
 }

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 )
 
-func (checker *Checker) VisitWhileStatement(statement *ast.WhileStatement) ast.Repr {
+func (checker *Checker) VisitWhileStatement(statement *ast.WhileStatement) Type {
 
 	checker.VisitExpression(statement.Test, BoolType)
 
@@ -33,7 +33,7 @@ func (checker *Checker) VisitWhileStatement(statement *ast.WhileStatement) ast.R
 
 	_ = checker.checkPotentiallyUnevaluated(func() Type {
 		checker.functionActivations.WithLoop(func() {
-			statement.Block.Accept(checker)
+			ast.Accept[Type](statement.Block, checker)
 		})
 
 		// ignored
@@ -99,7 +99,7 @@ func (checker *Checker) reportResourceUsesInLoop(startPos, endPos ast.Position) 
 	})
 }
 
-func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.Repr {
+func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) Type {
 
 	// Ensure that the `break` statement is inside a loop or switch statement
 
@@ -120,7 +120,7 @@ func (checker *Checker) VisitBreakStatement(statement *ast.BreakStatement) ast.R
 	return nil
 }
 
-func (checker *Checker) VisitContinueStatement(statement *ast.ContinueStatement) ast.Repr {
+func (checker *Checker) VisitContinueStatement(statement *ast.ContinueStatement) Type {
 
 	// Ensure that the `continue` statement is inside a loop statement
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -209,7 +209,7 @@ func (checker *Checker) Check() error {
 				}()
 			}
 
-			checker.Program.Accept(checker)
+			ast.Accept[Type](checker.Program, checker)
 		}
 		if checker.Config.CheckHandler != nil {
 			checker.Config.CheckHandler(checker, check)
@@ -251,7 +251,7 @@ func (checker *Checker) report(err error) {
 	}
 }
 
-func (checker *Checker) VisitProgram(program *ast.Program) ast.Repr {
+func (checker *Checker) VisitProgram(program *ast.Program) Type {
 
 	for _, declaration := range program.ImportDeclarations() {
 		checker.declareImportDeclaration(declaration)
@@ -321,7 +321,7 @@ func (checker *Checker) VisitProgram(program *ast.Program) ast.Repr {
 			continue
 		}
 
-		declaration.Accept(checker)
+		ast.Accept[Type](declaration, checker)
 		checker.declareGlobalDeclaration(declaration)
 	}
 
@@ -2189,11 +2189,7 @@ func (checker *Checker) visitExpressionWithForceType(
 		checker.expectedType = prevExpectedType
 	}()
 
-	actualType, ok := expr.Accept(checker).(Type)
-	if !ok {
-		// visiter must always return a Type
-		panic(errors.NewUnreachableError())
-	}
+	actualType = ast.Accept[Type](expr, checker)
 
 	if forceType &&
 		expectedType != nil &&


### PR DESCRIPTION
## Description

- Make the AST visitors generic
- Refactor the `Accept` method on `Element` to a global function, as Go does not support generic receiver methods (ideally we would like to have `Element` have a function `Accept[T](visitor Visitor[T]) T`)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
