### PR TITLE
Simplify parser

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -67,7 +67,7 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 	var accessPos *ast.Position
 
 	for {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 
 		switch p.current.Type {
 		case lexer.TokenPragma:
@@ -144,15 +144,13 @@ func parseAccess(p *parser) (ast.Access, error) {
 
 	case keywordPub:
 		// Skip the `pub` keyword
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 		if !p.current.Is(lexer.TokenParenOpen) {
 			return ast.AccessPublic, nil
 		}
 
 		// Skip the opening paren
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 
 		if !p.current.Is(lexer.TokenIdentifier) {
 			return ast.AccessNotSpecified, p.syntaxError(
@@ -172,8 +170,7 @@ func parseAccess(p *parser) (ast.Access, error) {
 		}
 
 		// Skip the `set` keyword
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 
 		_, err := p.mustOne(lexer.TokenParenClose)
 		if err != nil {
@@ -184,15 +181,14 @@ func parseAccess(p *parser) (ast.Access, error) {
 
 	case keywordAccess:
 		// Skip the `access` keyword
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 
 		_, err := p.mustOne(lexer.TokenParenOpen)
 		if err != nil {
 			return ast.AccessNotSpecified, err
 		}
 
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 
 		if !p.current.Is(lexer.TokenIdentifier) {
 			return ast.AccessNotSpecified, p.syntaxError(
@@ -227,8 +223,7 @@ func parseAccess(p *parser) (ast.Access, error) {
 		}
 
 		// Skip the keyword
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 
 		_, err = p.mustOne(lexer.TokenParenClose)
 		if err != nil {
@@ -265,9 +260,7 @@ func parseVariableDeclaration(
 	isLet := string(p.currentTokenSource()) == keywordLet
 
 	// Skip the `let` or `var` keyword
-	p.next()
-
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 	if !p.current.Is(lexer.TokenIdentifier) {
 		return nil, p.syntaxError(
 			"expected identifier after start of variable declaration, got %s",
@@ -278,16 +271,14 @@ func parseVariableDeclaration(
 	identifier := p.tokenToIdentifier(p.current)
 
 	// Skip the identifier
-	p.next()
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 
 	var typeAnnotation *ast.TypeAnnotation
 	var err error
 
 	if p.current.Is(lexer.TokenColon) {
 		// Skip the colon
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 
 		typeAnnotation, err = parseTypeAnnotation(p)
 		if err != nil {
@@ -295,7 +286,7 @@ func parseVariableDeclaration(
 		}
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	transfer := parseTransfer(p)
 	if transfer == nil {
 		return nil, p.syntaxError("expected transfer")
@@ -306,7 +297,7 @@ func parseVariableDeclaration(
 		return nil, err
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	secondTransfer := parseTransfer(p)
 	var secondValue ast.Expression
@@ -459,8 +450,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 
 		atEnd := false
 		for !atEnd {
-			p.next()
-			p.skipSpaceAndComments(true)
+			p.nextSemanticToken()
 
 			switch p.current.Type {
 			case lexer.TokenComma:
@@ -482,8 +472,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 						atEnd = true
 
 						// Skip the `from` keyword
-						p.next()
-						p.skipSpaceAndComments(true)
+						p.nextSemanticToken()
 
 						err := parseLocation()
 						if err != nil {
@@ -546,8 +535,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 		if string(p.currentTokenSource()) == keywordFrom {
 			identifiers = append(identifiers, identifier)
 			// Skip the `from` keyword
-			p.next()
-			p.skipSpaceAndComments(true)
+			p.nextSemanticToken()
 
 			err := parseLocation()
 			if err != nil {
@@ -561,8 +549,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 	}
 
 	// Skip the `import` keyword
-	p.next()
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 
 	switch p.current.Type {
 	case lexer.TokenString, lexer.TokenHexadecimalIntegerLiteral:
@@ -571,8 +558,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 	case lexer.TokenIdentifier:
 		identifier := p.tokenToIdentifier(p.current)
 		// Skip the identifier
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 
 		switch p.current.Type {
 		case lexer.TokenComma:
@@ -632,8 +618,7 @@ func isNextTokenCommaOrFrom(p *parser) (b bool, err error) {
 	}()
 
 	// skip the current token
-	p.next()
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 
 	// Lookahead the next token
 	switch p.current.Type {
@@ -691,9 +676,7 @@ func parseEventDeclaration(
 	}
 
 	// Skip the `event` keyword
-	p.next()
-
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 	if !p.current.Is(lexer.TokenIdentifier) {
 		return nil, p.syntaxError(
 			"expected identifier after start of event declaration, got %s",
@@ -799,9 +782,7 @@ func parseFieldWithVariableKind(
 	}
 
 	// Skip the `let` or `var` keyword
-	p.next()
-
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 	if !p.current.Is(lexer.TokenIdentifier) {
 		return nil, p.syntaxError(
 			"expected identifier after start of field declaration, got %s",
@@ -811,15 +792,14 @@ func parseFieldWithVariableKind(
 
 	identifier := p.tokenToIdentifier(p.current)
 	// Skip the identifier
-	p.next()
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 
 	_, err := p.mustOne(lexer.TokenColon)
 	if err != nil {
 		return nil, err
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	typeAnnotation, err := parseTypeAnnotation(p)
 	if err != nil {
@@ -871,7 +851,7 @@ func parseCompositeOrInterfaceDeclaration(
 	var identifier ast.Identifier
 
 	for {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 		if !p.current.Is(lexer.TokenIdentifier) {
 			return nil, p.syntaxError(
 				"expected %s, got %s",
@@ -901,7 +881,7 @@ func parseCompositeOrInterfaceDeclaration(
 		}
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	var conformances []*ast.NominalType
 	var err error
@@ -923,7 +903,7 @@ func parseCompositeOrInterfaceDeclaration(
 		}
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	_, err = p.mustOne(lexer.TokenBraceOpen)
 	if err != nil {
@@ -935,7 +915,7 @@ func parseCompositeOrInterfaceDeclaration(
 		return nil, err
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	endToken, err := p.mustOne(lexer.TokenBraceClose)
 	if err != nil {
@@ -1036,7 +1016,7 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 	var previousIdentifierToken *lexer.Token
 
 	for {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
@@ -1121,7 +1101,7 @@ func parseFieldDeclarationWithoutVariableKind(
 		return nil, err
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	typeAnnotation, err := parseTypeAnnotation(p)
 	if err != nil {
@@ -1164,7 +1144,7 @@ func parseSpecialFunctionDeclaration(
 		return nil, err
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	var functionBlock *ast.FunctionBlock
 
@@ -1221,9 +1201,7 @@ func parseEnumCase(
 	}
 
 	// Skip the `enum` keyword
-	p.next()
-
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 	if !p.current.Is(lexer.TokenIdentifier) {
 		return nil, p.syntaxError(
 			"expected identifier after start of enum case declaration, got %s",

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -559,8 +559,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 			defer p.endAmbiguity()
 
 			// Skip the `<` token.
-			p.next()
-			p.skipSpaceAndComments(true)
+			p.nextSemanticToken()
 
 			// First, try to parse zero or more comma-separated type
 			// arguments (type annotations), a closing greater token `>`,
@@ -591,7 +590,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 					return err
 				}
 
-				p.skipSpaceAndComments(true)
+				p.skipSpaceAndComments()
 				parenOpenToken, err := p.mustOne(lexer.TokenParenOpen)
 				if err != nil {
 					return err
@@ -664,8 +663,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 				// because it should have maybe not been parsed in the first place
 				// if the right binding power is higher.
 
-				p.next()
-				p.skipSpaceAndComments(true)
+				p.nextSemanticToken()
 
 				right, err := parseExpression(p, binaryExpressionLeftBindingPower)
 				if err != nil {
@@ -769,8 +767,7 @@ func defineGreaterThanOrBitwiseRightShiftExpression() {
 				nextRightBindingPower = exprLeftBindingPowerComparison
 			}
 
-			p.next()
-			p.skipSpaceAndComments(true)
+			p.nextSemanticToken()
 
 			right, err := parseExpression(p, nextRightBindingPower)
 			if err != nil {
@@ -961,7 +958,7 @@ func parseArgumentListRemainder(p *parser) (arguments []*ast.Argument, endPos as
 	atEnd := false
 	expectArgument := true
 	for !atEnd {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 
 		switch p.current.Type {
 		case lexer.TokenComma:
@@ -1001,7 +998,7 @@ func parseArgumentListRemainder(p *parser) (arguments []*ast.Argument, endPos as
 				return nil, ast.EmptyPosition, err
 			}
 
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 
 			argument.TrailingSeparatorPos = p.current.StartPos
 
@@ -1025,7 +1022,7 @@ func parseArgument(p *parser) (*ast.Argument, error) {
 		return nil, err
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	// If a colon follows the expression, the expression was our label.
 	if p.current.Is(lexer.TokenColon) {
@@ -1041,8 +1038,7 @@ func parseArgument(p *parser) (*ast.Argument, error) {
 		labelEndPos = expr.EndPosition(p.memoryGauge)
 
 		// Skip the identifier
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 
 		expr, err = parseExpression(p, lowestBindingPower)
 		if err != nil {
@@ -1066,7 +1062,7 @@ func defineNestedExpression() {
 	setExprNullDenotation(
 		lexer.TokenParenOpen,
 		func(p *parser, startToken lexer.Token) (ast.Expression, error) {
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 
 			// special case: parse a Void literal `()`
 			if p.current.Type == lexer.TokenParenClose {
@@ -1274,7 +1270,7 @@ func defineReferenceExpression() {
 	setExprNullDenotation(
 		lexer.TokenAmpersand,
 		func(p *parser, token lexer.Token) (ast.Expression, error) {
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 			expression, err := parseExpression(p, exprLeftBindingPowerCasting-exprBindingPowerGap)
 			if err != nil {
 				return nil, err
@@ -1285,7 +1281,7 @@ func defineReferenceExpression() {
 				return nil, p.syntaxError("expected casting expression")
 			}
 
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 
 			return ast.NewReferenceExpression(
 				p.memoryGauge,
@@ -1323,7 +1319,7 @@ func parseMemberAccess(p *parser, token lexer.Token, left ast.Expression, option
 
 	if p.current.Is(lexer.TokenSpace) {
 		errorPos := p.current.StartPos
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 		p.report(NewSyntaxError(
 			errorPos,
 			"invalid whitespace after %s",
@@ -1400,11 +1396,11 @@ func parseExpression(p *parser, rightBindingPower int) (ast.Expression, error) {
 		p.expressionDepth--
 	}()
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	t := p.current
 	p.next()
 
-	newLineAfterLeft := p.skipSpaceAndComments(true)
+	newLineAfterLeft := p.skipSpaceAndComments()
 
 	left, err := applyExprNullDenotation(p, t)
 	if err != nil {
@@ -1412,7 +1408,7 @@ func parseExpression(p *parser, rightBindingPower int) (ast.Expression, error) {
 	}
 
 	for {
-		newLineAfterLeft = p.skipSpaceAndComments(true) || newLineAfterLeft
+		newLineAfterLeft = p.skipSpaceAndComments() || newLineAfterLeft
 
 		if newLineAfterLeft && !exprLeftDenotationAllowsNewlineAfterNullDenotation(p.current.Type) {
 			break
@@ -1484,7 +1480,7 @@ func defaultExprMetaLeftDenotation(
 
 	p.next()
 	if allowWhitespace {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 	}
 
 	result, err = applyExprLeftDenotation(p, t, left)

--- a/runtime/parser/function.go
+++ b/runtime/parser/function.go
@@ -26,7 +26,7 @@ import (
 func parseParameterList(p *parser) (parameterList *ast.ParameterList, err error) {
 	var parameters []*ast.Parameter
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	if !p.current.Is(lexer.TokenParenOpen) {
 		return nil, p.syntaxError(
@@ -46,7 +46,7 @@ func parseParameterList(p *parser) (parameterList *ast.ParameterList, err error)
 
 	atEnd := false
 	for !atEnd {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
 			if !expectParameter {
@@ -112,7 +112,7 @@ func parseParameterList(p *parser) (parameterList *ast.ParameterList, err error)
 }
 
 func parseParameter(p *parser) (*ast.Parameter, error) {
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	startPos := p.current.StartPos
 	parameterPos := startPos
@@ -128,19 +128,16 @@ func parseParameter(p *parser) (*ast.Parameter, error) {
 	parameterName := string(p.currentTokenSource())
 
 	// Skip the identifier
-	p.next()
+	p.nextSemanticToken()
 
 	// If another identifier is provided, then the previous identifier
 	// is the argument label, and this identifier is the parameter name
-
-	p.skipSpaceAndComments(true)
 	if p.current.Is(lexer.TokenIdentifier) {
 		argumentLabel = parameterName
 		parameterName = string(p.currentTokenSource())
 		parameterPos = p.current.StartPos
 		// Skip the identifier
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 	}
 
 	if !p.current.Is(lexer.TokenColon) {
@@ -152,8 +149,7 @@ func parseParameter(p *parser) (*ast.Parameter, error) {
 	}
 
 	// Skip the colon
-	p.next()
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 
 	typeAnnotation, err := parseTypeAnnotation(p)
 	if err != nil {
@@ -193,9 +189,7 @@ func parseFunctionDeclaration(
 	}
 
 	// Skip the `fun` keyword
-	p.next()
-
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 	if !p.current.Is(lexer.TokenIdentifier) {
 		return nil, p.syntaxError(
 			"expected identifier after start of function declaration, got %s",
@@ -241,17 +235,16 @@ func parseFunctionParameterListAndRest(
 		return
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	if p.current.Is(lexer.TokenColon) {
 		// Skip the colon
-		p.next()
-		p.skipSpaceAndComments(true)
+		p.nextSemanticToken()
 		returnTypeAnnotation, err = parseTypeAnnotation(p)
 		if err != nil {
 			return
 		}
 
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 	} else {
 		positionBeforeMissingReturnType := parameterList.EndPos
 		returnType := ast.NewNominalType(
@@ -270,7 +263,7 @@ func parseFunctionParameterListAndRest(
 		)
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 
 	if !functionBlockIsOptional ||
 		p.current.Is(lexer.TokenBraceOpen) {

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -231,6 +231,13 @@ func (p *parser) next() {
 	}
 }
 
+// utility for the common pattern of advancing past the current token to
+// the next semantic token
+func (p *parser) nextSemanticToken() {
+	p.next()
+	p.skipSpaceAndComments()
+}
+
 func (p *parser) mustOne(tokenType lexer.TokenType) (lexer.Token, error) {
 	t := p.current
 	if !t.Is(tokenType) {
@@ -383,11 +390,12 @@ type triviaOptions struct {
 	parseDocStrings bool
 }
 
-func (p *parser) skipSpaceAndComments(skipNewlines bool) (containsNewline bool) {
+// utility for the common pattern of skipping past whitespace to the next semantic token
+func (p *parser) skipSpaceAndComments() (containsNewline bool) {
 	containsNewline, _ = p.parseTrivia(triviaOptions{
-		skipNewlines: skipNewlines,
+		skipNewlines: true,
 	})
-	return containsNewline
+	return
 }
 
 func (p *parser) parseTrivia(options triviaOptions) (containsNewline bool, docString string) {
@@ -578,7 +586,7 @@ func ParseArgumentList(input []byte, memoryGauge common.MemoryGauge) (arguments 
 	res, errs = Parse(
 		input,
 		func(p *parser) (any, error) {
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 
 			_, err := p.mustOne(lexer.TokenParenOpen)
 			if err != nil {

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -231,8 +231,8 @@ func (p *parser) next() {
 	}
 }
 
-// utility for the common pattern of advancing past the current token to
-// the next semantic token
+// nextSemanticToken advances past the current token to the next semantic token.
+// It skips whitespace, including newlines, and comments
 func (p *parser) nextSemanticToken() {
 	p.next()
 	p.skipSpaceAndComments()
@@ -390,7 +390,7 @@ type triviaOptions struct {
 	parseDocStrings bool
 }
 
-// utility for the common pattern of skipping past whitespace to the next semantic token
+// skipSpaceAndComments skips whitespace, including newlines, and comments
 func (p *parser) skipSpaceAndComments() (containsNewline bool) {
 	containsNewline, _ = p.parseTrivia(triviaOptions{
 		skipNewlines: true,

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -557,7 +557,7 @@ func TestParseEOF(t *testing.T) {
 			if err != nil {
 				return nil, err
 			}
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 			_, err = p.mustToken(lexer.TokenIdentifier, "b")
 			if err != nil {
 				return nil, err

--- a/runtime/parser/transaction.go
+++ b/runtime/parser/transaction.go
@@ -44,8 +44,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 	startPos := p.current.StartPos
 
 	// Skip the `transaction` keyword
-	p.next()
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 
 	// Parameter list (optional)
 
@@ -59,7 +58,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 		}
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	_, err = p.mustOne(lexer.TokenBraceOpen)
 	if err != nil {
 		return nil, err
@@ -77,7 +76,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 	var prepare *ast.SpecialFunctionDeclaration
 	var execute *ast.SpecialFunctionDeclaration
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	if p.current.Is(lexer.TokenIdentifier) {
 
 		keyword := p.currentTokenSource()
@@ -113,7 +112,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 	var preConditions *ast.Conditions
 
 	if execute == nil {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 		if p.isToken(p.current, lexer.TokenIdentifier, keywordPre) {
 			// Skip the `pre` keyword
 			p.next()
@@ -135,7 +134,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 	sawPost := false
 	atEnd := false
 	for !atEnd {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
@@ -244,8 +243,7 @@ func parseTransactionExecute(p *parser) (*ast.SpecialFunctionDeclaration, error)
 	identifier := p.tokenToIdentifier(p.current)
 
 	// Skip the `execute` keyword
-	p.next()
-	p.skipSpaceAndComments(true)
+	p.nextSemanticToken()
 
 	block, err := parseBlock(p)
 	if err != nil {

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -157,7 +157,7 @@ func init() {
 
 			switch string(p.tokenSource(token)) {
 			case keywordAuth:
-				p.skipSpaceAndComments(true)
+				p.skipSpaceAndComments()
 
 				_, err := p.mustOne(lexer.TokenAmpersand)
 				if err != nil {
@@ -229,15 +229,13 @@ func defineArrayType() {
 				return nil, err
 			}
 
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 
 			var size *ast.IntegerExpression
 
 			if p.current.Is(lexer.TokenSemicolon) {
 				// Skip the semicolon
-				p.next()
-
-				p.skipSpaceAndComments(true)
+				p.nextSemanticToken()
 
 				if !p.current.Type.IsIntegerLiteral() {
 					p.reportSyntaxError("expected positive integer size for constant sized type")
@@ -260,7 +258,7 @@ func defineArrayType() {
 				}
 			}
 
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 
 			endToken, err := p.mustOne(lexer.TokenBracketClose)
 			if err != nil {
@@ -360,7 +358,7 @@ func defineRestrictedOrDictionaryType() {
 			expectType := true
 
 			for !atEnd {
-				p.skipSpaceAndComments(true)
+				p.skipSpaceAndComments()
 
 				switch p.current.Type {
 				case lexer.TokenComma:
@@ -574,7 +572,7 @@ func parseNominalTypes(
 	expectType := true
 	atEnd := false
 	for !atEnd {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 
 		switch p.current.Type {
 		case lexer.TokenComma:
@@ -637,19 +635,19 @@ func defineFunctionType() {
 				return nil, err
 			}
 
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 			_, err = p.mustOne(lexer.TokenColon)
 			if err != nil {
 				return nil, err
 			}
 
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 			returnTypeAnnotation, err := parseTypeAnnotation(p)
 			if err != nil {
 				return nil, err
 			}
 
-			p.skipSpaceAndComments(true)
+			p.skipSpaceAndComments()
 			endToken, err := p.mustOne(lexer.TokenParenClose)
 			if err != nil {
 				return nil, err
@@ -671,7 +669,7 @@ func defineFunctionType() {
 
 func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnotation, err error) {
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	_, err = p.mustOne(lexer.TokenParenOpen)
 	if err != nil {
 		return
@@ -681,7 +679,7 @@ func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnota
 
 	atEnd := false
 	for !atEnd {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 		switch p.current.Type {
 		case lexer.TokenComma:
 			if expectTypeAnnotation {
@@ -740,7 +738,7 @@ func parseType(p *parser, rightBindingPower int) (ast.Type, error) {
 		p.typeDepth--
 	}()
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	t := p.current
 	p.next()
 
@@ -853,7 +851,7 @@ func applyTypeLeftDenotation(p *parser, token lexer.Token, left ast.Type) (ast.T
 }
 
 func parseNominalTypeInvocationRemainder(p *parser) (*ast.InvocationExpression, error) {
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	identifier, err := p.mustOne(lexer.TokenIdentifier)
 	if err != nil {
 		return nil, err
@@ -864,7 +862,7 @@ func parseNominalTypeInvocationRemainder(p *parser) (*ast.InvocationExpression, 
 		return nil, err
 	}
 
-	p.skipSpaceAndComments(true)
+	p.skipSpaceAndComments()
 	parenOpenToken, err := p.mustOne(lexer.TokenParenOpen)
 	if err != nil {
 		return nil, err
@@ -912,7 +910,7 @@ func parseCommaSeparatedTypeAnnotations(
 	expectTypeAnnotation := true
 	atEnd := false
 	for !atEnd {
-		p.skipSpaceAndComments(true)
+		p.skipSpaceAndComments()
 
 		switch p.current.Type {
 		case lexer.TokenComma:


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Quick PR that abstracts away some common patterns in the parser, namely:

`parser.skipSpaceAndComments(skipNewline bool)` is almost always called with `true`, with only 1 exception in parsing return statements. this PR simplifies it to always skip a newline since we often want to just skip past all whitespace until the next semantic token.

`parser.next()` followed by `parser.skipSpaceAndComments(true)` shows up a lot (a few dozen times), when you want to advance past the currently-read token to the next semantically significant one. Added a new method `parser.nextSemanticToken()` which combines these and aids clarity.

I honestly feel that reading `parser.Current` and manually advancing with `parser.next()` is a bit of an antipattern:  `parser.next()` should advance to the next token and return it directly, similar to an iterator over tokens. This is more in line with the behaviour of parser combinator libraries in other languages, but that refactor would be a more involved effort.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
