### PR TITLE
Optimize location range

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -754,7 +754,7 @@ func exportFromScript(t *testing.T, code string) cadence.Value {
 	result, err := inter.Invoke("main")
 	require.NoError(t, err)
 
-	exported, err := runtime.ExportValue(result, inter, interpreter.ReturnEmptyLocationRange)
+	exported, err := runtime.ExportValue(result, inter, interpreter.EmptyLocationRange)
 	require.NoError(t, err)
 
 	return exported

--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -373,7 +373,7 @@ func loadStorageKey(
 
 					if composite, ok := v.(*interpreter.CompositeValue); ok &&
 						composite.Kind == common.CompositeKindResource &&
-						composite.ResourceUUID(inter, interpreter.ReturnEmptyLocationRange) == nil {
+						composite.ResourceUUID(inter, interpreter.EmptyLocationRange) == nil {
 
 						log.Printf(
 							"Failed to get UUID for resource @ 0x%x %s",

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -167,10 +168,9 @@ func (executor *interpreterContractFunctionExecutor) execute() (val cadence.Valu
 			inter,
 			executor.arguments[i],
 			argumentType,
-			func() interpreter.LocationRange {
-				return interpreter.LocationRange{
-					Location: location,
-				}
+			interpreter.LocationRange{
+				Location:    location,
+				HasPosition: ast.EmptyRange,
 			},
 		)
 		if err != nil {
@@ -190,16 +190,15 @@ func (executor *interpreterContractFunctionExecutor) execute() (val cadence.Valu
 		interpreterArguments,
 		executor.argumentTypes,
 		nil,
-		func() interpreter.LocationRange {
-			return interpreter.LocationRange{
-				Location: context.Location,
-			}
+		interpreter.LocationRange{
+			Location:    context.Location,
+			HasPosition: ast.EmptyRange,
 		},
 	)
 
 	contractMember := contractValue.GetMember(
 		inter,
-		invocation.GetLocationRange,
+		invocation.LocationRange,
 		executor.functionName,
 	)
 
@@ -223,7 +222,7 @@ func (executor *interpreterContractFunctionExecutor) execute() (val cadence.Valu
 	}
 
 	var exportedValue cadence.Value
-	exportedValue, err = ExportValue(value, inter, interpreter.ReturnEmptyLocationRange)
+	exportedValue, err = ExportValue(value, inter, interpreter.EmptyLocationRange)
 	if err != nil {
 		return nil, newError(err, location, codesAndPrograms)
 	}
@@ -235,7 +234,7 @@ func (executor *interpreterContractFunctionExecutor) convertArgument(
 	inter *interpreter.Interpreter,
 	argument cadence.Value,
 	argumentType sema.Type,
-	getLocationRange func() interpreter.LocationRange,
+	locationRange interpreter.LocationRange,
 ) (interpreter.Value, error) {
 	environment := executor.environment
 
@@ -257,7 +256,7 @@ func (executor *interpreterContractFunctionExecutor) convertArgument(
 
 	return ImportValue(
 		inter,
-		getLocationRange,
+		locationRange,
 		argument,
 		argumentType,
 	)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -66,7 +66,7 @@ func TestExportValue(t *testing.T) {
 			actual, err := exportValueWithInterpreter(
 				value,
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				seenReferences{},
 			)
 			if tt.expected == nil {
@@ -168,7 +168,7 @@ func TestExportValue(t *testing.T) {
 			valueFactory: func(inter *interpreter.Interpreter) interpreter.Value {
 				return interpreter.NewArrayValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
@@ -185,7 +185,7 @@ func TestExportValue(t *testing.T) {
 			valueFactory: func(inter *interpreter.Interpreter) interpreter.Value {
 				return interpreter.NewArrayValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
@@ -206,7 +206,7 @@ func TestExportValue(t *testing.T) {
 			valueFactory: func(inter *interpreter.Interpreter) interpreter.Value {
 				return interpreter.NewDictionaryValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeString,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -224,7 +224,7 @@ func TestExportValue(t *testing.T) {
 			valueFactory: func(inter *interpreter.Interpreter) interpreter.Value {
 				return interpreter.NewDictionaryValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeString,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -394,14 +394,14 @@ func TestExportValue(t *testing.T) {
 					interpreter.NewUnmeteredIntValueFromInt64(1),
 					stdlib.NewPublicKeyValue(
 						inter,
-						interpreter.ReturnEmptyLocationRange,
+						interpreter.EmptyLocationRange,
 						&stdlib.PublicKey{
 							PublicKey: []byte{1, 2, 3},
 							SignAlgo:  2,
 						},
 						func(
 							_ *interpreter.Interpreter,
-							_ func() interpreter.LocationRange,
+							_ interpreter.LocationRange,
 							_ *interpreter.CompositeValue,
 						) error {
 							return nil
@@ -478,7 +478,7 @@ func TestExportValue(t *testing.T) {
 					interpreter.NewUnmeteredStringValue("C"),
 					interpreter.NewArrayValue(
 						newTestInterpreter(t),
-						interpreter.ReturnEmptyLocationRange,
+						interpreter.EmptyLocationRange,
 						interpreter.ByteArrayStaticType,
 						common.Address{},
 					),
@@ -513,7 +513,7 @@ func TestImportValue(t *testing.T) {
 
 			actual, err := ImportValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				tt.value,
 				tt.expectedType,
 			)
@@ -577,7 +577,7 @@ func TestImportValue(t *testing.T) {
 			value: cadence.NewArray([]cadence.Value{}),
 			expected: interpreter.NewArrayValue(
 				newTestInterpreter(t),
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
@@ -595,7 +595,7 @@ func TestImportValue(t *testing.T) {
 			}),
 			expected: interpreter.NewArrayValue(
 				newTestInterpreter(t),
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
@@ -611,7 +611,7 @@ func TestImportValue(t *testing.T) {
 			label: "Dictionary",
 			expected: interpreter.NewDictionaryValue(
 				newTestInterpreter(t),
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -627,7 +627,7 @@ func TestImportValue(t *testing.T) {
 			label: "Dictionary (non-empty)",
 			expected: interpreter.NewDictionaryValue(
 				newTestInterpreter(t),
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -1837,7 +1837,7 @@ func TestExportTypeValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			value,
 			newTestInterpreter(t),
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -1890,7 +1890,7 @@ func TestExportTypeValue(t *testing.T) {
 			},
 		}
 
-		actual, err := ExportValue(ty, inter, interpreter.ReturnEmptyLocationRange)
+		actual, err := ExportValue(ty, inter, interpreter.EmptyLocationRange)
 		require.NoError(t, err)
 
 		assert.Equal(t,
@@ -1934,7 +1934,7 @@ func TestExportCapabilityValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			capability,
 			newTestInterpreter(t),
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -1988,7 +1988,7 @@ func TestExportCapabilityValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			capability,
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -2022,7 +2022,7 @@ func TestExportCapabilityValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			capability,
 			newTestInterpreter(t),
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -2056,7 +2056,7 @@ func TestExportLinkValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			link,
 			newTestInterpreter(t),
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -2107,7 +2107,7 @@ func TestExportLinkValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			capability,
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -3113,7 +3113,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		value := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -3123,7 +3123,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			value,
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -3147,7 +3147,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		actual, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			value,
 			sema.ByteArrayType,
 		)
@@ -3158,7 +3158,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
@@ -3176,7 +3176,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		value := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -3188,7 +3188,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			value,
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -3217,7 +3217,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		actual, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			value,
 			&sema.VariableSizedType{
 				Type: sema.AnyStructType,
@@ -3230,7 +3230,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
@@ -3261,7 +3261,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		actual, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			value,
 			sema.AnyStructType,
 		)
@@ -3272,7 +3272,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
@@ -3281,7 +3281,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				common.Address{},
 				interpreter.NewArrayValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
@@ -3291,7 +3291,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				),
 				interpreter.NewArrayValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
@@ -3315,7 +3315,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		value := interpreter.NewDictionaryValue(
 			newTestInterpreter(t),
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -3325,7 +3325,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			value,
 			newTestInterpreter(t),
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -3350,7 +3350,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		actual, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			value,
 			&sema.DictionaryType{
 				KeyType:   sema.StringType,
@@ -3364,7 +3364,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			inter,
 			interpreter.NewDictionaryValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeUInt8,
@@ -3382,7 +3382,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		value := interpreter.NewDictionaryValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -3394,7 +3394,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			value,
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -3436,7 +3436,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		actual, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			value,
 			&sema.DictionaryType{
 				KeyType:   sema.StringType,
@@ -3450,7 +3450,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			inter,
 			interpreter.NewDictionaryValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -3499,7 +3499,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		actual, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			value,
 			sema.AnyStructType,
 		)
@@ -3510,7 +3510,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			inter,
 			interpreter.NewDictionaryValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.DictionaryStaticType{
 					KeyType: interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.DictionaryStaticType{
@@ -3522,7 +3522,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 				interpreter.NewUnmeteredStringValue("a"),
 				interpreter.NewDictionaryValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeInt8,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -3534,7 +3534,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 				interpreter.NewUnmeteredStringValue("b"),
 				interpreter.NewDictionaryValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeSignedInteger,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -4700,7 +4700,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 
 	internalArrayValue := interpreter.NewArrayValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		staticArrayType,
 		common.Address{},
 		interpreter.NewUnmeteredIntValueFromInt64(42),
@@ -4733,7 +4733,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 
 	internalDictionaryValue := interpreter.NewDictionaryValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		staticDictionaryType,
 		interpreter.NewUnmeteredStringValue("a"), internalArrayValue,
 	)
@@ -4792,7 +4792,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 
 	internalCompositeValue := interpreter.NewCompositeValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		TestLocation,
 		"Foo",
 		common.CompositeKindStructure,
@@ -4814,7 +4814,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		actual, err := exportValueWithInterpreter(
 			internalCompositeValue,
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			seenReferences{},
 		)
 		require.NoError(t, err)
@@ -4840,7 +4840,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 
 		actual, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			externalCompositeValue,
 			semaCompositeType,
 		)

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -74,7 +74,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 		codeHash, err := ImportValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			codeHashValue,
 			sema.ByteArrayType,
 		)

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -261,7 +261,7 @@ func (e *interpreterEnvironment) EmitEvent(
 	inter *interpreter.Interpreter,
 	eventType *sema.CompositeType,
 	values []interpreter.Value,
-	getLocationRange func() interpreter.LocationRange,
+	locationRange interpreter.LocationRange,
 ) {
 	eventFields := make([]exportableValue, 0, len(values))
 
@@ -271,7 +271,7 @@ func (e *interpreterEnvironment) EmitEvent(
 
 	emitEventFields(
 		inter,
-		getLocationRange,
+		locationRange,
 		eventType,
 		eventFields,
 		e.runtimeInterface.EmitEvent,
@@ -591,7 +591,7 @@ func (e *interpreterEnvironment) newOnRecordTraceHandler() interpreter.OnRecordT
 func (e *interpreterEnvironment) newHashHandler() interpreter.HashHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		getLocationRange func() interpreter.LocationRange,
+		locationRange interpreter.LocationRange,
 		dataValue *interpreter.ArrayValue,
 		tagValue *interpreter.StringValue,
 		hashAlgorithmValue interpreter.MemberAccessibleValue,
@@ -606,7 +606,7 @@ func (e *interpreterEnvironment) newHashHandler() interpreter.HashHandlerFunc {
 			tag = tagValue.Str
 		}
 
-		hashAlgorithm := stdlib.NewHashAlgorithmFromValue(inter, getLocationRange, hashAlgorithmValue)
+		hashAlgorithm := stdlib.NewHashAlgorithmFromValue(inter, locationRange, hashAlgorithmValue)
 
 		var result []byte
 		wrapPanic(func() {
@@ -628,7 +628,7 @@ func (e *interpreterEnvironment) newPublicAccountHandler() interpreter.PublicAcc
 func (e *interpreterEnvironment) newSignatureVerificationHandler() interpreter.SignatureVerificationHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		getLocationRange func() interpreter.LocationRange,
+		locationRange interpreter.LocationRange,
 		signatureValue *interpreter.ArrayValue,
 		signedDataValue *interpreter.ArrayValue,
 		domainSeparationTagValue *interpreter.StringValue,
@@ -648,9 +648,9 @@ func (e *interpreterEnvironment) newSignatureVerificationHandler() interpreter.S
 
 		domainSeparationTag := domainSeparationTagValue.Str
 
-		hashAlgorithm := stdlib.NewHashAlgorithmFromValue(inter, getLocationRange, hashAlgorithmValue)
+		hashAlgorithm := stdlib.NewHashAlgorithmFromValue(inter, locationRange, hashAlgorithmValue)
 
-		publicKey, err := stdlib.NewPublicKeyFromValue(inter, getLocationRange, publicKeyValue)
+		publicKey, err := stdlib.NewPublicKeyFromValue(inter, locationRange, publicKeyValue)
 		if err != nil {
 			return false
 		}
@@ -678,11 +678,11 @@ func (e *interpreterEnvironment) newSignatureVerificationHandler() interpreter.S
 func (e *interpreterEnvironment) newPublicKeyValidationHandler() interpreter.PublicKeyValidationHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		getLocationRange func() interpreter.LocationRange,
+		locationRange interpreter.LocationRange,
 		publicKeyValue *interpreter.CompositeValue,
 	) error {
 
-		publicKey, err := stdlib.NewPublicKeyFromValue(inter, getLocationRange, publicKeyValue)
+		publicKey, err := stdlib.NewPublicKeyFromValue(inter, locationRange, publicKeyValue)
 		if err != nil {
 			return err
 		}
@@ -750,13 +750,13 @@ func (e *interpreterEnvironment) newUUIDHandler() interpreter.UUIDHandlerFunc {
 func (e *interpreterEnvironment) newOnEventEmittedHandler() interpreter.OnEventEmittedFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		getLocationRange func() interpreter.LocationRange,
+		locationRange interpreter.LocationRange,
 		eventValue *interpreter.CompositeValue,
 		eventType *sema.CompositeType,
 	) error {
 		emitEventValue(
 			inter,
-			getLocationRange,
+			locationRange,
 			eventType,
 			eventValue,
 			e.runtimeInterface.EmitEvent,
@@ -1000,11 +1000,11 @@ func (e *interpreterEnvironment) newResourceOwnerChangedHandler() interpreter.On
 func (e *interpreterEnvironment) newBLSVerifyPopFunction() interpreter.BLSVerifyPoPHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		getLocationRange func() interpreter.LocationRange,
+		locationRange interpreter.LocationRange,
 		publicKeyValue interpreter.MemberAccessibleValue,
 		signatureValue *interpreter.ArrayValue,
 	) interpreter.BoolValue {
-		publicKey, err := stdlib.NewPublicKeyFromValue(inter, getLocationRange, publicKeyValue)
+		publicKey, err := stdlib.NewPublicKeyFromValue(inter, locationRange, publicKeyValue)
 		if err != nil {
 			panic(err)
 		}
@@ -1028,7 +1028,7 @@ func (e *interpreterEnvironment) newBLSVerifyPopFunction() interpreter.BLSVerify
 func (e *interpreterEnvironment) newBLSAggregateSignaturesFunction() interpreter.BLSAggregateSignaturesHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		getLocationRange func() interpreter.LocationRange,
+		locationRange interpreter.LocationRange,
 		signaturesValue *interpreter.ArrayValue,
 	) interpreter.OptionalValue {
 
@@ -1075,7 +1075,7 @@ func (e *interpreterEnvironment) newBLSAggregatePublicKeysFunction(
 ) interpreter.BLSAggregatePublicKeysHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		getLocationRange func() interpreter.LocationRange,
+		locationRange interpreter.LocationRange,
 		publicKeysValue *interpreter.ArrayValue,
 	) interpreter.OptionalValue {
 
@@ -1086,7 +1086,7 @@ func (e *interpreterEnvironment) newBLSAggregatePublicKeysFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			publicKey, err := stdlib.NewPublicKeyFromValue(inter, getLocationRange, publicKeyValue)
+			publicKey, err := stdlib.NewPublicKeyFromValue(inter, locationRange, publicKeyValue)
 			if err != nil {
 				panic(err)
 			}
@@ -1110,7 +1110,7 @@ func (e *interpreterEnvironment) newBLSAggregatePublicKeysFunction(
 
 		aggregatedPublicKeyValue := stdlib.NewPublicKeyValue(
 			inter,
-			getLocationRange,
+			locationRange,
 			aggregatedPublicKey,
 			publicKeyValidationHandler,
 		)

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -28,7 +28,7 @@ import (
 
 func emitEventValue(
 	inter *interpreter.Interpreter,
-	getLocationRange func() interpreter.LocationRange,
+	locationRange interpreter.LocationRange,
 	eventType *sema.CompositeType,
 	event *interpreter.CompositeValue,
 	emitEvent func(cadence.Event) error,
@@ -36,16 +36,16 @@ func emitEventValue(
 	fields := make([]exportableValue, len(eventType.ConstructorParameters))
 
 	for i, parameter := range eventType.ConstructorParameters {
-		value := event.GetField(inter, getLocationRange, parameter.Identifier)
+		value := event.GetField(inter, locationRange, parameter.Identifier)
 		fields[i] = newExportableValue(value, inter)
 	}
 
-	emitEventFields(inter, getLocationRange, eventType, fields, emitEvent)
+	emitEventFields(inter, locationRange, eventType, fields, emitEvent)
 }
 
 func emitEventFields(
 	gauge common.MemoryGauge,
-	getLocationRange func() interpreter.LocationRange,
+	locationRange interpreter.LocationRange,
 	eventType *sema.CompositeType,
 	eventFields []exportableValue,
 	emitEvent func(cadence.Event) error,
@@ -70,7 +70,7 @@ func emitEventFields(
 	exportedEvent, err := exportEvent(
 		gauge,
 		eventValue,
-		getLocationRange,
+		locationRange,
 		seenReferences{},
 	)
 	if err != nil {

--- a/runtime/interpreter/account.go
+++ b/runtime/interpreter/account.go
@@ -64,7 +64,7 @@ func NewAuthAccountValue(
 	var contracts Value
 	var keys Value
 
-	computeField := func(name string, inter *Interpreter, getLocationRange func() LocationRange) Value {
+	computeField := func(name string, inter *Interpreter, locationRange LocationRange) Value {
 		switch name {
 		case sema.AuthAccountContractsField:
 			if contracts == nil {
@@ -77,11 +77,11 @@ func NewAuthAccountValue(
 			}
 			return keys
 		case sema.AuthAccountPublicPathsField:
-			return inter.publicAccountPaths(address, getLocationRange)
+			return inter.publicAccountPaths(address, locationRange)
 		case sema.AuthAccountPrivatePathsField:
-			return inter.privateAccountPaths(address, getLocationRange)
+			return inter.privateAccountPaths(address, locationRange)
 		case sema.AuthAccountStoragePathsField:
-			return inter.storageAccountPaths(address, getLocationRange)
+			return inter.storageAccountPaths(address, locationRange)
 		case sema.AuthAccountForEachPublicField:
 			return inter.newStorageIterationFunction(address, common.PathDomainPublic, sema.PublicPathType)
 		case sema.AuthAccountForEachPrivateField:
@@ -174,7 +174,7 @@ func NewPublicAccountValue(
 	var keys Value
 	var contracts Value
 
-	computeField := func(name string, inter *Interpreter, getLocationRange func() LocationRange) Value {
+	computeField := func(name string, inter *Interpreter, locationRange LocationRange) Value {
 		switch name {
 		case sema.PublicAccountKeysField:
 			if keys == nil {
@@ -187,7 +187,7 @@ func NewPublicAccountValue(
 			}
 			return contracts
 		case sema.PublicAccountPathsField:
-			return inter.publicAccountPaths(address, getLocationRange)
+			return inter.publicAccountPaths(address, locationRange)
 		case sema.PublicAccountForEachPublicField:
 			return inter.newStorageIterationFunction(address, common.PathDomainPublic, sema.PublicPathType)
 		case sema.PublicAccountBalanceField:

--- a/runtime/interpreter/accountcontracts.go
+++ b/runtime/interpreter/accountcontracts.go
@@ -31,7 +31,7 @@ var authAccountContractsTypeID = sema.AuthAccountContractsType.ID()
 var authAccountContractsStaticType StaticType = PrimitiveStaticTypeAuthAccountContracts // unmetered
 var authAccountContractsFieldNames []string = nil
 
-type ContractNamesGetter func(interpreter *Interpreter, getLocationRange func() LocationRange) *ArrayValue
+type ContractNamesGetter func(interpreter *Interpreter, locationRange LocationRange) *ArrayValue
 
 func NewAuthAccountContractsValue(
 	gauge common.MemoryGauge,
@@ -53,11 +53,11 @@ func NewAuthAccountContractsValue(
 	computeField := func(
 		name string,
 		interpreter *Interpreter,
-		getLocationRange func() LocationRange,
+		locationRange LocationRange,
 	) Value {
 		switch name {
 		case sema.AuthAccountContractsTypeNamesField:
-			return namesGetter(interpreter, getLocationRange)
+			return namesGetter(interpreter, locationRange)
 		}
 		return nil
 	}
@@ -103,11 +103,11 @@ func NewPublicAccountContractsValue(
 	computeField := func(
 		name string,
 		interpreter *Interpreter,
-		getLocationRange func() LocationRange,
+		locationRange LocationRange,
 	) Value {
 		switch name {
 		case sema.PublicAccountContractsTypeNamesField:
-			return namesGetter(interpreter, getLocationRange)
+			return namesGetter(interpreter, locationRange)
 		}
 		return nil
 	}

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -96,7 +96,7 @@ func ByteSliceToByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue
 
 	return NewArrayValue(
 		interpreter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		ByteArrayStaticType,
 		common.Address{},
 		values...,

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -43,7 +43,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 		invalid := []Value{
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeUInt64,
 				},
@@ -52,7 +52,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			),
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt256,
 				},
@@ -77,7 +77,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 		invalid := map[Value][]byte{
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
@@ -85,7 +85,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			): {},
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
@@ -95,7 +95,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			): {2, 3},
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -59,14 +59,14 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	dictValueValue := NewUnmeteredInt256ValueFromInt64(1)
 	dictValue := NewDictionaryValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		dictionaryStaticType,
 		dictValueKey, dictValueValue,
 	)
 
 	arrayValue := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: dictionaryStaticType,
 		},
@@ -80,7 +80,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 
 	compositeValue.SetMember(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		"value",
 		optionalValue,
 	)

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -271,7 +271,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 
 		expected := NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			ConstantSizedStaticType{
 				Type: PrimitiveStaticTypeAnyStruct,
 				Size: 0,
@@ -303,7 +303,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 
 		expected := NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeAnyStruct,
 			},
@@ -340,7 +340,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		expected := NewCompositeValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			utils.TestLocation,
 			"TestStruct",
 			common.CompositeKindStructure,
@@ -378,7 +378,7 @@ func TestEncodeDecodeComposite(t *testing.T) {
 
 		expected := NewCompositeValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			utils.TestLocation,
 			"TestResource",
 			common.CompositeKindResource,

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -67,7 +67,7 @@ func (e Error) ChildErrors() []error {
 	errs := make([]error, 0, 1+len(e.StackTrace))
 
 	for _, invocation := range e.StackTrace {
-		locationRange := invocation.GetLocationRange()
+		locationRange := invocation.LocationRange
 		if locationRange.Location == nil {
 			continue
 		}

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -132,7 +132,7 @@ func (f *InterpretedFunctionValue) invoke(invocation Invocation) Value {
 
 func (f *InterpretedFunctionValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -152,7 +152,7 @@ func (*InterpretedFunctionValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (f *InterpretedFunctionValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -261,7 +261,7 @@ func (f *HostFunctionValue) invoke(invocation Invocation) Value {
 	return f.Function(invocation)
 }
 
-func (f *HostFunctionValue) GetMember(_ *Interpreter, _ func() LocationRange, name string) Value {
+func (f *HostFunctionValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
 	if f.NestedVariables != nil {
 		if variable, ok := f.NestedVariables[name]; ok {
 			return variable.GetValue()
@@ -270,19 +270,19 @@ func (f *HostFunctionValue) GetMember(_ *Interpreter, _ func() LocationRange, na
 	return nil
 }
 
-func (*HostFunctionValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (*HostFunctionValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Host functions have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (*HostFunctionValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (*HostFunctionValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Host functions have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (f *HostFunctionValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -302,7 +302,7 @@ func (*HostFunctionValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (f *HostFunctionValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -393,12 +393,12 @@ func (f BoundFunctionValue) invoke(invocation Invocation) Value {
 
 func (f BoundFunctionValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 	return f.Function.ConformsToStaticType(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		results,
 	)
 }
@@ -417,7 +417,7 @@ func (BoundFunctionValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (f BoundFunctionValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,

--- a/runtime/interpreter/function_test.go
+++ b/runtime/interpreter/function_test.go
@@ -81,7 +81,7 @@ func TestFunctionStaticType(t *testing.T) {
 
 		compositeValue := NewCompositeValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			utils.TestLocation,
 			"foo",
 			common.CompositeKindStructure,

--- a/runtime/interpreter/hashablevalue.go
+++ b/runtime/interpreter/hashablevalue.go
@@ -26,13 +26,13 @@ import (
 //
 type HashableValue interface {
 	Value
-	HashInput(interpreter *Interpreter, getLocationRange func() LocationRange, scratch []byte) []byte
+	HashInput(interpreter *Interpreter, locationRange LocationRange, scratch []byte) []byte
 }
 
-func newHashInputProvider(interpreter *Interpreter, getLocationRange func() LocationRange) atree.HashInputProvider {
+func newHashInputProvider(interpreter *Interpreter, locationRange LocationRange) atree.HashInputProvider {
 	return func(value atree.Value, scratch []byte) ([]byte, error) {
 		hashInput := MustConvertStoredValue(interpreter, value).(HashableValue).
-			HashInput(interpreter, getLocationRange, scratch)
+			HashInput(interpreter, locationRange, scratch)
 		return hashInput, nil
 	}
 }

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -44,14 +44,14 @@ func TestInspectValue(t *testing.T) {
 		dictValueValue := NewUnmeteredInt256ValueFromInt64(1)
 		dictValue := NewDictionaryValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			dictionaryStaticType,
 			dictValueKey, dictValueValue,
 		)
 
 		arrayValue := NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			VariableSizedStaticType{
 				Type: dictionaryStaticType,
 			},
@@ -64,7 +64,7 @@ func TestInspectValue(t *testing.T) {
 		compositeValue = newTestCompositeValue(inter, common.Address{})
 		compositeValue.SetMember(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			"value",
 			optionalValue,
 		)
@@ -73,12 +73,12 @@ func TestInspectValue(t *testing.T) {
 	// Get actually stored values.
 	// The values above were removed when they were inserted into the containers.
 
-	optionalValue := compositeValue.GetField(inter, ReturnEmptyLocationRange, "value").(*SomeValue)
-	arrayValue := optionalValue.InnerValue(inter, ReturnEmptyLocationRange).(*ArrayValue)
-	dictValue := arrayValue.Get(inter, ReturnEmptyLocationRange, 0).(*DictionaryValue)
+	optionalValue := compositeValue.GetField(inter, EmptyLocationRange, "value").(*SomeValue)
+	arrayValue := optionalValue.InnerValue(inter, EmptyLocationRange).(*ArrayValue)
+	dictValue := arrayValue.Get(inter, EmptyLocationRange, 0).(*DictionaryValue)
 	dictValueKey := NewUnmeteredStringValue("hello world")
 
-	dictValueValue, _ := dictValue.Get(inter, ReturnEmptyLocationRange, dictValueKey)
+	dictValueValue, _ := dictValue.Get(inter, EmptyLocationRange, dictValueKey)
 
 	t.Run("dict", func(t *testing.T) {
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -84,7 +84,10 @@ func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast
 		panic(errors.NewUnreachableError())
 	}
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, indexExpression)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: indexExpression,
+	}
 
 	// Evaluate, transfer, and convert the indexing value,
 	// as it is essentially an "argument" of the get/set operation
@@ -99,11 +102,10 @@ func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast
 		interpreter.evalExpression(indexExpression.IndexingExpression),
 		indexingType,
 		indexedType.IndexingType(),
-		locationRangeGetter(
-			interpreter,
-			interpreter.Location,
-			indexExpression.IndexingExpression,
-		),
+		LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: indexExpression.IndexingExpression,
+		},
 	)
 
 	_, isNestedResourceMove := elaboration.IsNestedResourceMoveExpression[indexExpression]
@@ -112,16 +114,16 @@ func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast
 		target: target,
 		get: func(_ bool) Value {
 			if isNestedResourceMove {
-				return target.RemoveKey(interpreter, getLocationRange, transferredIndexingValue)
+				return target.RemoveKey(interpreter, locationRange, transferredIndexingValue)
 			} else {
-				return target.GetKey(interpreter, getLocationRange, transferredIndexingValue)
+				return target.GetKey(interpreter, locationRange, transferredIndexingValue)
 			}
 		},
 		set: func(value Value) {
 			if isNestedResourceMove {
-				target.InsertKey(interpreter, getLocationRange, transferredIndexingValue, value)
+				target.InsertKey(interpreter, locationRange, transferredIndexingValue, value)
 			} else {
-				target.SetKey(interpreter, getLocationRange, transferredIndexingValue, value)
+				target.SetKey(interpreter, locationRange, transferredIndexingValue, value)
 			}
 		},
 	}
@@ -133,7 +135,10 @@ func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast
 func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *ast.MemberExpression) getterSetter {
 	target := interpreter.evalExpression(memberExpression.Expression)
 	identifier := memberExpression.Identifier.Identifier
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, memberExpression)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: memberExpression,
+	}
 
 	_, isNestedResourceMove := interpreter.Program.Elaboration.IsNestedResourceMoveExpression[memberExpression]
 
@@ -141,7 +146,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 		target: target,
 		get: func(allowMissing bool) Value {
 
-			interpreter.checkMemberAccess(memberExpression, target, getLocationRange)
+			interpreter.checkMemberAccess(memberExpression, target, locationRange)
 
 			isOptional := memberExpression.Optional
 
@@ -151,7 +156,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 					return typedTarget
 
 				case *SomeValue:
-					target = typedTarget.InnerValue(interpreter, getLocationRange)
+					target = typedTarget.InnerValue(interpreter, locationRange)
 
 				default:
 					panic(errors.NewUnreachableError())
@@ -160,14 +165,14 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 
 			var resultValue Value
 			if isNestedResourceMove {
-				resultValue = target.(MemberAccessibleValue).RemoveMember(interpreter, getLocationRange, identifier)
+				resultValue = target.(MemberAccessibleValue).RemoveMember(interpreter, locationRange, identifier)
 			} else {
-				resultValue = interpreter.getMember(target, getLocationRange, identifier)
+				resultValue = interpreter.getMember(target, locationRange, identifier)
 			}
 			if resultValue == nil && !allowMissing {
 				panic(MissingMemberValueError{
 					Name:          identifier,
-					LocationRange: getLocationRange(),
+					LocationRange: locationRange,
 				})
 			}
 
@@ -183,9 +188,9 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 			return resultValue
 		},
 		set: func(value Value) {
-			interpreter.checkMemberAccess(memberExpression, target, getLocationRange)
+			interpreter.checkMemberAccess(memberExpression, target, locationRange)
 
-			interpreter.setMember(target, getLocationRange, identifier, value)
+			interpreter.setMember(target, locationRange, identifier, value)
 		},
 	}
 }
@@ -193,7 +198,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 func (interpreter *Interpreter) checkMemberAccess(
 	memberExpression *ast.MemberExpression,
 	target Value,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 ) {
 	memberInfo := interpreter.Program.Elaboration.MemberExpressionMemberInfos[memberExpression]
 	expectedType := memberInfo.AccessedType
@@ -228,7 +233,7 @@ func (interpreter *Interpreter) checkMemberAccess(
 		panic(MemberAccessTypeError{
 			ExpectedType:  expectedType,
 			ActualType:    targetSemaType,
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 }
@@ -258,10 +263,13 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 
 	error := func(right Value) {
 		panic(InvalidOperandsError{
-			Operation:     expression.Operation,
-			LeftType:      leftValue.StaticType(interpreter),
-			RightType:     right.StaticType(interpreter),
-			LocationRange: locationRangeGetter(interpreter, interpreter.Location, expression)(),
+			Operation: expression.Operation,
+			LeftType:  leftValue.StaticType(interpreter),
+			RightType: right.StaticType(interpreter),
+			LocationRange: LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: expression,
+			},
 		})
 	}
 
@@ -425,11 +433,14 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		return right
 
 	case ast.OperationNilCoalesce:
-		getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression)
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: expression,
+		}
 
 		// only evaluate right-hand side if left-hand side is nil
 		if some, ok := leftValue.(*SomeValue); ok {
-			return some.InnerValue(interpreter, getLocationRange)
+			return some.InnerValue(interpreter, locationRange)
 		}
 
 		value := rightValue()
@@ -439,7 +450,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		resultType := binaryExpressionTypes.ResultType
 
 		// NOTE: important to convert both any and optional
-		return interpreter.ConvertAndBox(getLocationRange, value, rightType, resultType)
+		return interpreter.ConvertAndBox(locationRange, value, rightType, resultType)
 	}
 
 	panic(&unsupportedOperation{
@@ -451,12 +462,18 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 
 func (interpreter *Interpreter) testEqual(left, right Value, expression *ast.BinaryExpression) BoolValue {
 	left = interpreter.Unbox(
-		locationRangeGetter(interpreter, interpreter.Location, expression.Left),
+		LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: expression.Left,
+		},
 		left,
 	)
 
 	right = interpreter.Unbox(
-		locationRangeGetter(interpreter, interpreter.Location, expression.Right),
+		LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: expression.Right,
+		},
 		right,
 	)
 
@@ -468,7 +485,10 @@ func (interpreter *Interpreter) testEqual(left, right Value, expression *ast.Bin
 	return AsBoolValue(
 		leftEquatable.Equal(
 			interpreter,
-			locationRangeGetter(interpreter, interpreter.Location, expression),
+			LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: expression,
+			},
 			right,
 		),
 	)
@@ -667,18 +687,24 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 	for i, argument := range values {
 		argumentType := argumentTypes[i]
 		argumentExpression := expression.Values[i]
-		getLocationRange := locationRangeGetter(interpreter, interpreter.Location, argumentExpression)
-		copies[i] = interpreter.transferAndConvert(argument, argumentType, elementType, getLocationRange)
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: argumentExpression,
+		}
+		copies[i] = interpreter.transferAndConvert(argument, argumentType, elementType, locationRange)
 	}
 
 	// TODO: cache
 	arrayStaticType := ConvertSemaArrayTypeToStaticArrayType(interpreter, arrayType)
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: expression,
+	}
 
 	return NewArrayValue(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		arrayStaticType,
 		common.Address{},
 		copies...,
@@ -702,14 +728,20 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 			dictionaryEntryValues.Key,
 			entryType.KeyType,
 			dictionaryType.KeyType,
-			locationRangeGetter(interpreter, interpreter.Location, entry.Key),
+			LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: entry.Key,
+			},
 		)
 
 		value := interpreter.transferAndConvert(
 			dictionaryEntryValues.Value,
 			entryType.ValueType,
 			dictionaryType.ValueType,
-			locationRangeGetter(interpreter, interpreter.Location, entry.Value),
+			LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: entry.Value,
+			},
 		)
 
 		keyValuePairs = append(
@@ -721,11 +753,14 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 
 	dictionaryStaticType := ConvertSemaDictionaryTypeToStaticDictionaryType(interpreter, dictionaryType)
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: expression,
+	}
 
 	return NewDictionaryValue(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		dictionaryStaticType,
 		keyValuePairs...,
 	)
@@ -742,8 +777,11 @@ func (interpreter *Interpreter) VisitIndexExpression(expression *ast.IndexExpres
 		panic(errors.NewUnreachableError())
 	}
 	indexingValue := interpreter.evalExpression(expression.IndexingExpression)
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression)
-	return typedResult.GetKey(interpreter, getLocationRange, indexingValue)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: expression,
+	}
+	return typedResult.GetKey(interpreter, locationRange, indexingValue)
 }
 
 func (interpreter *Interpreter) VisitConditionalExpression(expression *ast.ConditionalExpression) Value {
@@ -794,7 +832,10 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 		case *SomeValue:
 			result = typedResult.InnerValue(
 				interpreter,
-				locationRangeGetter(interpreter, interpreter.Location, invocationExpression.InvokedExpression),
+				LocationRange{
+					Location:    interpreter.Location,
+					HasPosition: invocationExpression.InvokedExpression,
+				},
 			)
 
 		default:
@@ -915,7 +956,10 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingExpression) Value {
 	value := interpreter.evalExpression(expression.Expression)
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression.Expression)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: expression.Expression,
+	}
 
 	expectedType := interpreter.Program.Elaboration.CastingTargetTypes[expression]
 
@@ -931,7 +975,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 			}
 
 			// The failable cast may upcast to an optional type, e.g. `1 as? Int?`, so box
-			value = interpreter.BoxOptional(getLocationRange, value, expectedType)
+			value = interpreter.BoxOptional(locationRange, value, expectedType)
 
 			return NewSomeValueNonCopying(interpreter, value)
 
@@ -939,17 +983,20 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 			if !isSubType {
 				valueSemaType := interpreter.MustConvertStaticToSemaType(valueStaticType)
 
-				getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression.Expression)
+				locationRange := LocationRange{
+					Location:    interpreter.Location,
+					HasPosition: expression.Expression,
+				}
 
 				panic(ForceCastTypeMismatchError{
 					ExpectedType:  expectedType,
 					ActualType:    valueSemaType,
-					LocationRange: getLocationRange(),
+					LocationRange: locationRange,
 				})
 			}
 
 			// The failable cast may upcast to an optional type, e.g. `1 as? Int?`, so box
-			return interpreter.BoxOptional(getLocationRange, value, expectedType)
+			return interpreter.BoxOptional(locationRange, value, expectedType)
 
 		default:
 			panic(errors.NewUnreachableError())
@@ -958,7 +1005,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 	case ast.OperationCast:
 		staticValueType := interpreter.Program.Elaboration.CastingStaticValueTypes[expression]
 		// The cast may upcast to an optional type, e.g. `1 as Int?`, so box
-		return interpreter.ConvertAndBox(getLocationRange, value, staticValueType, expectedType)
+		return interpreter.ConvertAndBox(locationRange, value, staticValueType, expectedType)
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -974,9 +1021,12 @@ func (interpreter *Interpreter) VisitDestroyExpression(expression *ast.DestroyEx
 
 	interpreter.invalidateResource(value)
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: expression,
+	}
 
-	value.(ResourceKindedValue).Destroy(interpreter, getLocationRange)
+	value.(ResourceKindedValue).Destroy(interpreter, locationRange)
 
 	return Void
 }
@@ -1004,9 +1054,12 @@ func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *as
 			// References to optionals are transformed into optional references,
 			// so move the *SomeValue out to the reference itself
 
-			getLocationRange := locationRangeGetter(interpreter, interpreter.Location, referenceExpression.Expression)
+			locationRange := LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: referenceExpression.Expression,
+			}
 
-			innerValue := result.InnerValue(interpreter, getLocationRange)
+			innerValue := result.InnerValue(interpreter, locationRange)
 			if result, ok := innerValue.(ReferenceTrackedResourceKindedValue); ok {
 				interpreter.trackReferencedResourceKindedValue(result.StorageID(), result)
 			}
@@ -1029,10 +1082,13 @@ func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *as
 			// but the target type is optional,
 			// then box the reference properly
 
-			getLocationRange := locationRangeGetter(interpreter, interpreter.Location, referenceExpression)
+			locationRange := LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: referenceExpression,
+			}
 
 			return interpreter.BoxOptional(
-				getLocationRange,
+				locationRange,
 				NewEphemeralReferenceValue(
 					interpreter,
 					innerBorrowType.Authorized,
@@ -1054,18 +1110,18 @@ func (interpreter *Interpreter) VisitForceExpression(expression *ast.ForceExpres
 
 	switch result := result.(type) {
 	case *SomeValue:
-		getLocationRange := locationRangeGetter(interpreter, interpreter.Location, expression.Expression)
-		return result.InnerValue(interpreter, getLocationRange)
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: expression.Expression,
+		}
+		return result.InnerValue(interpreter, locationRange)
 
 	case NilValue:
 		panic(
 			ForceNilError{
 				LocationRange: LocationRange{
-					Location: interpreter.Location,
-					Range: ast.NewUnmeteredRange(
-						expression.EndPosition(nil),
-						expression.EndPosition(nil),
-					),
+					Location:    interpreter.Location,
+					HasPosition: expression,
 				},
 			},
 		)

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -75,7 +75,10 @@ func (interpreter *Interpreter) invokeFunctionValue(
 			locationPos = invocationPosition
 		}
 
-		getLocationRange := locationRangeGetter(interpreter, interpreter.Location, locationPos)
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: locationPos,
+		}
 
 		if i < parameterTypeCount {
 			parameterType := parameterTypes[i]
@@ -83,12 +86,12 @@ func (interpreter *Interpreter) invokeFunctionValue(
 				argument,
 				argumentType,
 				parameterType,
-				getLocationRange,
+				locationRange,
 			)
 		} else {
 			transferredArguments[i] = argument.Transfer(
 				interpreter,
-				getLocationRange,
+				locationRange,
 				atree.Address{},
 				false,
 				nil,
@@ -96,7 +99,10 @@ func (interpreter *Interpreter) invokeFunctionValue(
 		}
 	}
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, invocationPosition)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: invocationPosition,
+	}
 
 	invocation := NewInvocation(
 		interpreter,
@@ -104,7 +110,7 @@ func (interpreter *Interpreter) invokeFunctionValue(
 		transferredArguments,
 		argumentTypes,
 		typeParameterTypes,
-		getLocationRange,
+		locationRange,
 	)
 
 	return function.invoke(invocation)

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -80,10 +80,13 @@ func (interpreter *Interpreter) VisitReturnStatement(statement *ast.ReturnStatem
 		valueType := returnStatementTypes.ValueType
 		returnType := returnStatementTypes.ReturnType
 
-		getLocationRange := locationRangeGetter(interpreter, interpreter.Location, statement.Expression)
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: statement.Expression,
+		}
 
 		// NOTE: copy on return
-		value = interpreter.transferAndConvert(value, valueType, returnType, getLocationRange)
+		value = interpreter.transferAndConvert(value, valueType, returnType, locationRange)
 	}
 
 	return ReturnResult{value}
@@ -173,13 +176,16 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 	if someValue, ok := value.(*SomeValue); ok {
 
 		targetType := variableDeclarationTypes.TargetType
-		getLocationRange := locationRangeGetter(interpreter, interpreter.Location, declaration.Value)
-		innerValue := someValue.InnerValue(interpreter, getLocationRange)
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: declaration.Value,
+		}
+		innerValue := someValue.InnerValue(interpreter, locationRange)
 		transferredUnwrappedValue := interpreter.transferAndConvert(
 			innerValue,
 			valueType,
 			targetType,
-			getLocationRange,
+			locationRange,
 		)
 
 		interpreter.activations.PushNewWithCurrent()
@@ -216,7 +222,7 @@ func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.Switch
 			block := ast.NewBlock(
 				interpreter,
 				switchCase.Statements,
-				ReturnEmptyRange(),
+				ast.EmptyRange,
 			)
 
 			result := interpreter.visitBlock(block)
@@ -249,9 +255,12 @@ func (interpreter *Interpreter) VisitSwitchStatement(switchStatement *ast.Switch
 		// If the test value and case values are equal,
 		// evaluate the case's statements
 
-		getLocationRange := locationRangeGetter(interpreter, interpreter.Location, switchCase.Expression)
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: switchCase.Expression,
+		}
 
-		if testValue.Equal(interpreter, getLocationRange, caseValue) {
+		if testValue.Equal(interpreter, locationRange, caseValue) {
 			return runStatements()
 		}
 
@@ -300,12 +309,15 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) S
 		nil,
 	)
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, statement)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: statement,
+	}
 
 	value := interpreter.evalExpression(statement.Value)
 	transferredValue := value.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		atree.Address{},
 		false,
 		nil,
@@ -372,16 +384,19 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 
 	eventType := interpreter.Program.Elaboration.EmitStatementEventTypes[statement]
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, statement)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: statement,
+	}
 
 	onEventEmitted := interpreter.Config.OnEventEmitted
 	if onEventEmitted == nil {
 		panic(EventEmissionUnavailableError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
-	err := onEventEmitted(interpreter, getLocationRange, event, eventType)
+	err := onEventEmitted(interpreter, locationRange, event, eventType)
 	if err != nil {
 		panic(err)
 	}
@@ -445,9 +460,12 @@ func (interpreter *Interpreter) visitVariableDeclaration(
 	// Assignment is a potential resource move.
 	interpreter.invalidateResource(result)
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, declaration.Value)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: declaration.Value,
+	}
 
-	transferredValue := interpreter.transferAndConvert(result, valueType, targetType, getLocationRange)
+	transferredValue := interpreter.transferAndConvert(result, valueType, targetType, locationRange)
 
 	valueCallback(
 		declaration.Identifier.Identifier,
@@ -506,11 +524,17 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) Stat
 	// Set right value to left target
 	// and left value to right target
 
-	getLocationRange := locationRangeGetter(interpreter, interpreter.Location, swap.Right)
-	transferredRightValue := interpreter.transferAndConvert(rightValue, rightType, leftType, getLocationRange)
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: swap.Right,
+	}
+	transferredRightValue := interpreter.transferAndConvert(rightValue, rightType, leftType, locationRange)
 
-	getLocationRange = locationRangeGetter(interpreter, interpreter.Location, swap.Left)
-	transferredLeftValue := interpreter.transferAndConvert(leftValue, leftType, rightType, getLocationRange)
+	locationRange = LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: swap.Left,
+	}
+	transferredLeftValue := interpreter.transferAndConvert(leftValue, leftType, rightType, locationRange)
 
 	leftGetterSetter.set(transferredRightValue)
 	rightGetterSetter.set(transferredLeftValue)
@@ -525,8 +549,11 @@ func (interpreter *Interpreter) checkSwapValue(value Value, expression ast.Expre
 
 	if expression, ok := expression.(*ast.MemberExpression); ok {
 		panic(MissingMemberValueError{
-			Name:          expression.Identifier.Identifier,
-			LocationRange: locationRangeGetter(interpreter, interpreter.Location, expression)(),
+			Name: expression.Identifier.Identifier,
+			LocationRange: LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: expression,
+			},
 		})
 	}
 

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -37,7 +37,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		value := inter.BoxOptional(
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			BoolValue(true),
 			&sema.OptionalType{Type: sema.BoolType},
 		)
@@ -51,7 +51,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		value := inter.BoxOptional(
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			&sema.OptionalType{Type: sema.BoolType},
 		)
@@ -65,7 +65,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		value := inter.BoxOptional(
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
@@ -82,7 +82,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 
 		// NOTE:
 		value := inter.BoxOptional(
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			Nil,
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
@@ -97,7 +97,7 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 
 		// NOTE:
 		value := inter.BoxOptional(
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			NewUnmeteredSomeValueNonCopying(Nil),
 			&sema.OptionalType{Type: &sema.OptionalType{Type: sema.BoolType}},
 		)
@@ -127,7 +127,7 @@ func TestInterpreterBoxing(t *testing.T) {
 						BoolValue(true),
 					),
 					inter.ConvertAndBox(
-						ReturnEmptyLocationRange,
+						EmptyLocationRange,
 						BoolValue(true),
 						sema.BoolType,
 						&sema.OptionalType{Type: anyType},
@@ -144,7 +144,7 @@ func TestInterpreterBoxing(t *testing.T) {
 						BoolValue(true),
 					),
 					inter.ConvertAndBox(
-						ReturnEmptyLocationRange,
+						EmptyLocationRange,
 						NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 						&sema.OptionalType{Type: sema.BoolType},
 						&sema.OptionalType{Type: anyType},
@@ -181,7 +181,7 @@ func BenchmarkValueIsSubtypeOfSemaType(b *testing.B) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		typ,
 		owner,
 		values...,

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -66,7 +66,7 @@ func TestInterpreterTracing(t *testing.T) {
 		owner := common.Address{0x1}
 		array := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -83,7 +83,7 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 2)
 		require.Equal(t, traceOps[1], "array.deepRemove")
 
-		array.Destroy(inter, nil)
+		array.Destroy(inter, interpreter.EmptyLocationRange)
 		require.Equal(t, len(traceOps), 3)
 		require.Equal(t, traceOps[2], "array.destroy")
 	})
@@ -95,7 +95,7 @@ func TestInterpreterTracing(t *testing.T) {
 		})
 		dict := interpreter.NewDictionaryValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -113,7 +113,7 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 2)
 		require.Equal(t, traceOps[1], "dictionary.deepRemove")
 
-		dict.Destroy(inter, nil)
+		dict.Destroy(inter, interpreter.EmptyLocationRange)
 		require.Equal(t, len(traceOps), 3)
 		require.Equal(t, traceOps[2], "dictionary.destroy")
 	})
@@ -136,25 +136,25 @@ func TestInterpreterTracing(t *testing.T) {
 		require.Equal(t, len(traceOps), 2)
 		require.Equal(t, traceOps[1], "composite.deepRemove")
 
-		value.SetMember(inter, nil, "abc", interpreter.Nil)
+		value.SetMember(inter, interpreter.EmptyLocationRange, "abc", interpreter.Nil)
 		require.Equal(t, len(traceOps), 3)
 		require.Equal(t, traceOps[2], "composite.setMember.abc")
 
-		value.GetMember(inter, nil, "abc")
+		value.GetMember(inter, interpreter.EmptyLocationRange, "abc")
 		require.Equal(t, len(traceOps), 4)
 		require.Equal(t, traceOps[3], "composite.getMember.abc")
 
-		value.RemoveMember(inter, nil, "abc")
+		value.RemoveMember(inter, interpreter.EmptyLocationRange, "abc")
 		require.Equal(t, len(traceOps), 5)
 		require.Equal(t, traceOps[4], "composite.removeMember.abc")
 
-		value.Destroy(inter, nil)
+		value.Destroy(inter, interpreter.EmptyLocationRange)
 		require.Equal(t, len(traceOps), 6)
 		require.Equal(t, traceOps[5], "composite.destroy")
 
 		array := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},

--- a/runtime/interpreter/invocation.go
+++ b/runtime/interpreter/invocation.go
@@ -30,7 +30,7 @@ type Invocation struct {
 	Arguments          []Value
 	ArgumentTypes      []sema.Type
 	TypeParameterTypes *sema.TypeParameterTypeOrderedMap
-	GetLocationRange   func() LocationRange
+	LocationRange      LocationRange
 	Interpreter        *Interpreter
 }
 
@@ -40,7 +40,7 @@ func NewInvocation(
 	arguments []Value,
 	argumentTypes []sema.Type,
 	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 ) Invocation {
 	common.UseMemory(interpreter, common.InvocationMemoryUsage)
 
@@ -49,7 +49,7 @@ func NewInvocation(
 		Arguments:          arguments,
 		ArgumentTypes:      argumentTypes,
 		TypeParameterTypes: typeParameterTypes,
-		GetLocationRange:   getLocationRange,
+		LocationRange:      locationRange,
 		Interpreter:        interpreter,
 	}
 }

--- a/runtime/interpreter/location.go
+++ b/runtime/interpreter/location.go
@@ -36,16 +36,14 @@ type LocationPosition struct {
 // defines the start/end position within the source of that script.
 type LocationRange struct {
 	Location common.Location
-	ast.Range
+	ast.HasPosition
 }
 
 func (r LocationRange) ImportLocation() common.Location {
 	return r.Location
 }
 
-func ReturnEmptyLocationRange() LocationRange {
-	return LocationRange{}
-}
+var EmptyLocationRange = LocationRange{}
 
 func ReturnEmptyRange() ast.Range {
 	return ast.EmptyRange

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -35,7 +35,7 @@ type SimpleCompositeValue struct {
 	// FieldNames are the names of the field members (i.e. not functions, and not computed fields), in order
 	FieldNames      []string
 	Fields          map[string]Value
-	ComputeField    func(name string, interpreter *Interpreter, getLocationRange func() LocationRange) Value
+	ComputeField    func(name string, interpreter *Interpreter, locationRange LocationRange) Value
 	fieldFormatters map[string]func(common.MemoryGauge, Value, SeenReferences) string
 	// stringer is an optional function that is used to produce the string representation of the value.
 	// If nil, the FieldNames are used.
@@ -51,7 +51,7 @@ func NewSimpleCompositeValue(
 	staticType StaticType,
 	fieldNames []string,
 	fields map[string]Value,
-	computeField func(name string, interpreter *Interpreter, getLocationRange func() LocationRange) Value,
+	computeField func(name string, interpreter *Interpreter, locationRange LocationRange) Value,
 	fieldFormatters map[string]func(common.MemoryGauge, Value, SeenReferences) string,
 	stringer func(common.MemoryGauge, SeenReferences) string,
 ) *SimpleCompositeValue {
@@ -105,7 +105,7 @@ func (v *SimpleCompositeValue) IsImportable(inter *Interpreter) bool {
 
 func (v *SimpleCompositeValue) GetMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 ) Value {
 
@@ -116,18 +116,18 @@ func (v *SimpleCompositeValue) GetMember(
 
 	computeField := v.ComputeField
 	if computeField != nil {
-		return computeField(name, interpreter, getLocationRange)
+		return computeField(name, interpreter, locationRange)
 	}
 
 	return nil
 }
 
-func (*SimpleCompositeValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (*SimpleCompositeValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Simple composite values have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (v *SimpleCompositeValue) SetMember(_ *Interpreter, _ func() LocationRange, name string, value Value) {
+func (v *SimpleCompositeValue) SetMember(_ *Interpreter, _ LocationRange, name string, value Value) {
 	v.Fields[name] = value
 }
 
@@ -195,7 +195,7 @@ func (v *SimpleCompositeValue) MeteredString(memoryGauge common.MemoryGauge, see
 
 func (v *SimpleCompositeValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 
@@ -206,7 +206,7 @@ func (v *SimpleCompositeValue) ConformsToStaticType(
 		}
 		if !value.ConformsToStaticType(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			results,
 		) {
 			return false
@@ -230,7 +230,7 @@ func (v *SimpleCompositeValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v *SimpleCompositeValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -47,7 +47,7 @@ func TestCompositeStorage(t *testing.T) {
 
 	value := NewCompositeValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		TestLocation,
 		"TestStruct",
 		common.CompositeKindStructure,
@@ -65,7 +65,7 @@ func TestCompositeStorage(t *testing.T) {
 
 	const fieldName = "test"
 
-	value.SetMember(inter, ReturnEmptyLocationRange, fieldName, BoolValue(true))
+	value.SetMember(inter, EmptyLocationRange, fieldName, BoolValue(true))
 
 	require.Equal(t, 1, storage.BasicSlabStorage.Count())
 
@@ -82,7 +82,7 @@ func TestCompositeStorage(t *testing.T) {
 		t,
 		inter,
 		BoolValue(true),
-		storedComposite.GetField(inter, ReturnEmptyLocationRange, fieldName),
+		storedComposite.GetField(inter, EmptyLocationRange, fieldName),
 	)
 }
 
@@ -118,7 +118,7 @@ func TestArrayStorage(t *testing.T) {
 
 		value := NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
@@ -134,16 +134,16 @@ func TestArrayStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ok)
 
-		require.False(t, bool(value.Contains(inter, nil, element)))
+		require.False(t, bool(value.Contains(inter, EmptyLocationRange, element)))
 
 		value.Insert(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			0,
 			element,
 		)
 
-		require.True(t, bool(value.Contains(inter, nil, element)))
+		require.True(t, bool(value.Contains(inter, EmptyLocationRange, element)))
 
 		// array + original composite element + new copy of composite element
 		require.Equal(t, 3, storage.BasicSlabStorage.Count())
@@ -157,7 +157,7 @@ func TestArrayStorage(t *testing.T) {
 		require.IsType(t, storedValue, &ArrayValue{})
 		storedArray := storedValue.(*ArrayValue)
 
-		actual := storedArray.Get(inter, ReturnEmptyLocationRange, 0)
+		actual := storedArray.Get(inter, EmptyLocationRange, 0)
 
 		RequireValuesEqual(t, inter, element, actual)
 	})
@@ -184,7 +184,7 @@ func TestArrayStorage(t *testing.T) {
 
 		value := NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
@@ -192,7 +192,7 @@ func TestArrayStorage(t *testing.T) {
 			element,
 		)
 
-		require.True(t, bool(value.Contains(inter, nil, element)))
+		require.True(t, bool(value.Contains(inter, EmptyLocationRange, element)))
 
 		require.NotEqual(t, atree.StorageIDUndefined, value.StorageID())
 
@@ -205,7 +205,7 @@ func TestArrayStorage(t *testing.T) {
 
 		value.Remove(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			0,
 		)
 
@@ -220,7 +220,7 @@ func TestArrayStorage(t *testing.T) {
 		require.IsType(t, storedValue, &ArrayValue{})
 		storedArray := storedValue.(*ArrayValue)
 
-		require.False(t, bool(storedArray.Contains(inter, nil, element)))
+		require.False(t, bool(storedArray.Contains(inter, EmptyLocationRange, element)))
 	})
 }
 
@@ -243,7 +243,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value := NewDictionaryValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
@@ -263,7 +263,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value.SetKey(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			entryKey,
 			NewUnmeteredSomeValueNonCopying(entryValue),
 		)
@@ -279,7 +279,7 @@ func TestDictionaryStorage(t *testing.T) {
 		require.IsType(t, storedValue, &DictionaryValue{})
 		storedDictionary := storedValue.(*DictionaryValue)
 
-		actual, ok := storedDictionary.Get(inter, ReturnEmptyLocationRange, entryKey)
+		actual, ok := storedDictionary.Get(inter, EmptyLocationRange, entryKey)
 		require.True(t, ok)
 
 		RequireValuesEqual(t, inter, entryValue, actual)
@@ -300,7 +300,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value := NewDictionaryValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
@@ -319,7 +319,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value.SetKey(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			NewUnmeteredStringValue("test"),
 			Nil,
 		)
@@ -350,7 +350,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value := NewDictionaryValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
@@ -369,7 +369,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value.Remove(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			NewUnmeteredStringValue("test"),
 		)
 
@@ -399,7 +399,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value := NewDictionaryValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
@@ -416,7 +416,7 @@ func TestDictionaryStorage(t *testing.T) {
 
 		value.Insert(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			NewUnmeteredStringValue("test"),
 			NewUnmeteredSomeValueNonCopying(BoolValue(true)),
 		)
@@ -450,7 +450,7 @@ func TestInterpretStorageOverwriteAndRemove(t *testing.T) {
 
 	array1 := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -467,7 +467,7 @@ func TestInterpretStorageOverwriteAndRemove(t *testing.T) {
 
 	array2 := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -121,7 +121,7 @@ type Value interface {
 	// static types are subtypes.
 	ConformsToStaticType(
 		interpreter *Interpreter,
-		getLocationRange func() LocationRange,
+		locationRange LocationRange,
 		results TypeConformanceResults,
 	) bool
 	RecursiveString(seenReferences SeenReferences) string
@@ -130,7 +130,7 @@ type Value interface {
 	NeedsStoreTo(address atree.Address) bool
 	Transfer(
 		interpreter *Interpreter,
-		getLocationRange func() LocationRange,
+		locationRange LocationRange,
 		address atree.Address,
 		remove bool,
 		storable atree.Storable,
@@ -147,19 +147,19 @@ type Value interface {
 
 type ValueIndexableValue interface {
 	Value
-	GetKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value) Value
-	SetKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value, value Value)
-	RemoveKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value) Value
-	InsertKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value, value Value)
+	GetKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value
+	SetKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value)
+	RemoveKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value
+	InsertKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value)
 }
 
 // MemberAccessibleValue
 
 type MemberAccessibleValue interface {
 	Value
-	GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value
-	RemoveMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value
-	SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string, value Value)
+	GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value
+	RemoveMember(interpreter *Interpreter, locationRange LocationRange, name string) Value
+	SetMember(interpreter *Interpreter, locationRange LocationRange, name string, value Value)
 }
 
 // EquatableValue
@@ -167,15 +167,15 @@ type MemberAccessibleValue interface {
 type EquatableValue interface {
 	Value
 	// Equal returns true if the given value is equal to this value.
-	// If no location range is available, pass e.g. ReturnEmptyLocationRange
-	Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool
+	// If no location range is available, pass e.g. EmptyLocationRange
+	Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool
 }
 
-func newValueComparator(interpreter *Interpreter, getLocationRange func() LocationRange) atree.ValueComparator {
+func newValueComparator(interpreter *Interpreter, locationRange LocationRange) atree.ValueComparator {
 	return func(storage atree.SlabStorage, atreeValue atree.Value, otherStorable atree.Storable) (bool, error) {
 		value := MustConvertStoredValue(interpreter, atreeValue)
 		otherValue := StoredValue(interpreter, otherStorable, storage)
-		return value.(EquatableValue).Equal(interpreter, getLocationRange, otherValue), nil
+		return value.(EquatableValue).Equal(interpreter, locationRange, otherValue), nil
 	}
 }
 
@@ -183,17 +183,17 @@ func newValueComparator(interpreter *Interpreter, getLocationRange func() Locati
 
 type ResourceKindedValue interface {
 	Value
-	Destroy(interpreter *Interpreter, getLocationRange func() LocationRange)
+	Destroy(interpreter *Interpreter, locationRange LocationRange)
 	IsDestroyed() bool
 }
 
-func maybeDestroy(interpreter *Interpreter, getLocationRange func() LocationRange, value Value) {
+func maybeDestroy(interpreter *Interpreter, locationRange LocationRange, value Value) {
 	resourceKindedValue, ok := value.(ResourceKindedValue)
 	if !ok {
 		return
 	}
 
-	resourceKindedValue.Destroy(interpreter, getLocationRange)
+	resourceKindedValue.Destroy(interpreter, locationRange)
 }
 
 // ReferenceTrackedResourceKindedValue is a resource-kinded value
@@ -313,7 +313,7 @@ func (v TypeValue) MeteredString(memoryGauge common.MemoryGauge, _ SeenReference
 	return format.TypeValue(typeString)
 }
 
-func (v TypeValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v TypeValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherTypeValue, ok := other.(TypeValue)
 	if !ok {
 		return false
@@ -331,7 +331,7 @@ func (v TypeValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bo
 	return staticType.Equal(otherStaticType)
 }
 
-func (v TypeValue) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case "identifier":
 		var typeID string
@@ -377,19 +377,19 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ func() LocationRange, n
 	return nil
 }
 
-func (TypeValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (TypeValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Types have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (TypeValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (TypeValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Types have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (v TypeValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -418,7 +418,7 @@ func (TypeValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v TypeValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -452,7 +452,7 @@ func (TypeValue) ChildStorables() []atree.Storable {
 // HashInput returns a byte slice containing:
 // - HashInputTypeType (1 byte)
 // - type id (n bytes)
-func (v TypeValue) HashInput(interpreter *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v TypeValue) HashInput(interpreter *Interpreter, _ LocationRange, scratch []byte) []byte {
 	typeID := interpreter.MustConvertStaticToSemaType(v.Type).ID()
 
 	length := 1 + len(typeID)
@@ -511,13 +511,13 @@ func (v VoidValue) MeteredString(memoryGauge common.MemoryGauge, _ SeenReference
 
 func (v VoidValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
 }
 
-func (v VoidValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v VoidValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	_, ok := other.(VoidValue)
 	return ok
 }
@@ -536,7 +536,7 @@ func (VoidValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v VoidValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -611,7 +611,7 @@ func (v BoolValue) Negate(_ *Interpreter) BoolValue {
 	return TrueValue
 }
 
-func (v BoolValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v BoolValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherBool, ok := other.(BoolValue)
 	if !ok {
 		return false
@@ -622,7 +622,7 @@ func (v BoolValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bo
 // HashInput returns a byte slice containing:
 // - HashInputTypeBool (1 byte)
 // - 1/0 (1 byte)
-func (v BoolValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v BoolValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeBool)
 	if v {
 		scratch[1] = 1
@@ -652,7 +652,7 @@ func (v BoolValue) MeteredString(memoryGauge common.MemoryGauge, _ SeenReference
 
 func (v BoolValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -672,7 +672,7 @@ func (BoolValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v BoolValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -768,7 +768,7 @@ func (v CharacterValue) NormalForm() string {
 	return norm.NFC.String(string(v))
 }
 
-func (v CharacterValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v CharacterValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherChar, ok := other.(CharacterValue)
 	if !ok {
 		return false
@@ -776,7 +776,7 @@ func (v CharacterValue) Equal(_ *Interpreter, _ func() LocationRange, other Valu
 	return v.NormalForm() == otherChar.NormalForm()
 }
 
-func (v CharacterValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v CharacterValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	s := []byte(string(v))
 	length := 1 + len(s)
 	var buffer []byte
@@ -793,7 +793,7 @@ func (v CharacterValue) HashInput(_ *Interpreter, _ func() LocationRange, scratc
 
 func (v CharacterValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -813,7 +813,7 @@ func (CharacterValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v CharacterValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -844,7 +844,7 @@ func (CharacterValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func (v CharacterValue) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v CharacterValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case sema.ToStringFunctionName:
 		return NewHostFunctionValue(
@@ -866,12 +866,12 @@ func (v CharacterValue) GetMember(interpreter *Interpreter, _ func() LocationRan
 	return nil
 }
 
-func (CharacterValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (CharacterValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Characters have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (CharacterValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (CharacterValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Characters have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -954,7 +954,7 @@ func (v *StringValue) MeteredString(memoryGauge common.MemoryGauge, _ SeenRefere
 	return v.String()
 }
 
-func (v *StringValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v *StringValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherString, ok := other.(*StringValue)
 	if !ok {
 		return false
@@ -965,7 +965,7 @@ func (v *StringValue) Equal(_ *Interpreter, _ func() LocationRange, other Value)
 // HashInput returns a byte slice containing:
 // - HashInputTypeString (1 byte)
 // - string value (n bytes)
-func (v *StringValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v *StringValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	length := 1 + len(v.Str)
 	var buffer []byte
 	if length <= len(scratch) {
@@ -1008,7 +1008,7 @@ func (v *StringValue) Concat(interpreter *Interpreter, other *StringValue) Value
 
 var emptyString = NewUnmeteredStringValue("")
 
-func (v *StringValue) Slice(from IntValue, to IntValue, getLocationRange func() LocationRange) Value {
+func (v *StringValue) Slice(from IntValue, to IntValue, locationRange LocationRange) Value {
 	fromIndex := from.ToInt()
 
 	toIndex := to.ToInt()
@@ -1020,7 +1020,7 @@ func (v *StringValue) Slice(from IntValue, to IntValue, getLocationRange func() 
 			FromIndex:     fromIndex,
 			UpToIndex:     toIndex,
 			Length:        length,
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
@@ -1028,7 +1028,7 @@ func (v *StringValue) Slice(from IntValue, to IntValue, getLocationRange func() 
 		panic(InvalidSliceIndexError{
 			FromIndex:     fromIndex,
 			UpToIndex:     toIndex,
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
@@ -1055,21 +1055,21 @@ func (v *StringValue) Slice(from IntValue, to IntValue, getLocationRange func() 
 	return NewUnmeteredStringValue(v.Str[start:end])
 }
 
-func (v *StringValue) checkBounds(index int, getLocationRange func() LocationRange) {
+func (v *StringValue) checkBounds(index int, locationRange LocationRange) {
 	length := v.Length()
 
 	if index < 0 || index >= length {
 		panic(StringIndexOutOfBoundsError{
 			Index:         index,
 			Length:        length,
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 }
 
-func (v *StringValue) GetKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value) Value {
+func (v *StringValue) GetKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
 	index := key.(NumberValue).ToInt()
-	v.checkBounds(index, getLocationRange)
+	v.checkBounds(index, locationRange)
 
 	v.prepareGraphemes()
 
@@ -1087,19 +1087,19 @@ func (v *StringValue) GetKey(interpreter *Interpreter, getLocationRange func() L
 	)
 }
 
-func (*StringValue) SetKey(_ *Interpreter, _ func() LocationRange, _ Value, _ Value) {
+func (*StringValue) SetKey(_ *Interpreter, _ LocationRange, _ Value, _ Value) {
 	panic(errors.NewUnreachableError())
 }
 
-func (*StringValue) InsertKey(_ *Interpreter, _ func() LocationRange, _ Value, _ Value) {
+func (*StringValue) InsertKey(_ *Interpreter, _ LocationRange, _ Value, _ Value) {
 	panic(errors.NewUnreachableError())
 }
 
-func (*StringValue) RemoveKey(_ *Interpreter, _ func() LocationRange, _ Value) Value {
+func (*StringValue) RemoveKey(_ *Interpreter, _ LocationRange, _ Value) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (v *StringValue) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v *StringValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case "length":
 		length := v.Length()
@@ -1135,7 +1135,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, _ func() LocationRange
 					panic(errors.NewUnreachableError())
 				}
 
-				return v.Slice(from, to, invocation.GetLocationRange)
+				return v.Slice(from, to, invocation.LocationRange)
 			},
 			sema.StringTypeSliceFunctionType,
 		)
@@ -1146,7 +1146,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, _ func() LocationRange
 			func(invocation Invocation) Value {
 				return v.DecodeHex(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 				)
 			},
 			sema.StringTypeDecodeHexFunctionType,
@@ -1165,12 +1165,12 @@ func (v *StringValue) GetMember(interpreter *Interpreter, _ func() LocationRange
 	return nil
 }
 
-func (*StringValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (*StringValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Strings have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (*StringValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (*StringValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Strings have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -1229,7 +1229,7 @@ func (*StringValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v *StringValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -1265,19 +1265,19 @@ var ByteArrayStaticType = ConvertSemaArrayTypeToStaticArrayType(nil, sema.ByteAr
 
 // DecodeHex hex-decodes this string and returns an array of UInt8 values
 //
-func (v *StringValue) DecodeHex(interpreter *Interpreter, getLocationRange func() LocationRange) *ArrayValue {
+func (v *StringValue) DecodeHex(interpreter *Interpreter, locationRange LocationRange) *ArrayValue {
 	bs, err := hex.DecodeString(v.Str)
 	if err != nil {
 		if err, ok := err.(hex.InvalidByteError); ok {
 			panic(InvalidHexByteError{
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 				Byte:          byte(err),
 			})
 		}
 
 		if err == hex.ErrLength {
 			panic(InvalidHexLengthError{
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 
@@ -1312,7 +1312,7 @@ func (v *StringValue) DecodeHex(interpreter *Interpreter, getLocationRange func(
 
 func (v *StringValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -1331,7 +1331,7 @@ type ArrayValue struct {
 
 func NewArrayValue(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	arrayType ArrayStaticType,
 	address common.Address,
 	values ...Value,
@@ -1356,7 +1356,7 @@ func NewArrayValue(
 
 			value = value.Transfer(
 				interpreter,
-				getLocationRange,
+				locationRange,
 				atree.Address(address),
 				true,
 				nil,
@@ -1511,20 +1511,20 @@ func (v *ArrayValue) IsImportable(inter *Interpreter) bool {
 	return importable
 }
 
-func (v *ArrayValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *ArrayValue) checkInvalidatedResourceUse(interpreter *Interpreter, locationRange LocationRange) {
 	if v.isDestroyed || (v.array == nil && v.IsResourceKinded(interpreter)) {
 		panic(InvalidatedResourceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 }
 
-func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *ArrayValue) Destroy(interpreter *Interpreter, locationRange LocationRange) {
 
 	interpreter.ReportComputation(common.ComputationKindDestroyArrayValue, 1)
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	storageID := v.StorageID()
@@ -1545,7 +1545,7 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, getLocationRange func() L
 	}
 
 	v.Walk(interpreter, func(element Value) {
-		maybeDestroy(interpreter, getLocationRange, element)
+		maybeDestroy(interpreter, locationRange, element)
 	})
 
 	v.isDestroyed = true
@@ -1576,7 +1576,7 @@ func (v *ArrayValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *ArrayValue) Concat(interpreter *Interpreter, getLocationRange func() LocationRange, other *ArrayValue) Value {
+func (v *ArrayValue) Concat(interpreter *Interpreter, locationRange LocationRange, other *ArrayValue) Value {
 
 	first := true
 
@@ -1623,7 +1623,7 @@ func (v *ArrayValue) Concat(interpreter *Interpreter, getLocationRange func() Lo
 				if atreeValue != nil {
 					value = MustConvertStoredValue(interpreter, atreeValue)
 
-					interpreter.checkContainerMutation(elementType, value, getLocationRange)
+					interpreter.checkContainerMutation(elementType, value, locationRange)
 				}
 			}
 
@@ -1633,7 +1633,7 @@ func (v *ArrayValue) Concat(interpreter *Interpreter, getLocationRange func() Lo
 
 			return value.Transfer(
 				interpreter,
-				getLocationRange,
+				locationRange,
 				atree.Address{},
 				false,
 				nil,
@@ -1642,27 +1642,27 @@ func (v *ArrayValue) Concat(interpreter *Interpreter, getLocationRange func() Lo
 	)
 }
 
-func (v *ArrayValue) GetKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value) Value {
+func (v *ArrayValue) GetKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	index := key.(NumberValue).ToInt()
-	return v.Get(interpreter, getLocationRange, index)
+	return v.Get(interpreter, locationRange, index)
 }
 
-func (v *ArrayValue) handleIndexOutOfBoundsError(err error, index int, getLocationRange func() LocationRange) {
+func (v *ArrayValue) handleIndexOutOfBoundsError(err error, index int, locationRange LocationRange) {
 	if _, ok := err.(*atree.IndexOutOfBoundsError); ok {
 		panic(ArrayIndexOutOfBoundsError{
 			Index:         index,
 			Size:          v.Count(),
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 }
 
-func (v *ArrayValue) Get(interpreter *Interpreter, getLocationRange func() LocationRange, index int) Value {
+func (v *ArrayValue) Get(interpreter *Interpreter, locationRange LocationRange, index int) Value {
 
 	// We only need to check the lower bound before converting from `int` (signed) to `uint64` (unsigned).
 	// atree's Array.Get function will check the upper bound and report an atree.IndexOutOfBoundsError
@@ -1671,13 +1671,13 @@ func (v *ArrayValue) Get(interpreter *Interpreter, getLocationRange func() Locat
 		panic(ArrayIndexOutOfBoundsError{
 			Index:         index,
 			Size:          v.Count(),
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	storable, err := v.array.Get(uint64(index))
 	if err != nil {
-		v.handleIndexOutOfBoundsError(err, index, getLocationRange)
+		v.handleIndexOutOfBoundsError(err, index, locationRange)
 
 		panic(errors.NewExternalError(err))
 	}
@@ -1685,17 +1685,17 @@ func (v *ArrayValue) Get(interpreter *Interpreter, getLocationRange func() Locat
 	return StoredValue(interpreter, storable, interpreter.Config.Storage)
 }
 
-func (v *ArrayValue) SetKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value, value Value) {
+func (v *ArrayValue) SetKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	index := key.(NumberValue).ToInt()
-	v.Set(interpreter, getLocationRange, index, value)
+	v.Set(interpreter, locationRange, index, value)
 }
 
-func (v *ArrayValue) Set(interpreter *Interpreter, getLocationRange func() LocationRange, index int, element Value) {
+func (v *ArrayValue) Set(interpreter *Interpreter, locationRange LocationRange, index int, element Value) {
 
 	// We only need to check the lower bound before converting from `int` (signed) to `uint64` (unsigned).
 	// atree's Array.Set function will check the upper bound and report an atree.IndexOutOfBoundsError
@@ -1704,17 +1704,17 @@ func (v *ArrayValue) Set(interpreter *Interpreter, getLocationRange func() Locat
 		panic(ArrayIndexOutOfBoundsError{
 			Index:         index,
 			Size:          v.Count(),
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
-	interpreter.checkContainerMutation(v.Type.ElementType(), element, getLocationRange)
+	interpreter.checkContainerMutation(v.Type.ElementType(), element, locationRange)
 
 	common.UseMemory(interpreter, common.AtreeArrayElementOverhead)
 
 	element = element.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		v.array.Address(),
 		true,
 		nil,
@@ -1722,7 +1722,7 @@ func (v *ArrayValue) Set(interpreter *Interpreter, getLocationRange func() Locat
 
 	existingStorable, err := v.array.Set(uint64(index), element)
 	if err != nil {
-		v.handleIndexOutOfBoundsError(err, index, getLocationRange)
+		v.handleIndexOutOfBoundsError(err, index, locationRange)
 
 		panic(errors.NewExternalError(err))
 	}
@@ -1767,7 +1767,7 @@ func (v *ArrayValue) MeteredString(memoryGauge common.MemoryGauge, seenReference
 	return format.Array(values)
 }
 
-func (v *ArrayValue) Append(interpreter *Interpreter, getLocationRange func() LocationRange, element Value) {
+func (v *ArrayValue) Append(interpreter *Interpreter, locationRange LocationRange, element Value) {
 
 	// length increases by 1
 	dataSlabs, metaDataSlabs := common.AdditionalAtreeMemoryUsage(
@@ -1779,11 +1779,11 @@ func (v *ArrayValue) Append(interpreter *Interpreter, getLocationRange func() Lo
 	common.UseMemory(interpreter, metaDataSlabs)
 	common.UseMemory(interpreter, common.AtreeArrayElementOverhead)
 
-	interpreter.checkContainerMutation(v.Type.ElementType(), element, getLocationRange)
+	interpreter.checkContainerMutation(v.Type.ElementType(), element, locationRange)
 
 	element = element.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		v.array.Address(),
 		true,
 		nil,
@@ -1796,23 +1796,23 @@ func (v *ArrayValue) Append(interpreter *Interpreter, getLocationRange func() Lo
 	interpreter.maybeValidateAtreeValue(v.array)
 }
 
-func (v *ArrayValue) AppendAll(interpreter *Interpreter, getLocationRange func() LocationRange, other *ArrayValue) {
+func (v *ArrayValue) AppendAll(interpreter *Interpreter, locationRange LocationRange, other *ArrayValue) {
 	other.Walk(interpreter, func(value Value) {
-		v.Append(interpreter, getLocationRange, value)
+		v.Append(interpreter, locationRange, value)
 	})
 }
 
-func (v *ArrayValue) InsertKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value, value Value) {
+func (v *ArrayValue) InsertKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	index := key.(NumberValue).ToInt()
-	v.Insert(interpreter, getLocationRange, index, value)
+	v.Insert(interpreter, locationRange, index, value)
 }
 
-func (v *ArrayValue) Insert(interpreter *Interpreter, getLocationRange func() LocationRange, index int, element Value) {
+func (v *ArrayValue) Insert(interpreter *Interpreter, locationRange LocationRange, index int, element Value) {
 
 	// We only need to check the lower bound before converting from `int` (signed) to `uint64` (unsigned).
 	// atree's Array.Insert function will check the upper bound and report an atree.IndexOutOfBoundsError
@@ -1821,7 +1821,7 @@ func (v *ArrayValue) Insert(interpreter *Interpreter, getLocationRange func() Lo
 		panic(ArrayIndexOutOfBoundsError{
 			Index:         index,
 			Size:          v.Count(),
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
@@ -1835,11 +1835,11 @@ func (v *ArrayValue) Insert(interpreter *Interpreter, getLocationRange func() Lo
 	common.UseMemory(interpreter, metaDataSlabs)
 	common.UseMemory(interpreter, common.AtreeArrayElementOverhead)
 
-	interpreter.checkContainerMutation(v.Type.ElementType(), element, getLocationRange)
+	interpreter.checkContainerMutation(v.Type.ElementType(), element, locationRange)
 
 	element = element.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		v.array.Address(),
 		true,
 		nil,
@@ -1847,24 +1847,24 @@ func (v *ArrayValue) Insert(interpreter *Interpreter, getLocationRange func() Lo
 
 	err := v.array.Insert(uint64(index), element)
 	if err != nil {
-		v.handleIndexOutOfBoundsError(err, index, getLocationRange)
+		v.handleIndexOutOfBoundsError(err, index, locationRange)
 
 		panic(errors.NewExternalError(err))
 	}
 	interpreter.maybeValidateAtreeValue(v.array)
 }
 
-func (v *ArrayValue) RemoveKey(interpreter *Interpreter, getLocationRange func() LocationRange, key Value) Value {
+func (v *ArrayValue) RemoveKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	index := key.(NumberValue).ToInt()
-	return v.Remove(interpreter, getLocationRange, index)
+	return v.Remove(interpreter, locationRange, index)
 }
 
-func (v *ArrayValue) Remove(interpreter *Interpreter, getLocationRange func() LocationRange, index int) Value {
+func (v *ArrayValue) Remove(interpreter *Interpreter, locationRange LocationRange, index int) Value {
 
 	// We only need to check the lower bound before converting from `int` (signed) to `uint64` (unsigned).
 	// atree's Array.Remove function will check the upper bound and report an atree.IndexOutOfBoundsError
@@ -1873,13 +1873,13 @@ func (v *ArrayValue) Remove(interpreter *Interpreter, getLocationRange func() Lo
 		panic(ArrayIndexOutOfBoundsError{
 			Index:         index,
 			Size:          v.Count(),
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	storable, err := v.array.Remove(uint64(index))
 	if err != nil {
-		v.handleIndexOutOfBoundsError(err, index, getLocationRange)
+		v.handleIndexOutOfBoundsError(err, index, locationRange)
 
 		panic(errors.NewExternalError(err))
 	}
@@ -1889,22 +1889,22 @@ func (v *ArrayValue) Remove(interpreter *Interpreter, getLocationRange func() Lo
 
 	return value.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		atree.Address{},
 		true,
 		storable,
 	)
 }
 
-func (v *ArrayValue) RemoveFirst(interpreter *Interpreter, getLocationRange func() LocationRange) Value {
-	return v.Remove(interpreter, getLocationRange, 0)
+func (v *ArrayValue) RemoveFirst(interpreter *Interpreter, locationRange LocationRange) Value {
+	return v.Remove(interpreter, locationRange, 0)
 }
 
-func (v *ArrayValue) RemoveLast(interpreter *Interpreter, getLocationRange func() LocationRange) Value {
-	return v.Remove(interpreter, getLocationRange, v.Count()-1)
+func (v *ArrayValue) RemoveLast(interpreter *Interpreter, locationRange LocationRange) Value {
+	return v.Remove(interpreter, locationRange, v.Count()-1)
 }
 
-func (v *ArrayValue) FirstIndex(interpreter *Interpreter, getLocationRange func() LocationRange, needleValue Value) OptionalValue {
+func (v *ArrayValue) FirstIndex(interpreter *Interpreter, locationRange LocationRange, needleValue Value) OptionalValue {
 
 	needleEquatable, ok := needleValue.(EquatableValue)
 	if !ok {
@@ -1914,7 +1914,7 @@ func (v *ArrayValue) FirstIndex(interpreter *Interpreter, getLocationRange func(
 	var counter int64
 	var result bool
 	v.Iterate(interpreter, func(element Value) (resume bool) {
-		if needleEquatable.Equal(interpreter, getLocationRange, element) {
+		if needleEquatable.Equal(interpreter, locationRange, element) {
 			result = true
 			// stop iteration
 			return false
@@ -1933,7 +1933,7 @@ func (v *ArrayValue) FirstIndex(interpreter *Interpreter, getLocationRange func(
 
 func (v *ArrayValue) Contains(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	needleValue Value,
 ) BoolValue {
 
@@ -1944,7 +1944,7 @@ func (v *ArrayValue) Contains(
 
 	var result bool
 	v.Iterate(interpreter, func(element Value) (resume bool) {
-		if needleEquatable.Equal(interpreter, getLocationRange, element) {
+		if needleEquatable.Equal(interpreter, locationRange, element) {
 			result = true
 			// stop iteration
 			return false
@@ -1956,10 +1956,10 @@ func (v *ArrayValue) Contains(
 	return AsBoolValue(result)
 }
 
-func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
+func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 	switch name {
 	case "length":
@@ -1971,7 +1971,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 			func(invocation Invocation) Value {
 				v.Append(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
 				return Void
@@ -1991,7 +1991,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 				}
 				v.AppendAll(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					otherArray,
 				)
 				return Void
@@ -2011,7 +2011,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 				}
 				return v.Concat(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					otherArray,
 				)
 			},
@@ -2034,7 +2034,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 
 				v.Insert(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					index,
 					element,
 				)
@@ -2057,7 +2057,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 
 				return v.Remove(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					index,
 				)
 			},
@@ -2072,7 +2072,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 			func(invocation Invocation) Value {
 				return v.RemoveFirst(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 				)
 			},
 			sema.ArrayRemoveFirstFunctionType(
@@ -2086,7 +2086,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 			func(invocation Invocation) Value {
 				return v.RemoveLast(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 				)
 			},
 			sema.ArrayRemoveLastFunctionType(
@@ -2100,7 +2100,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 			func(invocation Invocation) Value {
 				return v.FirstIndex(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
 			},
@@ -2115,7 +2115,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 			func(invocation Invocation) Value {
 				return v.Contains(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
 			},
@@ -2142,7 +2142,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 					invocation.Interpreter,
 					from,
 					to,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 				)
 			},
 			sema.ArraySliceFunctionType(
@@ -2154,20 +2154,20 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, getLocationRange func()
 	return nil
 }
 
-func (v *ArrayValue) RemoveMember(interpreter *Interpreter, getLocationRange func() LocationRange, _ string) Value {
+func (v *ArrayValue) RemoveMember(interpreter *Interpreter, locationRange LocationRange, _ string) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	// Arrays have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (v *ArrayValue) SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, _ string, _ Value) {
+func (v *ArrayValue) SetMember(interpreter *Interpreter, locationRange LocationRange, _ string, _ Value) {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	// Arrays have no settable members (fields / functions)
@@ -2180,7 +2180,7 @@ func (v *ArrayValue) Count() int {
 
 func (v *ArrayValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 
@@ -2225,7 +2225,7 @@ func (v *ArrayValue) ConformsToStaticType(
 
 		if !element.ConformsToStaticType(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			results,
 		) {
 			elementMismatch = true
@@ -2240,7 +2240,7 @@ func (v *ArrayValue) ConformsToStaticType(
 	return !elementMismatch
 }
 
-func (v *ArrayValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
+func (v *ArrayValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
 	otherArray, ok := other.(*ArrayValue)
 	if !ok {
 		return false
@@ -2263,11 +2263,11 @@ func (v *ArrayValue) Equal(interpreter *Interpreter, getLocationRange func() Loc
 	}
 
 	for i := 0; i < count; i++ {
-		value := v.Get(interpreter, getLocationRange, i)
-		otherValue := otherArray.Get(interpreter, getLocationRange, i)
+		value := v.Get(interpreter, locationRange, i)
+		otherValue := otherArray.Get(interpreter, locationRange, i)
 
 		equatableValue, ok := value.(EquatableValue)
-		if !ok || !equatableValue.Equal(interpreter, getLocationRange, otherValue) {
+		if !ok || !equatableValue.Equal(interpreter, locationRange, otherValue) {
 			return false
 		}
 	}
@@ -2283,7 +2283,7 @@ func (v *ArrayValue) IsReferenceTrackedResourceKindedValue() {}
 
 func (v *ArrayValue) Transfer(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -2295,7 +2295,7 @@ func (v *ArrayValue) Transfer(
 	common.UseMemory(interpreter, metaDataSlabs)
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	interpreter.ReportComputation(common.ComputationKindTransferArrayValue, uint(v.Count()))
@@ -2344,7 +2344,7 @@ func (v *ArrayValue) Transfer(
 				}
 
 				element := MustConvertStoredValue(interpreter, value).
-					Transfer(interpreter, getLocationRange, address, remove, nil)
+					Transfer(interpreter, locationRange, address, remove, nil)
 
 				return element, nil
 			},
@@ -2519,7 +2519,7 @@ func (v *ArrayValue) Slice(
 	interpreter *Interpreter,
 	from IntValue,
 	to IntValue,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 ) Value {
 	fromIndex := from.ToInt()
 	toIndex := to.ToInt()
@@ -2532,7 +2532,7 @@ func (v *ArrayValue) Slice(
 			FromIndex:     fromIndex,
 			UpToIndex:     toIndex,
 			Size:          v.Count(),
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
@@ -2545,14 +2545,14 @@ func (v *ArrayValue) Slice(
 				FromIndex:     fromIndex,
 				UpToIndex:     toIndex,
 				Size:          v.Count(),
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 
 		case *atree.InvalidSliceIndexError:
 			panic(InvalidSliceIndexError{
 				FromIndex:     fromIndex,
 				UpToIndex:     toIndex,
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 
@@ -2583,7 +2583,7 @@ func (v *ArrayValue) Slice(
 
 			return value.Transfer(
 				interpreter,
-				getLocationRange,
+				locationRange,
 				atree.Address{},
 				false,
 				nil,
@@ -3106,7 +3106,7 @@ func (v IntValue) GreaterEqual(interpreter *Interpreter, other NumberValue) Bool
 	return AsBoolValue(cmp >= 0)
 }
 
-func (v IntValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v IntValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt, ok := other.(IntValue)
 	if !ok {
 		return false
@@ -3118,7 +3118,7 @@ func (v IntValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) boo
 // HashInput returns a byte slice containing:
 // - HashInputTypeInt (1 byte)
 // - big int encoded in big-endian (n bytes)
-func (v IntValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v IntValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	b := SignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
@@ -3250,16 +3250,16 @@ func (v IntValue) BitwiseRightShift(interpreter *Interpreter, other IntegerValue
 	)
 }
 
-func (v IntValue) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v IntValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.IntType)
 }
 
-func (IntValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (IntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (IntValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (IntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -3270,7 +3270,7 @@ func (v IntValue) ToBigEndianBytes() []byte {
 
 func (v IntValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -3290,7 +3290,7 @@ func (IntValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v IntValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -3704,7 +3704,7 @@ func (v Int8Value) GreaterEqual(interpreter *Interpreter, other NumberValue) Boo
 	return AsBoolValue(v >= o)
 }
 
-func (v Int8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Int8Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt8, ok := other.(Int8Value)
 	if !ok {
 		return false
@@ -3715,7 +3715,7 @@ func (v Int8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bo
 // HashInput returns a byte slice containing:
 // - HashInputTypeInt8 (1 byte)
 // - int8 value (1 byte)
-func (v Int8Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Int8Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeInt8)
 	scratch[1] = byte(v)
 	return scratch[:2]
@@ -3836,16 +3836,16 @@ func (v Int8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValu
 	return NewInt8Value(interpreter, valueGetter)
 }
 
-func (v Int8Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Int8Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Int8Type)
 }
 
-func (Int8Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Int8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int8Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Int8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -3856,7 +3856,7 @@ func (v Int8Value) ToBigEndianBytes() []byte {
 
 func (v Int8Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -3876,7 +3876,7 @@ func (Int8Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Int8Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -4290,7 +4290,7 @@ func (v Int16Value) GreaterEqual(interpreter *Interpreter, other NumberValue) Bo
 	return AsBoolValue(v >= o)
 }
 
-func (v Int16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Int16Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt16, ok := other.(Int16Value)
 	if !ok {
 		return false
@@ -4301,7 +4301,7 @@ func (v Int16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) b
 // HashInput returns a byte slice containing:
 // - HashInputTypeInt16 (1 byte)
 // - int16 value encoded in big-endian (2 bytes)
-func (v Int16Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Int16Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeInt16)
 	binary.BigEndian.PutUint16(scratch[1:], uint16(v))
 	return scratch[:3]
@@ -4422,16 +4422,16 @@ func (v Int16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 	return NewInt16Value(interpreter, valueGetter)
 }
 
-func (v Int16Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Int16Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Int16Type)
 }
 
-func (Int16Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Int16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int16Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Int16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -4444,7 +4444,7 @@ func (v Int16Value) ToBigEndianBytes() []byte {
 
 func (v Int16Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -4464,7 +4464,7 @@ func (Int16Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Int16Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -4879,7 +4879,7 @@ func (v Int32Value) GreaterEqual(interpreter *Interpreter, other NumberValue) Bo
 	return AsBoolValue(v >= o)
 }
 
-func (v Int32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Int32Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt32, ok := other.(Int32Value)
 	if !ok {
 		return false
@@ -4890,7 +4890,7 @@ func (v Int32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) b
 // HashInput returns a byte slice containing:
 // - HashInputTypeInt32 (1 byte)
 // - int32 value encoded in big-endian (4 bytes)
-func (v Int32Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Int32Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeInt32)
 	binary.BigEndian.PutUint32(scratch[1:], uint32(v))
 	return scratch[:5]
@@ -5010,16 +5010,16 @@ func (v Int32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 	return NewInt32Value(interpreter, valueGetter)
 }
 
-func (v Int32Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Int32Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Int32Type)
 }
 
-func (Int32Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Int32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int32Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Int32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -5032,7 +5032,7 @@ func (v Int32Value) ToBigEndianBytes() []byte {
 
 func (v Int32Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -5052,7 +5052,7 @@ func (Int32Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Int32Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -5468,7 +5468,7 @@ func (v Int64Value) GreaterEqual(interpreter *Interpreter, other NumberValue) Bo
 	return AsBoolValue(v >= o)
 }
 
-func (v Int64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Int64Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt64, ok := other.(Int64Value)
 	if !ok {
 		return false
@@ -5479,7 +5479,7 @@ func (v Int64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) b
 // HashInput returns a byte slice containing:
 // - HashInputTypeInt64 (1 byte)
 // - int64 value encoded in big-endian (8 bytes)
-func (v Int64Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Int64Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeInt64)
 	binary.BigEndian.PutUint64(scratch[1:], uint64(v))
 	return scratch[:9]
@@ -5594,16 +5594,16 @@ func (v Int64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 	return NewInt64Value(interpreter, valueGetter)
 }
 
-func (v Int64Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Int64Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Int64Type)
 }
 
-func (Int64Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Int64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int64Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Int64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -5616,7 +5616,7 @@ func (v Int64Value) ToBigEndianBytes() []byte {
 
 func (v Int64Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -5636,7 +5636,7 @@ func (Int64Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Int64Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -6120,7 +6120,7 @@ func (v Int128Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(cmp >= 0)
 }
 
-func (v Int128Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Int128Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt, ok := other.(Int128Value)
 	if !ok {
 		return false
@@ -6132,7 +6132,7 @@ func (v Int128Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeInt128 (1 byte)
 // - big int value encoded in big-endian (n bytes)
-func (v Int128Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Int128Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	b := SignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
@@ -6284,16 +6284,16 @@ func (v Int128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	return NewInt128ValueFromBigInt(interpreter, valueGetter)
 }
 
-func (v Int128Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Int128Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Int128Type)
 }
 
-func (Int128Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Int128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int128Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Int128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -6304,7 +6304,7 @@ func (v Int128Value) ToBigEndianBytes() []byte {
 
 func (v Int128Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -6324,7 +6324,7 @@ func (Int128Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Int128Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -6806,7 +6806,7 @@ func (v Int256Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(cmp >= 0)
 }
 
-func (v Int256Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Int256Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt, ok := other.(Int256Value)
 	if !ok {
 		return false
@@ -6818,7 +6818,7 @@ func (v Int256Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeInt256 (1 byte)
 // - big int value encoded in big-endian (n bytes)
-func (v Int256Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Int256Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	b := SignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
@@ -6969,16 +6969,16 @@ func (v Int256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	return NewInt256ValueFromBigInt(interpreter, valueGetter)
 }
 
-func (v Int256Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Int256Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Int256Type)
 }
 
-func (Int256Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Int256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int256Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Int256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -6989,7 +6989,7 @@ func (v Int256Value) ToBigEndianBytes() []byte {
 
 func (v Int256Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -7009,7 +7009,7 @@ func (Int256Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Int256Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -7414,7 +7414,7 @@ func (v UIntValue) GreaterEqual(interpreter *Interpreter, other NumberValue) Boo
 	return AsBoolValue(cmp >= 0)
 }
 
-func (v UIntValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UIntValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherUInt, ok := other.(UIntValue)
 	if !ok {
 		return false
@@ -7426,7 +7426,7 @@ func (v UIntValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bo
 // HashInput returns a byte slice containing:
 // - HashInputTypeUInt (1 byte)
 // - big int value encoded in big-endian (n bytes)
-func (v UIntValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UIntValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
@@ -7558,16 +7558,16 @@ func (v UIntValue) BitwiseRightShift(interpreter *Interpreter, other IntegerValu
 	)
 }
 
-func (v UIntValue) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UIntValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UIntType)
 }
 
-func (UIntValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UIntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UIntValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UIntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -7578,7 +7578,7 @@ func (v UIntValue) ToBigEndianBytes() []byte {
 
 func (v UIntValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -7598,7 +7598,7 @@ func (UIntValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v UIntValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -7936,7 +7936,7 @@ func (v UInt8Value) GreaterEqual(interpreter *Interpreter, other NumberValue) Bo
 	return AsBoolValue(v >= o)
 }
 
-func (v UInt8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UInt8Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherUInt8, ok := other.(UInt8Value)
 	if !ok {
 		return false
@@ -7947,7 +7947,7 @@ func (v UInt8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) b
 // HashInput returns a byte slice containing:
 // - HashInputTypeUInt8 (1 byte)
 // - uint8 value (1 byte)
-func (v UInt8Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UInt8Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeUInt8)
 	scratch[1] = byte(v)
 	return scratch[:2]
@@ -8103,16 +8103,16 @@ func (v UInt8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 	)
 }
 
-func (v UInt8Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UInt8Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UInt8Type)
 }
 
-func (UInt8Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UInt8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt8Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UInt8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -8123,7 +8123,7 @@ func (v UInt8Value) ToBigEndianBytes() []byte {
 
 func (v UInt8Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -8143,7 +8143,7 @@ func (UInt8Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v UInt8Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -8486,7 +8486,7 @@ func (v UInt16Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(v >= o)
 }
 
-func (v UInt16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UInt16Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherUInt16, ok := other.(UInt16Value)
 	if !ok {
 		return false
@@ -8497,7 +8497,7 @@ func (v UInt16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeUInt16 (1 byte)
 // - uint16 value encoded in big-endian (2 bytes)
-func (v UInt16Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UInt16Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeUInt16)
 	binary.BigEndian.PutUint16(scratch[1:], uint16(v))
 	return scratch[:3]
@@ -8607,16 +8607,16 @@ func (v UInt16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	)
 }
 
-func (v UInt16Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UInt16Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UInt16Type)
 }
 
-func (UInt16Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UInt16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt16Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UInt16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -8629,7 +8629,7 @@ func (v UInt16Value) ToBigEndianBytes() []byte {
 
 func (v UInt16Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -8653,7 +8653,7 @@ func (UInt16Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v UInt16Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -8997,7 +8997,7 @@ func (v UInt32Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(v >= o)
 }
 
-func (v UInt32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UInt32Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherUInt32, ok := other.(UInt32Value)
 	if !ok {
 		return false
@@ -9008,7 +9008,7 @@ func (v UInt32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeUInt32 (1 byte)
 // - uint32 value encoded in big-endian (4 bytes)
-func (v UInt32Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UInt32Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeUInt32)
 	binary.BigEndian.PutUint32(scratch[1:], uint32(v))
 	return scratch[:5]
@@ -9118,16 +9118,16 @@ func (v UInt32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	)
 }
 
-func (v UInt32Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UInt32Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UInt32Type)
 }
 
-func (UInt32Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UInt32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt32Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UInt32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -9140,7 +9140,7 @@ func (v UInt32Value) ToBigEndianBytes() []byte {
 
 func (v UInt32Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -9164,7 +9164,7 @@ func (UInt32Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v UInt32Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -9537,7 +9537,7 @@ func (v UInt64Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(v >= o)
 }
 
-func (v UInt64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UInt64Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherUInt64, ok := other.(UInt64Value)
 	if !ok {
 		return false
@@ -9548,7 +9548,7 @@ func (v UInt64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeUInt64 (1 byte)
 // - uint64 value encoded in big-endian (8 bytes)
-func (v UInt64Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UInt64Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeUInt64)
 	binary.BigEndian.PutUint64(scratch[1:], uint64(v))
 	return scratch[:9]
@@ -9658,16 +9658,16 @@ func (v UInt64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	)
 }
 
-func (v UInt64Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UInt64Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UInt64Type)
 }
 
-func (UInt64Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UInt64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt64Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UInt64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -9680,7 +9680,7 @@ func (v UInt64Value) ToBigEndianBytes() []byte {
 
 func (v UInt64Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -9704,7 +9704,7 @@ func (UInt64Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v UInt64Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -10126,7 +10126,7 @@ func (v UInt128Value) GreaterEqual(interpreter *Interpreter, other NumberValue) 
 	return AsBoolValue(cmp >= 0)
 }
 
-func (v UInt128Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UInt128Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt, ok := other.(UInt128Value)
 	if !ok {
 		return false
@@ -10138,7 +10138,7 @@ func (v UInt128Value) Equal(_ *Interpreter, _ func() LocationRange, other Value)
 // HashInput returns a byte slice containing:
 // - HashInputTypeUInt128 (1 byte)
 // - big int encoded in big endian (n bytes)
-func (v UInt128Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UInt128Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
@@ -10291,16 +10291,16 @@ func (v UInt128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerV
 	)
 }
 
-func (v UInt128Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UInt128Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UInt128Type)
 }
 
-func (UInt128Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UInt128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt128Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UInt128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -10311,7 +10311,7 @@ func (v UInt128Value) ToBigEndianBytes() []byte {
 
 func (v UInt128Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -10335,7 +10335,7 @@ func (UInt128Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v UInt128Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -10759,7 +10759,7 @@ func (v UInt256Value) GreaterEqual(interpreter *Interpreter, other NumberValue) 
 	return AsBoolValue(cmp >= 0)
 }
 
-func (v UInt256Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UInt256Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherInt, ok := other.(UInt256Value)
 	if !ok {
 		return false
@@ -10771,7 +10771,7 @@ func (v UInt256Value) Equal(_ *Interpreter, _ func() LocationRange, other Value)
 // HashInput returns a byte slice containing:
 // - HashInputTypeUInt256 (1 byte)
 // - big int encoded in big endian (n bytes)
-func (v UInt256Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UInt256Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
@@ -10922,16 +10922,16 @@ func (v UInt256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerV
 	)
 }
 
-func (v UInt256Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UInt256Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UInt256Type)
 }
 
-func (UInt256Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UInt256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt256Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UInt256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -10942,7 +10942,7 @@ func (v UInt256Value) ToBigEndianBytes() []byte {
 
 func (v UInt256Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -10965,7 +10965,7 @@ func (UInt256Value) IsResourceKinded(_ *Interpreter) bool {
 }
 func (v UInt256Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -11227,7 +11227,7 @@ func (v Word8Value) GreaterEqual(interpreter *Interpreter, other NumberValue) Bo
 	return AsBoolValue(v >= o)
 }
 
-func (v Word8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Word8Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherWord8, ok := other.(Word8Value)
 	if !ok {
 		return false
@@ -11238,7 +11238,7 @@ func (v Word8Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) b
 // HashInput returns a byte slice containing:
 // - HashInputTypeWord8 (1 byte)
 // - uint8 value (1 byte)
-func (v Word8Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Word8Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeWord8)
 	scratch[1] = byte(v)
 	return scratch[:2]
@@ -11338,16 +11338,16 @@ func (v Word8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 	return NewWord8Value(interpreter, valueGetter)
 }
 
-func (v Word8Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Word8Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Word8Type)
 }
 
-func (Word8Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Word8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word8Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Word8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -11358,7 +11358,7 @@ func (v Word8Value) ToBigEndianBytes() []byte {
 
 func (v Word8Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -11382,7 +11382,7 @@ func (Word8Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Word8Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -11643,7 +11643,7 @@ func (v Word16Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(v >= o)
 }
 
-func (v Word16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Word16Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherWord16, ok := other.(Word16Value)
 	if !ok {
 		return false
@@ -11654,7 +11654,7 @@ func (v Word16Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeWord16 (1 byte)
 // - uint16 value encoded in big-endian (2 bytes)
-func (v Word16Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Word16Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeWord16)
 	binary.BigEndian.PutUint16(scratch[1:], uint16(v))
 	return scratch[:3]
@@ -11754,16 +11754,16 @@ func (v Word16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	return NewWord16Value(interpreter, valueGetter)
 }
 
-func (v Word16Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Word16Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Word16Type)
 }
 
-func (Word16Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Word16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word16Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Word16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -11776,7 +11776,7 @@ func (v Word16Value) ToBigEndianBytes() []byte {
 
 func (v Word16Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -11800,7 +11800,7 @@ func (Word16Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Word16Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -12062,7 +12062,7 @@ func (v Word32Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(v >= o)
 }
 
-func (v Word32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Word32Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherWord32, ok := other.(Word32Value)
 	if !ok {
 		return false
@@ -12073,7 +12073,7 @@ func (v Word32Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeWord32 (1 byte)
 // - uint32 value encoded in big-endian (4 bytes)
-func (v Word32Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Word32Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeWord32)
 	binary.BigEndian.PutUint32(scratch[1:], uint32(v))
 	return scratch[:5]
@@ -12173,16 +12173,16 @@ func (v Word32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	return NewWord32Value(interpreter, valueGetter)
 }
 
-func (v Word32Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Word32Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Word32Type)
 }
 
-func (Word32Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Word32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word32Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Word32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -12195,7 +12195,7 @@ func (v Word32Value) ToBigEndianBytes() []byte {
 
 func (v Word32Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -12219,7 +12219,7 @@ func (Word32Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Word32Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -12507,7 +12507,7 @@ func (v Word64Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(v >= o)
 }
 
-func (v Word64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Word64Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherWord64, ok := other.(Word64Value)
 	if !ok {
 		return false
@@ -12518,7 +12518,7 @@ func (v Word64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeWord64 (1 byte)
 // - uint64 value encoded in big-endian (8 bytes)
-func (v Word64Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Word64Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeWord64)
 	binary.BigEndian.PutUint64(scratch[1:], uint64(v))
 	return scratch[:9]
@@ -12618,16 +12618,16 @@ func (v Word64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 	return NewWord64Value(interpreter, valueGetter)
 }
 
-func (v Word64Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Word64Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Word64Type)
 }
 
-func (Word64Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Word64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word64Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Word64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -12640,7 +12640,7 @@ func (v Word64Value) ToBigEndianBytes() []byte {
 
 func (v Word64Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -12664,7 +12664,7 @@ func (Word64Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Word64Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -13092,7 +13092,7 @@ func (v Fix64Value) GreaterEqual(interpreter *Interpreter, other NumberValue) Bo
 	return AsBoolValue(v >= o)
 }
 
-func (v Fix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v Fix64Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherFix64, ok := other.(Fix64Value)
 	if !ok {
 		return false
@@ -13103,7 +13103,7 @@ func (v Fix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) b
 // HashInput returns a byte slice containing:
 // - HashInputTypeFix64 (1 byte)
 // - int64 value encoded in big-endian (8 bytes)
-func (v Fix64Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v Fix64Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeFix64)
 	binary.BigEndian.PutUint64(scratch[1:], uint64(v))
 	return scratch[:9]
@@ -13157,16 +13157,16 @@ func ConvertFix64(memoryGauge common.MemoryGauge, value Value) Fix64Value {
 	}
 }
 
-func (v Fix64Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v Fix64Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.Fix64Type)
 }
 
-func (Fix64Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (Fix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Fix64Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (Fix64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -13179,7 +13179,7 @@ func (v Fix64Value) ToBigEndianBytes() []byte {
 
 func (v Fix64Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -13203,7 +13203,7 @@ func (Fix64Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v Fix64Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -13588,7 +13588,7 @@ func (v UFix64Value) GreaterEqual(interpreter *Interpreter, other NumberValue) B
 	return AsBoolValue(v >= o)
 }
 
-func (v UFix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v UFix64Value) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherUFix64, ok := other.(UFix64Value)
 	if !ok {
 		return false
@@ -13599,7 +13599,7 @@ func (v UFix64Value) Equal(_ *Interpreter, _ func() LocationRange, other Value) 
 // HashInput returns a byte slice containing:
 // - HashInputTypeUFix64 (1 byte)
 // - uint64 value encoded in big-endian (8 bytes)
-func (v UFix64Value) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v UFix64Value) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	scratch[0] = byte(HashInputTypeUFix64)
 	binary.BigEndian.PutUint64(scratch[1:], uint64(v))
 	return scratch[:9]
@@ -13661,16 +13661,16 @@ func ConvertUFix64(memoryGauge common.MemoryGauge, value Value) UFix64Value {
 	}
 }
 
-func (v UFix64Value) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v UFix64Value) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UFix64Type)
 }
 
-func (UFix64Value) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (UFix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UFix64Value) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (UFix64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -13683,7 +13683,7 @@ func (v UFix64Value) ToBigEndianBytes() []byte {
 
 func (v UFix64Value) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -13707,7 +13707,7 @@ func (UFix64Value) IsResourceKinded(_ *Interpreter) bool {
 
 func (v UFix64Value) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -13764,7 +13764,7 @@ type CompositeValue struct {
 	staticType          StaticType
 }
 
-type ComputedField func(*Interpreter, func() LocationRange) Value
+type ComputedField func(*Interpreter, LocationRange) Value
 
 type CompositeField struct {
 	Name  string
@@ -13785,7 +13785,7 @@ func NewUnmeteredCompositeField(name string, value Value) CompositeField {
 
 func NewCompositeValue(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	location common.Location,
 	qualifiedIdentifier string,
 	kind common.CompositeKind,
@@ -13849,7 +13849,7 @@ func NewCompositeValue(
 	for _, field := range fields {
 		v.SetMember(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			field.Name,
 			field.Value,
 		)
@@ -13937,12 +13937,12 @@ func (v *CompositeValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *CompositeValue) Destroy(interpreter *Interpreter, locationRange LocationRange) {
 
 	interpreter.ReportComputation(common.ComputationKindDestroyCompositeValue, 1)
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	storageID := v.StorageID()
@@ -13981,7 +13981,7 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 			nil,
 			nil,
 			nil,
-			getLocationRange,
+			locationRange,
 		)
 
 		destructor.invoke(invocation)
@@ -14011,10 +14011,10 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, getLocationRange func
 	)
 }
 
-func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
+func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	if interpreter.Config.TracingEnabled {
@@ -14038,7 +14038,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	if v.Kind == common.CompositeKindResource &&
 		name == sema.ResourceOwnerFieldName {
 
-		return v.OwnerValue(interpreter, getLocationRange)
+		return v.OwnerValue(interpreter, locationRange)
 	}
 
 	storable, err := v.dictionary.Get(
@@ -14066,7 +14066,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 
 	if v.ComputedFields != nil {
 		if computedField, ok := v.ComputedFields[name]; ok {
-			return computedField(interpreter, getLocationRange)
+			return computedField(interpreter, locationRange)
 		}
 	}
 
@@ -14100,10 +14100,10 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, getLocationRange fu
 	return nil
 }
 
-func (v *CompositeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
+func (v *CompositeValue) checkInvalidatedResourceUse(locationRange LocationRange) {
 	if v.isDestroyed || (v.dictionary == nil && v.Kind == common.CompositeKindResource) {
 		panic(InvalidatedResourceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 }
@@ -14130,7 +14130,7 @@ func (v *CompositeValue) InitializeFunctions(interpreter *Interpreter) {
 	v.Functions = interpreter.sharedState.typeCodes.CompositeCodes[v.TypeID()].CompositeFunctions
 }
 
-func (v *CompositeValue) OwnerValue(interpreter *Interpreter, getLocationRange func() LocationRange) OptionalValue {
+func (v *CompositeValue) OwnerValue(interpreter *Interpreter, locationRange LocationRange) OptionalValue {
 	address := v.StorageID().Address
 
 	if address == (atree.Address{}) {
@@ -14140,19 +14140,19 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter, getLocationRange f
 	ownerAccount := interpreter.Config.PublicAccountHandler(AddressValue(address))
 
 	// Owner must be of `PublicAccount` type.
-	interpreter.ExpectType(ownerAccount, sema.PublicAccountType, getLocationRange)
+	interpreter.ExpectType(ownerAccount, sema.PublicAccountType, locationRange)
 
 	return NewSomeValueNonCopying(interpreter, ownerAccount)
 }
 
 func (v *CompositeValue) RemoveMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 ) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	if interpreter.Config.TracingEnabled {
@@ -14199,7 +14199,7 @@ func (v *CompositeValue) RemoveMember(
 	return storedValue.
 		Transfer(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			atree.Address{},
 			true,
 			existingValueStorable,
@@ -14208,12 +14208,12 @@ func (v *CompositeValue) RemoveMember(
 
 func (v *CompositeValue) SetMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 	value Value,
 ) {
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	if interpreter.Config.TracingEnabled {
@@ -14238,7 +14238,7 @@ func (v *CompositeValue) SetMember(
 
 	value = value.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		address,
 		true,
 		nil,
@@ -14339,10 +14339,10 @@ func formatComposite(memoryGauge common.MemoryGauge, typeId string, fields []Com
 	return format.Composite(typeId, preparedFields)
 }
 
-func (v *CompositeValue) GetField(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
+func (v *CompositeValue) GetField(interpreter *Interpreter, locationRange LocationRange, name string) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	storable, err := v.dictionary.Get(
@@ -14360,7 +14360,7 @@ func (v *CompositeValue) GetField(interpreter *Interpreter, getLocationRange fun
 	return StoredValue(interpreter, storable, v.dictionary.Storage)
 }
 
-func (v *CompositeValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
+func (v *CompositeValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
 	otherComposite, ok := other.(*CompositeValue)
 	if !ok {
 		return false
@@ -14391,10 +14391,10 @@ func (v *CompositeValue) Equal(interpreter *Interpreter, getLocationRange func()
 
 		// NOTE: Do NOT use an iterator, iteration order of fields may be different
 		// (if stored in different account, as storage ID is used as hash seed)
-		otherValue := otherComposite.GetField(interpreter, getLocationRange, fieldName)
+		otherValue := otherComposite.GetField(interpreter, locationRange, fieldName)
 
 		equatableValue, ok := MustConvertStoredValue(interpreter, value).(EquatableValue)
-		if !ok || !equatableValue.Equal(interpreter, getLocationRange, otherValue) {
+		if !ok || !equatableValue.Equal(interpreter, locationRange, otherValue) {
 			return false
 		}
 	}
@@ -14404,13 +14404,13 @@ func (v *CompositeValue) Equal(interpreter *Interpreter, getLocationRange func()
 // - HashInputTypeEnum (1 byte)
 // - type id (n bytes)
 // - hash input of raw value field name (n bytes)
-func (v *CompositeValue) HashInput(interpreter *Interpreter, getLocationRange func() LocationRange, scratch []byte) []byte {
+func (v *CompositeValue) HashInput(interpreter *Interpreter, locationRange LocationRange, scratch []byte) []byte {
 	if v.Kind == common.CompositeKindEnum {
 		typeID := v.TypeID()
 
-		rawValue := v.GetField(interpreter, getLocationRange, sema.EnumRawValueFieldName)
+		rawValue := v.GetField(interpreter, locationRange, sema.EnumRawValueFieldName)
 		rawValueHashInput := rawValue.(HashableValue).
-			HashInput(interpreter, getLocationRange, scratch)
+			HashInput(interpreter, locationRange, scratch)
 
 		length := 1 + len(typeID) + len(rawValueHashInput)
 		if length <= len(scratch) {
@@ -14447,7 +14447,7 @@ func (v *CompositeValue) TypeID() common.TypeID {
 
 func (v *CompositeValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 
@@ -14490,7 +14490,7 @@ func (v *CompositeValue) ConformsToStaticType(
 	}
 
 	for _, fieldName := range compositeType.Fields {
-		value := v.GetField(interpreter, getLocationRange, fieldName)
+		value := v.GetField(interpreter, locationRange, fieldName)
 		if value == nil {
 			if v.ComputedFields == nil {
 				return false
@@ -14501,7 +14501,7 @@ func (v *CompositeValue) ConformsToStaticType(
 				return false
 			}
 
-			value = fieldGetter(interpreter, getLocationRange)
+			value = fieldGetter(interpreter, locationRange)
 		}
 
 		member, ok := compositeType.Members.Get(fieldName)
@@ -14517,7 +14517,7 @@ func (v *CompositeValue) ConformsToStaticType(
 
 		if !value.ConformsToStaticType(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			results,
 		) {
 			return false
@@ -14567,7 +14567,7 @@ func (v *CompositeValue) IsReferenceTrackedResourceKindedValue() {}
 
 func (v *CompositeValue) Transfer(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -14582,7 +14582,7 @@ func (v *CompositeValue) Transfer(
 	interpreter.ReportComputation(common.ComputationKindTransferCompositeValue, 1)
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	if interpreter.Config.TracingEnabled {
@@ -14647,7 +14647,7 @@ func (v *CompositeValue) Transfer(
 				// and does not need to be converted or copied
 
 				value := MustConvertStoredValue(interpreter, atreeValue).
-					Transfer(interpreter, getLocationRange, address, remove, nil)
+					Transfer(interpreter, locationRange, address, remove, nil)
 
 				return atreeKey, value, nil
 			},
@@ -14740,8 +14740,8 @@ func (v *CompositeValue) Transfer(
 	return res
 }
 
-func (v *CompositeValue) ResourceUUID(interpreter *Interpreter, getLocationRange func() LocationRange) *UInt64Value {
-	fieldValue := v.GetField(interpreter, getLocationRange, sema.ResourceUUIDFieldName)
+func (v *CompositeValue) ResourceUUID(interpreter *Interpreter, locationRange LocationRange) *UInt64Value {
+	fieldValue := v.GetField(interpreter, locationRange, sema.ResourceUUIDFieldName)
 	uuid, ok := fieldValue.(UInt64Value)
 	if !ok {
 		return nil
@@ -14869,7 +14869,7 @@ func (v *CompositeValue) StorageID() atree.StorageID {
 
 func (v *CompositeValue) RemoveField(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	name string,
 ) {
 
@@ -14907,7 +14907,7 @@ func (v *CompositeValue) SetNestedVariables(variables map[string]*Variable) {
 
 func NewEnumCaseValue(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	enumType *sema.CompositeType,
 	rawValue NumberValue,
 	functions map[string]FunctionValue,
@@ -14922,7 +14922,7 @@ func NewEnumCaseValue(
 
 	v := NewCompositeValue(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		enumType.Location,
 		enumType.QualifiedIdentifier(),
 		enumType.Kind,
@@ -14948,13 +14948,13 @@ type DictionaryValue struct {
 
 func NewDictionaryValue(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	dictionaryType DictionaryStaticType,
 	keysAndValues ...Value,
 ) *DictionaryValue {
 	return NewDictionaryValueWithAddress(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		dictionaryType,
 		common.Address{},
 		keysAndValues...,
@@ -14963,7 +14963,7 @@ func NewDictionaryValue(
 
 func NewDictionaryValueWithAddress(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	dictionaryType DictionaryStaticType,
 	address common.Address,
 	keysAndValues ...Value,
@@ -15021,7 +15021,7 @@ func NewDictionaryValueWithAddress(
 	for i := 0; i < keysAndValuesCount; i += 2 {
 		key := keysAndValues[i]
 		value := keysAndValues[i+1]
-		existingValue := v.Insert(interpreter, getLocationRange, key, value)
+		existingValue := v.Insert(interpreter, locationRange, key, value)
 		// If the dictionary already contained a value for the key,
 		// and the dictionary is resource-typed,
 		// then we need to prevent a resource loss
@@ -15033,7 +15033,7 @@ func NewDictionaryValueWithAddress(
 			}
 			if *lazyIsResourceTyped {
 				panic(DuplicateKeyInResourceDictionaryError{
-					LocationRange: getLocationRange(),
+					LocationRange: locationRange,
 				})
 			}
 		}
@@ -15146,20 +15146,20 @@ func (v *DictionaryValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *DictionaryValue) checkInvalidatedResourceUse(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *DictionaryValue) checkInvalidatedResourceUse(interpreter *Interpreter, locationRange LocationRange) {
 	if v.isDestroyed || (v.dictionary == nil && v.IsResourceKinded(interpreter)) {
 		panic(InvalidatedResourceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 }
 
-func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *DictionaryValue) Destroy(interpreter *Interpreter, locationRange LocationRange) {
 
 	interpreter.ReportComputation(common.ComputationKindDestroyDictionaryValue, 1)
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	storageID := v.StorageID()
@@ -15181,8 +15181,8 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 
 	v.Iterate(interpreter, func(key, value Value) (resume bool) {
 		// Resources cannot be keys at the moment, so should theoretically not be needed
-		maybeDestroy(interpreter, getLocationRange, key)
-		maybeDestroy(interpreter, getLocationRange, value)
+		maybeDestroy(interpreter, locationRange, key)
+		maybeDestroy(interpreter, locationRange, value)
 		return true
 	})
 
@@ -15212,7 +15212,7 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, getLocationRange fun
 
 func (v *DictionaryValue) ForEachKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	procedure FunctionValue,
 ) {
 	keyType := v.SemaType(interpreter).KeyType
@@ -15224,7 +15224,7 @@ func (v *DictionaryValue) ForEachKey(
 			[]Value{key},
 			[]sema.Type{keyType},
 			nil,
-			getLocationRange,
+			locationRange,
 		)
 	}
 
@@ -15248,12 +15248,12 @@ func (v *DictionaryValue) ForEachKey(
 
 func (v *DictionaryValue) ContainsKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	keyValue Value,
 ) BoolValue {
 
-	valueComparator := newValueComparator(interpreter, getLocationRange)
-	hashInputProvider := newHashInputProvider(interpreter, getLocationRange)
+	valueComparator := newValueComparator(interpreter, locationRange)
+	hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
 	_, err := v.dictionary.Get(
 		valueComparator,
@@ -15272,12 +15272,12 @@ func (v *DictionaryValue) ContainsKey(
 
 func (v *DictionaryValue) Get(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	keyValue Value,
 ) (Value, bool) {
 
-	valueComparator := newValueComparator(interpreter, getLocationRange)
-	hashInputProvider := newHashInputProvider(interpreter, getLocationRange)
+	valueComparator := newValueComparator(interpreter, locationRange)
+	hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
 	storable, err := v.dictionary.Get(
 		valueComparator,
@@ -15296,13 +15296,13 @@ func (v *DictionaryValue) Get(
 	return value, true
 }
 
-func (v *DictionaryValue) GetKey(interpreter *Interpreter, getLocationRange func() LocationRange, keyValue Value) Value {
+func (v *DictionaryValue) GetKey(interpreter *Interpreter, locationRange LocationRange, keyValue Value) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
-	value, ok := v.Get(interpreter, getLocationRange, keyValue)
+	value, ok := v.Get(interpreter, locationRange, keyValue)
 	if ok {
 		return NewSomeValueNonCopying(interpreter, value)
 	}
@@ -15312,31 +15312,31 @@ func (v *DictionaryValue) GetKey(interpreter *Interpreter, getLocationRange func
 
 func (v *DictionaryValue) SetKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	keyValue Value,
 	value Value,
 ) {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
-	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, getLocationRange)
+	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, locationRange)
 	interpreter.checkContainerMutation(
 		OptionalStaticType{ // intentionally unmetered
 			Type: v.Type.ValueType,
 		},
 		value,
-		getLocationRange,
+		locationRange,
 	)
 
 	switch value := value.(type) {
 	case *SomeValue:
-		innerValue := value.InnerValue(interpreter, getLocationRange)
-		_ = v.Insert(interpreter, getLocationRange, keyValue, innerValue)
+		innerValue := value.InnerValue(interpreter, locationRange)
+		_ = v.Insert(interpreter, locationRange, keyValue, innerValue)
 
 	case NilValue:
-		_ = v.Remove(interpreter, getLocationRange, keyValue)
+		_ = v.Remove(interpreter, locationRange, keyValue)
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -15391,12 +15391,12 @@ func (v *DictionaryValue) MeteredString(memoryGauge common.MemoryGauge, seenRefe
 
 func (v *DictionaryValue) GetMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 ) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	if interpreter.Config.TracingEnabled {
@@ -15442,7 +15442,7 @@ func (v *DictionaryValue) GetMember(
 				}
 
 				return MustConvertStoredValue(interpreter, key).
-					Transfer(interpreter, getLocationRange, atree.Address{}, false, nil)
+					Transfer(interpreter, locationRange, atree.Address{}, false, nil)
 			},
 		)
 
@@ -15469,7 +15469,7 @@ func (v *DictionaryValue) GetMember(
 				}
 
 				return MustConvertStoredValue(interpreter, value).
-					Transfer(interpreter, getLocationRange, atree.Address{}, false, nil)
+					Transfer(interpreter, locationRange, atree.Address{}, false, nil)
 			})
 
 	case "remove":
@@ -15480,7 +15480,7 @@ func (v *DictionaryValue) GetMember(
 
 				return v.Remove(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					keyValue,
 				)
 			},
@@ -15498,7 +15498,7 @@ func (v *DictionaryValue) GetMember(
 
 				return v.Insert(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					keyValue,
 					newValue,
 				)
@@ -15514,7 +15514,7 @@ func (v *DictionaryValue) GetMember(
 			func(invocation Invocation) Value {
 				return v.ContainsKey(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
 			},
@@ -15533,7 +15533,7 @@ func (v *DictionaryValue) GetMember(
 
 				v.ForEachKey(
 					invocation.Interpreter,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 					funcArgument,
 				)
 
@@ -15548,20 +15548,20 @@ func (v *DictionaryValue) GetMember(
 	return nil
 }
 
-func (v *DictionaryValue) RemoveMember(interpreter *Interpreter, getLocationRange func() LocationRange, _ string) Value {
+func (v *DictionaryValue) RemoveMember(interpreter *Interpreter, locationRange LocationRange, _ string) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	// Dictionaries have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (v *DictionaryValue) SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, _ string, _ Value) {
+func (v *DictionaryValue) SetMember(interpreter *Interpreter, locationRange LocationRange, _ string, _ Value) {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	// Dictionaries have no settable members (fields / functions)
@@ -15574,25 +15574,25 @@ func (v *DictionaryValue) Count() int {
 
 func (v *DictionaryValue) RemoveKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 ) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
-	return v.Remove(interpreter, getLocationRange, key)
+	return v.Remove(interpreter, locationRange, key)
 }
 
 func (v *DictionaryValue) Remove(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	keyValue Value,
 ) OptionalValue {
 
-	valueComparator := newValueComparator(interpreter, getLocationRange)
-	hashInputProvider := newHashInputProvider(interpreter, getLocationRange)
+	valueComparator := newValueComparator(interpreter, locationRange)
+	hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
 	// No need to clean up storable for passed-in key value,
 	// as atree never calls Storable()
@@ -15622,7 +15622,7 @@ func (v *DictionaryValue) Remove(
 	existingValue := StoredValue(interpreter, existingValueStorable, storage).
 		Transfer(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			atree.Address{},
 			true,
 			existingValueStorable,
@@ -15633,15 +15633,15 @@ func (v *DictionaryValue) Remove(
 
 func (v *DictionaryValue) InsertKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key, value Value,
 ) {
-	v.SetKey(interpreter, getLocationRange, key, value)
+	v.SetKey(interpreter, locationRange, key, value)
 }
 
 func (v *DictionaryValue) Insert(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	keyValue, value Value,
 ) OptionalValue {
 
@@ -15651,14 +15651,14 @@ func (v *DictionaryValue) Insert(
 	common.UseMemory(interpreter, dataSlabs)
 	common.UseMemory(interpreter, metaDataSlabs)
 
-	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, getLocationRange)
-	interpreter.checkContainerMutation(v.Type.ValueType, value, getLocationRange)
+	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, locationRange)
+	interpreter.checkContainerMutation(v.Type.ValueType, value, locationRange)
 
 	address := v.dictionary.Address()
 
 	keyValue = keyValue.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		address,
 		true,
 		nil,
@@ -15666,14 +15666,14 @@ func (v *DictionaryValue) Insert(
 
 	value = value.Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		address,
 		true,
 		nil,
 	)
 
-	valueComparator := newValueComparator(interpreter, getLocationRange)
-	hashInputProvider := newHashInputProvider(interpreter, getLocationRange)
+	valueComparator := newValueComparator(interpreter, locationRange)
+	hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
 	// atree only calls Storable() on keyValue if needed,
 	// i.e., if the key is a new key
@@ -15699,7 +15699,7 @@ func (v *DictionaryValue) Insert(
 		storage,
 	).Transfer(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		atree.Address{},
 		true,
 		existingValueStorable,
@@ -15715,7 +15715,7 @@ type DictionaryEntryValues struct {
 
 func (v *DictionaryValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 
@@ -15769,7 +15769,7 @@ func (v *DictionaryValue) ConformsToStaticType(
 
 		if !entryKey.ConformsToStaticType(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			results,
 		) {
 			return false
@@ -15787,7 +15787,7 @@ func (v *DictionaryValue) ConformsToStaticType(
 
 		if !entryValue.ConformsToStaticType(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			results,
 		) {
 			return false
@@ -15795,7 +15795,7 @@ func (v *DictionaryValue) ConformsToStaticType(
 	}
 }
 
-func (v *DictionaryValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
+func (v *DictionaryValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
 
 	otherDictionary, ok := other.(*DictionaryValue)
 	if !ok {
@@ -15829,7 +15829,7 @@ func (v *DictionaryValue) Equal(interpreter *Interpreter, getLocationRange func(
 		otherValue, otherValueExists :=
 			otherDictionary.Get(
 				interpreter,
-				getLocationRange,
+				locationRange,
 				MustConvertStoredValue(interpreter, key),
 			)
 
@@ -15838,7 +15838,7 @@ func (v *DictionaryValue) Equal(interpreter *Interpreter, getLocationRange func(
 		}
 
 		equatableValue, ok := MustConvertStoredValue(interpreter, value).(EquatableValue)
-		if !ok || !equatableValue.Equal(interpreter, getLocationRange, otherValue) {
+		if !ok || !equatableValue.Equal(interpreter, locationRange, otherValue) {
 			return false
 		}
 	}
@@ -15852,7 +15852,7 @@ func (v *DictionaryValue) IsReferenceTrackedResourceKindedValue() {}
 
 func (v *DictionaryValue) Transfer(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -15869,7 +15869,7 @@ func (v *DictionaryValue) Transfer(
 	interpreter.ReportComputation(common.ComputationKindTransferDictionaryValue, uint(v.Count()))
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(interpreter, getLocationRange)
+		v.checkInvalidatedResourceUse(interpreter, locationRange)
 	}
 
 	if interpreter.Config.TracingEnabled {
@@ -15897,8 +15897,8 @@ func (v *DictionaryValue) Transfer(
 
 	if needsStoreTo || !isResourceKinded {
 
-		valueComparator := newValueComparator(interpreter, getLocationRange)
-		hashInputProvider := newHashInputProvider(interpreter, getLocationRange)
+		valueComparator := newValueComparator(interpreter, locationRange)
+		hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
 		iterator, err := v.dictionary.Iterator()
 		if err != nil {
@@ -15927,10 +15927,10 @@ func (v *DictionaryValue) Transfer(
 				}
 
 				key := MustConvertStoredValue(interpreter, atreeKey).
-					Transfer(interpreter, getLocationRange, address, remove, nil)
+					Transfer(interpreter, locationRange, address, remove, nil)
 
 				value := MustConvertStoredValue(interpreter, atreeValue).
-					Transfer(interpreter, getLocationRange, address, remove, nil)
+					Transfer(interpreter, locationRange, address, remove, nil)
 
 				return key, value, nil
 			},
@@ -16000,8 +16000,8 @@ func (v *DictionaryValue) Transfer(
 
 func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 
-	valueComparator := newValueComparator(interpreter, ReturnEmptyLocationRange)
-	hashInputProvider := newHashInputProvider(interpreter, ReturnEmptyLocationRange)
+	valueComparator := newValueComparator(interpreter, EmptyLocationRange)
+	hashInputProvider := newHashInputProvider(interpreter, EmptyLocationRange)
 
 	iterator, err := v.dictionary.Iterator()
 	if err != nil {
@@ -16163,7 +16163,7 @@ func (NilValue) IsDestroyed() bool {
 	return false
 }
 
-func (v NilValue) Destroy(_ *Interpreter, _ func() LocationRange) {
+func (v NilValue) Destroy(_ *Interpreter, _ LocationRange) {
 	// NO-OP
 }
 
@@ -16193,7 +16193,7 @@ var nilValueMapFunction = NewUnmeteredHostFunctionValue(
 	},
 )
 
-func (v NilValue) GetMember(_ *Interpreter, _ func() LocationRange, name string) Value {
+func (v NilValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case "map":
 		return nilValueMapFunction
@@ -16202,25 +16202,25 @@ func (v NilValue) GetMember(_ *Interpreter, _ func() LocationRange, name string)
 	return nil
 }
 
-func (NilValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (NilValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Nil has no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (NilValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (NilValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Nil has no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (v NilValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
 }
 
-func (v NilValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v NilValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	_, ok := other.(NilValue)
 	return ok
 }
@@ -16243,7 +16243,7 @@ func (NilValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v NilValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -16335,15 +16335,15 @@ func (v *SomeValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *SomeValue) Destroy(interpreter *Interpreter, getLocationRange func() LocationRange) {
+func (v *SomeValue) Destroy(interpreter *Interpreter, locationRange LocationRange) {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
-	innerValue := v.InnerValue(interpreter, getLocationRange)
+	innerValue := v.InnerValue(interpreter, locationRange)
 
-	maybeDestroy(interpreter, getLocationRange, innerValue)
+	maybeDestroy(interpreter, locationRange, innerValue)
 	v.isDestroyed = true
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
@@ -16363,10 +16363,10 @@ func (v SomeValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences 
 	return v.value.MeteredString(memoryGauge, seenReferences)
 }
 
-func (v *SomeValue) GetMember(interpreter *Interpreter, getLocationRange func() LocationRange, name string) Value {
+func (v *SomeValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 	switch name {
 	case "map":
@@ -16392,7 +16392,7 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, getLocationRange func() 
 					[]Value{v.value},
 					[]sema.Type{valueType},
 					nil,
-					invocation.GetLocationRange,
+					invocation.LocationRange,
 				)
 
 				newValue := transformFunction.invoke(transformInvocation)
@@ -16410,19 +16410,19 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, getLocationRange func() 
 	return nil
 }
 
-func (v *SomeValue) RemoveMember(interpreter *Interpreter, getLocationRange func() LocationRange, _ string) Value {
+func (v *SomeValue) RemoveMember(interpreter *Interpreter, locationRange LocationRange, _ string) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	panic(errors.NewUnreachableError())
 }
 
-func (v *SomeValue) SetMember(interpreter *Interpreter, getLocationRange func() LocationRange, _ string, _ Value) {
+func (v *SomeValue) SetMember(interpreter *Interpreter, locationRange LocationRange, _ string, _ Value) {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	panic(errors.NewUnreachableError())
@@ -16430,7 +16430,7 @@ func (v *SomeValue) SetMember(interpreter *Interpreter, getLocationRange func() 
 
 func (v *SomeValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 
@@ -16438,29 +16438,29 @@ func (v *SomeValue) ConformsToStaticType(
 	// SomeValue.StaticType builds type from inner value (if available),
 	// so no need to check it
 
-	innerValue := v.InnerValue(interpreter, getLocationRange)
+	innerValue := v.InnerValue(interpreter, locationRange)
 
 	return innerValue.ConformsToStaticType(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		results,
 	)
 }
 
-func (v *SomeValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
+func (v *SomeValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
 	otherSome, ok := other.(*SomeValue)
 	if !ok {
 		return false
 	}
 
-	innerValue := v.InnerValue(interpreter, getLocationRange)
+	innerValue := v.InnerValue(interpreter, locationRange)
 
 	equatableValue, ok := innerValue.(EquatableValue)
 	if !ok {
 		return false
 	}
 
-	return equatableValue.Equal(interpreter, getLocationRange, otherSome.value)
+	return equatableValue.Equal(interpreter, locationRange, otherSome.value)
 }
 
 func (v *SomeValue) Storable(
@@ -16499,24 +16499,24 @@ func (v *SomeValue) IsResourceKinded(interpreter *Interpreter) bool {
 	return v.value.IsResourceKinded(interpreter)
 }
 
-func (v *SomeValue) checkInvalidatedResourceUse(getLocationRange func() LocationRange) {
+func (v *SomeValue) checkInvalidatedResourceUse(locationRange LocationRange) {
 	if v.isDestroyed || v.value == nil {
 		panic(InvalidatedResourceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 }
 
 func (v *SomeValue) Transfer(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
 ) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	innerValue := v.value
@@ -16526,7 +16526,7 @@ func (v *SomeValue) Transfer(
 
 	if needsStoreTo || !isResourceKinded {
 
-		innerValue = v.value.Transfer(interpreter, getLocationRange, address, remove, nil)
+		innerValue = v.value.Transfer(interpreter, locationRange, address, remove, nil)
 
 		if remove {
 			interpreter.RemoveReferencedSlab(v.valueStorable)
@@ -16577,10 +16577,10 @@ func (v *SomeValue) DeepRemove(interpreter *Interpreter) {
 	}
 }
 
-func (v *SomeValue) InnerValue(interpreter *Interpreter, getLocationRange func() LocationRange) Value {
+func (v *SomeValue) InnerValue(interpreter *Interpreter, locationRange LocationRange) Value {
 
 	if interpreter.Config.InvalidatedResourceValidationEnabled {
-		v.checkInvalidatedResourceUse(getLocationRange)
+		v.checkInvalidatedResourceUse(locationRange)
 	}
 
 	return v.value
@@ -16681,7 +16681,7 @@ func (v *StorageReferenceValue) MeteredString(memoryGauge common.MemoryGauge, _ 
 }
 
 func (v *StorageReferenceValue) StaticType(inter *Interpreter) StaticType {
-	referencedValue, err := v.dereference(inter, ReturnEmptyLocationRange)
+	referencedValue, err := v.dereference(inter, EmptyLocationRange)
 	if err != nil {
 		panic(err)
 	}
@@ -16698,7 +16698,7 @@ func (*StorageReferenceValue) IsImportable(_ *Interpreter) bool {
 	return false
 }
 
-func (v *StorageReferenceValue) dereference(interpreter *Interpreter, getLocationRange func() LocationRange) (*Value, error) {
+func (v *StorageReferenceValue) dereference(interpreter *Interpreter, locationRange LocationRange) (*Value, error) {
 	address := v.TargetStorageAddress
 	domain := v.TargetPath.Domain.Identifier()
 	identifier := v.TargetPath.Identifier
@@ -16717,7 +16717,7 @@ func (v *StorageReferenceValue) dereference(interpreter *Interpreter, getLocatio
 			return nil, ForceCastTypeMismatchError{
 				ExpectedType:  v.BorrowedType,
 				ActualType:    semaType,
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			}
 		}
 	}
@@ -16726,7 +16726,7 @@ func (v *StorageReferenceValue) dereference(interpreter *Interpreter, getLocatio
 }
 
 func (v *StorageReferenceValue) ReferencedValue(interpreter *Interpreter) *Value {
-	value, err := v.dereference(interpreter, ReturnEmptyLocationRange)
+	value, err := v.dereference(interpreter, EmptyLocationRange)
 	if err != nil {
 		return nil
 	}
@@ -16735,145 +16735,145 @@ func (v *StorageReferenceValue) ReferencedValue(interpreter *Interpreter) *Value
 
 func (v *StorageReferenceValue) GetMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 ) Value {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
-	return interpreter.getMember(self, getLocationRange, name)
+	return interpreter.getMember(self, locationRange, name)
 }
 
 func (v *StorageReferenceValue) RemoveMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 ) Value {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
-	return self.(MemberAccessibleValue).RemoveMember(interpreter, getLocationRange, name)
+	return self.(MemberAccessibleValue).RemoveMember(interpreter, locationRange, name)
 }
 
 func (v *StorageReferenceValue) SetMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 	value Value,
 ) {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
-	interpreter.setMember(self, getLocationRange, name, value)
+	interpreter.setMember(self, locationRange, name, value)
 }
 
 func (v *StorageReferenceValue) GetKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 ) Value {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	return self.(ValueIndexableValue).
-		GetKey(interpreter, getLocationRange, key)
+		GetKey(interpreter, locationRange, key)
 }
 
 func (v *StorageReferenceValue) SetKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 	value Value,
 ) {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	self.(ValueIndexableValue).
-		SetKey(interpreter, getLocationRange, key, value)
+		SetKey(interpreter, locationRange, key, value)
 }
 
 func (v *StorageReferenceValue) InsertKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 	value Value,
 ) {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	self.(ValueIndexableValue).
-		InsertKey(interpreter, getLocationRange, key, value)
+		InsertKey(interpreter, locationRange, key, value)
 }
 
 func (v *StorageReferenceValue) RemoveKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 ) Value {
 	referencedValue := v.ReferencedValue(interpreter)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	return self.(ValueIndexableValue).
-		RemoveKey(interpreter, getLocationRange, key)
+		RemoveKey(interpreter, locationRange, key)
 }
 
-func (v *StorageReferenceValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v *StorageReferenceValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherReference, ok := other.(*StorageReferenceValue)
 	if !ok ||
 		v.TargetStorageAddress != otherReference.TargetStorageAddress ||
@@ -16892,7 +16892,7 @@ func (v *StorageReferenceValue) Equal(_ *Interpreter, _ func() LocationRange, ot
 
 func (v *StorageReferenceValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 	referencedValue := v.ReferencedValue(interpreter)
@@ -16908,7 +16908,7 @@ func (v *StorageReferenceValue) ConformsToStaticType(
 
 	return (*referencedValue).ConformsToStaticType(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		results,
 	)
 }
@@ -16931,7 +16931,7 @@ func (*StorageReferenceValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v *StorageReferenceValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -17022,7 +17022,7 @@ func (v *EphemeralReferenceValue) MeteredString(memoryGauge common.MemoryGauge, 
 }
 
 func (v *EphemeralReferenceValue) StaticType(inter *Interpreter) StaticType {
-	referencedValue := v.ReferencedValue(inter, ReturnEmptyLocationRange)
+	referencedValue := v.ReferencedValue(inter, EmptyLocationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{})
 	}
@@ -17041,14 +17041,14 @@ func (*EphemeralReferenceValue) IsImportable(_ *Interpreter) bool {
 
 func (v *EphemeralReferenceValue) ReferencedValue(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 ) *Value {
 	// Just like for storage references, references to optionals are unwrapped,
 	// i.e. a reference to `nil` aborts when dereferenced.
 
 	switch referenced := v.Value.(type) {
 	case *SomeValue:
-		innerValue := referenced.InnerValue(interpreter, getLocationRange)
+		innerValue := referenced.InnerValue(interpreter, locationRange)
 		return &innerValue
 	case NilValue:
 		return nil
@@ -17059,41 +17059,41 @@ func (v *EphemeralReferenceValue) ReferencedValue(
 
 func (v *EphemeralReferenceValue) GetMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 ) Value {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
-	return interpreter.getMember(self, getLocationRange, name)
+	return interpreter.getMember(self, locationRange, name)
 }
 
 func (v *EphemeralReferenceValue) RemoveMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	identifier string,
 ) Value {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	if memberAccessibleValue, ok := self.(MemberAccessibleValue); ok {
-		return memberAccessibleValue.RemoveMember(interpreter, getLocationRange, identifier)
+		return memberAccessibleValue.RemoveMember(interpreter, locationRange, identifier)
 	}
 
 	return nil
@@ -17101,107 +17101,107 @@ func (v *EphemeralReferenceValue) RemoveMember(
 
 func (v *EphemeralReferenceValue) SetMember(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	name string,
 	value Value,
 ) {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
-	interpreter.setMember(self, getLocationRange, name, value)
+	interpreter.setMember(self, locationRange, name, value)
 }
 
 func (v *EphemeralReferenceValue) GetKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 ) Value {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	return self.(ValueIndexableValue).
-		GetKey(interpreter, getLocationRange, key)
+		GetKey(interpreter, locationRange, key)
 }
 
 func (v *EphemeralReferenceValue) SetKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 	value Value,
 ) {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	self.(ValueIndexableValue).
-		SetKey(interpreter, getLocationRange, key, value)
+		SetKey(interpreter, locationRange, key, value)
 }
 
 func (v *EphemeralReferenceValue) InsertKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 	value Value,
 ) {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	self.(ValueIndexableValue).
-		InsertKey(interpreter, getLocationRange, key, value)
+		InsertKey(interpreter, locationRange, key, value)
 }
 
 func (v *EphemeralReferenceValue) RemoveKey(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	key Value,
 ) Value {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		panic(DereferenceError{
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
 	self := *referencedValue
 
-	interpreter.checkReferencedResourceNotDestroyed(self, getLocationRange)
+	interpreter.checkReferencedResourceNotDestroyed(self, locationRange)
 
 	return self.(ValueIndexableValue).
-		RemoveKey(interpreter, getLocationRange, key)
+		RemoveKey(interpreter, locationRange, key)
 }
 
-func (v *EphemeralReferenceValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v *EphemeralReferenceValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherReference, ok := other.(*EphemeralReferenceValue)
 	if !ok ||
 		v.Value != otherReference.Value ||
@@ -17219,10 +17219,10 @@ func (v *EphemeralReferenceValue) Equal(_ *Interpreter, _ func() LocationRange, 
 
 func (v *EphemeralReferenceValue) ConformsToStaticType(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
-	referencedValue := v.ReferencedValue(interpreter, getLocationRange)
+	referencedValue := v.ReferencedValue(interpreter, locationRange)
 	if referencedValue == nil {
 		return false
 	}
@@ -17248,7 +17248,7 @@ func (v *EphemeralReferenceValue) ConformsToStaticType(
 
 	result := (*referencedValue).ConformsToStaticType(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		results,
 	)
 
@@ -17275,7 +17275,7 @@ func (*EphemeralReferenceValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v *EphemeralReferenceValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -17385,7 +17385,7 @@ func (v AddressValue) MeteredString(memoryGauge common.MemoryGauge, _ SeenRefere
 	return v.String()
 }
 
-func (v AddressValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v AddressValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherAddress, ok := other.(AddressValue)
 	if !ok {
 		return false
@@ -17396,7 +17396,7 @@ func (v AddressValue) Equal(_ *Interpreter, _ func() LocationRange, other Value)
 // HashInput returns a byte slice containing:
 // - HashInputTypeAddress (1 byte)
 // - address (8 bytes)
-func (v AddressValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v AddressValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	length := 1 + len(v)
 	var buffer []byte
 	if length <= len(scratch) {
@@ -17418,7 +17418,7 @@ func (v AddressValue) ToAddress() common.Address {
 	return common.Address(v)
 }
 
-func (v AddressValue) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v AddressValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 
 	case sema.ToStringFunctionName:
@@ -17454,19 +17454,19 @@ func (v AddressValue) GetMember(interpreter *Interpreter, _ func() LocationRange
 	return nil
 }
 
-func (AddressValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (AddressValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Addresses have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (AddressValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (AddressValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Addresses have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (v AddressValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
@@ -17490,7 +17490,7 @@ func (AddressValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v AddressValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -17547,7 +17547,7 @@ func accountGetCapabilityFunction(
 				panic(TypeMismatchError{
 					ExpectedType:  pathType,
 					ActualType:    pathSemaType,
-					LocationRange: invocation.GetLocationRange(),
+					LocationRange: invocation.LocationRange,
 				})
 			}
 
@@ -17654,7 +17654,7 @@ func (v PathValue) MeteredString(memoryGauge common.MemoryGauge, _ SeenReference
 	return v.String()
 }
 
-func (v PathValue) GetMember(inter *Interpreter, _ func() LocationRange, name string) Value {
+func (v PathValue) GetMember(inter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 
 	case sema.ToStringFunctionName:
@@ -17683,25 +17683,25 @@ func (v PathValue) GetMember(inter *Interpreter, _ func() LocationRange, name st
 	return nil
 }
 
-func (PathValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (PathValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Paths have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (PathValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (PathValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Paths have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (v PathValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
 }
 
-func (v PathValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bool {
+func (v PathValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	otherPath, ok := other.(PathValue)
 	if !ok {
 		return false
@@ -17715,7 +17715,7 @@ func (v PathValue) Equal(_ *Interpreter, _ func() LocationRange, other Value) bo
 // - HashInputTypePath (1 byte)
 // - domain (1 byte)
 // - identifier (n bytes)
-func (v PathValue) HashInput(_ *Interpreter, _ func() LocationRange, scratch []byte) []byte {
+func (v PathValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {
 	length := 1 + 1 + len(v.Identifier)
 	var buffer []byte
 	if length <= len(scratch) {
@@ -17795,7 +17795,7 @@ func (PathValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v PathValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -17908,7 +17908,7 @@ func (v *CapabilityValue) MeteredString(memoryGauge common.MemoryGauge, seenRefe
 	)
 }
 
-func (v *CapabilityValue) GetMember(interpreter *Interpreter, _ func() LocationRange, name string) Value {
+func (v *CapabilityValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case sema.CapabilityTypeBorrowField:
 		var borrowType *sema.ReferenceType
@@ -17933,25 +17933,25 @@ func (v *CapabilityValue) GetMember(interpreter *Interpreter, _ func() LocationR
 	return nil
 }
 
-func (*CapabilityValue) RemoveMember(_ *Interpreter, _ func() LocationRange, _ string) Value {
+func (*CapabilityValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Capabilities have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (*CapabilityValue) SetMember(_ *Interpreter, _ func() LocationRange, _ string, _ Value) {
+func (*CapabilityValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) {
 	// Capabilities have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (v *CapabilityValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
 }
 
-func (v *CapabilityValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
+func (v *CapabilityValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
 	otherCapability, ok := other.(*CapabilityValue)
 	if !ok {
 		return false
@@ -17967,8 +17967,8 @@ func (v *CapabilityValue) Equal(interpreter *Interpreter, getLocationRange func(
 		return false
 	}
 
-	return otherCapability.Address.Equal(interpreter, getLocationRange, v.Address) &&
-		otherCapability.Path.Equal(interpreter, getLocationRange, v.Path)
+	return otherCapability.Address.Equal(interpreter, locationRange, v.Address) &&
+		otherCapability.Path.Equal(interpreter, locationRange, v.Path)
 }
 
 func (*CapabilityValue) IsStorable() bool {
@@ -17998,7 +17998,7 @@ func (*CapabilityValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v *CapabilityValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -18105,19 +18105,19 @@ func (v LinkValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences 
 
 func (v LinkValue) ConformsToStaticType(
 	_ *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
 	return true
 }
 
-func (v LinkValue) Equal(interpreter *Interpreter, getLocationRange func() LocationRange, other Value) bool {
+func (v LinkValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
 	otherLink, ok := other.(LinkValue)
 	if !ok {
 		return false
 	}
 
-	return otherLink.TargetPath.Equal(interpreter, getLocationRange, v.TargetPath) &&
+	return otherLink.TargetPath.Equal(interpreter, locationRange, v.TargetPath) &&
 		otherLink.Type.Equal(v.Type)
 }
 
@@ -18139,7 +18139,7 @@ func (LinkValue) IsResourceKinded(_ *Interpreter) bool {
 
 func (v LinkValue) Transfer(
 	interpreter *Interpreter,
-	_ func() LocationRange,
+	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
@@ -18178,7 +18178,7 @@ func (v LinkValue) ChildStorables() []atree.Storable {
 // NewPublicKeyValue constructs a PublicKey value.
 func NewPublicKeyValue(
 	interpreter *Interpreter,
-	getLocationRange func() LocationRange,
+	locationRange LocationRange,
 	publicKey *ArrayValue,
 	signAlgo Value,
 	validatePublicKey PublicKeyValidationHandlerFunc,
@@ -18193,7 +18193,7 @@ func NewPublicKeyValue(
 
 	publicKeyValue := NewCompositeValue(
 		interpreter,
-		getLocationRange,
+		locationRange,
 		sema.PublicKeyType.Location,
 		sema.PublicKeyType.QualifiedIdentifier(),
 		sema.PublicKeyType.Kind,
@@ -18202,8 +18202,8 @@ func NewPublicKeyValue(
 	)
 
 	publicKeyValue.ComputedFields = map[string]ComputedField{
-		sema.PublicKeyPublicKeyField: func(interpreter *Interpreter, getLocationRange func() LocationRange) Value {
-			return publicKey.Transfer(interpreter, getLocationRange, atree.Address{}, false, nil)
+		sema.PublicKeyPublicKeyField: func(interpreter *Interpreter, locationRange LocationRange) Value {
+			return publicKey.Transfer(interpreter, locationRange, atree.Address{}, false, nil)
 		},
 	}
 	publicKeyValue.Functions = map[string]FunctionValue{
@@ -18211,12 +18211,12 @@ func NewPublicKeyValue(
 		sema.PublicKeyVerifyPoPFunction: publicKeyVerifyPoPFunction,
 	}
 
-	err := validatePublicKey(interpreter, getLocationRange, publicKeyValue)
+	err := validatePublicKey(interpreter, locationRange, publicKeyValue)
 	if err != nil {
 		panic(InvalidPublicKeyError{
 			PublicKey:     publicKey,
 			Err:           err,
-			LocationRange: getLocationRange(),
+			LocationRange: locationRange,
 		})
 	}
 
@@ -18235,7 +18235,7 @@ func NewPublicKeyValue(
 			{
 				Name: sema.PublicKeySignAlgoField,
 				// TODO: provide proper location range
-				Value: publicKeyValue.GetField(interpreter, ReturnEmptyLocationRange, sema.PublicKeySignAlgoField),
+				Value: publicKeyValue.GetField(interpreter, EmptyLocationRange, sema.PublicKeySignAlgoField),
 			},
 		}
 
@@ -18278,17 +18278,17 @@ var publicKeyVerifyFunction = NewUnmeteredHostFunctionValue(
 
 		interpreter := invocation.Interpreter
 
-		getLocationRange := invocation.GetLocationRange
+		locationRange := invocation.LocationRange
 
 		interpreter.ExpectType(
 			publicKey,
 			sema.PublicKeyType,
-			getLocationRange,
+			locationRange,
 		)
 
 		return interpreter.Config.SignatureVerificationHandler(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			signatureValue,
 			signedDataValue,
 			domainSeparationTag,
@@ -18312,17 +18312,17 @@ var publicKeyVerifyPoPFunction = NewUnmeteredHostFunctionValue(
 
 		interpreter := invocation.Interpreter
 
-		getLocationRange := invocation.GetLocationRange
+		locationRange := invocation.LocationRange
 
 		interpreter.ExpectType(
 			publicKey,
 			sema.PublicKeyType,
-			getLocationRange,
+			locationRange,
 		)
 
 		return interpreter.Config.BLSVerifyPoPHandler(
 			interpreter,
-			getLocationRange,
+			locationRange,
 			publicKey,
 			signatureValue,
 		)

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -43,7 +43,7 @@ import (
 func newTestCompositeValue(inter *Interpreter, owner common.Address) *CompositeValue {
 	return NewCompositeValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		utils.TestLocation,
 		"Test",
 		common.CompositeKindStructure,
@@ -104,7 +104,7 @@ func TestOwnerNewArray(t *testing.T) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -112,7 +112,7 @@ func TestOwnerNewArray(t *testing.T) {
 		value,
 	)
 
-	value = array.Get(inter, ReturnEmptyLocationRange, 0).(*CompositeValue)
+	value = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, common.Address{}, array.GetOwner())
 	assert.Equal(t, common.Address{}, value.GetOwner())
@@ -155,7 +155,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -165,7 +165,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 
 	arrayCopy := array.Transfer(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		atree.Address(newOwner),
 		false,
 		nil,
@@ -174,7 +174,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 
 	value = array.Get(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		0,
 	).(*CompositeValue)
 
@@ -207,7 +207,7 @@ func TestOwnerArrayElement(t *testing.T) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -215,7 +215,7 @@ func TestOwnerArrayElement(t *testing.T) {
 		value,
 	)
 
-	value = array.Get(inter, ReturnEmptyLocationRange, 0).(*CompositeValue)
+	value = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, newOwner, array.GetOwner())
 	assert.Equal(t, newOwner, value.GetOwner())
@@ -247,7 +247,7 @@ func TestOwnerArraySetIndex(t *testing.T) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -255,15 +255,15 @@ func TestOwnerArraySetIndex(t *testing.T) {
 		value1,
 	)
 
-	value1 = array.Get(inter, ReturnEmptyLocationRange, 0).(*CompositeValue)
+	value1 = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, newOwner, array.GetOwner())
 	assert.Equal(t, newOwner, value1.GetOwner())
 	assert.Equal(t, oldOwner, value2.GetOwner())
 
-	array.Set(inter, ReturnEmptyLocationRange, 0, value2)
+	array.Set(inter, EmptyLocationRange, 0, value2)
 
-	value2 = array.Get(inter, ReturnEmptyLocationRange, 0).(*CompositeValue)
+	value2 = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, newOwner, array.GetOwner())
 	assert.Equal(t, newOwner, value1.GetOwner())
@@ -295,7 +295,7 @@ func TestOwnerArrayAppend(t *testing.T) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -305,9 +305,9 @@ func TestOwnerArrayAppend(t *testing.T) {
 	assert.Equal(t, newOwner, array.GetOwner())
 	assert.Equal(t, oldOwner, value.GetOwner())
 
-	array.Append(inter, ReturnEmptyLocationRange, value)
+	array.Append(inter, EmptyLocationRange, value)
 
-	value = array.Get(inter, ReturnEmptyLocationRange, 0).(*CompositeValue)
+	value = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, newOwner, array.GetOwner())
 	assert.Equal(t, newOwner, value.GetOwner())
@@ -338,7 +338,7 @@ func TestOwnerArrayInsert(t *testing.T) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -348,9 +348,9 @@ func TestOwnerArrayInsert(t *testing.T) {
 	assert.Equal(t, newOwner, array.GetOwner())
 	assert.Equal(t, oldOwner, value.GetOwner())
 
-	array.Insert(inter, ReturnEmptyLocationRange, 0, value)
+	array.Insert(inter, EmptyLocationRange, 0, value)
 
-	value = array.Get(inter, ReturnEmptyLocationRange, 0).(*CompositeValue)
+	value = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, newOwner, array.GetOwner())
 	assert.Equal(t, newOwner, value.GetOwner())
@@ -380,7 +380,7 @@ func TestOwnerArrayRemove(t *testing.T) {
 
 	array := NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -391,7 +391,7 @@ func TestOwnerArrayRemove(t *testing.T) {
 	assert.Equal(t, owner, array.GetOwner())
 	assert.Equal(t, owner, value.GetOwner())
 
-	value = array.Remove(inter, ReturnEmptyLocationRange, 0).(*CompositeValue)
+	value = array.Remove(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, owner, array.GetOwner())
 	assert.Equal(t, common.Address{}, value.GetOwner())
@@ -424,7 +424,7 @@ func TestOwnerNewDictionary(t *testing.T) {
 
 	dictionary := NewDictionaryValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
@@ -434,7 +434,7 @@ func TestOwnerNewDictionary(t *testing.T) {
 
 	// NOTE: keyValue is string, has no owner
 
-	queriedValue, _ := dictionary.Get(inter, ReturnEmptyLocationRange, keyValue)
+	queriedValue, _ := dictionary.Get(inter, EmptyLocationRange, keyValue)
 	value = queriedValue.(*CompositeValue)
 
 	assert.Equal(t, common.Address{}, dictionary.GetOwner())
@@ -467,7 +467,7 @@ func TestOwnerDictionary(t *testing.T) {
 
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
@@ -478,7 +478,7 @@ func TestOwnerDictionary(t *testing.T) {
 
 	// NOTE: keyValue is string, has no owner
 
-	queriedValue, _ := dictionary.Get(inter, ReturnEmptyLocationRange, keyValue)
+	queriedValue, _ := dictionary.Get(inter, EmptyLocationRange, keyValue)
 	value = queriedValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
@@ -523,7 +523,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
@@ -534,7 +534,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 
 	copyResult := dictionary.Transfer(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		atree.Address{},
 		false,
 		nil,
@@ -544,7 +544,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 
 	queriedValue, _ := dictionaryCopy.Get(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		keyValue,
 	)
 	value = queriedValue.(*CompositeValue)
@@ -579,7 +579,7 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
@@ -592,12 +592,12 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 
 	dictionary.SetKey(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		keyValue,
 		NewUnmeteredSomeValueNonCopying(value),
 	)
 
-	queriedValue, _ := dictionary.Get(inter, ReturnEmptyLocationRange, keyValue)
+	queriedValue, _ := dictionary.Get(inter, EmptyLocationRange, keyValue)
 	value = queriedValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
@@ -630,7 +630,7 @@ func TestOwnerDictionaryInsertNonExisting(t *testing.T) {
 
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
@@ -643,13 +643,13 @@ func TestOwnerDictionaryInsertNonExisting(t *testing.T) {
 
 	existingValue := dictionary.Insert(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		keyValue,
 		value,
 	)
 	assert.Equal(t, Nil, existingValue)
 
-	queriedValue, _ := dictionary.Get(inter, ReturnEmptyLocationRange, keyValue)
+	queriedValue, _ := dictionary.Get(inter, EmptyLocationRange, keyValue)
 	value = queriedValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
@@ -683,7 +683,7 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
@@ -698,15 +698,15 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 
 	existingValue := dictionary.Insert(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		keyValue,
 		value2,
 	)
 	require.IsType(t, &SomeValue{}, existingValue)
-	innerValue := existingValue.(*SomeValue).InnerValue(inter, ReturnEmptyLocationRange)
+	innerValue := existingValue.(*SomeValue).InnerValue(inter, EmptyLocationRange)
 	value1 = innerValue.(*CompositeValue)
 
-	queriedValue, _ := dictionary.Get(inter, ReturnEmptyLocationRange, keyValue)
+	queriedValue, _ := dictionary.Get(inter, EmptyLocationRange, keyValue)
 	value2 = queriedValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
@@ -740,7 +740,7 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
@@ -754,11 +754,11 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 
 	existingValue := dictionary.Remove(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		keyValue,
 	)
 	require.IsType(t, &SomeValue{}, existingValue)
-	innerValue := existingValue.(*SomeValue).InnerValue(inter, ReturnEmptyLocationRange)
+	innerValue := existingValue.(*SomeValue).InnerValue(inter, EmptyLocationRange)
 	value = innerValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
@@ -795,9 +795,9 @@ func TestOwnerCompositeSet(t *testing.T) {
 
 	const fieldName = "test"
 
-	composite.SetMember(inter, ReturnEmptyLocationRange, fieldName, value)
+	composite.SetMember(inter, EmptyLocationRange, fieldName, value)
 
-	value = composite.GetMember(inter, ReturnEmptyLocationRange, fieldName).(*CompositeValue)
+	value = composite.GetMember(inter, EmptyLocationRange, fieldName).(*CompositeValue)
 
 	assert.Equal(t, newOwner, composite.GetOwner())
 	assert.Equal(t, newOwner, value.GetOwner())
@@ -818,14 +818,14 @@ func TestOwnerCompositeCopy(t *testing.T) {
 
 	composite.SetMember(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		fieldName,
 		value,
 	)
 
 	composite = composite.Transfer(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		atree.Address{},
 		false,
 		nil,
@@ -833,7 +833,7 @@ func TestOwnerCompositeCopy(t *testing.T) {
 
 	value = composite.GetMember(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		fieldName,
 	).(*CompositeValue)
 
@@ -954,7 +954,7 @@ func TestStringer(t *testing.T) {
 		"Array": {
 			value: NewArrayValue(
 				newTestInterpreter(t),
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeAnyStruct,
 				},
@@ -967,7 +967,7 @@ func TestStringer(t *testing.T) {
 		"Dictionary": {
 			value: NewDictionaryValue(
 				newTestInterpreter(t),
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				DictionaryStaticType{
 					KeyType:   PrimitiveStaticTypeString,
 					ValueType: PrimitiveStaticTypeUInt8,
@@ -994,7 +994,7 @@ func TestStringer(t *testing.T) {
 
 				return NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					utils.TestLocation,
 					"Foo",
 					common.CompositeKindResource,
@@ -1017,7 +1017,7 @@ func TestStringer(t *testing.T) {
 
 				compositeValue := NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					utils.TestLocation,
 					"Foo",
 					common.CompositeKindResource,
@@ -1079,14 +1079,14 @@ func TestStringer(t *testing.T) {
 			value: func() Value {
 				array := NewArrayValue(
 					newTestInterpreter(t),
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
 					common.Address{},
 				)
 				arrayRef := &EphemeralReferenceValue{Value: array}
-				array.Insert(newTestInterpreter(t), ReturnEmptyLocationRange, 0, arrayRef)
+				array.Insert(newTestInterpreter(t), EmptyLocationRange, 0, arrayRef)
 				return array
 			}(),
 			expected: `[[...]]`,
@@ -1133,7 +1133,7 @@ func TestVisitor(t *testing.T) {
 	value = NewUnmeteredSomeValueNonCopying(value)
 	value = NewArrayValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
@@ -1143,7 +1143,7 @@ func TestVisitor(t *testing.T) {
 
 	value = NewDictionaryValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAny,
@@ -1160,7 +1160,7 @@ func TestVisitor(t *testing.T) {
 
 	value = NewCompositeValue(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		utils.TestLocation,
 		"Foo",
 		common.CompositeKindStructure,
@@ -1468,7 +1468,7 @@ func TestGetHashInput(t *testing.T) {
 				}
 				return NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					utils.TestLocation,
 					"Foo",
 					common.CompositeKindEnum,
@@ -1496,7 +1496,7 @@ func TestGetHashInput(t *testing.T) {
 				}
 				return NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					utils.TestLocation,
 					strings.Repeat("a", 32),
 					common.CompositeKindEnum,
@@ -1554,7 +1554,7 @@ func TestGetHashInput(t *testing.T) {
 
 			inter := newTestInterpreter(t)
 
-			actual := testCase.value.HashInput(inter, ReturnEmptyLocationRange, scratch[:])
+			actual := testCase.value.HashInput(inter, EmptyLocationRange, scratch[:])
 
 			assert.Equal(t,
 				testCase.expected,
@@ -1580,7 +1580,7 @@ func TestBlockValue(t *testing.T) {
 		5,
 		NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			ByteArrayStaticType,
 			common.Address{},
 		),
@@ -1646,7 +1646,7 @@ func TestEphemeralReferenceTypeConformance(t *testing.T) {
 	// Check the dynamic type conformance on a cyclic value.
 	conforms := value.ConformsToStaticType(
 		inter,
-		ReturnEmptyLocationRange,
+		EmptyLocationRange,
 		TypeConformanceResults{},
 	)
 	assert.True(t, conforms)
@@ -1672,7 +1672,7 @@ func TestCapabilityValue_Equal(t *testing.T) {
 				BorrowType: PrimitiveStaticTypeInt,
 			}).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				&CapabilityValue{
 					Address: AddressValue{0x1},
 					Path: PathValue{
@@ -1700,7 +1700,7 @@ func TestCapabilityValue_Equal(t *testing.T) {
 				},
 			}).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				&CapabilityValue{
 					Address: AddressValue{0x1},
 					Path: PathValue{
@@ -1728,7 +1728,7 @@ func TestCapabilityValue_Equal(t *testing.T) {
 				BorrowType: PrimitiveStaticTypeInt,
 			}).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				&CapabilityValue{
 					Address: AddressValue{0x1},
 					Path: PathValue{
@@ -1757,7 +1757,7 @@ func TestCapabilityValue_Equal(t *testing.T) {
 				BorrowType: PrimitiveStaticTypeInt,
 			}).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				&CapabilityValue{
 					Address: AddressValue{0x2},
 					Path: PathValue{
@@ -1786,7 +1786,7 @@ func TestCapabilityValue_Equal(t *testing.T) {
 				BorrowType: PrimitiveStaticTypeInt,
 			}).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				&CapabilityValue{
 					Address: AddressValue{0x1},
 					Path: PathValue{
@@ -1815,7 +1815,7 @@ func TestCapabilityValue_Equal(t *testing.T) {
 				BorrowType: PrimitiveStaticTypeInt,
 			}).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredStringValue("test"),
 			),
 		)
@@ -1835,7 +1835,7 @@ func TestAddressValue_Equal(t *testing.T) {
 		require.True(t,
 			AddressValue{0x1}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				AddressValue{0x1},
 			),
 		)
@@ -1850,7 +1850,7 @@ func TestAddressValue_Equal(t *testing.T) {
 		require.False(t,
 			AddressValue{0x1}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				AddressValue{0x2},
 			),
 		)
@@ -1865,7 +1865,7 @@ func TestAddressValue_Equal(t *testing.T) {
 		require.False(t,
 			AddressValue{0x1}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredUInt8Value(1),
 			),
 		)
@@ -1880,7 +1880,7 @@ func TestVoidValue_Equal(t *testing.T) {
 	require.True(t,
 		VoidValue{}.Equal(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			VoidValue{},
 		),
 	)
@@ -1899,7 +1899,7 @@ func TestBoolValue_Equal(t *testing.T) {
 		require.True(t,
 			BoolValue(true).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				BoolValue(true),
 			),
 		)
@@ -1914,7 +1914,7 @@ func TestBoolValue_Equal(t *testing.T) {
 		require.True(t,
 			BoolValue(false).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				BoolValue(false),
 			),
 		)
@@ -1929,7 +1929,7 @@ func TestBoolValue_Equal(t *testing.T) {
 		require.False(t,
 			BoolValue(true).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				BoolValue(false),
 			),
 		)
@@ -1944,7 +1944,7 @@ func TestBoolValue_Equal(t *testing.T) {
 		require.False(t,
 			BoolValue(true).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredUInt8Value(1),
 			),
 		)
@@ -1964,7 +1964,7 @@ func TestStringValue_Equal(t *testing.T) {
 		require.True(t,
 			NewUnmeteredStringValue("test").Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredStringValue("test"),
 			),
 		)
@@ -1979,7 +1979,7 @@ func TestStringValue_Equal(t *testing.T) {
 		require.False(t,
 			NewUnmeteredStringValue("test").Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredStringValue("foo"),
 			),
 		)
@@ -1994,7 +1994,7 @@ func TestStringValue_Equal(t *testing.T) {
 		require.False(t,
 			NewUnmeteredStringValue("1").Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredUInt8Value(1),
 			),
 		)
@@ -2014,7 +2014,7 @@ func TestNilValue_Equal(t *testing.T) {
 		require.True(t,
 			NilValue{}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				Nil,
 			),
 		)
@@ -2029,7 +2029,7 @@ func TestNilValue_Equal(t *testing.T) {
 		require.False(t,
 			NilValue{}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredUInt8Value(0),
 			),
 		)
@@ -2049,7 +2049,7 @@ func TestSomeValue_Equal(t *testing.T) {
 		require.True(t,
 			NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("test")).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("test")),
 			),
 		)
@@ -2064,7 +2064,7 @@ func TestSomeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("test")).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("foo")),
 			),
 		)
@@ -2079,7 +2079,7 @@ func TestSomeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewUnmeteredSomeValueNonCopying(NewUnmeteredStringValue("1")).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredUInt8Value(1),
 			),
 		)
@@ -2101,7 +2101,7 @@ func TestTypeValue_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeString,
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				TypeValue{
 					Type: PrimitiveStaticTypeString,
 				},
@@ -2120,7 +2120,7 @@ func TestTypeValue_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeString,
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				TypeValue{
 					Type: PrimitiveStaticTypeInt,
 				},
@@ -2139,7 +2139,7 @@ func TestTypeValue_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeString,
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredStringValue("String"),
 			),
 		)
@@ -2162,7 +2162,7 @@ func TestPathValue_Equal(t *testing.T) {
 					Identifier: "test",
 				}.Equal(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					PathValue{
 						Domain:     domain,
 						Identifier: "test",
@@ -2189,7 +2189,7 @@ func TestPathValue_Equal(t *testing.T) {
 						Identifier: "test",
 					}.Equal(
 						inter,
-						ReturnEmptyLocationRange,
+						EmptyLocationRange,
 						PathValue{
 							Domain:     otherDomain,
 							Identifier: "test",
@@ -2212,7 +2212,7 @@ func TestPathValue_Equal(t *testing.T) {
 					Identifier: "test1",
 				}.Equal(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					PathValue{
 						Domain:     domain,
 						Identifier: "test2",
@@ -2234,7 +2234,7 @@ func TestPathValue_Equal(t *testing.T) {
 				Identifier: "test",
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredStringValue("/storage/test"),
 			),
 		)
@@ -2260,7 +2260,7 @@ func TestLinkValue_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeInt,
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				LinkValue{
 					TargetPath: PathValue{
 						Domain:     common.PathDomainStorage,
@@ -2287,7 +2287,7 @@ func TestLinkValue_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeInt,
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				LinkValue{
 					TargetPath: PathValue{
 						Domain:     common.PathDomainStorage,
@@ -2314,7 +2314,7 @@ func TestLinkValue_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeInt,
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				LinkValue{
 					TargetPath: PathValue{
 						Domain:     common.PathDomainStorage,
@@ -2341,7 +2341,7 @@ func TestLinkValue_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeInt,
 			}.Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredStringValue("test"),
 			),
 		)
@@ -2365,17 +2365,17 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.True(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				uint8ArrayStaticType,
 				common.Address{},
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					uint8ArrayStaticType,
 					common.Address{},
 					NewUnmeteredUInt8Value(1),
@@ -2394,17 +2394,17 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.False(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				uint8ArrayStaticType,
 				common.Address{},
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					uint8ArrayStaticType,
 					common.Address{},
 					NewUnmeteredUInt8Value(2),
@@ -2423,16 +2423,16 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.False(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				uint8ArrayStaticType,
 				common.Address{},
 				NewUnmeteredUInt8Value(1),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					uint8ArrayStaticType,
 					common.Address{},
 					NewUnmeteredUInt8Value(1),
@@ -2451,17 +2451,17 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.False(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				uint8ArrayStaticType,
 				common.Address{},
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					uint8ArrayStaticType,
 					common.Address{},
 					NewUnmeteredUInt8Value(1),
@@ -2483,15 +2483,15 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.False(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				uint8ArrayStaticType,
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					uint16ArrayStaticType,
 					common.Address{},
 				),
@@ -2508,15 +2508,15 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.False(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				nil,
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					uint8ArrayStaticType,
 					common.Address{},
 				),
@@ -2533,15 +2533,15 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.False(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				uint8ArrayStaticType,
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					nil,
 					common.Address{},
 				),
@@ -2558,15 +2558,15 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.True(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				nil,
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					nil,
 					common.Address{},
 				),
@@ -2583,13 +2583,13 @@ func TestArrayValue_Equal(t *testing.T) {
 		require.False(t,
 			NewArrayValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				uint8ArrayStaticType,
 				common.Address{},
 				NewUnmeteredUInt8Value(1),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredUInt8Value(1),
 			),
 		)
@@ -2614,7 +2614,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 		require.True(t,
 			NewDictionaryValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				byteStringDictionaryType,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredStringValue("1"),
@@ -2622,10 +2622,10 @@ func TestDictionaryValue_Equal(t *testing.T) {
 				NewUnmeteredStringValue("2"),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewDictionaryValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					byteStringDictionaryType,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredStringValue("1"),
@@ -2645,7 +2645,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 		require.False(t,
 			NewDictionaryValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				byteStringDictionaryType,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredStringValue("1"),
@@ -2653,10 +2653,10 @@ func TestDictionaryValue_Equal(t *testing.T) {
 				NewUnmeteredStringValue("2"),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewDictionaryValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					byteStringDictionaryType,
 					NewUnmeteredUInt8Value(2),
 					NewUnmeteredStringValue("1"),
@@ -2676,7 +2676,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 		require.False(t,
 			NewDictionaryValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				byteStringDictionaryType,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredStringValue("1"),
@@ -2684,10 +2684,10 @@ func TestDictionaryValue_Equal(t *testing.T) {
 				NewUnmeteredStringValue("2"),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewDictionaryValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					byteStringDictionaryType,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredStringValue("2"),
@@ -2707,16 +2707,16 @@ func TestDictionaryValue_Equal(t *testing.T) {
 		require.False(t,
 			NewDictionaryValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				byteStringDictionaryType,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredStringValue("1"),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewDictionaryValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					byteStringDictionaryType,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredStringValue("1"),
@@ -2736,7 +2736,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 		require.False(t,
 			NewDictionaryValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				byteStringDictionaryType,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredStringValue("1"),
@@ -2744,10 +2744,10 @@ func TestDictionaryValue_Equal(t *testing.T) {
 				NewUnmeteredStringValue("2"),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewDictionaryValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					byteStringDictionaryType,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredStringValue("1"),
@@ -2770,14 +2770,14 @@ func TestDictionaryValue_Equal(t *testing.T) {
 		require.False(t,
 			NewDictionaryValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				byteStringDictionaryType,
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewDictionaryValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					stringByteDictionaryStaticType,
 				),
 			),
@@ -2793,7 +2793,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 		require.False(t,
 			NewDictionaryValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				byteStringDictionaryType,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredStringValue("1"),
@@ -2801,10 +2801,10 @@ func TestDictionaryValue_Equal(t *testing.T) {
 				NewUnmeteredStringValue("2"),
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					ByteArrayStaticType,
 					common.Address{},
 					NewUnmeteredUInt8Value(1),
@@ -2842,7 +2842,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.True(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				utils.TestLocation,
 				"X",
 				common.CompositeKindStructure,
@@ -2850,10 +2850,10 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					utils.TestLocation,
 					"X",
 					common.CompositeKindStructure,
@@ -2887,7 +2887,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				common.IdentifierLocation("A"),
 				"X",
 				common.CompositeKindStructure,
@@ -2895,10 +2895,10 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					common.IdentifierLocation("B"),
 					"X",
 					common.CompositeKindStructure,
@@ -2932,7 +2932,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				common.IdentifierLocation("A"),
 				"X",
 				common.CompositeKindStructure,
@@ -2940,10 +2940,10 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					common.IdentifierLocation("A"),
 					"Y",
 					common.CompositeKindStructure,
@@ -2977,7 +2977,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				common.IdentifierLocation("A"),
 				"X",
 				common.CompositeKindStructure,
@@ -2985,10 +2985,10 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					common.IdentifierLocation("A"),
 					"X",
 					common.CompositeKindStructure,
@@ -3026,7 +3026,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				common.IdentifierLocation("A"),
 				"X",
 				common.CompositeKindStructure,
@@ -3034,10 +3034,10 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					common.IdentifierLocation("A"),
 					"X",
 					common.CompositeKindStructure,
@@ -3075,7 +3075,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				common.IdentifierLocation("A"),
 				"X",
 				common.CompositeKindStructure,
@@ -3083,10 +3083,10 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					common.IdentifierLocation("A"),
 					"X",
 					common.CompositeKindStructure,
@@ -3120,7 +3120,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				common.IdentifierLocation("A"),
 				"X",
 				common.CompositeKindStructure,
@@ -3128,10 +3128,10 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewCompositeValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					common.IdentifierLocation("A"),
 					"X",
 					common.CompositeKindResource,
@@ -3158,7 +3158,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 		require.False(t,
 			NewCompositeValue(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				common.IdentifierLocation("A"),
 				"X",
 				common.CompositeKindStructure,
@@ -3166,7 +3166,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				common.Address{},
 			).Equal(
 				inter,
-				ReturnEmptyLocationRange,
+				EmptyLocationRange,
 				NewUnmeteredStringValue("test"),
 			),
 		)
@@ -3208,7 +3208,7 @@ func TestNumberValue_Equal(t *testing.T) {
 			require.True(t,
 				value.Equal(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					value,
 				),
 			)
@@ -3229,7 +3229,7 @@ func TestNumberValue_Equal(t *testing.T) {
 				require.False(t,
 					value.Equal(
 						inter,
-						ReturnEmptyLocationRange,
+						EmptyLocationRange,
 						otherValue,
 					),
 				)
@@ -3246,7 +3246,7 @@ func TestNumberValue_Equal(t *testing.T) {
 			require.False(t,
 				value.Equal(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					AddressValue{0x1},
 				),
 			)
@@ -3269,7 +3269,7 @@ func TestPublicKeyValue(t *testing.T) {
 			utils.TestLocation,
 			&Config{
 				Storage: storage,
-				PublicKeyValidationHandler: func(_ *Interpreter, _ func() LocationRange, _ *CompositeValue) error {
+				PublicKeyValidationHandler: func(_ *Interpreter, _ LocationRange, _ *CompositeValue) error {
 					return nil
 				},
 			},
@@ -3278,7 +3278,7 @@ func TestPublicKeyValue(t *testing.T) {
 
 		publicKey := NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
@@ -3294,7 +3294,7 @@ func TestPublicKeyValue(t *testing.T) {
 
 		key := NewPublicKeyValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			publicKey,
 			sigAlgo,
 			inter.Config.PublicKeyValidationHandler,
@@ -3319,7 +3319,7 @@ func TestPublicKeyValue(t *testing.T) {
 			utils.TestLocation,
 			&Config{
 				Storage: storage,
-				PublicKeyValidationHandler: func(_ *Interpreter, _ func() LocationRange, _ *CompositeValue) error {
+				PublicKeyValidationHandler: func(_ *Interpreter, _ LocationRange, _ *CompositeValue) error {
 					return fakeError
 				},
 			},
@@ -3330,7 +3330,7 @@ func TestPublicKeyValue(t *testing.T) {
 
 		publicKey := NewArrayValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
@@ -3349,7 +3349,7 @@ func TestPublicKeyValue(t *testing.T) {
 			func() {
 				_ = NewPublicKeyValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					publicKey,
 					sigAlgo,
 					inter.Config.PublicKeyValidationHandler,
@@ -3636,7 +3636,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 	newCompositeValue := func(inter *Interpreter, fields []CompositeField) *CompositeValue {
 		return NewCompositeValue(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			utils.TestLocation,
 			"Test",
 			common.CompositeKindStructure,
@@ -3691,7 +3691,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 
 		result := value.ConformsToStaticType(
 			inter,
-			ReturnEmptyLocationRange,
+			EmptyLocationRange,
 			TypeConformanceResults{},
 		)
 		if expected {
@@ -4016,7 +4016,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					VariableSizedStaticType{
 						Type: PrimitiveStaticTypeNumber,
 					},
@@ -4032,7 +4032,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
@@ -4048,7 +4048,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					VariableSizedStaticType{
 						Type: PrimitiveStaticTypeInteger,
 					},
@@ -4064,7 +4064,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewArrayValue(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
@@ -4084,7 +4084,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewDictionaryValueWithAddress(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeString,
 						ValueType: PrimitiveStaticTypeNumber,
@@ -4103,7 +4103,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewDictionaryValueWithAddress(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeString,
 						ValueType: PrimitiveStaticTypeAnyStruct,
@@ -4122,7 +4122,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewDictionaryValueWithAddress(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeAnyStruct,
 						ValueType: PrimitiveStaticTypeNumber,
@@ -4175,7 +4175,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			func(inter *Interpreter) Value {
 				return NewDictionaryValueWithAddress(
 					inter,
-					ReturnEmptyLocationRange,
+					EmptyLocationRange,
 					DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeAnyStruct,
 						ValueType: PrimitiveStaticTypeAnyStruct,

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -196,7 +196,7 @@ func integerLiteralValue(
 		return nil, err
 	}
 
-	return ExportValue(convertedValue, inter, interpreter.ReturnEmptyLocationRange)
+	return ExportValue(convertedValue, inter, interpreter.EmptyLocationRange)
 }
 
 func convertIntValue(

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -354,7 +354,7 @@ func userPanicToError(f func()) (returnedError error) {
 func validateArgumentParams(
 	inter *interpreter.Interpreter,
 	runtimeInterface Interface,
-	getLocationRange func() interpreter.LocationRange,
+	locationRange interpreter.LocationRange,
 	arguments [][]byte,
 	parameters []*sema.Parameter,
 ) (
@@ -401,7 +401,7 @@ func validateArgumentParams(
 			// if importing an invalid public key, this call panics
 			arg, err = ImportValue(
 				inter,
-				getLocationRange,
+				locationRange,
 				value,
 				parameterType,
 			)
@@ -443,7 +443,7 @@ func validateArgumentParams(
 		// Check whether the decoded value conforms to the type associated with the value
 		if !arg.ConformsToStaticType(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.TypeConformanceResults{},
 		) {
 			return nil, &InvalidEntryPointArgumentError{
@@ -599,7 +599,7 @@ func (r *interpreterRuntime) ReadStored(
 
 	var exportedValue cadence.Value
 	if value != nil {
-		exportedValue, err = ExportValue(value, inter, interpreter.ReturnEmptyLocationRange)
+		exportedValue, err = ExportValue(value, inter, interpreter.EmptyLocationRange)
 		if err != nil {
 			return nil, newError(err, location, codesAndPrograms)
 		}
@@ -640,7 +640,7 @@ func (r *interpreterRuntime) ReadLinked(
 		&sema.ReferenceType{
 			Type: sema.AnyType,
 		},
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 	)
 	if err != nil {
 		return nil, err
@@ -658,7 +658,7 @@ func (r *interpreterRuntime) ReadLinked(
 
 	var exportedValue cadence.Value
 	if value != nil {
-		exportedValue, err = ExportValue(value, inter, interpreter.ReturnEmptyLocationRange)
+		exportedValue, err = ExportValue(value, inter, interpreter.EmptyLocationRange)
 		if err != nil {
 			return nil, newError(err, location, codesAndPrograms)
 		}

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -198,7 +198,7 @@ func (executor *interpreterScriptExecutor) execute() (val cadence.Value, err err
 	exportableValue := newExportableValue(value, inter)
 	result, err := exportValue(
 		exportableValue,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 	)
 	if err != nil {
 		return nil, newError(err, location, codesAndPrograms)
@@ -235,7 +235,7 @@ func scriptExecutionFunction(
 		values, err := validateArgumentParams(
 			inter,
 			runtimeInterface,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			arguments,
 			parameters,
 		)

--- a/runtime/stdlib/assert.go
+++ b/runtime/stdlib/assert.go
@@ -74,7 +74,7 @@ var AssertFunction = NewStandardLibraryFunction(
 			}
 			panic(AssertionError{
 				Message:       message,
-				LocationRange: invocation.GetLocationRange(),
+				LocationRange: invocation.LocationRange,
 			})
 		}
 		return interpreter.Void

--- a/runtime/stdlib/block.go
+++ b/runtime/stdlib/block.go
@@ -87,7 +87,7 @@ func NewGetBlockFunction(provider BlockAtHeightProvider) StandardLibraryValue {
 			}
 
 			memoryGauge := invocation.Interpreter
-			getLocationRange := invocation.GetLocationRange
+			locationRange := invocation.LocationRange
 
 			block, exists := getBlockAtHeight(
 				provider,
@@ -97,7 +97,7 @@ func NewGetBlockFunction(provider BlockAtHeightProvider) StandardLibraryValue {
 				return interpreter.Nil
 			}
 
-			blockValue := NewBlockValue(memoryGauge, getLocationRange, block)
+			blockValue := NewBlockValue(memoryGauge, locationRange, block)
 			return interpreter.NewSomeValueNonCopying(memoryGauge, blockValue)
 		},
 	)
@@ -114,7 +114,7 @@ var blockIDMemoryUsage = common.NewNumberMemoryUsage(
 
 func NewBlockValue(
 	inter *interpreter.Interpreter,
-	getLocationRange func() interpreter.LocationRange,
+	locationRange interpreter.LocationRange,
 	block Block,
 ) interpreter.Value {
 
@@ -143,7 +143,7 @@ func NewBlockValue(
 
 	idValue := interpreter.NewArrayValue(
 		inter,
-		getLocationRange,
+		locationRange,
 		BlockIDStaticType,
 		common.Address{},
 		values...,
@@ -216,9 +216,9 @@ func NewGetCurrentBlockFunction(provider CurrentBlockProvider) StandardLibraryVa
 			}
 
 			memoryGauge := invocation.Interpreter
-			getLocationRange := invocation.GetLocationRange
+			locationRange := invocation.LocationRange
 
-			return NewBlockValue(memoryGauge, getLocationRange, block)
+			return NewBlockValue(memoryGauge, locationRange, block)
 		},
 	)
 }

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -119,17 +119,17 @@ var blsAggregatePublicKeysFunction = interpreter.NewUnmeteredHostFunctionValue(
 		}
 
 		inter := invocation.Interpreter
-		getLocationRange := invocation.GetLocationRange
+		locationRange := invocation.LocationRange
 
 		inter.ExpectType(
 			publicKeys,
 			sema.PublicKeyArrayType,
-			getLocationRange,
+			locationRange,
 		)
 
 		return inter.Config.BLSAggregatePublicKeysHandler(
 			inter,
-			getLocationRange,
+			locationRange,
 			publicKeys,
 		)
 	},
@@ -144,17 +144,17 @@ var blsAggregateSignaturesFunction = interpreter.NewUnmeteredHostFunctionValue(
 		}
 
 		inter := invocation.Interpreter
-		getLocationRange := invocation.GetLocationRange
+		locationRange := invocation.LocationRange
 
 		inter.ExpectType(
 			signatures,
 			sema.ByteArrayArrayType,
-			getLocationRange,
+			locationRange,
 		)
 
 		return inter.Config.BLSAggregateSignaturesHandler(
 			inter,
-			getLocationRange,
+			locationRange,
 			signatures,
 		)
 	},

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -162,7 +162,7 @@ func cryptoAlgorithmEnumValueAndCaseValues(
 
 	value = interpreter.EnumConstructorFunction(
 		nil,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		enumType,
 		caseValues,
 		constructorNestedVariables,

--- a/runtime/stdlib/hashalgorithm.go
+++ b/runtime/stdlib/hashalgorithm.go
@@ -61,11 +61,11 @@ func hashAlgorithmHashFunction(hashAlgoValue interpreter.MemberAccessibleValue) 
 
 			inter := invocation.Interpreter
 
-			getLocationRange := invocation.GetLocationRange
+			locationRange := invocation.LocationRange
 
 			return inter.Config.HashHandler(
 				inter,
-				getLocationRange,
+				locationRange,
 				dataValue,
 				nil,
 				hashAlgoValue,
@@ -90,11 +90,11 @@ func hashAlgorithmHashWithTagFunction(hashAlgoValue interpreter.MemberAccessible
 
 			inter := invocation.Interpreter
 
-			getLocationRange := invocation.GetLocationRange
+			locationRange := invocation.LocationRange
 
 			return inter.Config.HashHandler(
 				inter,
-				getLocationRange,
+				locationRange,
 				dataValue,
 				tagValue,
 				hashAlgoValue,

--- a/runtime/stdlib/panic.go
+++ b/runtime/stdlib/panic.go
@@ -69,7 +69,7 @@ var PanicFunction = NewStandardLibraryFunction(
 
 		panic(PanicError{
 			Message:       message,
-			LocationRange: invocation.GetLocationRange(),
+			LocationRange: invocation.LocationRange,
 		})
 	},
 )

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -58,10 +58,11 @@ var PublicKeyConstructor = NewStandardLibraryFunction(
 		}
 
 		inter := invocation.Interpreter
+		locationRange := invocation.LocationRange
 
 		return interpreter.NewPublicKeyValue(
 			inter,
-			invocation.GetLocationRange,
+			locationRange,
 			publicKey,
 			signAlgo,
 			inter.Config.PublicKeyValidationHandler,

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -105,26 +105,26 @@ var rlpDecodeStringFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		invocation.Interpreter.ReportComputation(common.ComputationKindSTDLIBRLPDecodeString, uint(input.Count()))
 
-		getLocationRange := invocation.GetLocationRange
+		locationRange := invocation.LocationRange
 
 		convertedInput, err := interpreter.ByteArrayValueToByteSlice(invocation.Interpreter, input)
 		if err != nil {
 			panic(RLPDecodeStringError{
 				Msg:           err.Error(),
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 		output, bytesRead, err := rlp.DecodeString(convertedInput, 0)
 		if err != nil {
 			panic(RLPDecodeStringError{
 				Msg:           err.Error(),
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 		if bytesRead != len(convertedInput) {
 			panic(RLPDecodeStringError{
 				Msg:           rlpErrMsgInputContainsExtraBytes,
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 		return interpreter.ByteSliceToByteArrayValue(invocation.Interpreter, output)
@@ -179,13 +179,13 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		invocation.Interpreter.ReportComputation(common.ComputationKindSTDLIBRLPDecodeList, uint(input.Count()))
 
-		getLocationRange := invocation.GetLocationRange
+		locationRange := invocation.LocationRange
 
 		convertedInput, err := interpreter.ByteArrayValueToByteSlice(invocation.Interpreter, input)
 		if err != nil {
 			panic(RLPDecodeListError{
 				Msg:           err.Error(),
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 
@@ -194,14 +194,14 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
 		if err != nil {
 			panic(RLPDecodeListError{
 				Msg:           err.Error(),
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 
 		if bytesRead != len(convertedInput) {
 			panic(RLPDecodeListError{
 				Msg:           rlpErrMsgInputContainsExtraBytes,
-				LocationRange: getLocationRange(),
+				LocationRange: locationRange,
 			})
 		}
 
@@ -212,7 +212,7 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		return interpreter.NewArrayValue(
 			invocation.Interpreter,
-			getLocationRange,
+			locationRange,
 			interpreter.NewVariableSizedStaticType(
 				invocation.Interpreter,
 				interpreter.ByteArrayStaticType,

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1861,7 +1861,7 @@ func TestRuntimeResourceOwnerChange(t *testing.T) {
 				resourceOwnerChange{
 					typeID: resource.TypeID(),
 					// TODO: provide proper location range
-					uuid:       resource.ResourceUUID(inter, interpreter.ReturnEmptyLocationRange),
+					uuid:       resource.ResourceUUID(inter, interpreter.EmptyLocationRange),
 					oldAddress: oldAddress,
 					newAddress: newAddress,
 				},
@@ -3366,7 +3366,7 @@ func TestRuntimeStorageInternalAccess(t *testing.T) {
 
 	arrayValue := secondValue.(*interpreter.ArrayValue)
 
-	element := arrayValue.Get(inter, interpreter.ReturnEmptyLocationRange, 2)
+	element := arrayValue.Get(inter, interpreter.EmptyLocationRange, 2)
 	utils.RequireValuesEqual(
 		t,
 		inter,
@@ -3379,6 +3379,6 @@ func TestRuntimeStorageInternalAccess(t *testing.T) {
 	rValue := storageMap.ReadValue(nil, "r")
 	require.IsType(t, &interpreter.CompositeValue{}, rValue)
 
-	_, err = ExportValue(rValue, inter, interpreter.ReturnEmptyLocationRange)
+	_, err = ExportValue(rValue, inter, interpreter.EmptyLocationRange)
 	require.NoError(t, err)
 }

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -384,7 +384,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 			assert.IsType(t, &interpreter.CompositeValue{}, innerValue)
 
@@ -467,7 +467,7 @@ func TestInterpretAuthAccount_load(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 			assert.IsType(t, &interpreter.CompositeValue{}, innerValue)
 
@@ -555,7 +555,7 @@ func TestInterpretAuthAccount_copy(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 			assert.IsType(t, &interpreter.CompositeValue{}, innerValue)
 
@@ -679,7 +679,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -710,7 +710,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -821,7 +821,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -852,7 +852,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			require.IsType(t, &interpreter.SomeValue{}, value)
 
-			innerValue = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 			assert.IsType(t, &interpreter.StorageReferenceValue{}, innerValue)
 
@@ -948,7 +948,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 					rType := checker.RequireGlobalType(t, inter.Program.Elaboration, "R")
 
@@ -997,7 +997,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 					r2Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R2")
 
@@ -1100,7 +1100,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 					sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 
@@ -1149,7 +1149,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 
 					require.IsType(t, &interpreter.SomeValue{}, value)
 
-					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+					capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 					require.IsType(t, &interpreter.CapabilityValue{}, capability)
 
 					s2Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "S2")
@@ -1256,7 +1256,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 				require.NoError(t, err)
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+				capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S1")
 				expectedBorrowType := interpreter.ConvertSemaToStaticType(
@@ -1336,7 +1336,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 				// 1 value + 2 links
 				require.Len(t, getAccountValues(), 3)
 
-				capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+				capability := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 				expectedBorrowType := interpreter.ConvertSemaToStaticType(
@@ -1365,7 +1365,7 @@ func TestInterpretAuthAccount_link(t *testing.T) {
 				require.NoError(t, err)
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				capability = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+				capability = value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 				sType = checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 				expectedBorrowType = interpreter.ConvertSemaToStaticType(
@@ -1598,7 +1598,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+				innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 				AssertValuesEqual(
 					t,
@@ -1676,7 +1676,7 @@ func TestInterpretAccount_getLinkTarget(t *testing.T) {
 
 				require.IsType(t, &interpreter.SomeValue{}, value)
 
-				innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+				innerValue := value.(*interpreter.SomeValue).InnerValue(inter, interpreter.EmptyLocationRange)
 
 				AssertValuesEqual(
 					t,

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -818,7 +818,7 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 				require.NoError(t, err)
 
 				require.True(t,
-					call.expected.Equal(inter, interpreter.ReturnEmptyLocationRange, result),
+					call.expected.Equal(inter, interpreter.EmptyLocationRange, result),
 					fmt.Sprintf(
 						"%s(%s, %s) = %s != %s",
 						method, call.left, call.right, result, call.expected,

--- a/runtime/tests/interpreter/array_test.go
+++ b/runtime/tests/interpreter/array_test.go
@@ -26,7 +26,7 @@ func arrayElements(inter *interpreter.Interpreter, array *interpreter.ArrayValue
 	count := array.Count()
 	result := make([]interpreter.Value, count)
 	for i := 0; i < count; i++ {
-		result[i] = array.Get(inter, interpreter.ReturnEmptyLocationRange, i)
+		result[i] = array.Get(inter, interpreter.EmptyLocationRange, i)
 	}
 	return result
 }

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -128,7 +128,7 @@ func TestInterpretToBytes(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -110,7 +110,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		map[string]interpreter.Value{
 			"name": interpreter.NewUnmeteredStringValue("Apple"),
 		},
-		func(name string, _ *interpreter.Interpreter, _ func() interpreter.LocationRange) interpreter.Value {
+		func(name string, _ *interpreter.Interpreter, _ interpreter.LocationRange) interpreter.Value {
 			if name == "color" {
 				return interpreter.NewUnmeteredStringValue("Red")
 			}

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -60,7 +60,7 @@ func TestArrayMutation(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
@@ -136,7 +136,7 @@ func TestArrayMutation(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
@@ -213,7 +213,7 @@ func TestArrayMutation(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
@@ -276,7 +276,7 @@ func TestArrayMutation(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
@@ -393,12 +393,12 @@ func TestArrayMutation(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from foo"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 0),
+			array.Get(inter, interpreter.EmptyLocationRange, 0),
 		)
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from bar"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 1),
+			array.Get(inter, interpreter.EmptyLocationRange, 1),
 		)
 	})
 
@@ -444,12 +444,12 @@ func TestArrayMutation(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from foo"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 0),
+			array.Get(inter, interpreter.EmptyLocationRange, 0),
 		)
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from bar"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 1),
+			array.Get(inter, interpreter.EmptyLocationRange, 1),
 		)
 	})
 
@@ -543,7 +543,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		val, present := dictionary.Get(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
 		assert.True(t, present)
@@ -623,7 +623,7 @@ func TestDictionaryMutation(t *testing.T) {
 
 		val, present := dictionary.Get(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
 		assert.True(t, present)
@@ -788,12 +788,12 @@ func TestDictionaryMutation(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from foo"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 0),
+			array.Get(inter, interpreter.EmptyLocationRange, 0),
 		)
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from bar"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 1),
+			array.Get(inter, interpreter.EmptyLocationRange, 1),
 		)
 	})
 
@@ -839,12 +839,12 @@ func TestDictionaryMutation(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from foo"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 0),
+			array.Get(inter, interpreter.EmptyLocationRange, 0),
 		)
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("hello from bar"),
-			array.Get(inter, interpreter.ReturnEmptyLocationRange, 1),
+			array.Get(inter, interpreter.EmptyLocationRange, 1),
 		)
 	})
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -611,7 +611,7 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 						require.IsType(t,
 							&interpreter.CompositeValue{},
 							inter.Globals["y"].GetValue().(*interpreter.SomeValue).
-								InnerValue(inter, interpreter.ReturnEmptyLocationRange),
+								InnerValue(inter, interpreter.EmptyLocationRange),
 						)
 					})
 				}
@@ -764,7 +764,7 @@ func testResourceCastValid(t *testing.T, types, fromType string, targetType stri
 		require.IsType(t,
 			&interpreter.CompositeValue{},
 			value.(*interpreter.SomeValue).
-				InnerValue(inter, interpreter.ReturnEmptyLocationRange),
+				InnerValue(inter, interpreter.EmptyLocationRange),
 		)
 
 	case ast.OperationForceCast:
@@ -914,7 +914,7 @@ func testStructCastValid(t *testing.T, types, fromType string, targetType string
 		require.IsType(t,
 			&interpreter.CompositeValue{},
 			value.(*interpreter.SomeValue).
-				InnerValue(inter, interpreter.ReturnEmptyLocationRange),
+				InnerValue(inter, interpreter.EmptyLocationRange),
 		)
 
 	case ast.OperationForceCast:
@@ -1229,7 +1229,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 						require.IsType(t, zValue, &interpreter.SomeValue{})
 						zSome := zValue.(*interpreter.SomeValue)
 
-						innerValue := zSome.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+						innerValue := zSome.InnerValue(inter, interpreter.EmptyLocationRange)
 						require.IsType(t, innerValue, &interpreter.ArrayValue{})
 						innerArray := innerValue.(*interpreter.ArrayValue)
 
@@ -1375,7 +1375,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 
 						expectedDictionary := interpreter.NewDictionaryValue(
 							inter,
-							interpreter.ReturnEmptyLocationRange,
+							interpreter.EmptyLocationRange,
 							interpreter.DictionaryStaticType{
 								KeyType:   interpreter.PrimitiveStaticTypeString,
 								ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -2343,7 +2343,7 @@ func testReferenceCastValid(t *testing.T, types, fromType, targetType string, op
 		require.IsType(t,
 			&interpreter.EphemeralReferenceValue{},
 			value.(*interpreter.SomeValue).
-				InnerValue(inter, interpreter.ReturnEmptyLocationRange),
+				InnerValue(inter, interpreter.EmptyLocationRange),
 		)
 
 	case ast.OperationForceCast:

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -135,7 +135,7 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -171,7 +171,7 @@ func TestInterpretEnumConstructor(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -206,7 +206,7 @@ func TestInterpretEnumInstance(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -249,7 +249,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 
-	eValue := contract.GetField(inter, interpreter.ReturnEmptyLocationRange, "e")
+	eValue := contract.GetField(inter, interpreter.EmptyLocationRange, "e")
 	require.NotNil(t, eValue)
 
 	require.IsType(t, &interpreter.CompositeValue{}, eValue)
@@ -257,7 +257,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 
 	rawValue := enumCase.GetMember(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		"rawValue",
 	)
 

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -84,7 +84,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 
 					value := interpreter.NewCompositeValue(
 						inter,
-						interpreter.ReturnEmptyLocationRange,
+						interpreter.EmptyLocationRange,
 						location,
 						"Foo",
 						common.CompositeKindContract,

--- a/runtime/tests/interpreter/interface_test.go
+++ b/runtime/tests/interpreter/interface_test.go
@@ -149,11 +149,11 @@ func TestInterpretInterfaceDefaultImplementation(t *testing.T) {
 
 		assert.Equal(t,
 			interpreter.NewUnmeteredIntValueFromInt64(123),
-			array.Get(inter, nil, 0),
+			array.Get(inter, interpreter.EmptyLocationRange, 0),
 		)
 		assert.Equal(t,
 			interpreter.NewUnmeteredIntValueFromInt64(456),
-			array.Get(inter, nil, 1),
+			array.Get(inter, interpreter.EmptyLocationRange, 1),
 		)
 	})
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -273,7 +273,7 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -646,19 +646,15 @@ func TestInterpretInvalidArrayIndexing(t *testing.T) {
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
 
-			require.Equal(t,
-				interpreter.ArrayIndexOutOfBoundsError{
-					Index: index,
-					Size:  2,
-					LocationRange: interpreter.LocationRange{
-						Location: TestLocation,
-						Range: ast.Range{
-							StartPos: ast.Position{Offset: 107, Line: 4, Column: 27},
-							EndPos:   ast.Position{Offset: 113, Line: 4, Column: 33},
-						},
-					},
-				},
-				indexErr,
+			assert.Equal(t, index, indexErr.Index)
+			assert.Equal(t, 2, indexErr.Size)
+			assert.Equal(t,
+				ast.Position{Offset: 107, Line: 4, Column: 27},
+				indexErr.HasPosition.StartPosition(),
+			)
+			assert.Equal(t,
+				ast.Position{Offset: 113, Line: 4, Column: 33},
+				indexErr.HasPosition.EndPosition(nil),
 			)
 		})
 	}
@@ -683,7 +679,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 
 	expectedArray := interpreter.NewArrayValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeInt,
 		},
@@ -726,19 +722,15 @@ func TestInterpretInvalidArrayIndexingAssignment(t *testing.T) {
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
 
-			require.Equal(t,
-				interpreter.ArrayIndexOutOfBoundsError{
-					Index: index,
-					Size:  2,
-					LocationRange: interpreter.LocationRange{
-						Location: TestLocation,
-						Range: ast.Range{
-							StartPos: ast.Position{Offset: 95, Line: 4, Column: 20},
-							EndPos:   ast.Position{Offset: 101, Line: 4, Column: 26},
-						},
-					},
-				},
-				indexErr,
+			assert.Equal(t, index, indexErr.Index)
+			assert.Equal(t, 2, indexErr.Size)
+			assert.Equal(t,
+				ast.Position{Offset: 95, Line: 4, Column: 20},
+				indexErr.HasPosition.StartPosition(),
+			)
+			assert.Equal(t,
+				ast.Position{Offset: 101, Line: 4, Column: 26},
+				indexErr.HasPosition.EndPosition(nil),
 			)
 		})
 	}
@@ -801,19 +793,15 @@ func TestInterpretInvalidStringIndexing(t *testing.T) {
 			var indexErr interpreter.StringIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
 
-			require.Equal(t,
-				interpreter.StringIndexOutOfBoundsError{
-					Index:  index,
-					Length: 2,
-					LocationRange: interpreter.LocationRange{
-						Location: TestLocation,
-						Range: ast.Range{
-							StartPos: ast.Position{Offset: 93, Line: 4, Column: 20},
-							EndPos:   ast.Position{Offset: 99, Line: 4, Column: 26},
-						},
-					},
-				},
-				indexErr,
+			assert.Equal(t, index, indexErr.Index)
+			assert.Equal(t, 2, indexErr.Length)
+			assert.Equal(t,
+				ast.Position{Offset: 93, Line: 4, Column: 20},
+				indexErr.HasPosition.StartPosition(),
+			)
+			assert.Equal(t,
+				ast.Position{Offset: 99, Line: 4, Column: 26},
+				indexErr.HasPosition.EndPosition(nil),
 			)
 		})
 	}
@@ -860,28 +848,22 @@ func TestInterpretStringSlicing(t *testing.T) {
 
 	t.Parallel()
 
-	locationRange1 := interpreter.LocationRange{
-		Location: TestLocation,
-		Range: ast.Range{
-			StartPos: ast.Position{Offset: 116, Line: 4, Column: 31},
-			EndPos:   ast.Position{Offset: 140, Line: 4, Column: 55},
-		},
+	range1 := ast.Range{
+		StartPos: ast.Position{Offset: 116, Line: 4, Column: 31},
+		EndPos:   ast.Position{Offset: 140, Line: 4, Column: 55},
 	}
 
-	locationRange2 := interpreter.LocationRange{
-		Location: TestLocation,
-		Range: ast.Range{
-			StartPos: ast.Position{Offset: 116, Line: 4, Column: 31},
-			EndPos:   ast.Position{Offset: 141, Line: 4, Column: 56},
-		},
+	range2 := ast.Range{
+		StartPos: ast.Position{Offset: 116, Line: 4, Column: 31},
+		EndPos:   ast.Position{Offset: 141, Line: 4, Column: 56},
 	}
 
 	type test struct {
-		str           string
-		from          int
-		to            int
-		result        string
-		expectedError error
+		str        string
+		from       int
+		to         int
+		result     string
+		checkError func(t *testing.T, err error)
 	}
 
 	tests := []test{
@@ -894,28 +876,68 @@ func TestInterpretStringSlicing(t *testing.T) {
 		{"abcdef", 5, 6, "f", nil},
 		{"abcdef", 1, 6, "bcdef", nil},
 		// Invalid indices
-		{"abcdef", -1, 0, "", interpreter.StringSliceIndicesError{
-			FromIndex:     -1,
-			UpToIndex:     0,
-			Length:        6,
-			LocationRange: locationRange2,
+		{"abcdef", -1, 0, "", func(t *testing.T, err error) {
+			var sliceErr interpreter.StringSliceIndicesError
+			require.ErrorAs(t, err, &sliceErr)
+
+			assert.Equal(t, -1, sliceErr.FromIndex)
+			assert.Equal(t, 0, sliceErr.UpToIndex)
+			assert.Equal(t, 6, sliceErr.Length)
+			assert.Equal(t,
+				range2.StartPos,
+				sliceErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range2.EndPos,
+				sliceErr.LocationRange.EndPosition(nil),
+			)
 		}},
-		{"abcdef", 0, -1, "", interpreter.StringSliceIndicesError{
-			FromIndex:     0,
-			UpToIndex:     -1,
-			Length:        6,
-			LocationRange: locationRange2,
+		{"abcdef", 0, -1, "", func(t *testing.T, err error) {
+			var sliceErr interpreter.StringSliceIndicesError
+			require.ErrorAs(t, err, &sliceErr)
+
+			assert.Equal(t, 0, sliceErr.FromIndex)
+			assert.Equal(t, -1, sliceErr.UpToIndex)
+			assert.Equal(t, 6, sliceErr.Length)
+			assert.Equal(t,
+				range2.StartPos,
+				sliceErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range2.EndPos,
+				sliceErr.LocationRange.EndPosition(nil),
+			)
 		}},
-		{"abcdef", 0, 10, "", interpreter.StringSliceIndicesError{
-			FromIndex:     0,
-			UpToIndex:     10,
-			Length:        6,
-			LocationRange: locationRange2,
+		{"abcdef", 0, 10, "", func(t *testing.T, err error) {
+			var sliceErr interpreter.StringSliceIndicesError
+			require.ErrorAs(t, err, &sliceErr)
+
+			assert.Equal(t, 0, sliceErr.FromIndex)
+			assert.Equal(t, 10, sliceErr.UpToIndex)
+			assert.Equal(t, 6, sliceErr.Length)
+			assert.Equal(t,
+				range2.StartPos,
+				sliceErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range2.EndPos,
+				sliceErr.LocationRange.EndPosition(nil),
+			)
 		}},
-		{"abcdef", 2, 1, "", interpreter.InvalidSliceIndexError{
-			FromIndex:     2,
-			UpToIndex:     1,
-			LocationRange: locationRange1,
+		{"abcdef", 2, 1, "", func(t *testing.T, err error) {
+			var indexErr interpreter.InvalidSliceIndexError
+			require.ErrorAs(t, err, &indexErr)
+
+			assert.Equal(t, 2, indexErr.FromIndex)
+			assert.Equal(t, 1, indexErr.UpToIndex)
+			assert.Equal(t,
+				range1.StartPos,
+				indexErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range1.EndPos,
+				indexErr.LocationRange.EndPosition(nil),
+			)
 		}},
 		// Unicode: indices are based on characters = grapheme clusters
 		{"cafe\\u{301}b", 0, 5, "cafe\u0301b", nil},
@@ -931,8 +953,10 @@ func TestInterpretStringSlicing(t *testing.T) {
 		{"cafe\\u{301}ba\\u{308}be", 5, 6, "a\u0308", nil},
 	}
 
-	for _, test := range tests {
+	runTest := func(test test) {
 		t.Run("", func(t *testing.T) {
+
+			t.Parallel()
 
 			inter := parseCheckAndInterpret(t,
 				fmt.Sprintf(
@@ -949,7 +973,7 @@ func TestInterpretStringSlicing(t *testing.T) {
 			)
 
 			value, err := inter.Invoke("test")
-			if test.expectedError == nil {
+			if test.checkError == nil {
 				require.NoError(t, err)
 
 				AssertValuesEqual(
@@ -963,11 +987,14 @@ func TestInterpretStringSlicing(t *testing.T) {
 					interpreter.Error{},
 					err,
 				)
-				err = err.(interpreter.Error).Unwrap()
 
-				assert.Equal(t, test.expectedError, err)
+				test.checkError(t, err)
 			}
 		})
+	}
+
+	for _, test := range tests {
+		runTest(test)
 	}
 }
 
@@ -2281,7 +2308,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		test.GetField(inter, interpreter.ReturnEmptyLocationRange, "foo"),
+		test.GetField(inter, interpreter.EmptyLocationRange, "foo"),
 	)
 
 	value, err := inter.Invoke("callTest")
@@ -2298,7 +2325,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		test.GetField(inter, interpreter.ReturnEmptyLocationRange, "foo"),
+		test.GetField(inter, interpreter.EmptyLocationRange, "foo"),
 	)
 }
 
@@ -2319,7 +2346,7 @@ func TestInterpretStructureInitializesConstant(t *testing.T) {
     `)
 
 	actual := inter.Globals["test"].GetValue().(*interpreter.CompositeValue).
-		GetMember(inter, interpreter.ReturnEmptyLocationRange, "foo")
+		GetMember(inter, interpreter.EmptyLocationRange, "foo")
 	AssertValuesEqual(
 		t,
 		inter,
@@ -2393,7 +2420,7 @@ func TestInterpretStructCopyOnDeclaration(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -2438,7 +2465,7 @@ func TestInterpretStructCopyOnDeclarationModifiedWithStructFunction(t *testing.T
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -2480,7 +2507,7 @@ func TestInterpretStructCopyOnIdentifierAssignment(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -2522,7 +2549,7 @@ func TestInterpretStructCopyOnIndexingAssignment(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -2571,7 +2598,7 @@ func TestInterpretStructCopyOnMemberAssignment(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
@@ -2647,7 +2674,7 @@ func TestInterpretArrayCopy(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -2688,7 +2715,7 @@ func TestInterpretStructCopyInArray(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -4085,7 +4112,7 @@ func TestInterpretDictionary(t *testing.T) {
 
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -4114,7 +4141,7 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -4326,7 +4353,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 
 	newValue := actualDict.GetKey(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.NewUnmeteredStringValue("abc"),
 	)
 
@@ -4371,7 +4398,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -4391,7 +4418,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 
 	newValue := actualDict.GetKey(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.NewUnmeteredStringValue("abc"),
 	)
 
@@ -4438,7 +4465,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
@@ -4457,7 +4484,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 
 	newValue := actualDict.GetKey(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.NewUnmeteredStringValue("def"),
 	)
 
@@ -4774,7 +4801,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 
 		r = r.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			atree.Address(storageAddress),
 			true,
 			nil,
@@ -5234,19 +5261,15 @@ func TestInterpretInvalidArrayInsert(t *testing.T) {
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
 
-			require.Equal(t,
-				interpreter.ArrayIndexOutOfBoundsError{
-					Index: index,
-					Size:  3,
-					LocationRange: interpreter.LocationRange{
-						Location: TestLocation,
-						Range: ast.Range{
-							StartPos: ast.Position{Offset: 94, Line: 5, Column: 19},
-							EndPos:   ast.Position{Offset: 115, Line: 5, Column: 40},
-						},
-					},
-				},
-				indexErr,
+			assert.Equal(t, index, indexErr.Index)
+			assert.Equal(t, 3, indexErr.Size)
+			assert.Equal(t,
+				ast.Position{Offset: 94, Line: 5, Column: 19},
+				indexErr.HasPosition.StartPosition(),
+			)
+			assert.Equal(t,
+				ast.Position{Offset: 115, Line: 5, Column: 40},
+				indexErr.HasPosition.EndPosition(nil),
 			)
 		})
 	}
@@ -5310,19 +5333,15 @@ func TestInterpretInvalidArrayRemove(t *testing.T) {
 			var indexErr interpreter.ArrayIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
 
-			require.Equal(t,
-				interpreter.ArrayIndexOutOfBoundsError{
-					Index: index,
-					Size:  3,
-					LocationRange: interpreter.LocationRange{
-						Location: TestLocation,
-						Range: ast.Range{
-							StartPos: ast.Position{Offset: 94, Line: 5, Column: 19},
-							EndPos:   ast.Position{Offset: 112, Line: 5, Column: 37},
-						},
-					},
-				},
-				indexErr,
+			assert.Equal(t, index, indexErr.Index)
+			assert.Equal(t, 3, indexErr.Size)
+			assert.Equal(t,
+				ast.Position{Offset: 94, Line: 5, Column: 19},
+				indexErr.HasPosition.StartPosition(),
+			)
+			assert.Equal(t,
+				ast.Position{Offset: 112, Line: 5, Column: 37},
+				indexErr.HasPosition.EndPosition(nil),
 			)
 		})
 	}
@@ -5378,19 +5397,15 @@ func TestInterpretInvalidArrayRemoveFirst(t *testing.T) {
 	var indexErr interpreter.ArrayIndexOutOfBoundsError
 	require.ErrorAs(t, err, &indexErr)
 
-	require.Equal(t,
-		interpreter.ArrayIndexOutOfBoundsError{
-			Index: 0,
-			Size:  0,
-			LocationRange: interpreter.LocationRange{
-				Location: TestLocation,
-				Range: ast.Range{
-					StartPos: ast.Position{Offset: 58, Line: 5, Column: 11},
-					EndPos:   ast.Position{Offset: 72, Line: 5, Column: 25},
-				},
-			},
-		},
-		indexErr,
+	assert.Equal(t, 0, indexErr.Index)
+	assert.Equal(t, 0, indexErr.Size)
+	assert.Equal(t,
+		ast.Position{Offset: 58, Line: 5, Column: 11},
+		indexErr.HasPosition.StartPosition(),
+	)
+	assert.Equal(t,
+		ast.Position{Offset: 72, Line: 5, Column: 25},
+		indexErr.HasPosition.EndPosition(nil),
 	)
 }
 
@@ -5445,19 +5460,15 @@ func TestInterpretInvalidArrayRemoveLast(t *testing.T) {
 	var indexErr interpreter.ArrayIndexOutOfBoundsError
 	require.ErrorAs(t, err, &indexErr)
 
-	require.Equal(t,
-		interpreter.ArrayIndexOutOfBoundsError{
-			Index: -1,
-			Size:  0,
-			LocationRange: interpreter.LocationRange{
-				Location: TestLocation,
-				Range: ast.Range{
-					StartPos: ast.Position{Offset: 58, Line: 5, Column: 11},
-					EndPos:   ast.Position{Offset: 71, Line: 5, Column: 24},
-				},
-			},
-		},
-		indexErr,
+	assert.Equal(t, -1, indexErr.Index)
+	assert.Equal(t, 0, indexErr.Size)
+	assert.Equal(t,
+		ast.Position{Offset: 58, Line: 5, Column: 11},
+		indexErr.HasPosition.StartPosition(),
+	)
+	assert.Equal(t,
+		ast.Position{Offset: 71, Line: 5, Column: 24},
+		indexErr.HasPosition.EndPosition(nil),
 	)
 }
 
@@ -5465,28 +5476,22 @@ func TestInterpretArraySlicing(t *testing.T) {
 
 	t.Parallel()
 
-	locationRange1 := interpreter.LocationRange{
-		Location: TestLocation,
-		Range: ast.Range{
-			StartPos: ast.Position{Offset: 125, Line: 4, Column: 31},
-			EndPos:   ast.Position{Offset: 149, Line: 4, Column: 55},
-		},
+	range1 := ast.Range{
+		StartPos: ast.Position{Offset: 125, Line: 4, Column: 31},
+		EndPos:   ast.Position{Offset: 149, Line: 4, Column: 55},
 	}
 
-	locationRange2 := interpreter.LocationRange{
-		Location: TestLocation,
-		Range: ast.Range{
-			StartPos: ast.Position{Offset: 125, Line: 4, Column: 31},
-			EndPos:   ast.Position{Offset: 150, Line: 4, Column: 56},
-		},
+	range2 := ast.Range{
+		StartPos: ast.Position{Offset: 125, Line: 4, Column: 31},
+		EndPos:   ast.Position{Offset: 150, Line: 4, Column: 56},
 	}
 
 	type test struct {
-		literal       string
-		from          int
-		to            int
-		result        string
-		expectedError error
+		literal    string
+		from       int
+		to         int
+		result     string
+		checkError func(t *testing.T, err error)
 	}
 
 	tests := []test{
@@ -5499,33 +5504,75 @@ func TestInterpretArraySlicing(t *testing.T) {
 		{"[1, 2, 3, 4, 5, 6]", 5, 6, "[6]", nil},
 		{"[1, 2, 3, 4, 5, 6]", 1, 6, "[2, 3, 4, 5, 6]", nil},
 		// Invalid indices
-		{"[1, 2, 3, 4, 5, 6]", -1, 0, "", interpreter.ArraySliceIndicesError{
-			FromIndex:     -1,
-			UpToIndex:     0,
-			Size:          6,
-			LocationRange: locationRange2,
+		{"[1, 2, 3, 4, 5, 6]", -1, 0, "", func(t *testing.T, err error) {
+			var sliceErr interpreter.ArraySliceIndicesError
+			require.ErrorAs(t, err, &sliceErr)
+
+			assert.Equal(t, -1, sliceErr.FromIndex)
+			assert.Equal(t, 0, sliceErr.UpToIndex)
+			assert.Equal(t, 6, sliceErr.Size)
+			assert.Equal(t,
+				range2.StartPos,
+				sliceErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range2.EndPos,
+				sliceErr.LocationRange.EndPosition(nil),
+			)
 		}},
-		{"[1, 2, 3, 4, 5, 6]", 0, -1, "", interpreter.ArraySliceIndicesError{
-			FromIndex:     0,
-			UpToIndex:     -1,
-			Size:          6,
-			LocationRange: locationRange2,
+		{"[1, 2, 3, 4, 5, 6]", 0, -1, "", func(t *testing.T, err error) {
+			var sliceErr interpreter.ArraySliceIndicesError
+			require.ErrorAs(t, err, &sliceErr)
+
+			assert.Equal(t, 0, sliceErr.FromIndex)
+			assert.Equal(t, -1, sliceErr.UpToIndex)
+			assert.Equal(t, 6, sliceErr.Size)
+			assert.Equal(t,
+				range2.StartPos,
+				sliceErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range2.EndPos,
+				sliceErr.LocationRange.EndPosition(nil),
+			)
 		}},
-		{"[1, 2, 3, 4, 5, 6]", 0, 10, "", interpreter.ArraySliceIndicesError{
-			FromIndex:     0,
-			UpToIndex:     10,
-			Size:          6,
-			LocationRange: locationRange2,
+		{"[1, 2, 3, 4, 5, 6]", 0, 10, "", func(t *testing.T, err error) {
+			var sliceErr interpreter.ArraySliceIndicesError
+			require.ErrorAs(t, err, &sliceErr)
+
+			assert.Equal(t, 0, sliceErr.FromIndex)
+			assert.Equal(t, 10, sliceErr.UpToIndex)
+			assert.Equal(t, 6, sliceErr.Size)
+			assert.Equal(t,
+				range2.StartPos,
+				sliceErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range2.EndPos,
+				sliceErr.LocationRange.EndPosition(nil),
+			)
 		}},
-		{"[1, 2, 3, 4, 5, 6]", 2, 1, "", interpreter.InvalidSliceIndexError{
-			FromIndex:     2,
-			UpToIndex:     1,
-			LocationRange: locationRange1,
+		{"[1, 2, 3, 4, 5, 6]", 2, 1, "", func(t *testing.T, err error) {
+			var indexErr interpreter.InvalidSliceIndexError
+			require.ErrorAs(t, err, &indexErr)
+
+			assert.Equal(t, 2, indexErr.FromIndex)
+			assert.Equal(t, 1, indexErr.UpToIndex)
+			assert.Equal(t,
+				range1.StartPos,
+				indexErr.LocationRange.StartPosition(),
+			)
+			assert.Equal(t,
+				range1.EndPos,
+				indexErr.LocationRange.EndPosition(nil),
+			)
 		}},
 	}
 
-	for _, test := range tests {
+	runTest := func(test test) {
 		t.Run("", func(t *testing.T) {
+
+			t.Parallel()
 
 			inter := parseCheckAndInterpret(t,
 				fmt.Sprintf(
@@ -5542,7 +5589,7 @@ func TestInterpretArraySlicing(t *testing.T) {
 			)
 
 			value, err := inter.Invoke("test")
-			if test.expectedError == nil {
+			if test.checkError == nil {
 				require.NoError(t, err)
 
 				assert.Equal(
@@ -5555,11 +5602,14 @@ func TestInterpretArraySlicing(t *testing.T) {
 					interpreter.Error{},
 					err,
 				)
-				err = err.(interpreter.Error).Unwrap()
 
-				assert.Equal(t, test.expectedError, err)
+				test.checkError(t, err)
 			}
 		})
+	}
+
+	for _, test := range tests {
+		runTest(test)
 	}
 }
 
@@ -6303,7 +6353,7 @@ func TestInterpretSwapVariables(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -6344,7 +6394,7 @@ func TestInterpretSwapArrayAndField(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -6715,7 +6765,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 			Config: &interpreter.Config{
 				OnEventEmitted: func(
 					_ *interpreter.Interpreter,
-					_ func() interpreter.LocationRange,
+					_ interpreter.LocationRange,
 					event *interpreter.CompositeValue,
 					eventType *sema.CompositeType,
 				) error {
@@ -6773,7 +6823,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 	expectedEvents := []interpreter.Value{
 		interpreter.NewCompositeValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			TestLocation,
 			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
@@ -6782,7 +6832,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 		),
 		interpreter.NewCompositeValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			TestLocation,
 			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
@@ -6791,7 +6841,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 		),
 		interpreter.NewCompositeValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			TestLocation,
 			TestLocation.QualifiedIdentifier(transferAmountEventType.ID()),
 			common.CompositeKindEvent,
@@ -6849,7 +6899,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 	sValue := interpreter.NewCompositeValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		TestLocation,
 		"S",
 		common.CompositeKindStructure,
@@ -7009,7 +7059,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			testValue{
 				value: interpreter.NewArrayValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 					},
@@ -7023,7 +7073,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			testValue{
 				value: interpreter.NewArrayValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					interpreter.ConstantSizedStaticType{
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 						Size: 1,
@@ -7038,7 +7088,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 			value := interpreter.NewDictionaryValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.DictionaryStaticType{
 					KeyType:   interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 					ValueType: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
@@ -7097,7 +7147,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 						Storage: storage,
 						OnEventEmitted: func(
 							_ *interpreter.Interpreter,
-							_ func() interpreter.LocationRange,
+							_ interpreter.LocationRange,
 							event *interpreter.CompositeValue,
 							eventType *sema.CompositeType,
 						) error {
@@ -7124,7 +7174,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			expectedEvents := []interpreter.Value{
 				interpreter.NewCompositeValue(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					TestLocation,
 					TestLocation.QualifiedIdentifier(testType.ID()),
 					common.CompositeKindEvent,
@@ -7200,7 +7250,7 @@ func TestInterpretSwapResourceDictionaryElementReturnDictionary(t *testing.T) {
 	)
 
 	foo := value.(*interpreter.DictionaryValue).
-		GetKey(inter, interpreter.ReturnEmptyLocationRange, interpreter.NewUnmeteredStringValue("foo"))
+		GetKey(inter, interpreter.EmptyLocationRange, interpreter.NewUnmeteredStringValue("foo"))
 
 	require.IsType(t,
 		&interpreter.SomeValue{},
@@ -7210,7 +7260,7 @@ func TestInterpretSwapResourceDictionaryElementReturnDictionary(t *testing.T) {
 	assert.IsType(t,
 		&interpreter.CompositeValue{},
 		foo.(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange),
+			InnerValue(inter, interpreter.EmptyLocationRange),
 	)
 }
 
@@ -7241,7 +7291,7 @@ func TestInterpretSwapResourceDictionaryElementRemoveUsingNil(t *testing.T) {
 	assert.IsType(t,
 		&interpreter.CompositeValue{},
 		value.(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange),
+			InnerValue(inter, interpreter.EmptyLocationRange),
 	)
 }
 
@@ -7312,7 +7362,7 @@ func TestInterpretReferenceUse(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -7364,7 +7414,7 @@ func TestInterpretReferenceUseAccess(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -7444,7 +7494,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 	)
 
 	firstValue := values[0].(*interpreter.SomeValue).
-		InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+		InnerValue(inter, interpreter.EmptyLocationRange)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -7457,7 +7507,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		firstResource.GetField(inter, interpreter.ReturnEmptyLocationRange, "id"),
+		firstResource.GetField(inter, interpreter.EmptyLocationRange, "id"),
 	)
 
 	require.IsType(t,
@@ -7466,7 +7516,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 	)
 
 	secondValue := values[1].(*interpreter.SomeValue).
-		InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+		InnerValue(inter, interpreter.EmptyLocationRange)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -7479,7 +7529,7 @@ func TestInterpretVariableDeclarationSecondValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		secondResource.GetField(inter, interpreter.ReturnEmptyLocationRange, "id"),
+		secondResource.GetField(inter, interpreter.EmptyLocationRange, "id"),
 	)
 }
 
@@ -7541,7 +7591,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.OptionalStaticType{
 						Type: interpreter.PrimitiveStaticTypeString,
@@ -7611,7 +7661,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 		r1, err := inter.Invoke("createR1")
 		require.NoError(t, err)
 
-		r1 = r1.Transfer(inter, interpreter.ReturnEmptyLocationRange, atree.Address{1}, false, nil)
+		r1 = r1.Transfer(inter, interpreter.EmptyLocationRange, atree.Address{1}, false, nil)
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
@@ -7628,7 +7678,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.OptionalStaticType{
 						Type: interpreter.PrimitiveStaticTypeString,
@@ -7825,7 +7875,7 @@ func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
 	assert.IsType(t,
 		interpreter.BoundFunctionValue{},
 		inter.Globals["x2"].GetValue().(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange),
+			InnerValue(inter, interpreter.EmptyLocationRange),
 	)
 }
 
@@ -8146,7 +8196,7 @@ func TestInterpretFungibleTokenContract(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.ConstantSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 				Size: 2,
@@ -8344,7 +8394,7 @@ func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
 	require.NoError(t, err)
 
 	i := inter.Globals["C"].GetValue().(interpreter.MemberAccessibleValue).
-		GetMember(inter, interpreter.ReturnEmptyLocationRange, "i")
+		GetMember(inter, interpreter.EmptyLocationRange, "i")
 
 	require.IsType(t,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
@@ -8895,7 +8945,7 @@ func TestInterpretReferenceUseAfterCopy(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
@@ -9007,11 +9057,11 @@ func newTestAuthAccountValue(gauge common.MemoryGauge, addressValue interpreter.
 				panicFunction,
 				func(
 					inter *interpreter.Interpreter,
-					getLocationRange func() interpreter.LocationRange,
+					locationRange interpreter.LocationRange,
 				) *interpreter.ArrayValue {
 					return interpreter.NewArrayValue(
 						inter,
-						getLocationRange,
+						locationRange,
 						interpreter.VariableSizedStaticType{
 							Type: interpreter.PrimitiveStaticTypeString,
 						},
@@ -9063,11 +9113,11 @@ func newTestPublicAccountValue(gauge common.MemoryGauge, addressValue interprete
 				panicFunction,
 				func(
 					inter *interpreter.Interpreter,
-					getLocationRange func() interpreter.LocationRange,
+					locationRange interpreter.LocationRange,
 				) *interpreter.ArrayValue {
 					return interpreter.NewArrayValue(
 						inter,
-						interpreter.ReturnEmptyLocationRange,
+						interpreter.EmptyLocationRange,
 						interpreter.VariableSizedStaticType{
 							Type: interpreter.PrimitiveStaticTypeString,
 						},
@@ -9632,14 +9682,14 @@ func TestInterpretInternalAssignment(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: stringIntDictionaryStaticType,
 			},
 			common.Address{},
 			interpreter.NewDictionaryValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				stringIntDictionaryStaticType,
 				interpreter.NewUnmeteredStringValue("a"),
 				interpreter.NewUnmeteredIntValueFromInt64(1),
@@ -9648,7 +9698,7 @@ func TestInterpretInternalAssignment(t *testing.T) {
 			),
 			interpreter.NewDictionaryValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				stringIntDictionaryStaticType,
 				interpreter.NewUnmeteredStringValue("a"),
 				interpreter.NewUnmeteredIntValueFromInt64(1),
@@ -9752,7 +9802,7 @@ func TestInterpretCopyOnReturn(t *testing.T) {
 		inter,
 		interpreter.NewDictionaryValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeString,
@@ -9814,7 +9864,7 @@ func TestInterpretMissingMember(t *testing.T) {
 
 	// Remove field `y`
 	compositeValue := inter.Globals["x"].GetValue().(*interpreter.CompositeValue)
-	compositeValue.RemoveField(inter, interpreter.ReturnEmptyLocationRange, "y")
+	compositeValue.RemoveField(inter, interpreter.EmptyLocationRange, "y")
 
 	_, err := inter.Invoke("test")
 	require.Error(t, err)

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -1114,7 +1114,7 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 					BaseActivation: baseActivation,
 					PublicKeyValidationHandler: func(
 						_ *interpreter.Interpreter,
-						_ func() interpreter.LocationRange,
+						_ interpreter.LocationRange,
 						_ *interpreter.CompositeValue,
 					) error {
 						return nil
@@ -1172,7 +1172,7 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 					BaseActivation: baseActivation,
 					PublicKeyValidationHandler: func(
 						_ *interpreter.Interpreter,
-						_ func() interpreter.LocationRange,
+						_ interpreter.LocationRange,
 						_ *interpreter.CompositeValue,
 					) error {
 						return nil

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -475,7 +475,7 @@ func TestInterpretResourceReferenceAfterMove(t *testing.T) {
 
 		array := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.ConvertSemaToStaticType(nil, rType),
 			},
@@ -528,7 +528,7 @@ func TestInterpretResourceReferenceAfterMove(t *testing.T) {
 
 		array := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.VariableSizedStaticType{
 					Type: interpreter.ConvertSemaToStaticType(nil, rType),
@@ -585,7 +585,7 @@ func TestInterpretResourceReferenceAfterMove(t *testing.T) {
 
 		array := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeInt,
@@ -747,7 +747,7 @@ func TestInterpretReferenceUseAfterShiftStatementMove(t *testing.T) {
 		r1, err := inter.Invoke("createR1")
 		require.NoError(t, err)
 
-		r1 = r1.Transfer(inter, interpreter.ReturnEmptyLocationRange, atree.Address{1}, false, nil)
+		r1 = r1.Transfer(inter, interpreter.EmptyLocationRange, atree.Address{1}, false, nil)
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
@@ -817,7 +817,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			InnerValue(inter, interpreter.EmptyLocationRange)
 		require.IsType(t, &interpreter.EphemeralReferenceValue{}, innerValue)
 	})
 
@@ -836,7 +836,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			InnerValue(inter, interpreter.EmptyLocationRange)
 		require.IsType(t, &interpreter.EphemeralReferenceValue{}, innerValue)
 	})
 
@@ -853,7 +853,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			InnerValue(inter, interpreter.EmptyLocationRange)
 		require.IsType(t, &interpreter.EphemeralReferenceValue{}, innerValue)
 	})
 
@@ -870,7 +870,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			InnerValue(inter, interpreter.EmptyLocationRange)
 		require.IsType(t, &interpreter.EphemeralReferenceValue{}, innerValue)
 	})
 
@@ -900,7 +900,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
-			InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			InnerValue(inter, interpreter.EmptyLocationRange)
 		require.IsType(t, &interpreter.EphemeralReferenceValue{}, innerValue)
 	})
 }

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -189,7 +189,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		r1, err := inter.Invoke("createR1")
 		require.NoError(t, err)
 
-		r1 = r1.Transfer(inter, interpreter.ReturnEmptyLocationRange, atree.Address{1}, false, nil)
+		r1 = r1.Transfer(inter, interpreter.EmptyLocationRange, atree.Address{1}, false, nil)
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
@@ -311,7 +311,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		r1, err := inter.Invoke("createR1")
 		require.NoError(t, err)
 
-		r1 = r1.Transfer(inter, interpreter.ReturnEmptyLocationRange, atree.Address{1}, false, nil)
+		r1 = r1.Transfer(inter, interpreter.EmptyLocationRange, atree.Address{1}, false, nil)
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
@@ -428,7 +428,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		r1, err := inter.Invoke("createR1")
 		require.NoError(t, err)
 
-		r1 = r1.Transfer(inter, interpreter.ReturnEmptyLocationRange, atree.Address{1}, false, nil)
+		r1 = r1.Transfer(inter, interpreter.EmptyLocationRange, atree.Address{1}, false, nil)
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 
@@ -550,7 +550,7 @@ func TestInterpretImplicitResourceRemovalFromContainer(t *testing.T) {
 		r1, err := inter.Invoke("createR1")
 		require.NoError(t, err)
 
-		r1 = r1.Transfer(inter, interpreter.ReturnEmptyLocationRange, atree.Address{1}, false, nil)
+		r1 = r1.Transfer(inter, interpreter.EmptyLocationRange, atree.Address{1}, false, nil)
 
 		r1Type := checker.RequireGlobalType(t, inter.Program.Elaboration, "R1")
 

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -54,7 +54,7 @@ func TestInterpretRecursiveValueString(t *testing.T) {
 	require.Equal(t,
 		`{"mapRef": ...}`,
 		mapValue.(*interpreter.DictionaryValue).
-			GetKey(inter, interpreter.ReturnEmptyLocationRange, interpreter.NewUnmeteredStringValue("mapRef")).
+			GetKey(inter, interpreter.EmptyLocationRange, interpreter.NewUnmeteredStringValue("mapRef")).
 			String(),
 	)
 }
@@ -102,7 +102,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 			inter,
 			interpreter.NewArrayValue(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
@@ -249,7 +249,7 @@ func TestInterpretStringUtf8Field(t *testing.T) {
 		inter,
 		interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeUInt8,
 			},

--- a/runtime/tests/interpreter/uuid_test.go
+++ b/runtime/tests/interpreter/uuid_test.go
@@ -128,14 +128,14 @@ func TestInterpretResourceUUID(t *testing.T) {
 	require.Equal(t, length, array.Count())
 
 	for i := 0; i < length; i++ {
-		element := array.Get(inter, interpreter.ReturnEmptyLocationRange, i)
+		element := array.Get(inter, interpreter.EmptyLocationRange, i)
 
 		require.IsType(t, &interpreter.CompositeValue{}, element)
 		res := element.(*interpreter.CompositeValue)
 
 		uuidValue := res.GetMember(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			sema.ResourceUUIDFieldName,
 		)
 

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -100,7 +100,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 		testMap = interpreter.NewDictionaryValueWithAddress(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -114,10 +114,10 @@ func TestRandomMapOperations(t *testing.T) {
 		require.Equal(t, testMap.Count(), entries.size())
 
 		entries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			exists := testMap.ContainsKey(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			exists := testMap.ContainsKey(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, bool(exists))
 
-			value, found := testMap.Get(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			value, found := testMap.Get(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, found)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 
@@ -144,7 +144,7 @@ func TestRandomMapOperations(t *testing.T) {
 		newOwner := atree.Address{'B'}
 		copyOfTestMap = testMap.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			newOwner,
 			false,
 			nil,
@@ -153,10 +153,10 @@ func TestRandomMapOperations(t *testing.T) {
 		require.Equal(t, entries.size(), copyOfTestMap.Count())
 
 		entries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			exists := copyOfTestMap.ContainsKey(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			exists := copyOfTestMap.ContainsKey(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, bool(exists))
 
-			value, found := copyOfTestMap.Get(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			value, found := copyOfTestMap.Get(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, found)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 
@@ -181,10 +181,10 @@ func TestRandomMapOperations(t *testing.T) {
 
 		// go over original values again and check no missing data (no side effect should be found)
 		entries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			exists := testMap.ContainsKey(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			exists := testMap.ContainsKey(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, bool(exists))
 
-			value, found := testMap.Get(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			value, found := testMap.Get(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, found)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 
@@ -200,7 +200,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -215,17 +215,17 @@ func TestRandomMapOperations(t *testing.T) {
 
 			newEntries.put(inter, key, value)
 
-			_ = dictionary.Insert(inter, interpreter.ReturnEmptyLocationRange, key, value)
+			_ = dictionary.Insert(inter, interpreter.EmptyLocationRange, key, value)
 		}
 
 		require.Equal(t, newEntries.size(), dictionary.Count())
 
 		// Go over original values again and check no missing data (no side effect should be found)
 		newEntries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			exists := dictionary.ContainsKey(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			exists := dictionary.ContainsKey(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, bool(exists))
 
-			value, found := dictionary.Get(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			value, found := dictionary.Get(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, found)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 
@@ -249,7 +249,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -264,20 +264,20 @@ func TestRandomMapOperations(t *testing.T) {
 
 		// Insert
 		for _, keyValue := range keyValues {
-			dictionary.Insert(inter, interpreter.ReturnEmptyLocationRange, keyValue[0], keyValue[1])
+			dictionary.Insert(inter, interpreter.EmptyLocationRange, keyValue[0], keyValue[1])
 		}
 
 		require.Equal(t, newEntries.size(), dictionary.Count())
 
 		// Remove
 		newEntries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			removedValue := dictionary.Remove(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			removedValue := dictionary.Remove(inter, interpreter.EmptyLocationRange, orgKey)
 
 			assert.IsType(t, &interpreter.SomeValue{}, removedValue)
 			someValue := removedValue.(*interpreter.SomeValue)
 
 			// Removed value must be same as the original value
-			innerValue := someValue.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue := someValue.InnerValue(inter, interpreter.EmptyLocationRange)
 			utils.AssertValuesEqual(t, inter, orgValue, innerValue)
 
 			return false
@@ -297,7 +297,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -326,18 +326,18 @@ func TestRandomMapOperations(t *testing.T) {
 
 		// Insert
 		for _, keyValue := range keyValues {
-			dictionary.Insert(inter, interpreter.ReturnEmptyLocationRange, keyValue[0], keyValue[1])
+			dictionary.Insert(inter, interpreter.EmptyLocationRange, keyValue[0], keyValue[1])
 		}
 
 		// Remove
 		newEntries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			removedValue := dictionary.Remove(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			removedValue := dictionary.Remove(inter, interpreter.EmptyLocationRange, orgKey)
 
 			assert.IsType(t, &interpreter.SomeValue{}, removedValue)
 			someValue := removedValue.(*interpreter.SomeValue)
 
 			// Removed value must be same as the original value
-			innerValue := someValue.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+			innerValue := someValue.InnerValue(inter, interpreter.EmptyLocationRange)
 			utils.AssertValuesEqual(t, inter, orgValue, innerValue)
 
 			return false
@@ -362,7 +362,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -402,7 +402,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 				dictionary.Insert(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					key,
 					value,
 				)
@@ -411,13 +411,13 @@ func TestRandomMapOperations(t *testing.T) {
 				key := keyValues[deleteCount][0]
 				orgValue := keyValues[deleteCount][1]
 
-				removedValue := dictionary.Remove(inter, interpreter.ReturnEmptyLocationRange, key)
+				removedValue := dictionary.Remove(inter, interpreter.EmptyLocationRange, key)
 
 				assert.IsType(t, &interpreter.SomeValue{}, removedValue)
 				someValue := removedValue.(*interpreter.SomeValue)
 
 				// Removed value must be same as the original value
-				innerValue := someValue.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+				innerValue := someValue.InnerValue(inter, interpreter.EmptyLocationRange)
 				utils.AssertValuesEqual(t, inter, orgValue, innerValue)
 
 				deleteCount++
@@ -452,7 +452,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -465,7 +465,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 		movedDictionary := dictionary.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			newOwner,
 			true,
 			nil,
@@ -479,10 +479,10 @@ func TestRandomMapOperations(t *testing.T) {
 
 		// Check the values
 		entries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			exists := movedDictionary.ContainsKey(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			exists := movedDictionary.ContainsKey(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, bool(exists))
 
-			value, found := movedDictionary.Get(inter, interpreter.ReturnEmptyLocationRange, orgKey)
+			value, found := movedDictionary.Get(inter, interpreter.EmptyLocationRange, orgKey)
 			require.True(t, found)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 
@@ -539,7 +539,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		testArray = interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -552,7 +552,7 @@ func TestRandomArrayOperations(t *testing.T) {
 		require.Equal(t, len(elements), testArray.Count())
 
 		for index, orgElement := range elements {
-			element := testArray.Get(inter, interpreter.ReturnEmptyLocationRange, index)
+			element := testArray.Get(inter, interpreter.EmptyLocationRange, index)
 			utils.AssertValuesEqual(t, inter, orgElement, element)
 		}
 
@@ -568,7 +568,7 @@ func TestRandomArrayOperations(t *testing.T) {
 			orgElement := elements[index]
 			utils.AssertValuesEqual(t, inter, orgElement, element)
 
-			elementByIndex := testArray.Get(inter, interpreter.ReturnEmptyLocationRange, index)
+			elementByIndex := testArray.Get(inter, interpreter.EmptyLocationRange, index)
 			utils.AssertValuesEqual(t, inter, element, elementByIndex)
 
 			index++
@@ -580,7 +580,7 @@ func TestRandomArrayOperations(t *testing.T) {
 		newOwner := atree.Address{'B'}
 		copyOfTestArray = testArray.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			newOwner,
 			false,
 			nil,
@@ -589,7 +589,7 @@ func TestRandomArrayOperations(t *testing.T) {
 		require.Equal(t, len(elements), copyOfTestArray.Count())
 
 		for index, orgElement := range elements {
-			element := copyOfTestArray.Get(inter, interpreter.ReturnEmptyLocationRange, index)
+			element := copyOfTestArray.Get(inter, interpreter.EmptyLocationRange, index)
 			utils.AssertValuesEqual(t, inter, orgElement, element)
 		}
 
@@ -611,7 +611,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		// go over original elements again and check no missing data (no side effect should be found)
 		for index, orgElement := range elements {
-			element := testArray.Get(inter, interpreter.ReturnEmptyLocationRange, index)
+			element := testArray.Get(inter, interpreter.EmptyLocationRange, index)
 			utils.AssertValuesEqual(t, inter, orgElement, element)
 		}
 
@@ -624,7 +624,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		testArray = interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -639,7 +639,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 			testArray.Insert(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				i,
 				deepCopyValue(inter, element),
 			)
@@ -649,7 +649,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		// Go over original values again and check no missing data (no side effect should be found)
 		for index, element := range newElements {
-			value := testArray.Get(inter, interpreter.ReturnEmptyLocationRange, index)
+			value := testArray.Get(inter, interpreter.EmptyLocationRange, index)
 			utils.AssertValuesEqual(t, inter, element, value)
 		}
 	})
@@ -659,7 +659,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		testArray = interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -674,7 +674,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 			testArray.Append(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				deepCopyValue(inter, element),
 			)
 		}
@@ -683,7 +683,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		// Go over original values again and check no missing data (no side effect should be found)
 		for index, element := range newElements {
-			value := testArray.Get(inter, interpreter.ReturnEmptyLocationRange, index)
+			value := testArray.Get(inter, interpreter.EmptyLocationRange, index)
 			utils.AssertValuesEqual(t, inter, element, value)
 		}
 	})
@@ -697,7 +697,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		testArray = interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -713,7 +713,7 @@ func TestRandomArrayOperations(t *testing.T) {
 		for index, element := range newElements {
 			testArray.Insert(
 				inter,
-				interpreter.ReturnEmptyLocationRange,
+				interpreter.EmptyLocationRange,
 				index,
 				deepCopyValue(inter, element),
 			)
@@ -723,7 +723,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		// Remove
 		for _, element := range newElements {
-			removedValue := testArray.Remove(inter, interpreter.ReturnEmptyLocationRange, 0)
+			removedValue := testArray.Remove(inter, interpreter.EmptyLocationRange, 0)
 
 			// Removed value must be same as the original value
 			utils.AssertValuesEqual(t, inter, element, removedValue)
@@ -748,7 +748,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		testArray = interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -782,13 +782,13 @@ func TestRandomArrayOperations(t *testing.T) {
 
 				testArray.Append(
 					inter,
-					interpreter.ReturnEmptyLocationRange,
+					interpreter.EmptyLocationRange,
 					value,
 				)
 				insertCount++
 			} else {
 				orgValue := elements[deleteCount]
-				removedValue := testArray.RemoveFirst(inter, interpreter.ReturnEmptyLocationRange)
+				removedValue := testArray.RemoveFirst(inter, interpreter.EmptyLocationRange)
 
 				// Removed value must be same as the original value
 				utils.AssertValuesEqual(t, inter, orgValue, removedValue)
@@ -819,7 +819,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		array := interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -835,7 +835,7 @@ func TestRandomArrayOperations(t *testing.T) {
 		newOwner := atree.Address{'B'}
 		movedArray := array.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			newOwner,
 			true,
 			nil,
@@ -849,7 +849,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 		// Check the elements
 		for index, orgElement := range elements {
-			element := movedArray.Get(inter, interpreter.ReturnEmptyLocationRange, index)
+			element := movedArray.Get(inter, interpreter.EmptyLocationRange, index)
 			utils.AssertValuesEqual(t, inter, orgElement, element)
 		}
 
@@ -898,7 +898,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 		storageSize, slabCounts = getSlabStorageSize(t, storage)
 
 		for fieldName, orgFieldValue := range orgFields {
-			fieldValue := testComposite.GetField(inter, interpreter.ReturnEmptyLocationRange, fieldName)
+			fieldValue := testComposite.GetField(inter, interpreter.EmptyLocationRange, fieldName)
 			utils.AssertValuesEqual(t, inter, orgFieldValue, fieldValue)
 		}
 
@@ -923,14 +923,14 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 
 		copyOfTestComposite = testComposite.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			newOwner,
 			false,
 			nil,
 		).(*interpreter.CompositeValue)
 
 		for name, orgValue := range orgFields {
-			value := copyOfTestComposite.GetField(inter, interpreter.ReturnEmptyLocationRange, name)
+			value := copyOfTestComposite.GetField(inter, interpreter.EmptyLocationRange, name)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 		}
 
@@ -950,7 +950,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 
 		// go over original values again and check no missing data (no side effect should be found)
 		for name, orgValue := range orgFields {
-			value := testComposite.GetField(inter, interpreter.ReturnEmptyLocationRange, name)
+			value := testComposite.GetField(inter, interpreter.EmptyLocationRange, name)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 		}
 
@@ -963,7 +963,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 
 		composite := testComposite.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			newOwner,
 			false,
 			nil,
@@ -972,8 +972,8 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 		require.NoError(t, err)
 
 		for name := range orgFields {
-			composite.RemoveField(inter, interpreter.ReturnEmptyLocationRange, name)
-			value := composite.GetField(inter, interpreter.ReturnEmptyLocationRange, name)
+			composite.RemoveField(inter, interpreter.EmptyLocationRange, name)
+			value := composite.GetField(inter, interpreter.EmptyLocationRange, name)
 			assert.Nil(t, value)
 		}
 	})
@@ -987,7 +987,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 		newOwner := atree.Address{'B'}
 		movedComposite := composite.Transfer(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			newOwner,
 			true,
 			nil,
@@ -999,7 +999,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 
 		// Check the elements
 		for fieldName, orgFieldValue := range fields {
-			fieldValue := movedComposite.GetField(inter, interpreter.ReturnEmptyLocationRange, fieldName)
+			fieldValue := movedComposite.GetField(inter, interpreter.EmptyLocationRange, fieldName)
 			utils.AssertValuesEqual(t, inter, orgFieldValue, fieldValue)
 		}
 
@@ -1073,7 +1073,7 @@ func newCompositeValue(
 
 	testComposite := interpreter.NewCompositeValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		location,
 		identifier,
 		kind,
@@ -1185,7 +1185,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 
 		return interpreter.NewDictionaryValueWithAddress(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			interpreter.DictionaryStaticType{
 				KeyType:   v.Type.KeyType,
 				ValueType: v.Type.ValueType,
@@ -1202,7 +1202,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 
 		return interpreter.NewArrayValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			v.Type,
 			v.GetOwner(),
 			elements...,
@@ -1218,7 +1218,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 
 		return interpreter.NewCompositeValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			v.Location,
 			v.QualifiedIdentifier,
 			v.Kind,
@@ -1233,7 +1233,7 @@ func deepCopyValue(inter *interpreter.Interpreter, value interpreter.Value) inte
 			BorrowType: v.BorrowType,
 		}
 	case *interpreter.SomeValue:
-		innerValue := v.InnerValue(inter, interpreter.ReturnEmptyLocationRange)
+		innerValue := v.InnerValue(inter, interpreter.EmptyLocationRange)
 		return interpreter.NewUnmeteredSomeValueNonCopying(deepCopyValue(inter, innerValue))
 	case interpreter.NilValue:
 		return interpreter.Nil
@@ -1388,7 +1388,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 
 		enum := interpreter.NewCompositeValue(
 			inter,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			location,
 			enumType.QualifiedIdentifier(),
 			enumType.Kind,
@@ -1401,7 +1401,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 			common.Address{},
 		)
 
-		if enum.GetField(inter, interpreter.ReturnEmptyLocationRange, sema.EnumRawValueFieldName) == nil {
+		if enum.GetField(inter, interpreter.EmptyLocationRange, sema.EnumRawValueFieldName) == nil {
 			panic("enum without raw value")
 		}
 
@@ -1453,7 +1453,7 @@ func randomDictionaryValue(
 
 	return interpreter.NewDictionaryValueWithAddress(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 			ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -1478,7 +1478,7 @@ func randomArrayValue(inter *interpreter.Interpreter, currentDepth int) interpre
 
 	return interpreter.NewArrayValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeAnyStruct,
 		},
@@ -1539,7 +1539,7 @@ func randomCompositeValue(
 
 	return interpreter.NewCompositeValue(
 		inter,
-		interpreter.ReturnEmptyLocationRange,
+		interpreter.EmptyLocationRange,
 		location,
 		identifier,
 		kind,
@@ -1711,7 +1711,7 @@ func (m *valueMap) internalKey(inter *interpreter.Interpreter, key interpreter.V
 			location:            key.Location,
 			qualifiedIdentifier: key.QualifiedIdentifier,
 			kind:                key.Kind,
-			rawValue:            key.GetField(inter, interpreter.ReturnEmptyLocationRange, sema.EnumRawValueFieldName),
+			rawValue:            key.GetField(inter, interpreter.EmptyLocationRange, sema.EnumRawValueFieldName),
 		}
 	case interpreter.Value:
 		return key

--- a/runtime/tests/utils/utils.go
+++ b/runtime/tests/utils/utils.go
@@ -131,7 +131,7 @@ func ValuesAreEqual(inter *interpreter.Interpreter, expected, actual interpreter
 	}
 
 	if expected, ok := expected.(interpreter.EquatableValue); ok {
-		return expected.Equal(inter, interpreter.ReturnEmptyLocationRange, actual)
+		return expected.Equal(inter, interpreter.EmptyLocationRange, actual)
 	}
 
 	return assert.ObjectsAreEqual(expected, actual)

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -257,7 +257,7 @@ func transactionExecutionFunction(
 		values, err := validateArgumentParams(
 			inter,
 			runtimeInterface,
-			interpreter.ReturnEmptyLocationRange,
+			interpreter.EmptyLocationRange,
 			arguments,
 			parameters,
 		)


### PR DESCRIPTION
Closes #1451 

## Description

Great optimization discovered by @SupunS: The lazy location ranges, i.e. closures, can be optimized:
- Instead of allocating a closure, just allocate the struct. 
- Keep the the range being computed lazily by changing the location range field from struct `Range` to interface `HasPosition`.


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
