### PR TITLE
Improve type information in interpreter errors

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -192,6 +192,8 @@ func TestRuntimeAccountKeyConstructor(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
+	_ = err.Error()
+
 	assert.Contains(t, err.Error(), "cannot find variable in this scope: `AccountKey`")
 }
 
@@ -230,6 +232,8 @@ func TestRuntimeStoreAccountAPITypes(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.Contains(t, err.Error(), "expected `Storable`")
 	}
 }
@@ -1073,6 +1077,8 @@ func TestRuntimePublicKey(t *testing.T) {
 
 		_, err := executeScript(script, runtimeInterface)
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.Contains(t, err.Error(), "value of type `PublicKey` has no member `validate`")
 	})
 
@@ -1111,6 +1117,8 @@ func TestRuntimePublicKey(t *testing.T) {
 				assert.NoError(t, err)
 			} else {
 				assert.Nil(t, value)
+				_ = err.Error()
+
 				assert.ErrorAs(t, err, &errorToReturn)
 				assert.ErrorAs(t, err, &interpreter.InvalidPublicKeyError{})
 			}
@@ -1257,6 +1265,7 @@ func TestRuntimePublicKey(t *testing.T) {
 
 		_, err := executeScript(script, runtimeInterface)
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1294,6 +1303,7 @@ func TestRuntimePublicKey(t *testing.T) {
 		_, err := executeScript(script, runtimeInterface)
 
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1424,6 +1434,7 @@ func TestAuthAccountContracts(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1659,6 +1670,7 @@ func TestPublicAccountContracts(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1703,6 +1715,7 @@ func TestPublicAccountContracts(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1773,6 +1786,7 @@ func TestGetAuthAccount(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1806,6 +1820,7 @@ func TestGetAuthAccount(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1839,6 +1854,7 @@ func TestGetAuthAccount(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)
@@ -1879,6 +1895,7 @@ func TestGetAuthAccount(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
 
 		var checkerErr *sema.CheckerError
 		require.ErrorAs(t, err, &checkerErr)

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -269,6 +269,8 @@ func TestRuntimeContract(t *testing.T) {
 
 			} else {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.Empty(t, deployedCode)
 				require.Empty(t, events)
 				require.Equal(t,
@@ -304,6 +306,7 @@ func TestRuntimeContract(t *testing.T) {
 				},
 			)
 			require.Error(t, err)
+			_ = err.Error()
 
 			// the deployed code should not have been updated,
 			// and no events should have been emitted,
@@ -445,6 +448,8 @@ func TestRuntimeContract(t *testing.T) {
 
 			} else {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.Empty(t, deployedCode)
 				require.Empty(t, events)
 				require.Empty(t, loggedMessages)

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -184,6 +184,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "Test", "a", "String", "Int")
@@ -217,6 +218,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertExtraneousFieldError(t, cause, "Test", "b")
@@ -298,6 +300,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "TestResource", "b", "Int", "String")
@@ -351,6 +354,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertExtraneousFieldError(t, cause, "TestResource", "c")
@@ -404,6 +408,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "TestStruct", "b", "Int", "String")
@@ -481,6 +486,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "Bar", "d", "Bar?", "String")
@@ -599,6 +605,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err = executeTransaction(newContractUpdateTransaction("Test", newCode))
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "Test", "x", "TestImport.TestStruct", "TestStruct")
@@ -624,6 +631,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "Test", "a", "String", "Int")
@@ -657,6 +665,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertDeclTypeChangeError(
@@ -696,6 +705,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertDeclTypeChangeError(
@@ -790,6 +800,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 		// Changing unused public composite types should also fail, since those could be
 		// referred by anyone in the chain, and may cause data inconsistency.
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "UnusedStruct", "a", "Int", "String")
@@ -833,6 +844,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertConformanceMismatchError(t, cause, "Foo")
@@ -876,6 +888,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "TestStruct", "a", "String", "Int")
@@ -907,6 +920,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertDeclTypeChangeError(
@@ -966,6 +980,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertMissingDeclarationError(t, cause, "TestStruct")
@@ -995,6 +1010,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertExtraneousFieldError(t, cause, "Test", "b")
@@ -1040,6 +1056,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		updateErr := getContractUpdateError(t, err, "Test")
 		require.NotNil(t, updateErr)
@@ -1098,6 +1115,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		const expectedError = "error: mismatching field `a` in `Test`\n" +
 			" --> 0000000000000042.Test:3:27\n" +
@@ -1206,6 +1224,8 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.Contains(t, err.Error(), "error: field add has non-storable type: ((Int, Int): Int)")
 	})
 
@@ -1517,6 +1537,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		assert.Contains(t, err.Error(), "pub var a: {TestInterface}"+
 			"\n  |                            ^^^^^^^^^^^^^^^ "+
@@ -1576,6 +1597,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertMissingEnumCasesError(t, cause, "Foo", 2, 1)
@@ -1634,6 +1656,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		updateErr := getContractUpdateError(t, err, "Test")
 		require.NotNil(t, updateErr)
@@ -1677,6 +1700,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err = executeTransaction(newContractUpdateTransaction("Test", updateCode1))
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertMissingDeclarationError(t, cause, "TestStruct")
@@ -1696,6 +1720,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err = executeTransaction(newContractUpdateTransaction("Test", updateCode2))
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause = getSingleContractUpdateErrorCause(t, err, "Test")
 		assertFieldTypeMismatchError(t, cause, "TestStruct", "a", "Int", "String")
@@ -1737,6 +1762,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertMissingDeclarationError(t, cause, "TestStruct")
@@ -1755,6 +1781,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndRemove(t, "Test", code)
 		require.Error(t, err)
+		_ = err.Error()
 
 		assertContractRemovalError(t, err, "Test")
 	})
@@ -1770,6 +1797,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 		err := testDeployAndRemove(t, "Test", code)
 		require.Error(t, err)
+		_ = err.Error()
 
 		assertContractRemovalError(t, err, "Test")
 	})
@@ -1816,6 +1844,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 			err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 			require.Error(t, err)
+			_ = err.Error()
 
 			updateErr := getContractUpdateError(t, err, "Test")
 
@@ -1925,6 +1954,7 @@ func getSingleContractUpdateErrorCause(t *testing.T, err error, contractName str
 
 func getContractUpdateError(t *testing.T, err error, contractName string) *stdlib.ContractUpdateError {
 	require.Error(t, err)
+	_ = err.Error()
 
 	var invalidContractDeploymentErr *stdlib.InvalidContractDeploymentError
 	require.ErrorAs(t, err, &invalidContractDeploymentErr)
@@ -2024,6 +2054,7 @@ func TestRuntimeContractUpdateConformanceChanges(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 
@@ -2068,6 +2099,7 @@ func TestRuntimeContractUpdateConformanceChanges(t *testing.T) {
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode)
 		require.Error(t, err)
+		_ = err.Error()
 
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -88,6 +88,9 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 	expectFailure := func(expectedErrorMessage string) expectation {
 		return func(t *testing.T, err error, accountCode []byte, events []cadence.Event, _ cadence.Type) {
+			require.Error(t, err)
+			_ = err.Error()
+
 			var runtimeErr Error
 			require.ErrorAs(t, err, &runtimeErr)
 

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -81,6 +81,7 @@ func TestRuntimeCyclicImport(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
+	_ = err.Error()
 
 	require.Contains(t, err.Error(), "cyclic import of `p1`")
 
@@ -143,6 +144,8 @@ func TestRuntimeExport(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.IsType(t, Error{}, err)
 	})
 }

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1294,7 +1294,7 @@ func (t CapabilityStaticType) Encode(e *cbor.StreamEncoder) error {
 
 func (t FunctionStaticType) Encode(_ *cbor.StreamEncoder) error {
 	return NonStorableStaticTypeError{
-		Type: t,
+		Type: t.Type,
 	}
 }
 

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -340,6 +340,7 @@ func (e ForceNilError) Error() string {
 //
 type ForceCastTypeMismatchError struct {
 	ExpectedType sema.Type
+	ActualType   sema.Type
 	LocationRange
 }
 
@@ -349,8 +350,9 @@ func (ForceCastTypeMismatchError) IsUserError() {}
 
 func (e ForceCastTypeMismatchError) Error() string {
 	return fmt.Sprintf(
-		"unexpectedly found non-`%s` while force-casting value",
+		"failed to force-cast value: expected `%s`, got `%s`",
 		e.ExpectedType.QualifiedString(),
+		e.ActualType.QualifiedString(),
 	)
 }
 
@@ -358,6 +360,7 @@ func (e ForceCastTypeMismatchError) Error() string {
 //
 type TypeMismatchError struct {
 	ExpectedType sema.Type
+	ActualType   sema.Type
 	LocationRange
 }
 
@@ -367,8 +370,9 @@ func (TypeMismatchError) IsUserError() {}
 
 func (e TypeMismatchError) Error() string {
 	return fmt.Sprintf(
-		"type mismatch: expected %s",
+		"type mismatch: expected `%s`, got `%s`",
 		e.ExpectedType.QualifiedString(),
+		e.ActualType.QualifiedString(),
 	)
 }
 
@@ -620,7 +624,7 @@ func (InvocationArgumentTypeError) IsUserError() {}
 
 func (e InvocationArgumentTypeError) Error() string {
 	return fmt.Sprintf(
-		"invalid invocation with argument at index %d: expected %s",
+		"invalid invocation with argument at index %d: expected `%s`",
 		e.Index,
 		e.ParameterType.QualifiedString(),
 	)
@@ -630,6 +634,7 @@ func (e InvocationArgumentTypeError) Error() string {
 //
 type MemberAccessTypeError struct {
 	ExpectedType sema.Type
+	ActualType   sema.Type
 	LocationRange
 }
 
@@ -639,15 +644,17 @@ func (MemberAccessTypeError) IsUserError() {}
 
 func (e MemberAccessTypeError) Error() string {
 	return fmt.Sprintf(
-		"invalid member access: expected %s",
+		"invalid member access: expected `%s`, got `%s`",
 		e.ExpectedType.QualifiedString(),
+		e.ActualType.QualifiedString(),
 	)
 }
 
 // ValueTransferTypeError
 //
 type ValueTransferTypeError struct {
-	TargetType sema.Type
+	ExpectedType sema.Type
+	ActualType   sema.Type
 	LocationRange
 }
 
@@ -657,8 +664,9 @@ func (ValueTransferTypeError) IsUserError() {}
 
 func (e ValueTransferTypeError) Error() string {
 	return fmt.Sprintf(
-		"invalid transfer of value: expected %s",
-		e.TargetType.QualifiedString(),
+		"invalid transfer of value: expected `%s`, got `%s`",
+		e.ExpectedType.QualifiedString(),
+		e.ActualType.QualifiedString(),
 	)
 }
 
@@ -675,7 +683,7 @@ func (ResourceConstructionError) IsUserError() {}
 
 func (e ResourceConstructionError) Error() string {
 	return fmt.Sprintf(
-		"cannot create resource %s: outside of declaring location %s",
+		"cannot create resource `%s`: outside of declaring location %s",
 		e.CompositeType.QualifiedString(),
 		e.CompositeType.Location.String(),
 	)
@@ -695,7 +703,7 @@ func (ContainerMutationError) IsUserError() {}
 
 func (e ContainerMutationError) Error() string {
 	return fmt.Sprintf(
-		"invalid container update: expected a subtype of '%s', found '%s'",
+		"invalid container update: expected a subtype of `%s`, found `%s`",
 		e.ExpectedType.QualifiedString(),
 		e.ActualType.QualifiedString(),
 	)
@@ -718,7 +726,7 @@ func (e NonStorableValueError) Error() string {
 // NonStorableStaticTypeError
 //
 type NonStorableStaticTypeError struct {
-	Type StaticType
+	Type sema.Type
 }
 
 var _ errors.UserError = NonStorableStaticTypeError{}
@@ -727,8 +735,8 @@ func (NonStorableStaticTypeError) IsUserError() {}
 
 func (e NonStorableStaticTypeError) Error() string {
 	return fmt.Sprintf(
-		"cannot store non-storable static type: %s",
-		e.Type,
+		"cannot store non-storable type: `%s`",
+		e.Type.QualifiedString(),
 	)
 }
 

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -350,7 +350,7 @@ func (ForceCastTypeMismatchError) IsUserError() {}
 
 func (e ForceCastTypeMismatchError) Error() string {
 	return fmt.Sprintf(
-		"failed to force-cast value: expected `%s`, got `%s`",
+		"failed to force-cast value: expected type `%s`, got `%s`",
 		e.ExpectedType.QualifiedString(),
 		e.ActualType.QualifiedString(),
 	)

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -99,10 +99,7 @@ func (v *SimpleCompositeValue) StaticType(_ *Interpreter) StaticType {
 
 func (v *SimpleCompositeValue) IsImportable(inter *Interpreter) bool {
 	staticType := v.StaticType(inter)
-	semaType, err := inter.ConvertStaticToSemaType(staticType)
-	if err != nil {
-		panic(err)
-	}
+	semaType := inter.MustConvertStaticToSemaType(staticType)
 	return semaType.IsImportable(map[*sema.Member]bool{})
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -14340,10 +14340,7 @@ func (v *CompositeValue) StaticType(interpreter *Interpreter) StaticType {
 
 func (v *CompositeValue) IsImportable(inter *Interpreter) bool {
 	staticType := v.StaticType(inter)
-	semaType, err := inter.ConvertStaticToSemaType(staticType)
-	if err != nil {
-		panic(err)
-	}
+	semaType := inter.MustConvertStaticToSemaType(staticType)
 	return semaType.IsImportable(map[*sema.Member]bool{})
 }
 
@@ -14884,10 +14881,7 @@ func (v *CompositeValue) ConformsToStaticType(
 
 	staticType := v.StaticType(interpreter).(CompositeStaticType)
 
-	semaType, err := interpreter.ConvertStaticToSemaType(staticType)
-	if err != nil {
-		return false
-	}
+	semaType := interpreter.MustConvertStaticToSemaType(staticType)
 
 	compositeType, ok := semaType.(*sema.CompositeType)
 	if !ok ||
@@ -17079,9 +17073,13 @@ func (v *StorageReferenceValue) dereference(interpreter *Interpreter, getLocatio
 
 	if v.BorrowedType != nil {
 		staticType := referenced.StaticType(interpreter)
+
 		if !interpreter.IsSubTypeOfSemaType(staticType, v.BorrowedType) {
+			semaType := interpreter.MustConvertStaticToSemaType(staticType)
+
 			return nil, ForceCastTypeMismatchError{
 				ExpectedType:  v.BorrowedType,
+				ActualType:    semaType,
 				LocationRange: getLocationRange(),
 			}
 		}
@@ -17902,9 +17900,16 @@ func accountGetCapabilityFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			if !invocation.Interpreter.IsSubTypeOfSemaType(path.StaticType(invocation.Interpreter), pathType) {
+			interpreter := invocation.Interpreter
+
+			pathStaticType := path.StaticType(interpreter)
+
+			if !interpreter.IsSubTypeOfSemaType(pathStaticType, pathType) {
+				pathSemaType := interpreter.MustConvertStaticToSemaType(pathStaticType)
+
 				panic(TypeMismatchError{
 					ExpectedType:  pathType,
+					ActualType:    pathSemaType,
 					LocationRange: invocation.GetLocationRange(),
 				})
 			}
@@ -17921,7 +17926,7 @@ func accountGetCapabilityFunction(
 
 			var borrowStaticType StaticType
 			if borrowType != nil {
-				borrowStaticType = ConvertSemaToStaticType(invocation.Interpreter, borrowType)
+				borrowStaticType = ConvertSemaToStaticType(interpreter, borrowType)
 			}
 
 			return NewCapabilityValue(gauge, addressValue, path, borrowStaticType)

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -43,6 +43,8 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("String, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`true`, sema.StringType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -58,6 +60,8 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("Bool, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`"hello"`, sema.BoolType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -94,6 +98,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -132,6 +138,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -170,6 +178,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -220,6 +230,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -278,6 +290,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -304,6 +318,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -314,6 +330,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -324,6 +342,8 @@ func TestLiteralValue(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -358,12 +378,16 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("CapabilityPath, invalid literal (storage)", func(t *testing.T) {
 		value, err := ParseLiteral(`/storage/foo`, sema.CapabilityPathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
 	t.Run("CapabilityPath, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`true`, sema.CapabilityPathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -382,18 +406,24 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("PublicPath, invalid literal (private)", func(t *testing.T) {
 		value, err := ParseLiteral(`/private/foo`, sema.PublicPathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
 	t.Run("PublicPath, invalid literal (storage)", func(t *testing.T) {
 		value, err := ParseLiteral(`/storage/foo`, sema.PublicPathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
 	t.Run("PublicPath, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`true`, sema.PublicPathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -412,18 +442,24 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("PrivatePath, invalid literal (public)", func(t *testing.T) {
 		value, err := ParseLiteral(`/public/foo`, sema.PrivatePathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
 	t.Run("PrivatePath, invalid literal (storage)", func(t *testing.T) {
 		value, err := ParseLiteral(`/storage/foo`, sema.PrivatePathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
 	t.Run("PrivatePath, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`true`, sema.PrivatePathType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -439,6 +475,8 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("Address, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`1`, &sema.AddressType{}, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -463,6 +501,8 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("Fix64, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`1`, sema.Fix64Type, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -478,12 +518,16 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("UFix64, invalid literal, negative", func(t *testing.T) {
 		value, err := ParseLiteral(`-1.0`, sema.UFix64Type, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
 	t.Run("UFix64, invalid literal, invalid expression", func(t *testing.T) {
 		value, err := ParseLiteral(`1`, sema.UFix64Type, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -508,6 +552,8 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("FixedPoint, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`1`, sema.FixedPointType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -532,6 +578,8 @@ func TestLiteralValue(t *testing.T) {
 	t.Run("SignedFixedPoint, invalid literal", func(t *testing.T) {
 		value, err := ParseLiteral(`1`, sema.SignedFixedPointType, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.Nil(t, value)
 	})
 
@@ -557,6 +605,8 @@ func TestLiteralValue(t *testing.T) {
 			func(t *testing.T) {
 				value, err := ParseLiteral(`-1`, unsignedIntegerType, newTestInterpreter(t))
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.Nil(t, value)
 			},
 		)
@@ -569,6 +619,8 @@ func TestLiteralValue(t *testing.T) {
 			func(t *testing.T) {
 				value, err := ParseLiteral(`true`, unsignedIntegerType, newTestInterpreter(t))
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.Nil(t, value)
 			},
 		)
@@ -612,6 +664,8 @@ func TestLiteralValue(t *testing.T) {
 			func(t *testing.T) {
 				value, err := ParseLiteral(`true`, signedIntegerType, newTestInterpreter(t))
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.Nil(t, value)
 			},
 		)
@@ -623,6 +677,8 @@ func TestParseLiteralArgumentList(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		_, err := ParseLiteralArgumentList("", nil, newTestInterpreter(t))
 		require.Error(t, err)
+		_ = err.Error()
+
 	})
 
 	t.Run("empty", func(t *testing.T) {
@@ -677,6 +733,8 @@ func TestParseLiteralArgumentList(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 	})
 
 	t.Run("too many arguments", func(t *testing.T) {
@@ -688,6 +746,8 @@ func TestParseLiteralArgumentList(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 	})
 
 	t.Run("too few arguments", func(t *testing.T) {
@@ -700,6 +760,8 @@ func TestParseLiteralArgumentList(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 	})
 
 	t.Run("non-literal argument", func(t *testing.T) {
@@ -711,5 +773,6 @@ func TestParseLiteralArgumentList(t *testing.T) {
 			newTestInterpreter(t),
 		)
 		require.Error(t, err)
+		_ = err.Error()
 	})
 }

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -38,6 +38,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 
 	expectNonImportableError := func(t *testing.T, err error) {
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t, Error{}, err)
 		runtimeErr := err.(Error)
@@ -47,6 +48,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 
 	expectRuntimeError := func(t *testing.T, err error, expectedError error) {
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t, Error{}, err)
 		runtimeErr := err.(Error)
@@ -469,6 +471,8 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 
 		err := executeScript(t, script, publicAccountKeys)
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.Contains(t, err.Error(), "cannot import value of type PublicAccount.Keys")
 	})
 
@@ -488,6 +492,8 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 			}),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.Contains(t, err.Error(), "cannot import value of type PublicAccount.Keys")
 	})
 
@@ -502,6 +508,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 			).WithType(HashAlgoType),
 		)
 		require.Error(t, err)
+		_ = err.Error()
 
 		var entryPointErr *InvalidEntryPointArgumentError
 		require.ErrorAs(t, err, &entryPointErr)
@@ -518,6 +525,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 			).WithType(SignAlgoType),
 		)
 		require.Error(t, err)
+		_ = err.Error()
 
 		var entryPointErr *InvalidEntryPointArgumentError
 		require.ErrorAs(t, err, &entryPointErr)
@@ -530,6 +538,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 	expectCheckerErrors := func(t *testing.T, err error, expectedErrors ...error) {
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t, Error{}, err)
 		runtimeErr := err.(Error)
@@ -547,6 +556,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 	expectRuntimeError := func(t *testing.T, err error, expectedError error) {
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t, Error{}, err)
 		runtimeErr := err.(Error)
@@ -985,6 +995,8 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 		err := executeTransaction(t, script, publicAccountKeys)
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.Contains(t, err.Error(), "cannot import value of type PublicAccount.Keys")
 	})
 
@@ -1003,6 +1015,8 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 			}),
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.Contains(t, err.Error(), "cannot import value of type PublicAccount.Keys")
 	})
 
@@ -1017,6 +1031,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 			).WithType(HashAlgoType),
 		)
 		require.Error(t, err)
+		_ = err.Error()
 
 		var entryPointErr *InvalidEntryPointArgumentError
 		require.ErrorAs(t, err, &entryPointErr)
@@ -1033,6 +1048,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 			).WithType(SignAlgoType),
 		)
 		require.Error(t, err)
+		_ = err.Error()
 
 		var entryPointErr *InvalidEntryPointArgumentError
 		require.ErrorAs(t, err, &entryPointErr)

--- a/runtime/resource_duplicate_test.go
+++ b/runtime/resource_duplicate_test.go
@@ -199,6 +199,7 @@ func TestRuntimeResourceDuplicationWithContractTransfer(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
+	_ = err.Error()
 
 	var nonTransferableValueError interpreter.NonTransferableValueError
 	require.ErrorAs(t, err, &nonTransferableValueError)

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -152,6 +152,8 @@ func TestRLPDecodeString(t *testing.T) {
 			)
 			if len(test.expectedErrMsg) > 0 {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assert.ErrorContains(t, err, test.expectedErrMsg)
 			} else {
 				require.NoError(t, err)
@@ -310,6 +312,8 @@ func TestRLPDecodeList(t *testing.T) {
 			)
 			if len(test.expectedErrMsg) > 0 {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assert.ErrorContains(t, err, test.expectedErrMsg)
 			} else {
 				require.NoError(t, err)

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -1037,6 +1037,8 @@ func TestMemoryMeteringErrors(t *testing.T) {
 			memoryMeter{},
 			cadence.String("hello"),
 		)
+		require.Error(t, err)
+		_ = err.Error()
 
 		assert.ErrorIs(t, err, testMemoryError{})
 	})
@@ -1071,6 +1073,9 @@ func TestMemoryMeteringErrors(t *testing.T) {
         `)
 
 		err := executeScript(script, memoryMeter{})
+		require.Error(t, err)
+		_ = err.Error()
+
 		assert.ErrorIs(t, err, testMemoryError{})
 	})
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -883,7 +883,9 @@ func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
-	assert.Error(t, err)
+	require.Error(t, err)
+	_ = err.Error()
+
 }
 
 func TestRuntimeTransactionWithAccount(t *testing.T) {
@@ -1001,7 +1003,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 				{1, 2, 3, 4}, // not valid JSON-CDC
 			},
 			check: func(t *testing.T, err error) {
-				assert.Error(t, err)
+				require.Error(t, err)
+				_ = err.Error()
+
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
 			},
 		},
@@ -1018,7 +1022,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 				jsoncdc.MustEncode(cadence.String("foo")),
 			},
 			check: func(t *testing.T, err error) {
-				assert.Error(t, err)
+				require.Error(t, err)
+				_ = err.Error()
+
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
 				assert.IsType(t, &InvalidValueTypeError{}, errors.Unwrap(errors.Unwrap(err)))
 			},
@@ -1113,6 +1119,8 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assertRuntimeErrorIsUserError(t, err)
 
 				var argErr interpreter.ContainerMutationError
@@ -1304,6 +1312,8 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assertRuntimeErrorIsUserError(t, err)
 
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
@@ -1321,6 +1331,8 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assertRuntimeErrorIsUserError(t, err)
 
 				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
@@ -1386,6 +1398,8 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assertRuntimeErrorIsUserError(t, err)
 
 				var invalidEntryPointArgumentErr *InvalidEntryPointArgumentError
@@ -1410,6 +1424,8 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assertRuntimeErrorIsUserError(t, err)
 
 				var invalidEntryPointArgumentErr *InvalidEntryPointArgumentError
@@ -1458,6 +1474,8 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assertRuntimeErrorIsUserError(t, err)
 
 				var argErr interpreter.ContainerMutationError
@@ -1608,6 +1626,8 @@ func TestRuntimeProgramWithNoTransaction(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
+	require.Error(t, err)
+	_ = err.Error()
 
 	require.ErrorAs(t, err, &InvalidTransactionCountError{})
 }
@@ -1640,6 +1660,8 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
+	require.Error(t, err)
+	_ = err.Error()
 
 	require.ErrorAs(t, err, &InvalidTransactionCountError{})
 }
@@ -2533,6 +2555,9 @@ func TestRuntimeScriptReturnTypeNotReturnableError(t *testing.T) {
 		)
 
 		if expected == nil {
+			require.Error(t, err)
+			_ = err.Error()
+
 			var subErr *InvalidScriptReturnTypeError
 			require.ErrorAs(t, err, &subErr)
 		} else {
@@ -2715,6 +2740,8 @@ func TestRuntimeScriptParameterTypeNotImportableError(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
+	require.Error(t, err)
+	_ = err.Error()
 
 	var subErr *ScriptParameterTypeNotImportableError
 	require.ErrorAs(t, err, &subErr)
@@ -2749,7 +2776,9 @@ func TestRuntimeSyntaxError(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
-	assert.Error(t, err)
+	require.Error(t, err)
+	_ = err.Error()
+
 }
 
 func TestRuntimeStorageChanges(t *testing.T) {
@@ -3274,7 +3303,7 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 
 	assert.NotNil(t, accountCode)
 
-	t.Run("simple function", func(tt *testing.T) {
+	t.Run("simple function", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3288,12 +3317,12 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(tt, err)
+		require.NoError(t, err)
 
-		assert.Equal(tt, `"Hello World!"`, loggedMessage)
+		assert.Equal(t, `"Hello World!"`, loggedMessage)
 	})
 
-	t.Run("function with parameter", func(tt *testing.T) {
+	t.Run("function with parameter", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3311,11 +3340,11 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(tt, err)
+		require.NoError(t, err)
 
-		assert.Equal(tt, `"Hello there!"`, loggedMessage)
+		assert.Equal(t, `"Hello there!"`, loggedMessage)
 	})
-	t.Run("function with return type", func(tt *testing.T) {
+	t.Run("function with return type", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3333,11 +3362,11 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(tt, err)
+		require.NoError(t, err)
 
-		assert.Equal(tt, `"Hello return!"`, loggedMessage)
+		assert.Equal(t, `"Hello return!"`, loggedMessage)
 	})
-	t.Run("function with multiple arguments", func(tt *testing.T) {
+	t.Run("function with multiple arguments", func(t *testing.T) {
 
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
@@ -3360,12 +3389,12 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(tt, err)
+		require.NoError(t, err)
 
-		assert.Equal(tt, `"Hello number 42 from 0x0000000000000001"`, loggedMessage)
+		assert.Equal(t, `"Hello number 42 from 0x0000000000000001"`, loggedMessage)
 	})
 
-	t.Run("function with not enough arguments panics", func(tt *testing.T) {
+	t.Run("function with not enough arguments panics", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3386,10 +3415,12 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 			},
 		)
 
-		require.Error(tt, err)
-		assert.ErrorAs(tt, err, &Error{})
+		require.Error(t, err)
+		_ = err.Error()
+
+		assert.ErrorAs(t, err, &Error{})
 	})
-	t.Run("function with incorrect argument type errors", func(tt *testing.T) {
+	t.Run("function with incorrect argument type errors", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3407,9 +3438,12 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.ErrorAs(tt, err, &interpreter.ValueTransferTypeError{})
+		require.Error(t, err)
+		_ = err.Error()
+
+		require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
 	})
-	t.Run("function with un-importable argument errors and error propagates", func(tt *testing.T) {
+	t.Run("function with un-importable argument errors and error propagates", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3429,9 +3463,12 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.ErrorContains(tt, err, "cannot import capability")
+		require.Error(t, err)
+		_ = err.Error()
+
+		require.ErrorContains(t, err, "cannot import capability")
 	})
-	t.Run("function with auth account works", func(tt *testing.T) {
+	t.Run("function with auth account works", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3449,11 +3486,11 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(tt, err)
+		require.NoError(t, err)
 
-		assert.Equal(tt, `"Hello 0x0000000000000001"`, loggedMessage)
+		assert.Equal(t, `"Hello 0x0000000000000001"`, loggedMessage)
 	})
-	t.Run("function with public account works", func(tt *testing.T) {
+	t.Run("function with public account works", func(t *testing.T) {
 		_, err = runtime.InvokeContractFunction(
 			common.AddressLocation{
 				Address: addressValue,
@@ -3471,9 +3508,9 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(tt, err)
+		require.NoError(t, err)
 
-		assert.Equal(tt, `"Hello pub 0x0000000000000001"`, loggedMessage)
+		assert.Equal(t, `"Hello pub 0x0000000000000001"`, loggedMessage)
 	})
 }
 
@@ -3876,6 +3913,8 @@ func TestRuntimeStorageLoadedDestructionAfterRemoval(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
+	require.Error(t, err)
+	_ = err.Error()
 
 	var typeLoadingErr interpreter.TypeLoadingError
 	require.ErrorAs(t, err, &typeLoadingErr)
@@ -4440,6 +4479,8 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 					assert.NoError(t, err)
 				} else {
 					require.Error(t, err)
+					_ = err.Error()
+
 					assertRuntimeErrorIsUserError(t, err)
 
 					require.ErrorAs(t, err, &interpreter.ConditionError{})
@@ -4626,6 +4667,8 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsUserError(t, err)
 
 		var checkerErr *sema.CheckerError
@@ -5850,6 +5893,8 @@ func TestRuntimeExternalError(t *testing.T) {
 	)
 
 	require.Error(t, err)
+	_ = err.Error()
+
 	assertRuntimeErrorIsExternalError(t, err)
 }
 
@@ -6648,6 +6693,8 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
+				_ = err.Error()
+
 				assertRuntimeErrorIsUserError(t, err)
 
 				require.ErrorAs(t, err, &InvalidEntryPointParameterCountError{})
@@ -6730,7 +6777,9 @@ func TestRuntimePanics(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
-	assert.Error(t, err)
+	require.Error(t, err)
+	_ = err.Error()
+
 }
 
 func TestRuntimeGetCapability(t *testing.T) {
@@ -6767,6 +6816,8 @@ func TestRuntimeGetCapability(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsUserError(t, err)
 
 		var typeErr interpreter.ContainerMutationError
@@ -6803,6 +6854,8 @@ func TestRuntimeGetCapability(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsUserError(t, err)
 
 		var typeErr interpreter.ContainerMutationError
@@ -6934,6 +6987,8 @@ func TestRuntimeStackOverflow(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
+	_ = err.Error()
+
 	assertRuntimeErrorIsUserError(t, err)
 
 	var callStackLimitExceededErr CallStackLimitExceededError
@@ -6977,6 +7032,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsInternalError(t, err)
 	})
 
@@ -7010,6 +7067,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsExternalError(t, err)
 	})
 
@@ -7047,6 +7106,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsInternalError(t, err)
 	})
 
@@ -7124,6 +7185,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsInternalError(t, err)
 	})
 
@@ -7149,6 +7212,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsExternalError(t, err)
 	})
 
@@ -7179,6 +7244,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsExternalError(t, err)
 	})
 
@@ -7209,6 +7276,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsExternalError(t, err)
 	})
 
@@ -7238,6 +7307,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		)
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assertRuntimeErrorIsInternalError(t, err)
 	})
 
@@ -7344,6 +7415,9 @@ func TestRuntimeComputationMetring(t *testing.T) {
 			if test.ok {
 				require.NoError(t, err)
 			} else {
+				require.Error(t, err)
+				_ = err.Error()
+
 				var executionErr Error
 				require.ErrorAs(t, err, &executionErr)
 				require.ErrorAs(t, err.(Error).Unwrap(), &compErr)
@@ -7491,6 +7565,8 @@ func TestImportingTestStdlib(t *testing.T) {
 	)
 
 	require.Error(t, err)
+	_ = err.Error()
+
 	errs := checker.ExpectCheckerErrors(t, err, 1)
 
 	notDeclaredErr := &sema.NotDeclaredError{}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3290,7 +3290,7 @@ func (*InvalidRestrictedTypeError) IsUserError() {}
 
 func (e *InvalidRestrictedTypeError) Error() string {
 	return fmt.Sprintf(
-		"cannot restrict type: %s",
+		"cannot restrict type: `%s`",
 		e.Type.QualifiedString(),
 	)
 }
@@ -3311,7 +3311,7 @@ func (*InvalidRestrictionTypeError) IsUserError() {}
 
 func (e *InvalidRestrictionTypeError) Error() string {
 	return fmt.Sprintf(
-		"cannot restrict using non-resource/structure interface type: %s",
+		"cannot restrict using non-resource/structure interface type: `%s`",
 		e.Type.QualifiedString(),
 	)
 }
@@ -3355,7 +3355,7 @@ func (*InvalidRestrictionTypeDuplicateError) IsUserError() {}
 
 func (e *InvalidRestrictionTypeDuplicateError) Error() string {
 	return fmt.Sprintf(
-		"duplicate restriction: %s",
+		"duplicate restriction: `%s`",
 		e.Type.QualifiedString(),
 	)
 }
@@ -3376,7 +3376,7 @@ func (*InvalidNonConformanceRestrictionError) IsUserError() {}
 
 func (e *InvalidNonConformanceRestrictionError) Error() string {
 	return fmt.Sprintf(
-		"restricted type does not conform to restricting type: %s",
+		"restricted type does not conform to restricting type: `%s`",
 		e.Type.QualifiedString(),
 	)
 }

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1493,12 +1493,14 @@ func newMatcherWithGenericTestFunction(
 
 			for i, argument := range invocation.Arguments {
 				paramType := parameters[i].TypeAnnotation.Type
-				argumentType := argument.StaticType(inter)
-				argTypeMatch := inter.IsSubTypeOfSemaType(argumentType, paramType)
+				argumentStaticType := argument.StaticType(inter)
 
-				if !argTypeMatch {
+				if !inter.IsSubTypeOfSemaType(argumentStaticType, paramType) {
+					argumentSemaType := inter.MustConvertStaticToSemaType(argumentStaticType)
+
 					panic(interpreter.TypeMismatchError{
 						ExpectedType:  paramType,
+						ActualType:    argumentSemaType,
 						LocationRange: invocation.GetLocationRange(),
 					})
 				}

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1591,7 +1591,7 @@ func TestRuntimeStorageReferenceCast(t *testing.T) {
 
 	require.Error(t, err)
 
-	require.Contains(t, err.Error(), "unexpectedly found non-`&Test.R` while force-casting value")
+	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 }
 
 func TestRuntimeStorageNonStorable(t *testing.T) {

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -617,6 +617,7 @@ transaction {
 	)
 
 	require.Error(t, err)
+	_ = err.Error()
 
 	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 }
@@ -1590,6 +1591,7 @@ func TestRuntimeStorageReferenceCast(t *testing.T) {
 	)
 
 	require.Error(t, err)
+	_ = err.Error()
 
 	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 }
@@ -1650,6 +1652,7 @@ func TestRuntimeStorageNonStorable(t *testing.T) {
 				},
 			)
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.Contains(t, err.Error(), "cannot store non-storable value")
 		})
@@ -1693,6 +1696,7 @@ func TestRuntimeStorageRecursiveReference(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
+	_ = err.Error()
 
 	require.Contains(t, err.Error(), "cannot store non-storable value")
 }
@@ -3012,6 +3016,7 @@ func TestRuntimeNoAtreeSendOnClosedChannelDuringCommit(t *testing.T) {
 				},
 			)
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.Contains(t, err.Error(), "cannot store non-storable value")
 		}

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -189,6 +189,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 			_, err := inter.Invoke("test")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.OverwriteError{})
 		})
@@ -235,6 +236,7 @@ func TestInterpretAuthAccount_save(t *testing.T) {
 
 			_, err := inter.Invoke("test")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.OverwriteError{})
 		})
@@ -410,6 +412,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			_, err = inter.Invoke("loadR2")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
@@ -492,6 +495,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			_, err = inter.Invoke("loadS2")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
@@ -588,6 +592,7 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 
 		_, err = inter.Invoke("copyS2")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
@@ -717,6 +722,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("borrowR2")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
@@ -728,6 +734,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("changeAfterBorrow")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
 		})
@@ -857,6 +864,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			_, err = inter.Invoke("borrowS2")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
@@ -868,6 +876,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("changeAfterBorrow")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
 		})
@@ -875,6 +884,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		t.Run("borrow as invalid type", func(t *testing.T) {
 			_, err = inter.Invoke("invalidBorrowS")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 		})
@@ -2544,6 +2554,8 @@ func TestInterpretAccount_iteration(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 	})
 
@@ -2621,6 +2633,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2654,6 +2668,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2687,6 +2703,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2724,6 +2742,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2764,6 +2784,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2797,6 +2819,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2830,6 +2854,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2863,6 +2889,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err := inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)
@@ -2985,6 +3013,8 @@ func TestInterpretAccountIterationMutation(t *testing.T) {
 			_, err = inter.Invoke("test")
 			if continueAfterMutation {
 				require.Error(t, err)
+				_ = err.Error()
+
 				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
 			} else {
 				require.NoError(t, err)

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -212,6 +212,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceNilError{})
 		})
@@ -220,6 +221,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
+			_ = err.Error()
 
 			var cyclicLinkErr interpreter.CyclicLinkError
 			require.ErrorAs(t, err, &cyclicLinkErr)
@@ -246,6 +248,9 @@ func TestInterpretCapability_borrow(t *testing.T) {
 		t.Run("r2", func(t *testing.T) {
 
 			_, err := inter.Invoke("r2")
+			require.Error(t, err)
+			_ = err.Error()
+
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 		})
 
@@ -253,6 +258,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("singleChangeAfterBorrow")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
 		})
@@ -437,6 +443,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("nonExistent")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceNilError{})
 		})
@@ -445,6 +452,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
+			_ = err.Error()
 
 			var cyclicLinkErr interpreter.CyclicLinkError
 			require.ErrorAs(t, err, &cyclicLinkErr)
@@ -471,6 +479,9 @@ func TestInterpretCapability_borrow(t *testing.T) {
 		t.Run("s2", func(t *testing.T) {
 
 			_, err := inter.Invoke("s2")
+			require.Error(t, err)
+			_ = err.Error()
+
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 		})
 
@@ -478,6 +489,7 @@ func TestInterpretCapability_borrow(t *testing.T) {
 
 			_, err := inter.Invoke("singleChangeAfterBorrow")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
 		})
@@ -668,6 +680,7 @@ func TestInterpretCapability_check(t *testing.T) {
 
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
+			_ = err.Error()
 
 			var cyclicLinkErr interpreter.CyclicLinkError
 			require.ErrorAs(t, err, &cyclicLinkErr)
@@ -885,6 +898,7 @@ func TestInterpretCapability_check(t *testing.T) {
 
 			_, err := inter.Invoke("loop")
 			require.Error(t, err)
+			_ = err.Error()
 
 			var cyclicLinkErr interpreter.CyclicLinkError
 			require.ErrorAs(t, err, &cyclicLinkErr)
@@ -1169,6 +1183,7 @@ func TestInterpretCapabilityFunctionMultipleTypes(t *testing.T) {
 
 			_, err := inter.Invoke("what")
 			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &interpreter.ForceNilError{})
 		})

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -189,6 +189,7 @@ func TestInterpretContractTransfer(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var nonTransferableValueError interpreter.NonTransferableValueError
 		require.ErrorAs(t, err, &nonTransferableValueError)

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -53,6 +53,9 @@ func TestInterpretFunctionPreCondition(t *testing.T) {
 		"test",
 		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
+	require.Error(t, err)
+	_ = err.Error()
+
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
@@ -81,6 +84,9 @@ func TestInterpretFunctionPostCondition(t *testing.T) {
 		"test",
 		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
+	require.Error(t, err)
+	_ = err.Error()
+
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
@@ -108,6 +114,8 @@ func TestInterpretFunctionWithResultAndPostConditionWithResult(t *testing.T) {
 		"test",
 		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
+	require.Error(t, err)
+	_ = err.Error()
 
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
@@ -191,6 +199,8 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPreCondition(t *testing.
     `)
 
 	_, err := inter.Invoke("test")
+	require.Error(t, err)
+	_ = err.Error()
 
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
@@ -220,6 +230,8 @@ func TestInterpretFunctionPostConditionWithBeforeFailingPostCondition(t *testing
     `)
 
 	_, err := inter.Invoke("test")
+	require.Error(t, err)
+	_ = err.Error()
 
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
@@ -248,6 +260,8 @@ func TestInterpretFunctionPostConditionWithMessageUsingStringLiteral(t *testing.
 		"test",
 		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
+	require.Error(t, err)
+	_ = err.Error()
 
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
@@ -287,6 +301,9 @@ func TestInterpretFunctionPostConditionWithMessageUsingResult(t *testing.T) {
 		"test",
 		interpreter.NewUnmeteredIntValueFromInt64(42),
 	)
+	require.Error(t, err)
+	_ = err.Error()
+
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
@@ -321,6 +338,8 @@ func TestInterpretFunctionPostConditionWithMessageUsingBefore(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewUnmeteredStringValue("parameter value"))
+	require.Error(t, err)
+	_ = err.Error()
 
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
@@ -345,6 +364,8 @@ func TestInterpretFunctionPostConditionWithMessageUsingParameter(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test", interpreter.NewUnmeteredStringValue("parameter value"))
+	require.Error(t, err)
+	_ = err.Error()
 
 	var conditionErr interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
@@ -430,6 +451,8 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = inter.Invoke("callTest", interpreter.NewUnmeteredIntValueFromInt64(0))
+			require.Error(t, err)
+			_ = err.Error()
 
 			var conditionErr interpreter.ConditionError
 			require.ErrorAs(t, err, &conditionErr)
@@ -445,6 +468,8 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 			)
 
 			_, err = inter.Invoke("callTest", interpreter.NewUnmeteredIntValueFromInt64(2))
+			require.Error(t, err)
+			_ = err.Error()
 
 			require.ErrorAs(t, err, &conditionErr)
 		})
@@ -653,6 +678,8 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 
 	t.Run("-1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(-1))
+		require.Error(t, err)
+		_ = err.Error()
 
 		var conditionErr interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)
@@ -665,6 +692,8 @@ func TestInterpretTypeRequirementWithPreCondition(t *testing.T) {
 
 	t.Run("0", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(0))
+		require.Error(t, err)
+		_ = err.Error()
 
 		var conditionErr interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)
@@ -734,6 +763,7 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 	t.Run("1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(1))
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t,
 			interpreter.Error{},
@@ -758,6 +788,7 @@ func TestInterpretResourceInterfaceInitializerAndDestructorPreConditions(t *test
 	t.Run("3", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(3))
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t,
 			interpreter.Error{},
@@ -829,6 +860,7 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 	t.Run("1", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(1))
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t,
 			interpreter.Error{},
@@ -853,6 +885,7 @@ func TestInterpretResourceTypeRequirementInitializerAndDestructorPreConditions(t
 	t.Run("3", func(t *testing.T) {
 		_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(3))
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.IsType(t,
 			interpreter.Error{},
@@ -1052,6 +1085,7 @@ func TestInterpretIsInstanceCheckInPreCondition(t *testing.T) {
 
 		_, err = inter.Invoke("test2")
 		require.Error(t, err)
+		_ = err.Error()
 	}
 
 	t.Run("isInstance", func(t *testing.T) {

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -84,6 +84,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -104,6 +105,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -159,6 +161,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -179,6 +182,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -234,6 +238,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -256,6 +261,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.ContainerMutationError{})
 
@@ -295,6 +301,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -487,6 +494,7 @@ func TestArrayMutation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -554,6 +562,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -633,6 +642,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -653,6 +663,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -674,6 +685,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)
@@ -877,6 +889,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		mutationError := &interpreter.ContainerMutationError{}
 		require.ErrorAs(t, err, mutationError)

--- a/runtime/tests/interpreter/contract_test.go
+++ b/runtime/tests/interpreter/contract_test.go
@@ -153,6 +153,9 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
 				},
 			},
 		)
+		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.MissingMemberValueError{})
 	})
 }

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -168,6 +168,9 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 										result,
 									)
 								} else {
+									require.Error(t, err)
+									_ = err.Error()
+
 									require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 								}
 							})
@@ -264,6 +267,9 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 								result,
 							)
 						} else {
+							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -355,6 +361,9 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 								result,
 							)
 						} else {
+							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -446,6 +455,9 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 								result,
 							)
 						} else {
+							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -542,6 +554,9 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 								result,
 							)
 						} else {
+							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -632,6 +647,9 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 							result,
 						)
 					} else {
+						require.Error(t, err)
+						_ = err.Error()
+
 						require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 					}
 				})
@@ -673,6 +691,9 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 								result,
 							)
 						} else {
+							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -781,6 +802,9 @@ func testResourceCastInvalid(t *testing.T, types, fromType, targetType string, o
 		)
 
 	case ast.OperationForceCast:
+		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 	default:
@@ -929,6 +953,9 @@ func testStructCastInvalid(t *testing.T, types, fromType, targetType string, ope
 		)
 
 	case ast.OperationForceCast:
+		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 	default:
@@ -1139,6 +1166,9 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								result,
 							)
 						} else {
+							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -1246,6 +1276,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							)
 						} else {
 							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -1279,6 +1311,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 					)
 				} else {
 					require.Error(t, err)
+					_ = err.Error()
+
 					require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 				}
 			})
@@ -1296,6 +1330,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 		_, err := inter.Invoke("test")
 
 		require.Error(t, err)
+		_ = err.Error()
+
 		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 	})
 }
@@ -1401,6 +1437,8 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							)
 						} else {
 							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -1433,6 +1471,8 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 					)
 				} else {
 					require.Error(t, err)
+					_ = err.Error()
+
 					require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 				}
 			})
@@ -2338,6 +2378,9 @@ func testReferenceCastInvalid(t *testing.T, types, fromType, targetType string, 
 		)
 
 	case ast.OperationForceCast:
+		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 
 	default:
@@ -3596,6 +3639,9 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 								result,
 							)
 						} else {
+							require.Error(t, err)
+							_ = err.Error()
+
 							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 						}
 					})
@@ -3628,6 +3674,7 @@ func TestInterpretResourceConstructorCast(t *testing.T) {
 			require.Equal(t, interpreter.NilValue{}, result)
 		} else {
 			require.Error(t, err)
+			_ = err.Error()
 		}
 	}
 }
@@ -3691,6 +3738,9 @@ func TestInterpretFunctionTypeCasting(t *testing.T) {
         `)
 
 		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 	})
 
@@ -3728,6 +3778,9 @@ func TestInterpretFunctionTypeCasting(t *testing.T) {
         `)
 
 		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 	})
 
@@ -3777,6 +3830,9 @@ func TestInterpretReferenceCasting(t *testing.T) {
 		inter := parseCheckAndInterpret(t, code)
 
 		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		_ = err.Error()
+
 		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 	})
 
@@ -3798,6 +3854,9 @@ func TestInterpretReferenceCasting(t *testing.T) {
 		inter := parseCheckAndInterpret(t, code)
 
 		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		_ = err.Error()
+
 		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 	})
 }

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -208,6 +208,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)
+						_ = err.Error()
 
 						operandError := &interpreter.InvalidOperandsError{}
 						require.ErrorAs(t, err, operandError)
@@ -258,6 +259,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)
+						_ = err.Error()
 
 						operandError := &interpreter.InvalidOperandsError{}
 						require.ErrorAs(t, err, operandError)
@@ -308,6 +310,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						assert.Equal(t, interpreter.BoolValue(true), result)
 					default:
 						require.Error(t, err)
+						_ = err.Error()
 
 						operandError := &interpreter.InvalidOperandsError{}
 						require.ErrorAs(t, err, operandError)

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -327,6 +327,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		`)
 
 		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.UnderflowError{})
 	})
@@ -346,6 +348,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.OverflowError{})
 	})
@@ -370,6 +374,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.IsType(t,
 					interpreter.Error{},
@@ -410,6 +415,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				)
 
 				_, err := inter.Invoke("test")
+				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.OverflowError{})
 			})
@@ -446,6 +453,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				)
 
 				_, err := inter.Invoke("test")
+				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.OverflowError{})
 			})
@@ -483,6 +492,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.OverflowError{})
 			})
@@ -520,6 +530,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 				_, err := inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.UnderflowError{})
 			})

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -390,6 +390,7 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
 
 	_, err = inter.Invoke("test", rConstructor)
 	require.Error(t, err)
+	_ = err.Error()
 
 	var resourceConstructionError interpreter.ResourceConstructionError
 	require.ErrorAs(t, err, &resourceConstructionError)

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -238,6 +238,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.OverflowError{})
 	})
@@ -255,6 +256,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.UnderflowError{})
 	})
@@ -553,6 +555,8 @@ func TestInterpretIntegerConversion(t *testing.T) {
 
 		if expectedError != nil {
 			require.Error(t, err)
+			_ = err.Error()
+
 			require.ErrorAs(t, err, &expectedError)
 		} else {
 			require.NoError(t, err)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -639,6 +639,8 @@ func TestInterpretInvalidArrayIndexing(t *testing.T) {
 
 			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
+			require.Error(t, err)
+			_ = err.Error()
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
@@ -717,6 +719,8 @@ func TestInterpretInvalidArrayIndexingAssignment(t *testing.T) {
 
 			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
+			require.Error(t, err)
+			_ = err.Error()
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
@@ -790,6 +794,8 @@ func TestInterpretInvalidStringIndexing(t *testing.T) {
 
 			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
+			require.Error(t, err)
+			_ = err.Error()
 
 			var indexErr interpreter.StringIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
@@ -4056,6 +4062,8 @@ func TestInterpretImportError(t *testing.T) {
 			"  |                  ^^^^^^^^^^^\n",
 		sb.String(),
 	)
+	require.Error(t, err)
+	_ = err.Error()
 
 	var panicErr stdlib.PanicError
 	require.ErrorAs(t, err, &panicErr)
@@ -5219,6 +5227,8 @@ func TestInterpretInvalidArrayInsert(t *testing.T) {
 
 			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
+			require.Error(t, err)
+			_ = err.Error()
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
@@ -5293,6 +5303,8 @@ func TestInterpretInvalidArrayRemove(t *testing.T) {
 
 			indexValue := interpreter.NewUnmeteredIntValueFromInt64(int64(index))
 			_, err := inter.Invoke("test", indexValue)
+			require.Error(t, err)
+			_ = err.Error()
 
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
@@ -5359,6 +5371,8 @@ func TestInterpretInvalidArrayRemoveFirst(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
+	require.Error(t, err)
+	_ = err.Error()
 
 	var indexErr interpreter.ArrayIndexOutOfBoundsError
 	require.ErrorAs(t, err, &indexErr)
@@ -5424,6 +5438,8 @@ func TestInterpretInvalidArrayRemoveLast(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
+	require.Error(t, err)
+	_ = err.Error()
 
 	var indexErr interpreter.ArrayIndexOutOfBoundsError
 	require.ErrorAs(t, err, &indexErr)
@@ -7294,6 +7310,7 @@ func TestInterpretReferenceDereferenceFailure(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
+	_ = err.Error()
 
 	require.ErrorAs(t, err, &interpreter.DestroyedResourceError{})
 }
@@ -8316,6 +8333,7 @@ func TestInterpretNonStorageReferenceAfterDestruction(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
+	_ = err.Error()
 
 	require.ErrorAs(t, err, &interpreter.DestroyedResourceError{})
 }
@@ -8363,6 +8381,8 @@ func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		_, err := inter.Invoke("testNil")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.ForceNilError{})
 	})
 }
@@ -9007,6 +9027,7 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.ForceAssignmentToNonNilResourceError{})
 	})
@@ -9043,6 +9064,7 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.ForceAssignmentToNonNilResourceError{})
 	})
@@ -9121,6 +9143,7 @@ func TestInterpretForce(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.ForceNilError{})
 	})
@@ -9642,6 +9665,7 @@ func TestInterpretMissingMember(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
+	_ = err.Error()
 
 	var missingMemberError interpreter.MissingMemberValueError
 	require.ErrorAs(t, err, &missingMemberError)
@@ -9895,6 +9919,9 @@ func TestInterpretOptionalReference(t *testing.T) {
 	)
 
 	_, err = inter.Invoke("absent")
+	require.Error(t, err)
+	_ = err.Error()
+
 	var forceNilError interpreter.ForceNilError
 	require.ErrorAs(t, err, &forceNilError)
 }
@@ -10050,6 +10077,7 @@ func TestInterpretDictionaryDuplicateKey(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.DuplicateKeyInResourceDictionaryError{})
 

--- a/runtime/tests/interpreter/invocation_test.go
+++ b/runtime/tests/interpreter/invocation_test.go
@@ -38,6 +38,7 @@ func TestInterpretFunctionInvocationCheckArgumentTypes(t *testing.T) {
 
 	_, err := inter.Invoke("test", interpreter.BoolValue(true))
 	require.Error(t, err)
+	_ = err.Error()
 
 	require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
 }

--- a/runtime/tests/interpreter/member_test.go
+++ b/runtime/tests/interpreter/member_test.go
@@ -108,11 +108,13 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				_, err = inter.Invoke("get", value)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 
 				_, err = inter.Invoke("set", value)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 			})
@@ -188,6 +190,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 					interpreter.NewUnmeteredSomeValueNonCopying(value),
 				)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 			})
@@ -279,11 +282,13 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				_, err = inter.Invoke("get", value)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 
 				_, err = inter.Invoke("set", value)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 			})
@@ -367,6 +372,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 					interpreter.NewUnmeteredSomeValueNonCopying(value),
 				)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 			})
@@ -458,11 +464,13 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				_, err = inter.Invoke("get", ref)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 
 				_, err = inter.Invoke("set", ref)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 			})
@@ -550,6 +558,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 					),
 				)
 				require.Error(t, err)
+				_ = err.Error()
 
 				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
 			})

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -125,6 +125,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationErr interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationErr)
@@ -159,6 +160,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationErr interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationErr)
@@ -198,6 +200,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
@@ -236,6 +239,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
@@ -280,6 +284,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
@@ -322,6 +327,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
@@ -350,6 +356,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
@@ -380,6 +387,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
@@ -404,6 +412,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
@@ -428,6 +437,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var containerMutationError interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -620,6 +620,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -666,6 +667,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -712,6 +714,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -758,6 +761,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -801,6 +805,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -841,6 +846,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -881,6 +887,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -921,6 +928,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -963,6 +971,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1004,6 +1013,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1042,6 +1052,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1075,6 +1086,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1108,6 +1120,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1139,6 +1152,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1190,6 +1204,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1235,6 +1250,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1280,6 +1296,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1325,6 +1342,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1366,6 +1384,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1404,6 +1423,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1442,6 +1462,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1480,6 +1501,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1521,6 +1543,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1561,6 +1584,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1599,6 +1623,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1631,6 +1656,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1663,6 +1689,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1695,6 +1722,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 				_, err = inter.Invoke("test")
 				require.Error(t, err)
+				_ = err.Error()
 
 				var invalidatedResourceErr interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -1729,6 +1757,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1756,6 +1786,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1790,6 +1822,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1818,6 +1852,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1845,6 +1881,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1876,6 +1914,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1904,6 +1944,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1932,6 +1974,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1964,6 +2008,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 
@@ -1996,6 +2042,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 }
@@ -2027,6 +2075,8 @@ func TestCheckResourceInvalidationWithConditionalExprInDestroy(t *testing.T) {
 
 	_, err = inter.Invoke("test")
 	require.Error(t, err)
+	_ = err.Error()
+
 	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 }
 
@@ -2068,6 +2118,7 @@ func TestInterpretResourceUseAfterInvalidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		invalidatedResourceError := interpreter.InvalidatedResourceError{}
 		require.ErrorAs(t, err, &invalidatedResourceError)
@@ -2105,6 +2156,8 @@ func TestInterpretResourceUseAfterInvalidation(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
+
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 	})
 }
@@ -2410,6 +2463,8 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
         `)
 
 		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		_ = err.Error()
 
 		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -2440,6 +2495,7 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -2470,6 +2526,7 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -2499,6 +2556,7 @@ func TestInterpretReferenceUseAfterTransferAndDestruction(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var invalidatedResourceErr interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
@@ -2549,5 +2607,7 @@ func TestInterpretResourceDestroyedInPreCondition(t *testing.T) {
 
 	_, err = inter.Invoke("test")
 	require.Error(t, err)
+	_ = err.Error()
+
 	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 }

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -128,6 +128,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var typedErr interpreter.InvalidHexByteError
 		require.ErrorAs(t, err, &typedErr)
@@ -146,6 +147,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		var typedErr interpreter.InvalidHexLengthError
 		require.ErrorAs(t, err, &typedErr)

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -116,6 +116,8 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(0)
+		require.Error(t, err)
+		_ = err.Error()
 
 		var conditionErr interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)
@@ -177,6 +179,8 @@ func TestInterpretTransactions(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(0)
+		require.Error(t, err)
+		_ = err.Error()
 
 		var conditionErr interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)

--- a/runtime/tests/interpreter/transfer_test.go
+++ b/runtime/tests/interpreter/transfer_test.go
@@ -88,6 +88,7 @@ func TestInterpretTransferCheck(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		_ = err.Error()
 
 		require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
 	})

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -83,6 +83,8 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
+		require.Error(t, err)
+		_ = err.Error()
 
 		var typeLoadingErr interpreter.TypeLoadingError
 		require.ErrorAs(t, err, &typeLoadingErr)
@@ -133,6 +135,8 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
+		require.Error(t, err)
+		_ = err.Error()
 
 		var typeLoadingErr interpreter.TypeLoadingError
 		require.ErrorAs(t, err, &typeLoadingErr)


### PR DESCRIPTION
Closes #1986

## Description

- Include actual type in error
- Use qualified strings, which helps with debugging, e.g., when force-casting a stored type which has the same qualified identifier, but different location (e.g. `0x1.C.S` vs `0x2.C.S`)
- Simplify related code by using `MustConvertStaticToSemaType` helper

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
