### PR TITLE
Improve parser function naming, remove dead code

### DIFF
--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -250,7 +250,7 @@ func (p *parser) currentTokenSource() []byte {
 	return p.tokenSource(p.current)
 }
 
-func (p *parser) mustToken(token lexer.Token, tokenType lexer.TokenType, expected string) bool {
+func (p *parser) isToken(token lexer.Token, tokenType lexer.TokenType, expected string) bool {
 	if !token.Is(tokenType) {
 		return false
 	}
@@ -259,10 +259,9 @@ func (p *parser) mustToken(token lexer.Token, tokenType lexer.TokenType, expecte
 	return string(actual) == expected
 }
 
-func (p *parser) mustOneString(tokenType lexer.TokenType, string string) (lexer.Token, error) {
+func (p *parser) mustToken(tokenType lexer.TokenType, string string) (lexer.Token, error) {
 	t := p.current
-	p.tokens.Input()
-	if !p.mustToken(t, tokenType, string) {
+	if !p.isToken(t, tokenType, string) {
 		return lexer.Token{}, p.syntaxError("expected token %s with string value %s", tokenType, string)
 	}
 	p.next()

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -100,7 +100,7 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			[]byte("a b c d"),
 			func(p *parser) (any, error) {
-				_, err := p.mustOneString(lexer.TokenIdentifier, "a")
+				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
 					return nil, err
 				}
@@ -112,7 +112,7 @@ func TestParseBuffering(t *testing.T) {
 
 				p.startBuffering()
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "b")
+				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
 					return nil, err
 				}
@@ -122,7 +122,7 @@ func TestParseBuffering(t *testing.T) {
 					return nil, err
 				}
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "c")
+				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
 					return nil, err
 				}
@@ -134,7 +134,7 @@ func TestParseBuffering(t *testing.T) {
 					return nil, err
 				}
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "d")
+				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
 					return nil, err
 				}
@@ -154,7 +154,7 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			[]byte("a b x d"),
 			func(p *parser) (any, error) {
-				_, err := p.mustOneString(lexer.TokenIdentifier, "a")
+				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
 					return nil, err
 				}
@@ -166,7 +166,7 @@ func TestParseBuffering(t *testing.T) {
 
 				p.startBuffering()
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "b")
+				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
 					return nil, err
 				}
@@ -176,7 +176,7 @@ func TestParseBuffering(t *testing.T) {
 					return nil, err
 				}
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "c")
+				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
 					return nil, err
 				}
@@ -188,7 +188,7 @@ func TestParseBuffering(t *testing.T) {
 					return nil, err
 				}
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "d")
+				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
 					return nil, err
 				}
@@ -216,7 +216,7 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			[]byte("a b c d"),
 			func(p *parser) (any, error) {
-				_, err := p.mustOneString(lexer.TokenIdentifier, "a")
+				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
 					return nil, err
 				}
@@ -227,7 +227,7 @@ func TestParseBuffering(t *testing.T) {
 
 				p.startBuffering()
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "b")
+				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
 					return nil, err
 				}
@@ -235,7 +235,7 @@ func TestParseBuffering(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				_, err = p.mustOneString(lexer.TokenIdentifier, "c")
+				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
 					return nil, err
 				}
@@ -245,7 +245,7 @@ func TestParseBuffering(t *testing.T) {
 					return nil, err
 				}
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "b")
+				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
 					return nil, err
 				}
@@ -253,7 +253,7 @@ func TestParseBuffering(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				_, err = p.mustOneString(lexer.TokenIdentifier, "c")
+				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
 					return nil, err
 				}
@@ -261,7 +261,7 @@ func TestParseBuffering(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				_, err = p.mustOneString(lexer.TokenIdentifier, "d")
+				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
 					return nil, err
 				}
@@ -281,7 +281,7 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			[]byte("a b c d"),
 			func(p *parser) (any, error) {
-				_, err := p.mustOneString(lexer.TokenIdentifier, "a")
+				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
 					return nil, err
 				}
@@ -305,7 +305,7 @@ func TestParseBuffering(t *testing.T) {
 						}
 					}()
 
-					_, bufferingError = p.mustOneString(lexer.TokenIdentifier, "x")
+					_, bufferingError = p.mustToken(lexer.TokenIdentifier, "x")
 					if bufferingError != nil {
 						return
 					}
@@ -313,7 +313,7 @@ func TestParseBuffering(t *testing.T) {
 					if bufferingError != nil {
 						return
 					}
-					_, bufferingError = p.mustOneString(lexer.TokenIdentifier, "c")
+					_, bufferingError = p.mustToken(lexer.TokenIdentifier, "c")
 					if bufferingError != nil {
 						return
 					}
@@ -329,7 +329,7 @@ func TestParseBuffering(t *testing.T) {
 					return nil, err
 				}
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "b")
+				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
 					return nil, err
 				}
@@ -337,7 +337,7 @@ func TestParseBuffering(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				_, err = p.mustOneString(lexer.TokenIdentifier, "c")
+				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
 					return nil, err
 				}
@@ -345,7 +345,7 @@ func TestParseBuffering(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				_, err = p.mustOneString(lexer.TokenIdentifier, "d")
+				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
 					return nil, err
 				}
@@ -365,7 +365,7 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			[]byte("a b c x"),
 			func(p *parser) (any, error) {
-				_, err := p.mustOneString(lexer.TokenIdentifier, "a")
+				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
 					return nil, err
 				}
@@ -388,7 +388,7 @@ func TestParseBuffering(t *testing.T) {
 						}
 					}()
 
-					_, bufferingError = p.mustOneString(lexer.TokenIdentifier, "x")
+					_, bufferingError = p.mustToken(lexer.TokenIdentifier, "x")
 					if bufferingError != nil {
 						return
 					}
@@ -396,7 +396,7 @@ func TestParseBuffering(t *testing.T) {
 					if bufferingError != nil {
 						return
 					}
-					_, bufferingError = p.mustOneString(lexer.TokenIdentifier, "c")
+					_, bufferingError = p.mustToken(lexer.TokenIdentifier, "c")
 					if bufferingError != nil {
 						return
 					}
@@ -412,7 +412,7 @@ func TestParseBuffering(t *testing.T) {
 					return nil, err
 				}
 
-				_, err = p.mustOneString(lexer.TokenIdentifier, "b")
+				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
 					return nil, err
 				}
@@ -420,7 +420,7 @@ func TestParseBuffering(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				_, err = p.mustOneString(lexer.TokenIdentifier, "c")
+				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
 					return nil, err
 				}
@@ -428,7 +428,7 @@ func TestParseBuffering(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				_, err = p.mustOneString(lexer.TokenIdentifier, "d")
+				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
 					return nil, err
 				}
@@ -553,12 +553,12 @@ func TestParseEOF(t *testing.T) {
 	_, errs := Parse(
 		[]byte("a b"),
 		func(p *parser) (any, error) {
-			_, err := p.mustOneString(lexer.TokenIdentifier, "a")
+			_, err := p.mustToken(lexer.TokenIdentifier, "a")
 			if err != nil {
 				return nil, err
 			}
 			p.skipSpaceAndComments(true)
-			_, err = p.mustOneString(lexer.TokenIdentifier, "b")
+			_, err = p.mustToken(lexer.TokenIdentifier, "b")
 			if err != nil {
 				return nil, err
 			}

--- a/runtime/parser/statement.go
+++ b/runtime/parser/statement.go
@@ -293,11 +293,11 @@ func parseIfStatement(p *parser) (*ast.IfStatement, error) {
 		parseNested := false
 
 		p.skipSpaceAndComments(true)
-		if p.mustToken(p.current, lexer.TokenIdentifier, keywordElse) {
+		if p.isToken(p.current, lexer.TokenIdentifier, keywordElse) {
 			p.next()
 
 			p.skipSpaceAndComments(true)
-			if p.mustToken(p.current, lexer.TokenIdentifier, keywordIf) {
+			if p.isToken(p.current, lexer.TokenIdentifier, keywordIf) {
 				parseNested = true
 			} else {
 				elseBlock, err = parseBlock(p)
@@ -378,7 +378,7 @@ func parseForStatement(p *parser) (*ast.ForStatement, error) {
 
 	p.skipSpaceAndComments(true)
 
-	if p.mustToken(p.current, lexer.TokenIdentifier, keywordIn) {
+	if p.isToken(p.current, lexer.TokenIdentifier, keywordIn) {
 		p.reportSyntaxError(
 			"expected identifier, got keyword %q",
 			keywordIn,
@@ -410,7 +410,7 @@ func parseForStatement(p *parser) (*ast.ForStatement, error) {
 		identifier = firstValue
 	}
 
-	if !p.mustToken(p.current, lexer.TokenIdentifier, keywordIn) {
+	if !p.isToken(p.current, lexer.TokenIdentifier, keywordIn) {
 		p.reportSyntaxError(
 			"expected keyword %q, got %s",
 			keywordIn,
@@ -480,7 +480,7 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	p.skipSpaceAndComments(true)
 
 	var preConditions *ast.Conditions
-	if p.mustToken(p.current, lexer.TokenIdentifier, keywordPre) {
+	if p.isToken(p.current, lexer.TokenIdentifier, keywordPre) {
 		p.next()
 		conditions, err := parseConditions(p, ast.ConditionKindPre)
 		if err != nil {
@@ -493,7 +493,7 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	p.skipSpaceAndComments(true)
 
 	var postConditions *ast.Conditions
-	if p.mustToken(p.current, lexer.TokenIdentifier, keywordPost) {
+	if p.isToken(p.current, lexer.TokenIdentifier, keywordPost) {
 		p.next()
 		conditions, err := parseConditions(p, ast.ConditionKindPost)
 		if err != nil {

--- a/runtime/parser/transaction.go
+++ b/runtime/parser/transaction.go
@@ -115,7 +115,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 
 	if execute == nil {
 		p.skipSpaceAndComments(true)
-		if p.mustToken(p.current, lexer.TokenIdentifier, keywordPre) {
+		if p.isToken(p.current, lexer.TokenIdentifier, keywordPre) {
 			// Skip the `pre` keyword
 			p.next()
 			conditions, err := parseConditions(p, ast.ConditionKindPre)


### PR DESCRIPTION
## Description

While resolving conflicts in #2014 I realized the naming can be improved and dead code can be removed.
The `must` prefix is commonly used for functions that panic on failure.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
