### PR TITLE
Lint with gofmt 1.19, upgrade to go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.18.1'
+        go-version: '1.19.2'
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: env.GO_VERSION
+        go-version: $env:GO_VERSION
     - uses: actions/setup-node@v2
       with:
         node-version: '15'
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: env.GO_VERSION
+        go-version: $env:GO_VERSION
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: $env:GO_VERSION
+        go-version: ${{ env.GO_VERSION }}
     - uses: actions/setup-node@v2
       with:
         node-version: '15'
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: $env:GO_VERSION
+        go-version: ${{ env.GO_VERSION }}
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - 'v**'
 
 env:
-  go-version: '1.19.2'
+  GO_VERSION: '1.19.2'
 
 jobs:
   test:
@@ -27,16 +27,16 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.18.x'
+        go-version: env.GO_VERSION
     - uses: actions/setup-node@v2
       with:
         node-version: '15'
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ env.go-version }}-
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-
     - name: Build
       run: make build
     - name: Test
@@ -58,13 +58,13 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: env.go-version
+        go-version: env.GO_VERSION
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-
     - name: Lint
       run: make lint-github-actions
     - name: Check license headers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
       - 'feature/**'
       - 'v**'
 
+env:
+  go-version: '1.19.2'
+
 jobs:
   test:
     name: Test
@@ -31,9 +34,9 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-${{ env.go-version }}-
     - name: Build
       run: make build
     - name: Test
@@ -55,7 +58,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.19.2'
+        go-version: env.go-version
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -47,7 +47,6 @@ type Option func(*Decoder)
 // WithAllowUnstructuredStaticTypes returns a new Decoder Option
 // which enables or disables if the decoding of a static type
 // as a type ID (cadence.TypeID) is allowed
-//
 func WithAllowUnstructuredStaticTypes(allow bool) Option {
 	return func(decoder *Decoder) {
 		decoder.allowUnstructuredStaticTypes = allow

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -18,5 +18,4 @@
 
 // Package json implements the JSON-Cadence specification:
 // https://github.com/onflow/flow/blob/master/docs/json-cadence-spec.md
-//
 package json

--- a/fixedpoint/fixedpoint.go
+++ b/fixedpoint/fixedpoint.go
@@ -18,5 +18,4 @@
 
 // Package fixedpoint provides constants, as well as formatting, conversion,
 // and checking functionality for Cadence fixed-point number types
-//
 package fixedpoint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence
 
-go 1.19
+go 1.18
 
 require (
 	github.com/bits-and-blooms/bitset v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bits-and-blooms/bitset v1.2.2

--- a/runtime/ast/ast.go
+++ b/runtime/ast/ast.go
@@ -22,5 +22,4 @@
 // and can be traversed using the Visitor interface.
 // Elements also implement the json.Marshaler interface
 // so can be serialized to a standardized/stable JSON format.
-//
 package ast

--- a/runtime/ast/composite.go
+++ b/runtime/ast/composite.go
@@ -80,7 +80,6 @@ func (*CompositeDeclaration) isDeclaration() {}
 
 // NOTE: statement, so it can be represented in the AST,
 // but will be rejected in semantic analysis
-//
 func (*CompositeDeclaration) isStatement() {}
 
 func (d *CompositeDeclaration) DeclarationIdentifier() *Identifier {

--- a/runtime/ast/expression_as_type.go
+++ b/runtime/ast/expression_as_type.go
@@ -20,7 +20,6 @@ package ast
 
 // ExpressionAsType attempts to convert an expression to a type.
 // Some expressions can be considered both an expression and a type
-//
 func ExpressionAsType(expression Expression) Type {
 	switch expression := expression.(type) {
 	case *IdentifierExpression:

--- a/runtime/ast/inspector.go
+++ b/runtime/ast/inspector.go
@@ -37,22 +37,22 @@ package ast
 // do not use Inspector for one-off traversals.
 //
 // There are four orthogonal features in a traversal:
-//  1 type filtering
-//  2 pruning
-//  3 postorder calls to f
-//  4 stack
+//
+//	1 type filtering
+//	2 pruning
+//	3 postorder calls to f
+//	4 stack
 //
 // Rather than offer all of them in the API,
 // only a few combinations are exposed:
-// - Preorder is the fastest and has the fewest features,
-//   but is the most commonly needed traversal.
-// - Elements and WithStack both provide pruning and postorder calls,
-//   even though few clients need it, because supporting two versions
-//   is not justified.
+//   - Preorder is the fastest and has the fewest features,
+//     but is the most commonly needed traversal.
+//   - Elements and WithStack both provide pruning and postorder calls,
+//     even though few clients need it, because supporting two versions
+//     is not justified.
 //
 // More combinations could be supported  by expressing them as wrappers
 // around a more generic traversal, but likely has worse performance.
-//
 type Inspector struct {
 	events []event
 }
@@ -78,7 +78,6 @@ type event struct {
 //
 // Preorder is almost twice as fast as Elements,
 // because it avoids postorder calls to f, and the pruning check.
-//
 func (in *Inspector) Preorder(types []Element, f func(Element)) {
 	mask := maskOf(types)
 	for _, ev := range in.events {
@@ -96,7 +95,6 @@ func (in *Inspector) Preorder(types []Element, f func(Element)) {
 //
 // The types argument, if non-empty, enables type-based filtering of events.
 // The function f if is called only for elements whose type matches an element of the types slice.
-//
 func (in *Inspector) Elements(types []Element, f func(element Element, push bool) (proceed bool)) {
 	mask := maskOf(types)
 	for i := 0; i < len(in.events); {
@@ -122,7 +120,6 @@ func (in *Inspector) Elements(types []Element, f func(element Element, push bool
 // the current traversal stack.
 //
 // The stack's first element is the outermost element, its last is the innermost.
-//
 func (in *Inspector) WithStack(types []Element, f func(element Element, push bool, stack []Element) (proceed bool)) {
 	mask := maskOf(types)
 	var stack []Element

--- a/runtime/ast/inspector_test.go
+++ b/runtime/ast/inspector_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 // TestInspector_Elements compares Inspector against Inspect.
-//
 func TestInspector_Elements(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/ast/interface.go
+++ b/runtime/ast/interface.go
@@ -74,7 +74,6 @@ func (*InterfaceDeclaration) isDeclaration() {}
 
 // NOTE: statement, so it can be represented in the AST,
 // but will be rejected in semantic analysis
-//
 func (*InterfaceDeclaration) isStatement() {}
 
 func (d *InterfaceDeclaration) DeclarationIdentifier() *Identifier {

--- a/runtime/ast/memberindices.go
+++ b/runtime/ast/memberindices.go
@@ -25,7 +25,6 @@ import (
 )
 
 // programIndices is a container for all indices of members
-//
 type memberIndices struct {
 	once sync.Once
 	// Use `Fields()` instead

--- a/runtime/ast/parameter.go
+++ b/runtime/ast/parameter.go
@@ -47,7 +47,6 @@ func NewParameter(
 // an argument in a call must use:
 // If no argument label is declared for parameter,
 // the parameter name is used as the argument label
-//
 func (p Parameter) EffectiveArgumentLabel() string {
 	if p.Label != "" {
 		return p.Label

--- a/runtime/ast/parameterlist.go
+++ b/runtime/ast/parameterlist.go
@@ -49,7 +49,6 @@ func NewParameterList(
 // the arguments of a call must use:
 // If no argument label is declared for parameter,
 // the parameter name is used as the argument label
-//
 func (l *ParameterList) EffectiveArgumentLabels() []string {
 	argumentLabels := make([]string, len(l.Parameters))
 

--- a/runtime/ast/precedence.go
+++ b/runtime/ast/precedence.go
@@ -23,7 +23,6 @@ package ast
 // precedence is the order of importance of expressions / operators.
 // NOTE: this enumeration does *NOT* influence parsing,
 // and should be kept in sync with the binding powers in the parser
-//
 type precedence uint
 
 const (

--- a/runtime/ast/program.go
+++ b/runtime/ast/program.go
@@ -100,7 +100,6 @@ func (p *Program) VariableDeclarations() []*VariableDeclaration {
 
 // SoleContractDeclaration returns the sole contract declaration, if any,
 // and if there are no other actionable declarations.
-//
 func (p *Program) SoleContractDeclaration() *CompositeDeclaration {
 
 	compositeDeclarations := p.CompositeDeclarations()
@@ -124,7 +123,6 @@ func (p *Program) SoleContractDeclaration() *CompositeDeclaration {
 
 // SoleContractInterfaceDeclaration returns the sole contract interface declaration, if any,
 // and if there are no other actionable declarations.
-//
 func (p *Program) SoleContractInterfaceDeclaration() *InterfaceDeclaration {
 
 	interfaceDeclarations := p.InterfaceDeclarations()
@@ -148,7 +146,6 @@ func (p *Program) SoleContractInterfaceDeclaration() *InterfaceDeclaration {
 
 // SoleTransactionDeclaration returns the sole transaction declaration, if any,
 // and if there are no other actionable declarations.
-//
 func (p *Program) SoleTransactionDeclaration() *TransactionDeclaration {
 
 	transactionDeclarations := p.TransactionDeclarations()

--- a/runtime/ast/programindices.go
+++ b/runtime/ast/programindices.go
@@ -23,7 +23,6 @@ import (
 )
 
 // programIndices is a container for all indices of a program's declarations
-//
 type programIndices struct {
 	once sync.Once
 	// Use `pragmaDeclarations` instead

--- a/runtime/ast/transfer.go
+++ b/runtime/ast/transfer.go
@@ -28,7 +28,6 @@ import (
 
 // Transfer represents the operation in variable declarations
 // and assignments
-//
 type Transfer struct {
 	Operation TransferOperation
 	Pos       Position `json:"-"`

--- a/runtime/ast/walk.go
+++ b/runtime/ast/walk.go
@@ -32,7 +32,6 @@ type Walker interface {
 // followed by a call of Walk(nil) on the returned walker.
 //
 // The initial walker may not be nil.
-//
 func Walk(walker Walker, element Element) {
 	if walker = walker.Walk(element); walker == nil {
 		return

--- a/runtime/cmd/execute/debugger.go
+++ b/runtime/cmd/execute/debugger.go
@@ -72,7 +72,6 @@ func (d *InteractiveDebugger) Next() {
 
 // Show shows the values for the variables with the given names.
 // If no names are given, lists all non-base variables
-//
 func (d *InteractiveDebugger) Show(names []string) {
 	current := d.debugger.CurrentActivation(d.stop.Interpreter)
 	switch len(names) {

--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -34,7 +34,6 @@ type Address [AddressLength]byte
 // MustBytesToAddress returns Address with value b.
 //
 // If the address is too large, then the function panics.
-//
 func MustBytesToAddress(b []byte) Address {
 	address, err := BytesToAddress(b)
 	if err != nil {
@@ -46,7 +45,6 @@ func MustBytesToAddress(b []byte) Address {
 // BytesToAddress returns Address with value b.
 //
 // If the address is too large, then the function returns an error.
-//
 func BytesToAddress(b []byte) (Address, error) {
 	if len(b) > AddressLength {
 		return Address{}, addressOverflowError

--- a/runtime/common/addresslocation.go
+++ b/runtime/common/addresslocation.go
@@ -30,7 +30,6 @@ import (
 const AddressLocationPrefix = "A"
 
 // AddressLocation is the location of a contract/contract interface at an address
-//
 type AddressLocation struct {
 	Address Address
 	Name    string

--- a/runtime/common/deps/set.go
+++ b/runtime/common/deps/set.go
@@ -21,7 +21,6 @@ package deps
 import "github.com/onflow/cadence/runtime/common/orderedmap"
 
 // NodeSet is a set of Node
-//
 type NodeSet interface {
 	Add(*Node)
 	Remove(*Node)
@@ -31,7 +30,6 @@ type NodeSet interface {
 
 // MapNodeSet is a Node set backed by a Go map (unordered).
 // NOTE: DO *NOT* USE this for on-chain operations, but OrderedNodeSet
-//
 type MapNodeSet map[*Node]struct{}
 
 func NewMapNodeSet() NodeSet {
@@ -64,7 +62,6 @@ func (m MapNodeSet) ForEach(f func(*Node) error) error {
 }
 
 // OrderedNodeSet is a Node set backed by an ordered map
-//
 type OrderedNodeSet orderedmap.OrderedMap[*Node, struct{}]
 
 var _ NodeSet = &OrderedNodeSet{}

--- a/runtime/common/identifierlocation.go
+++ b/runtime/common/identifierlocation.go
@@ -28,7 +28,6 @@ import (
 const IdentifierLocationPrefix = "I"
 
 // IdentifierLocation
-//
 type IdentifierLocation string
 
 var _ Location = IdentifierLocation("")

--- a/runtime/common/intervalst/intervalst.go
+++ b/runtime/common/intervalst/intervalst.go
@@ -52,7 +52,6 @@ func (t *IntervalST[T]) Contains(interval Interval) bool {
 // Put associates an interval with a value.
 //
 // NOTE: does *not* check if the interval already exists
-//
 func (t *IntervalST[T]) Put(interval Interval, value T) {
 	t.root = t.randomizedInsert(t.root, interval, value)
 }

--- a/runtime/common/list/list.go
+++ b/runtime/common/list/list.go
@@ -5,10 +5,10 @@
 // Package list implements a doubly linked list.
 //
 // To iterate over a list (where l is a *List):
+//
 //	for e := l.Front(); e != nil; e = e.Next() {
 //		// do something with e.Value
 //	}
-//
 package list
 
 // Element is an element of a linked list.

--- a/runtime/common/location.go
+++ b/runtime/common/location.go
@@ -28,7 +28,6 @@ import (
 
 // Location describes the origin of a Cadence script.
 // This could be a file, a transaction, or a smart contract.
-//
 type Location interface {
 	fmt.Stringer
 	// TypeID returns a type ID for the given qualified identifier
@@ -42,7 +41,6 @@ type Location interface {
 // LocationsInSameAccount returns true if both locations are nil,
 // if both locations are address locations when both locations have the same address,
 // or otherwise if their IDs are the same.
-//
 func LocationsInSameAccount(first, second Location) bool {
 
 	if first == nil {

--- a/runtime/common/memorykind.go
+++ b/runtime/common/memorykind.go
@@ -21,7 +21,6 @@ package common
 //go:generate go run golang.org/x/tools/cmd/stringer -type=MemoryKind -trimprefix=MemoryKind
 
 // MemoryKind
-//
 type MemoryKind uint
 
 const (

--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -26,7 +26,6 @@ import (
 )
 
 // OrderedMap
-//
 type OrderedMap[K comparable, V any] struct {
 	pairs map[K]*Pair[K, V]
 	list  *list.List[*Pair[K, V]]
@@ -192,7 +191,6 @@ func (om OrderedMap[K, V]) ForeachWithError(f func(key K, value V) error) error 
 }
 
 // Pair is an entry in an OrderedMap
-//
 type Pair[K any, V any] struct {
 	Key   K
 	Value V

--- a/runtime/common/repllocation.go
+++ b/runtime/common/repllocation.go
@@ -28,7 +28,6 @@ import (
 const REPLLocationPrefix = "REPL"
 
 // REPLLocation
-//
 type REPLLocation struct{}
 
 var _ Location = REPLLocation{}

--- a/runtime/common/scriptlocation.go
+++ b/runtime/common/scriptlocation.go
@@ -32,7 +32,6 @@ const ScriptLocationPrefix = "s"
 const ScriptIDLength = 32
 
 // ScriptLocation
-//
 type ScriptLocation [ScriptIDLength]byte
 
 var _ Location = ScriptLocation{}

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -28,7 +28,6 @@ import (
 const StringLocationPrefix = "S"
 
 // StringLocation
-//
 type StringLocation string
 
 var _ Location = StringLocation("")

--- a/runtime/common/transactionlocation.go
+++ b/runtime/common/transactionlocation.go
@@ -32,7 +32,6 @@ const TransactionLocationPrefix = "t"
 const TransactionIDLength = 32
 
 // TransactionLocation
-//
 type TransactionLocation [TransactionIDLength]byte
 
 var _ Location = TransactionLocation{}

--- a/runtime/compiler/wasm/buf.go
+++ b/runtime/compiler/wasm/buf.go
@@ -25,7 +25,6 @@ import (
 type offset int
 
 // Buffer is a byte buffer, which allows reading and writing.
-//
 type Buffer struct {
 	data   []byte
 	offset offset

--- a/runtime/compiler/wasm/data.go
+++ b/runtime/compiler/wasm/data.go
@@ -20,7 +20,6 @@ package wasm
 
 // Data represents a data segment, which initializes a range of memory,
 // at a given offset, with a static vector of bytes.
-//
 type Data struct {
 	MemoryIndex uint32
 	// must be constant, as defined in the spec

--- a/runtime/compiler/wasm/errors.go
+++ b/runtime/compiler/wasm/errors.go
@@ -24,7 +24,6 @@ import (
 
 // InvalidMagicError is returned when the WASM binary
 // does not start with the magic byte sequence
-//
 type InvalidMagicError struct {
 	Offset    int
 	ReadError error
@@ -43,7 +42,6 @@ func (e InvalidMagicError) Unwrap() error {
 
 // InvalidMagicError is returned when the WASM binary
 // does not have the expected version
-//
 type InvalidVersionError struct {
 	Offset    int
 	ReadError error
@@ -62,7 +60,6 @@ func (e InvalidVersionError) Unwrap() error {
 
 // InvalidSectionIDError is returned when the WASM binary specifies
 // an invalid section ID
-//
 type InvalidSectionIDError struct {
 	Offset    int
 	SectionID sectionID
@@ -83,7 +80,6 @@ func (e InvalidSectionIDError) Unwrap() error {
 
 // InvalidDuplicateSectionError is returned when the WASM binary specifies
 // a duplicate section
-//
 type InvalidDuplicateSectionError struct {
 	Offset    int
 	SectionID sectionID
@@ -99,7 +95,6 @@ func (e InvalidDuplicateSectionError) Error() string {
 
 // InvalidSectionOrderError is returned when the WASM binary specifies
 // a non-custom section out-of-order
-//
 type InvalidSectionOrderError struct {
 	Offset    int
 	SectionID sectionID
@@ -115,7 +110,6 @@ func (e InvalidSectionOrderError) Error() string {
 
 // InvalidSectionSizeError is returned when the WASM binary specifies
 // an invalid section size
-//
 type InvalidSectionSizeError struct {
 	Offset    int
 	ReadError error
@@ -135,7 +129,6 @@ func (e InvalidSectionSizeError) Unwrap() error {
 
 // InvalidValTypeError is returned when the WASM binary specifies
 // an invalid value type
-//
 type InvalidValTypeError struct {
 	Offset    int
 	ValType   ValueType
@@ -156,7 +149,6 @@ func (e InvalidValTypeError) Unwrap() error {
 
 // InvalidFuncTypeIndicatorError is returned when the WASM binary specifies
 // an invalid function type indicator
-//
 type InvalidFuncTypeIndicatorError struct {
 	Offset            int
 	FuncTypeIndicator byte
@@ -178,7 +170,6 @@ func (e InvalidFuncTypeIndicatorError) Unwrap() error {
 
 // InvalidFuncTypeParameterCountError is returned when the WASM binary specifies
 // an invalid func type parameter count
-//
 type InvalidFuncTypeParameterCountError struct {
 	Offset    int
 	ReadError error
@@ -197,7 +188,6 @@ func (e InvalidFuncTypeParameterCountError) Unwrap() error {
 
 // InvalidFuncTypeParameterTypeError is returned when the WASM binary specifies
 // an invalid function type parameter type
-//
 type InvalidFuncTypeParameterTypeError struct {
 	Index     int
 	ReadError error
@@ -216,7 +206,6 @@ func (e InvalidFuncTypeParameterTypeError) Unwrap() error {
 
 // InvalidFuncTypeResultCountError is returned when the WASM binary specifies
 // an invalid func type result count
-//
 type InvalidFuncTypeResultCountError struct {
 	Offset    int
 	ReadError error
@@ -235,7 +224,6 @@ func (e InvalidFuncTypeResultCountError) Unwrap() error {
 
 // InvalidFuncTypeResultTypeError is returned when the WASM binary specifies
 // an invalid function type result type
-//
 type InvalidFuncTypeResultTypeError struct {
 	Index     int
 	ReadError error
@@ -254,7 +242,6 @@ func (e InvalidFuncTypeResultTypeError) Unwrap() error {
 
 // InvalidTypeSectionTypeCountError is returned when the WASM binary specifies
 // an invalid count in the type section
-//
 type InvalidTypeSectionTypeCountError struct {
 	Offset    int
 	ReadError error
@@ -273,7 +260,6 @@ func (e InvalidTypeSectionTypeCountError) Unwrap() error {
 
 // InvalidImportSectionImportCountError is returned when the WASM binary specifies
 // an invalid count in the import section
-//
 type InvalidImportSectionImportCountError struct {
 	Offset    int
 	ReadError error
@@ -292,7 +278,6 @@ func (e InvalidImportSectionImportCountError) Unwrap() error {
 
 // InvalidImportError is returned when the WASM binary specifies
 // invalid import in the import section
-//
 type InvalidImportError struct {
 	Index     int
 	ReadError error
@@ -311,7 +296,6 @@ func (e InvalidImportError) Unwrap() error {
 
 // InvalidImportIndicatorError is returned when the WASM binary specifies
 // an invalid type indicator in the import section
-//
 type InvalidImportIndicatorError struct {
 	Offset          int
 	ImportIndicator importIndicator
@@ -332,7 +316,6 @@ func (e InvalidImportIndicatorError) Unwrap() error {
 
 // InvalidImportSectionTypeIndexError is returned when the WASM binary specifies
 // an invalid type index in the import section
-//
 type InvalidImportSectionTypeIndexError struct {
 	Offset    int
 	ReadError error
@@ -351,7 +334,6 @@ func (e InvalidImportSectionTypeIndexError) Unwrap() error {
 
 // InvalidFunctionSectionFunctionCountError is returned when the WASM binary specifies
 // an invalid count in the function section
-//
 type InvalidFunctionSectionFunctionCountError struct {
 	Offset    int
 	ReadError error
@@ -370,7 +352,6 @@ func (e InvalidFunctionSectionFunctionCountError) Unwrap() error {
 
 // InvalidFunctionSectionTypeIndexError is returned when the WASM binary specifies
 // an invalid type index in the function section
-//
 type InvalidFunctionSectionTypeIndexError struct {
 	Offset    int
 	Index     int
@@ -391,7 +372,6 @@ func (e InvalidFunctionSectionTypeIndexError) Unwrap() error {
 
 // FunctionCountMismatchError is returned when the WASM binary specifies
 // information for a different number of functions than previously specified
-//
 type FunctionCountMismatchError struct {
 	Offset int
 }
@@ -405,7 +385,6 @@ func (e FunctionCountMismatchError) Error() string {
 
 // InvalidExportSectionExportCountError is returned when the WASM binary specifies
 // an invalid count in the export section
-//
 type InvalidExportSectionExportCountError struct {
 	Offset    int
 	ReadError error
@@ -424,7 +403,6 @@ func (e InvalidExportSectionExportCountError) Unwrap() error {
 
 // InvalidExportError is returned when the WASM binary specifies
 // invalid export in the export section
-//
 type InvalidExportError struct {
 	Index     int
 	ReadError error
@@ -443,7 +421,6 @@ func (e InvalidExportError) Unwrap() error {
 
 // InvalidExportIndicatorError is returned when the WASM binary specifies
 // an invalid type indicator in the export section
-//
 type InvalidExportIndicatorError struct {
 	Offset          int
 	ExportIndicator exportIndicator
@@ -464,7 +441,6 @@ func (e InvalidExportIndicatorError) Unwrap() error {
 
 // InvalidExportSectionIndexError is returned when the WASM binary specifies
 // an invalid index in the export section
-//
 type InvalidExportSectionIndexError struct {
 	Offset    int
 	ReadError error
@@ -483,7 +459,6 @@ func (e InvalidExportSectionIndexError) Unwrap() error {
 
 // InvalidCodeSectionFunctionCountError is returned when the WASM binary specifies
 // an invalid function count in the code section
-//
 type InvalidCodeSectionFunctionCountError struct {
 	Offset    int
 	ReadError error
@@ -502,7 +477,6 @@ func (e InvalidCodeSectionFunctionCountError) Unwrap() error {
 
 // InvalidFunctionCodeError is returned when the WASM binary specifies
 // invalid code for a function in the code section
-//
 type InvalidFunctionCodeError struct {
 	Index     int
 	ReadError error
@@ -521,7 +495,6 @@ func (e InvalidFunctionCodeError) Unwrap() error {
 
 // InvalidCodeSizeError is returned when the WASM binary specifies
 // an invalid code size in the code section
-//
 type InvalidCodeSizeError struct {
 	Offset    int
 	ReadError error
@@ -536,7 +509,6 @@ func (e InvalidCodeSizeError) Error() string {
 
 // InvalidCodeSectionLocalsCountError is returned when the WASM binary specifies
 // an invalid locals count in the code section
-//
 type InvalidCodeSectionLocalsCountError struct {
 	Offset    int
 	ReadError error
@@ -555,7 +527,6 @@ func (e InvalidCodeSectionLocalsCountError) Unwrap() error {
 
 // InvalidCodeSectionCompressedLocalsCountError is returned when the WASM binary specifies
 // an invalid local type in the code section
-//
 type InvalidCodeSectionCompressedLocalsCountError struct {
 	Offset    int
 	ReadError error
@@ -574,7 +545,6 @@ func (e InvalidCodeSectionCompressedLocalsCountError) Unwrap() error {
 
 // InvalidCodeSectionLocalTypeError is returned when the WASM binary specifies
 // an invalid local type in the code section
-//
 type InvalidCodeSectionLocalTypeError struct {
 	Offset    int
 	ReadError error
@@ -594,7 +564,6 @@ func (e InvalidCodeSectionLocalTypeError) Unwrap() error {
 // CodeSectionLocalsCountMismatchError is returned when
 // the sum of the compressed locals locals count in the code section does not match
 // the number of locals in the code section of the WASM binary
-//
 type CodeSectionLocalsCountMismatchError struct {
 	Offset   int
 	Expected uint32
@@ -612,7 +581,6 @@ func (e CodeSectionLocalsCountMismatchError) Error() string {
 
 // InvalidOpcodeError is returned when the WASM binary specifies
 // an invalid opcode in the code section
-//
 type InvalidOpcodeError struct {
 	Offset    int
 	Opcode    opcode
@@ -633,7 +601,6 @@ func (e InvalidOpcodeError) Unwrap() error {
 
 // InvalidInstructionArgumentError is returned when the WASM binary specifies
 // an invalid argument for an instruction in the code section
-//
 type InvalidInstructionArgumentError struct {
 	Offset    int
 	ReadError error
@@ -652,7 +619,6 @@ func (e InvalidInstructionArgumentError) Unwrap() error {
 
 // MissingEndInstructionError is returned when the WASM binary
 // misses an end instruction for a function in the code section
-//
 type MissingEndInstructionError struct {
 	Offset int
 }
@@ -666,7 +632,6 @@ func (e MissingEndInstructionError) Error() string {
 
 // InvalidNonUTF8NameError is returned when the WASM binary specifies
 // or the writer is given a name which is not properly UTF-8 encoded
-//
 type InvalidNonUTF8NameError struct {
 	Name   string
 	Offset int
@@ -682,7 +647,6 @@ func (e InvalidNonUTF8NameError) Error() string {
 
 // InvalidNameLengthError is returned the WASM binary specifies
 // an invalid name length
-//
 type InvalidNameLengthError struct {
 	Offset    int
 	ReadError error
@@ -701,7 +665,6 @@ func (e InvalidNameLengthError) Unwrap() error {
 
 // InvalidNameError is returned the WASM binary specifies
 // an invalid name
-//
 type InvalidNameError struct {
 	Offset    int
 	ReadError error
@@ -720,7 +683,6 @@ func (e InvalidNameError) Unwrap() error {
 
 // IncompleteNameError is returned the WASM binary specifies
 // an incomplete name
-//
 type IncompleteNameError struct {
 	Offset   int
 	Expected uint32
@@ -739,7 +701,6 @@ func (e IncompleteNameError) Error() string {
 // InvalidBlockSecondInstructionsError is returned when the WASM binary specifies
 // or the writer is given a second set of instructions in a block that
 // is not allowed to have it (only the 'if' instruction may have it)
-//
 type InvalidBlockSecondInstructionsError struct {
 	Offset int
 }
@@ -753,7 +714,6 @@ func (e InvalidBlockSecondInstructionsError) Error() string {
 
 // InvalidInstructionVectorArgumentCountError is returned when the WASM binary specifies
 // an invalid count for a vector argument of an instruction
-//
 type InvalidInstructionVectorArgumentCountError struct {
 	Offset    int
 	ReadError error
@@ -772,7 +732,6 @@ func (e InvalidInstructionVectorArgumentCountError) Unwrap() error {
 
 // InvalidBlockTypeTypeIndexError is returned when the WASM binary specifies
 // an invalid type index as a block type
-//
 type InvalidBlockTypeTypeIndexError struct {
 	TypeIndex int64
 	Offset    int
@@ -788,7 +747,6 @@ func (e InvalidBlockTypeTypeIndexError) Error() string {
 
 // InvalidDataSectionSegmentCountError is returned when the WASM binary specifies
 // an invalid count in the data section
-//
 type InvalidDataSectionSegmentCountError struct {
 	Offset    int
 	ReadError error
@@ -807,7 +765,6 @@ func (e InvalidDataSectionSegmentCountError) Unwrap() error {
 
 // InvalidDataSegmentError is returned when the WASM binary specifies
 // invalid segment in the data section
-//
 type InvalidDataSegmentError struct {
 	Index     int
 	ReadError error
@@ -826,7 +783,6 @@ func (e InvalidDataSegmentError) Unwrap() error {
 
 // InvalidDataSectionMemoryIndexError is returned when the WASM binary specifies
 // an invalid memory index in the data section
-//
 type InvalidDataSectionMemoryIndexError struct {
 	Offset    int
 	ReadError error
@@ -845,7 +801,6 @@ func (e InvalidDataSectionMemoryIndexError) Unwrap() error {
 
 // InvalidDataSectionInitByteCountError is returned when the WASM binary specifies
 // an invalid init byte count in the data section
-//
 type InvalidDataSectionInitByteCountError struct {
 	Offset    int
 	ReadError error
@@ -864,7 +819,6 @@ func (e InvalidDataSectionInitByteCountError) Unwrap() error {
 
 // InvalidMemorySectionMemoryCountError is returned when the WASM binary specifies
 // an invalid count in the memory section
-//
 type InvalidMemorySectionMemoryCountError struct {
 	Offset    int
 	ReadError error
@@ -883,7 +837,6 @@ func (e InvalidMemorySectionMemoryCountError) Unwrap() error {
 
 // InvalidMemoryError is returned when the WASM binary specifies
 // invalid memory in the memory section
-//
 type InvalidMemoryError struct {
 	Index     int
 	ReadError error
@@ -902,7 +855,6 @@ func (e InvalidMemoryError) Unwrap() error {
 
 // InvalidLimitIndicatorError is returned when the WASM binary specifies
 // an invalid limit indicator
-//
 type InvalidLimitIndicatorError struct {
 	Offset         int
 	LimitIndicator byte
@@ -923,7 +875,6 @@ func (e InvalidLimitIndicatorError) Unwrap() error {
 
 // InvalidLimitMinError is returned when the WASM binary specifies
 // an invalid limit minimum
-//
 type InvalidLimitMinError struct {
 	Offset    int
 	ReadError error
@@ -942,7 +893,6 @@ func (e InvalidLimitMinError) Unwrap() error {
 
 // InvalidLimitMaxError is returned when the WASM binary specifies
 // an invalid limit maximum
-//
 type InvalidLimitMaxError struct {
 	Offset    int
 	ReadError error
@@ -961,7 +911,6 @@ func (e InvalidLimitMaxError) Unwrap() error {
 
 // InvalidStartSectionFunctionIndexError is returned when the WASM binary specifies
 // an invalid function index in the start section
-//
 type InvalidStartSectionFunctionIndexError struct {
 	Offset    int
 	ReadError error

--- a/runtime/compiler/wasm/export.go
+++ b/runtime/compiler/wasm/export.go
@@ -19,7 +19,6 @@
 package wasm
 
 // Exports represents an export
-//
 type Export struct {
 	Name       string
 	Descriptor ExportDescriptor
@@ -36,13 +35,11 @@ const (
 )
 
 // ExportDescriptor represents an export (e.g. a function, memory, etc.)
-//
 type ExportDescriptor interface {
 	isExportDescriptor()
 }
 
 // FunctionExport represents the export of a function
-//
 type FunctionExport struct {
 	FunctionIndex uint32
 }
@@ -50,7 +47,6 @@ type FunctionExport struct {
 func (FunctionExport) isExportDescriptor() {}
 
 // MemoryExport represents the export of a memory
-//
 type MemoryExport struct {
 	MemoryIndex uint32
 }

--- a/runtime/compiler/wasm/function.go
+++ b/runtime/compiler/wasm/function.go
@@ -19,7 +19,6 @@
 package wasm
 
 // Function represents a function
-//
 type Function struct {
 	Name      string
 	TypeIndex uint32
@@ -27,7 +26,6 @@ type Function struct {
 }
 
 // Code represents the code of a function
-//
 type Code struct {
 	Locals       []ValueType
 	Instructions []Instruction

--- a/runtime/compiler/wasm/functiontype.go
+++ b/runtime/compiler/wasm/functiontype.go
@@ -23,7 +23,6 @@ const functionTypeIndicator = 0x60
 
 // FunctionType is the type of a function.
 // It may have multiple parameters and return values
-//
 type FunctionType struct {
 	Params  []ValueType
 	Results []ValueType

--- a/runtime/compiler/wasm/import.go
+++ b/runtime/compiler/wasm/import.go
@@ -21,7 +21,6 @@ package wasm
 import "fmt"
 
 // Import represents an import
-//
 type Import struct {
 	Module string
 	Name   string

--- a/runtime/compiler/wasm/instruction.go
+++ b/runtime/compiler/wasm/instruction.go
@@ -19,7 +19,6 @@
 package wasm
 
 // Instruction represents an instruction in the code of a WASM binary
-//
 type Instruction interface {
 	isInstruction()
 	write(*WASMWriter) error

--- a/runtime/compiler/wasm/instructions.go
+++ b/runtime/compiler/wasm/instructions.go
@@ -27,7 +27,6 @@ import (
 )
 
 // InstructionUnreachable is the 'unreachable' instruction
-//
 type InstructionUnreachable struct{}
 
 func (InstructionUnreachable) isInstruction() {}
@@ -42,7 +41,6 @@ func (i InstructionUnreachable) write(w *WASMWriter) error {
 }
 
 // InstructionNop is the 'nop' instruction
-//
 type InstructionNop struct{}
 
 func (InstructionNop) isInstruction() {}
@@ -57,7 +55,6 @@ func (i InstructionNop) write(w *WASMWriter) error {
 }
 
 // InstructionBlock is the 'block' instruction
-//
 type InstructionBlock struct {
 	Block Block
 }
@@ -80,7 +77,6 @@ func (i InstructionBlock) write(w *WASMWriter) error {
 }
 
 // InstructionLoop is the 'loop' instruction
-//
 type InstructionLoop struct {
 	Block Block
 }
@@ -103,7 +99,6 @@ func (i InstructionLoop) write(w *WASMWriter) error {
 }
 
 // InstructionIf is the 'if' instruction
-//
 type InstructionIf struct {
 	Block Block
 }
@@ -126,7 +121,6 @@ func (i InstructionIf) write(w *WASMWriter) error {
 }
 
 // InstructionEnd is the 'end' instruction
-//
 type InstructionEnd struct{}
 
 func (InstructionEnd) isInstruction() {}
@@ -141,7 +135,6 @@ func (i InstructionEnd) write(w *WASMWriter) error {
 }
 
 // InstructionBr is the 'br' instruction
-//
 type InstructionBr struct {
 	LabelIndex uint32
 }
@@ -164,7 +157,6 @@ func (i InstructionBr) write(w *WASMWriter) error {
 }
 
 // InstructionBrIf is the 'br_if' instruction
-//
 type InstructionBrIf struct {
 	LabelIndex uint32
 }
@@ -187,7 +179,6 @@ func (i InstructionBrIf) write(w *WASMWriter) error {
 }
 
 // InstructionBrTable is the 'br_table' instruction
-//
 type InstructionBrTable struct {
 	LabelIndices      []uint32
 	DefaultLabelIndex uint32
@@ -226,7 +217,6 @@ func (i InstructionBrTable) write(w *WASMWriter) error {
 }
 
 // InstructionReturn is the 'return' instruction
-//
 type InstructionReturn struct{}
 
 func (InstructionReturn) isInstruction() {}
@@ -241,7 +231,6 @@ func (i InstructionReturn) write(w *WASMWriter) error {
 }
 
 // InstructionCall is the 'call' instruction
-//
 type InstructionCall struct {
 	FuncIndex uint32
 }
@@ -264,7 +253,6 @@ func (i InstructionCall) write(w *WASMWriter) error {
 }
 
 // InstructionCallIndirect is the 'call_indirect' instruction
-//
 type InstructionCallIndirect struct {
 	TypeIndex  uint32
 	TableIndex uint32
@@ -294,7 +282,6 @@ func (i InstructionCallIndirect) write(w *WASMWriter) error {
 }
 
 // InstructionRefNull is the 'ref.null' instruction
-//
 type InstructionRefNull struct {
 	TypeIndex uint32
 }
@@ -317,7 +304,6 @@ func (i InstructionRefNull) write(w *WASMWriter) error {
 }
 
 // InstructionRefIsNull is the 'ref.is_null' instruction
-//
 type InstructionRefIsNull struct{}
 
 func (InstructionRefIsNull) isInstruction() {}
@@ -332,7 +318,6 @@ func (i InstructionRefIsNull) write(w *WASMWriter) error {
 }
 
 // InstructionRefFunc is the 'ref.func' instruction
-//
 type InstructionRefFunc struct {
 	FuncIndex uint32
 }
@@ -355,7 +340,6 @@ func (i InstructionRefFunc) write(w *WASMWriter) error {
 }
 
 // InstructionDrop is the 'drop' instruction
-//
 type InstructionDrop struct{}
 
 func (InstructionDrop) isInstruction() {}
@@ -370,7 +354,6 @@ func (i InstructionDrop) write(w *WASMWriter) error {
 }
 
 // InstructionSelect is the 'select' instruction
-//
 type InstructionSelect struct{}
 
 func (InstructionSelect) isInstruction() {}
@@ -385,7 +368,6 @@ func (i InstructionSelect) write(w *WASMWriter) error {
 }
 
 // InstructionLocalGet is the 'local.get' instruction
-//
 type InstructionLocalGet struct {
 	LocalIndex uint32
 }
@@ -408,7 +390,6 @@ func (i InstructionLocalGet) write(w *WASMWriter) error {
 }
 
 // InstructionLocalSet is the 'local.set' instruction
-//
 type InstructionLocalSet struct {
 	LocalIndex uint32
 }
@@ -431,7 +412,6 @@ func (i InstructionLocalSet) write(w *WASMWriter) error {
 }
 
 // InstructionLocalTee is the 'local.tee' instruction
-//
 type InstructionLocalTee struct {
 	LocalIndex uint32
 }
@@ -454,7 +434,6 @@ func (i InstructionLocalTee) write(w *WASMWriter) error {
 }
 
 // InstructionGlobalGet is the 'global.get' instruction
-//
 type InstructionGlobalGet struct {
 	GlobalIndex uint32
 }
@@ -477,7 +456,6 @@ func (i InstructionGlobalGet) write(w *WASMWriter) error {
 }
 
 // InstructionGlobalSet is the 'global.set' instruction
-//
 type InstructionGlobalSet struct {
 	GlobalIndex uint32
 }
@@ -500,7 +478,6 @@ func (i InstructionGlobalSet) write(w *WASMWriter) error {
 }
 
 // InstructionI32Const is the 'i32.const' instruction
-//
 type InstructionI32Const struct {
 	Value int32
 }
@@ -523,7 +500,6 @@ func (i InstructionI32Const) write(w *WASMWriter) error {
 }
 
 // InstructionI64Const is the 'i64.const' instruction
-//
 type InstructionI64Const struct {
 	Value int64
 }
@@ -546,7 +522,6 @@ func (i InstructionI64Const) write(w *WASMWriter) error {
 }
 
 // InstructionI32Eqz is the 'i32.eqz' instruction
-//
 type InstructionI32Eqz struct{}
 
 func (InstructionI32Eqz) isInstruction() {}
@@ -561,7 +536,6 @@ func (i InstructionI32Eqz) write(w *WASMWriter) error {
 }
 
 // InstructionI32Eq is the 'i32.eq' instruction
-//
 type InstructionI32Eq struct{}
 
 func (InstructionI32Eq) isInstruction() {}
@@ -576,7 +550,6 @@ func (i InstructionI32Eq) write(w *WASMWriter) error {
 }
 
 // InstructionI32Ne is the 'i32.ne' instruction
-//
 type InstructionI32Ne struct{}
 
 func (InstructionI32Ne) isInstruction() {}
@@ -591,7 +564,6 @@ func (i InstructionI32Ne) write(w *WASMWriter) error {
 }
 
 // InstructionI32LtS is the 'i32.lt_s' instruction
-//
 type InstructionI32LtS struct{}
 
 func (InstructionI32LtS) isInstruction() {}
@@ -606,7 +578,6 @@ func (i InstructionI32LtS) write(w *WASMWriter) error {
 }
 
 // InstructionI32LtU is the 'i32.lt_u' instruction
-//
 type InstructionI32LtU struct{}
 
 func (InstructionI32LtU) isInstruction() {}
@@ -621,7 +592,6 @@ func (i InstructionI32LtU) write(w *WASMWriter) error {
 }
 
 // InstructionI32GtS is the 'i32.gt_s' instruction
-//
 type InstructionI32GtS struct{}
 
 func (InstructionI32GtS) isInstruction() {}
@@ -636,7 +606,6 @@ func (i InstructionI32GtS) write(w *WASMWriter) error {
 }
 
 // InstructionI32GtU is the 'i32.gt_u' instruction
-//
 type InstructionI32GtU struct{}
 
 func (InstructionI32GtU) isInstruction() {}
@@ -651,7 +620,6 @@ func (i InstructionI32GtU) write(w *WASMWriter) error {
 }
 
 // InstructionI32LeS is the 'i32.le_s' instruction
-//
 type InstructionI32LeS struct{}
 
 func (InstructionI32LeS) isInstruction() {}
@@ -666,7 +634,6 @@ func (i InstructionI32LeS) write(w *WASMWriter) error {
 }
 
 // InstructionI32LeU is the 'i32.le_u' instruction
-//
 type InstructionI32LeU struct{}
 
 func (InstructionI32LeU) isInstruction() {}
@@ -681,7 +648,6 @@ func (i InstructionI32LeU) write(w *WASMWriter) error {
 }
 
 // InstructionI32GeS is the 'i32.ge_s' instruction
-//
 type InstructionI32GeS struct{}
 
 func (InstructionI32GeS) isInstruction() {}
@@ -696,7 +662,6 @@ func (i InstructionI32GeS) write(w *WASMWriter) error {
 }
 
 // InstructionI32GeU is the 'i32.ge_u' instruction
-//
 type InstructionI32GeU struct{}
 
 func (InstructionI32GeU) isInstruction() {}
@@ -711,7 +676,6 @@ func (i InstructionI32GeU) write(w *WASMWriter) error {
 }
 
 // InstructionI64Eqz is the 'i64.eqz' instruction
-//
 type InstructionI64Eqz struct{}
 
 func (InstructionI64Eqz) isInstruction() {}
@@ -726,7 +690,6 @@ func (i InstructionI64Eqz) write(w *WASMWriter) error {
 }
 
 // InstructionI64Eq is the 'i64.eq' instruction
-//
 type InstructionI64Eq struct{}
 
 func (InstructionI64Eq) isInstruction() {}
@@ -741,7 +704,6 @@ func (i InstructionI64Eq) write(w *WASMWriter) error {
 }
 
 // InstructionI64Ne is the 'i64.ne' instruction
-//
 type InstructionI64Ne struct{}
 
 func (InstructionI64Ne) isInstruction() {}
@@ -756,7 +718,6 @@ func (i InstructionI64Ne) write(w *WASMWriter) error {
 }
 
 // InstructionI64LtS is the 'i64.lt_s' instruction
-//
 type InstructionI64LtS struct{}
 
 func (InstructionI64LtS) isInstruction() {}
@@ -771,7 +732,6 @@ func (i InstructionI64LtS) write(w *WASMWriter) error {
 }
 
 // InstructionI64LtU is the 'i64.lt_u' instruction
-//
 type InstructionI64LtU struct{}
 
 func (InstructionI64LtU) isInstruction() {}
@@ -786,7 +746,6 @@ func (i InstructionI64LtU) write(w *WASMWriter) error {
 }
 
 // InstructionI64GtS is the 'i64.gt_s' instruction
-//
 type InstructionI64GtS struct{}
 
 func (InstructionI64GtS) isInstruction() {}
@@ -801,7 +760,6 @@ func (i InstructionI64GtS) write(w *WASMWriter) error {
 }
 
 // InstructionI64GtU is the 'i64.gt_u' instruction
-//
 type InstructionI64GtU struct{}
 
 func (InstructionI64GtU) isInstruction() {}
@@ -816,7 +774,6 @@ func (i InstructionI64GtU) write(w *WASMWriter) error {
 }
 
 // InstructionI64LeS is the 'i64.le_s' instruction
-//
 type InstructionI64LeS struct{}
 
 func (InstructionI64LeS) isInstruction() {}
@@ -831,7 +788,6 @@ func (i InstructionI64LeS) write(w *WASMWriter) error {
 }
 
 // InstructionI64LeU is the 'i64.le_u' instruction
-//
 type InstructionI64LeU struct{}
 
 func (InstructionI64LeU) isInstruction() {}
@@ -846,7 +802,6 @@ func (i InstructionI64LeU) write(w *WASMWriter) error {
 }
 
 // InstructionI64GeS is the 'i64.ge_s' instruction
-//
 type InstructionI64GeS struct{}
 
 func (InstructionI64GeS) isInstruction() {}
@@ -861,7 +816,6 @@ func (i InstructionI64GeS) write(w *WASMWriter) error {
 }
 
 // InstructionI64GeU is the 'i64.ge_u' instruction
-//
 type InstructionI64GeU struct{}
 
 func (InstructionI64GeU) isInstruction() {}
@@ -876,7 +830,6 @@ func (i InstructionI64GeU) write(w *WASMWriter) error {
 }
 
 // InstructionI32Clz is the 'i32.clz' instruction
-//
 type InstructionI32Clz struct{}
 
 func (InstructionI32Clz) isInstruction() {}
@@ -891,7 +844,6 @@ func (i InstructionI32Clz) write(w *WASMWriter) error {
 }
 
 // InstructionI32Ctz is the 'i32.ctz' instruction
-//
 type InstructionI32Ctz struct{}
 
 func (InstructionI32Ctz) isInstruction() {}
@@ -906,7 +858,6 @@ func (i InstructionI32Ctz) write(w *WASMWriter) error {
 }
 
 // InstructionI32Popcnt is the 'i32.popcnt' instruction
-//
 type InstructionI32Popcnt struct{}
 
 func (InstructionI32Popcnt) isInstruction() {}
@@ -921,7 +872,6 @@ func (i InstructionI32Popcnt) write(w *WASMWriter) error {
 }
 
 // InstructionI32Add is the 'i32.add' instruction
-//
 type InstructionI32Add struct{}
 
 func (InstructionI32Add) isInstruction() {}
@@ -936,7 +886,6 @@ func (i InstructionI32Add) write(w *WASMWriter) error {
 }
 
 // InstructionI32Sub is the 'i32.sub' instruction
-//
 type InstructionI32Sub struct{}
 
 func (InstructionI32Sub) isInstruction() {}
@@ -951,7 +900,6 @@ func (i InstructionI32Sub) write(w *WASMWriter) error {
 }
 
 // InstructionI32Mul is the 'i32.mul' instruction
-//
 type InstructionI32Mul struct{}
 
 func (InstructionI32Mul) isInstruction() {}
@@ -966,7 +914,6 @@ func (i InstructionI32Mul) write(w *WASMWriter) error {
 }
 
 // InstructionI32DivS is the 'i32.div_s' instruction
-//
 type InstructionI32DivS struct{}
 
 func (InstructionI32DivS) isInstruction() {}
@@ -981,7 +928,6 @@ func (i InstructionI32DivS) write(w *WASMWriter) error {
 }
 
 // InstructionI32DivU is the 'i32.div_u' instruction
-//
 type InstructionI32DivU struct{}
 
 func (InstructionI32DivU) isInstruction() {}
@@ -996,7 +942,6 @@ func (i InstructionI32DivU) write(w *WASMWriter) error {
 }
 
 // InstructionI32RemS is the 'i32.rem_s' instruction
-//
 type InstructionI32RemS struct{}
 
 func (InstructionI32RemS) isInstruction() {}
@@ -1011,7 +956,6 @@ func (i InstructionI32RemS) write(w *WASMWriter) error {
 }
 
 // InstructionI32RemU is the 'i32.rem_u' instruction
-//
 type InstructionI32RemU struct{}
 
 func (InstructionI32RemU) isInstruction() {}
@@ -1026,7 +970,6 @@ func (i InstructionI32RemU) write(w *WASMWriter) error {
 }
 
 // InstructionI32And is the 'i32.and' instruction
-//
 type InstructionI32And struct{}
 
 func (InstructionI32And) isInstruction() {}
@@ -1041,7 +984,6 @@ func (i InstructionI32And) write(w *WASMWriter) error {
 }
 
 // InstructionI32Or is the 'i32.or' instruction
-//
 type InstructionI32Or struct{}
 
 func (InstructionI32Or) isInstruction() {}
@@ -1056,7 +998,6 @@ func (i InstructionI32Or) write(w *WASMWriter) error {
 }
 
 // InstructionI32Xor is the 'i32.xor' instruction
-//
 type InstructionI32Xor struct{}
 
 func (InstructionI32Xor) isInstruction() {}
@@ -1071,7 +1012,6 @@ func (i InstructionI32Xor) write(w *WASMWriter) error {
 }
 
 // InstructionI32Shl is the 'i32.shl' instruction
-//
 type InstructionI32Shl struct{}
 
 func (InstructionI32Shl) isInstruction() {}
@@ -1086,7 +1026,6 @@ func (i InstructionI32Shl) write(w *WASMWriter) error {
 }
 
 // InstructionI32ShrS is the 'i32.shr_s' instruction
-//
 type InstructionI32ShrS struct{}
 
 func (InstructionI32ShrS) isInstruction() {}
@@ -1101,7 +1040,6 @@ func (i InstructionI32ShrS) write(w *WASMWriter) error {
 }
 
 // InstructionI32ShrU is the 'i32.shr_u' instruction
-//
 type InstructionI32ShrU struct{}
 
 func (InstructionI32ShrU) isInstruction() {}
@@ -1116,7 +1054,6 @@ func (i InstructionI32ShrU) write(w *WASMWriter) error {
 }
 
 // InstructionI32Rotl is the 'i32.rotl' instruction
-//
 type InstructionI32Rotl struct{}
 
 func (InstructionI32Rotl) isInstruction() {}
@@ -1131,7 +1068,6 @@ func (i InstructionI32Rotl) write(w *WASMWriter) error {
 }
 
 // InstructionI32Rotr is the 'i32.rotr' instruction
-//
 type InstructionI32Rotr struct{}
 
 func (InstructionI32Rotr) isInstruction() {}
@@ -1146,7 +1082,6 @@ func (i InstructionI32Rotr) write(w *WASMWriter) error {
 }
 
 // InstructionI64Clz is the 'i64.clz' instruction
-//
 type InstructionI64Clz struct{}
 
 func (InstructionI64Clz) isInstruction() {}
@@ -1161,7 +1096,6 @@ func (i InstructionI64Clz) write(w *WASMWriter) error {
 }
 
 // InstructionI64Ctz is the 'i64.ctz' instruction
-//
 type InstructionI64Ctz struct{}
 
 func (InstructionI64Ctz) isInstruction() {}
@@ -1176,7 +1110,6 @@ func (i InstructionI64Ctz) write(w *WASMWriter) error {
 }
 
 // InstructionI64Popcnt is the 'i64.popcnt' instruction
-//
 type InstructionI64Popcnt struct{}
 
 func (InstructionI64Popcnt) isInstruction() {}
@@ -1191,7 +1124,6 @@ func (i InstructionI64Popcnt) write(w *WASMWriter) error {
 }
 
 // InstructionI64Add is the 'i64.add' instruction
-//
 type InstructionI64Add struct{}
 
 func (InstructionI64Add) isInstruction() {}
@@ -1206,7 +1138,6 @@ func (i InstructionI64Add) write(w *WASMWriter) error {
 }
 
 // InstructionI64Sub is the 'i64.sub' instruction
-//
 type InstructionI64Sub struct{}
 
 func (InstructionI64Sub) isInstruction() {}
@@ -1221,7 +1152,6 @@ func (i InstructionI64Sub) write(w *WASMWriter) error {
 }
 
 // InstructionI64Mul is the 'i64.mul' instruction
-//
 type InstructionI64Mul struct{}
 
 func (InstructionI64Mul) isInstruction() {}
@@ -1236,7 +1166,6 @@ func (i InstructionI64Mul) write(w *WASMWriter) error {
 }
 
 // InstructionI64DivS is the 'i64.div_s' instruction
-//
 type InstructionI64DivS struct{}
 
 func (InstructionI64DivS) isInstruction() {}
@@ -1251,7 +1180,6 @@ func (i InstructionI64DivS) write(w *WASMWriter) error {
 }
 
 // InstructionI64DivU is the 'i64.div_u' instruction
-//
 type InstructionI64DivU struct{}
 
 func (InstructionI64DivU) isInstruction() {}
@@ -1266,7 +1194,6 @@ func (i InstructionI64DivU) write(w *WASMWriter) error {
 }
 
 // InstructionI64RemS is the 'i64.rem_s' instruction
-//
 type InstructionI64RemS struct{}
 
 func (InstructionI64RemS) isInstruction() {}
@@ -1281,7 +1208,6 @@ func (i InstructionI64RemS) write(w *WASMWriter) error {
 }
 
 // InstructionI64RemU is the 'i64.rem_u' instruction
-//
 type InstructionI64RemU struct{}
 
 func (InstructionI64RemU) isInstruction() {}
@@ -1296,7 +1222,6 @@ func (i InstructionI64RemU) write(w *WASMWriter) error {
 }
 
 // InstructionI64And is the 'i64.and' instruction
-//
 type InstructionI64And struct{}
 
 func (InstructionI64And) isInstruction() {}
@@ -1311,7 +1236,6 @@ func (i InstructionI64And) write(w *WASMWriter) error {
 }
 
 // InstructionI64Or is the 'i64.or' instruction
-//
 type InstructionI64Or struct{}
 
 func (InstructionI64Or) isInstruction() {}
@@ -1326,7 +1250,6 @@ func (i InstructionI64Or) write(w *WASMWriter) error {
 }
 
 // InstructionI64Xor is the 'i64.xor' instruction
-//
 type InstructionI64Xor struct{}
 
 func (InstructionI64Xor) isInstruction() {}
@@ -1341,7 +1264,6 @@ func (i InstructionI64Xor) write(w *WASMWriter) error {
 }
 
 // InstructionI64Shl is the 'i64.shl' instruction
-//
 type InstructionI64Shl struct{}
 
 func (InstructionI64Shl) isInstruction() {}
@@ -1356,7 +1278,6 @@ func (i InstructionI64Shl) write(w *WASMWriter) error {
 }
 
 // InstructionI64ShrS is the 'i64.shr_s' instruction
-//
 type InstructionI64ShrS struct{}
 
 func (InstructionI64ShrS) isInstruction() {}
@@ -1371,7 +1292,6 @@ func (i InstructionI64ShrS) write(w *WASMWriter) error {
 }
 
 // InstructionI64ShrU is the 'i64.shr_u' instruction
-//
 type InstructionI64ShrU struct{}
 
 func (InstructionI64ShrU) isInstruction() {}
@@ -1386,7 +1306,6 @@ func (i InstructionI64ShrU) write(w *WASMWriter) error {
 }
 
 // InstructionI64Rotl is the 'i64.rotl' instruction
-//
 type InstructionI64Rotl struct{}
 
 func (InstructionI64Rotl) isInstruction() {}
@@ -1401,7 +1320,6 @@ func (i InstructionI64Rotl) write(w *WASMWriter) error {
 }
 
 // InstructionI64Rotr is the 'i64.rotr' instruction
-//
 type InstructionI64Rotr struct{}
 
 func (InstructionI64Rotr) isInstruction() {}
@@ -1416,7 +1334,6 @@ func (i InstructionI64Rotr) write(w *WASMWriter) error {
 }
 
 // InstructionI32WrapI64 is the 'i32.wrap_i64' instruction
-//
 type InstructionI32WrapI64 struct{}
 
 func (InstructionI32WrapI64) isInstruction() {}
@@ -1431,7 +1348,6 @@ func (i InstructionI32WrapI64) write(w *WASMWriter) error {
 }
 
 // InstructionI64ExtendI32S is the 'i64.extend_i32_s' instruction
-//
 type InstructionI64ExtendI32S struct{}
 
 func (InstructionI64ExtendI32S) isInstruction() {}
@@ -1446,7 +1362,6 @@ func (i InstructionI64ExtendI32S) write(w *WASMWriter) error {
 }
 
 // InstructionI64ExtendI32U is the 'i64.extend_i32_u' instruction
-//
 type InstructionI64ExtendI32U struct{}
 
 func (InstructionI64ExtendI32U) isInstruction() {}
@@ -1634,7 +1549,6 @@ const (
 )
 
 // readInstruction reads an instruction in the WASM binary
-//
 func (r *WASMReader) readInstruction() (Instruction, error) {
 	opcodeOffset := r.buf.offset
 	b, err := r.buf.ReadByte()

--- a/runtime/compiler/wasm/leb128.go
+++ b/runtime/compiler/wasm/leb128.go
@@ -28,7 +28,6 @@ import (
 //
 // "the total number of bytes encoding a value of type uN must not exceed ceil(N/7) bytes"
 // "the total number of bytes encoding a value of type sN must not exceed ceil(N/7) bytes"
-//
 const max32bitLEB128ByteCount = 5
 
 // max64bitLEB128ByteCount is the maximum number of bytes a 64-bit integer
@@ -37,7 +36,6 @@ const max32bitLEB128ByteCount = 5
 //
 // "the total number of bytes encoding a value of type uN must not exceed ceil(N/7) bytes"
 // "the total number of bytes encoding a value of type sN must not exceed ceil(N/7) bytes"
-//
 const max64bitLEB128ByteCount = 10
 
 // writeUint32LEB128 encodes and writes the given unsigned 32-bit integer
@@ -103,7 +101,6 @@ func (buf *Buffer) writeUint64LEB128(v uint64) error {
 // writeUint32LEB128FixedLength encodes and writes the given unsigned 32-bit integer
 // in non-canonical (fixed-size, instead of with the fewest bytes possible)
 // unsigned little endian base 128 format
-//
 func (buf *Buffer) writeUint32LEB128FixedLength(v uint32, length int) error {
 	for i := 0; i < length; i++ {
 		c := uint8(v & 0x7f)
@@ -123,7 +120,6 @@ func (buf *Buffer) writeUint32LEB128FixedLength(v uint32, length int) error {
 }
 
 // readUint32LEB128 reads and decodes an unsigned 32-bit integer
-//
 func (buf *Buffer) readUint32LEB128() (uint32, error) {
 	var result uint32
 	var shift, i uint
@@ -208,7 +204,6 @@ func (buf *Buffer) writeInt64LEB128(v int64) error {
 }
 
 // readInt32LEB128 reads and decodes a signed 32-bit integer
-//
 func (buf *Buffer) readInt32LEB128() (int32, error) {
 	var result int32
 	var i uint
@@ -231,7 +226,6 @@ func (buf *Buffer) readInt32LEB128() (int32, error) {
 }
 
 // readInt64LEB128 reads and decodes a signed 64-bit integer
-//
 func (buf *Buffer) readInt64LEB128() (int64, error) {
 	var result int64
 	var i uint
@@ -255,7 +249,6 @@ func (buf *Buffer) readInt64LEB128() (int64, error) {
 
 // writeFixedUint32LEB128Space writes a non-canonical 5-byte fixed-size space
 // (instead of the minimal size if canonical encoding would be used)
-//
 func (buf *Buffer) writeFixedUint32LEB128Space() (offset, error) {
 	off := buf.offset
 	for i := 0; i < max32bitLEB128ByteCount; i++ {
@@ -272,7 +265,6 @@ func (buf *Buffer) writeFixedUint32LEB128Space() (offset, error) {
 // as an uint32 in non-canonical 5-byte fixed-size format
 // (instead of the minimal size if canonical encoding would be used)
 // at the given offset
-//
 func (buf *Buffer) writeUint32LEB128SizeAt(off offset) error {
 	currentOff := buf.offset
 	if currentOff < max32bitLEB128ByteCount || currentOff-max32bitLEB128ByteCount < off {

--- a/runtime/compiler/wasm/magic.go
+++ b/runtime/compiler/wasm/magic.go
@@ -25,7 +25,6 @@ package wasm
 // The encoding of a module starts with a preamble containing a 4-byte magic number (the string '\0asm')
 //
 // magic ::= 0x00 0x61 0x73 0x6d
-//
 var wasmMagic = []byte{0x00, 0x61, 0x73, 0x6d}
 
 // wasmVersion is the byte sequence that appears after wasmMagic
@@ -37,5 +36,4 @@ var wasmMagic = []byte{0x00, 0x61, 0x73, 0x6d}
 // The current version of the WebAssembly binary format is 1.
 //
 // version ::= 0x01 0x00 0x00 0x00
-//
 var wasmVersion = []byte{0x01, 0x00, 0x00, 0x00}

--- a/runtime/compiler/wasm/memory.go
+++ b/runtime/compiler/wasm/memory.go
@@ -22,7 +22,6 @@ package wasm
 const MemoryPageSize = 64 * 1024
 
 // Memory represents a memory
-//
 type Memory struct {
 	// minimum number of pages (each one is 64KiB in size)
 	Min uint32

--- a/runtime/compiler/wasm/module.go
+++ b/runtime/compiler/wasm/module.go
@@ -19,7 +19,6 @@
 package wasm
 
 // Module represents a module
-//
 type Module struct {
 	Name               string
 	Types              []*FunctionType

--- a/runtime/compiler/wasm/modulebuilder.go
+++ b/runtime/compiler/wasm/modulebuilder.go
@@ -24,7 +24,6 @@ import (
 )
 
 // ModuleBuilder allows building modules
-//
 type ModuleBuilder struct {
 	functionImports    []*Import
 	types              []*FunctionType

--- a/runtime/compiler/wasm/opcode.go
+++ b/runtime/compiler/wasm/opcode.go
@@ -19,7 +19,6 @@
 package wasm
 
 // opcode is the byte used to indicate a certain instruction in the WASM binary
-//
 type opcode byte
 
 const opcodeElse opcode = 0x05

--- a/runtime/compiler/wasm/reader.go
+++ b/runtime/compiler/wasm/reader.go
@@ -25,7 +25,6 @@ import (
 )
 
 // WASMReader allows reading WASM binaries
-//
 type WASMReader struct {
 	buf              *Buffer
 	Module           Module
@@ -45,7 +44,6 @@ func NewWASMReader(buf *Buffer) *WASMReader {
 // See https://webassembly.github.io/spec/core/binary/modules.html#binary-module:
 //
 // The encoding of a module starts with a preamble containing a 4-byte magic number [...] and a version field.
-//
 func (r *WASMReader) readMagicAndVersion() error {
 
 	// Read the magic
@@ -70,7 +68,6 @@ func (r *WASMReader) readMagicAndVersion() error {
 }
 
 // readSection reads a section in the WASM binary
-//
 func (r *WASMReader) readSection() error {
 	// read the section ID
 	sectionIDOffset := r.buf.offset
@@ -212,7 +209,6 @@ func (r *WASMReader) readSection() error {
 }
 
 // readSectionSize reads the content size of a section
-//
 func (r *WASMReader) readSectionSize() (uint32, error) {
 	// read the size
 	sizeOffset := r.buf.offset
@@ -229,7 +225,6 @@ func (r *WASMReader) readSectionSize() (uint32, error) {
 
 // readTypeSection reads the section that declares all function types
 // so they can be referenced by index
-//
 func (r *WASMReader) readTypeSection() error {
 
 	_, err := r.readSectionSize()
@@ -264,7 +259,6 @@ func (r *WASMReader) readTypeSection() error {
 }
 
 // readFuncType reads a function type
-//
 func (r *WASMReader) readFuncType() (*FunctionType, error) {
 	// read the function type indicator
 	funcTypeIndicatorOffset := r.buf.offset
@@ -339,7 +333,6 @@ func (r *WASMReader) readFuncType() (*FunctionType, error) {
 }
 
 // readValType reads a value type
-//
 func (r *WASMReader) readValType() (ValueType, error) {
 	valTypeOffset := r.buf.offset
 	b, err := r.buf.ReadByte()
@@ -366,7 +359,6 @@ func (r *WASMReader) readValType() (ValueType, error) {
 }
 
 // readImportSection reads the section that declares the imports
-//
 func (r *WASMReader) readImportSection() error {
 
 	_, err := r.readSectionSize()
@@ -404,7 +396,6 @@ func (r *WASMReader) readImportSection() error {
 }
 
 // readImport reads an import in the import section
-//
 func (r *WASMReader) readImport() (*Import, error) {
 
 	// read the module
@@ -453,7 +444,6 @@ func (r *WASMReader) readImport() (*Import, error) {
 
 // readFunctionSection reads the section that declares the types of functions.
 // The bodies of these functions will later be provided in the code section
-//
 func (r *WASMReader) readFunctionSection() error {
 
 	_, err := r.readSectionSize()
@@ -514,7 +504,6 @@ func (r *WASMReader) ensureModuleFunctions(count int) bool {
 }
 
 // readMemorySection reads the section that declares the memories
-//
 func (r *WASMReader) readMemorySection() error {
 
 	_, err := r.readSectionSize()
@@ -552,7 +541,6 @@ func (r *WASMReader) readMemorySection() error {
 }
 
 // readMemory reads a memory in the memory section
-//
 func (r *WASMReader) readMemory() (*Memory, error) {
 	min, max, err := r.readLimit()
 	if err != nil {
@@ -566,7 +554,6 @@ func (r *WASMReader) readMemory() (*Memory, error) {
 }
 
 // readLimit reads a limit
-//
 func (r *WASMReader) readLimit() (min uint32, max *uint32, err error) {
 	// read the limit indicator
 	indicatorOffset := r.buf.offset
@@ -622,7 +609,6 @@ func (r *WASMReader) readLimit() (min uint32, max *uint32, err error) {
 }
 
 // readExportSection reads the section that declares the exports
-//
 func (r *WASMReader) readExportSection() error {
 
 	_, err := r.readSectionSize()
@@ -660,7 +646,6 @@ func (r *WASMReader) readExportSection() error {
 }
 
 // readExport reads an export in the export section
-//
 func (r *WASMReader) readExport() (*Export, error) {
 
 	// read the name
@@ -722,7 +707,6 @@ func (r *WASMReader) readExport() (*Export, error) {
 
 // readStartSection reads the section that declares the types of functions.
 // The bodies of these functions will later be provided in the code section
-//
 func (r *WASMReader) readStartSection() error {
 
 	_, err := r.readSectionSize()
@@ -747,7 +731,6 @@ func (r *WASMReader) readStartSection() error {
 
 // readCodeSection reads the section that provides the function bodies for the functions
 // declared by the function section (which only provides the function types)
-//
 func (r *WASMReader) readCodeSection() error {
 
 	_, err := r.readSectionSize()
@@ -794,7 +777,6 @@ func (r *WASMReader) readCodeSection() error {
 }
 
 // readFunctionBody reads the body (locals and instruction) of one function in the code section
-//
 func (r *WASMReader) readFunctionBody() (*Code, error) {
 
 	// read the size
@@ -827,7 +809,6 @@ func (r *WASMReader) readFunctionBody() (*Code, error) {
 }
 
 // readLocals reads the locals for one function in the code sections
-//
 func (r *WASMReader) readLocals() ([]ValueType, error) {
 	// read the number of locals
 	localsCountOffset := r.buf.offset
@@ -881,7 +862,6 @@ func (r *WASMReader) readLocals() ([]ValueType, error) {
 }
 
 // readInstructions reads the instructions for one function in the code sections
-//
 func (r *WASMReader) readInstructions() (instructions []Instruction, err error) {
 	for {
 		instruction, err := r.readInstruction()
@@ -898,7 +878,6 @@ func (r *WASMReader) readInstructions() (instructions []Instruction, err error) 
 }
 
 // readName reads a name
-//
 func (r *WASMReader) readName() (string, error) {
 
 	// read the length
@@ -946,7 +925,6 @@ func (r *WASMReader) readName() (string, error) {
 
 // readUint32LEB128InstructionArgument reads a uint32 instruction argument
 // (in LEB128 format)
-//
 func (r *WASMReader) readUint32LEB128InstructionArgument() (uint32, error) {
 	offset := r.buf.offset
 	v, err := r.buf.readUint32LEB128()
@@ -961,7 +939,6 @@ func (r *WASMReader) readUint32LEB128InstructionArgument() (uint32, error) {
 
 // readInt32LEB128InstructionArgument reads an int32 instruction argument
 // (in LEB128 format)
-//
 func (r *WASMReader) readInt32LEB128InstructionArgument() (int32, error) {
 	offset := r.buf.offset
 	v, err := r.buf.readInt32LEB128()
@@ -976,7 +953,6 @@ func (r *WASMReader) readInt32LEB128InstructionArgument() (int32, error) {
 
 // readInt64LEB128InstructionArgument reads an int64 instruction argument
 // (in LEB128 format)
-//
 func (r *WASMReader) readInt64LEB128InstructionArgument() (int64, error) {
 	offset := r.buf.offset
 	v, err := r.buf.readInt64LEB128()
@@ -990,7 +966,6 @@ func (r *WASMReader) readInt64LEB128InstructionArgument() (int64, error) {
 }
 
 // readBlockInstructionArgument reads a block instruction argument
-//
 func (r *WASMReader) readBlockInstructionArgument(allowElse bool) (Block, error) {
 	// read the block type.
 	blockType, err := r.readBlockType()
@@ -1104,7 +1079,6 @@ func (r *WASMReader) readBlockType() (BlockType, error) {
 
 // readBlockTypeValueType reads a value type block type
 // and returns nil if the next byte is not a valid value type
-//
 func (r *WASMReader) readBlockTypeValueType() (BlockType, error) {
 	b, err := r.buf.PeekByte()
 	if err != nil {
@@ -1119,7 +1093,6 @@ func (r *WASMReader) readBlockTypeValueType() (BlockType, error) {
 }
 
 // readCustomSection reads a custom section
-//
 func (r *WASMReader) readCustomSection() error {
 
 	size, err := r.readSectionSize()
@@ -1149,7 +1122,6 @@ func (r *WASMReader) readCustomSection() error {
 }
 
 // readDataSection reads the section that declares the data segments
-//
 func (r *WASMReader) readDataSection() error {
 
 	_, err := r.readSectionSize()
@@ -1187,7 +1159,6 @@ func (r *WASMReader) readDataSection() error {
 }
 
 // readDataSegment reads a segment in the data section
-//
 func (r *WASMReader) readDataSegment() (*Data, error) {
 
 	// read the memory index
@@ -1235,7 +1206,6 @@ func (r *WASMReader) readDataSegment() (*Data, error) {
 }
 
 // readNameSection reads the section that provides names
-//
 func (r *WASMReader) readNameSection(size uint32) error {
 
 	// TODO: read the names and store them. for now, just skip the content

--- a/runtime/compiler/wasm/section.go
+++ b/runtime/compiler/wasm/section.go
@@ -36,7 +36,6 @@ package wasm
 // 9 = element section
 // 10 = code section
 // 11 = data section
-//
 type sectionID byte
 
 const (

--- a/runtime/compiler/wasm/valuetype.go
+++ b/runtime/compiler/wasm/valuetype.go
@@ -19,7 +19,6 @@
 package wasm
 
 // ValueType is the type of a value
-//
 type ValueType byte
 
 const (
@@ -46,7 +45,6 @@ const (
 
 // AsValueType returns the value type for the given byte,
 // or 0 if the byte is not a valid value type
-//
 func AsValueType(b byte) ValueType {
 	switch ValueType(b) {
 	case ValueTypeI32:

--- a/runtime/compiler/wasm/wasm.go
+++ b/runtime/compiler/wasm/wasm.go
@@ -46,5 +46,4 @@
 //
 // Package wasm is not a compiler for Cadence programs, but rather a building block that allows
 // reading and writing WebAssembly modules.
-//
 package wasm

--- a/runtime/compiler/wasm/writer.go
+++ b/runtime/compiler/wasm/writer.go
@@ -24,7 +24,6 @@ import (
 )
 
 // WASMWriter allows writing WASM binaries
-//
 type WASMWriter struct {
 	buf        *Buffer
 	WriteNames bool
@@ -37,7 +36,6 @@ func NewWASMWriter(buf *Buffer) *WASMWriter {
 }
 
 // writeMagicAndVersion writes the magic byte sequence and version at the beginning of the WASM binary
-//
 func (w *WASMWriter) writeMagicAndVersion() error {
 	err := w.buf.WriteBytes(wasmMagic)
 	if err != nil {
@@ -48,7 +46,6 @@ func (w *WASMWriter) writeMagicAndVersion() error {
 
 // writeSection writes a section in the WASM binary, with the given section ID and the given content.
 // The content is a function that writes the contents of the section.
-//
 func (w *WASMWriter) writeSection(sectionID sectionID, content func() error) error {
 	// write the section ID
 	err := w.buf.WriteByte(byte(sectionID))
@@ -62,7 +59,6 @@ func (w *WASMWriter) writeSection(sectionID sectionID, content func() error) err
 
 // writeContentWithSize writes the size of the content,
 // and the content itself
-//
 func (w *WASMWriter) writeContentWithSize(content func() error) error {
 
 	// write the temporary placeholder for the size
@@ -83,7 +79,6 @@ func (w *WASMWriter) writeContentWithSize(content func() error) error {
 
 // writeCustomSection writes a custom section with the given name and content.
 // The content is a function that writes the contents of the section.
-//
 func (w *WASMWriter) writeCustomSection(name string, content func() error) error {
 	return w.writeSection(sectionIDCustom, func() error {
 		err := w.writeName(name)
@@ -97,7 +92,6 @@ func (w *WASMWriter) writeCustomSection(name string, content func() error) error
 
 // writeTypeSection writes the section that declares all function types
 // so they can be referenced by index
-//
 func (w *WASMWriter) writeTypeSection(funcTypes []*FunctionType) error {
 	return w.writeSection(sectionIDType, func() error {
 
@@ -120,7 +114,6 @@ func (w *WASMWriter) writeTypeSection(funcTypes []*FunctionType) error {
 }
 
 // writeFuncType writes the function type
-//
 func (w *WASMWriter) writeFuncType(funcType *FunctionType) error {
 	// write the type
 	err := w.buf.WriteByte(functionTypeIndicator)
@@ -160,7 +153,6 @@ func (w *WASMWriter) writeFuncType(funcType *FunctionType) error {
 }
 
 // writeImportSection writes the section that declares all imports
-//
 func (w *WASMWriter) writeImportSection(imports []*Import) error {
 	return w.writeSection(sectionIDImport, func() error {
 
@@ -183,7 +175,6 @@ func (w *WASMWriter) writeImportSection(imports []*Import) error {
 }
 
 // writeImport writes the import
-//
 func (w *WASMWriter) writeImport(im *Import) error {
 	// write the module
 	err := w.writeName(im.Module)
@@ -210,7 +201,6 @@ func (w *WASMWriter) writeImport(im *Import) error {
 
 // writeFunctionSection writes the section that declares the types of functions.
 // The bodies of these functions will later be provided in the code section
-//
 func (w *WASMWriter) writeFunctionSection(functions []*Function) error {
 	return w.writeSection(sectionIDFunction, func() error {
 		// write the number of functions
@@ -232,7 +222,6 @@ func (w *WASMWriter) writeFunctionSection(functions []*Function) error {
 }
 
 // writeMemorySection writes the section that declares all memories
-//
 func (w *WASMWriter) writeMemorySection(memories []*Memory) error {
 	return w.writeSection(sectionIDMemory, func() error {
 
@@ -255,7 +244,6 @@ func (w *WASMWriter) writeMemorySection(memories []*Memory) error {
 }
 
 // writeMemory writes the memory
-//
 func (w *WASMWriter) writeMemory(memory *Memory) error {
 	return w.writeLimit(memory.Max, memory.Min)
 }
@@ -291,7 +279,6 @@ func (w *WASMWriter) writeLimit(max *uint32, min uint32) error {
 }
 
 // writeExportSection writes the section that declares all exports
-//
 func (w *WASMWriter) writeExportSection(exports []*Export) error {
 	return w.writeSection(sectionIDExport, func() error {
 
@@ -314,7 +301,6 @@ func (w *WASMWriter) writeExportSection(exports []*Export) error {
 }
 
 // writeExport writes the export
-//
 func (w *WASMWriter) writeExport(export *Export) error {
 
 	// write the name
@@ -350,7 +336,6 @@ func (w *WASMWriter) writeExport(export *Export) error {
 }
 
 // writeStartSection writes the section that declares the start function
-//
 func (w *WASMWriter) writeStartSection(funcIndex uint32) error {
 	return w.writeSection(sectionIDStart, func() error {
 		// write the index of the start function
@@ -360,7 +345,6 @@ func (w *WASMWriter) writeStartSection(funcIndex uint32) error {
 
 // writeCodeSection writes the section that provides the function bodies for the functions
 // declared by the function section (which only provides the function types)
-//
 func (w *WASMWriter) writeCodeSection(functions []*Function) error {
 	return w.writeSection(sectionIDCode, func() error {
 		// write the number of code entries (one for each function)
@@ -383,7 +367,6 @@ func (w *WASMWriter) writeCodeSection(functions []*Function) error {
 }
 
 // writeFunctionBody writes the body of the function
-//
 func (w *WASMWriter) writeFunctionBody(code *Code) error {
 	return w.writeContentWithSize(func() error {
 
@@ -417,7 +400,6 @@ func (w *WASMWriter) writeFunctionBody(code *Code) error {
 }
 
 // writeInstructions writes an instruction sequence
-//
 func (w *WASMWriter) writeInstructions(instructions []Instruction) error {
 	for _, instruction := range instructions {
 		err := instruction.write(w)
@@ -429,7 +411,6 @@ func (w *WASMWriter) writeInstructions(instructions []Instruction) error {
 }
 
 // writeOpcode writes the opcode of an instruction
-//
 func (w *WASMWriter) writeOpcode(opcodes ...opcode) error {
 	for _, b := range opcodes {
 		err := w.buf.WriteByte(byte(b))
@@ -441,7 +422,6 @@ func (w *WASMWriter) writeOpcode(opcodes ...opcode) error {
 }
 
 // writeName writes a name, a UTF-8 byte sequence
-//
 func (w *WASMWriter) writeName(name string) error {
 
 	// ensure the name is valid UTF-8
@@ -463,7 +443,6 @@ func (w *WASMWriter) writeName(name string) error {
 }
 
 // writeBlockInstructionArgument writes a block instruction argument
-//
 func (w *WASMWriter) writeBlockInstructionArgument(block Block, allowElse bool) error {
 
 	// write the block type
@@ -516,7 +495,6 @@ const customSectionNameName = "name"
 
 // writeNameSection writes the section which declares
 // the names of the module, functions, and locals
-//
 func (w *WASMWriter) writeNameSection(moduleName string, imports []*Import, functions []*Function) error {
 	return w.writeCustomSection(customSectionNameName, func() error {
 
@@ -532,7 +510,6 @@ func (w *WASMWriter) writeNameSection(moduleName string, imports []*Import, func
 }
 
 // nameSubSectionID is the ID of a sub-section in the name section of the WASM binary
-//
 type nameSubSectionID byte
 
 const (
@@ -545,7 +522,6 @@ const (
 // writeNameSubSection writes a sub-section in the name section of the WASM binary,
 // with the given sub-section ID and the given content.
 // The content is a function that writes the contents of the section.
-//
 func (w *WASMWriter) writeNameSubSection(nameSubSectionID nameSubSectionID, content func() error) error {
 	// write the name sub-section ID
 	err := w.buf.WriteByte(byte(nameSubSectionID))
@@ -558,7 +534,6 @@ func (w *WASMWriter) writeNameSubSection(nameSubSectionID nameSubSectionID, cont
 }
 
 // writeNameSectionModuleName writes the module name sub-section in the name section of the WASM binary
-//
 func (w *WASMWriter) writeNameSectionModuleNameSubSection(moduleName string) error {
 	return w.writeNameSubSection(nameSubSectionIDModuleName, func() error {
 		return w.writeName(moduleName)
@@ -566,7 +541,6 @@ func (w *WASMWriter) writeNameSectionModuleNameSubSection(moduleName string) err
 }
 
 // writeNameSectionFunctionNames writes the module name sub-section in the name section of the WASM binary
-//
 func (w *WASMWriter) writeNameSectionFunctionNamesSubSection(imports []*Import, functions []*Function) error {
 	return w.writeNameSubSection(nameSubSectionIDFunctionNames, func() error {
 
@@ -625,7 +599,6 @@ func (w *WASMWriter) writeNameSectionFunctionNamesSubSection(imports []*Import, 
 }
 
 // writeDataSection writes the section that declares the data segments
-//
 func (w *WASMWriter) writeDataSection(segments []*Data) error {
 	return w.writeSection(sectionIDData, func() error {
 		// write the number of data segments
@@ -647,7 +620,6 @@ func (w *WASMWriter) writeDataSection(segments []*Data) error {
 }
 
 // writeDataSegment writes the data segment
-//
 func (w *WASMWriter) writeDataSegment(segment *Data) error {
 
 	// write the memory index

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -23,7 +23,6 @@ import (
 )
 
 // Config is a constant/read-only configuration of an environment.
-//
 type Config struct {
 	Debugger *interpreter.Debugger
 	// AtreeValidationEnabled configures if atree validation is enabled.

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -68,7 +68,6 @@ type seenReferences map[*interpreter.EphemeralReferenceValue]struct{}
 // The export is recursive, the results parameter prevents cycles:
 // it is checked at the start of the recursively called function,
 // and pre-set before a recursive call.
-//
 func exportValueWithInterpreter(
 	value interpreter.Value,
 	inter *interpreter.Interpreter,

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -25,7 +25,6 @@ import (
 )
 
 // LocationCoverage records coverage information for a location
-//
 type LocationCoverage struct {
 	LineHits map[int]int `json:"line_hits"`
 }
@@ -41,7 +40,6 @@ func NewLocationCoverage() *LocationCoverage {
 }
 
 // CoverageReport is a collection of coverage per location
-//
 type CoverageReport struct {
 	Coverage map[common.Location]*LocationCoverage `json:"-"`
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -138,7 +138,6 @@ func (e InvalidTransactionAuthorizerCountError) Error() string {
 }
 
 // InvalidEntryPointArgumentError
-//
 type InvalidEntryPointArgumentError struct {
 	Index int
 	Err   error
@@ -178,7 +177,6 @@ func (e *MalformedValueError) Error() string {
 }
 
 // InvalidValueTypeError
-//
 type InvalidValueTypeError struct {
 	ExpectedType sema.Type
 }
@@ -200,7 +198,6 @@ func (e *InvalidValueTypeError) Error() string {
 // For example, the type `Int` is valid,
 // whereas a function type is not,
 // because it cannot be exported/serialized.
-//
 type InvalidScriptReturnTypeError struct {
 	Type sema.Type
 }
@@ -221,7 +218,6 @@ func (e *InvalidScriptReturnTypeError) Error() string {
 //
 // For example, the type `Int` is a storable type,
 // whereas a function type is not.
-//
 type ScriptParameterTypeNotStorableError struct {
 	Type sema.Type
 }
@@ -242,7 +238,6 @@ func (e *ScriptParameterTypeNotStorableError) Error() string {
 //
 // For example, the type `Int` is an importable type,
 // whereas a function-type is not.
-//
 type ScriptParameterTypeNotImportableError struct {
 	Type sema.Type
 }
@@ -260,7 +255,6 @@ func (e *ScriptParameterTypeNotImportableError) Error() string {
 
 // ArgumentNotImportableError is an error that is reported for
 // script arguments that belongs to non-importable types.
-//
 type ArgumentNotImportableError struct {
 	Type interpreter.StaticType
 }
@@ -278,7 +272,6 @@ func (e *ArgumentNotImportableError) Error() string {
 
 // ParsingCheckingError is an error wrapper
 // for a parsing or a checking error at a specific location
-//
 type ParsingCheckingError struct {
 	Err      error
 	Location Location

--- a/runtime/errors/errors.go
+++ b/runtime/errors/errors.go
@@ -26,7 +26,6 @@ import (
 )
 
 // NewUnreachableError creates an internal error that indicates executing an unimplemented path.
-//
 func NewUnreachableError() InternalError {
 	return NewUnexpectedError("unreachable")
 }
@@ -35,7 +34,6 @@ func NewUnreachableError() InternalError {
 // A program should never throw an InternalError in an ideal world.
 //
 // InternalError s must always be thrown and not be caught (recovered), i.e. be propagated up the call stack.
-//
 type InternalError interface {
 	error
 	IsInternalError()
@@ -49,7 +47,6 @@ type UserError interface {
 
 // ExternalError is an error that occurred externally.
 // It contains the recovered value.
-//
 type ExternalError struct {
 	Recovered any
 }
@@ -67,13 +64,11 @@ func (e ExternalError) Error() string {
 // SecondaryError
 
 // SecondaryError is an interface for errors that provide a secondary error message
-//
 type SecondaryError interface {
 	SecondaryError() string
 }
 
 // ErrorNotes is an interface for errors that provide notes
-//
 type ErrorNotes interface {
 	ErrorNotes() []ErrorNote
 }
@@ -89,7 +84,6 @@ type ParentError interface {
 }
 
 // HasPrefix is an interface for errors that provide a custom prefix
-//
 type HasPrefix interface {
 	Prefix() string
 }
@@ -116,7 +110,6 @@ func (e MemoryError) Error() string {
 // It's a generic error that wraps an implementation error, which should have never occurred.
 //
 // NOTE: This error is not used for errors occur due to bugs in a user-provided program.
-//
 type UnexpectedError struct {
 	Err   error
 	Stack []byte
@@ -150,7 +143,6 @@ func (e UnexpectedError) Error() string {
 
 // DefaultUserError is the default implementation of UserError interface.
 // It's a generic error that wraps a user error.
-//
 type DefaultUserError struct {
 	Err error
 }
@@ -175,7 +167,6 @@ func (e DefaultUserError) Error() string {
 
 // IsInternalError Checks whether a given error was caused by an InternalError.
 // An error in an internal error, if it has at-least one InternalError in the error chain.
-//
 func IsInternalError(err error) bool {
 	switch err := err.(type) {
 	case InternalError:
@@ -189,7 +180,6 @@ func IsInternalError(err error) bool {
 
 // IsUserError Checks whether a given error was caused by an UserError.
 // An error in a user error, if it has at-least one UserError in the error chain.
-//
 func IsUserError(err error) bool {
 	switch err := err.(type) {
 	case UserError:

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -3344,7 +3344,6 @@ func TestDivModUFix64(t *testing.T) {
 
 // TestNegativeMod ensures that modulo uses the dividend's sign
 // when an operand is negative
-//
 func TestNegativeMod(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -229,7 +229,6 @@ const (
 //
 // See https://github.com/fxamacker/cbor:
 // "For best performance, reuse EncMode and DecMode after creating them."
-//
 var CBOREncMode = func() cbor.EncMode {
 	options := cbor.CanonicalEncOptions()
 	options.BigIntConvert = cbor.BigIntConvertNone
@@ -241,21 +240,18 @@ var CBOREncMode = func() cbor.EncMode {
 }()
 
 // Encode encodes the value as a CBOR nil
-//
 func (v NilValue) Encode(e *atree.Encoder) error {
 	// NOTE: when updating, also update NilValue.ByteSize
 	return e.CBOR.EncodeNil()
 }
 
 // Encode encodes the value as a CBOR bool
-//
 func (v BoolValue) Encode(e *atree.Encoder) error {
 	// NOTE: when updating, also update BoolValue.ByteSize
 	return e.CBOR.EncodeBool(bool(v))
 }
 
 // Encode encodes the value as a CBOR string
-//
 func (v CharacterValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -268,7 +264,6 @@ func (v CharacterValue) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes the value as a CBOR string
-//
 func (v *StringValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -281,18 +276,16 @@ func (v *StringValue) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes the value as a CBOR string
-//
 func (v StringAtreeValue) Encode(e *atree.Encoder) error {
 	return e.CBOR.EncodeString(string(v))
 }
 
 // cborVoidValue represents the CBOR value:
 //
-// 	cbor.Tag{
-// 		Number: CBORTagVoidValue,
-// 		Content: nil
-// 	}
-//
+//	cbor.Tag{
+//		Number: CBORTagVoidValue,
+//		Content: nil
+//	}
 var cborVoidValue = []byte{
 	// tag
 	0xd8, CBORTagVoidValue,
@@ -301,7 +294,6 @@ var cborVoidValue = []byte{
 }
 
 // Encode writes a value of type Void to the encoder
-//
 func (v VoidValue) Encode(e *atree.Encoder) error {
 
 	// TODO: optimize: use 0xf7, but decoded by github.com/fxamacker/cbor/v2 as Go `nil`:
@@ -311,10 +303,11 @@ func (v VoidValue) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes the value as
-// cbor.Tag{
-//		Number:  CBORTagIntValue,
-//		Content: *big.Int(v.BigInt),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagIntValue,
+//			Content: *big.Int(v.BigInt),
+//	}
 func (v IntValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -327,10 +320,11 @@ func (v IntValue) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Int8Value as
-// cbor.Tag{
-//		Number:  CBORTagInt8Value,
-//		Content: int8(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagInt8Value,
+//			Content: int8(v),
+//	}
 func (v Int8Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -343,10 +337,11 @@ func (v Int8Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Int16Value as
-// cbor.Tag{
-//		Number:  CBORTagInt16Value,
-//		Content: int16(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagInt16Value,
+//			Content: int16(v),
+//	}
 func (v Int16Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -359,10 +354,11 @@ func (v Int16Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Int32Value as
-// cbor.Tag{
-//		Number:  CBORTagInt32Value,
-//		Content: int32(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagInt32Value,
+//			Content: int32(v),
+//	}
 func (v Int32Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -375,10 +371,11 @@ func (v Int32Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Int64Value as
-// cbor.Tag{
-//		Number:  CBORTagInt64Value,
-//		Content: int64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagInt64Value,
+//			Content: int64(v),
+//	}
 func (v Int64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -391,10 +388,11 @@ func (v Int64Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Int128Value as
-// cbor.Tag{
-//		Number:  CBORTagInt128Value,
-//		Content: *big.Int(v.BigInt),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagInt128Value,
+//			Content: *big.Int(v.BigInt),
+//	}
 func (v Int128Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -407,10 +405,11 @@ func (v Int128Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Int256Value as
-// cbor.Tag{
-//		Number:  CBORTagInt256Value,
-//		Content: *big.Int(v.BigInt),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagInt256Value,
+//			Content: *big.Int(v.BigInt),
+//	}
 func (v Int256Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -423,10 +422,11 @@ func (v Int256Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UIntValue as
-// cbor.Tag{
-//		Number:  CBORTagUIntValue,
-//		Content: *big.Int(v.BigInt),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUIntValue,
+//			Content: *big.Int(v.BigInt),
+//	}
 func (v UIntValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -439,10 +439,11 @@ func (v UIntValue) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UInt8Value as
-// cbor.Tag{
-//		Number:  CBORTagUInt8Value,
-//		Content: uint8(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUInt8Value,
+//			Content: uint8(v),
+//	}
 func (v UInt8Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -455,10 +456,11 @@ func (v UInt8Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UInt16Value as
-// cbor.Tag{
-//		Number:  CBORTagUInt16Value,
-//		Content: uint16(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUInt16Value,
+//			Content: uint16(v),
+//	}
 func (v UInt16Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -471,10 +473,11 @@ func (v UInt16Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UInt32Value as
-// cbor.Tag{
-//		Number:  CBORTagUInt32Value,
-//		Content: uint32(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUInt32Value,
+//			Content: uint32(v),
+//	}
 func (v UInt32Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -487,10 +490,11 @@ func (v UInt32Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UInt64Value as
-// cbor.Tag{
-//		Number:  CBORTagUInt64Value,
-//		Content: uint64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUInt64Value,
+//			Content: uint64(v),
+//	}
 func (v UInt64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -503,10 +507,11 @@ func (v UInt64Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UInt128Value as
-// cbor.Tag{
-//		Number:  CBORTagUInt128Value,
-//		Content: *big.Int(v.BigInt),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUInt128Value,
+//			Content: *big.Int(v.BigInt),
+//	}
 func (v UInt128Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -519,10 +524,11 @@ func (v UInt128Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UInt256Value as
-// cbor.Tag{
-//		Number:  CBORTagUInt256Value,
-//		Content: *big.Int(v.BigInt),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUInt256Value,
+//			Content: *big.Int(v.BigInt),
+//	}
 func (v UInt256Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -535,10 +541,11 @@ func (v UInt256Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Word8Value as
-// cbor.Tag{
-//		Number:  CBORTagWord8Value,
-//		Content: uint8(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagWord8Value,
+//			Content: uint8(v),
+//	}
 func (v Word8Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -551,10 +558,11 @@ func (v Word8Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Word16Value as
-// cbor.Tag{
-//		Number:  CBORTagWord16Value,
-//		Content: uint16(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagWord16Value,
+//			Content: uint16(v),
+//	}
 func (v Word16Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -567,10 +575,11 @@ func (v Word16Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Word32Value as
-// cbor.Tag{
-//		Number:  CBORTagWord32Value,
-//		Content: uint32(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagWord32Value,
+//			Content: uint32(v),
+//	}
 func (v Word32Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -583,10 +592,11 @@ func (v Word32Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Word64Value as
-// cbor.Tag{
-//		Number:  CBORTagWord64Value,
-//		Content: uint64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagWord64Value,
+//			Content: uint64(v),
+//	}
 func (v Word64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -599,10 +609,11 @@ func (v Word64Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes Fix64Value as
-// cbor.Tag{
-//		Number:  CBORTagFix64Value,
-//		Content: int64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagFix64Value,
+//			Content: int64(v),
+//	}
 func (v Fix64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -615,10 +626,11 @@ func (v Fix64Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes UFix64Value as
-// cbor.Tag{
-//		Number:  CBORTagUFix64Value,
-//		Content: uint64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagUFix64Value,
+//			Content: uint64(v),
+//	}
 func (v UFix64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -631,10 +643,11 @@ func (v UFix64Value) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes SomeStorable as
-// cbor.Tag{
-//		Number: CBORTagSomeValue,
-//		Content: Value(v.Value),
-// }
+//
+//	cbor.Tag{
+//			Number: CBORTagSomeValue,
+//			Content: Value(v.Value),
+//	}
 func (s SomeStorable) Encode(e *atree.Encoder) error {
 	// NOTE: when updating, also update SomeStorable.ByteSize
 	err := e.CBOR.EncodeRawBytes([]byte{
@@ -648,10 +661,11 @@ func (s SomeStorable) Encode(e *atree.Encoder) error {
 }
 
 // Encode encodes AddressValue as
-// cbor.Tag{
-//		Number:  CBORTagAddressValue,
-//		Content: []byte(v.ToAddress().Bytes()),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagAddressValue,
+//			Content: []byte(v.ToAddress().Bytes()),
+//	}
 func (v AddressValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -676,13 +690,14 @@ const (
 )
 
 // Encode encodes PathValue as
-// cbor.Tag{
-//			Number: CBORTagPathValue,
-//			Content: []any{
-//				encodedPathValueDomainFieldKey:     uint(v.Domain),
-//				encodedPathValueIdentifierFieldKey: string(v.Identifier),
-//			},
-// }
+//
+//	cbor.Tag{
+//				Number: CBORTagPathValue,
+//				Content: []any{
+//					encodedPathValueDomainFieldKey:     uint(v.Domain),
+//					encodedPathValueIdentifierFieldKey: string(v.Identifier),
+//				},
+//	}
 func (v PathValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
@@ -719,14 +734,15 @@ const (
 )
 
 // Encode encodes CapabilityStorable as
-// cbor.Tag{
-//			Number: CBORTagCapabilityValue,
-//			Content: []any{
-//					encodedCapabilityValueAddressFieldKey:    AddressValue(v.Address),
-// 					encodedCapabilityValuePathFieldKey:       PathValue(v.Path),
-// 					encodedCapabilityValueBorrowTypeFieldKey: StaticType(v.BorrowType),
-// 				},
-// }
+//
+//	cbor.Tag{
+//				Number: CBORTagCapabilityValue,
+//				Content: []any{
+//						encodedCapabilityValueAddressFieldKey:    AddressValue(v.Address),
+//						encodedCapabilityValuePathFieldKey:       PathValue(v.Path),
+//						encodedCapabilityValueBorrowTypeFieldKey: StaticType(v.BorrowType),
+//					},
+//	}
 func (v *CapabilityValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
@@ -887,13 +903,14 @@ const (
 )
 
 // Encode encodes LinkValue as
-// cbor.Tag{
-//			Number: CBORTagLinkValue,
-//			Content: []any{
-//				encodedLinkValueTargetPathFieldKey: PathValue(v.TargetPath),
-//				encodedLinkValueTypeFieldKey:       StaticType(v.Type),
-//			},
-// }
+//
+//	cbor.Tag{
+//				Number: CBORTagLinkValue,
+//				Content: []any{
+//					encodedLinkValueTargetPathFieldKey: PathValue(v.TargetPath),
+//					encodedLinkValueTypeFieldKey:       StaticType(v.Type),
+//				},
+//	}
 func (v LinkValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
@@ -927,13 +944,14 @@ const (
 )
 
 // Encode encodes PublishedValue as
-// cbor.Tag{
-//			Number: CBORTagPublishedValue,
-//			Content: []any{
-//				encodedPublishedValueRecipientFieldKey: AddressValue(v.Recipient),
-//				encodedPublishedValueValueFieldKey:     v.Value,
-//			},
-// }
+//
+//	cbor.Tag{
+//				Number: CBORTagPublishedValue,
+//				Content: []any{
+//					encodedPublishedValueRecipientFieldKey: AddressValue(v.Recipient),
+//					encodedPublishedValueValueFieldKey:     v.Value,
+//				},
+//	}
 func (v *PublishedValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
@@ -966,12 +984,13 @@ const (
 )
 
 // Encode encodes TypeValue as
-// cbor.Tag{
-//			Number: CBORTagTypeValue,
-//			Content: cborArray{
-//				encodedTypeValueTypeFieldKey: StaticType(v.Type),
-//			},
-//	}
+//
+//	cbor.Tag{
+//				Number: CBORTagTypeValue,
+//				Content: cborArray{
+//					encodedTypeValueTypeFieldKey: StaticType(v.Type),
+//				},
+//		}
 func (v TypeValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
@@ -1014,10 +1033,11 @@ func EncodeStaticType(e *cbor.StreamEncoder, t StaticType) error {
 }
 
 // Encode encodes PrimitiveStaticType as
-// cbor.Tag{
-//		Number:  CBORTagPrimitiveStaticType,
-//		Content: uint(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagPrimitiveStaticType,
+//			Content: uint(v),
+//	}
 func (t PrimitiveStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
@@ -1030,10 +1050,11 @@ func (t PrimitiveStaticType) Encode(e *cbor.StreamEncoder) error {
 }
 
 // Encode encodes OptionalStaticType as
-// cbor.Tag{
-//		Number:  CBORTagOptionalStaticType,
-//		Content: StaticType(v.Type),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagOptionalStaticType,
+//			Content: StaticType(v.Type),
+//	}
 func (t OptionalStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
@@ -1058,13 +1079,14 @@ const (
 )
 
 // Encode encodes CompositeStaticType as
-// cbor.Tag{
-//			Number: CBORTagCompositeStaticType,
-// 			Content: cborArray{
-//				encodedCompositeStaticTypeLocationFieldKey:            Location(v.Location),
-//				encodedCompositeStaticTypeQualifiedIdentifierFieldKey: string(v.QualifiedIdentifier),
-//		},
-// }
+//
+//	cbor.Tag{
+//				Number: CBORTagCompositeStaticType,
+//				Content: cborArray{
+//					encodedCompositeStaticTypeLocationFieldKey:            Location(v.Location),
+//					encodedCompositeStaticTypeQualifiedIdentifierFieldKey: string(v.QualifiedIdentifier),
+//			},
+//	}
 func (t CompositeStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
@@ -1100,13 +1122,14 @@ const (
 )
 
 // Encode encodes InterfaceStaticType as
-// cbor.Tag{
-//		Number: CBORTagInterfaceStaticType,
-//		Content: cborArray{
-//				encodedInterfaceStaticTypeLocationFieldKey:            Location(v.Location),
-//				encodedInterfaceStaticTypeQualifiedIdentifierFieldKey: string(v.QualifiedIdentifier),
-//		},
-// }
+//
+//	cbor.Tag{
+//			Number: CBORTagInterfaceStaticType,
+//			Content: cborArray{
+//					encodedInterfaceStaticTypeLocationFieldKey:            Location(v.Location),
+//					encodedInterfaceStaticTypeQualifiedIdentifierFieldKey: string(v.QualifiedIdentifier),
+//			},
+//	}
 func (t InterfaceStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
@@ -1130,10 +1153,11 @@ func (t InterfaceStaticType) Encode(e *cbor.StreamEncoder) error {
 }
 
 // Encode encodes VariableSizedStaticType as
-// cbor.Tag{
-//		Number:  CBORTagVariableSizedStaticType,
-//		Content: StaticType(v.Type),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagVariableSizedStaticType,
+//			Content: StaticType(v.Type),
+//	}
 func (t VariableSizedStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
@@ -1158,13 +1182,14 @@ const (
 )
 
 // Encode encodes ConstantSizedStaticType as
-// cbor.Tag{
-//		Number: CBORTagConstantSizedStaticType,
-//		Content: cborArray{
-//				encodedConstantSizedStaticTypeSizeFieldKey: int64(v.Size),
-//				encodedConstantSizedStaticTypeTypeFieldKey: StaticType(v.Type),
-//		},
-// }
+//
+//	cbor.Tag{
+//			Number: CBORTagConstantSizedStaticType,
+//			Content: cborArray{
+//					encodedConstantSizedStaticTypeSizeFieldKey: int64(v.Size),
+//					encodedConstantSizedStaticTypeTypeFieldKey: StaticType(v.Type),
+//			},
+//	}
 func (t ConstantSizedStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
@@ -1198,13 +1223,14 @@ const (
 )
 
 // Encode encodes ReferenceStaticType as
-// cbor.Tag{
-//		Number: CBORTagReferenceStaticType,
-//		Content: cborArray{
-//				encodedReferenceStaticTypeAuthorizedFieldKey: bool(v.Authorized),
-//				encodedReferenceStaticTypeTypeFieldKey:       StaticType(v.Type),
-//		},
-//	}
+//
+//	cbor.Tag{
+//			Number: CBORTagReferenceStaticType,
+//			Content: cborArray{
+//					encodedReferenceStaticTypeAuthorizedFieldKey: bool(v.Authorized),
+//					encodedReferenceStaticTypeTypeFieldKey:       StaticType(v.Type),
+//			},
+//		}
 func (t ReferenceStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
@@ -1238,13 +1264,14 @@ const (
 )
 
 // Encode encodes DictionaryStaticType as
-// cbor.Tag{
-//		Number: CBORTagDictionaryStaticType,
-// 		Content: []any{
-//				encodedDictionaryStaticTypeKeyTypeFieldKey:   StaticType(v.KeyType),
-//				encodedDictionaryStaticTypeValueTypeFieldKey: StaticType(v.ValueType),
-//		},
-// }
+//
+//	cbor.Tag{
+//			Number: CBORTagDictionaryStaticType,
+//			Content: []any{
+//					encodedDictionaryStaticTypeKeyTypeFieldKey:   StaticType(v.KeyType),
+//					encodedDictionaryStaticTypeValueTypeFieldKey: StaticType(v.ValueType),
+//			},
+//	}
 func (t DictionaryStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
@@ -1278,13 +1305,14 @@ const (
 )
 
 // Encode encodes RestrictedStaticType as
-// cbor.Tag{
-//		Number: CBORTagRestrictedStaticType,
-//		Content: cborArray{
-//				encodedRestrictedStaticTypeTypeFieldKey:         StaticType(v.Type),
-//				encodedRestrictedStaticTypeRestrictionsFieldKey: []any(v.Restrictions),
-//		},
-// }
+//
+//	cbor.Tag{
+//			Number: CBORTagRestrictedStaticType,
+//			Content: cborArray{
+//					encodedRestrictedStaticTypeTypeFieldKey:         StaticType(v.Type),
+//					encodedRestrictedStaticTypeRestrictionsFieldKey: []any(v.Restrictions),
+//			},
+//	}
 func (t *RestrictedStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
@@ -1317,10 +1345,11 @@ func (t *RestrictedStaticType) Encode(e *cbor.StreamEncoder) error {
 }
 
 // Encode encodes CapabilityStaticType as
-// cbor.Tag{
-//		Number:  CBORTagCapabilityStaticType,
-//		Content: StaticType(v.BorrowType),
-// }
+//
+//	cbor.Tag{
+//			Number:  CBORTagCapabilityStaticType,
+//			Content: StaticType(v.BorrowType),
+//	}
 func (t CapabilityStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
@@ -1339,7 +1368,6 @@ func (t FunctionStaticType) Encode(_ *cbor.StreamEncoder) error {
 }
 
 // compositeTypeInfo
-//
 type compositeTypeInfo struct {
 	location            common.Location
 	qualifiedIdentifier string
@@ -1403,7 +1431,6 @@ func (c compositeTypeInfo) Equal(o atree.TypeInfo) bool {
 }
 
 // EmptyTypeInfo
-//
 type EmptyTypeInfo struct{}
 
 func (e EmptyTypeInfo) Encode(encoder *cbor.StreamEncoder) error {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -104,7 +104,6 @@ func (e StackTraceError) ImportLocation() common.Location {
 }
 
 // PositionedError wraps an unpositioned error with position info
-//
 type PositionedError struct {
 	Err error
 	ast.Range
@@ -280,7 +279,6 @@ func (e DivisionByZeroError) Error() string {
 }
 
 // InvalidatedResourceError
-//
 type InvalidatedResourceError struct {
 	LocationRange
 }
@@ -295,7 +293,6 @@ func (e InvalidatedResourceError) Error() string {
 
 // DestroyedResourceError is the error which is reported
 // when a user uses a destroyed resource through a reference
-//
 type DestroyedResourceError struct {
 	LocationRange
 }
@@ -309,7 +306,6 @@ func (e DestroyedResourceError) Error() string {
 }
 
 // ForceAssignmentToNonNilResourceError
-//
 type ForceAssignmentToNonNilResourceError struct {
 	LocationRange
 }
@@ -323,7 +319,6 @@ func (e ForceAssignmentToNonNilResourceError) Error() string {
 }
 
 // ForceNilError
-//
 type ForceNilError struct {
 	LocationRange
 }
@@ -337,7 +332,6 @@ func (e ForceNilError) Error() string {
 }
 
 // ForceCastTypeMismatchError
-//
 type ForceCastTypeMismatchError struct {
 	ExpectedType sema.Type
 	ActualType   sema.Type
@@ -357,7 +351,6 @@ func (e ForceCastTypeMismatchError) Error() string {
 }
 
 // TypeMismatchError
-//
 type TypeMismatchError struct {
 	ExpectedType sema.Type
 	ActualType   sema.Type
@@ -377,7 +370,6 @@ func (e TypeMismatchError) Error() string {
 }
 
 // InvalidPathDomainError
-//
 type InvalidPathDomainError struct {
 	ActualDomain    common.PathDomain
 	ExpectedDomains []common.PathDomain
@@ -409,7 +401,6 @@ func (e InvalidPathDomainError) SecondaryError() string {
 }
 
 // OverwriteError
-//
 type OverwriteError struct {
 	Address AddressValue
 	Path    PathValue
@@ -429,7 +420,6 @@ func (e OverwriteError) Error() string {
 }
 
 // CyclicLinkError
-//
 type CyclicLinkError struct {
 	Address common.Address
 	Paths   []PathValue
@@ -458,7 +448,6 @@ func (e CyclicLinkError) Error() string {
 }
 
 // ArrayIndexOutOfBoundsError
-//
 type ArrayIndexOutOfBoundsError struct {
 	Index int
 	Size  int
@@ -478,7 +467,6 @@ func (e ArrayIndexOutOfBoundsError) Error() string {
 }
 
 // ArraySliceIndicesError
-//
 type ArraySliceIndicesError struct {
 	FromIndex int
 	UpToIndex int
@@ -514,7 +502,6 @@ func (e InvalidSliceIndexError) Error() string {
 }
 
 // StringIndexOutOfBoundsError
-//
 type StringIndexOutOfBoundsError struct {
 	Index  int
 	Length int
@@ -534,7 +521,6 @@ func (e StringIndexOutOfBoundsError) Error() string {
 }
 
 // StringSliceIndicesError
-//
 type StringSliceIndicesError struct {
 	FromIndex int
 	UpToIndex int
@@ -554,7 +540,6 @@ func (e StringSliceIndicesError) Error() string {
 }
 
 // EventEmissionUnavailableError
-//
 type EventEmissionUnavailableError struct {
 	LocationRange
 }
@@ -568,7 +553,6 @@ func (e EventEmissionUnavailableError) Error() string {
 }
 
 // UUIDUnavailableError
-//
 type UUIDUnavailableError struct {
 	LocationRange
 }
@@ -582,7 +566,6 @@ func (e UUIDUnavailableError) Error() string {
 }
 
 // TypeLoadingError
-//
 type TypeLoadingError struct {
 	TypeID common.TypeID
 }
@@ -611,7 +594,6 @@ func (e MissingMemberValueError) Error() string {
 }
 
 // InvocationArgumentTypeError
-//
 type InvocationArgumentTypeError struct {
 	Index         int
 	ParameterType sema.Type
@@ -631,7 +613,6 @@ func (e InvocationArgumentTypeError) Error() string {
 }
 
 // MemberAccessTypeError
-//
 type MemberAccessTypeError struct {
 	ExpectedType sema.Type
 	ActualType   sema.Type
@@ -651,7 +632,6 @@ func (e MemberAccessTypeError) Error() string {
 }
 
 // ValueTransferTypeError
-//
 type ValueTransferTypeError struct {
 	ExpectedType sema.Type
 	ActualType   sema.Type
@@ -671,7 +651,6 @@ func (e ValueTransferTypeError) Error() string {
 }
 
 // ResourceConstructionError
-//
 type ResourceConstructionError struct {
 	CompositeType *sema.CompositeType
 	LocationRange
@@ -690,7 +669,6 @@ func (e ResourceConstructionError) Error() string {
 }
 
 // ContainerMutationError
-//
 type ContainerMutationError struct {
 	ExpectedType sema.Type
 	ActualType   sema.Type
@@ -710,7 +688,6 @@ func (e ContainerMutationError) Error() string {
 }
 
 // NonStorableValueError
-//
 type NonStorableValueError struct {
 	Value Value
 }
@@ -724,7 +701,6 @@ func (e NonStorableValueError) Error() string {
 }
 
 // NonStorableStaticTypeError
-//
 type NonStorableStaticTypeError struct {
 	Type sema.Type
 }
@@ -758,7 +734,6 @@ func (e InterfaceMissingLocationError) Error() string {
 }
 
 // InvalidOperandsError
-//
 type InvalidOperandsError struct {
 	Operation    ast.Operation
 	FunctionName string
@@ -807,7 +782,6 @@ func (e InvalidPublicKeyError) Unwrap() error {
 }
 
 // NonTransferableValueError
-//
 type NonTransferableValueError struct {
 	Value Value
 }
@@ -821,7 +795,6 @@ func (e NonTransferableValueError) Error() string {
 }
 
 // DuplicateKeyInResourceDictionaryError
-//
 type DuplicateKeyInResourceDictionaryError struct {
 	LocationRange
 }

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -31,7 +31,6 @@ import (
 )
 
 // FunctionValue
-//
 type FunctionValue interface {
 	Value
 	isFunctionValue()
@@ -43,7 +42,6 @@ type FunctionValue interface {
 }
 
 // InterpretedFunctionValue
-//
 type InterpretedFunctionValue struct {
 	Interpreter      *Interpreter
 	ParameterList    *ast.ParameterList
@@ -173,7 +171,6 @@ func (*InterpretedFunctionValue) DeepRemove(_ *Interpreter) {
 }
 
 // HostFunctionValue
-//
 type HostFunction func(invocation Invocation) Value
 
 type HostFunctionValue struct {
@@ -327,7 +324,6 @@ func (v *HostFunctionValue) SetNestedVariables(variables map[string]*Variable) {
 }
 
 // BoundFunctionValue
-//
 type BoundFunctionValue struct {
 	Function FunctionValue
 	Self     *CompositeValue

--- a/runtime/interpreter/globalvariables.go
+++ b/runtime/interpreter/globalvariables.go
@@ -19,7 +19,6 @@
 package interpreter
 
 // GlobalVariables represents global variables defined in a program.
-//
 type GlobalVariables map[string]*Variable
 
 func (globalVars GlobalVariables) Contains(name string) bool {

--- a/runtime/interpreter/hashablevalue.go
+++ b/runtime/interpreter/hashablevalue.go
@@ -23,7 +23,6 @@ import (
 )
 
 // HashableValue is an immutable value that can be hashed
-//
 type HashableValue interface {
 	Value
 	HashInput(interpreter *Interpreter, locationRange LocationRange, scratch []byte) []byte
@@ -52,7 +51,6 @@ func newHashInputProvider(interpreter *Interpreter, locationRange LocationRange)
 
 // HashInputType is a type flag that is included in the hash input for a value,
 // i.e., it should be included in the result of HashableValue.HashInput.
-//
 type HashInputType byte
 
 const (

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -31,7 +31,6 @@ import (
 
 // assignmentGetterSetter returns a getter/setter function pair
 // for the target expression
-//
 func (interpreter *Interpreter) assignmentGetterSetter(expression ast.Expression) getterSetter {
 	switch expression := expression.(type) {
 	case *ast.IdentifierExpression:
@@ -57,7 +56,6 @@ func (interpreter *Interpreter) assignmentGetterSetter(expression ast.Expression
 
 // identifierExpressionGetterSetter returns a getter/setter function pair
 // for the target identifier expression
-//
 func (interpreter *Interpreter) identifierExpressionGetterSetter(identifierExpression *ast.IdentifierExpression) getterSetter {
 	identifier := identifierExpression.Identifier.Identifier
 	variable := interpreter.FindVariable(identifier)
@@ -77,7 +75,6 @@ func (interpreter *Interpreter) identifierExpressionGetterSetter(identifierExpre
 
 // indexExpressionGetterSetter returns a getter/setter function pair
 // for the target index expression
-//
 func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast.IndexExpression) getterSetter {
 	target, ok := interpreter.evalExpression(indexExpression.TargetExpression).(ValueIndexableValue)
 	if !ok {
@@ -131,7 +128,6 @@ func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast
 
 // memberExpressionGetterSetter returns a getter/setter function pair
 // for the target member expression
-//
 func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *ast.MemberExpression) getterSetter {
 	target := interpreter.evalExpression(memberExpression.Expression)
 	identifier := memberExpression.Identifier.Identifier

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -138,7 +138,6 @@ func (interpreter *Interpreter) invokeInterpretedFunction(
 }
 
 // NOTE: assumes the function's activation (or an extension of it) is pushed!
-//
 func (interpreter *Interpreter) invokeInterpretedFunctionActivated(
 	function *InterpretedFunctionValue,
 	arguments []Value,
@@ -168,7 +167,6 @@ func (interpreter *Interpreter) invokeInterpretedFunctionActivated(
 }
 
 // bindParameterArguments binds the argument values to the given parameters
-//
 func (interpreter *Interpreter) bindParameterArguments(
 	parameterList *ast.ParameterList,
 	arguments []Value,

--- a/runtime/interpreter/invocation.go
+++ b/runtime/interpreter/invocation.go
@@ -24,7 +24,6 @@ import (
 )
 
 // Invocation
-//
 type Invocation struct {
 	Self               MemberAccessibleValue
 	Arguments          []Value
@@ -55,7 +54,6 @@ func NewInvocation(
 }
 
 // CallStack is the stack of invocations (call stack).
-//
 type CallStack struct {
 	Invocations []Invocation
 }

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -431,7 +431,6 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 // ConvertSemaToPrimitiveStaticType converts a `sema.Type` to a `PrimitiveStaticType`.
 //
 // Returns `PrimitiveStaticTypeUnknown` if the given type is not a primitive type.
-//
 func ConvertSemaToPrimitiveStaticType(
 	memoryGauge common.MemoryGauge,
 	t sema.Type,

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -38,7 +38,6 @@ const UnknownElementSize = 0
 //
 // This allows static types to be efficiently serialized and deserialized,
 // for example in the world state.
-//
 type StaticType interface {
 	fmt.Stringer
 	isStaticType()
@@ -414,7 +413,6 @@ func NewRestrictedStaticType(
 // which are used as keys in maps when exporting.
 // Key types in Go maps must be (transitively) hashable types,
 // and slices are not, but `Restrictions` is one.
-//
 func (*RestrictedStaticType) isStaticType() {}
 
 func (RestrictedStaticType) elementSize() uint {

--- a/runtime/interpreter/storage.go
+++ b/runtime/interpreter/storage.go
@@ -111,7 +111,6 @@ func (k StorageKey) IsLess(o StorageKey) bool {
 }
 
 // InMemoryStorage
-//
 type InMemoryStorage struct {
 	*atree.BasicSlabStorage
 	StorageMaps map[StorageKey]*StorageMap
@@ -165,7 +164,6 @@ func (i InMemoryStorage) CheckHealth() error {
 }
 
 // writeCounter is an io.Writer which counts the amount of written data.
-//
 type writeCounter struct {
 	length uint64
 }
@@ -179,7 +177,6 @@ func (w *writeCounter) Write(p []byte) (n int, err error) {
 }
 
 // mustStorableSize returns the result of StorableSize, and panics if it fails.
-//
 func mustStorableSize(storable atree.Storable) uint32 {
 	size, err := StorableSize(storable)
 	if err != nil {
@@ -189,7 +186,6 @@ func mustStorableSize(storable atree.Storable) uint32 {
 }
 
 // StorableSize returns the size of the storable in bytes.
-//
 func StorableSize(storable atree.Storable) (uint32, error) {
 	var writer writeCounter
 	enc := atree.NewEncoder(&writer, CBOREncMode)
@@ -215,7 +211,6 @@ func StorableSize(storable atree.Storable) (uint32, error) {
 // maybeLargeImmutableStorable either returns the given immutable atree.Storable
 // if it can be stored inline inside its parent container,
 // or else stores it in a separate slab and returns an atree.StorageIDStorable.
-//
 func maybeLargeImmutableStorable(
 	storable atree.Storable,
 	storage atree.SlabStorage,

--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -26,7 +26,6 @@ import (
 )
 
 // StorageMap is an ordered map which stores values in an account.
-//
 type StorageMap struct {
 	orderedMap *atree.OrderedMap
 }
@@ -65,7 +64,6 @@ func NewStorageMapWithRootID(storage atree.SlabStorage, storageID atree.StorageI
 }
 
 // ValueExists returns true if the given key exists in the storage map.
-//
 func (s StorageMap) ValueExists(key string) bool {
 	_, err := s.orderedMap.Get(
 		StringAtreeComparator,
@@ -84,7 +82,6 @@ func (s StorageMap) ValueExists(key string) bool {
 
 // ReadValue returns the value for the given key.
 // Returns nil if the key does not exist.
-//
 func (s StorageMap) ReadValue(gauge common.MemoryGauge, key string) Value {
 	storable, err := s.orderedMap.Get(
 		StringAtreeComparator,
@@ -104,7 +101,6 @@ func (s StorageMap) ReadValue(gauge common.MemoryGauge, key string) Value {
 // WriteValue sets or removes a value in the storage map.
 // If the given value is nil, the key is removed.
 // If the given value is non-nil, the key is added/updated.
-//
 func (s StorageMap) WriteValue(interpreter *Interpreter, key string, value atree.Value) {
 	if value == nil {
 		s.RemoveValue(interpreter, key)
@@ -115,7 +111,6 @@ func (s StorageMap) WriteValue(interpreter *Interpreter, key string, value atree
 
 // SetValue sets a value in the storage map.
 // If the given key already stores a value, it is overwritten.
-//
 func (s StorageMap) SetValue(interpreter *Interpreter, key string, value atree.Value) {
 	existingStorable, err := s.orderedMap.Set(
 		StringAtreeComparator,
@@ -136,7 +131,6 @@ func (s StorageMap) SetValue(interpreter *Interpreter, key string, value atree.V
 }
 
 // RemoveValue removes a value in the storage map, if it exists.
-//
 func (s StorageMap) RemoveValue(interpreter *Interpreter, key string) {
 	existingKeyStorable, existingValueStorable, err := s.orderedMap.Remove(
 		StringAtreeComparator,
@@ -168,7 +162,6 @@ func (s StorageMap) RemoveValue(interpreter *Interpreter, key string) {
 
 // Iterator returns an iterator (StorageMapIterator),
 // which allows iterating over the keys and values of the storage map
-//
 func (s StorageMap) Iterator(gauge common.MemoryGauge) StorageMapIterator {
 	mapIterator, err := s.orderedMap.Iterator()
 	if err != nil {
@@ -191,7 +184,6 @@ func (s StorageMap) Count() uint64 {
 }
 
 // StorageMapIterator is an iterator over StorageMap
-//
 type StorageMapIterator struct {
 	gauge       common.MemoryGauge
 	mapIterator *atree.MapIterator
@@ -200,7 +192,6 @@ type StorageMapIterator struct {
 
 // Next returns the next key and value of the storage map iterator.
 // If there is no further key-value pair, ("", nil) is returned.
-//
 func (i StorageMapIterator) Next() (string, Value) {
 	k, v, err := i.mapIterator.Next()
 	if err != nil {
@@ -219,7 +210,6 @@ func (i StorageMapIterator) Next() (string, Value) {
 
 // NextKey returns the next key of the storage map iterator.
 // If there is no further key, "" is returned.
-//
 func (i StorageMapIterator) NextKey() string {
 	k, err := i.mapIterator.NextKey()
 	if err != nil {
@@ -235,7 +225,6 @@ func (i StorageMapIterator) NextKey() string {
 
 // NextValue returns the next value in the storage map iterator.
 // If there is nop further value, nil is returned.
-//
 func (i StorageMapIterator) NextValue() Value {
 	v, err := i.mapIterator.NextValue()
 	if err != nil {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -56,11 +56,9 @@ type typeConformanceResultEntry struct {
 //
 // NOTE: Do not generalize to map[interpreter.Value],
 // as not all values are Go hashable, i.e. this might lead to run-time panics
-//
 type SeenReferences map[*EphemeralReferenceValue]struct{}
 
 // NonStorable represents a value that cannot be stored
-//
 type NonStorable struct {
 	Value Value
 }
@@ -198,7 +196,6 @@ func maybeDestroy(interpreter *Interpreter, locationRange LocationRange, value V
 
 // ReferenceTrackedResourceKindedValue is a resource-kinded value
 // that must be tracked when a reference of it is taken.
-//
 type ReferenceTrackedResourceKindedValue interface {
 	ResourceKindedValue
 	IsReferenceTrackedResourceKindedValue()
@@ -708,7 +705,6 @@ func (BoolValue) ChildStorables() []atree.Storable {
 // CharacterValue represents a Cadence character, which is a Unicode extended grapheme cluster.
 // Hence, use a Go string to be able to hold multiple Unicode code points (Go runes).
 // It should consist of exactly one grapheme cluster
-//
 type CharacterValue string
 
 func NewUnmeteredCharacterValue(r string) CharacterValue {
@@ -1176,7 +1172,6 @@ func (*StringValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 }
 
 // Length returns the number of characters (grapheme clusters)
-//
 func (v *StringValue) Length() int {
 	if v.length < 0 {
 		var length int
@@ -1264,7 +1259,6 @@ func (*StringValue) ChildStorables() []atree.Storable {
 var ByteArrayStaticType = ConvertSemaArrayTypeToStaticArrayType(nil, sema.ByteArrayType)
 
 // DecodeHex hex-decodes this string and returns an array of UInt8 values
-//
 func (v *StringValue) DecodeHex(interpreter *Interpreter, locationRange LocationRange) *ArrayValue {
 	bs, err := hex.DecodeString(v.Str)
 	if err != nil {
@@ -2593,7 +2587,6 @@ func (v *ArrayValue) Slice(
 }
 
 // NumberValue
-//
 type NumberValue interface {
 	EquatableValue
 	ToInt() int
@@ -2746,7 +2739,6 @@ type IntegerValue interface {
 }
 
 // BigNumberValue is a number value with an integer value outside the range of int64
-//
 type BigNumberValue interface {
 	NumberValue
 	ByteLength() int
@@ -9211,7 +9203,6 @@ var _ MemberAccessibleValue = UInt64Value(0)
 // UInt64 values > math.MaxInt64 overflow int.
 // Implementing BigNumberValue ensures conversion functions
 // call ToBigInt instead of ToInt.
-//
 var _ BigNumberValue = UInt64Value(0)
 
 var UInt64MemoryUsage = common.NewNumberMemoryUsage(int(unsafe.Sizeof(UInt64Value(0))))
@@ -9279,7 +9270,6 @@ func (v UInt64Value) ByteLength() int {
 // UInt64 values > math.MaxInt64 overflow int.
 // Implementing BigNumberValue ensures conversion functions
 // call ToBigInt instead of ToInt.
-//
 func (v UInt64Value) ToBigInt(memoryGauge common.MemoryGauge) *big.Int {
 	common.UseMemory(memoryGauge, common.NewBigIntMemoryUsage(v.ByteLength()))
 	return new(big.Int).SetUint64(uint64(v))
@@ -12280,7 +12270,6 @@ func NewUnmeteredWord64Value(value uint64) Word64Value {
 // Word64 values > math.MaxInt64 overflow int.
 // Implementing BigNumberValue ensures conversion functions
 // call ToBigInt instead of ToInt.
-//
 var _ BigNumberValue = Word64Value(0)
 
 func (Word64Value) IsValue() {}
@@ -12336,7 +12325,6 @@ func (v Word64Value) ByteLength() int {
 // Word64 values > math.MaxInt64 overflow int.
 // Implementing BigNumberValue ensures conversion functions
 // call ToBigInt instead of ToInt.
-//
 func (v Word64Value) ToBigInt(memoryGauge common.MemoryGauge) *big.Int {
 	common.UseMemory(memoryGauge, common.NewBigIntMemoryUsage(v.ByteLength()))
 	return new(big.Int).SetUint64(uint64(v))
@@ -12696,7 +12684,6 @@ func (Word64Value) ChildStorables() []atree.Storable {
 }
 
 // FixedPointValue is a fixed-point number value
-//
 type FixedPointValue interface {
 	NumberValue
 	IntegerPart() NumberValue
@@ -12704,7 +12691,6 @@ type FixedPointValue interface {
 }
 
 // Fix64Value
-//
 type Fix64Value int64
 
 const Fix64MaxValue = math.MaxInt64
@@ -13243,7 +13229,6 @@ func (Fix64Value) Scale() int {
 }
 
 // UFix64Value
-//
 type UFix64Value uint64
 
 const UFix64MaxValue = math.MaxUint64
@@ -13906,7 +13891,6 @@ func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
 
 // Walk iterates over all field values of the composite value.
 // It does NOT walk the computed fields and functions!
-//
 func (v *CompositeValue) Walk(interpreter *Interpreter, walkChild func(Value)) {
 	v.ForEachField(interpreter, func(_ string, value Value) {
 		walkChild(value)
@@ -14848,7 +14832,6 @@ func (v *CompositeValue) GetOwner() common.Address {
 
 // ForEachField iterates over all field-name field-value pairs of the composite value.
 // It does NOT iterate over computed fields and functions!
-//
 func (v *CompositeValue) ForEachField(gauge common.MemoryGauge, f func(fieldName string, fieldValue Value)) {
 
 	err := v.dictionary.Iterate(func(key atree.Value, value atree.Value) (resume bool, err error) {
@@ -17313,7 +17296,6 @@ func (*EphemeralReferenceValue) DeepRemove(_ *Interpreter) {
 }
 
 // AddressValue
-//
 type AddressValue common.Address
 
 func NewAddressValueFromBytes(memoryGauge common.MemoryGauge, constructor func() []byte) AddressValue {
@@ -17333,7 +17315,6 @@ func NewUnmeteredAddressValueFromBytes(b []byte) AddressValue {
 // This method must only be used if the `address` value is already constructed,
 // and/or already loaded onto memory. This is a convenient method for better performance.
 // If the `address` needs to be constructed, the `NewAddressValueFromConstructor` must be used.
-//
 func NewAddressValue(
 	memoryGauge common.MemoryGauge,
 	address common.Address,
@@ -18486,7 +18467,6 @@ var publicKeyVerifyPoPFunction = NewUnmeteredHostFunctionValue(
 // Under normal circumstances, a contract value is always a CompositeValue.
 // However, in the test framework, an imported contract is constructed via a constructor function.
 // Hence, during tests, the value is a HostFunctionValue.
-//
 type ContractValue interface {
 	Value
 	SetNestedVariables(variables map[string]*Variable)

--- a/runtime/interpreter/walk.go
+++ b/runtime/interpreter/walk.go
@@ -32,8 +32,6 @@ type ValueWalker interface {
 // followed by a call of WalkValue(nil) on the returned walker.
 //
 // The initial walker may not be nil.
-//
-//
 func WalkValue(interpreter *Interpreter, walker ValueWalker, value Value) {
 	if walker = walker.WalkValue(interpreter, value); walker == nil {
 		return

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -38,7 +38,6 @@ var LiteralExpressionTypeError = parser.NewUnpositionedSyntaxError("input is not
 //
 // Returns an error if the literal string is not a literal (e.g. it does not have valid syntax,
 // or does not parse to a literal).
-//
 func ParseLiteral(
 	literal string,
 	ty sema.Type,
@@ -65,7 +64,6 @@ func ParseLiteral(
 //
 // Note: This method is not used directly within Cadence, but used by downstream dependencies
 // such as CLI, playground, etc. Hence, shouldn't be moved to test.
-//
 func ParseLiteralArgumentList(
 	argumentList string,
 	parameterTypes []sema.Type,

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -130,11 +130,10 @@ var enumeratedAccessModifierKeywords = common.EnumerateWords(
 
 // parseAccess parses an access modifier
 //
-//     access
-//         : 'priv'
-//         | 'pub' ( '(' 'set' ')' )?
-//         | 'access' '(' ( 'self' | 'contract' | 'account' | 'all' ) ')'
-//
+//	access
+//	    : 'priv'
+//	    | 'pub' ( '(' 'set' ')' )?
+//	    | 'access' '(' ( 'self' | 'contract' | 'account' | 'all' ) ')'
 func parseAccess(p *parser) (ast.Access, error) {
 
 	switch string(p.currentTokenSource()) {
@@ -245,13 +244,12 @@ func parseAccess(p *parser) (ast.Access, error) {
 
 // parseVariableDeclaration parses a variable declaration.
 //
-//     variableKind : 'var' | 'let'
+//	variableKind : 'var' | 'let'
 //
-//     variableDeclaration :
-//         variableKind identifier ( ':' typeAnnotation )?
-//         transfer expression
-//         ( transfer expression )?
-//
+//	variableDeclaration :
+//	    variableKind identifier ( ':' typeAnnotation )?
+//	    transfer expression
+//	    ( transfer expression )?
 func parseVariableDeclaration(
 	p *parser,
 	access ast.Access,
@@ -343,8 +341,7 @@ func parseVariableDeclaration(
 
 // parseTransfer parses a transfer.
 //
-//     transfer : '=' | '<-' | '<-!'
-//
+//	transfer : '=' | '<-' | '<-!'
 func parseTransfer(p *parser) *ast.Transfer {
 	var operation ast.TransferOperation
 
@@ -396,11 +393,10 @@ func parsePragmaDeclaration(p *parser) (*ast.PragmaDeclaration, error) {
 
 // parseImportDeclaration parses an import declaration
 //
-//     importDeclaration :
-//         'import'
-//         ( identifier (',' identifier)* 'from' )?
-//         ( string | hexadecimalLiteral | identifier )
-//
+//	importDeclaration :
+//	    'import'
+//	    ( identifier (',' identifier)* 'from' )?
+//	    ( string | hexadecimalLiteral | identifier )
 func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 
 	startPosition := p.current.StartPos
@@ -681,8 +677,7 @@ func parseHexadecimalLocation(p *parser) common.AddressLocation {
 
 // parseEventDeclaration parses an event declaration.
 //
-//     eventDeclaration : 'event' identifier parameterList
-//
+//	eventDeclaration : 'event' identifier parameterList
 func parseEventDeclaration(
 	p *parser,
 	access ast.Access,
@@ -755,8 +750,7 @@ func parseEventDeclaration(
 
 // parseCompositeKind parses a composite kind.
 //
-//     compositeKind : 'struct' | 'resource' | 'contract' | 'enum'
-//
+//	compositeKind : 'struct' | 'resource' | 'contract' | 'enum'
 func parseCompositeKind(p *parser) common.CompositeKind {
 
 	if p.current.Is(lexer.TokenIdentifier) {
@@ -780,10 +774,9 @@ func parseCompositeKind(p *parser) common.CompositeKind {
 
 // parseFieldWithVariableKind parses a field which has a variable kind.
 //
-//     variableKind : 'var' | 'let'
+//	variableKind : 'var' | 'let'
 //
-//     field : variableKind identifier ':' typeAnnotation
-//
+//	field : variableKind identifier ':' typeAnnotation
 func parseFieldWithVariableKind(
 	p *parser,
 	access ast.Access,
@@ -850,14 +843,13 @@ func parseFieldWithVariableKind(
 
 // parseCompositeOrInterfaceDeclaration parses an event declaration.
 //
-//     conformances : ':' nominalType ( ',' nominalType )*
+//	conformances : ':' nominalType ( ',' nominalType )*
 //
-//     compositeDeclaration : compositeKind identifier conformances?
-//                            '{' membersAndNestedDeclarations '}'
+//	compositeDeclaration : compositeKind identifier conformances?
+//	                       '{' membersAndNestedDeclarations '}'
 //
-//     interfaceDeclaration : compositeKind 'interface' identifier conformances?
-//                            '{' membersAndNestedDeclarations '}'
-//
+//	interfaceDeclaration : compositeKind 'interface' identifier conformances?
+//	                       '{' membersAndNestedDeclarations '}'
 func parseCompositeOrInterfaceDeclaration(
 	p *parser,
 	access ast.Access,
@@ -989,8 +981,7 @@ func parseCompositeOrInterfaceDeclaration(
 // parseMembersAndNestedDeclarations parses composite or interface members,
 // and nested declarations.
 //
-//     membersAndNestedDeclarations : ( memberOrNestedDeclaration ';'* )*
-//
+//	membersAndNestedDeclarations : ( memberOrNestedDeclaration ';'* )*
 func parseMembersAndNestedDeclarations(p *parser, endTokenType lexer.TokenType) (*ast.Members, error) {
 
 	var declarations []ast.Declaration
@@ -1028,14 +1019,13 @@ func parseMembersAndNestedDeclarations(p *parser, endTokenType lexer.TokenType) 
 // parseMemberOrNestedDeclaration parses a composite or interface member,
 // or a declaration nested in it.
 //
-//     memberOrNestedDeclaration : field
-//                               | specialFunctionDeclaration
-//                               | functionDeclaration
-//                               | interfaceDeclaration
-//                               | compositeDeclaration
-//                               | eventDeclaration
-//                               | enumCase
-//
+//	memberOrNestedDeclaration : field
+//	                          | specialFunctionDeclaration
+//	                          | functionDeclaration
+//	                          | interfaceDeclaration
+//	                          | compositeDeclaration
+//	                          | eventDeclaration
+//	                          | enumCase
 func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 	const functionBlockIsOptional = true
@@ -1217,8 +1207,7 @@ func parseSpecialFunctionDeclaration(
 
 // parseEnumCase parses a field which has a variable kind.
 //
-//     enumCase : 'case' identifier
-//
+//	enumCase : 'case' identifier
 func parseEnumCase(
 	p *parser,
 	access ast.Access,

--- a/runtime/parser/docstring.go
+++ b/runtime/parser/docstring.go
@@ -31,7 +31,6 @@ var pragmaArgumentRegexp = regexp.MustCompile(`^\s+pragma\s+arguments\s+(.*)(?:\
 // where <argument-list> is a Cadence argument list.
 //
 // The validity of the argument list is NOT checked by this function.
-//
 func ParseDocstringPragmaArguments(docString string) []string {
 	var pragmaArguments []string
 
@@ -54,7 +53,6 @@ var pragmaSignersRegexp = regexp.MustCompile(`^\s+pragma\s+signers\s+(.*)(?:\n|$
 // where <signers-list> is a list of strings.
 //
 // The validity of the argument list is NOT checked by this function.
-//
 func ParseDocstringPragmaSigners(docString string) []string {
 	var pragmaSigners []string
 

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -692,7 +692,6 @@ func defineLessThanOrTypeArgumentsExpression() {
 // because that would introduce a parsing problem for function calls/invocations
 // which have a type argument, where the type argument is a type instantiation,
 // for example, `f<T<U>>()`.
-//
 func defineGreaterThanOrBitwiseRightShiftExpression() {
 
 	setExprMetaLeftDenotation(
@@ -934,8 +933,7 @@ func parseCreateExpressionRemainder(p *parser, token lexer.Token) (*ast.CreateEx
 
 // Invocation Expression Grammar:
 //
-//     invocation : '(' ( argument ( ',' argument )* )? ')'
-//
+//	invocation : '(' ( argument ( ',' argument )* )? ')'
 func defineInvocationExpression() {
 	setExprLeftBindingPower(lexer.TokenParenOpen, exprLeftBindingPowerAccess)
 
@@ -1017,8 +1015,7 @@ func parseArgumentListRemainder(p *parser) (arguments []*ast.Argument, endPos as
 
 // parseArgument parses an argument in an invocation.
 //
-//     argument : (identifier ':' )? expression
-//
+//	argument : (identifier ':' )? expression
 func parseArgument(p *parser) (*ast.Argument, error) {
 	var label string
 	var labelStartPos, labelEndPos ast.Position
@@ -1390,7 +1387,6 @@ func exprLeftDenotationAllowsWhitespaceAfterToken(tokenType lexer.TokenType) boo
 
 // parseExpression uses "Top-Down operator precedence parsing" (TDOP) technique to
 // parse expressions.
-//
 func parseExpression(p *parser, rightBindingPower int) (ast.Expression, error) {
 
 	if p.expressionDepth == expressionDepthLimit {
@@ -1464,7 +1460,6 @@ func applyExprMetaLeftDenotation(
 
 // defaultExprMetaLeftDenotation is the default expression left denotation, which applies
 // if the right binding power is less than the left binding power of the current token
-//
 func defaultExprMetaLeftDenotation(
 	p *parser,
 	rightBindingPower int,
@@ -1524,7 +1519,6 @@ func applyExprLeftDenotation(p *parser, token lexer.Token, left ast.Expression) 
 }
 
 // parseStringLiteral parses a whole string literal, including start and end quotes
-//
 func parseStringLiteral(p *parser, literal []byte) (result string) {
 	length := len(literal)
 	if length == 0 {
@@ -1563,7 +1557,6 @@ func parseStringLiteral(p *parser, literal []byte) (result string) {
 }
 
 // parseStringLiteralContent parses the string literalExpr contents, excluding start and end quotes
-//
 func parseStringLiteralContent(p *parser, s []byte) (result string) {
 
 	var builder strings.Builder

--- a/runtime/parser/lexer/lexer.go
+++ b/runtime/parser/lexer/lexer.go
@@ -237,7 +237,6 @@ func (l *lexer) word() []byte {
 // acceptOne reads one rune ahead.
 // It returns true if the next rune matches with the input rune,
 // otherwise it steps back one rune and returns false.
-//
 func (l *lexer) acceptOne(r rune) bool {
 	if l.next() == r {
 		return true

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -72,7 +72,6 @@ type parser struct {
 //
 // It can be composed with different parse functions to parse the input string into different results.
 // See "ParseExpression", "ParseStatements" as examples.
-//
 func Parse[T any](
 	input []byte,
 	parse func(*parser) (T, error),

--- a/runtime/parser/statement.go
+++ b/runtime/parser/statement.go
@@ -532,7 +532,6 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 }
 
 // parseConditions parses conditions (pre/post)
-//
 func parseConditions(p *parser, kind ast.ConditionKind) (conditions ast.Conditions, err error) {
 
 	p.skipSpaceAndComments(true)
@@ -570,8 +569,7 @@ func parseConditions(p *parser, kind ast.ConditionKind) (conditions ast.Conditio
 
 // parseCondition parses a condition (pre/post)
 //
-//    condition : expression (':' expression )?
-//
+//	condition : expression (':' expression )?
 func parseCondition(p *parser, kind ast.ConditionKind) (*ast.Condition, error) {
 
 	test, err := parseExpression(p, lowestBindingPower)
@@ -651,8 +649,7 @@ func parseSwitchStatement(p *parser) (*ast.SwitchStatement, error) {
 
 // parseSwitchCases parses cases of a switch statement.
 //
-//     switchCases : switchCase*
-//
+//	switchCases : switchCase*
 func parseSwitchCases(p *parser) (cases []*ast.SwitchCase, err error) {
 
 	reportUnexpected := func() {
@@ -702,9 +699,8 @@ func parseSwitchCases(p *parser) (cases []*ast.SwitchCase, err error) {
 // parseSwitchCase parses a switch case (hasExpression == true)
 // or default case (hasExpression == false)
 //
-//     switchCase : `case` expression `:` statements
-//                | `default` `:` statements
-//
+//	switchCase : `case` expression `:` statements
+//	           | `default` `:` statements
 func parseSwitchCase(p *parser, hasExpression bool) (*ast.SwitchCase, error) {
 
 	startPos := p.current.StartPos

--- a/runtime/parser/transaction.go
+++ b/runtime/parser/transaction.go
@@ -26,20 +26,19 @@ import (
 
 // parseTransactionDeclaration parses a transaction declaration.
 //
-//     transactionDeclaration : 'transaction'
-//         parameterList?
-//         '{'
-//         fields
-//         prepare?
-//         preConditions?
-//         ( execute
-//         | execute postConditions
-//         | postConditions
-//         | postConditions execute
-//         | /* no execute or postConditions */
-//         )
-//         '}'
-//
+//	transactionDeclaration : 'transaction'
+//	    parameterList?
+//	    '{'
+//	    fields
+//	    prepare?
+//	    preConditions?
+//	    ( execute
+//	    | execute postConditions
+//	    | postConditions
+//	    | postConditions execute
+//	    | /* no execute or postConditions */
+//	    )
+//	    '}'
 func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionDeclaration, error) {
 
 	startPos := p.current.StartPos

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -563,7 +563,6 @@ func defineRestrictedOrDictionaryType() {
 }
 
 // parseNominalTypes parses zero or more nominal types separated by comma.
-//
 func parseNominalTypes(
 	p *parser,
 	endTokenType lexer.TokenType,
@@ -791,7 +790,6 @@ func applyTypeMetaLeftDenotation(
 
 // defaultTypeMetaLeftDenotation is the default type left denotation, which applies
 // if the right binding power is less than the left binding power of the current token
-//
 func defaultTypeMetaLeftDenotation(
 	p *parser,
 	rightBindingPower int,
@@ -904,7 +902,6 @@ func parseNominalTypeInvocationRemainder(p *parser) (*ast.InvocationExpression, 
 }
 
 // parseCommaSeparatedTypeAnnotations parses zero or more type annotations separated by comma.
-//
 func parseCommaSeparatedTypeAnnotations(
 	p *parser,
 	endTokenType lexer.TokenType,

--- a/runtime/sema/any_type.go
+++ b/runtime/sema/any_type.go
@@ -20,7 +20,6 @@ package sema
 
 // AnyType represents the top type of all types.
 // NOTE: This type is only used internally and is not available in programs.
-//
 var AnyType = &SimpleType{
 	Name:          "Any",
 	QualifiedName: "Any",

--- a/runtime/sema/anyresource_type.go
+++ b/runtime/sema/anyresource_type.go
@@ -19,7 +19,6 @@
 package sema
 
 // AnyResourceType represents the top type of all resource types
-//
 var AnyResourceType = &SimpleType{
 	Name:          "AnyResource",
 	QualifiedName: "AnyResource",

--- a/runtime/sema/anystruct_type.go
+++ b/runtime/sema/anystruct_type.go
@@ -19,7 +19,6 @@
 package sema
 
 // AnyStructType represents the top type of all non-resource types
-//
 var AnyStructType = &SimpleType{
 	Name:          "AnyStruct",
 	QualifiedName: "AnyStruct",

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -30,7 +30,6 @@ const AuthAccountContractsTypeUpdateExperimentalFunctionName = "update__experime
 const AuthAccountContractsTypeNamesField = "names"
 
 // AuthAccountContractsType represents the type `AuthAccount.Contracts`
-//
 var AuthAccountContractsType = func() *CompositeType {
 
 	authAccountContractsType := &CompositeType{

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -55,7 +55,6 @@ const AuthAccountInboxClaimField = "claim"
 // AuthAccountType represents the authorized access to an account.
 // Access to an AuthAccount means having full access to its storage, public keys, and code.
 // Only signed transactions can get the AuthAccount for an account.
-//
 var AuthAccountType = func() *CompositeType {
 
 	authAccountType := &CompositeType{

--- a/runtime/sema/block.go
+++ b/runtime/sema/block.go
@@ -24,7 +24,6 @@ import (
 )
 
 // BlockType
-//
 var BlockType = &SimpleType{
 	Name:                 "Block",
 	QualifiedName:        "Block",

--- a/runtime/sema/bool_type.go
+++ b/runtime/sema/bool_type.go
@@ -19,7 +19,6 @@
 package sema
 
 // BoolType represents the boolean type
-//
 var BoolType = &SimpleType{
 	Name:                 "Bool",
 	QualifiedName:        "Bool",

--- a/runtime/sema/character_type.go
+++ b/runtime/sema/character_type.go
@@ -26,7 +26,6 @@ import (
 )
 
 // CharacterType represents the character type
-//
 var CharacterType = &SimpleType{
 	Name:                 "Character",
 	QualifiedName:        "Character",

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -163,7 +163,6 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 // FailableCastCanSucceed checks a failable (dynamic) cast, i.e. a cast that might succeed at run-time.
 // It returns true if the cast from subType to superType could potentially succeed at run-time,
 // and returns false if the cast will definitely always fail.
-//
 func FailableCastCanSucceed(subType, superType Type) bool {
 
 	// TODO: report impossible casts, e.g.

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -39,7 +39,6 @@ func (checker *Checker) VisitCompositeDeclaration(declaration *ast.CompositeDecl
 // `declareCompositeType` and exists in `checker.Elaboration.CompositeDeclarationTypes`,
 // and that the members and nested declarations for the composite type were declared
 // through `declareCompositeMembersAndValue`.
-//
 func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDeclaration, kind ContainerKind) {
 
 	compositeType := checker.Elaboration.CompositeDeclarationTypes[declaration]
@@ -216,7 +215,6 @@ func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDecl
 //
 // It assumes the types were previously added to the elaboration in `CompositeNestedDeclarations`,
 // and the type for the declaration was added to the elaboration in `CompositeDeclarationTypes`.
-//
 func (checker *Checker) declareCompositeNestedTypes(
 	declaration *ast.CompositeDeclaration,
 	kind ContainerKind,
@@ -419,7 +417,6 @@ func (checker *Checker) declareNestedDeclarations(
 //
 // See `declareCompositeMembersAndValue` for the declaration of the composite type members.
 // See `visitCompositeDeclaration` for the checking of the composite declaration.
-//
 func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclaration) *CompositeType {
 
 	identifier := declaration.Identifier
@@ -502,7 +499,6 @@ func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclarati
 //
 // NOTE: This function assumes that the composite type was previously declared using
 // `declareCompositeType` and exists in `checker.Elaboration.CompositeDeclarationTypes`.
-//
 func (checker *Checker) declareCompositeMembersAndValue(
 	declaration *ast.CompositeDeclaration,
 	kind ContainerKind,
@@ -887,7 +883,6 @@ func EnumConstructorType(compositeType *CompositeType) *FunctionType {
 }
 
 // checkMemberStorability check that all fields have a type that is storable.
-//
 func (checker *Checker) checkMemberStorability(members *StringMemberOrderedMap) {
 
 	storableResults := map[*Member]bool{}
@@ -1042,7 +1037,6 @@ type compositeConformanceCheckOptions struct {
 // typeRequirementsInheritedMembers is an "input/output parameter":
 // It tracks which members were inherited in each nested type, which may be a conformance to a type requirement.
 // It allows tracking this across conformance checks of multiple interfaces' type requirements.
-//
 func (checker *Checker) checkCompositeConformance(
 	compositeDeclaration *ast.CompositeDeclaration,
 	compositeType *CompositeType,
@@ -1307,7 +1301,6 @@ func (checker *Checker) memberSatisfied(compositeMember, interfaceMember *Member
 
 // checkTypeRequirement checks conformance of a nested type declaration
 // to a type requirement of an interface.
-//
 func (checker *Checker) checkTypeRequirement(
 	declaredType Type,
 	containerDeclaration *ast.CompositeDeclaration,
@@ -1828,7 +1821,6 @@ func (checker *Checker) checkInitializers(
 // checkNoInitializerNoFields checks that if there are no initializers,
 // then there should also be no fields. Otherwise the fields will be uninitialized.
 // In interfaces this is allowed.
-//
 func (checker *Checker) checkNoInitializerNoFields(
 	fields []*ast.FieldDeclaration,
 	containerType Type,
@@ -1971,7 +1963,6 @@ func (checker *Checker) declareSelfValue(selfType Type, selfDocString string) {
 
 // checkNestedIdentifiers checks that nested identifiers, i.e. fields, functions,
 // and nested interfaces and composites, are unique and aren't named `init` or `destroy`
-//
 func (checker *Checker) checkNestedIdentifiers(members *ast.Members) {
 	positions := map[string]ast.Position{}
 
@@ -1996,7 +1987,6 @@ func (checker *Checker) checkNestedIdentifiers(members *ast.Members) {
 
 // checkNestedIdentifier checks that the nested identifier is unique
 // and isn't named `init` or `destroy`
-//
 func (checker *Checker) checkNestedIdentifier(
 	identifier ast.Identifier,
 	kind common.DeclarationKind,
@@ -2047,7 +2037,6 @@ func (checker *Checker) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) str
 
 // checkUnknownSpecialFunctions checks that the special function declarations
 // are supported, i.e., they are either initializers or destructors
-//
 func (checker *Checker) checkUnknownSpecialFunctions(functions []*ast.SpecialFunctionDeclaration) {
 	for _, function := range functions {
 		switch function.Kind {
@@ -2139,7 +2128,6 @@ func (checker *Checker) checkDestructors(
 // checkNoDestructorNoResourceFields checks that if there is no destructor there are
 // also no fields which have a resource type – otherwise those fields will be lost.
 // In interfaces this is allowed.
-//
 func (checker *Checker) checkNoDestructorNoResourceFields(
 	members *StringMemberOrderedMap,
 	fields map[string]*ast.FieldDeclaration,
@@ -2206,7 +2194,6 @@ func (checker *Checker) checkDestructor(
 
 // checkCompositeResourceInvalidated checks that if the container is a resource,
 // that all resource fields are invalidated (moved or destroyed)
-//
 func (checker *Checker) checkCompositeResourceInvalidated(containerType Type) {
 	compositeType, isComposite := containerType.(*CompositeType)
 	if !isComposite || compositeType.Kind != common.CompositeKindResource {
@@ -2218,7 +2205,6 @@ func (checker *Checker) checkCompositeResourceInvalidated(containerType Type) {
 
 // checkResourceFieldsInvalidated checks that all resource fields for a container
 // type are invalidated.
-//
 func (checker *Checker) checkResourceFieldsInvalidated(
 	containerType Type,
 	members *StringMemberOrderedMap,
@@ -2248,7 +2234,6 @@ func (checker *Checker) checkResourceFieldsInvalidated(
 
 // checkResourceUseAfterInvalidation checks if a resource (variable or composite member)
 // is used after it was previously invalidated (moved or destroyed)
-//
 func (checker *Checker) checkResourceUseAfterInvalidation(resource Resource, usePosition ast.HasPosition) {
 	resourceInfo := checker.resources.Get(resource)
 	invalidation := resourceInfo.Invalidation()

--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -120,7 +120,6 @@ func (checker *Checker) VisitConditionalExpression(expression *ast.ConditionalEx
 // It is assumed that either one of the branches is taken, so function returns,
 // resource uses and invalidations, as well as field initializations,
 // are only potential in each branch, but definite if they occur in both branches.
-//
 func (checker *Checker) checkConditionalBranches(
 	checkThen TypeCheckFunc,
 	checkElse TypeCheckFunc,
@@ -188,7 +187,6 @@ func (checker *Checker) checkConditionalBranches(
 // checkBranch checks a conditional branch.
 // It is assumed that function returns, resource uses and invalidations,
 // as well as field initializations, are only potential / temporary.
-//
 func (checker *Checker) checkBranch(
 	check TypeCheckFunc,
 	temporaryReturnInfo *ReturnInfo,

--- a/runtime/sema/check_event_declaration.go
+++ b/runtime/sema/check_event_declaration.go
@@ -25,7 +25,6 @@ import (
 
 // checkEventParameters checks that the event initializer's parameters are valid,
 // as determined by `isValidEventParameterType`.
-//
 func (checker *Checker) checkEventParameters(
 	parameterList *ast.ParameterList,
 	parameters []*Parameter,
@@ -56,7 +55,6 @@ func (checker *Checker) checkEventParameters(
 // IsValidEventParameterType returns true if the given type is a valid event parameter type.
 //
 // Events currently only support a few simple Cadence types.
-//
 func IsValidEventParameterType(t Type, results map[*Member]bool) bool {
 
 	switch t := t.(type) {

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -49,7 +49,6 @@ func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpr
 
 // checkSelfVariableUseInInitializer checks uses of `self` in the initializer
 // and ensures it is properly initialized
-//
 func (checker *Checker) checkSelfVariableUseInInitializer(variable *Variable, position ast.Position) {
 
 	// Is this a use of `self`?
@@ -113,7 +112,6 @@ func (checker *Checker) checkSelfVariableUseInInitializer(variable *Variable, po
 }
 
 // checkResourceVariableCapturingInFunction checks if a resource variable is captured in a function
-//
 func (checker *Checker) checkResourceVariableCapturingInFunction(variable *Variable, useIdentifier ast.Identifier) {
 	currentFunctionDepth := -1
 	currentFunctionActivation := checker.functionActivations.Current()
@@ -241,7 +239,6 @@ func (checker *Checker) VisitIndexExpression(expression *ast.IndexExpression) Ty
 // visitIndexExpression checks if the indexed expression is indexable,
 // checks if the indexing expression can be used to index into the indexed expression,
 // and returns the expected element type
-//
 func (checker *Checker) visitIndexExpression(
 	indexExpression *ast.IndexExpression,
 	isAssignment bool,

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -192,7 +192,6 @@ func (checker *Checker) checkFunction(
 // checkFunctionExits checks that the given function block exits
 // with a return-type appropriate return statement.
 // The return is not needed if the function has a `Void` return type.
-//
 func (checker *Checker) checkFunctionExits(functionBlock *ast.FunctionBlock, returnType Type) {
 
 	if returnType == VoidType {
@@ -228,7 +227,6 @@ func (checker *Checker) checkParameters(parameterList *ast.ParameterList, parame
 }
 
 // checkArgumentLabels checks that all argument labels (if any) are unique
-//
 func (checker *Checker) checkArgumentLabels(parameterList *ast.ParameterList) {
 
 	argumentLabelPositions := map[string]ast.Position{}
@@ -258,7 +256,6 @@ func (checker *Checker) checkArgumentLabels(parameterList *ast.ParameterList) {
 
 // declareParameters declares a constant for each parameter,
 // ensuring names are unique and constants don't already exist
-//
 func (checker *Checker) declareParameters(
 	parameterList *ast.ParameterList,
 	parameters []*Parameter,

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -30,7 +30,6 @@ import (
 // `declareInterfaceType` and exists in `checker.Elaboration.InterfaceDeclarationTypes`,
 // and that the members and nested declarations for the interface type were declared
 // through `declareInterfaceMembers`.
-//
 func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) (_ struct{}) {
 
 	const kind = ContainerKindInterface
@@ -133,7 +132,6 @@ func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDecl
 //
 // It assumes the types were previously added to the elaboration in `InterfaceNestedDeclarations`,
 // and the type for the declaration was added to the elaboration in `InterfaceDeclarationTypes`.
-//
 func (checker *Checker) declareInterfaceNestedTypes(
 	declaration *ast.InterfaceDeclaration,
 ) {
@@ -222,7 +220,6 @@ func (checker *Checker) checkInterfaceFunctions(
 //
 // See `declareInterfaceMembers` for the declaration of the interface type members.
 // See `VisitInterfaceDeclaration` for the checking of the interface declaration.
-//
 func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclaration) *InterfaceType {
 
 	identifier := declaration.Identifier
@@ -302,7 +299,6 @@ func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclarati
 // NOTE: This function assumes that the interface type and the nested declarations' types
 // were previously declared using `declareInterfaceType` and exists
 // in the elaboration's `InterfaceDeclarationTypes` and `InterfaceNestedDeclarations` fields.
-//
 func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclaration) {
 
 	interfaceType := checker.Elaboration.InterfaceDeclarationTypes[declaration]

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -482,7 +482,6 @@ func (checker *Checker) checkInvocation(
 
 // checkTypeParameterInference checks that all type parameters
 // of the given generic function type have been assigned a type.
-//
 func (checker *Checker) checkTypeParameterInference(
 	functionType *FunctionType,
 	typeArguments *TypeParameterTypeOrderedMap,

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -24,7 +24,6 @@ import (
 )
 
 // NOTE: only called if the member expression is *not* an assignment
-//
 func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) Type {
 	accessedType, member, isOptional := checker.visitMember(expression)
 
@@ -288,7 +287,6 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 
 // isReadableMember returns true if the given member can be read from
 // in the current location of the checker
-//
 func (checker *Checker) isReadableMember(member *Member) bool {
 	if checker.isReadableAccess(member.Access) ||
 		checker.containerTypes[member.ContainerType] {
@@ -326,7 +324,6 @@ func (checker *Checker) isReadableMember(member *Member) bool {
 
 // isWriteableMember returns true if the given member can be written to
 // in the current location of the checker
-//
 func (checker *Checker) isWriteableMember(member *Member) bool {
 	return checker.isWriteableAccess(member.Access) ||
 		checker.containerTypes[member.ContainerType]
@@ -343,7 +340,6 @@ func (checker *Checker) isMutatableMember(member *Member) bool {
 // of the given type, if any.
 //
 // The given type itself might be the result.
-//
 func containingContractKindedType(t Type) CompositeKindedType {
 	for {
 		if compositeKindedType, ok := t.(CompositeKindedType); ok &&

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -24,7 +24,6 @@ import (
 
 // VisitReferenceExpression checks a reference expression `&t as T`,
 // where `t` is the referenced expression, and `T` is the result type.
-//
 func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.ReferenceExpression) Type {
 
 	// Check the result type and ensure it is a reference type

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -113,7 +113,6 @@ func (checker *Checker) checkTransactionParameters(declaration *ast.TransactionD
 }
 
 // checkTransactionFields validates the field declarations for a transaction.
-//
 func (checker *Checker) checkTransactionFields(declaration *ast.TransactionDeclaration) {
 	for _, field := range declaration.Fields {
 		if field.Access != ast.AccessNotSpecified {
@@ -131,7 +130,6 @@ func (checker *Checker) checkTransactionFields(declaration *ast.TransactionDecla
 // checkTransactionBlocks checks that a transaction contains the required prepare and execute blocks.
 //
 // An execute block is always required, but a prepare block is only required if fields are present.
-//
 func (checker *Checker) checkTransactionBlocks(declaration *ast.TransactionDeclaration) {
 	if declaration.Prepare != nil {
 		// parser allows any identifier so it must be checked here
@@ -170,7 +168,6 @@ func (checker *Checker) checkTransactionBlocks(declaration *ast.TransactionDecla
 }
 
 // visitTransactionPrepareFunction visits and checks the prepare function of a transaction.
-//
 func (checker *Checker) visitTransactionPrepareFunction(
 	prepareFunction *ast.SpecialFunctionDeclaration,
 	transactionType *TransactionType,
@@ -201,7 +198,6 @@ func (checker *Checker) visitTransactionPrepareFunction(
 }
 
 // checkTransactionPrepareFunctionParameters checks that the parameters are each of type Account.
-//
 func (checker *Checker) checkTransactionPrepareFunctionParameters(
 	parameterList *ast.ParameterList,
 	parameters []*Parameter,

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -24,7 +24,6 @@ import (
 )
 
 // DeployedContractType represents the type `DeployedContract`
-//
 var DeployedContractType = &SimpleType{
 	Name:                 "DeployedContract",
 	QualifiedName:        "DeployedContract",

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -211,7 +211,6 @@ func (e *Elaboration) setIsChecking(isChecking bool) {
 // FunctionEntryPointType returns the type of the entry point function declaration, if any.
 //
 // Returns an error if no valid entry point function declaration exists.
-//
 func (e *Elaboration) FunctionEntryPointType() (*FunctionType, error) {
 
 	entryPointValue, ok := e.GlobalValues.Get(FunctionEntryPointName)

--- a/runtime/sema/entrypoint.go
+++ b/runtime/sema/entrypoint.go
@@ -27,7 +27,6 @@ const FunctionEntryPointName = "main"
 // FunctionEntryPointDeclaration returns the entry point function declaration, if any.
 //
 // Returns nil if there are multiple function declarations with the same function entry point name, or a transaction declaration.
-//
 func FunctionEntryPointDeclaration(program *ast.Program) *ast.FunctionDeclaration {
 
 	functionDeclarations := program.FunctionDeclarations()
@@ -58,7 +57,6 @@ func FunctionEntryPointDeclaration(program *ast.Program) *ast.FunctionDeclaratio
 // EntryPointParameters returns the parameters of the transaction or script, if any.
 //
 // Returns nil if the program specifies both a valid transaction and entry point function declaration.
-//
 func (checker *Checker) EntryPointParameters() []*Parameter {
 	transactionDeclaration := checker.Program.SoleTransactionDeclaration()
 	if transactionDeclaration != nil {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -868,7 +868,6 @@ func (e *AssignmentToConstantMemberError) Error() string {
 }
 
 // FieldReinitializationError
-//
 type FieldReinitializationError struct {
 	Name string
 	ast.Range
@@ -886,7 +885,6 @@ func (e *FieldReinitializationError) Error() string {
 }
 
 // FieldUninitializedError
-//
 type FieldUninitializedError struct {
 	Name          string
 	ContainerType Type
@@ -1214,7 +1212,6 @@ func (n MemberMismatchNote) Message() string {
 // DuplicateConformanceError
 //
 // TODO: just make this a warning?
-//
 type DuplicateConformanceError struct {
 	CompositeType *CompositeType
 	InterfaceType *InterfaceType
@@ -1239,7 +1236,6 @@ func (e *DuplicateConformanceError) Error() string {
 }
 
 // MultipleInterfaceDefaultImplementationsError
-//
 type MultipleInterfaceDefaultImplementationsError struct {
 	CompositeType *CompositeType
 	Member        *Member
@@ -1270,7 +1266,6 @@ func (e *MultipleInterfaceDefaultImplementationsError) EndPosition(memoryGauge c
 }
 
 // SpecialFunctionDefaultImplementationError
-//
 type SpecialFunctionDefaultImplementationError struct {
 	Container  ast.Declaration
 	Identifier *ast.Identifier
@@ -1302,7 +1297,6 @@ func (e *SpecialFunctionDefaultImplementationError) EndPosition(memoryGauge comm
 }
 
 // DefaultFunctionConflictError
-//
 type DefaultFunctionConflictError struct {
 	CompositeType *CompositeType
 	Member        *Member
@@ -1333,7 +1327,6 @@ func (e *DefaultFunctionConflictError) EndPosition(memoryGauge common.MemoryGaug
 }
 
 // MissingConformanceError
-//
 type MissingConformanceError struct {
 	CompositeType *CompositeType
 	InterfaceType *InterfaceType

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -32,7 +32,6 @@ type Import interface {
 }
 
 // ImportElement
-//
 type ImportElement struct {
 	DeclarationKind common.DeclarationKind
 	Access          ast.Access
@@ -41,7 +40,6 @@ type ImportElement struct {
 }
 
 // ElaborationImport
-//
 type ElaborationImport struct {
 	Elaboration *Elaboration
 }

--- a/runtime/sema/initialization_info.go
+++ b/runtime/sema/initialization_info.go
@@ -41,7 +41,6 @@ func NewInitializationInfo(
 
 // InitializationComplete returns true if all fields of the container
 // were initialized, false if some fields are uninitialized
-//
 func (info *InitializationInfo) InitializationComplete() bool {
 	for pair := info.FieldMembers.Oldest(); pair != nil; pair = pair.Next() {
 		member := pair.Key

--- a/runtime/sema/invalid_type.go
+++ b/runtime/sema/invalid_type.go
@@ -21,7 +21,6 @@ package sema
 // InvalidType represents a type that is invalid.
 // It is the result of type checking failing and
 // can't be expressed in programs.
-//
 var InvalidType = &SimpleType{
 	Name:                 "<<invalid>>",
 	QualifiedName:        "<<invalid>>",

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -34,7 +34,6 @@ Returns true if this type is a subtype of the given type at run-time
 const MetaTypeName = "Type"
 
 // MetaType represents the type of a type.
-//
 var MetaType = &SimpleType{
 	Name:                 MetaTypeName,
 	QualifiedName:        MetaTypeName,

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -27,7 +27,6 @@ const PublicAccountContractsTypeGetFunctionName = "get"
 const PublicAccountContractsTypeNamesField = "names"
 
 // PublicAccountContractsType represents the type `PublicAccount.Contracts`
-//
 var PublicAccountContractsType = func() *CompositeType {
 
 	publicAccountContractsType := &CompositeType{

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -36,7 +36,6 @@ const PublicAccountContractsField = "contracts"
 const PublicAccountPathsField = "publicPaths"
 
 // PublicAccountType represents the publicly accessible portion of an account.
-//
 var PublicAccountType = func() *CompositeType {
 
 	publicAccountType := &CompositeType{

--- a/runtime/sema/resolve.go
+++ b/runtime/sema/resolve.go
@@ -29,7 +29,6 @@ type AddressContractNamesResolver func(address common.Address) ([]string, error)
 // which returns a single location for non-address locations,
 // and uses the given address contract names resolve function
 // to get all contract names for an address
-//
 func AddressLocationHandlerFunc(resolveAddressContractNames AddressContractNamesResolver) LocationHandlerFunc {
 	return func(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error) {
 		addressLocation, isAddress := location.(common.AddressLocation)

--- a/runtime/sema/resources.go
+++ b/runtime/sema/resources.go
@@ -101,7 +101,6 @@ func (ris *Resources) MaybeRecordInvalidation(resource Resource, invalidation Re
 
 // RemoveTemporaryMoveInvalidation removes the given invalidation
 // from the set of invalidations for the given resource.
-//
 func (ris *Resources) RemoveTemporaryMoveInvalidation(resource Resource, invalidation ResourceInvalidation) {
 	if invalidation.Kind != ResourceInvalidationKindMoveTemporary {
 		panic(errors.NewUnreachableError())
@@ -136,7 +135,6 @@ func (ris *Resources) ForEach(f func(resource Resource, info ResourceInfo)) {
 // Invalidations occurring in both branches are considered definitive,
 // other new invalidations are only considered potential.
 // The else resources are optional.
-//
 func (ris *Resources) MergeBranches(
 	thenResources *Resources,
 	thenReturnInfo *ReturnInfo,

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -32,7 +32,6 @@ type ValueIndexingInfo struct {
 }
 
 // SimpleType represents a simple nominal type.
-//
 type SimpleType struct {
 	Name                 string
 	QualifiedName        string

--- a/runtime/sema/storable_type.go
+++ b/runtime/sema/storable_type.go
@@ -23,7 +23,6 @@ package sema
 // It is only used as e.g. a type bound, but is not accessible
 // to user programs, i.e. can't be used in type annotations
 // for e.g. parameters, return types, fields, etc.
-//
 var StorableType = &SimpleType{
 	Name:          "Storable",
 	QualifiedName: "Storable",

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -34,7 +34,6 @@ Attempt to decode the input as a UTF-8 encoded string. Returns nil if the input 
 `
 
 // StringType represents the string type
-//
 var StringType = &SimpleType{
 	Name:                 "String",
 	QualifiedName:        "String",

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4971,19 +4971,19 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 //
 // The differences between these methods is as follows:
 //
-//	IsSubType()
+//   - IsSubType():
 //
-// To check the assignability, e.g: is argument type T is a sub-type
-// of parameter type R? This is the more frequent use-case.
+//     To check the assignability, e.g: is argument type T is a sub-type
+//     of parameter type R? This is the more frequent use-case.
 //
-//	IsSameTypeKind()
+//   - IsSameTypeKind():
 //
-// To check if a type strictly belongs to a certain category. e.g: Is the
-// expression type T is any of the integer types, but nothing else.
-// Another way to check is, asking the question of "if the subType is Never,
-// should the check still pass?". A common code-smell for potential incorrect
-// usage is, using IsSubType() method with a constant/pre-defined superType.
-// e.g: IsSubType(<<someType>>, FixedPointType)
+//     To check if a type strictly belongs to a certain category. e.g: Is the
+//     expression type T is any of the integer types, but nothing else.
+//     Another way to check is, asking the question of "if the subType is Never,
+//     should the check still pass?". A common code-smell for potential incorrect
+//     usage is, using IsSubType() method with a constant/pre-defined superType.
+//     e.g: IsSubType(<<someType>>, FixedPointType)
 func IsSubType(subType Type, superType Type) bool {
 
 	if subType == nil {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -172,7 +172,6 @@ type Type interface {
 }
 
 // ValueIndexableType is a type which can be indexed into using a value
-//
 type ValueIndexableType interface {
 	Type
 	isValueIndexableType() bool
@@ -193,7 +192,6 @@ type MemberResolver struct {
 }
 
 // ContainedType is a type which might have a container type
-//
 type ContainedType interface {
 	Type
 	GetContainerType() Type
@@ -201,7 +199,6 @@ type ContainedType interface {
 }
 
 // ContainerType is a type which might have nested types
-//
 type ContainerType interface {
 	Type
 	IsContainerType() bool
@@ -222,21 +219,18 @@ func VisitThisAndNested(t Type, visit func(ty Type)) {
 }
 
 // CompositeKindedType is a type which has a composite kind
-//
 type CompositeKindedType interface {
 	Type
 	GetCompositeKind() common.CompositeKind
 }
 
 // LocatedType is a type which has a location
-//
 type LocatedType interface {
 	Type
 	GetLocation() common.Location
 }
 
 // ParameterizedType is a type which might have type parameters
-//
 type ParameterizedType interface {
 	Type
 	TypeParameters() []*TypeParameter
@@ -690,7 +684,6 @@ func OptionalTypeMapFunctionType(typ Type) *FunctionType {
 }
 
 // GenericType
-//
 type GenericType struct {
 	TypeParameter *TypeParameter
 }
@@ -823,7 +816,6 @@ type FractionalRangedType interface {
 }
 
 // SaturatingArithmeticType is a type that supports saturating arithmetic functions
-//
 type SaturatingArithmeticType interface {
 	Type
 	SupportsSaturatingAdd() bool
@@ -905,7 +897,6 @@ func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[st
 
 // NumericType represent all the types in the integer range
 // and non-fractional ranged types.
-//
 type NumericType struct {
 	name                       string
 	tag                        TypeTag
@@ -1075,7 +1066,6 @@ func (t *NumericType) IsSuperType() bool {
 }
 
 // FixedPointNumericType represents all the types in the fixed-point range.
-//
 type FixedPointNumericType struct {
 	name                       string
 	tag                        TypeTag
@@ -2400,7 +2390,6 @@ func (p *Parameter) QualifiedString() string {
 // an argument in a call must use:
 // If no argument label is declared for parameter,
 // the parameter name is used as the argument label
-//
 func (p *Parameter) EffectiveArgumentLabel() string {
 	if p.Label != "" {
 		return p.Label
@@ -2522,7 +2511,6 @@ func formatFunctionType(
 }
 
 // FunctionType
-//
 type FunctionType struct {
 	IsConstructor            bool
 	TypeParameters           []*TypeParameter
@@ -2979,7 +2967,6 @@ type ArgumentExpressionsCheck func(
 
 // BaseTypeActivation is the base activation that contains
 // the types available in programs
-//
 var BaseTypeActivation = NewVariableActivation(nil)
 
 func init() {
@@ -3048,7 +3035,6 @@ func baseTypeVariable(name string, ty Type) *Variable {
 
 // BaseValueActivation is the base activation that contains
 // the values available in programs
-//
 var BaseValueActivation = NewVariableActivation(nil)
 
 var AllSignedFixedPointTypes = []Type{
@@ -4982,15 +4968,22 @@ func (t *AddressType) GetMembers() map[string]MemberResolver {
 // However, to check if a type *strictly* belongs to a certain category, then consider
 // using `IsSameTypeKind` method. e.g: "Is type `T` an Integer type?". Using this method
 // for the later use-case may produce incorrect results.
-//   * IsSubType()      - To check the assignability. e.g: Is argument type T is a sub-type
-//                        of parameter type R. This is the more frequent use-case.
-//   * IsSameTypeKind() - To check if a type strictly belongs to a certain category. e.g: Is the
-//                        expression type T is any of the integer types, but nothing else.
-//                        Another way to check is, asking the question of "if the subType is Never,
-//                        should the check still pass?". A common code-smell for potential incorrect
-//                        usage is, using IsSubType() method with a constant/pre-defined superType.
-//                        e.g: IsSubType(<<someType>>, FixedPointType)
 //
+// The differences between these methods is as follows:
+//
+//	IsSubType()
+//
+// To check the assignability, e.g: is argument type T is a sub-type
+// of parameter type R? This is the more frequent use-case.
+//
+//	IsSameTypeKind()
+//
+// To check if a type strictly belongs to a certain category. e.g: Is the
+// expression type T is any of the integer types, but nothing else.
+// Another way to check is, asking the question of "if the subType is Never,
+// should the check still pass?". A common code-smell for potential incorrect
+// usage is, using IsSubType() method with a constant/pre-defined superType.
+// e.g: IsSubType(<<someType>>, FixedPointType)
 func IsSubType(subType Type, superType Type) bool {
 
 	if subType == nil {
@@ -5010,7 +5003,6 @@ func IsSubType(subType Type, superType Type) bool {
 // e.g: 'Never' type is a subtype of 'Integer', but not of the
 // same kind as 'Integer'. Whereas, 'Int8' is both a subtype
 // and also of same kind as 'Integer'.
-//
 func IsSameTypeKind(subType Type, superType Type) bool {
 
 	if subType == NeverType {
@@ -5024,7 +5016,6 @@ func IsSameTypeKind(subType Type, superType Type) bool {
 // i.e. it determines if the given subtype is a subtype
 // of the given supertype, but returns false
 // if the subtype and supertype refer to the same type.
-//
 func IsProperSubType(subType Type, superType Type) bool {
 
 	if subType.Equal(superType) {
@@ -5040,7 +5031,6 @@ func IsProperSubType(subType Type, superType Type) bool {
 // value when the two types are equal or are not.
 //
 // Consider using IsSubType or IsProperSubType
-//
 func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
 	if subType == NeverType {
@@ -5630,7 +5620,6 @@ func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
 // UnwrapOptionalType returns the type if it is not an optional type,
 // or the inner-most type if it is (optional types are repeatedly unwrapped)
-//
 func UnwrapOptionalType(ty Type) Type {
 	for {
 		optionalType, ok := ty.(*OptionalType)
@@ -5665,7 +5654,6 @@ func AreCompatibleEquatableTypes(leftType, rightType Type) bool {
 }
 
 // IsNilType returns true if the given type is the type of `nil`, i.e. `Never?`.
-//
 func IsNilType(ty Type) bool {
 	optionalType, ok := ty.(*OptionalType)
 	if !ok {
@@ -5795,7 +5783,6 @@ func (t *TransactionType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
 //
 // No restrictions implies the type is fully restricted,
 // i.e. no members of the underlying resource type are available.
-//
 type RestrictedType struct {
 	Type         Type
 	Restrictions []*InterfaceType

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -26,7 +26,6 @@ import (
 // Each type has a unique dedicated bit/bit-pattern in the bitmask.
 // The mask consist of two sections: `lowerMask` and the `upperMask`.
 // Each section can represent 64-types.
-//
 type TypeTag struct {
 	lowerMask uint64
 	upperMask uint64

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -29,7 +29,6 @@ import (
 // An VariableActivation is a map of strings to variables.
 // It is used to represent an active scope in a program,
 // i.e. it is used as a symbol table during semantic analysis.
-//
 type VariableActivation struct {
 	entries        *StringVariableOrderedMap
 	Depth          int
@@ -41,7 +40,6 @@ type EndPositionGetter func(common.MemoryGauge) ast.Position
 
 // NewVariableActivation returns as new activation with the given parent.
 // The parent may be nil.
-//
 func NewVariableActivation(parent *VariableActivation) *VariableActivation {
 	activation := &VariableActivation{}
 	activation.SetParent(parent)
@@ -50,7 +48,6 @@ func NewVariableActivation(parent *VariableActivation) *VariableActivation {
 
 // SetParent sets the parent of this activation to the given parent
 // and updates the depth.
-//
 func (a *VariableActivation) SetParent(parent *VariableActivation) {
 	a.Parent = parent
 
@@ -63,7 +60,6 @@ func (a *VariableActivation) SetParent(parent *VariableActivation) {
 
 // Find returns the variable for a given name in the activation.
 // It returns nil if no variable is found.
-//
 func (a *VariableActivation) Find(name string) *Variable {
 
 	current := a
@@ -83,7 +79,6 @@ func (a *VariableActivation) Find(name string) *Variable {
 }
 
 // Set sets the given variable.
-//
 func (a *VariableActivation) Set(name string, variable *Variable) {
 	if a.entries == nil {
 		a.entries = &StringVariableOrderedMap{}
@@ -93,7 +88,6 @@ func (a *VariableActivation) Set(name string, variable *Variable) {
 }
 
 // Clear removes all variables from this activation.
-//
 func (a *VariableActivation) Clear() {
 	a.LeaveCallbacks = nil
 
@@ -106,7 +100,6 @@ func (a *VariableActivation) Clear() {
 
 // ForEach calls the given function for each name-variable pair in the activation.
 // It can be used to iterate over all entries of the activation.
-//
 func (a *VariableActivation) ForEach(cb func(string, *Variable) error) error {
 
 	activation := a
@@ -182,7 +175,6 @@ func getVariableActivation() *VariableActivation {
 //
 // The current / most nested activation record can be found
 // at the top of the stack (see function `Current`).
-//
 type VariableActivations struct {
 	activations []*VariableActivation
 }
@@ -196,7 +188,6 @@ func NewVariableActivations(parent *VariableActivation) *VariableActivations {
 // pushNewWithParent pushes a new empty activation
 // to the top of the activation stack.
 // The new activation has the given parent as its parent.
-//
 func (a *VariableActivations) pushNewWithParent(parent *VariableActivation) *VariableActivation {
 	activation := getVariableActivation()
 	activation.SetParent(parent)
@@ -206,7 +197,6 @@ func (a *VariableActivations) pushNewWithParent(parent *VariableActivation) *Var
 
 // push pushes the given activation
 // onto the top of the activation stack.
-//
 func (a *VariableActivations) push(activation *VariableActivation) {
 	a.activations = append(
 		a.activations,
@@ -217,14 +207,12 @@ func (a *VariableActivations) push(activation *VariableActivation) {
 // Enter pushes a new empty activation
 // to the top of the activation stack.
 // The new activation has the current activation as its parent.
-//
 func (a *VariableActivations) Enter() {
 	a.pushNewWithParent(a.Current())
 }
 
 // Leave pops the top-most (current) activation
 // from the top of the activation stack.
-//
 func (a *VariableActivations) Leave(getEndPosition func(common.MemoryGauge) ast.Position) {
 	count := len(a.activations)
 	if count < 1 {
@@ -241,7 +229,6 @@ func (a *VariableActivations) Leave(getEndPosition func(common.MemoryGauge) ast.
 }
 
 // Set sets the variable in the current activation.
-//
 func (a *VariableActivations) Set(name string, variable *Variable) {
 	current := a.Current()
 	// create the first scope if there is no scope
@@ -254,7 +241,6 @@ func (a *VariableActivations) Set(name string, variable *Variable) {
 // Find returns the variable for a given name in the current activation.
 // It returns nil if no variable is found
 // or if there is no current activation.
-//
 func (a *VariableActivations) Find(name string) *Variable {
 
 	current := a.Current()
@@ -266,7 +252,6 @@ func (a *VariableActivations) Find(name string) *Variable {
 }
 
 // Depth returns the depth (size) of the activation stack.
-//
 func (a *VariableActivations) Depth() int {
 	return len(a.activations)
 }
@@ -403,7 +388,6 @@ func (a *VariableActivations) ForEachVariableDeclaredInAndBelow(depth int, f fun
 // Current returns the current / most nested activation,
 // which can be found at the top of the stack.
 // It returns nil if there is no active activation.
-//
 func (a *VariableActivations) Current() *VariableActivation {
 	count := len(a.activations)
 	if count < 1 {

--- a/runtime/sema/void_type.go
+++ b/runtime/sema/void_type.go
@@ -19,7 +19,6 @@
 package sema
 
 // VoidType represents the void type
-//
 var VoidType = &SimpleType{
 	Name:                 "Void",
 	QualifiedName:        "Void",

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1171,7 +1171,6 @@ type AccountContractAdditionHandler interface {
 // newAuthAccountContractsChangeFunction called when e.g.
 // - adding: `AuthAccount.contracts.add(name: "Foo", code: [...])` (isUpdate = false)
 // - updating: `AuthAccount.contracts.update__experimental(name: "Foo", code: [...])` (isUpdate = true)
-//
 func newAuthAccountContractsChangeFunction(
 	gauge common.MemoryGauge,
 	handler AccountContractAdditionHandler,
@@ -1428,7 +1427,6 @@ func newAuthAccountContractsChangeFunction(
 }
 
 // InvalidContractDeploymentError
-//
 type InvalidContractDeploymentError struct {
 	Err error
 	interpreter.LocationRange
@@ -1457,7 +1455,6 @@ func (e *InvalidContractDeploymentError) Unwrap() error {
 }
 
 // InvalidContractDeploymentOriginError
-//
 type InvalidContractDeploymentOriginError struct {
 	interpreter.LocationRange
 }
@@ -1498,7 +1495,6 @@ type updateAccountContractCodeOptions struct {
 
 // updateAccountContractCode updates an account contract's code.
 // This function is only used for the new account code/contract API.
-//
 func updateAccountContractCode(
 	handler AccountContractAdditionHandler,
 	location common.AddressLocation,
@@ -1755,7 +1751,6 @@ func newAuthAccountContractsRemoveFunction(
 }
 
 // ContractRemovalError
-//
 type ContractRemovalError struct {
 	Name string
 	interpreter.LocationRange

--- a/runtime/stdlib/test-framework.go
+++ b/runtime/stdlib/test-framework.go
@@ -27,7 +27,6 @@ import (
 // TestFramework is the interface to be implemented by the test providers.
 // Cadence standard library talks to test providers via this interface.
 // This is used as a way to inject test provider dependencies dynamically.
-//
 type TestFramework interface {
 	RunScript(code string, arguments []interpreter.Value) *ScriptResult
 

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -861,7 +861,6 @@ func arrayValueToSlice(value interpreter.Value) ([]interpreter.Value, error) {
 }
 
 // newScriptResult Creates a "ScriptResult" using the return value of the executed script.
-//
 func newScriptResult(
 	inter *interpreter.Interpreter,
 	returnValue interpreter.Value,
@@ -1187,7 +1186,6 @@ func emulatorBackendExecuteNextTransactionFunction(testFramework TestFramework) 
 }
 
 // newTransactionResult Creates a "TransactionResult" indicating the status of the transaction execution.
-//
 func newTransactionResult(inter *interpreter.Interpreter, result *TransactionResult) interpreter.Value {
 	// Lookup and get 'ResultStatus' enum value.
 	resultStatusConstructor := getConstructor(inter, resultStatusTypeName)

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -186,7 +186,6 @@ func SortContractUpdates(updates []ContractUpdate) {
 
 // commitContractUpdates writes the contract updates to storage.
 // The contract updates were delayed so they are not observable during execution.
-//
 func (s *Storage) commitContractUpdates(inter *interpreter.Interpreter) {
 
 	contractUpdateCount := len(s.contractUpdates)
@@ -256,7 +255,6 @@ func sortWrites(writes []write) {
 }
 
 // Commit serializes/saves all values in the readCache in storage (through the runtime interface).
-//
 func (s *Storage) Commit(inter *interpreter.Interpreter, commitContractUpdates bool) error {
 
 	if commitContractUpdates {

--- a/runtime/tests/errors_test.go
+++ b/runtime/tests/errors_test.go
@@ -36,7 +36,6 @@ import (
 
 // TestErrorInterfaceConformance checks whether all the error structs implement
 // one of the interfaces.
-//
 func TestErrorInterfaceConformance(t *testing.T) {
 	t.Parallel()
 

--- a/runtime/tests/interpreter/indexing_test.go
+++ b/runtime/tests/interpreter/indexing_test.go
@@ -32,7 +32,6 @@ import (
 // it will be transferred into the indexed value,
 // and as part of it, will get removed.
 // Ensure the *copy* is removed, and *not the original*.
-//
 func TestInterpretIndexingExpressionTransfer(t *testing.T) {
 
 	t.Parallel()

--- a/tools/analysis/analyzer.go
+++ b/tools/analysis/analyzer.go
@@ -19,7 +19,6 @@
 package analysis
 
 // Analyzer describes an analysis function and its options
-//
 type Analyzer struct {
 	Description string
 

--- a/tools/analysis/loadmode.go
+++ b/tools/analysis/loadmode.go
@@ -20,7 +20,6 @@ package analysis
 
 // LoadMode controls the amount of detail to return when loading.
 // The bits below can be combined to specify what information is required.
-//
 type LoadMode int
 
 const (

--- a/tools/analysis/pass.go
+++ b/tools/analysis/pass.go
@@ -20,7 +20,6 @@ package analysis
 
 // Pass provides information to the Analyzer.Run function,
 // which applies a specific analyzer to a single location.
-//
 type Pass struct {
 	Program *Program
 

--- a/tools/analysis/program.go
+++ b/tools/analysis/program.go
@@ -34,7 +34,6 @@ type Program struct {
 }
 
 // Run runs the given DAG of analyzers in parallel
-//
 func (program *Program) Run(analyzers []*Analyzer, report func(Diagnostic)) {
 
 	type action struct {

--- a/tools/batch-script/address_provider.go
+++ b/tools/batch-script/address_provider.go
@@ -120,7 +120,6 @@ func InitAddressProvider(
 // 3. (4,8): check address (8 - 4) / 2 = 6  address exists so next pair is (6,8)
 // 4. (6,8): check address 7 address exists so next pair is (7,8)
 // 5. (7,8): check address (8 - 7) / 2 = 7 ... ok already checked so this is the last existing address
-//
 func (p *AddressProvider) getLastAddress(
 	lowerIndex uint,
 	upperIndex uint,

--- a/tools/batch-script/go.mod
+++ b/tools/batch-script/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/batch-script
 
-go 1.19
+go 1.18
 
 require (
 	github.com/onflow/cadence v0.21.2

--- a/tools/batch-script/go.mod
+++ b/tools/batch-script/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/batch-script
 
-go 1.18
+go 1.19
 
 require (
 	github.com/onflow/cadence v0.21.2

--- a/tools/constructorcheck/go.mod
+++ b/tools/constructorcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/constructorcheck
 
-go 1.19
+go 1.18
 
 require golang.org/x/tools v0.1.10
 

--- a/tools/constructorcheck/go.mod
+++ b/tools/constructorcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/constructorcheck
 
-go 1.18
+go 1.19
 
 require golang.org/x/tools v0.1.10
 

--- a/tools/golangci-lint/go.mod
+++ b/tools/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-project/tools/golangci-lint
 
-go 1.18
+go 1.19
 
 require github.com/golangci/golangci-lint v1.45.2
 

--- a/tools/golangci-lint/go.mod
+++ b/tools/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-project/tools/golangci-lint
 
-go 1.19
+go 1.18
 
 require github.com/golangci/golangci-lint v1.45.2
 

--- a/tools/maprangecheck/go.mod
+++ b/tools/maprangecheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/maprangecheck
 
-go 1.18
+go 1.19
 
 require golang.org/x/tools v0.1.10
 

--- a/tools/maprangecheck/go.mod
+++ b/tools/maprangecheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/maprangecheck
 
-go 1.19
+go 1.18
 
 require golang.org/x/tools v0.1.10
 

--- a/tools/pretty/main.go
+++ b/tools/pretty/main.go
@@ -43,7 +43,7 @@ func pretty(code string, maxLineWidth int) string {
 	return b.String()
 }
 
-//language=html
+// language=html
 const page = `
 <html>
 <head>

--- a/types.go
+++ b/types.go
@@ -33,7 +33,6 @@ type Type interface {
 // This type should not be used when encoding values,
 // and should only be used for decoding values that were encoded
 // using an older format of the JSON encoding (<v0.3.0)
-//
 type TypeID string
 
 func (TypeID) isType() {}

--- a/values.go
+++ b/values.go
@@ -255,7 +255,6 @@ func (v Bytes) String() string {
 // Character represents a Cadence character, which is a Unicode extended grapheme cluster.
 // Hence, use a Go string to be able to hold multiple Unicode code points (Go runes).
 // It should consist of exactly one grapheme cluster
-//
 type Character string
 
 var _ Value = Character("")


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Just a housekeeping task since we've been putting off switching to gofmt 1.19 for a while. Most formatting is preserved, save for trailing line comments. Only 1 doc comment had to be manually edited in runtime/sema/type.go (IsSubType).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
