### PR TITLE
Add language clarifying the type parameter's type in the private and public path iteration functions

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -633,6 +633,8 @@ fun forEachStored(_ function: ((StoragePath, Type): Bool))
 Each of these iterates over every element in the specified domain (public, private, and storage), 
 applying the function argument to each. 
 The first argument of the function is the path of the element, and the second is its runtime type. 
+In the case of the `private` and `public` path iteration functions,
+this is the runtime type of the capability linked at that path. 
 The `Bool` return value determines whether iteration continues; 
 `true` will proceed to the next stored element, 
 while `false` will terminate iteration. 


### PR DESCRIPTION
Closes #2011 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
