### PR TITLE
Fix accounts not being returnable from scripts

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -197,6 +197,92 @@ func TestRuntimeAccountKeyConstructor(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot find variable in this scope: `AccountKey`")
 }
 
+func TestRuntimeReturnPublicAccount(t *testing.T) {
+
+	t.Parallel()
+
+	rt := newTestInterpreterRuntime()
+
+	script := []byte(`
+        pub fun main(): PublicAccount {
+			let acc = getAccount(0x02)
+            return acc
+          }
+    `)
+
+	runtimeInterface := &testRuntimeInterface{
+		getAccountBalance: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		getAccountAvailableBalance: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		getStorageUsed: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		getStorageCapacity: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		storage: newTestLedger(nil, nil),
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	_, err := rt.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+}
+
+func TestRuntimeReturnAuthAccount(t *testing.T) {
+
+	t.Parallel()
+
+	rt := newTestInterpreterRuntime()
+
+	script := []byte(`
+        pub fun main(): AuthAccount {
+			let acc = getAuthAccount(0x02)
+            return acc
+          }
+    `)
+
+	runtimeInterface := &testRuntimeInterface{
+		getAccountBalance: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		getAccountAvailableBalance: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		getStorageUsed: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		getStorageCapacity: func(_ common.Address) (uint64, error) {
+			return 0, nil
+		},
+		storage: newTestLedger(nil, nil),
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	_, err := rt.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+}
+
 func TestRuntimeStoreAccountAPITypes(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -194,19 +194,19 @@ var AuthAccountType = func() *CompositeType {
 			AuthAccountStoragePathsType,
 			authAccountTypeStoragePathsFieldDocString,
 		),
-		NewUnmeteredPublicConstantFieldMember(
+		NewUnmeteredPublicFunctionMember(
 			authAccountType,
 			AuthAccountForEachPublicField,
 			AuthAccountForEachPublicFunctionType,
 			authAccountForEachPublicDocString,
 		),
-		NewUnmeteredPublicConstantFieldMember(
+		NewUnmeteredPublicFunctionMember(
 			authAccountType,
 			AuthAccountForEachPrivateField,
 			AuthAccountForEachPrivateFunctionType,
 			authAccountForEachPrivateDocString,
 		),
-		NewUnmeteredPublicConstantFieldMember(
+		NewUnmeteredPublicFunctionMember(
 			authAccountType,
 			AuthAccountForEachStoredField,
 			AuthAccountForEachStoredFunctionType,

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -113,7 +113,7 @@ var PublicAccountType = func() *CompositeType {
 			PublicAccountPathsType,
 			publicAccountTypePathsFieldDocString,
 		),
-		NewUnmeteredPublicConstantFieldMember(
+		NewUnmeteredPublicFunctionMember(
 			publicAccountType,
 			PublicAccountForEachPublicField,
 			PublicAccountForEachPublicFunctionType,


### PR DESCRIPTION
Adding the storage iteration functions to the accounts as field members rather than function members accidentally prevented them from being considered externally returnable. This re-labels these as function members to fix this regression. 
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
