### PR TITLE
DOCS: Fix line about storable fields in composite types

### DIFF
--- a/docs/language/composite-types.mdx
+++ b/docs/language/composite-types.mdx
@@ -137,7 +137,7 @@ There are three kinds of fields:
 In initializers, the special constant `self` refers to the composite value
 that is to be initialized.
 
-Field types must be storable. Non-storable types are:
+If a composite type is to be stored, all its field types must be storable. Non-storable types are:
 
 - Functions
 - [Accounts (`AuthAccount` / `PublicAccount`)](accounts)


### PR DESCRIPTION
Closes #???

No issue was created for this since it was a really small fixed raised on an internal slack channel (should I create an issue though?)

## Description

Fields in composite types only needs to be storable if the composite type needs to be stored. This fixes the line on the docs referring to that.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
