### PR TITLE
Add "why Cadence" section to Cadence docs

### DIFF
--- a/docs/why-cadence.md
+++ b/docs/why-cadence.md
@@ -2,7 +2,8 @@
 
 ### 1) **Security and Safety**
 
-Cadence provides security and safety guarantees that greatly simplify the development of secure smart contracts. As smart contracts often deal with valuable assets, Cadence provides the resource-oriented programming paradigm, which guarantees that assets can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted. Cadence includes several language features which prevent entire classes of bugs.
+Cadence provides security and safety guarantees that greatly simplify the development of secure smart contracts. As smart contracts often deal with valuable assets, Cadence provides the resource-oriented programming paradigm, which guarantees that assets can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted. 
+Cadence includes several language features which prevent entire classes of bugs.
 These security and safety features allow smart contract developers to focus on the business logic of their contract instead of preventing accidents and attacks.
 
 ### 2) Composability

--- a/docs/why-cadence.md
+++ b/docs/why-cadence.md
@@ -1,0 +1,15 @@
+## Why should you use Cadence for building smart contracts ?
+
+### 1) **Security and Safety**
+
+Cadence provides security and safety guarantees that greatly simplify the development of secure smart contracts. As smart contracts often deal with valuable assets, Cadence provides the resource-oriented programming paradigm, which guarantees that assets can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted. Cadence includes several language features which prevent entire classes of bugs.
+These security and safety features allow smart contract developers to focus on the business logic of their contract instead of preventing accidents and attacks.
+
+### 2) Composability
+
+Cadence enables composability. Resources (which are arbitrary user-defined data types) are stored directly in users’ accounts, and can flow freely between contracts: They can be passed as arguments to functions, returned from functions, or even combined in arbitrary data structures. This makes implementing business logic easier, more natural and promotes reuse of existing logic.
+
+### 3) **Simplicity**
+
+Cadence’s syntax is inspired by popular modern general-purpose programming languages like **[Swift](https://developer.apple.com/swift/)**, **[Kotlin](https://kotlinlang.org/)**, and **[Rust](https://www.rust-lang.org/),** so developers will find the syntax and the semantics familiar. 
+Practical tooling, documentation, and examples enable developers to start creating programs quickly and effectively. Hundreds of developers were able to learn Cadence quickly and develop production-quality smart contracts with it shortly.


### PR DESCRIPTION


## Description


Adding section to the docs on why should devs use Cadence. The 4th top-level tile is added in https://github.com/onflow/cadence/pull/2040.


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
