### PR TITLE
Improve reference expressions

### DIFF
--- a/docs/language/references.md
+++ b/docs/language/references.md
@@ -7,30 +7,45 @@ A reference can be used to access fields and call functions on the referenced ob
 
 References are **copied**, i.e. they are value types.
 
-References are created by using the `&` operator, followed by the object,
-the `as` keyword, and the type through which they should be accessed.
-The given type must be a supertype of the referenced object's type.
-
 References have the type `&T`, where `T` is the type of the referenced object.
+
+References are created using the `&` operator.
+The reference type must be explicitly provided,
+for example through a type annotation on a variable declaration,
+or a type assertion using the `as` operator.
 
 ```cadence
 let hello = "Hello"
 
-// Create a reference to the "Hello" string, typed as a `String`
+// Create a reference to the `String` `hello`.
+// Provide the reference type `&String` using a type assertion
 //
-let helloRef: &String = &hello as &String
+let helloRef = &hello as &String
 
 helloRef.length // is `5`
 
+// Create another reference to the `String` `hello`.
+// Provide the reference type `&String` using a type annotation instead
+//
+let alsoHelloRef: &String = &hello
+
+// Invalid: Cannot create a reference without an explicit type
+//
+let unknownRef = &hello
+```
+
+The reference type must be a supertype of the referenced object's type.
+
+```cadence
 // Invalid: Cannot create a reference to `hello`
 // typed as `&Int`, as it has type `String`
 //
-let intRef: &Int = &hello as &Int
+let intRef = &hello as &Int
 ```
 
-If you attempt to reference an optional value, you will receive an optional reference.
-If the referenced value is nil, the reference itself will be nil. If the referenced value
-exists, then forcing the optional reference will yield a reference to that value:
+When creating a reference to an optional value, the result is an optional reference.
+If the referenced value is nil, the resulting reference itself will be nil.
+If the referenced value exists, then forcing the optional reference will yield a reference to that value:
 
 ```cadence
 let nilValue: String? = nil
@@ -98,7 +113,7 @@ Also, authorized references are subtypes of unauthorized references.
 // typed with the restricted type `&{HasCount}`,
 // i.e. some resource that conforms to the `HasCount` interface
 //
-let countRef: &{HasCount} = &counter as &{HasCount}
+let countRef = &counter as &{HasCount}
 
 countRef.count  // is `43`
 
@@ -120,7 +135,7 @@ let counterRef2: &Counter = countRef as? &Counter
 // again with the restricted type `{HasCount}`, i.e. some resource
 // that conforms to the `HasCount` interface
 //
-let authCountRef: auth &{HasCount} = &counter as auth &{HasCount}
+let authCountRef = &counter as auth &{HasCount}
 
 // Conditionally downcast to reference type `&Counter`.
 // This is valid, because the reference `authCountRef` is authorized
@@ -134,5 +149,5 @@ counterRef3.increment()
 counterRef3.count  // is `44`
 ```
 
-References are ephemeral, i.e they cannot be [stored](accounts#account-storage).
+References are ephemeral, i.e. they cannot be [stored](accounts#account-storage).
 Instead, consider [storing a capability and borrowing it](capability-based-access-control) when needed.

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/stretchr/testify/assert"
@@ -816,7 +817,7 @@ func encodeArgs(argValues []cadence.Value) [][]byte {
 		var err error
 		args[i], err = json.Encode(arg)
 		if err != nil {
-			panic(fmt.Errorf("broken test: invalid argument: %w", err))
+			panic(errors.NewUnexpectedError("broken test: invalid argument: %w", err))
 		}
 	}
 	return args

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1739,7 +1739,6 @@ func (*DestroyExpression) precedence() precedence {
 
 type ReferenceExpression struct {
 	Expression Expression
-	Type       Type     `json:"TargetType"`
 	StartPos   Position `json:"-"`
 }
 
@@ -1749,14 +1748,12 @@ var _ Expression = &ReferenceExpression{}
 func NewReferenceExpression(
 	gauge common.MemoryGauge,
 	expression Expression,
-	targetType Type,
 	startPos Position,
 ) *ReferenceExpression {
 	common.UseMemory(gauge, common.ReferenceExpressionMemoryUsage)
 
 	return &ReferenceExpression{
 		Expression: expression,
-		Type:       targetType,
 		StartPos:   startPos,
 	}
 }
@@ -1779,7 +1776,6 @@ func (e *ReferenceExpression) String() string {
 }
 
 var referenceExpressionRefOperatorDoc prettier.Doc = prettier.Text("&")
-var referenceExpressionAsOperatorDoc prettier.Doc = prettier.Text("as")
 
 func (e *ReferenceExpression) Doc() prettier.Doc {
 	doc := parenthesizedExpressionDoc(
@@ -1793,10 +1789,6 @@ func (e *ReferenceExpression) Doc() prettier.Doc {
 			prettier.Group{
 				Doc: doc,
 			},
-			prettier.Line{},
-			referenceExpressionAsOperatorDoc,
-			prettier.Line{},
-			e.Type.Doc(),
 		},
 	}
 }
@@ -1806,7 +1798,7 @@ func (e *ReferenceExpression) StartPosition() Position {
 }
 
 func (e *ReferenceExpression) EndPosition(memoryGauge common.MemoryGauge) Position {
-	return e.Type.EndPosition(memoryGauge)
+	return e.Expression.EndPosition(memoryGauge)
 }
 
 func (e *ReferenceExpression) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4091,12 +4091,6 @@ func TestReferenceExpression_MarshalJSON(t *testing.T) {
 				Pos:        Position{Offset: 1, Line: 2, Column: 3},
 			},
 		},
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "AB",
-				Pos:        Position{Offset: 4, Line: 5, Column: 6},
-			},
-		},
 		StartPos: Position{Offset: 7, Line: 8, Column: 9},
 	}
 
@@ -4117,18 +4111,8 @@ func TestReferenceExpression_MarshalJSON(t *testing.T) {
                "StartPos": {"Offset": 1, "Line": 2, "Column": 3},
                "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
             },
-            "TargetType": {
-               "Type": "NominalType",
-               "Identifier": {
-                   "Identifier": "AB",
-                   "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
-                   "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
-               },
-               "StartPos": {"Offset": 4, "Line": 5, "Column": 6},
-               "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
-            },
             "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
-            "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
+            "EndPos": {"Offset": 6, "Line": 2, "Column": 8}
         }
         `,
 		string(actual),
@@ -4149,14 +4133,6 @@ func TestReferenceExpression_Doc(t *testing.T) {
 				Value:           big.NewInt(42),
 				Base:            10,
 			},
-			Type: &ReferenceType{
-				Authorized: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "Int",
-					},
-				},
-			},
 		}
 
 		assert.Equal(t,
@@ -4165,14 +4141,6 @@ func TestReferenceExpression_Doc(t *testing.T) {
 					prettier.Text("&"),
 					prettier.Group{
 						Doc: prettier.Text("42"),
-					},
-					prettier.Line{},
-					prettier.Text("as"),
-					prettier.Line{},
-					prettier.Concat{
-						prettier.Text("auth "),
-						prettier.Text("&"),
-						prettier.Text("Int"),
 					},
 				},
 			},
@@ -4191,22 +4159,6 @@ func TestReferenceExpression_Doc(t *testing.T) {
 					Value:           big.NewInt(42),
 					Base:            10,
 				},
-				Type: &ReferenceType{
-					Authorized: true,
-					Type: &NominalType{
-						Identifier: Identifier{
-							Identifier: "AnyStruct",
-						},
-					},
-				},
-			},
-			Type: &ReferenceType{
-				Authorized: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "XYZ",
-					},
-				},
 			},
 		}
 
@@ -4221,24 +4173,8 @@ func TestReferenceExpression_Doc(t *testing.T) {
 								prettier.Group{
 									Doc: prettier.Text("42"),
 								},
-								prettier.Line{},
-								prettier.Text("as"),
-								prettier.Line{},
-								prettier.Concat{
-									prettier.Text("auth "),
-									prettier.Text("&"),
-									prettier.Text("AnyStruct"),
-								},
 							},
 						},
-					},
-					prettier.Line{},
-					prettier.Text("as"),
-					prettier.Line{},
-					prettier.Concat{
-						prettier.Text("auth "),
-						prettier.Text("&"),
-						prettier.Text("XYZ"),
 					},
 				},
 			},
@@ -4261,14 +4197,6 @@ func TestReferenceExpression_Doc(t *testing.T) {
 				Right: &IdentifierExpression{
 					Identifier: Identifier{
 						Identifier: "bar",
-					},
-				},
-			},
-			Type: &ReferenceType{
-				Authorized: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "Int",
 					},
 				},
 			},
@@ -4304,14 +4232,6 @@ func TestReferenceExpression_Doc(t *testing.T) {
 							},
 						},
 					},
-					prettier.Line{},
-					prettier.Text("as"),
-					prettier.Line{},
-					prettier.Concat{
-						prettier.Text("auth "),
-						prettier.Text("&"),
-						prettier.Text("Int"),
-					},
 				},
 			},
 			expr.Doc(),
@@ -4333,18 +4253,10 @@ func TestReferenceExpression_String(t *testing.T) {
 				Value:           big.NewInt(42),
 				Base:            10,
 			},
-			Type: &ReferenceType{
-				Authorized: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "Int",
-					},
-				},
-			},
 		}
 
 		assert.Equal(t,
-			"&42 as auth &Int",
+			"&42",
 			expr.String(),
 		)
 	})
@@ -4360,27 +4272,11 @@ func TestReferenceExpression_String(t *testing.T) {
 					Value:           big.NewInt(42),
 					Base:            10,
 				},
-				Type: &ReferenceType{
-					Authorized: true,
-					Type: &NominalType{
-						Identifier: Identifier{
-							Identifier: "AnyStruct",
-						},
-					},
-				},
-			},
-			Type: &ReferenceType{
-				Authorized: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "XYZ",
-					},
-				},
 			},
 		}
 
 		assert.Equal(t,
-			"&&42 as auth &AnyStruct as auth &XYZ",
+			"&&42",
 			expr.String(),
 		)
 	})
@@ -4403,18 +4299,10 @@ func TestReferenceExpression_String(t *testing.T) {
 					},
 				},
 			},
-			Type: &ReferenceType{
-				Authorized: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "Int",
-					},
-				},
-			},
 		}
 
 		assert.Equal(t,
-			"&(foo - bar) as auth &Int",
+			"&(foo - bar)",
 			expr.String(),
 		)
 	})

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -30,9 +30,18 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-var InvalidLiteralError = parser.NewUnpositionedSyntaxError("invalid literal")
-var UnsupportedLiteralError = parser.NewUnpositionedSyntaxError("unsupported literal")
-var LiteralExpressionTypeError = parser.NewUnpositionedSyntaxError("input is not a literal")
+var InvalidLiteralError = parser.NewSyntaxError(
+	ast.Position{Line: 1},
+	"invalid literal",
+)
+var UnsupportedLiteralError = parser.NewSyntaxError(
+	ast.Position{Line: 1},
+	"unsupported literal",
+)
+var LiteralExpressionTypeError = parser.NewSyntaxError(
+	ast.Position{Line: 1},
+	"input is not a literal",
+)
 
 // ParseLiteral parses a single literal string, that should have the given type.
 //
@@ -83,7 +92,8 @@ func ParseLiteralArgumentList(
 	parameterCount := len(parameterTypes)
 
 	if argumentCount != parameterCount {
-		return nil, parser.NewUnpositionedSyntaxError(
+		return nil, parser.NewSyntaxError(
+			ast.Position{Line: 1},
 			"invalid number of arguments: got %d, expected %d",
 			argumentCount,
 			parameterCount,
@@ -96,7 +106,8 @@ func ParseLiteralArgumentList(
 		parameterType := parameterTypes[i]
 		value, err := LiteralValue(inter, argument.Expression, parameterType)
 		if err != nil {
-			return nil, parser.NewUnpositionedSyntaxError(
+			return nil, parser.NewSyntaxError(
+				ast.Position{Line: 1},
 				"invalid argument at index %d: %v", i, err,
 			)
 		}
@@ -146,7 +157,8 @@ func pathLiteralValue(memoryGauge common.MemoryGauge, expression ast.Expression,
 	}
 
 	if !sema.IsSubType(pathType, ty) {
-		return nil, parser.NewUnpositionedSyntaxError(
+		return nil, parser.NewSyntaxError(
+			ast.Position{Line: 1},
 			"path literal type %s is not subtype of requested path type %s",
 			pathType, ty,
 		)

--- a/runtime/parser/errors.go
+++ b/runtime/parser/errors.go
@@ -72,12 +72,6 @@ func NewSyntaxError(pos ast.Position, message string, params ...any) *SyntaxErro
 	}
 }
 
-func NewUnpositionedSyntaxError(message string, params ...any) *SyntaxError {
-	return &SyntaxError{
-		Message: fmt.Sprintf(message, params...),
-	}
-}
-
 var _ ParseError = &SyntaxError{}
 var _ errors.UserError = &SyntaxError{}
 

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -19,7 +19,6 @@
 package parser
 
 import (
-	"fmt"
 	"math/big"
 	"strings"
 	"unicode/utf8"
@@ -199,7 +198,7 @@ func defineExpr(def any) {
 func setExprNullDenotation(tokenType lexer.TokenType, nullDenotation exprNullDenotationFunc) {
 	current := exprNullDenotations[tokenType]
 	if current != nil {
-		panic(fmt.Errorf(
+		panic(errors.NewUnexpectedError(
 			"expression null denotation for token %s already exists",
 			tokenType,
 		))
@@ -226,7 +225,7 @@ func setExprIdentifierLeftBindingPower(keyword string, power int) {
 func setExprLeftDenotation(tokenType lexer.TokenType, leftDenotation exprLeftDenotationFunc) {
 	current := exprLeftDenotations[tokenType]
 	if current != nil {
-		panic(fmt.Errorf(
+		panic(errors.NewUnexpectedError(
 			"expression left denotation for token %s already exists",
 			tokenType,
 		))
@@ -238,7 +237,7 @@ func setExprLeftDenotation(tokenType lexer.TokenType, leftDenotation exprLeftDen
 func setExprMetaLeftDenotation(tokenType lexer.TokenType, metaLeftDenotation exprMetaLeftDenotationFunc) {
 	current := exprMetaLeftDenotations[tokenType]
 	if current != nil {
-		panic(fmt.Errorf(
+		panic(errors.NewUnexpectedError(
 			"expression meta left denotation for token %s already exists",
 			tokenType,
 		))

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -19,6 +19,7 @@
 package parser
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 	"unicode/utf8"
@@ -198,7 +199,7 @@ func defineExpr(def any) {
 func setExprNullDenotation(tokenType lexer.TokenType, nullDenotation exprNullDenotationFunc) {
 	current := exprNullDenotations[tokenType]
 	if current != nil {
-		panic(NewUnpositionedSyntaxError(
+		panic(fmt.Errorf(
 			"expression null denotation for token %s already exists",
 			tokenType,
 		))
@@ -225,7 +226,7 @@ func setExprIdentifierLeftBindingPower(keyword string, power int) {
 func setExprLeftDenotation(tokenType lexer.TokenType, leftDenotation exprLeftDenotationFunc) {
 	current := exprLeftDenotations[tokenType]
 	if current != nil {
-		panic(NewUnpositionedSyntaxError(
+		panic(fmt.Errorf(
 			"expression left denotation for token %s already exists",
 			tokenType,
 		))
@@ -237,7 +238,7 @@ func setExprLeftDenotation(tokenType lexer.TokenType, leftDenotation exprLeftDen
 func setExprMetaLeftDenotation(tokenType lexer.TokenType, metaLeftDenotation exprMetaLeftDenotationFunc) {
 	current := exprMetaLeftDenotations[tokenType]
 	if current != nil {
-		panic(NewUnpositionedSyntaxError(
+		panic(fmt.Errorf(
 			"expression meta left denotation for token %s already exists",
 			tokenType,
 		))
@@ -540,7 +541,7 @@ func init() {
 	defineIdentifierExpression()
 
 	setExprNullDenotation(lexer.TokenEOF, func(parser *parser, token lexer.Token) (ast.Expression, error) {
-		return nil, NewUnpositionedSyntaxError("expected expression")
+		return nil, NewSyntaxError(token.StartPos, "expected expression")
 	})
 }
 

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -720,7 +720,6 @@ func defineLessThanOrTypeArgumentsExpression() {
 // because that would introduce a parsing problem for function calls/invocations
 // which have a type argument, where the type argument is a type instantiation,
 // for example, `f<T<U>>()`.
-//
 func defineGreaterThanOrBitwiseRightShiftExpression() {
 
 	setExprMetaLeftDenotation(
@@ -966,8 +965,7 @@ func parseCreateExpressionRemainder(p *parser, token lexer.Token) (*ast.CreateEx
 
 // Invocation Expression Grammar:
 //
-//     invocation : '(' ( argument ( ',' argument )* )? ')'
-//
+//	invocation : '(' ( argument ( ',' argument )* )? ')'
 func defineInvocationExpression() {
 	setExprLeftBindingPower(lexer.TokenParenOpen, exprLeftBindingPowerAccess)
 
@@ -1049,8 +1047,7 @@ func parseArgumentListRemainder(p *parser) (arguments []*ast.Argument, endPos as
 
 // parseArgument parses an argument in an invocation.
 //
-//     argument : (identifier ':' )? expression
-//
+//	argument : (identifier ':' )? expression
 func parseArgument(p *parser) (*ast.Argument, error) {
 	var label string
 	var labelStartPos, labelEndPos ast.Position
@@ -1295,30 +1292,17 @@ func definePathExpression() {
 }
 
 func defineReferenceExpression() {
-	setExprNullDenotation(
-		lexer.TokenAmpersand,
-		func(p *parser, token lexer.Token) (ast.Expression, error) {
-			p.skipSpaceAndComments(true)
-			expression, err := parseExpression(p, exprLeftBindingPowerCasting-exprBindingPowerGap)
-			if err != nil {
-				return nil, err
-			}
-
-			castingExpression, ok := expression.(*ast.CastingExpression)
-			if !ok {
-				return nil, p.syntaxError("expected casting expression")
-			}
-
-			p.skipSpaceAndComments(true)
-
+	defineExpr(prefixExpr{
+		tokenType:    lexer.TokenAmpersand,
+		bindingPower: exprLeftBindingPowerUnaryPrefix,
+		nullDenotation: func(p *parser, right ast.Expression, tokenRange ast.Range) (ast.Expression, error) {
 			return ast.NewReferenceExpression(
 				p.memoryGauge,
-				castingExpression.Expression,
-				castingExpression.TypeAnnotation.Type,
-				token.StartPos,
+				right,
+				tokenRange.StartPos,
 			), nil
 		},
-	)
+	})
 }
 
 func defineMemberExpression() {
@@ -1411,7 +1395,6 @@ func exprLeftDenotationAllowsWhitespaceAfterToken(tokenType lexer.TokenType) boo
 
 // parseExpression uses "Top-Down operator precedence parsing" (TDOP) technique to
 // parse expressions.
-//
 func parseExpression(p *parser, rightBindingPower int) (ast.Expression, error) {
 
 	if p.expressionDepth == expressionDepthLimit {
@@ -1485,7 +1468,6 @@ func applyExprMetaLeftDenotation(
 
 // defaultExprMetaLeftDenotation is the default expression left denotation, which applies
 // if the right binding power is less than the left binding power of the current token
-//
 func defaultExprMetaLeftDenotation(
 	p *parser,
 	rightBindingPower int,
@@ -1551,7 +1533,6 @@ func applyExprLeftDenotation(p *parser, token lexer.Token, left ast.Expression) 
 }
 
 // parseStringLiteral parses a whole string literal, including start and end quotes
-//
 func parseStringLiteral(p *parser, literal string) (result string) {
 	length := len(literal)
 	if length == 0 {
@@ -1590,7 +1571,6 @@ func parseStringLiteral(p *parser, literal string) (result string) {
 }
 
 // parseStringLiteralContent parses the string literalExpr contents, excluding start and end quotes
-//
 func parseStringLiteralContent(p *parser, s string) (result string) {
 
 	var builder strings.Builder

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -1966,28 +1966,6 @@ func TestParseReference(t *testing.T) {
 			result,
 		)
 	})
-
-	t.Run("invalid: optional referenced value", func(t *testing.T) {
-
-		t.Parallel()
-
-		const code = `&x[y]? as &Z?`
-
-		_, errs := ParseExpression(code, nil)
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "expected casting expression",
-					Pos: ast.Position{
-						Offset: 5,
-						Line:   1,
-						Column: 5,
-					},
-				},
-			},
-			errs,
-		)
-	})
 }
 
 func TestParseNilCoelesceReference(t *testing.T) {

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -1950,7 +1950,7 @@ func TestParseReference(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseExpression("& t as T", nil)
+		result, errs := ParseExpression("& t", nil)
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
@@ -1961,37 +1961,9 @@ func TestParseReference(t *testing.T) {
 						Pos:        ast.Position{Line: 1, Column: 2, Offset: 2},
 					},
 				},
-				Type: &ast.NominalType{
-					Identifier: ast.Identifier{
-						Identifier: "T",
-						Pos:        ast.Position{Line: 1, Column: 7, Offset: 7},
-					},
-				},
 				StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 			},
 			result,
-		)
-	})
-
-	t.Run("invalid: missing casting expression", func(t *testing.T) {
-
-		t.Parallel()
-
-		const code = `&y[z]`
-
-		_, errs := ParseExpression(code, nil)
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "expected casting expression",
-					Pos: ast.Position{
-						Offset: 5,
-						Line:   1,
-						Column: 5,
-					},
-				},
-			},
-			errs,
 		)
 	})
 
@@ -2030,75 +2002,85 @@ func TestParseNilCoelesceReference(t *testing.T) {
 	utils.AssertEqualWithDiff(t,
 		&ast.BinaryExpression{
 			Operation: ast.OperationNilCoalesce,
-			Left: &ast.ReferenceExpression{
-				Expression: &ast.IndexExpression{
-					TargetExpression: &ast.IdentifierExpression{
-						Identifier: ast.Identifier{
-							Identifier: "xs",
-							Pos: ast.Position{
-								Offset: 12,
-								Line:   2,
-								Column: 11,
-							},
-						},
-					},
-					IndexingExpression: &ast.StringExpression{
-						Value: "a",
-						Range: ast.Range{
-							StartPos: ast.Position{
-								Offset: 15,
-								Line:   2,
-								Column: 14,
-							},
-							EndPos: ast.Position{
-								Offset: 17,
-								Line:   2,
-								Column: 16,
-							},
-						},
-					},
-					Range: ast.Range{
-						StartPos: ast.Position{
-							Offset: 14,
-							Line:   2,
-							Column: 13,
-						},
-						EndPos: ast.Position{
-							Offset: 18,
-							Line:   2,
-							Column: 17,
-						},
-					},
-				},
-				Type: &ast.OptionalType{
-					Type: &ast.ReferenceType{
-						Authorized: false,
-						Type: &ast.NominalType{
+			Left: &ast.CastingExpression{
+				Expression: &ast.ReferenceExpression{
+					Expression: &ast.IndexExpression{
+						TargetExpression: &ast.IdentifierExpression{
 							Identifier: ast.Identifier{
-								Identifier: "Int",
+								Identifier: "xs",
 								Pos: ast.Position{
-									Offset: 24,
+									Offset: 12,
 									Line:   2,
-									Column: 23,
+									Column: 11,
 								},
 							},
 						},
-						StartPos: ast.Position{
-							Offset: 23,
-							Line:   2,
-							Column: 22,
+						IndexingExpression: &ast.StringExpression{
+							Value: "a",
+							Range: ast.Range{
+								StartPos: ast.Position{
+									Offset: 15,
+									Line:   2,
+									Column: 14,
+								},
+								EndPos: ast.Position{
+									Offset: 17,
+									Line:   2,
+									Column: 16,
+								},
+							},
+						},
+						Range: ast.Range{
+							StartPos: ast.Position{
+								Offset: 14,
+								Line:   2,
+								Column: 13,
+							},
+							EndPos: ast.Position{
+								Offset: 18,
+								Line:   2,
+								Column: 17,
+							},
 						},
 					},
-					EndPos: ast.Position{
-						Offset: 27,
+					StartPos: ast.Position{
+						Offset: 11,
 						Line:   2,
-						Column: 26,
+						Column: 10,
 					},
 				},
-				StartPos: ast.Position{
-					Offset: 11,
-					Line:   2,
-					Column: 10,
+				Operation: ast.OperationCast,
+				TypeAnnotation: &ast.TypeAnnotation{
+					Type: &ast.OptionalType{
+						Type: &ast.ReferenceType{
+							Authorized: false,
+							Type: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "Int",
+									Pos: ast.Position{
+										Offset: 24,
+										Line:   2,
+										Column: 23,
+									},
+								},
+							},
+							StartPos: ast.Position{
+								Offset: 23,
+								Line:   2,
+								Column: 22,
+							},
+						},
+						EndPos: ast.Position{
+							Offset: 27,
+							Line:   2,
+							Column: 26,
+						},
+					},
+					StartPos: ast.Position{
+						Offset: 23,
+						Line:   2,
+						Column: 22,
+					},
 				},
 			},
 			Right: &ast.IntegerExpression{
@@ -5758,57 +5740,67 @@ func TestParseReferenceInVariableDeclaration(t *testing.T) {
 	result, errs := ParseProgram(code, nil)
 	require.Empty(t, errs)
 
+	expected := &ast.VariableDeclaration{
+		IsConstant: true,
+		Identifier: ast.Identifier{
+			Identifier: "x",
+			Pos:        ast.Position{Offset: 12, Line: 2, Column: 11},
+		},
+		Value: &ast.CastingExpression{
+			Operation: ast.OperationCast,
+			Expression: &ast.ReferenceExpression{
+				Expression: &ast.IndexExpression{
+					TargetExpression: &ast.MemberExpression{
+						Expression: &ast.IdentifierExpression{
+							Identifier: ast.Identifier{
+								Identifier: "account",
+								Pos:        ast.Position{Offset: 17, Line: 2, Column: 16},
+							},
+						},
+						AccessPos: ast.Position{Offset: 24, Line: 2, Column: 23},
+						Identifier: ast.Identifier{
+							Identifier: "storage",
+							Pos:        ast.Position{Offset: 25, Line: 2, Column: 24},
+						},
+					},
+					IndexingExpression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "R",
+							Pos:        ast.Position{Offset: 33, Line: 2, Column: 32},
+						},
+					},
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 32, Line: 2, Column: 31},
+						EndPos:   ast.Position{Offset: 34, Line: 2, Column: 33},
+					},
+				},
+				StartPos: ast.Position{Offset: 16, Line: 2, Column: 15},
+			},
+			TypeAnnotation: &ast.TypeAnnotation{
+				Type: &ast.ReferenceType{
+					Type: &ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: "R",
+							Pos:        ast.Position{Offset: 40, Line: 2, Column: 39},
+						},
+					},
+					StartPos: ast.Position{Offset: 39, Line: 2, Column: 38},
+				},
+				StartPos: ast.Position{Offset: 39, Line: 2, Column: 38},
+			},
+		},
+		Transfer: &ast.Transfer{
+			Operation: ast.TransferOperationCopy,
+			Pos:       ast.Position{Offset: 14, Line: 2, Column: 13},
+		},
+		StartPos: ast.Position{Offset: 8, Line: 2, Column: 7},
+	}
+
+	expected.Value.(*ast.CastingExpression).ParentVariableDeclaration = expected
+
 	utils.AssertEqualWithDiff(t,
 		[]ast.Declaration{
-			&ast.VariableDeclaration{
-				IsConstant: true,
-				Identifier: ast.Identifier{
-					Identifier: "x",
-					Pos:        ast.Position{Offset: 12, Line: 2, Column: 11},
-				},
-				Value: &ast.ReferenceExpression{
-					Expression: &ast.IndexExpression{
-						TargetExpression: &ast.MemberExpression{
-							Expression: &ast.IdentifierExpression{
-								Identifier: ast.Identifier{
-									Identifier: "account",
-									Pos:        ast.Position{Offset: 17, Line: 2, Column: 16},
-								},
-							},
-							AccessPos: ast.Position{Offset: 24, Line: 2, Column: 23},
-							Identifier: ast.Identifier{
-								Identifier: "storage",
-								Pos:        ast.Position{Offset: 25, Line: 2, Column: 24},
-							},
-						},
-						IndexingExpression: &ast.IdentifierExpression{
-							Identifier: ast.Identifier{
-								Identifier: "R",
-								Pos:        ast.Position{Offset: 33, Line: 2, Column: 32},
-							},
-						},
-						Range: ast.Range{
-							StartPos: ast.Position{Offset: 32, Line: 2, Column: 31},
-							EndPos:   ast.Position{Offset: 34, Line: 2, Column: 33},
-						},
-					},
-					Type: &ast.ReferenceType{
-						Type: &ast.NominalType{
-							Identifier: ast.Identifier{
-								Identifier: "R",
-								Pos:        ast.Position{Offset: 40, Line: 2, Column: 39},
-							},
-						},
-						StartPos: ast.Position{Offset: 39, Line: 2, Column: 38},
-					},
-					StartPos: ast.Position{Offset: 16, Line: 2, Column: 15},
-				},
-				Transfer: &ast.Transfer{
-					Operation: ast.TransferOperationCopy,
-					Pos:       ast.Position{Offset: 14, Line: 2, Column: 13},
-				},
-				StartPos: ast.Position{Offset: 8, Line: 2, Column: 7},
-			},
+			expected,
 		},
 		result.Declarations(),
 	)

--- a/runtime/parser/statement_test.go
+++ b/runtime/parser/statement_test.go
@@ -52,6 +52,7 @@ func TestParseReplInput(t *testing.T) {
 	assert.IsType(t, &ast.VariableDeclaration{}, actual[1])
 	assert.IsType(t, &ast.ExpressionStatement{}, actual[2])
 }
+
 func TestParseReturnStatement(t *testing.T) {
 
 	t.Parallel()
@@ -2530,5 +2531,81 @@ func TestParseSwapStatementInFunctionDeclaration(t *testing.T) {
 			},
 		},
 		result.Declarations(),
+	)
+}
+
+func TestParseReferenceExpressionStatement(t *testing.T) {
+
+	t.Parallel()
+
+	result, errs := ParseStatements(
+		`
+           let x = &1 as &Int
+           (x!)
+	     `,
+		nil,
+	)
+	require.Empty(t, errs)
+
+	castingExpression := &ast.CastingExpression{
+		Expression: &ast.ReferenceExpression{
+			Expression: &ast.IntegerExpression{
+				PositiveLiteral: "1",
+				Value:           big.NewInt(1),
+				Base:            10,
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
+					EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+				},
+			},
+			StartPos: ast.Position{Offset: 17, Line: 2, Column: 16},
+		},
+		Operation: ast.OperationCast,
+		TypeAnnotation: &ast.TypeAnnotation{
+			Type: &ast.ReferenceType{
+				Type: &ast.NominalType{
+					Identifier: ast.Identifier{
+						Identifier: "Int",
+						Pos:        ast.Position{Offset: 24, Line: 2, Column: 23},
+					},
+				},
+				StartPos: ast.Position{Offset: 23, Line: 2, Column: 22},
+			},
+			StartPos: ast.Position{Offset: 23, Line: 2, Column: 22},
+		},
+	}
+
+	expectedVariableDeclaration := &ast.VariableDeclaration{
+		IsConstant: true,
+		Identifier: ast.Identifier{
+			Identifier: "x",
+			Pos:        ast.Position{Line: 2, Column: 12, Offset: 13},
+		},
+		StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},
+		Value:    castingExpression,
+		Transfer: &ast.Transfer{
+			Operation: ast.TransferOperationCopy,
+			Pos:       ast.Position{Offset: 15, Line: 2, Column: 14},
+		},
+	}
+
+	castingExpression.ParentVariableDeclaration = expectedVariableDeclaration
+
+	utils.AssertEqualWithDiff(t,
+		[]ast.Statement{
+			expectedVariableDeclaration,
+			&ast.ExpressionStatement{
+				Expression: &ast.ForceExpression{
+					Expression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "x",
+							Pos:        ast.Position{Offset: 40, Line: 3, Column: 12},
+						},
+					},
+					EndPos: ast.Position{Offset: 41, Line: 3, Column: 13},
+				},
+			},
+		},
+		result,
 	)
 }

--- a/runtime/parser/statement_test.go
+++ b/runtime/parser/statement_test.go
@@ -2540,9 +2540,9 @@ func TestParseReferenceExpressionStatement(t *testing.T) {
 
 	result, errs := ParseStatements(
 		`
-           let x = &1 as &Int
-           (x!)
-	     `,
+          let x = &1 as &Int
+          (x!)
+	    `,
 		nil,
 	)
 	require.Empty(t, errs)
@@ -2554,11 +2554,11 @@ func TestParseReferenceExpressionStatement(t *testing.T) {
 				Value:           big.NewInt(1),
 				Base:            10,
 				Range: ast.Range{
-					StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
-					EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+					StartPos: ast.Position{Offset: 20, Line: 2, Column: 19},
+					EndPos:   ast.Position{Offset: 20, Line: 2, Column: 19},
 				},
 			},
-			StartPos: ast.Position{Offset: 17, Line: 2, Column: 16},
+			StartPos: ast.Position{Offset: 19, Line: 2, Column: 18},
 		},
 		Operation: ast.OperationCast,
 		TypeAnnotation: &ast.TypeAnnotation{
@@ -2566,12 +2566,12 @@ func TestParseReferenceExpressionStatement(t *testing.T) {
 				Type: &ast.NominalType{
 					Identifier: ast.Identifier{
 						Identifier: "Int",
-						Pos:        ast.Position{Offset: 24, Line: 2, Column: 23},
+						Pos:        ast.Position{Offset: 26, Line: 2, Column: 25},
 					},
 				},
-				StartPos: ast.Position{Offset: 23, Line: 2, Column: 22},
+				StartPos: ast.Position{Offset: 25, Line: 2, Column: 24},
 			},
-			StartPos: ast.Position{Offset: 23, Line: 2, Column: 22},
+			StartPos: ast.Position{Offset: 25, Line: 2, Column: 24},
 		},
 	}
 
@@ -2579,13 +2579,13 @@ func TestParseReferenceExpressionStatement(t *testing.T) {
 		IsConstant: true,
 		Identifier: ast.Identifier{
 			Identifier: "x",
-			Pos:        ast.Position{Line: 2, Column: 12, Offset: 13},
+			Pos:        ast.Position{Line: 2, Column: 14, Offset: 15},
 		},
-		StartPos: ast.Position{Offset: 9, Line: 2, Column: 8},
+		StartPos: ast.Position{Offset: 11, Line: 2, Column: 10},
 		Value:    castingExpression,
 		Transfer: &ast.Transfer{
 			Operation: ast.TransferOperationCopy,
-			Pos:       ast.Position{Offset: 15, Line: 2, Column: 14},
+			Pos:       ast.Position{Offset: 17, Line: 2, Column: 16},
 		},
 	}
 
@@ -2599,10 +2599,10 @@ func TestParseReferenceExpressionStatement(t *testing.T) {
 					Expression: &ast.IdentifierExpression{
 						Identifier: ast.Identifier{
 							Identifier: "x",
-							Pos:        ast.Position{Offset: 40, Line: 3, Column: 12},
+							Pos:        ast.Position{Offset: 41, Line: 3, Column: 11},
 						},
 					},
-					EndPos: ast.Position{Offset: 41, Line: 3, Column: 13},
+					EndPos: ast.Position{Offset: 42, Line: 3, Column: 12},
 				},
 			},
 		},

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -19,6 +19,8 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser/lexer"
@@ -53,7 +55,7 @@ var typeMetaLeftDenotations [lexer.TokenMax]typeMetaLeftDenotationFunc
 func setTypeNullDenotation(tokenType lexer.TokenType, nullDenotation typeNullDenotationFunc) {
 	current := typeNullDenotations[tokenType]
 	if current != nil {
-		panic(NewUnpositionedSyntaxError(
+		panic(fmt.Errorf(
 			"type null denotation for token %s already exists",
 			tokenType,
 		))
@@ -72,7 +74,7 @@ func setTypeLeftBindingPower(tokenType lexer.TokenType, power int) {
 func setTypeLeftDenotation(tokenType lexer.TokenType, leftDenotation typeLeftDenotationFunc) {
 	current := typeLeftDenotations[tokenType]
 	if current != nil {
-		panic(NewUnpositionedSyntaxError(
+		panic(fmt.Errorf(
 			"type left denotation for token %s already exists",
 			tokenType,
 		))
@@ -83,7 +85,7 @@ func setTypeLeftDenotation(tokenType lexer.TokenType, leftDenotation typeLeftDen
 func setTypeMetaLeftDenotation(tokenType lexer.TokenType, metaLeftDenotation typeMetaLeftDenotationFunc) {
 	current := typeMetaLeftDenotations[tokenType]
 	if current != nil {
-		panic(NewUnpositionedSyntaxError(
+		panic(fmt.Errorf(
 			"type meta left denotation for token %s already exists",
 			tokenType,
 		))

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -19,8 +19,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/parser/lexer"
@@ -55,7 +53,7 @@ var typeMetaLeftDenotations [lexer.TokenMax]typeMetaLeftDenotationFunc
 func setTypeNullDenotation(tokenType lexer.TokenType, nullDenotation typeNullDenotationFunc) {
 	current := typeNullDenotations[tokenType]
 	if current != nil {
-		panic(fmt.Errorf(
+		panic(errors.NewUnexpectedError(
 			"type null denotation for token %s already exists",
 			tokenType,
 		))
@@ -74,7 +72,7 @@ func setTypeLeftBindingPower(tokenType lexer.TokenType, power int) {
 func setTypeLeftDenotation(tokenType lexer.TokenType, leftDenotation typeLeftDenotationFunc) {
 	current := typeLeftDenotations[tokenType]
 	if current != nil {
-		panic(fmt.Errorf(
+		panic(errors.NewUnexpectedError(
 			"type left denotation for token %s already exists",
 			tokenType,
 		))
@@ -85,7 +83,7 @@ func setTypeLeftDenotation(tokenType lexer.TokenType, leftDenotation typeLeftDen
 func setTypeMetaLeftDenotation(tokenType lexer.TokenType, metaLeftDenotation typeMetaLeftDenotationFunc) {
 	current := typeMetaLeftDenotations[tokenType]
 	if current != nil {
-		panic(fmt.Errorf(
+		panic(errors.NewUnexpectedError(
 			"type meta left denotation for token %s already exists",
 			tokenType,
 		))

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -81,7 +81,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 		if elementType == InvalidType {
 			checker.report(
 				&TypeAnnotationRequiredError{
-					Cause: "cannot infer type from array literal: ",
+					Cause: "cannot infer type from array literal:",
 					Pos:   expression.StartPos,
 				},
 			)

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -73,7 +73,7 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 			valueType == InvalidType {
 			checker.report(
 				&TypeAnnotationRequiredError{
-					Cause: "cannot infer type from dictionary literal: ",
+					Cause: "cannot infer type from dictionary literal:",
 					Pos:   expression.StartPos,
 				},
 			)

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -22,15 +22,21 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 )
 
-// VisitReferenceExpression checks a reference expression `&t as T`,
-// where `t` is the referenced expression, and `T` is the result type.
-//
+// VisitReferenceExpression checks a reference expression
 func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.ReferenceExpression) Type {
 
-	// Check the result type and ensure it is a reference type
+	resultType := checker.expectedType
+	if resultType == nil {
+		checker.report(
+			&TypeAnnotationRequiredError{
+				Cause: "cannot infer type from reference expression:",
+				Pos:   referenceExpression.Expression.StartPosition(),
+			},
+		)
+		return InvalidType
+	}
 
-	resultType := checker.ConvertType(referenceExpression.Type)
-	checker.checkInvalidInterfaceAsType(resultType, referenceExpression.Type)
+	// Check the result type and ensure it is a reference type
 
 	var referenceType *ReferenceType
 	var targetType, returnType Type
@@ -55,7 +61,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 			checker.report(
 				&NonReferenceTypeReferenceError{
 					ActualType: resultType,
-					Range:      ast.NewRangeFromPositioned(checker.memoryGauge, referenceExpression.Type),
+					Range:      ast.NewRangeFromPositioned(checker.memoryGauge, referenceExpression),
 				},
 			)
 		} else {

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -6384,7 +6384,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 			}
 		})
 
-		t.Run("Reference, without type", func(t *testing.T) {
+		t.Run("Reference, with cast", func(t *testing.T) {
 			t.Parallel()
 
 			checker, err := ParseAndCheckWithAny(t, `
@@ -6394,7 +6394,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
+			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
 		})
 
 		t.Run("Reference, with type", func(t *testing.T) {
@@ -6407,7 +6407,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
+			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
 		})
 
 		t.Run("Conditional expr valid", func(t *testing.T) {

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -29,6 +29,117 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
+func TestCheckReference(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("variable declaration type annotation", func(t *testing.T) {
+
+		t.Parallel()
+
+		t.Run("non-auth", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              let x: &Int = &1
+            `)
+
+			require.NoError(t, err)
+
+		})
+
+		t.Run("auth", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              let x: auth &Int = &1
+            `)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("non-reference type", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              let x: Int = &1
+            `)
+
+			errs := ExpectCheckerErrors(t, err, 1)
+
+			assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[0])
+		})
+	})
+
+	t.Run("variable declaration type annotation", func(t *testing.T) {
+
+		t.Run("non-auth", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              let x = &1 as &Int
+            `)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("non-auth", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              let x = &1 as auth &Int
+            `)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("non-reference type", func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t, `
+              let x = &1 as Int
+            `)
+
+			errs := ExpectCheckerErrors(t, err, 1)
+
+			assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[0])
+		})
+	})
+
+	t.Run("invalid non-auth to auth cast", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let x = &1 as &Int as auth &Int
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
+
+	t.Run("missing type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let x = &1
+        `)
+
+		errs := ExpectCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeAnnotationRequiredError{}, errs[0])
+	})
+
+}
+
 func TestCheckReferenceTypeOuter(t *testing.T) {
 
 	t.Parallel()
@@ -1113,10 +1224,12 @@ func TestCheckInvalidReferenceExpressionNonReferenceAnyResource(t *testing.T) {
       let y = &x as AnyResource{}
     `)
 
-	errs := ExpectCheckerErrors(t, err, 2)
+	errs := ExpectCheckerErrors(t, err, 4)
 
-	assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[0])
-	assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
+	assert.IsType(t, &sema.MissingResourceAnnotationError{}, errs[0])
+	assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errs[1])
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[2])
+	assert.IsType(t, &sema.IncorrectTransferOperationError{}, errs[3])
 }
 
 func TestCheckInvalidReferenceExpressionNonReferenceAnyStruct(t *testing.T) {


### PR DESCRIPTION
Re-port of #1661 to Stable Cadence. 
It had been previously accidentally reverted by merging `master` into the Stable Cadence branch

Also:
- Update documentation
- Make parser-initalization errors non-syntax errors: they are implementation errors and not user errors.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
