### PR TITLE
Catch interpreter panics in REPL

### DIFF
--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -315,9 +315,6 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 				indicatorLength = maxLineLength
 			}
 
-			if indicatorLength >= len(line) {
-				indicatorLength = len(line)
-			}
 
 			p.writeString(" ")
 			for i := 0; i < indicatorLength; i++ {

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -315,7 +315,6 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 				indicatorLength = maxLineLength
 			}
 
-
 			p.writeString(" ")
 			for i := 0; i < indicatorLength; i++ {
 				c := line[i]

--- a/runtime/pretty/print.go
+++ b/runtime/pretty/print.go
@@ -315,6 +315,10 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 				indicatorLength = maxLineLength
 			}
 
+			if indicatorLength >= len(line) {
+				indicatorLength = len(line)
+			}
+
 			p.writeString(" ")
 			for i := 0; i < indicatorLength; i++ {
 				c := line[i]


### PR DESCRIPTION
Closes #2027

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Catches interpreter-thrown panics in the REPL, fixing the long-standing issue of out of bounds accesses or variable declarations completely crashing the program.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
