### PR TITLE
Fixed result given by slice

### DIFF
--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -682,7 +682,7 @@ Strings have multiple built-in functions you can use:
 
   // Create a new slice of part of the original string.
   let slice = example.slice(from: 3, upTo: 6)
-  // `slice` is now `"lowo"`
+  // `slice` is now `"low"`
 
   // Run-time error: Out of bounds index, the program aborts.
   let outOfBounds = example.slice(from: 2, upTo: 10)


### PR DESCRIPTION
Closes #...

## Description

Fixed result given by slice in the language documentation

let example = "helloworld"
let slice = example.slice(from: 3, upTo: 6)

gives "low" as result on slice

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
