### PR TITLE
Fix composite types documentation

### DIFF
--- a/docs/language/composite-types.mdx
+++ b/docs/language/composite-types.mdx
@@ -481,3 +481,27 @@ let six = value!.setAndReturn(new: 6)
 ### Resources
 
 Resources are explained in detail [in the following page](resources).
+
+## Unbound References / Nulls
+
+There is **no** support for `null`.
+
+## Inheritance and Abstract Types
+
+There is **no** support for inheritance.
+Inheritance is a feature common in other programming languages,
+that allows including the fields and functions of one type in another type.
+
+Instead, follow the "composition over inheritance" principle,
+the idea of composing functionality from multiple individual parts,
+rather than building an inheritance tree.
+
+Furthermore, there is also **no** support for abstract types.
+An abstract type is a feature common in other programming languages,
+that prevents creating values of the type and only
+allows the creation of values of a subtype.
+In addition, abstract types may declare functions,
+but omit the implementation of them
+and instead require subtypes to implement them.
+
+Instead, consider using [interfaces](interfaces).

--- a/docs/language/resources.mdx
+++ b/docs/language/resources.mdx
@@ -606,27 +606,3 @@ Otherwise the field is `nil`.
 The field's value changes when the resource is moved from outside account storage
 into account storage, when it is moved from the storage of one account
 to the storage of another account, and when it is moved out of account storage.
-
-## Unbound References / Nulls
-
-There is **no** support for `null`.
-
-## Inheritance and Abstract Types
-
-There is **no** support for inheritance.
-Inheritance is a feature common in other programming languages,
-that allows including the fields and functions of one type in another type.
-
-Instead, follow the "composition over inheritance" principle,
-the idea of composing functionality from multiple individual parts,
-rather than building an inheritance tree.
-
-Furthermore, there is also **no** support for abstract types.
-An abstract type is a feature common in other programming languages,
-that prevents creating values of the type and only
-allows the creation of values of a subtype.
-In addition, abstract types may declare functions,
-but omit the implementation of them
-and instead require subtypes to implement them.
-
-Instead, consider using [interfaces](interfaces).


### PR DESCRIPTION


## Description

Move the two subsections back to the composite types page after they were accidentally moved to the resources page, after it was split out from the composite types page.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
