### PR TITLE
Improve resource tracking for optional binding

### DIFF
--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -45,12 +45,25 @@ func (checker *Checker) VisitIfStatement(statement *ast.IfStatement) (_ struct{}
 		)
 
 	case *ast.VariableDeclaration:
+		declarationType := checker.visitVariableDeclarationValues(test, true)
+
 		checker.checkConditionalBranches(
 			func() Type {
 				checker.enterValueScope()
 				defer checker.leaveValueScope(thenElement.EndPosition, true)
 
-				checker.visitVariableDeclaration(test, true)
+				if castingExpression, ok := test.Value.(*ast.CastingExpression); ok &&
+					castingExpression.Operation == ast.OperationFailableCast {
+					leftHandType := checker.Elaboration.CastingStaticValueTypes[castingExpression]
+					if leftHandType.IsResourceType() {
+						checker.recordResourceInvalidation(
+							castingExpression.Expression,
+							leftHandType,
+							ResourceInvalidationKindMoveDefinite,
+						)
+					}
+				}
+				checker.declareVariableDeclaration(test, declarationType)
 
 				checker.checkBlock(thenElement)
 				return nil

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -24,11 +24,13 @@ import (
 )
 
 func (checker *Checker) VisitVariableDeclaration(declaration *ast.VariableDeclaration) (_ struct{}) {
-	checker.visitVariableDeclaration(declaration, false)
+	declarationType := checker.visitVariableDeclarationValues(declaration, false)
+	checker.declareVariableDeclaration(declaration, declarationType)
+
 	return
 }
 
-func (checker *Checker) visitVariableDeclaration(declaration *ast.VariableDeclaration, isOptionalBinding bool) {
+func (checker *Checker) visitVariableDeclarationValues(declaration *ast.VariableDeclaration, isOptionalBinding bool) Type {
 
 	checker.checkDeclarationAccessModifier(
 		declaration.Access,
@@ -177,6 +179,10 @@ func (checker *Checker) visitVariableDeclaration(declaration *ast.VariableDeclar
 			SecondValueType: secondValueType,
 		}
 
+	return declarationType
+}
+
+func (checker *Checker) declareVariableDeclaration(declaration *ast.VariableDeclaration, declarationType Type) {
 	// Finally, declare the variable in the current value activation
 
 	identifier := declaration.Identifier.Identifier


### PR DESCRIPTION
Closes dapperlabs/cadence-private-issues#57

Port of dapperlabs/cadence-internal#104

## Description

Optional-bindings, if-statements with variable declarations as a test, were implemented incorrectly.
The variable declaration was correctly only declared inside of the then-branch.
However, incorrectly, the value(s) were also only considered evaluated in the then branch. This produced incorrect resource-tracking errors, requiring users to unnecessarily invalidate the value in the else-branch, even though it should have been already definitely invalidated.

The variable declaration was initially only considered evaluated in the then-branch to support a special case: failable casing of resources (`r as? @R`). The failable cast was always definitely invalidating the casted variable, so it needed to be only occur in the then-branch. The proper way to handle this case is to always evaluate the variable declaration's value (as described above), but specifically handle the special construct of failable casting, and consider the casted variable invalidated in the then branch (the cast succeeded), and consider it not-invalidated in the else-branch (the cast failed).

This is a breaking change, as it also now makes the unnecessary invalidation in the else-branch illegal.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
