### PR TITLE
Make Void values constructible

### DIFF
--- a/runtime/ast/elementtype.go
+++ b/runtime/ast/elementtype.go
@@ -58,6 +58,7 @@ const (
 
 	// Expressions
 
+	ElementTypeVoidExpression
 	ElementTypeBoolExpression
 	ElementTypeNilExpression
 	ElementTypeIntegerExpression

--- a/runtime/ast/elementtype_string.go
+++ b/runtime/ast/elementtype_string.go
@@ -33,32 +33,33 @@ func _() {
 	_ = x[ElementTypeAssignmentStatement-22]
 	_ = x[ElementTypeSwapStatement-23]
 	_ = x[ElementTypeExpressionStatement-24]
-	_ = x[ElementTypeBoolExpression-25]
-	_ = x[ElementTypeNilExpression-26]
-	_ = x[ElementTypeIntegerExpression-27]
-	_ = x[ElementTypeFixedPointExpression-28]
-	_ = x[ElementTypeArrayExpression-29]
-	_ = x[ElementTypeDictionaryExpression-30]
-	_ = x[ElementTypeIdentifierExpression-31]
-	_ = x[ElementTypeInvocationExpression-32]
-	_ = x[ElementTypeMemberExpression-33]
-	_ = x[ElementTypeIndexExpression-34]
-	_ = x[ElementTypeConditionalExpression-35]
-	_ = x[ElementTypeUnaryExpression-36]
-	_ = x[ElementTypeBinaryExpression-37]
-	_ = x[ElementTypeFunctionExpression-38]
-	_ = x[ElementTypeStringExpression-39]
-	_ = x[ElementTypeCastingExpression-40]
-	_ = x[ElementTypeCreateExpression-41]
-	_ = x[ElementTypeDestroyExpression-42]
-	_ = x[ElementTypeReferenceExpression-43]
-	_ = x[ElementTypeForceExpression-44]
-	_ = x[ElementTypePathExpression-45]
+	_ = x[ElementTypeVoidExpression-25]
+	_ = x[ElementTypeBoolExpression-26]
+	_ = x[ElementTypeNilExpression-27]
+	_ = x[ElementTypeIntegerExpression-28]
+	_ = x[ElementTypeFixedPointExpression-29]
+	_ = x[ElementTypeArrayExpression-30]
+	_ = x[ElementTypeDictionaryExpression-31]
+	_ = x[ElementTypeIdentifierExpression-32]
+	_ = x[ElementTypeInvocationExpression-33]
+	_ = x[ElementTypeMemberExpression-34]
+	_ = x[ElementTypeIndexExpression-35]
+	_ = x[ElementTypeConditionalExpression-36]
+	_ = x[ElementTypeUnaryExpression-37]
+	_ = x[ElementTypeBinaryExpression-38]
+	_ = x[ElementTypeFunctionExpression-39]
+	_ = x[ElementTypeStringExpression-40]
+	_ = x[ElementTypeCastingExpression-41]
+	_ = x[ElementTypeCreateExpression-42]
+	_ = x[ElementTypeDestroyExpression-43]
+	_ = x[ElementTypeReferenceExpression-44]
+	_ = x[ElementTypeForceExpression-45]
+	_ = x[ElementTypePathExpression-46]
 }
 
-const _ElementType_name = "ElementTypeUnknownElementTypeProgramElementTypeBlockElementTypeFunctionBlockElementTypeFunctionDeclarationElementTypeSpecialFunctionDeclarationElementTypeCompositeDeclarationElementTypeInterfaceDeclarationElementTypeFieldDeclarationElementTypeEnumCaseDeclarationElementTypePragmaDeclarationElementTypeImportDeclarationElementTypeTransactionDeclarationElementTypeReturnStatementElementTypeBreakStatementElementTypeContinueStatementElementTypeIfStatementElementTypeSwitchStatementElementTypeWhileStatementElementTypeForStatementElementTypeEmitStatementElementTypeVariableDeclarationElementTypeAssignmentStatementElementTypeSwapStatementElementTypeExpressionStatementElementTypeBoolExpressionElementTypeNilExpressionElementTypeIntegerExpressionElementTypeFixedPointExpressionElementTypeArrayExpressionElementTypeDictionaryExpressionElementTypeIdentifierExpressionElementTypeInvocationExpressionElementTypeMemberExpressionElementTypeIndexExpressionElementTypeConditionalExpressionElementTypeUnaryExpressionElementTypeBinaryExpressionElementTypeFunctionExpressionElementTypeStringExpressionElementTypeCastingExpressionElementTypeCreateExpressionElementTypeDestroyExpressionElementTypeReferenceExpressionElementTypeForceExpressionElementTypePathExpression"
+const _ElementType_name = "ElementTypeUnknownElementTypeProgramElementTypeBlockElementTypeFunctionBlockElementTypeFunctionDeclarationElementTypeSpecialFunctionDeclarationElementTypeCompositeDeclarationElementTypeInterfaceDeclarationElementTypeFieldDeclarationElementTypeEnumCaseDeclarationElementTypePragmaDeclarationElementTypeImportDeclarationElementTypeTransactionDeclarationElementTypeReturnStatementElementTypeBreakStatementElementTypeContinueStatementElementTypeIfStatementElementTypeSwitchStatementElementTypeWhileStatementElementTypeForStatementElementTypeEmitStatementElementTypeVariableDeclarationElementTypeAssignmentStatementElementTypeSwapStatementElementTypeExpressionStatementElementTypeVoidExpressionElementTypeBoolExpressionElementTypeNilExpressionElementTypeIntegerExpressionElementTypeFixedPointExpressionElementTypeArrayExpressionElementTypeDictionaryExpressionElementTypeIdentifierExpressionElementTypeInvocationExpressionElementTypeMemberExpressionElementTypeIndexExpressionElementTypeConditionalExpressionElementTypeUnaryExpressionElementTypeBinaryExpressionElementTypeFunctionExpressionElementTypeStringExpressionElementTypeCastingExpressionElementTypeCreateExpressionElementTypeDestroyExpressionElementTypeReferenceExpressionElementTypeForceExpressionElementTypePathExpression"
 
-var _ElementType_index = [...]uint16{0, 18, 36, 52, 76, 106, 143, 174, 205, 232, 262, 290, 318, 351, 377, 402, 430, 452, 478, 503, 526, 550, 580, 610, 634, 664, 689, 713, 741, 772, 798, 829, 860, 891, 918, 944, 976, 1002, 1029, 1058, 1085, 1113, 1140, 1168, 1198, 1224, 1249}
+var _ElementType_index = [...]uint16{0, 18, 36, 52, 76, 106, 143, 174, 205, 232, 262, 290, 318, 351, 377, 402, 430, 452, 478, 503, 526, 550, 580, 610, 634, 664, 689, 714, 738, 766, 797, 823, 854, 885, 916, 943, 969, 1001, 1027, 1054, 1083, 1110, 1138, 1165, 1193, 1223, 1249, 1274}
 
 func (i ElementType) String() string {
 	if i >= ElementType(len(_ElementType_index)-1) {

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -2009,8 +2009,10 @@ func (v *VoidExpression) String() string {
 
 func (v *VoidExpression) isIfStatementTest() {}
 
+var voidExpressionDoc prettier.Doc = prettier.Text("()")
+
 func (v *VoidExpression) Doc() prettier.Doc {
-	return prettier.Text("()")
+	return voidExpressionDoc
 }
 
 func (v *VoidExpression) isExpression() {}
@@ -2024,6 +2026,7 @@ func NewVoidExpression(
 	startPos Position,
 	endPos Position,
 ) *VoidExpression {
+	common.UseMemory(gauge, common.VoidValueMemoryUsage)
 	return &VoidExpression{Range: Range{startPos, endPos}}
 }
 

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -2024,7 +2024,8 @@ func NewVoidExpression(
 	startPos Position,
 	endPos Position,
 ) *VoidExpression {
-	 return &VoidExpression{Range : Range {startPos, endPos}}
+	return &VoidExpression{Range: Range{startPos, endPos}}
 }
+
 var _ Element = &VoidExpression{}
 var _ Expression = &VoidExpression{}

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1981,3 +1981,50 @@ func (e *PathExpression) MarshalJSON() ([]byte, error) {
 func (*PathExpression) precedence() precedence {
 	return precedenceLiteral
 }
+
+// ()
+type VoidExpression struct {
+	Range
+}
+
+func (v *VoidExpression) StartPosition() Position {
+	return v.StartPos
+}
+
+func (v *VoidExpression) EndPosition(memoryGauge common.MemoryGauge) Position {
+	return v.EndPos
+}
+
+func (v *VoidExpression) ElementType() ElementType {
+	return ElementTypeVoidExpression
+}
+
+func (v *VoidExpression) Walk(walkChild func(Element)) {
+	// NO-OP
+}
+
+func (v *VoidExpression) String() string {
+	return "()"
+}
+
+func (v *VoidExpression) isIfStatementTest() {}
+
+func (v *VoidExpression) Doc() prettier.Doc {
+	return prettier.Text("()")
+}
+
+func (v *VoidExpression) isExpression() {}
+
+func (v *VoidExpression) precedence() precedence {
+	return precedenceLiteral
+}
+
+func NewVoidExpression(
+	gauge common.MemoryGauge,
+	startPos Position,
+	endPos Position,
+) *VoidExpression {
+	 return &VoidExpression{Range : Range {startPos, endPos}}
+}
+var _ Element = &VoidExpression{}
+var _ Expression = &VoidExpression{}

--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -172,7 +172,7 @@ type ExpressionExtraction struct {
 }
 
 // utility for expressions whose rewritten form is identical, i.e. nothing to rewrite
-func RewriteAsIs(expression Expression) ExpressionExtraction {
+func rewriteAsIs(expression Expression) ExpressionExtraction {
 	return ExpressionExtraction{
 		RewrittenExpression:  expression,
 		ExtractedExpressions: nil,
@@ -188,7 +188,7 @@ func (extractor *ExpressionExtractor) VisitVoidExpression(expression *VoidExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractVoid(expression *VoidExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpression) ExpressionExtraction {
@@ -203,7 +203,7 @@ func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractBool(expression *BoolExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpression) ExpressionExtraction {
@@ -218,7 +218,7 @@ func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpressi
 }
 
 func (extractor *ExpressionExtractor) ExtractNil(expression *NilExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *IntegerExpression) ExpressionExtraction {
@@ -233,7 +233,7 @@ func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *Integer
 }
 
 func (extractor *ExpressionExtractor) ExtractInteger(expression *IntegerExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *FixedPointExpression) ExpressionExtraction {
@@ -248,7 +248,7 @@ func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *Fixe
 }
 
 func (extractor *ExpressionExtractor) ExtractFixedPoint(expression *FixedPointExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringExpression) ExpressionExtraction {
@@ -263,7 +263,7 @@ func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringEx
 }
 
 func (extractor *ExpressionExtractor) ExtractString(expression *StringExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitArrayExpression(expression *ArrayExpression) ExpressionExtraction {
@@ -376,7 +376,7 @@ func (extractor *ExpressionExtractor) VisitIdentifierExpression(expression *Iden
 }
 
 func (extractor *ExpressionExtractor) ExtractIdentifier(expression *IdentifierExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitInvocationExpression(expression *InvocationExpression) ExpressionExtraction {
@@ -779,5 +779,5 @@ func (extractor *ExpressionExtractor) VisitPathExpression(expression *PathExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractPath(expression *PathExpression) ExpressionExtraction {
-	return RewriteAsIs(expression)
+	return rewriteAsIs(expression)
 }

--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -25,6 +25,9 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
+type VoidExtractor interface {
+	ExtractVoid(extractor *ExpressionExtractor, expression *VoidExpression) ExpressionExtraction
+}
 type BoolExtractor interface {
 	ExtractBool(extractor *ExpressionExtractor, expression *BoolExpression) ExpressionExtraction
 }
@@ -111,6 +114,7 @@ type PathExtractor interface {
 
 type ExpressionExtractor struct {
 	nextIdentifier       int
+	VoidExtractor		VoidExtractor
 	BoolExtractor        BoolExtractor
 	NilExtractor         NilExtractor
 	IntExtractor         IntExtractor
@@ -167,6 +171,27 @@ type ExpressionExtraction struct {
 	ExtractedExpressions []ExtractedExpression
 }
 
+// utility for expressions whose rewritten form is identical, i.e. nothing to rewrite
+func RewriteAsIs(expression Expression) ExpressionExtraction {
+	return ExpressionExtraction {
+		RewrittenExpression: expression,
+		ExtractedExpressions: nil,
+	}
+}
+
+func (extractor *ExpressionExtractor) VisitVoidExpression(expression *VoidExpression) ExpressionExtraction {
+	if extractor.VoidExtractor != nil {
+		return extractor.VoidExtractor.ExtractVoid(extractor, expression)
+	}
+
+	return extractor.ExtractVoid(expression)
+}
+
+func (extractor *ExpressionExtractor) ExtractVoid(expression *VoidExpression) ExpressionExtraction {
+	return RewriteAsIs(expression)
+}
+
+
 func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpression) ExpressionExtraction {
 
 	// delegate to child extractor, if any,
@@ -179,13 +204,7 @@ func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractBool(expression *BoolExpression) ExpressionExtraction {
-
-	// nothing to rewrite, return as-is
-
-	return ExpressionExtraction{
-		RewrittenExpression:  expression,
-		ExtractedExpressions: nil,
-	}
+	return RewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpression) ExpressionExtraction {
@@ -200,13 +219,7 @@ func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpressi
 }
 
 func (extractor *ExpressionExtractor) ExtractNil(expression *NilExpression) ExpressionExtraction {
-
-	// nothing to rewrite, return as-is
-
-	return ExpressionExtraction{
-		RewrittenExpression:  expression,
-		ExtractedExpressions: nil,
-	}
+	return RewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *IntegerExpression) ExpressionExtraction {
@@ -221,13 +234,7 @@ func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *Integer
 }
 
 func (extractor *ExpressionExtractor) ExtractInteger(expression *IntegerExpression) ExpressionExtraction {
-
-	// nothing to rewrite, return as-is
-
-	return ExpressionExtraction{
-		RewrittenExpression:  expression,
-		ExtractedExpressions: nil,
-	}
+	return RewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *FixedPointExpression) ExpressionExtraction {
@@ -242,13 +249,7 @@ func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *Fixe
 }
 
 func (extractor *ExpressionExtractor) ExtractFixedPoint(expression *FixedPointExpression) ExpressionExtraction {
-
-	// nothing to rewrite, return as-is
-
-	return ExpressionExtraction{
-		RewrittenExpression:  expression,
-		ExtractedExpressions: nil,
-	}
+	return RewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringExpression) ExpressionExtraction {
@@ -263,13 +264,7 @@ func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringEx
 }
 
 func (extractor *ExpressionExtractor) ExtractString(expression *StringExpression) ExpressionExtraction {
-
-	// nothing to rewrite, return as-is
-
-	return ExpressionExtraction{
-		RewrittenExpression:  expression,
-		ExtractedExpressions: nil,
-	}
+	return RewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitArrayExpression(expression *ArrayExpression) ExpressionExtraction {
@@ -382,12 +377,7 @@ func (extractor *ExpressionExtractor) VisitIdentifierExpression(expression *Iden
 }
 
 func (extractor *ExpressionExtractor) ExtractIdentifier(expression *IdentifierExpression) ExpressionExtraction {
-
-	// nothing to rewrite, return as-is
-
-	return ExpressionExtraction{
-		RewrittenExpression: expression,
-	}
+	return RewriteAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitInvocationExpression(expression *InvocationExpression) ExpressionExtraction {
@@ -790,11 +780,5 @@ func (extractor *ExpressionExtractor) VisitPathExpression(expression *PathExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractPath(expression *PathExpression) ExpressionExtraction {
-
-	// nothing to rewrite, return as-is
-
-	return ExpressionExtraction{
-		RewrittenExpression:  expression,
-		ExtractedExpressions: nil,
-	}
+	return RewriteAsIs(expression)
 }

--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -188,7 +188,7 @@ func (extractor *ExpressionExtractor) VisitVoidExpression(expression *VoidExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractVoid(expression *VoidExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpression) ExpressionExtraction {
@@ -203,7 +203,7 @@ func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractBool(expression *BoolExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpression) ExpressionExtraction {
@@ -218,7 +218,7 @@ func (extractor *ExpressionExtractor) VisitNilExpression(expression *NilExpressi
 }
 
 func (extractor *ExpressionExtractor) ExtractNil(expression *NilExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *IntegerExpression) ExpressionExtraction {
@@ -233,7 +233,7 @@ func (extractor *ExpressionExtractor) VisitIntegerExpression(expression *Integer
 }
 
 func (extractor *ExpressionExtractor) ExtractInteger(expression *IntegerExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *FixedPointExpression) ExpressionExtraction {
@@ -248,7 +248,7 @@ func (extractor *ExpressionExtractor) VisitFixedPointExpression(expression *Fixe
 }
 
 func (extractor *ExpressionExtractor) ExtractFixedPoint(expression *FixedPointExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringExpression) ExpressionExtraction {
@@ -263,7 +263,7 @@ func (extractor *ExpressionExtractor) VisitStringExpression(expression *StringEx
 }
 
 func (extractor *ExpressionExtractor) ExtractString(expression *StringExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitArrayExpression(expression *ArrayExpression) ExpressionExtraction {
@@ -376,7 +376,7 @@ func (extractor *ExpressionExtractor) VisitIdentifierExpression(expression *Iden
 }
 
 func (extractor *ExpressionExtractor) ExtractIdentifier(expression *IdentifierExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }
 
 func (extractor *ExpressionExtractor) VisitInvocationExpression(expression *InvocationExpression) ExpressionExtraction {
@@ -779,5 +779,5 @@ func (extractor *ExpressionExtractor) VisitPathExpression(expression *PathExpres
 }
 
 func (extractor *ExpressionExtractor) ExtractPath(expression *PathExpression) ExpressionExtraction {
-	return rewriteAsIs(expression)
+	return rewriteExpressionAsIs(expression)
 }

--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -172,7 +172,7 @@ type ExpressionExtraction struct {
 }
 
 // utility for expressions whose rewritten form is identical, i.e. nothing to rewrite
-func rewriteAsIs(expression Expression) ExpressionExtraction {
+func rewriteExpressionAsIs(expression Expression) ExpressionExtraction {
 	return ExpressionExtraction{
 		RewrittenExpression:  expression,
 		ExtractedExpressions: nil,

--- a/runtime/ast/expression_extractor.go
+++ b/runtime/ast/expression_extractor.go
@@ -114,7 +114,7 @@ type PathExtractor interface {
 
 type ExpressionExtractor struct {
 	nextIdentifier       int
-	VoidExtractor		VoidExtractor
+	VoidExtractor        VoidExtractor
 	BoolExtractor        BoolExtractor
 	NilExtractor         NilExtractor
 	IntExtractor         IntExtractor
@@ -173,8 +173,8 @@ type ExpressionExtraction struct {
 
 // utility for expressions whose rewritten form is identical, i.e. nothing to rewrite
 func RewriteAsIs(expression Expression) ExpressionExtraction {
-	return ExpressionExtraction {
-		RewrittenExpression: expression,
+	return ExpressionExtraction{
+		RewrittenExpression:  expression,
 		ExtractedExpressions: nil,
 	}
 }
@@ -190,7 +190,6 @@ func (extractor *ExpressionExtractor) VisitVoidExpression(expression *VoidExpres
 func (extractor *ExpressionExtractor) ExtractVoid(expression *VoidExpression) ExpressionExtraction {
 	return RewriteAsIs(expression)
 }
-
 
 func (extractor *ExpressionExtractor) VisitBoolExpression(expression *BoolExpression) ExpressionExtraction {
 

--- a/runtime/ast/visitor.go
+++ b/runtime/ast/visitor.go
@@ -157,6 +157,7 @@ func AcceptStatement[T any](statement Statement, visitor StatementVisitor[T]) (_
 }
 
 type ExpressionVisitor[T any] interface {
+	VisitVoidExpression(*VoidExpression) T
 	VisitNilExpression(*NilExpression) T
 	VisitBoolExpression(*BoolExpression) T
 	VisitStringExpression(*StringExpression) T
@@ -184,6 +185,8 @@ func AcceptExpression[T any](expression Expression, visitor ExpressionVisitor[T]
 
 	switch expression.ElementType() {
 
+	case ElementTypeVoidExpression:
+		return visitor.VisitVoidExpression(expression.(*VoidExpression))
 	case ElementTypeNilExpression:
 		return visitor.VisitNilExpression(expression.(*NilExpression))
 

--- a/runtime/compiler/compiler.go
+++ b/runtime/compiler/compiler.go
@@ -136,6 +136,10 @@ func (compiler *Compiler) VisitExpressionStatement(_ *ast.ExpressionStatement) i
 	panic(errors.NewUnreachableError())
 }
 
+func (compiler *Compiler) VisitVoidExpression(_ *ast.VoidExpression) ir.Expr {
+	panic(errors.NewUnreachableError())
+}
+
 func (compiler *Compiler) VisitBoolExpression(_ *ast.BoolExpression) ir.Expr {
 	// TODO
 	panic(errors.NewUnreachableError())

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -506,6 +506,10 @@ func (interpreter *Interpreter) VisitUnaryExpression(expression *ast.UnaryExpres
 	})
 }
 
+func (interpreter *Interpreter) VisitVoidExpression(expression *ast.VoidExpression) Value {
+	return NewVoidValue(interpreter)
+}
+
 func (interpreter *Interpreter) VisitBoolExpression(expression *ast.BoolExpression) Value {
 	return NewBoolValue(interpreter, expression.Value)
 }

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -1872,6 +1872,20 @@ func TestAddressValue_Equal(t *testing.T) {
 	})
 }
 
+// ensure () == ()
+func TestVoidValue_Equal(t *testing.T) {
+	t.Parallel()
+
+	inter := newTestInterpreter(t)
+	require.True(t,
+		VoidValue{}.Equal(
+			inter,
+			ReturnEmptyLocationRange,
+			VoidValue{},
+		),
+	)
+}
+
 func TestBoolValue_Equal(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -1068,7 +1068,18 @@ func parseArgument(p *parser) (*ast.Argument, error) {
 func defineNestedExpression() {
 	setExprNullDenotation(
 		lexer.TokenParenOpen,
-		func(p *parser, token lexer.Token) (ast.Expression, error) {
+		func(p *parser, startToken lexer.Token) (ast.Expression, error) {
+			p.skipSpaceAndComments(true)
+
+			// special case: parse a Void literal `()`
+			if p.current.Type == lexer.TokenParenClose {
+				// skip the closing parenthesis
+				p.next()
+
+				voidExpr := ast.NewVoidExpression(p.memoryGauge, startToken.StartPos, p.current.EndPos)
+				return voidExpr, nil
+			}
+
 			expression, err := parseExpression(p, lowestBindingPower)
 			if err != nil {
 				return nil, err

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -5029,6 +5029,50 @@ func TestParseTernaryRightAssociativity(t *testing.T) {
 	)
 }
 
+func TestParseVoidLiteral(t *testing.T) {
+	t.Parallel()
+
+	const code = `
+		let void: Void = ()
+	`
+
+	result, errs := testParseProgram(code)
+	require.Empty(t, errs)
+
+	utils.AssertEqualWithDiff(t,
+		[]ast.Declaration{
+			&ast.VariableDeclaration{
+				IsConstant: true,
+				Identifier: ast.Identifier{
+					Identifier: "void",
+					Pos:        ast.Position{Offset: 7, Line: 2, Column: 6},
+				},
+				TypeAnnotation: &ast.TypeAnnotation{
+					IsResource: false,
+					Type: &ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: "Void",
+							Pos:        ast.Position{Offset: 13, Line: 2, Column: 12},
+						},
+						NestedIdentifiers: nil,
+					},
+					StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+				Value: &ast.VoidExpression{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 20, Line: 2, Column: 19},
+						EndPos:   ast.Position{Offset: 23, Line: 3, Column: 0},
+					},
+				},
+				Transfer: &ast.Transfer{
+					Operation: 1,
+					Pos:       ast.Position{Offset: 18, Line: 2, Column: 17},
+				},
+				StartPos: ast.Position{Offset: 3, Line: 2, Column: 2},
+			},
+		}, result.Declarations())
+}
+
 func TestParseMissingReturnType(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -152,6 +152,10 @@ func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatem
 	return
 }
 
+func (checker *Checker) VisitVoidExpression(_ *ast.VoidExpression) Type {
+	return VoidType
+}
+
 func (checker *Checker) VisitBoolExpression(_ *ast.BoolExpression) Type {
 	return BoolType
 }

--- a/runtime/sema/void_type.go
+++ b/runtime/sema/void_type.go
@@ -28,7 +28,7 @@ var VoidType = &SimpleType{
 	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             false,
-	Equatable:            false,
+	Equatable:            true,
 	ExternallyReturnable: true,
 	Importable:           false,
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -9645,6 +9645,7 @@ func TestInterpretVoidReturn(t *testing.T) {
 		arrayVal,
 	)
 }
+
 func TestInterpretCopyOnReturn(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -9572,6 +9572,50 @@ func TestInterpretInternalAssignment(t *testing.T) {
 	)
 }
 
+func TestInterpretVoidReturn(t *testing.T) {
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+		// implicit void return
+		fun emptyFunction() {
+			return
+		}
+
+		// explicit void return
+		fun alsoEmptyFunction(): Void {
+			return ()
+		}
+
+		fun test(): [Void] {
+			return [ 
+				(),
+				(fun(){})(),
+			    emptyFunction(),
+				alsoEmptyFunction() 
+			]
+		}
+	`)
+
+	value, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	arrayVal, ok := value.(*interpreter.ArrayValue)
+	require.True(t, ok)
+
+	voidVal := interpreter.VoidValue{}
+
+	AssertValuesEqual(
+		t,
+		inter,
+		interpreter.NewArrayValue(
+			inter, interpreter.ReturnEmptyLocationRange,
+			interpreter.VariableSizedStaticType{Type: interpreter.PrimitiveStaticTypeVoid},
+			common.Address{},
+			voidVal, voidVal, voidVal, voidVal,
+		),
+		arrayVal,
+	)
+}
 func TestInterpretCopyOnReturn(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #2005 

## Description

Currently, the `Void` type is a little inconsistent - it serves as an implicit return value for procedures, but isn't constructible on its own despite being a first-class value. The only way to conjure up a `Void` value is to bind a name to a procedure call:

```cadence
let v: Void = (fun() {})()
```

In the REPL, Void values are currently printed as `()` (the empty tuple, similar to other languages with unit types) but writing `()` on its own results in a parse error. This PR introduces the following changes:

1. Introduce the `()` literal, which corresponds to `Void`. This equivalence (where `Void` refers to the empty tuple) is inspired by Swift, where `Void` is just a [type alias](https://developer.apple.com/documentation/swift/void). If tuples are added to the language later on, `Void` could also become a type alias for the empty tuple, piggybacking off the same parsing mechanisms as n-ary tuples. Using these values is cheap, as all instances of `Void` point to the same singleton object. Though it's outside the scope of this PR, future optimizations could treat unit types as having zero-size and elide their creation altogether. 

2. Make `Void` values equatable, i.e.

```cadence
() == ()
```

since equality is reflexive. This is a non-breaking change, as attempting to equate `Void` values previously resulted in an `InvalidBinaryOperandsError`.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
