### PR TITLE
Improve REPL

### DIFF
--- a/runtime/cmd/execute/repl.go
+++ b/runtime/cmd/execute/repl.go
@@ -58,29 +58,22 @@ func RunREPL() {
 	}
 
 	executor := func(line string) {
-		defer func() {
-			lineNumber++
-		}()
-
 		if code == "" && strings.HasPrefix(line, ".") {
 			handleCommand(line)
 			code = ""
 			return
 		}
 
-		// Prefix the code with empty lines,
-		// so that error messages match current line number
-
-		for i := 1; i < lineNumber; i++ {
-			code = "\n" + code
-		}
-
 		code += line + "\n"
 
-		inputIsComplete := repl.Accept([]byte(code))
-		if !inputIsComplete {
-			lineIsContinuation = true
-			return
+		inputIsComplete, err := repl.Accept([]byte(code))
+		if err == nil {
+			lineNumber++
+
+			if !inputIsComplete {
+				lineIsContinuation = true
+				return
+			}
 		}
 
 		lineIsContinuation = false

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -110,6 +110,26 @@ func (r *REPL) handleCheckerError() error {
 var lineSep = []byte{'\n'}
 
 func (r *REPL) Accept(code []byte) (inputIsComplete bool, err error) {
+
+	// We need two codes:
+	//
+	// 1. The code used for parsing and type checking (`code`).
+	//
+	//    This is only the code that was just entered in the REPL,
+	//    as we do not want to re-check and re-run the whole program already previously entered into the REPL –
+	//    the checker's and interpreter's state are kept, and they already have the previously entered declarations.
+	//
+	//    However, just parsing the entered code would result in an AST with wrong position information,
+	//    the line number would be always 1. To adjust the line information, we prepend the new code with empty lines.
+	//
+	// 2. The code used for error pretty printing (`codes`).
+	//
+	//    We temporarily update the full code of the whole program to include the new code.
+	//    This allows the error pretty printer to properly refer to previous code (instead of empty lines),
+	//    as well as the new code.
+	//    However, if an error occurs, we revert the addition of the new code
+	//    and leave the program code as it was before.
+
 	// Append the new code to the existing code (used for error reporting),
 	// temporarily, so that errors for the new code can be reported
 

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -442,7 +442,7 @@ func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclarati
 	})
 	checker.report(err)
 
-	if checker.PositionInfo != nil {
+	if checker.PositionInfo != nil && variable != nil {
 		checker.recordVariableDeclarationOccurrence(
 			identifier.Identifier,
 			variable,

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -83,7 +83,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 		allowOuterScopeShadowing: false,
 	})
 	checker.report(err)
-	if checker.PositionInfo != nil {
+	if checker.PositionInfo != nil && variable != nil {
 		checker.recordVariableDeclarationOccurrence(identifier, variable)
 	}
 
@@ -99,7 +99,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 			allowOuterScopeShadowing: false,
 		})
 		checker.report(err)
-		if checker.PositionInfo != nil {
+		if checker.PositionInfo != nil && indexVariable != nil {
 			checker.recordVariableDeclarationOccurrence(index, indexVariable)
 		}
 	}

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -244,7 +244,7 @@ func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclarati
 		allowOuterScopeShadowing: false,
 	})
 	checker.report(err)
-	if checker.PositionInfo != nil {
+	if checker.PositionInfo != nil && variable != nil {
 		checker.recordVariableDeclarationOccurrence(
 			identifier.Identifier,
 			variable,

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -193,7 +193,7 @@ func (checker *Checker) visitVariableDeclaration(declaration *ast.VariableDeclar
 	})
 	checker.report(err)
 
-	if checker.PositionInfo != nil {
+	if checker.PositionInfo != nil && variable != nil {
 		checker.recordVariableDeclarationOccurrence(identifier, variable)
 		checker.recordVariableDeclarationRange(declaration, identifier, declarationType)
 	}

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -283,7 +283,7 @@ type variableDeclaration struct {
 	allowOuterScopeShadowing bool
 }
 
-func (a *VariableActivations) declare(declaration variableDeclaration) (variable *Variable, err error) {
+func (a *VariableActivations) declare(declaration variableDeclaration) (*Variable, error) {
 
 	depth := a.Depth()
 
@@ -309,7 +309,7 @@ func (a *VariableActivations) declare(declaration variableDeclaration) (variable
 	// A variable with this name is not yet declared in the current scope,
 	// declare it.
 
-	variable = &Variable{
+	variable := &Variable{
 		Identifier:      declaration.identifier,
 		Access:          declaration.access,
 		DeclarationKind: declaration.kind,

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -298,15 +298,12 @@ func (a *VariableActivations) declare(declaration variableDeclaration) (variable
 			existingVariable.ActivationDepth == depth ||
 			existingVariable.ActivationDepth == 0) {
 
-		err = &RedeclarationError{
+		return nil, &RedeclarationError{
 			Kind:        declaration.kind,
 			Name:        declaration.identifier,
 			Pos:         declaration.pos,
 			PreviousPos: existingVariable.Pos,
 		}
-
-		// NOTE: Don't return if there is an error,
-		// still declare the variable and return it
 	}
 
 	// A variable with this name is not yet declared in the current scope,
@@ -324,7 +321,7 @@ func (a *VariableActivations) declare(declaration variableDeclaration) (variable
 		DocString:       declaration.docString,
 	}
 	a.Set(declaration.identifier, variable)
-	return variable, err
+	return variable, nil
 }
 
 func (a *VariableActivations) DeclareValue(declaration ValueDeclaration) (*Variable, error) {


### PR DESCRIPTION
## Description

As previously reported in #1995, the REPL crashes during error pretty printing.
To fix this problem, we need two codes:
1. The code used for parsing and type checking (`code`). 

    Like before, this should be only the code that was just entered into the REPL, as we do not want to re-check and re-run the whole program already previously entered in the REPL – the checker's and interpreter's state are kept, and they already have the previously entered declarations. 

    However, just parsing the entered code would result in an AST with wrong position information, the line number would be always 1. To adjust the line information, we prepend the new code with empty lines.

2. The code used for error pretty printing (`codes`). 

    We temporarily update the full code of the whole program to include the new code. This allows the error pretty printer to properly refer to previous code (instead of empty lines), as well as the new code.
    However, if an error occurs, we revert the addition of the new code and leave the program code as it was before.

In addition, don't increment the line number if the code was invalid. Basically we properly completely invalid code now.

Also, fix the type checker and do not redeclare variables. The idea here was to improve error messages, by "assuming" a new type for a variable, which would follow what the user "means", and thus reduce follow-up error messages. For example:

```cadence
fun foo(bar: Int): String {
    // ...
    let bar: String = "..."    // previously, we would still re-declare `bar` as `String` (we still report an invalid re-declaration)
    return bar                 // ... so that e.g. we avoid a useless/additional type-mismatch error here
}
```

This is a nice-to-have feature, but also makes it impossible for the REPL to redact incorrect redeclared variables. 
Removing the feature allows the REPL to continue after invalid declarations were entered, but will also slightly decrease error message UX for developers. 
Alternatively we could make the variable declaration a checker option, have it enabled by default, and disable it for the REPL.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
