### PR TITLE
[0.26] Fix unnecessarily specific cast in storage iteration

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3159,7 +3159,7 @@ func (interpreter *Interpreter) newStorageIterationFunction(addressValue Address
 	return NewHostFunctionValue(
 		interpreter,
 		func(invocation Invocation) Value {
-			fn, ok := invocation.Arguments[0].(*InterpretedFunctionValue)
+			fn, ok := invocation.Arguments[0].(FunctionValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -3025,4 +3025,49 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		require.NoError(t, err)
 	})
+
+	t.Run("non-lambda", func(t *testing.T) {
+		t.Parallel()
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
+
+		inter, _ := testAccount(
+			t,
+			address,
+			true,
+			`
+			fun foo  (path: StoragePath, type: Type): Bool {
+				return true
+			}
+			fun test() {
+				account.forEachStored(foo)
+			}`,
+		)
+
+		_, err := inter.Invoke("test")
+		require.NoError(t, err)
+	})
+
+	t.Run("method", func(t *testing.T) {
+		t.Parallel()
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
+
+		inter, _ := testAccount(
+			t,
+			address,
+			true,
+			`
+			struct S {
+				fun foo(path: StoragePath, type: Type): Bool {
+					return true
+				}
+			}
+			fun test() {
+				let s = S()
+				account.forEachStored(s.foo)
+			}`,
+		)
+
+		_, err := inter.Invoke("test")
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Port of https://github.com/onflow/cadence/pull/1984 to v0.26

______

<!-- Complete: -->

- [] Targeted PR against `master` branch
- [] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
