### PR TITLE
Update flow-docs.json to include "why cadence" section.

### DIFF
--- a/docs/flow-docs.json
+++ b/docs/flow-docs.json
@@ -10,7 +10,7 @@
          {
           "title": "Why Use Cadence?",
           "tags": ["reference", "patterns"],
-          "description": "Write and deploy your first smart contract within minutes on our Playground.",
+          "description":"Learn the main benefits of using Cadence for smart contract development."
           "href": "/cadence/why-cadence"
         },
         {

--- a/docs/flow-docs.json
+++ b/docs/flow-docs.json
@@ -11,7 +11,7 @@
           "title": "Why Use Cadence?",
           "tags": ["reference", "patterns"],
           "description": "Write and deploy your first smart contract within minutes on our Playground.",
-          "href": "/cadence/why"
+          "href": "/cadence/why-cadence"
         },
         {
           "title": "Hello World Tutorial",

--- a/docs/flow-docs.json
+++ b/docs/flow-docs.json
@@ -7,20 +7,26 @@
       "title": "Cadence",
       "description": "Cadence is a resource-oriented programming language that introduces new features to smart contract programming that help developers ensure that their code is safe, secure, clear, and approachable. Some of these features are:",
       "headerCards": [
+         {
+          "title": "Why Use Cadence?",
+          "tags": ["reference", "patterns"],
+          "description": "Write and deploy your first smart contract within minutes on our Playground.",
+          "href": "/cadence/why"
+        },
         {
-          "title": "Hello World!",
+          "title": "Hello World Tutorial",
           "tags": ["tutorial", "playground"],
           "description": "Write and deploy your first smart contract within minutes on our Playground.",
           "href": "/cadence/tutorial/02-hello-world"
         },
         {
-          "title": "Cadence Language",
+          "title": "Language Reference",
           "tags": ["reference", "syntax"],
           "description": "Learn the functionality, terminology and syntax of the Cadence language.",
           "href": "/cadence/language"
         },
         {
-          "title": "Solidity to Cadence Intro",
+          "title": "From Solidity to Cadence",
           "tags": ["guide", "patterns"],
           "description": "Learn the key differences in the account models between Solidity and Cadence.",
           "href": "/cadence/msg-sender"


### PR DESCRIPTION
## Description

Adds header CTA to new "why Cadence" section on the Cadence homepage: 
https://developer.flow.com/cadence/why
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
