### PR TITLE
Make missing casting expression a user error

### DIFF
--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -19,7 +19,6 @@
 package parser
 
 import (
-	"fmt"
 	"math/big"
 	"strings"
 	"unicode/utf8"
@@ -1297,12 +1296,12 @@ func defineReferenceExpression() {
 				return nil, err
 			}
 
-			p.skipSpaceAndComments(true)
-
 			castingExpression, ok := expression.(*ast.CastingExpression)
 			if !ok {
-				panic(fmt.Errorf("expected casting expression"))
+				return nil, p.syntaxError("expected casting expression")
 			}
+
+			p.skipSpaceAndComments(true)
 
 			return ast.NewReferenceExpression(
 				p.memoryGauge,

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -868,7 +868,7 @@ func TestParseLocalReplayLimit(t *testing.T) {
 	builder.WriteString(">()")
 
 	code := builder.String()
-	_, errs := ParseProgram(code, nil)
+	_, err := ParseProgram(code, nil)
 	utils.AssertEqualWithDiff(t,
 		Error{
 			Code: code,
@@ -886,7 +886,7 @@ func TestParseLocalReplayLimit(t *testing.T) {
 				},
 			},
 		},
-		errs,
+		err,
 	)
 }
 
@@ -903,7 +903,7 @@ func TestParseGlobalReplayLimit(t *testing.T) {
 	}
 
 	code := builder.String()
-	_, errs := ParseProgram(code, nil)
+	_, err := ParseProgram(code, nil)
 	utils.AssertEqualWithDiff(t,
 		Error{
 			Code: code,
@@ -921,6 +921,6 @@ func TestParseGlobalReplayLimit(t *testing.T) {
 				},
 			},
 		},
-		errs,
+		err,
 	)
 }


### PR DESCRIPTION
Work towards onflow/flow-emulator#189

## Description

When parsing a reference expression, a missing casting expression should not be an implementation error (panic), but just a user error.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
