### PR TITLE
Make argument names in test-stdlib compatible with stable cadence

### DIFF
--- a/docs/testing-framework.mdx
+++ b/docs/testing-framework.mdx
@@ -173,8 +173,8 @@ pub struct Blockchain {
 
     /// Executes a given transaction and commit the current block.
     ///
-    pub fun executeTransaction(_ transaction: Transaction): TransactionResult {
-        self.addTransaction(transaction)
+    pub fun executeTransaction(_ tx: Transaction): TransactionResult {
+        self.addTransaction(tx)
         let txResult = self.executeNextTransaction()!
         self.commitBlock()
         return txResult
@@ -226,7 +226,7 @@ pub struct interface BlockchainBackend {
 
     pub fun createAccount(): Account
 
-    pub fun addTransaction(_ transaction: Transaction)
+    pub fun addTransaction(_ tx: Transaction)
 
     pub fun executeNextTransaction(): TransactionResult?
 

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -49,8 +49,8 @@ pub contract Test {
 
         /// Executes a given transaction and commit the current block.
         ///
-        pub fun executeTransaction(_ transaction: Transaction): TransactionResult {
-            self.addTransaction(transaction)
+        pub fun executeTransaction(_ tx: Transaction): TransactionResult {
+            self.addTransaction(tx)
             let txResult = self.executeNextTransaction()!
             self.commitBlock()
             return txResult
@@ -224,7 +224,7 @@ pub contract Test {
 
         /// Add a transaction to the current block.
         ///
-        pub fun addTransaction(_ transaction: Transaction)
+        pub fun addTransaction(_ tx: Transaction)
 
         /// Executes the next transaction in the block, if any.
         /// Returns the result of the transaction, or nil if no transaction was scheduled.


### PR DESCRIPTION
## Description

Keywords are not allowed to be used as variable names in Stable cadence. So changing the argument `transaction` to `tx`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
