### PR TITLE
Update wasmtime-based VM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bits-and-blooms/bitset v1.2.2
-	github.com/bytecodealliance/wasmtime-go v0.22.0
+	github.com/bytecodealliance/wasmtime-go v0.40.0
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/cheekybits/genny v1.0.0
 	github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bits-and-blooms/bitset v1.2.2 h1:J5gbX05GpMdBjCvQ9MteIg2KKDExr7DrgK+Yc15FvIk=
 github.com/bits-and-blooms/bitset v1.2.2/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/bytecodealliance/wasmtime-go v0.22.0 h1:PMlq+dS0IZiG7qQB8zq8MQdJE2ryYGUrX81Q7+rAvSw=
-github.com/bytecodealliance/wasmtime-go v0.22.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.40.0 h1:7cGLQEctJf09JWBl3Ai0eMl1PTrXVAjkAb27+KHfIq0=
+github.com/bytecodealliance/wasmtime-go v0.40.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/c-bata/go-prompt v0.2.5 h1:3zg6PecEywxNn0xiqcXHD96fkbxghD+gdB2tbsYfl+Y=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=

--- a/runtime/compiler/wasm/leb128.go
+++ b/runtime/compiler/wasm/leb128.go
@@ -41,8 +41,7 @@ const max32bitLEB128ByteCount = 5
 const max64bitLEB128ByteCount = 10
 
 // writeUint32LEB128 encodes and writes the given unsigned 32-bit integer
-// in canonical (with fewest bytes possible) unsigned little endian base 128 format
-//
+// in canonical (with the fewest bytes possible) unsigned little endian base 128 format
 func (buf *Buffer) writeUint32LEB128(v uint32) error {
 	if v < 128 {
 		err := buf.WriteByte(uint8(v))
@@ -72,8 +71,7 @@ func (buf *Buffer) writeUint32LEB128(v uint32) error {
 }
 
 // writeUint64LEB128 encodes and writes the given unsigned 64-bit integer
-// in canonical (with fewest bytes possible) unsigned little endian base 128 format
-//
+// in canonical (with the fewest bytes possible) unsigned little endian base 128 format
 func (buf *Buffer) writeUint64LEB128(v uint64) error {
 	if v < 128 {
 		err := buf.WriteByte(uint8(v))
@@ -103,7 +101,7 @@ func (buf *Buffer) writeUint64LEB128(v uint64) error {
 }
 
 // writeUint32LEB128FixedLength encodes and writes the given unsigned 32-bit integer
-// in non-canonical (fixed-size, instead of with fewest bytes possible)
+// in non-canonical (fixed-size, instead of with the fewest bytes possible)
 // unsigned little endian base 128 format
 //
 func (buf *Buffer) writeUint32LEB128FixedLength(v uint32, length int) error {
@@ -146,8 +144,7 @@ func (buf *Buffer) readUint32LEB128() (uint32, error) {
 	return result, nil
 }
 
-// readUint64LEB128 reads and decodes an unsigned 32-bit integer
-//
+// readUint64LEB128 reads and decodes an unsigned 64-bit integer
 func (buf *Buffer) readUint64LEB128() (uint64, error) {
 	var result uint64
 	var shift, i uint
@@ -169,8 +166,7 @@ func (buf *Buffer) readUint64LEB128() (uint64, error) {
 }
 
 // writeInt32LEB128 encodes and writes the given signed 32-bit integer
-// in canonical (with fewest bytes possible) signed little endian base 128 format
-//
+// in canonical (with the fewest bytes possible) signed little endian base 128 format
 func (buf *Buffer) writeInt32LEB128(v int32) error {
 	more := true
 	for more {
@@ -191,8 +187,7 @@ func (buf *Buffer) writeInt32LEB128(v int32) error {
 }
 
 // writeInt64LEB128 encodes and writes the given signed 64-bit integer
-// in canonical (with fewest bytes possible) signed little endian base 128 format
-//
+// in canonical (with the fewest bytes possible) signed little endian base 128 format
 func (buf *Buffer) writeInt64LEB128(v int64) error {
 	more := true
 	for more {
@@ -274,7 +269,7 @@ func (buf *Buffer) writeFixedUint32LEB128Space() (offset, error) {
 
 // writeUint32LEB128SizeAt writes the size, the number of bytes
 // between the given offset and the current offset,
-// as a uint32 in non-canonical 5-byte fixed-size format
+// as an uint32 in non-canonical 5-byte fixed-size format
 // (instead of the minimal size if canonical encoding would be used)
 // at the given offset
 //

--- a/runtime/compiler/wasm/wasm2wat.go
+++ b/runtime/compiler/wasm/wasm2wat.go
@@ -43,7 +43,7 @@ func WASM2WAT(binary []byte) string {
 		panic(err)
 	}
 
-	cmd := exec.Command("wasm2wat", "--enable-reference-types", f.Name())
+	cmd := exec.Command("wasm2wat", f.Name())
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION

## Description

- Update wasmtime to latest release which has fixed the memory-leak bug and runs on M1
- Update usage of wasm2wat, the flag was inverted (enabled by default, can only be disabled)
- Adopt the new wasmtime API

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
