### PR TITLE
[Test Framework] Update Cadence

### DIFF
--- a/test-framework/go.mod
+++ b/test-framework/go.mod
@@ -3,7 +3,7 @@ module github.com/onflow/cadence/test-framework
 go 1.18
 
 require (
-	github.com/onflow/cadence v0.25.1-0.20220826214217-4cbb639788bf
+	github.com/onflow/cadence v0.26.1-0.20220909232540-62e315a7e81f
 	github.com/onflow/flow-emulator v0.35.1-0.20220826215327-49d7d4833873
 	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220826214949-34ce2747b7be
 	github.com/onflow/flow-go-sdk v0.27.1-0.20220826214515-3abcaea89a15

--- a/test-framework/go.sum
+++ b/test-framework/go.sum
@@ -504,8 +504,8 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/onflow/atree v0.4.0 h1:+TbNisavAkukAKhgQ4plWnvR9o5+SkwPIsi3jaeAqKs=
 github.com/onflow/atree v0.4.0/go.mod h1:7Qe1xaW0YewvouLXrugzMFUYXNoRQ8MT/UsVAWx1Ndo=
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
-github.com/onflow/cadence v0.25.1-0.20220826214217-4cbb639788bf h1:MlqqpKqZ74SBL+p63j9vUqx9DwYXSc7tx7jiwVA3fGM=
-github.com/onflow/cadence v0.25.1-0.20220826214217-4cbb639788bf/go.mod h1:8RSiMVIBt943QreHjxTLduVZSSNa+yamhm1ffPvMOw0=
+github.com/onflow/cadence v0.26.1-0.20220909232540-62e315a7e81f h1:TIPaD5cE3g97vhVWFhbs9Hvj5Go3lglXg1I62jEfQqg=
+github.com/onflow/cadence v0.26.1-0.20220909232540-62e315a7e81f/go.mod h1:zr8So9HhKAZA1ru9fKJNugzsULULNIlZ2M00i1MntvY=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa h1:hcEp3INfkLh9jFODC9PHPQeisAd9rterujabee9il8w=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:T6yhM+kWrFxiP6F3hh8lh9DcocHfmv48P4ITnjLhKSk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa h1:0brc9iDezo2Gc7yH3p7+La1iFe4WRDg6HYT6llyP8+E=

--- a/test-framework/test_runner.go
+++ b/test-framework/test_runner.go
@@ -220,7 +220,7 @@ func (r *TestRunner) parseCheckAndInterpret(script string) (*interpreter.Program
 
 	// Checker configs
 	env.CheckerConfig.ImportHandler = r.checkerImportHandler(ctx)
-	env.CheckerConfig.ContractVariableHandler = contractVariableHandler
+	env.CheckerConfig.ContractValueHandler = contractValueHandler
 
 	// Interpreter configs
 	env.InterpreterConfig.ImportLocationHandler = r.interpreterImportHandler(ctx)
@@ -283,27 +283,24 @@ func (r *TestRunner) checkerImportHandler(ctx runtime.Context) sema.ImportHandle
 	}
 }
 
-func contractVariableHandler(
+func contractValueHandler(
 	checker *sema.Checker,
 	declaration *ast.CompositeDeclaration,
 	compositeType *sema.CompositeType,
-) sema.VariableDeclaration {
+) sema.ValueDeclaration {
 	constructorType, constructorArgumentLabels := sema.CompositeConstructorType(
 		checker.Elaboration,
 		declaration,
 		compositeType,
 	)
 
-	return sema.VariableDeclaration{
-		Identifier:               declaration.Identifier.Identifier,
-		Type:                     constructorType,
-		DocString:                declaration.DocString,
-		Access:                   declaration.Access,
-		Kind:                     declaration.DeclarationKind(),
-		Pos:                      declaration.Identifier.Pos,
-		IsConstant:               true,
-		ArgumentLabels:           constructorArgumentLabels,
-		AllowOuterScopeShadowing: false,
+	return stdlib.StandardLibraryValue{
+		Name:           declaration.Identifier.Identifier,
+		Type:           constructorType,
+		DocString:      declaration.DocString,
+		Kind:           declaration.DeclarationKind(),
+		Position:       &declaration.Identifier.Pos,
+		ArgumentLabels: constructorArgumentLabels,
 	}
 }
 
@@ -439,7 +436,7 @@ func (r *TestRunner) parseAndCheckImport(location common.Location, startCtx runt
 		return nil, fmt.Errorf("nested imports are not supported")
 	}
 
-	env.CheckerConfig.ContractVariableHandler = contractVariableHandler
+	env.CheckerConfig.ContractValueHandler = contractValueHandler
 
 	program, err := r.testRuntime.ParseAndCheckProgram([]byte(code), ctx)
 


### PR DESCRIPTION
## Description

Update the testing framework to the latest commit of Cadence `master`.

The API for overriding the result of a contract declaration changed in #1923 / [cbf628a](https://github.com/onflow/cadence/pull/1923/commits/cbf628af6e4bb039ce7dba82949fdc13dff0f3c0).
Adjust the test framework to use the new API.

This unfortunately requires and is blocked by an update of all downstream dependencies, due to FVM depending on some metering constants that got removed on Cadence `master`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
