### PR TITLE
Directly transfer published values

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -18288,8 +18288,7 @@ func (v *PublishedValue) Transfer(
 			interpreter.RemoveReferencedSlab(storable)
 		}
 
-		var res *PublishedValue = NewPublishedValue(interpreter, addressValue, innerValue)
-		return res
+		return NewPublishedValue(interpreter, addressValue, innerValue)
 	}
 
 	return v

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -845,23 +845,13 @@ func accountInboxPublishFunction(
 				locationRange,
 			)
 
-			value = value.Transfer(
+			publishedValue := interpreter.NewPublishedValue(inter, recipientValue, value).Transfer(
 				inter,
 				locationRange,
 				atree.Address(address),
 				true,
 				nil,
-			).(*interpreter.CapabilityValue)
-
-			recipient := recipientValue.Transfer(
-				inter,
-				locationRange,
-				atree.Address(address),
-				true,
-				nil,
-			).(interpreter.AddressValue)
-
-			publishedValue := interpreter.NewPublishedValue(inter, recipient, value)
+			)
 
 			inter.WriteStored(address, inboxStorageDomain, nameValue.Str, publishedValue)
 
@@ -912,16 +902,6 @@ func accountInboxUnpublishFunction(
 				})
 			}
 
-			handler.EmitEvent(
-				inter,
-				AccountInboxUnpublishedEventType,
-				[]interpreter.Value{
-					providerValue,
-					nameValue,
-				},
-				locationRange,
-			)
-
 			value := publishedValue.Value.Transfer(
 				inter,
 				locationRange,
@@ -931,6 +911,16 @@ func accountInboxUnpublishFunction(
 			)
 
 			inter.WriteStored(address, inboxStorageDomain, nameValue.Str, nil)
+
+			handler.EmitEvent(
+				inter,
+				AccountInboxUnpublishedEventType,
+				[]interpreter.Value{
+					providerValue,
+					nameValue,
+				},
+				locationRange,
+			)
 
 			return interpreter.NewSomeValueNonCopying(inter, value)
 		},


### PR DESCRIPTION
Transfer `PublishedValue` objects directly instead of transferring their component parts. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
