### PR TITLE
Invalidate resource references when the referenced resource is moved

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -865,3 +865,18 @@ func (InvalidHexLengthError) IsUserError() {}
 func (InvalidHexLengthError) Error() string {
 	return "hex string has non-even length"
 }
+
+// MovedResourceReferenceError is reported when accessing a reference value
+// that is pointing to a moved resource.
+//
+type MovedResourceReferenceError struct {
+	LocationRange
+}
+
+var _ errors.UserError = MovedResourceReferenceError{}
+
+func (MovedResourceReferenceError) IsUserError() {}
+
+func (e MovedResourceReferenceError) Error() string {
+	return "referring resource is moved"
+}

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -878,5 +878,5 @@ var _ errors.UserError = MovedResourceReferenceError{}
 func (MovedResourceReferenceError) IsUserError() {}
 
 func (e MovedResourceReferenceError) Error() string {
-	return "referring resource is moved"
+	return "referenced resource has been moved after creating the reference"
 }

--- a/runtime/missingmember_test.go
+++ b/runtime/missingmember_test.go
@@ -1619,20 +1619,12 @@ pub contract ItemNFT: NonFungibleToken {
 
        // get a reference to the garment that item stores
        pub fun borrowGarment(): &GarmentNFT.NFT? {
-           let garmentOptional <- self.garment <- nil
-           let garment <- garmentOptional!
-           let garmentRef = &garment as auth &GarmentNFT.NFT
-           self.garment <-! garment
-           return garmentRef
+           return &self.garment as auth &GarmentNFT.NFT?
        }
 
        // get a reference to the material that item stores
        pub fun borrowMaterial(): &MaterialNFT.NFT?  {
-           let materialOptional <- self.material <- nil
-           let material <- materialOptional!
-           let materialRef = &material as auth &MaterialNFT.NFT
-           self.material <-! material
-           return materialRef
+           return &self.material as auth &MaterialNFT.NFT?
        }
 
        // change name of item nft

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -2317,7 +2317,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
                   accountA.save(<-testResource, to: /storage/test)
 
-                  // At this point the resource is in storage A
+                  // At this point the resource is in storage A. Reference must be invalidated.
                   log(ref.owner?.address)
 
                   let testResource2 <- accountA.load<@TestContract.TestResource>(from: /storage/test)!
@@ -2422,19 +2422,8 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(t, err)
-
-		require.Equal(t,
-			[]string{
-				"nil",
-				"0x0000000000000001",
-				"nil",
-				"nil",
-				"0x0000000000000002",
-				"0x0000000000000002",
-			},
-			loggedMessages,
-		)
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
 	})
 
 	t.Run("resource (array element)", func(t *testing.T) {
@@ -2466,7 +2455,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
                   account.save(<-testResources, to: /storage/test)
 
-                  // At this point the resource is in storage
+                  // At this point the resource is in storage. Reference must be invalidated.
                   log(ref.owner?.address)
               }
           }
@@ -2552,15 +2541,8 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(t, err)
-
-		require.Equal(t,
-			[]string{
-				"nil",
-				"0x0000000000000001",
-			},
-			loggedMessages,
-		)
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
 	})
 
 	t.Run("resource (nested field, array element)", func(t *testing.T) {
@@ -2606,7 +2588,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
                   account.save(<-nestingResource, to: /storage/test)
 
-                  // At this point the nesting and nested resources are both in storage
+                  // At this point the nesting and nested resources are both in storage. References must be invalidated.
                   log(nestingResourceRef.owner?.address)
                   log(nestedElementResourceRef.owner?.address)
               }
@@ -2693,17 +2675,8 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(t, err)
-
-		require.Equal(t,
-			[]string{
-				"nil",
-				"nil",
-				"0x0000000000000001",
-				"0x0000000000000001",
-			},
-			loggedMessages,
-		)
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
 	})
 
 	t.Run("array", func(t *testing.T) {
@@ -2735,7 +2708,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
                   account.save(<-testResources, to: /storage/test)
 
-                  // At this point the resource is in storage
+                  // At this point the resource is in storage. Reference must be invalidated.
                   log(ref[0].owner?.address)
               }
           }
@@ -2821,15 +2794,8 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(t, err)
-
-		require.Equal(t,
-			[]string{
-				"nil",
-				"0x0000000000000001",
-			},
-			loggedMessages,
-		)
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
 	})
 
 	t.Run("dictionary", func(t *testing.T) {
@@ -2861,7 +2827,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 
                   account.save(<-testResources, to: /storage/test)
 
-                  // At this point the resource is in storage
+                  // At this point the resource is in storage. Reference must be invalidated.
                   log(ref[0]?.owner?.address)
               }
           }
@@ -2947,15 +2913,8 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(t, err)
-
-		require.Equal(t,
-			[]string{
-				"nil",
-				"0x0000000000000001",
-			},
-			loggedMessages,
-		)
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
 	})
 }
 

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -194,10 +194,11 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
-		ref := &interpreter.EphemeralReferenceValue{
-			Value:        r1,
-			BorrowedType: r1Type,
-		}
+		ref := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			r1,
+			r1Type,
+		)
 
 		value, err := inter.Invoke("test", ref)
 		require.NoError(t, err)
@@ -316,10 +317,11 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
-		ref := &interpreter.EphemeralReferenceValue{
-			Value:        r1,
-			BorrowedType: r1Type,
-		}
+		ref := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			r1,
+			r1Type,
+		)
 
 		value, err := inter.Invoke("test", ref)
 		require.NoError(t, err)
@@ -433,11 +435,11 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
-		ref := &interpreter.EphemeralReferenceValue{
-			Value:        r1,
-			BorrowedType: r1Type,
-		}
-
+		ref := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			r1,
+			r1Type,
+		)
 		value, err := inter.Invoke("test", ref)
 		require.NoError(t, err)
 
@@ -555,10 +557,11 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
-		ref := &interpreter.EphemeralReferenceValue{
-			Value:        r1,
-			BorrowedType: r1Type,
-		}
+		ref := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			r1,
+			r1Type,
+		)
 
 		value, err := inter.Invoke("test", ref)
 		require.NoError(t, err)
@@ -2331,7 +2334,8 @@ func TestInterpretOptionalResourceReference(t *testing.T) {
 	)
 
 	_, err := inter.Invoke("test")
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
 }
 
 func TestInterpretArrayOptionalResourceReference(t *testing.T) {
@@ -2367,7 +2371,8 @@ func TestInterpretArrayOptionalResourceReference(t *testing.T) {
 	)
 
 	_, err := inter.Invoke("test")
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
 }
 
 func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/onflow/atree"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/checker"
 	. "github.com/onflow/cadence/runtime/tests/utils"
@@ -2550,4 +2551,343 @@ func TestInterpretResourceDestroyedInPreCondition(t *testing.T) {
 	_, err = inter.Invoke("test")
 	require.Error(t, err)
 	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+}
+
+func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("stack to account", func(t *testing.T) {
+
+		t.Parallel()
+
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
+
+		inter, _ := testAccount(
+			t,
+			address,
+			true,
+			`
+            resource R {
+                pub(set) var id: Int
+
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun test() {
+                let r <-create R()
+                let ref = &r as &R
+
+                // Move the resource into the account
+                account.save(<-r, to: /storage/r)
+
+                // Update the reference
+                ref.id = 2
+            }`,
+		)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
+	})
+
+	t.Run("stack to account readonly", func(t *testing.T) {
+
+		t.Parallel()
+
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
+
+		inter, _ := testAccount(
+			t,
+			address,
+			true,
+			`
+            resource R {
+                pub(set) var id: Int
+
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun test() {
+                let r <-create R()
+                let ref = &r as &R
+
+                // Move the resource into the account
+                account.save(<-r, to: /storage/r)
+
+                // 'Read'' a field from the reference
+                let id = ref.id
+            }`,
+		)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
+	})
+
+	t.Run("account to stack", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            resource R {
+                pub(set) var id: Int
+
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun test(target: &[R]) {
+                target.append(<- create R())
+
+                // Take reference while in the account
+                let ref = &target[0] as &R
+
+                // Move the resource out of the account onto the stack
+                let movedR <- target.remove(at: 0)
+
+                // Update the reference
+                ref.id = 2
+
+                destroy movedR
+            }
+        `)
+
+		address := common.Address{0x1}
+
+		rType := checker.RequireGlobalType(t, inter.Program.Elaboration, "R").(*sema.CompositeType)
+
+		array := interpreter.NewArrayValue(
+			inter,
+			interpreter.ReturnEmptyLocationRange,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.ConvertSemaToStaticType(nil, rType),
+			},
+			address,
+		)
+
+		arrayRef := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			array,
+			&sema.VariableSizedType{
+				Type: rType,
+			},
+		)
+
+		_, err := inter.Invoke("test", arrayRef)
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
+	})
+
+	t.Run("stack to stack", func(t *testing.T) {
+
+		t.Parallel()
+
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
+
+		inter, _ := testAccount(
+			t,
+			address,
+			true,
+			`
+            resource R {
+                pub(set) var id: Int
+
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun test() {
+                let r1 <-create R()
+                let ref = &r1 as &R
+
+                // Move the resource into the account
+                let r2 <- r1
+
+                // Update the reference
+                ref.id = 2
+
+                destroy r2
+            }`,
+		)
+
+		_, err := inter.Invoke("test")
+		require.NoError(t, err)
+	})
+
+	t.Run("one account to another account", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            resource R {
+                pub(set) var id: Int
+
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun test(target1: &[R], target2: &[R]) {
+                target1.append(<- create R())
+
+                // Take reference while in the account_1
+                let ref = &target1[0] as &R
+
+                // Move the resource out of the account_1 into the account_2
+                target2.append(<- target1.remove(at: 0))
+
+                // Update the reference
+                ref.id = 2
+            }
+        `)
+
+		rType := checker.RequireGlobalType(t, inter.Program.Elaboration, "R").(*sema.CompositeType)
+
+		// Resource array in account 0x01
+
+		array1 := interpreter.NewArrayValue(
+			inter,
+			interpreter.ReturnEmptyLocationRange,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.ConvertSemaToStaticType(nil, rType),
+			},
+			common.Address{0x1},
+		)
+
+		arrayRef1 := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			array1,
+			&sema.VariableSizedType{
+				Type: rType,
+			},
+		)
+
+		// Resource array in account 0x02
+
+		array2 := interpreter.NewArrayValue(
+			inter,
+			interpreter.ReturnEmptyLocationRange,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.ConvertSemaToStaticType(nil, rType),
+			},
+			common.Address{0x2},
+		)
+
+		arrayRef2 := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			array2,
+			&sema.VariableSizedType{
+				Type: rType,
+			},
+		)
+
+		_, err := inter.Invoke("test", arrayRef1, arrayRef2)
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.MovedResourceReferenceError{})
+	})
+
+	t.Run("account to stack to same account", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            resource R {
+                pub(set) var id: Int
+
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun test(target: &[R]): Int {
+                target.append(<- create R())
+
+                // Take reference while in the account
+                let ref = &target[0] as &R
+
+                // Move the resource out of the account onto the stack
+                let movedR <- target.remove(at: 0)
+
+                // Append an extra resource just to force an index change
+                target.append(<- create R())
+
+                // Move the resource back into the account (now at a different index)
+                target.append(<- movedR)
+
+                // Update the reference
+                ref.id = 2
+
+                return target[1].id
+            }
+        `)
+
+		address := common.Address{0x1}
+
+		rType := checker.RequireGlobalType(t, inter.Program.Elaboration, "R").(*sema.CompositeType)
+
+		array := interpreter.NewArrayValue(
+			inter,
+			interpreter.ReturnEmptyLocationRange,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.ConvertSemaToStaticType(nil, rType),
+			},
+			address,
+		)
+
+		arrayRef := interpreter.NewUnmeteredEphemeralReferenceValue(
+			false,
+			array,
+			&sema.VariableSizedType{
+				Type: rType,
+			},
+		)
+
+		val, err := inter.Invoke("test", arrayRef)
+		require.NoError(t, err)
+		AssertValuesEqual(t, inter, interpreter.NewUnmeteredIntValueFromInt64(2), val)
+	})
+
+	t.Run("account to stack storage reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
+
+		inter, _ := testAccount(
+			t,
+			address,
+			true,
+			`
+            resource R {
+                pub(set) var id: Int
+
+                init() {
+                    self.id = 1
+                }
+            }
+
+             fun test() {
+                let r1 <-create R()
+                account.save(<-r1, to: /storage/r)
+
+                let r1Ref = account.borrow<&R>(from: /storage/r)!
+
+                let r2 <- account.load<@R>(from: /storage/r)!
+
+                r1Ref.id = 2
+                destroy r2
+            }`,
+		)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		require.ErrorAs(t, err, &interpreter.DereferenceError{})
+	})
 }


### PR DESCRIPTION
## Description

This is the draft implementation of the FLIP: https://github.com/onflow/flow/pull/1043

The general idea is that, a resource reference is invalidated, if the pointed resource is being moved.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
