### PR TITLE
Add String.fromUTF8 for conversion from [UInt8]

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3051,7 +3051,7 @@ var stringFunction = func() Value {
 				memoryUsage := common.NewStringMemoryUsage(len(buf))
 
 				return NewSomeValueNonCopying(
-					inter, 
+					inter,
 					NewStringValue(inter, memoryUsage, func() string {
 						return string(buf)
 					}),

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -81,6 +81,7 @@ type getterSetter struct {
 // are treated like they are returning a value.
 
 // OnEventEmittedFunc is a function that is triggered when an event is emitted by the program.
+//
 type OnEventEmittedFunc func(
 	inter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -89,21 +90,25 @@ type OnEventEmittedFunc func(
 ) error
 
 // OnStatementFunc is a function that is triggered when a statement is about to be executed.
+//
 type OnStatementFunc func(
 	inter *Interpreter,
 	statement ast.Statement,
 )
 
 // OnLoopIterationFunc is a function that is triggered when a loop iteration is about to be executed.
+//
 type OnLoopIterationFunc func(
 	inter *Interpreter,
 	line int,
 )
 
 // OnFunctionInvocationFunc is a function that is triggered when a function is about to be invoked.
+//
 type OnFunctionInvocationFunc func(inter *Interpreter)
 
 // OnInvokedFunctionReturnFunc is a function that is triggered when an invoked function returned.
+//
 type OnInvokedFunctionReturnFunc func(inter *Interpreter)
 
 // OnRecordTraceFunc is a function that records a trace.
@@ -132,6 +137,7 @@ type OnMeterComputationFunc func(
 )
 
 // InjectedCompositeFieldsHandlerFunc is a function that handles storage reads.
+//
 type InjectedCompositeFieldsHandlerFunc func(
 	inter *Interpreter,
 	location common.Location,
@@ -140,6 +146,7 @@ type InjectedCompositeFieldsHandlerFunc func(
 ) map[string]Value
 
 // ContractValueHandlerFunc is a function that handles contract values.
+//
 type ContractValueHandlerFunc func(
 	inter *Interpreter,
 	compositeType *sema.CompositeType,
@@ -148,6 +155,7 @@ type ContractValueHandlerFunc func(
 ) *CompositeValue
 
 // ImportLocationHandlerFunc is a function that handles imports of locations.
+//
 type ImportLocationHandlerFunc func(
 	inter *Interpreter,
 	location common.Location,
@@ -155,6 +163,7 @@ type ImportLocationHandlerFunc func(
 
 // PublicAccountHandlerFunc is a function that handles retrieving a public account at a given address.
 // The account returned must be of type `PublicAccount`.
+//
 type PublicAccountHandlerFunc func(
 	address AddressValue,
 ) Value
@@ -165,6 +174,7 @@ type UUIDHandlerFunc func() (uint64, error)
 // PublicKeyValidationHandlerFunc is a function that validates a given public key.
 // Parameter types:
 // - publicKey: PublicKey
+//
 type PublicKeyValidationHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -176,6 +186,7 @@ type PublicKeyValidationHandlerFunc func(
 // - publicKey: PublicKey
 // - signature: [UInt8]
 // Expected result type: Bool
+//
 type BLSVerifyPoPHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -187,6 +198,7 @@ type BLSVerifyPoPHandlerFunc func(
 // Parameter types:
 // - signatures: [[UInt8]]
 // Expected result type: [UInt8]?
+//
 type BLSAggregateSignaturesHandlerFunc func(
 	inter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -197,6 +209,7 @@ type BLSAggregateSignaturesHandlerFunc func(
 // Parameter types:
 // - publicKeys: [PublicKey]
 // Expected result type: PublicKey?
+//
 type BLSAggregatePublicKeysHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -211,6 +224,7 @@ type BLSAggregatePublicKeysHandlerFunc func(
 // - hashAlgorithm: HashAlgorithm
 // - publicKey: PublicKey
 // Expected result type: Bool
+//
 type SignatureVerificationHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -227,6 +241,7 @@ type SignatureVerificationHandlerFunc func(
 // - domainSeparationTag: [UInt8]
 // - hashAlgorithm: HashAlgorithm
 // Expected result type: [UInt8]
+//
 type HashHandlerFunc func(
 	inter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -241,6 +256,7 @@ type HashHandlerFunc func(
 //
 // As there is no support for inheritance of concrete types,
 // these are the "leaf" nodes in the call chain, and are functions.
+//
 type CompositeTypeCode struct {
 	CompositeFunctions map[string]FunctionValue
 	DestructorFunction FunctionValue
@@ -253,6 +269,7 @@ type FunctionWrapper = func(inner FunctionValue) FunctionValue
 //
 // These are "branch" nodes in the call chain, and are function wrappers,
 // i.e. they wrap the functions / function wrappers that inherit them.
+//
 type WrapperCode struct {
 	InitializerFunctionWrapper FunctionWrapper
 	DestructorFunctionWrapper  FunctionWrapper
@@ -262,6 +279,7 @@ type WrapperCode struct {
 
 // TypeCodes is the value which stores the "prepared" / "callable" "code"
 // of all composite types, interface types, and type requirements.
+//
 type TypeCodes struct {
 	CompositeCodes       map[sema.TypeID]CompositeTypeCode
 	InterfaceCodes       map[sema.TypeID]WrapperCode
@@ -310,6 +328,7 @@ var _ common.MemoryGauge = &Interpreter{}
 
 // BaseActivation is the activation which contains all base declarations.
 // It is reused across all interpreters.
+//
 var BaseActivation = func() *VariableActivation {
 	// No need to meter since this is only created once
 	activation := NewVariableActivation(nil, nil)
@@ -365,6 +384,7 @@ func newInterpreter(
 
 // locationRangeGetter returns a function that returns the location range
 // for the given location and positioned element.
+//
 func locationRangeGetter(
 	memoryGauge common.MemoryGauge,
 	location common.Location,
@@ -415,6 +435,7 @@ func (interpreter *Interpreter) Interpret() (err error) {
 
 // visitGlobalDeclaration firsts interprets the global declaration,
 // then finds the declaration and adds it to the globals
+//
 func (interpreter *Interpreter) visitGlobalDeclaration(declaration ast.Declaration) {
 	declaration.Accept(interpreter)
 	interpreter.declareGlobal(declaration)
@@ -961,6 +982,7 @@ func (interpreter *Interpreter) VisitCompositeDeclaration(declaration *ast.Compo
 // a contract value / instance (singleton).
 //
 // For all other composite kinds the constructor function is declared.
+//
 func (interpreter *Interpreter) declareCompositeValue(
 	declaration *ast.CompositeDeclaration,
 	lexicalScope *VariableActivation,
@@ -2235,6 +2257,7 @@ type ValueConverterDeclaration struct {
 }
 
 // It would be nice if return types in Go's function types would be covariant
+//
 var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.IntTypeName,
@@ -2736,6 +2759,7 @@ type converterFunction struct {
 }
 
 // Converter functions are stateless functions. Hence they can be re-used across interpreters.
+//
 var converterFunctionValues = func() []converterFunction {
 
 	converterFuncValues := make([]converterFunction, len(ConverterDeclarations))
@@ -2788,6 +2812,7 @@ type runtimeTypeConstructor struct {
 }
 
 // Constructor functions are stateless functions. Hence they can be re-used across interpreters.
+//
 var runtimeTypeConstructors = []runtimeTypeConstructor{
 	{
 		name: "OptionalType",
@@ -2922,6 +2947,7 @@ func defineRuntimeTypeConstructorFunctions(activation *VariableActivation) {
 }
 
 // typeFunction is the `Type` function. It is stateless, hence it can be re-used across interpreters.
+//
 var typeFunction = NewUnmeteredHostFunctionValue(
 	func(invocation Invocation) Value {
 		typeParameterPair := invocation.TypeParameterTypes.Oldest()
@@ -2953,6 +2979,7 @@ func defineBaseValue(activation *VariableActivation, name string, value Value) {
 }
 
 // stringFunction is the `String` function. It is stateless, hence it can be re-used across interpreters.
+//
 var stringFunction = func() Value {
 	functionValue := NewUnmeteredHostFunctionValue(
 		func(invocation Invocation) Value {
@@ -4343,6 +4370,7 @@ func (interpreter *Interpreter) invalidateResource(value Value) {
 }
 
 // MeterMemory delegates the memory usage to the interpreter's memory gauge, if any.
+//
 func (interpreter *Interpreter) MeterMemory(usage common.MemoryUsage) error {
 	common.UseMemory(interpreter.Config.MemoryGauge, usage)
 	return nil

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -80,7 +80,6 @@ type getterSetter struct {
 // are treated like they are returning a value.
 
 // OnEventEmittedFunc is a function that is triggered when an event is emitted by the program.
-//
 type OnEventEmittedFunc func(
 	inter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -89,25 +88,21 @@ type OnEventEmittedFunc func(
 ) error
 
 // OnStatementFunc is a function that is triggered when a statement is about to be executed.
-//
 type OnStatementFunc func(
 	inter *Interpreter,
 	statement ast.Statement,
 )
 
 // OnLoopIterationFunc is a function that is triggered when a loop iteration is about to be executed.
-//
 type OnLoopIterationFunc func(
 	inter *Interpreter,
 	line int,
 )
 
 // OnFunctionInvocationFunc is a function that is triggered when a function is about to be invoked.
-//
 type OnFunctionInvocationFunc func(inter *Interpreter)
 
 // OnInvokedFunctionReturnFunc is a function that is triggered when an invoked function returned.
-//
 type OnInvokedFunctionReturnFunc func(inter *Interpreter)
 
 // OnRecordTraceFunc is a function that records a trace.
@@ -136,7 +131,6 @@ type OnMeterComputationFunc func(
 )
 
 // InjectedCompositeFieldsHandlerFunc is a function that handles storage reads.
-//
 type InjectedCompositeFieldsHandlerFunc func(
 	inter *Interpreter,
 	location common.Location,
@@ -145,7 +139,6 @@ type InjectedCompositeFieldsHandlerFunc func(
 ) map[string]Value
 
 // ContractValueHandlerFunc is a function that handles contract values.
-//
 type ContractValueHandlerFunc func(
 	inter *Interpreter,
 	compositeType *sema.CompositeType,
@@ -154,7 +147,6 @@ type ContractValueHandlerFunc func(
 ) *CompositeValue
 
 // ImportLocationHandlerFunc is a function that handles imports of locations.
-//
 type ImportLocationHandlerFunc func(
 	inter *Interpreter,
 	location common.Location,
@@ -162,7 +154,6 @@ type ImportLocationHandlerFunc func(
 
 // PublicAccountHandlerFunc is a function that handles retrieving a public account at a given address.
 // The account returned must be of type `PublicAccount`.
-//
 type PublicAccountHandlerFunc func(
 	address AddressValue,
 ) Value
@@ -173,7 +164,6 @@ type UUIDHandlerFunc func() (uint64, error)
 // PublicKeyValidationHandlerFunc is a function that validates a given public key.
 // Parameter types:
 // - publicKey: PublicKey
-//
 type PublicKeyValidationHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -185,7 +175,6 @@ type PublicKeyValidationHandlerFunc func(
 // - publicKey: PublicKey
 // - signature: [UInt8]
 // Expected result type: Bool
-//
 type BLSVerifyPoPHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -197,7 +186,6 @@ type BLSVerifyPoPHandlerFunc func(
 // Parameter types:
 // - signatures: [[UInt8]]
 // Expected result type: [UInt8]?
-//
 type BLSAggregateSignaturesHandlerFunc func(
 	inter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -208,7 +196,6 @@ type BLSAggregateSignaturesHandlerFunc func(
 // Parameter types:
 // - publicKeys: [PublicKey]
 // Expected result type: PublicKey?
-//
 type BLSAggregatePublicKeysHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -223,7 +210,6 @@ type BLSAggregatePublicKeysHandlerFunc func(
 // - hashAlgorithm: HashAlgorithm
 // - publicKey: PublicKey
 // Expected result type: Bool
-//
 type SignatureVerificationHandlerFunc func(
 	interpreter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -240,7 +226,6 @@ type SignatureVerificationHandlerFunc func(
 // - domainSeparationTag: [UInt8]
 // - hashAlgorithm: HashAlgorithm
 // Expected result type: [UInt8]
-//
 type HashHandlerFunc func(
 	inter *Interpreter,
 	getLocationRange func() LocationRange,
@@ -255,7 +240,6 @@ type HashHandlerFunc func(
 //
 // As there is no support for inheritance of concrete types,
 // these are the "leaf" nodes in the call chain, and are functions.
-//
 type CompositeTypeCode struct {
 	CompositeFunctions map[string]FunctionValue
 	DestructorFunction FunctionValue
@@ -268,7 +252,6 @@ type FunctionWrapper = func(inner FunctionValue) FunctionValue
 //
 // These are "branch" nodes in the call chain, and are function wrappers,
 // i.e. they wrap the functions / function wrappers that inherit them.
-//
 type WrapperCode struct {
 	InitializerFunctionWrapper FunctionWrapper
 	DestructorFunctionWrapper  FunctionWrapper
@@ -278,7 +261,6 @@ type WrapperCode struct {
 
 // TypeCodes is the value which stores the "prepared" / "callable" "code"
 // of all composite types, interface types, and type requirements.
-//
 type TypeCodes struct {
 	CompositeCodes       map[sema.TypeID]CompositeTypeCode
 	InterfaceCodes       map[sema.TypeID]WrapperCode
@@ -327,7 +309,6 @@ var _ common.MemoryGauge = &Interpreter{}
 
 // BaseActivation is the activation which contains all base declarations.
 // It is reused across all interpreters.
-//
 var BaseActivation = func() *VariableActivation {
 	// No need to meter since this is only created once
 	activation := NewVariableActivation(nil, nil)
@@ -383,7 +364,6 @@ func newInterpreter(
 
 // locationRangeGetter returns a function that returns the location range
 // for the given location and positioned element.
-//
 func locationRangeGetter(
 	memoryGauge common.MemoryGauge,
 	location common.Location,
@@ -434,7 +414,6 @@ func (interpreter *Interpreter) Interpret() (err error) {
 
 // visitGlobalDeclaration firsts interprets the global declaration,
 // then finds the declaration and adds it to the globals
-//
 func (interpreter *Interpreter) visitGlobalDeclaration(declaration ast.Declaration) {
 	declaration.Accept(interpreter)
 	interpreter.declareGlobal(declaration)
@@ -981,7 +960,6 @@ func (interpreter *Interpreter) VisitCompositeDeclaration(declaration *ast.Compo
 // a contract value / instance (singleton).
 //
 // For all other composite kinds the constructor function is declared.
-//
 func (interpreter *Interpreter) declareCompositeValue(
 	declaration *ast.CompositeDeclaration,
 	lexicalScope *VariableActivation,
@@ -2256,7 +2234,6 @@ type ValueConverterDeclaration struct {
 }
 
 // It would be nice if return types in Go's function types would be covariant
-//
 var ConverterDeclarations = []ValueConverterDeclaration{
 	{
 		name:         sema.IntTypeName,
@@ -2758,7 +2735,6 @@ type converterFunction struct {
 }
 
 // Converter functions are stateless functions. Hence they can be re-used across interpreters.
-//
 var converterFunctionValues = func() []converterFunction {
 
 	converterFuncValues := make([]converterFunction, len(ConverterDeclarations))
@@ -2811,7 +2787,6 @@ type runtimeTypeConstructor struct {
 }
 
 // Constructor functions are stateless functions. Hence they can be re-used across interpreters.
-//
 var runtimeTypeConstructors = []runtimeTypeConstructor{
 	{
 		name: "OptionalType",
@@ -2946,7 +2921,6 @@ func defineRuntimeTypeConstructorFunctions(activation *VariableActivation) {
 }
 
 // typeFunction is the `Type` function. It is stateless, hence it can be re-used across interpreters.
-//
 var typeFunction = NewUnmeteredHostFunctionValue(
 	func(invocation Invocation) Value {
 		typeParameterPair := invocation.TypeParameterTypes.Oldest()
@@ -2978,7 +2952,6 @@ func defineBaseValue(activation *VariableActivation, name string, value Value) {
 }
 
 // stringFunction is the `String` function. It is stateless, hence it can be re-used across interpreters.
-//
 var stringFunction = func() Value {
 	functionValue := NewUnmeteredHostFunctionValue(
 		func(invocation Invocation) Value {
@@ -3026,6 +2999,32 @@ var stringFunction = func() Value {
 		),
 	)
 
+	addMember(
+		sema.StringTypeFromUtf8FunctionName,
+		NewUnmeteredHostFunctionValue(
+			func(invocation Invocation) Value {
+				argument, ok := invocation.Arguments[0].(*ArrayValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				inter := invocation.Interpreter
+				memoryUsage := common.NewArrayExpressionMemoryUsage(
+					argument.Count(),
+				)
+
+				// convert to UTF-8 here
+				return NewStringValue(
+					inter,
+					memoryUsage,
+					func() string {
+						return "TODO UNIMPLEMENTED!! >:("
+					},
+				)
+			},
+			sema.StringTypeEncodeHexFunctionType,
+		),
+	)
 	return functionValue
 }()
 
@@ -4317,7 +4316,6 @@ func (interpreter *Interpreter) invalidateResource(value Value) {
 }
 
 // MeterMemory delegates the memory usage to the interpreter's memory gauge, if any.
-//
 func (interpreter *Interpreter) MeterMemory(usage common.MemoryUsage) error {
 	common.UseMemory(interpreter.Config.MemoryGauge, usage)
 	return nil

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -28,8 +28,12 @@ const StringTypeEncodeHexFunctionDocString = `
 Returns a hexadecimal string for the given byte array
 `
 
+const StringTypeFromUtf8FunctionName = "fromUTF8"
+const StringTypeFromUtf8FunctionDocString = `
+Attempt to decode the input as a UTF-8 encoded string. Returns nil if the input bytes are malformed UTF-8.
+`
+
 // StringType represents the string type
-//
 var StringType = &SimpleType{
 	Name:                 "String",
 	QualifiedName:        "String",

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -34,6 +34,7 @@ Attempt to decode the input as a UTF-8 encoded string. Returns nil if the input 
 `
 
 // StringType represents the string type
+//
 var StringType = &SimpleType{
 	Name:                 "String",
 	QualifiedName:        "String",

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -172,6 +172,7 @@ type Type interface {
 }
 
 // ValueIndexableType is a type which can be indexed into using a value
+//
 type ValueIndexableType interface {
 	Type
 	isValueIndexableType() bool
@@ -192,6 +193,7 @@ type MemberResolver struct {
 }
 
 // ContainedType is a type which might have a container type
+//
 type ContainedType interface {
 	Type
 	GetContainerType() Type
@@ -219,18 +221,21 @@ func VisitThisAndNested(t Type, visit func(ty Type)) {
 }
 
 // CompositeKindedType is a type which has a composite kind
+//
 type CompositeKindedType interface {
 	Type
 	GetCompositeKind() common.CompositeKind
 }
 
 // LocatedType is a type which has a location
+//
 type LocatedType interface {
 	Type
 	GetLocation() common.Location
 }
 
 // ParameterizedType is a type which might have type parameters
+//
 type ParameterizedType interface {
 	Type
 	TypeParameters() []*TypeParameter
@@ -643,6 +648,7 @@ func OptionalTypeMapFunctionType(typ Type) *FunctionType {
 }
 
 // GenericType
+//
 type GenericType struct {
 	TypeParameter *TypeParameter
 }
@@ -775,6 +781,7 @@ type FractionalRangedType interface {
 }
 
 // SaturatingArithmeticType is a type that supports saturating arithmetic functions
+//
 type SaturatingArithmeticType interface {
 	Type
 	SupportsSaturatingAdd() bool
@@ -856,6 +863,7 @@ func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[st
 
 // NumericType represent all the types in the integer range
 // and non-fractional ranged types.
+//
 type NumericType struct {
 	name                       string
 	tag                        TypeTag
@@ -1025,6 +1033,7 @@ func (t *NumericType) IsSuperType() bool {
 }
 
 // FixedPointNumericType represents all the types in the fixed-point range.
+//
 type FixedPointNumericType struct {
 	name                       string
 	tag                        TypeTag
@@ -2349,6 +2358,7 @@ func (p *Parameter) QualifiedString() string {
 // an argument in a call must use:
 // If no argument label is declared for parameter,
 // the parameter name is used as the argument label
+//
 func (p *Parameter) EffectiveArgumentLabel() string {
 	if p.Label != "" {
 		return p.Label
@@ -2470,6 +2480,7 @@ func formatFunctionType(
 }
 
 // FunctionType
+//
 type FunctionType struct {
 	IsConstructor            bool
 	TypeParameters           []*TypeParameter
@@ -2926,6 +2937,7 @@ type ArgumentExpressionsCheck func(
 
 // BaseTypeActivation is the base activation that contains
 // the types available in programs
+//
 var BaseTypeActivation = NewVariableActivation(nil)
 
 func init() {
@@ -2994,6 +3006,7 @@ func baseTypeVariable(name string, ty Type) *Variable {
 
 // BaseValueActivation is the base activation that contains
 // the values available in programs
+//
 var BaseValueActivation = NewVariableActivation(nil)
 
 var AllSignedFixedPointTypes = []Type{
@@ -4862,14 +4875,14 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 // However, to check if a type *strictly* belongs to a certain category, then consider
 // using `IsSameTypeKind` method. e.g: "Is type `T` an Integer type?". Using this method
 // for the later use-case may produce incorrect results.
-//   - IsSubType()      - To check the assignability. e.g: Is argument type T is a sub-type
-//     of parameter type R. This is the more frequent use-case.
-//   - IsSameTypeKind() - To check if a type strictly belongs to a certain category. e.g: Is the
-//     expression type T is any of the integer types, but nothing else.
-//     Another way to check is, asking the question of "if the subType is Never,
-//     should the check still pass?". A common code-smell for potential incorrect
-//     usage is, using IsSubType() method with a constant/pre-defined superType.
-//     e.g: IsSubType(<<someType>>, FixedPointType)
+//   * IsSubType()      - To check the assignability. e.g: Is argument type T is a sub-type
+//                        of parameter type R. This is the more frequent use-case.
+//   * IsSameTypeKind() - To check if a type strictly belongs to a certain category. e.g: Is the
+//                        expression type T is any of the integer types, but nothing else.
+//                        Another way to check is, asking the question of "if the subType is Never,
+//                        should the check still pass?". A common code-smell for potential incorrect
+//                        usage is, using IsSubType() method with a constant/pre-defined superType.
+//                        e.g: IsSubType(<<someType>>, FixedPointType)
 func IsSubType(subType Type, superType Type) bool {
 
 	if subType == nil {
@@ -4889,6 +4902,7 @@ func IsSubType(subType Type, superType Type) bool {
 // e.g: 'Never' type is a subtype of 'Integer', but not of the
 // same kind as 'Integer'. Whereas, 'Int8' is both a subtype
 // and also of same kind as 'Integer'.
+//
 func IsSameTypeKind(subType Type, superType Type) bool {
 
 	if subType == NeverType {
@@ -4902,6 +4916,7 @@ func IsSameTypeKind(subType Type, superType Type) bool {
 // i.e. it determines if the given subtype is a subtype
 // of the given supertype, but returns false
 // if the subtype and supertype refer to the same type.
+//
 func IsProperSubType(subType Type, superType Type) bool {
 
 	if subType.Equal(superType) {
@@ -4917,6 +4932,7 @@ func IsProperSubType(subType Type, superType Type) bool {
 // value when the two types are equal or are not.
 //
 // Consider using IsSubType or IsProperSubType
+//
 func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
 	if subType == NeverType {
@@ -5506,6 +5522,7 @@ func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
 // UnwrapOptionalType returns the type if it is not an optional type,
 // or the inner-most type if it is (optional types are repeatedly unwrapped)
+//
 func UnwrapOptionalType(ty Type) Type {
 	for {
 		optionalType, ok := ty.(*OptionalType)
@@ -5540,6 +5557,7 @@ func AreCompatibleEquatableTypes(leftType, rightType Type) bool {
 }
 
 // IsNilType returns true if the given type is the type of `nil`, i.e. `Never?`.
+//
 func IsNilType(ty Type) bool {
 	optionalType, ok := ty.(*OptionalType)
 	if !ok {
@@ -5669,6 +5687,7 @@ func (t *TransactionType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
 //
 // No restrictions implies the type is fully restricted,
 // i.e. no members of the underlying resource type are available.
+//
 type RestrictedType struct {
 	Type         Type
 	Restrictions []*InterfaceType

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -201,6 +201,7 @@ type ContainedType interface {
 }
 
 // ContainerType is a type which might have nested types
+//
 type ContainerType interface {
 	Type
 	IsContainerType() bool
@@ -4883,6 +4884,7 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 //                        should the check still pass?". A common code-smell for potential incorrect
 //                        usage is, using IsSubType() method with a constant/pre-defined superType.
 //                        e.g: IsSubType(<<someType>>, FixedPointType)
+//
 func IsSubType(subType Type, superType Type) bool {
 
 	if subType == nil {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3349,7 +3349,7 @@ var StringTypeEncodeHexFunctionType = &FunctionType{
 }
 
 var StringTypeFromUtf8FunctionType = &FunctionType{
-	Paramters: []*Parameter{
+	Parameters: []*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "bytes",

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -172,7 +172,6 @@ type Type interface {
 }
 
 // ValueIndexableType is a type which can be indexed into using a value
-//
 type ValueIndexableType interface {
 	Type
 	isValueIndexableType() bool
@@ -193,7 +192,6 @@ type MemberResolver struct {
 }
 
 // ContainedType is a type which might have a container type
-//
 type ContainedType interface {
 	Type
 	GetContainerType() Type
@@ -201,7 +199,6 @@ type ContainedType interface {
 }
 
 // ContainerType is a type which might have nested types
-//
 type ContainerType interface {
 	Type
 	IsContainerType() bool
@@ -222,21 +219,18 @@ func VisitThisAndNested(t Type, visit func(ty Type)) {
 }
 
 // CompositeKindedType is a type which has a composite kind
-//
 type CompositeKindedType interface {
 	Type
 	GetCompositeKind() common.CompositeKind
 }
 
 // LocatedType is a type which has a location
-//
 type LocatedType interface {
 	Type
 	GetLocation() common.Location
 }
 
 // ParameterizedType is a type which might have type parameters
-//
 type ParameterizedType interface {
 	Type
 	TypeParameters() []*TypeParameter
@@ -649,7 +643,6 @@ func OptionalTypeMapFunctionType(typ Type) *FunctionType {
 }
 
 // GenericType
-//
 type GenericType struct {
 	TypeParameter *TypeParameter
 }
@@ -782,7 +775,6 @@ type FractionalRangedType interface {
 }
 
 // SaturatingArithmeticType is a type that supports saturating arithmetic functions
-//
 type SaturatingArithmeticType interface {
 	Type
 	SupportsSaturatingAdd() bool
@@ -864,7 +856,6 @@ func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[st
 
 // NumericType represent all the types in the integer range
 // and non-fractional ranged types.
-//
 type NumericType struct {
 	name                       string
 	tag                        TypeTag
@@ -1034,7 +1025,6 @@ func (t *NumericType) IsSuperType() bool {
 }
 
 // FixedPointNumericType represents all the types in the fixed-point range.
-//
 type FixedPointNumericType struct {
 	name                       string
 	tag                        TypeTag
@@ -2359,7 +2349,6 @@ func (p *Parameter) QualifiedString() string {
 // an argument in a call must use:
 // If no argument label is declared for parameter,
 // the parameter name is used as the argument label
-//
 func (p *Parameter) EffectiveArgumentLabel() string {
 	if p.Label != "" {
 		return p.Label
@@ -2481,7 +2470,6 @@ func formatFunctionType(
 }
 
 // FunctionType
-//
 type FunctionType struct {
 	IsConstructor            bool
 	TypeParameters           []*TypeParameter
@@ -2938,7 +2926,6 @@ type ArgumentExpressionsCheck func(
 
 // BaseTypeActivation is the base activation that contains
 // the types available in programs
-//
 var BaseTypeActivation = NewVariableActivation(nil)
 
 func init() {
@@ -3007,7 +2994,6 @@ func baseTypeVariable(name string, ty Type) *Variable {
 
 // BaseValueActivation is the base activation that contains
 // the values available in programs
-//
 var BaseValueActivation = NewVariableActivation(nil)
 
 var AllSignedFixedPointTypes = []Type{
@@ -3330,6 +3316,13 @@ func init() {
 		StringTypeEncodeHexFunctionDocString,
 	))
 
+	addMember(NewUnmeteredPublicFunctionMember(
+		functionType,
+		StringTypeFromUtf8FunctionName,
+		StringTypeFromUtf8FunctionType,
+		StringTypeFromUtf8FunctionDocString,
+	))
+
 	BaseValueActivation.Set(
 		typeName,
 		baseFunctionVariable(
@@ -3352,6 +3345,21 @@ var StringTypeEncodeHexFunctionType = &FunctionType{
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
 		StringType,
+	),
+}
+
+var StringTypeFromUtf8FunctionType = &FunctionType{
+	Paramters: []*Parameter{
+		{
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "bytes",
+			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: StringType,
+		},
 	),
 }
 
@@ -4854,15 +4862,14 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 // However, to check if a type *strictly* belongs to a certain category, then consider
 // using `IsSameTypeKind` method. e.g: "Is type `T` an Integer type?". Using this method
 // for the later use-case may produce incorrect results.
-//   * IsSubType()      - To check the assignability. e.g: Is argument type T is a sub-type
-//                        of parameter type R. This is the more frequent use-case.
-//   * IsSameTypeKind() - To check if a type strictly belongs to a certain category. e.g: Is the
-//                        expression type T is any of the integer types, but nothing else.
-//                        Another way to check is, asking the question of "if the subType is Never,
-//                        should the check still pass?". A common code-smell for potential incorrect
-//                        usage is, using IsSubType() method with a constant/pre-defined superType.
-//                        e.g: IsSubType(<<someType>>, FixedPointType)
-//
+//   - IsSubType()      - To check the assignability. e.g: Is argument type T is a sub-type
+//     of parameter type R. This is the more frequent use-case.
+//   - IsSameTypeKind() - To check if a type strictly belongs to a certain category. e.g: Is the
+//     expression type T is any of the integer types, but nothing else.
+//     Another way to check is, asking the question of "if the subType is Never,
+//     should the check still pass?". A common code-smell for potential incorrect
+//     usage is, using IsSubType() method with a constant/pre-defined superType.
+//     e.g: IsSubType(<<someType>>, FixedPointType)
 func IsSubType(subType Type, superType Type) bool {
 
 	if subType == nil {
@@ -4882,7 +4889,6 @@ func IsSubType(subType Type, superType Type) bool {
 // e.g: 'Never' type is a subtype of 'Integer', but not of the
 // same kind as 'Integer'. Whereas, 'Int8' is both a subtype
 // and also of same kind as 'Integer'.
-//
 func IsSameTypeKind(subType Type, superType Type) bool {
 
 	if subType == NeverType {
@@ -4896,7 +4902,6 @@ func IsSameTypeKind(subType Type, superType Type) bool {
 // i.e. it determines if the given subtype is a subtype
 // of the given supertype, but returns false
 // if the subtype and supertype refer to the same type.
-//
 func IsProperSubType(subType Type, superType Type) bool {
 
 	if subType.Equal(superType) {
@@ -4912,7 +4917,6 @@ func IsProperSubType(subType Type, superType Type) bool {
 // value when the two types are equal or are not.
 //
 // Consider using IsSubType or IsProperSubType
-//
 func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
 	if subType == NeverType {
@@ -5502,7 +5506,6 @@ func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
 // UnwrapOptionalType returns the type if it is not an optional type,
 // or the inner-most type if it is (optional types are repeatedly unwrapped)
-//
 func UnwrapOptionalType(ty Type) Type {
 	for {
 		optionalType, ok := ty.(*OptionalType)
@@ -5537,7 +5540,6 @@ func AreCompatibleEquatableTypes(leftType, rightType Type) bool {
 }
 
 // IsNilType returns true if the given type is the type of `nil`, i.e. `Never?`.
-//
 func IsNilType(ty Type) bool {
 	optionalType, ok := ty.(*OptionalType)
 	if !ok {
@@ -5667,7 +5669,6 @@ func (t *TransactionType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
 //
 // No restrictions implies the type is fully restricted,
 // i.e. no members of the underlying resource type are available.
-//
 type RestrictedType struct {
 	Type         Type
 	Restrictions []*InterfaceType

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -19,6 +19,7 @@
 package interpreter_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -170,6 +171,62 @@ func TestInterpretStringEncodeHex(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("010203cade"),
 		result,
 	)
+}
+
+func TestInterpretStringFromUtf8(t *testing.T) {
+	t.Parallel()
+
+	type Testcase struct {
+		expr     string
+		expected any
+	}
+
+	testCases := [...]Testcase{
+		// String.fromUTF(str.utf8) = str
+		{`"omae wa mou shindeiru".utf8`, "omae wa mou shindeiru"},
+		{`"would you still use cadence if i was a worm 🥺😳 👉👈".utf8`, "would you still use cadence if i was a worm 🥺😳 👉👈"},
+		// ¥: yen symbol
+		{"[0xC2, 0xA5]", "¥"},
+		// cyrillic multiocular O
+		{"[0xEA, 0x99, 0xAE]", "ꙮ"},
+		// chinese biangbiang noodles, doesn't render in 99% of fonts
+		{"[0xF0, 0xB0, 0xBB, 0x9E]", "𰻞"},
+		{"[0xF0, 0x9F, 0x98, 0x94]", "😔"},
+		{"[]", ""},
+		// invalid codepoint
+		{"[0xc3, 0x28]", nil},
+	}
+
+	for _, testCase := range testCases {
+
+		code := fmt.Sprintf(`
+			fun testString(): String? {
+				return String.fromUTF8(%s)
+			}
+		`, testCase.expr)
+
+		inter := parseCheckAndInterpret(t, code)
+
+		var expected interpreter.Value
+		strValue, ok := testCase.expected.(string)
+		// assume that a nil expected means that conversion should fail
+		if ok {
+			expected = interpreter.NewSomeValueNonCopying(inter,
+				interpreter.NewUnmeteredStringValue(strValue))
+		} else {
+			expected = interpreter.NewNilValue(inter)
+		}
+
+		result, err := inter.Invoke("testString")
+		require.NoError(t, err)
+
+		RequireValuesEqual(
+			t,
+			inter,
+			expected,
+			result,
+		)
+	}
 }
 
 func TestInterpretStringUtf8Field(t *testing.T) {


### PR DESCRIPTION
Closes #1894 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds a static method on the `String` type for attempting to convert byte arrays into Strings:

```cadence
fun fromUTF8(_ input: [UInt8]): String?
```

Currently, the conversion naively loads the entire input into a Go bytearray and runs UTF-8 validation. A better approach might be to stream the bytes from slab storage, and incrementally clustering bytes into codepoints with a state machine approach. This would allow for linear space usage with short-circuiting.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
