### PR TITLE
Define standard library values in analysis

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -159,21 +159,17 @@ func (e *interpreterEnvironment) newCheckerConfig() *sema.Config {
 
 func NewBaseInterpreterEnvironment(config Config) *interpreterEnvironment {
 	env := newInterpreterEnvironment(config)
-	for _, valueDeclaration := range stdlib.BuiltinValues {
+	for _, valueDeclaration := range stdlib.DefaultStandardLibraryValues(env) {
 		env.Declare(valueDeclaration)
 	}
-	env.Declare(stdlib.NewLogFunction(env))
-	env.Declare(stdlib.NewUnsafeRandomFunction(env))
-	env.Declare(stdlib.NewGetBlockFunction(env))
-	env.Declare(stdlib.NewGetCurrentBlockFunction(env))
-	env.Declare(stdlib.NewGetAccountFunction(env))
-	env.Declare(stdlib.NewAuthAccountConstructor(env))
 	return env
 }
 
 func NewScriptInterpreterEnvironment(config Config) Environment {
-	env := NewBaseInterpreterEnvironment(config)
-	env.Declare(stdlib.NewGetAuthAccountFunction(env))
+	env := newInterpreterEnvironment(config)
+	for _, valueDeclaration := range stdlib.DefaultScriptStandardLibraryValues(env) {
+		env.Declare(valueDeclaration)
+	}
 	return env
 }
 

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -56,7 +56,6 @@ func DefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLibr
 	)
 }
 
-// TODO: use in language server
 func DefaultScriptStandardLibraryValues(handler StandardLibraryHandler) []StandardLibraryValue {
 	return append(
 		DefaultStandardLibraryValues(handler),

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -34,3 +34,32 @@ var BuiltinValues = []StandardLibraryValue{
 	//   (BLSVerifyPoPHandler, BLSAggregateSignaturesHandler, BLSAggregatePublicKeysHandler)
 	BLSContract,
 }
+
+type StandardLibraryHandler interface {
+	Logger
+	UnsafeRandomGenerator
+	BlockAtHeightProvider
+	CurrentBlockProvider
+	PublicAccountHandler
+	AccountCreator
+}
+
+func DefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLibraryValue {
+	return append(
+		BuiltinValues[:],
+		NewLogFunction(handler),
+		NewUnsafeRandomFunction(handler),
+		NewGetBlockFunction(handler),
+		NewGetCurrentBlockFunction(handler),
+		NewGetAccountFunction(handler),
+		NewAuthAccountConstructor(handler),
+	)
+}
+
+// TODO: use in language server
+func DefaultScriptStandardLibraryValues(handler StandardLibraryHandler) []StandardLibraryValue {
+	return append(
+		DefaultStandardLibraryValues(handler),
+		NewGetAuthAccountFunction(handler),
+	)
+}

--- a/tools/analysis/analysis_test.go
+++ b/tools/analysis/analysis_test.go
@@ -261,7 +261,7 @@ func TestStdlib(t *testing.T) {
 
 	t.Parallel()
 
-	location := common.ScriptLocation{}
+	scriptLocation := common.ScriptLocation{}
 
 	const code = `
 	  pub fun main() {
@@ -277,7 +277,7 @@ func TestStdlib(t *testing.T) {
 			importRange ast.Range,
 		) ([]byte, error) {
 			switch location {
-			case location:
+			case scriptLocation:
 				return []byte(code), nil
 
 			default:
@@ -291,7 +291,7 @@ func TestStdlib(t *testing.T) {
 		},
 	}
 
-	_, err := analysis.Load(config, location)
+	_, err := analysis.Load(config, scriptLocation)
 	require.NoError(t, err)
 
 }

--- a/tools/analysis/analysis_test.go
+++ b/tools/analysis/analysis_test.go
@@ -256,3 +256,42 @@ func TestCheckError(t *testing.T) {
 	var checkerError *sema.CheckerError
 	require.ErrorAs(t, err, &checkerError)
 }
+
+func TestStdlib(t *testing.T) {
+
+	t.Parallel()
+
+	location := common.ScriptLocation{}
+
+	const code = `
+	  pub fun main() {
+          panic("test")
+      }
+	`
+
+	config := &analysis.Config{
+		Mode: analysis.NeedTypes,
+		ResolveCode: func(
+			location common.Location,
+			importingLocation common.Location,
+			importRange ast.Range,
+		) ([]byte, error) {
+			switch location {
+			case location:
+				return []byte(code), nil
+
+			default:
+				require.FailNow(t,
+					"import of unknown location: %s",
+					"location: %s",
+					location,
+				)
+				return nil, nil
+			}
+		},
+	}
+
+	_, err := analysis.Load(config, location)
+	require.NoError(t, err)
+
+}

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -86,13 +86,18 @@ func (programs Programs) check(
 	*sema.Elaboration,
 	error,
 ) {
+	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	for _, value := range stdlib.DefaultScriptStandardLibraryValues(nil) {
+		baseValueActivation.DeclareValue(value)
+	}
 
 	checker, err := sema.NewChecker(
 		program,
 		location,
 		nil,
 		&sema.Config{
-			AccessCheckMode: sema.AccessCheckModeStrict,
+			BaseValueActivation: baseValueActivation,
+			AccessCheckMode:     sema.AccessCheckModeStrict,
 			LocationHandler: sema.AddressLocationHandlerFunc(
 				config.ResolveAddressContractNames,
 			),


### PR DESCRIPTION
## Description

The linter is currently failing to analyze contracts and transactions, as the standard library values are not declared.
The language server had the same problem previously, and required ugly code duplication to define it:
https://github.com/onflow/cadence/pull/1970/files#diff-263f98e13a4ba92698ccd60d8d54cc92ab67c3b5fd1f89039c08f83899f20f30
Refactor the existing declaration in the runtime environment and make it reusable, so it can be used in the analysis package, and in the language server in the future.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
