### PR TITLE
Make the interpreter globals map allocation lazy

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -926,8 +926,8 @@ func (e *interpreterEnvironment) InterpretContract(
 		return nil, err
 	}
 
-	variable, ok := inter.Globals.Get(name)
-	if !ok {
+	variable := inter.Globals.Get(name)
+	if variable == nil {
 		return nil, errors.NewDefaultUserError(
 			"cannot find contract: `%s`",
 			name,

--- a/runtime/interpreter/globalvariables.go
+++ b/runtime/interpreter/globalvariables.go
@@ -19,18 +19,28 @@
 package interpreter
 
 // GlobalVariables represents global variables defined in a program.
-type GlobalVariables map[string]*Variable
+type GlobalVariables struct {
+	variables map[string]*Variable
+}
 
-func (globalVars GlobalVariables) Contains(name string) bool {
-	_, ok := globalVars[name]
+func (g *GlobalVariables) Contains(name string) bool {
+	if g.variables == nil {
+		return false
+	}
+	_, ok := g.variables[name]
 	return ok
 }
 
-func (globalVars GlobalVariables) Get(name string) (*Variable, bool) {
-	variable, ok := globalVars[name]
-	return variable, ok
+func (g *GlobalVariables) Get(name string) *Variable {
+	if g.variables == nil {
+		return nil
+	}
+	return g.variables[name]
 }
 
-func (globalVars GlobalVariables) Set(name string, variable *Variable) {
-	globalVars[name] = variable
+func (g *GlobalVariables) Set(name string, variable *Variable) {
+	if g.variables == nil {
+		g.variables = map[string]*Variable{}
+	}
+	g.variables[name] = variable
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -329,7 +329,6 @@ func newInterpreter(
 		Location:    location,
 		sharedState: sharedState,
 		Config:      config,
-		Globals:     map[string]*Variable{},
 	}
 
 	// Register self
@@ -412,8 +411,8 @@ func (interpreter *Interpreter) invokeVariable(
 ) {
 
 	// function must be defined as a global variable
-	variable, ok := interpreter.Globals.Get(functionName)
-	if !ok {
+	variable := interpreter.Globals.Get(functionName)
+	if variable == nil {
 		return nil, NotDeclaredError{
 			ExpectedKind: common.DeclarationKindFunction,
 			Name:         functionName,
@@ -4007,8 +4006,8 @@ func (interpreter *Interpreter) getElaboration(location common.Location) *sema.E
 
 // GetContractComposite gets the composite value of the contract at the address location.
 func (interpreter *Interpreter) GetContractComposite(contractLocation common.AddressLocation) (*CompositeValue, error) {
-	contractGlobal, ok := interpreter.Globals.Get(contractLocation.Name)
-	if !ok {
+	contractGlobal := interpreter.Globals.Get(contractLocation.Name)
+	if contractGlobal == nil {
 		return nil, NotDeclaredError{
 			ExpectedKind: common.DeclarationKindContract,
 			Name:         contractLocation.Name,

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -60,12 +60,12 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 	if identifierLength > 0 {
 		variables = make(map[string]*Variable, identifierLength)
 		for _, identifier := range resolvedLocation.Identifiers {
-			variable, _ := subInterpreter.Globals.Get(identifier.Identifier)
-			variables[identifier.Identifier] = variable
+			variables[identifier.Identifier] =
+				subInterpreter.Globals.Get(identifier.Identifier)
 		}
 	} else {
 		// Only take the global values defined in the program.
-		variables = subInterpreter.Globals
+		variables = subInterpreter.Globals.variables
 	}
 
 	// Gather all variable names and sort them lexicographically

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -92,7 +92,7 @@ func TestInterpretPlusOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -121,7 +121,7 @@ func TestInterpretMinusOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -150,7 +150,7 @@ func TestInterpretMulOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -179,7 +179,7 @@ func TestInterpretDivOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -208,7 +208,7 @@ func TestInterpretModOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/bitwise_test.go
+++ b/runtime/tests/interpreter/bitwise_test.go
@@ -124,7 +124,7 @@ func TestInterpretBitwiseOr(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00010101),
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -153,7 +153,7 @@ func TestInterpretBitwiseXor(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00000101),
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -182,7 +182,7 @@ func TestInterpretBitwiseAnd(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00010000),
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -211,7 +211,7 @@ func TestInterpretBitwiseLeftShift(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b01100000),
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}
@@ -240,7 +240,7 @@ func TestInterpretBitwiseRightShift(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00001100),
-				inter.Globals["c"].GetValue(),
+				inter.Globals.Get("c").GetValue(),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -50,7 +50,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredStringValue("42"),
-				inter.Globals["y"].GetValue(),
+				inter.Globals.Get("y").GetValue(),
 			)
 		})
 	}
@@ -68,7 +68,7 @@ func TestInterpretToString(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("0x0000000000000042"),
-			inter.Globals["y"].GetValue(),
+			inter.Globals.Get("y").GetValue(),
 		)
 	})
 
@@ -104,7 +104,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				expected,
-				inter.Globals["y"].GetValue(),
+				inter.Globals.Get("y").GetValue(),
 			)
 		})
 	}
@@ -142,7 +142,7 @@ func TestInterpretToBytes(t *testing.T) {
 				interpreter.NewUnmeteredUInt8Value(0x34),
 				interpreter.NewUnmeteredUInt8Value(0x56),
 			),
-			inter.Globals["y"].GetValue(),
+			inter.Globals.Get("y").GetValue(),
 		)
 	})
 }
@@ -345,7 +345,7 @@ func TestInterpretToBigEndianBytes(t *testing.T) {
 					t,
 					inter,
 					interpreter.ByteSliceToByteArrayValue(inter, expected),
-					inter.Globals["result"].GetValue(),
+					inter.Globals.Get("result").GetValue(),
 				)
 			})
 		}

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -56,14 +56,14 @@ func TestInterpretCompositeValue(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("Apple"),
-			inter.Globals["name"].GetValue(),
+			inter.Globals.Get("name").GetValue(),
 		)
 
 		RequireValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("Red"),
-			inter.Globals["color"].GetValue(),
+			inter.Globals.Get("color").GetValue(),
 		)
 	})
 }

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -261,7 +261,7 @@ func TestArrayMutation(t *testing.T) {
 
 		// Check original array
 
-		namesVal := inter.Globals["names"].GetValue()
+		namesVal := inter.Globals.Get("names").GetValue()
 		require.IsType(t, &interpreter.ArrayValue{}, namesVal)
 		namesValArray := namesVal.(*interpreter.ArrayValue)
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -111,14 +111,14 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 									t,
 									inter,
 									test.expected,
-									inter.Globals["x"].GetValue(),
+									inter.Globals.Get("x").GetValue(),
 								)
 
 								AssertValuesEqual(
 									t,
 									inter,
 									test.expected,
-									inter.Globals["y"].GetValue(),
+									inter.Globals.Get("y").GetValue(),
 								)
 
 								AssertValuesEqual(
@@ -127,7 +127,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 									interpreter.NewUnmeteredSomeValueNonCopying(
 										test.expected,
 									),
-									inter.Globals["z"].GetValue(),
+									inter.Globals.Get("z").GetValue(),
 								)
 							})
 						}
@@ -217,7 +217,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 							t,
 							inter,
 							interpreter.Void,
-							inter.Globals["x"].GetValue(),
+							inter.Globals.Get("x").GetValue(),
 						)
 
 						AssertValuesEqual(
@@ -226,7 +226,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.Void,
 							),
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 					})
 				}
@@ -311,7 +311,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 							t,
 							inter,
 							interpreter.NewUnmeteredStringValue("test"),
-							inter.Globals["x"].GetValue(),
+							inter.Globals.Get("x").GetValue(),
 						)
 
 						AssertValuesEqual(
@@ -320,7 +320,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.NewUnmeteredStringValue("test"),
 							),
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 					})
 				}
@@ -404,7 +404,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 							t,
 							inter,
 							interpreter.BoolValue(true),
-							inter.Globals["x"].GetValue(),
+							inter.Globals.Get("x").GetValue(),
 						)
 
 						AssertValuesEqual(
@@ -413,7 +413,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.BoolValue(true),
 							),
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 					})
 				}
@@ -501,7 +501,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 							t,
 							inter,
 							addressValue,
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 
 						AssertValuesEqual(
@@ -510,7 +510,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								addressValue,
 							),
-							inter.Globals["z"].GetValue(),
+							inter.Globals.Get("z").GetValue(),
 						)
 					})
 				}
@@ -595,17 +595,17 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 
 						assert.IsType(t,
 							&interpreter.CompositeValue{},
-							inter.Globals["x"].GetValue(),
+							inter.Globals.Get("x").GetValue(),
 						)
 
 						require.IsType(t,
 							&interpreter.SomeValue{},
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 
 						require.IsType(t,
 							&interpreter.CompositeValue{},
-							inter.Globals["y"].GetValue().(*interpreter.SomeValue).
+							inter.Globals.Get("y").GetValue().(*interpreter.SomeValue).
 								InnerValue(inter, interpreter.EmptyLocationRange),
 						)
 					})
@@ -1098,7 +1098,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							t,
 							inter,
 							expectedValue,
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 
 						if targetType == sema.AnyStructType && !returnsOptional {
@@ -1107,7 +1107,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								t,
 								inter,
 								expectedValue,
-								inter.Globals["z"].GetValue(),
+								inter.Globals.Get("z").GetValue(),
 							)
 
 						} else {
@@ -1117,7 +1117,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								interpreter.NewUnmeteredSomeValueNonCopying(
 									expectedValue,
 								),
-								inter.Globals["z"].GetValue(),
+								inter.Globals.Get("z").GetValue(),
 							)
 						}
 
@@ -1204,7 +1204,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							interpreter.NewUnmeteredIntValueFromInt64(42),
 						}
 
-						yValue := inter.Globals["y"].GetValue()
+						yValue := inter.Globals.Get("y").GetValue()
 						require.IsType(t, yValue, &interpreter.ArrayValue{})
 						yArray := yValue.(*interpreter.ArrayValue)
 
@@ -1215,7 +1215,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							arrayElements(inter, yArray),
 						)
 
-						zValue := inter.Globals["z"].GetValue()
+						zValue := inter.Globals.Get("z").GetValue()
 						require.IsType(t, zValue, &interpreter.SomeValue{})
 						zSome := zValue.(*interpreter.SomeValue)
 
@@ -1375,7 +1375,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							t,
 							inter,
 							expectedDictionary,
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 
 						AssertValuesEqual(
@@ -1384,7 +1384,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								expectedDictionary,
 							),
-							inter.Globals["z"].GetValue(),
+							inter.Globals.Get("z").GetValue(),
 						)
 					})
 				}
@@ -3572,7 +3572,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 							t,
 							inter,
 							capabilityValue,
-							inter.Globals["x"].GetValue(),
+							inter.Globals.Get("x").GetValue(),
 						)
 
 						AssertValuesEqual(
@@ -3581,7 +3581,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								capabilityValue,
 							),
-							inter.Globals["y"].GetValue(),
+							inter.Globals.Get("y").GetValue(),
 						)
 					})
 				}

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -43,7 +43,7 @@ func TestInterpretEnum(t *testing.T) {
 
 	assert.IsType(t,
 		&interpreter.HostFunctionValue{},
-		inter.Globals["E"].GetValue(),
+		inter.Globals.Get("E").GetValue(),
 	)
 }
 
@@ -61,7 +61,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
       let b = E.b
     `)
 
-	a := inter.Globals["a"].GetValue()
+	a := inter.Globals.Get("a").GetValue()
 	require.IsType(t,
 		&interpreter.CompositeValue{},
 		a,
@@ -72,7 +72,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
 		a.(*interpreter.CompositeValue).Kind,
 	)
 
-	b := inter.Globals["b"].GetValue()
+	b := inter.Globals.Get("b").GetValue()
 	require.IsType(t,
 		&interpreter.CompositeValue{},
 		b,
@@ -102,14 +102,14 @@ func TestInterpretEnumCaseRawValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredInt64Value(0),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	RequireValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredInt64Value(1),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 }
 
@@ -144,7 +144,7 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
 		),
-		inter.Globals["res"].GetValue(),
+		inter.Globals.Get("res").GetValue(),
 	)
 }
 
@@ -181,7 +181,7 @@ func TestInterpretEnumConstructor(t *testing.T) {
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
 		),
-		inter.Globals["res"].GetValue(),
+		inter.Globals.Get("res").GetValue(),
 	)
 }
 
@@ -214,7 +214,7 @@ func TestInterpretEnumInstance(t *testing.T) {
 			interpreter.BoolValue(true),
 			interpreter.BoolValue(true),
 		),
-		inter.Globals["res"].GetValue(),
+		inter.Globals.Get("res").GetValue(),
 	)
 }
 
@@ -245,7 +245,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c := inter.Globals["C"].GetValue()
+	c := inter.Globals.Get("C").GetValue()
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -85,14 +85,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(true),
-			inter.Globals["res1"].GetValue(),
+			inter.Globals.Get("res1").GetValue(),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.BoolValue(true),
-			inter.Globals["res2"].GetValue(),
+			inter.Globals.Get("res2").GetValue(),
 		)
 	})
 
@@ -113,14 +113,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(true),
-			inter.Globals["res1"].GetValue(),
+			inter.Globals.Get("res1").GetValue(),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.BoolValue(true),
-			inter.Globals["res2"].GetValue(),
+			inter.Globals.Get("res2").GetValue(),
 		)
 	})
 
@@ -137,7 +137,7 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(false),
-			inter.Globals["res"].GetValue(),
+			inter.Globals.Get("res").GetValue(),
 		)
 	})
 }

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -44,7 +44,7 @@ func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-42000000),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -90,21 +90,21 @@ func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals["y"].GetValue(),
+				inter.Globals.Get("y").GetValue(),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.BoolValue(true),
-				inter.Globals["z"].GetValue(),
+				inter.Globals.Get("z").GetValue(),
 			)
 
 		})
@@ -159,14 +159,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					fixedPointValue,
-					inter.Globals["x"].GetValue(),
+					inter.Globals.Get("x").GetValue(),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					integerValue,
-					inter.Globals["y"].GetValue(),
+					inter.Globals.Get("y").GetValue(),
 				)
 			})
 		}
@@ -198,14 +198,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals["x"].GetValue(),
+					inter.Globals.Get("x").GetValue(),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals["y"].GetValue(),
+					inter.Globals.Get("y").GetValue(),
 				)
 			})
 		}
@@ -238,14 +238,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals["x"].GetValue(),
+					inter.Globals.Get("x").GetValue(),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals["y"].GetValue(),
+					inter.Globals.Get("y").GetValue(),
 				)
 			})
 		}
@@ -271,14 +271,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals["x"].GetValue(),
+					inter.Globals.Get("x").GetValue(),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals["y"].GetValue(),
+					inter.Globals.Get("y").GetValue(),
 				)
 			})
 		}
@@ -304,14 +304,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals["x"].GetValue(),
+					inter.Globals.Get("x").GetValue(),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals["y"].GetValue(),
+					inter.Globals.Get("y").GetValue(),
 				)
 			})
 		}
@@ -556,13 +556,13 @@ func TestInterpretFixedPointMinMax(t *testing.T) {
 			t,
 			inter,
 			test.min,
-			inter.Globals["min"].GetValue(),
+			inter.Globals.Get("min").GetValue(),
 		)
 		RequireValuesEqual(
 			t,
 			inter,
 			test.max,
-			inter.Globals["max"].GetValue(),
+			inter.Globals.Get("max").GetValue(),
 		)
 	}
 

--- a/runtime/tests/interpreter/if_test.go
+++ b/runtime/tests/interpreter/if_test.go
@@ -146,7 +146,7 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 	})
 
@@ -163,7 +163,7 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 	})
 }
@@ -201,7 +201,7 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 	})
 
@@ -218,7 +218,7 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 
 	})
@@ -260,7 +260,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 	})
 
@@ -280,7 +280,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 	})
 }
@@ -321,7 +321,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 
 	})
@@ -341,7 +341,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals["branch"].GetValue(),
+			inter.Globals.Get("branch").GetValue(),
 		)
 	})
 }

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -386,7 +386,7 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
 	err = inter.Interpret()
 	require.NoError(t, err)
 
-	rConstructor := subInterpreter.Globals["R"].GetValue()
+	rConstructor := subInterpreter.Globals.Get("R").GetValue()
 
 	_, err = inter.Invoke("test", rConstructor)
 	RequireError(t, err)

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -95,21 +95,21 @@ func TestInterpretIntegerConversions(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals["y"].GetValue(),
+				inter.Globals.Get("y").GetValue(),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.BoolValue(true),
-				inter.Globals["z"].GetValue(),
+				inter.Globals.Get("z").GetValue(),
 			)
 
 		})
@@ -145,7 +145,7 @@ func TestInterpretWordOverflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				"0",
-				inter.Globals["y"].GetValue().String(),
+				inter.Globals.Get("y").GetValue().String(),
 			)
 		})
 	}
@@ -179,7 +179,7 @@ func TestInterpretWordUnderflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				value.String(),
-				inter.Globals["y"].GetValue().String(),
+				inter.Globals.Get("y").GetValue().String(),
 			)
 		})
 	}
@@ -203,7 +203,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 			},
-			inter.Globals["x"].GetValue(),
+			inter.Globals.Get("x").GetValue(),
 		)
 
 	})
@@ -222,7 +222,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
 			},
-			inter.Globals["x"].GetValue(),
+			inter.Globals.Get("x").GetValue(),
 		)
 	})
 
@@ -282,7 +282,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T
 				t,
 				inter,
 				value,
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 
 		})
@@ -310,7 +310,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *t
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}
@@ -340,7 +340,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 
 			_, err := inter.Invoke("test")
@@ -351,7 +351,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				numberValue.Plus(inter, numberValue),
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}
@@ -381,7 +381,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 
 			_, err := inter.Invoke("test")
@@ -395,7 +395,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					numberValue.Plus(inter, numberValue),
 				),
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}
@@ -425,7 +425,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.
 				t,
 				inter,
 				value,
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}
@@ -455,7 +455,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}
@@ -785,7 +785,7 @@ func TestInterpretIntegerMinMax(t *testing.T) {
 			t,
 			inter,
 			expected,
-			inter.Globals["x"].GetValue(),
+			inter.Globals.Get("x").GetValue(),
 		)
 	}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -170,7 +170,7 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 				continue
 			}
 
-			contractVariable := inter.Globals[compositeDeclaration.Identifier.Identifier]
+			contractVariable := inter.Globals.Get(compositeDeclaration.Identifier.Identifier)
 
 			_ = contractVariable.GetValue()
 		}
@@ -243,28 +243,28 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -280,14 +280,14 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredStringValue("123"),
-		inter.Globals["s"].GetValue(),
+		inter.Globals.Get("s").GetValue(),
 	)
 }
 
@@ -357,7 +357,7 @@ func TestInterpretLexicalScope(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(10),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	value, err := inter.Invoke("f")
@@ -409,7 +409,7 @@ func TestInterpretFunctionSideEffects(t *testing.T) {
 		t,
 		inter,
 		newValue,
-		inter.Globals["value"].GetValue(),
+		inter.Globals.Get("value").GetValue(),
 	)
 }
 
@@ -443,7 +443,7 @@ func TestInterpretNoHoisting(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -462,14 +462,14 @@ func TestInterpretFunctionExpressionsAndScope(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(10),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -513,7 +513,7 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	value, err := inter.Invoke("test")
@@ -530,7 +530,7 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -551,7 +551,7 @@ func TestInterpretConstantRedeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	value, err := inter.Invoke("test")
@@ -673,7 +673,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	actualArray := inter.Globals["z"].GetValue()
+	actualArray := inter.Globals.Get("z").GetValue()
 
 	expectedArray := interpreter.NewArrayValue(
 		inter,
@@ -748,19 +748,19 @@ func TestInterpretStringIndexing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("a"),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("b"),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("c"),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -1403,21 +1403,21 @@ func TestInterpretOrOperatorShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["test"].GetValue(),
+		inter.Globals.Get("test").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -1446,21 +1446,21 @@ func TestInterpretOrOperatorShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["test"].GetValue(),
+		inter.Globals.Get("test").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -1531,21 +1531,21 @@ func TestInterpretAndOperatorShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["test"].GetValue(),
+		inter.Globals.Get("test").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -1574,21 +1574,21 @@ func TestInterpretAndOperatorShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["test"].GetValue(),
+		inter.Globals.Get("test").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -1613,7 +1613,7 @@ func TestInterpretExpressionStatement(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	value, err := inter.Invoke("test")
@@ -1630,7 +1630,7 @@ func TestInterpretExpressionStatement(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -1755,14 +1755,14 @@ func TestInterpretUnaryIntegerNegation(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(-2),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -1781,28 +1781,28 @@ func TestInterpretUnaryBooleanNegation(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 }
 
@@ -1884,7 +1884,7 @@ func TestInterpretHostFunction(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 }
 
@@ -2241,7 +2241,7 @@ func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
 
 	AssertValuesEqual(
 		t,
-		inter, newValue, inter.Globals["value"].GetValue())
+		inter, newValue, inter.Globals.Get("value").GetValue())
 }
 
 func TestInterpretStructureFunctionCall(t *testing.T) {
@@ -2266,7 +2266,7 @@ func TestInterpretStructureFunctionCall(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals["value"].GetValue(),
+		inter.Globals.Get("value").GetValue(),
 	)
 }
 
@@ -2298,7 +2298,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
       }
     `)
 
-	test := inter.Globals["test"].GetValue().(*interpreter.CompositeValue)
+	test := inter.Globals.Get("test").GetValue().(*interpreter.CompositeValue)
 
 	AssertValuesEqual(
 		t,
@@ -2341,7 +2341,7 @@ func TestInterpretStructureInitializesConstant(t *testing.T) {
       let test = Test()
     `)
 
-	actual := inter.Globals["test"].GetValue().(*interpreter.CompositeValue).
+	actual := inter.Globals.Get("test").GetValue().(*interpreter.CompositeValue).
 		GetMember(inter, interpreter.EmptyLocationRange, "foo")
 	AssertValuesEqual(
 		t,
@@ -2789,7 +2789,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["tests"].GetValue(),
+		inter.Globals.Get("tests").GetValue(),
 	)
 
 	value, err := inter.Invoke("test")
@@ -2804,7 +2804,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals["tests"].GetValue(),
+		inter.Globals.Get("tests").GetValue(),
 	)
 
 	value, err = inter.Invoke("test")
@@ -2819,7 +2819,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["tests"].GetValue(),
+		inter.Globals.Get("tests").GetValue(),
 	)
 }
 
@@ -2839,7 +2839,7 @@ func TestInterpretOptionalVariableDeclaration(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -2955,7 +2955,7 @@ func TestInterpretOptionalAssignment(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -2971,7 +2971,7 @@ func TestInterpretNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -2987,7 +2987,7 @@ func TestInterpretOptionalNestingNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3076,7 +3076,7 @@ func TestInterpretNilCoalescingNilIntToOptional(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3096,7 +3096,7 @@ func TestInterpretNilCoalescingNilIntToOptionals(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3115,7 +3115,7 @@ func TestInterpretNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3131,7 +3131,7 @@ func TestInterpretNilCoalescingRightSubtype(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3149,7 +3149,7 @@ func TestInterpretNilCoalescingNilInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3166,7 +3166,7 @@ func TestInterpretNilCoalescingNilLiteralInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3195,21 +3195,21 @@ func TestInterpretNilCoalescingShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals["test"].GetValue(),
+		inter.Globals.Get("test").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3238,21 +3238,21 @@ func TestInterpretNilCoalescingShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["test"].GetValue(),
+		inter.Globals.Get("test").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3269,7 +3269,7 @@ func TestInterpretNilCoalescingOptionalAnyStructNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3286,7 +3286,7 @@ func TestInterpretNilCoalescingOptionalAnyStructSome(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3306,7 +3306,7 @@ func TestInterpretNilCoalescingOptionalRightHandSide(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -3326,7 +3326,7 @@ func TestInterpretNilCoalescingBothOptional(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -3346,7 +3346,7 @@ func TestInterpretNilCoalescingBothOptionalLeftNil(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -3362,7 +3362,7 @@ func TestInterpretNilsComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -3380,14 +3380,14 @@ func TestInterpretNonOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -3404,7 +3404,7 @@ func TestInterpretOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3421,7 +3421,7 @@ func TestInterpretNestedOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3438,7 +3438,7 @@ func TestInterpretOptionalNilComparisonSwapped(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3455,7 +3455,7 @@ func TestInterpretNestedOptionalNilComparisonSwapped(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3473,7 +3473,7 @@ func TestInterpretNestedOptionalComparisonNils(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -3491,7 +3491,7 @@ func TestInterpretNestedOptionalComparisonValues(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -3509,7 +3509,7 @@ func TestInterpretNestedOptionalComparisonMixed(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -3526,7 +3526,7 @@ func TestInterpretOptionalSomeValueComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3543,7 +3543,7 @@ func TestInterpretOptionalNilValueComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -3566,7 +3566,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("42"),
 			),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 
@@ -3583,7 +3583,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 			t,
 			inter,
 			interpreter.Nil,
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 }
@@ -3650,14 +3650,14 @@ func TestInterpretCompositeNilEquality(t *testing.T) {
 				t,
 				inter,
 				interpreter.BoolValue(false),
-				inter.Globals["y"].GetValue(),
+				inter.Globals.Get("y").GetValue(),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.BoolValue(false),
-				inter.Globals["z"].GetValue(),
+				inter.Globals.Get("z").GetValue(),
 			)
 		})
 	}
@@ -3710,7 +3710,7 @@ func TestInterpretInterfaceConformanceNoRequirements(t *testing.T) {
 
 			assert.IsType(t,
 				&interpreter.CompositeValue{},
-				inter.Globals["test"].GetValue(),
+				inter.Globals.Get("test").GetValue(),
 			)
 		})
 	}
@@ -3790,7 +3790,7 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredIntValueFromInt64(1),
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}
@@ -3858,7 +3858,7 @@ func TestInterpretInterfaceFunctionUse(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredIntValueFromInt64(2),
-				inter.Globals["val"].GetValue(),
+				inter.Globals.Get("val").GetValue(),
 			)
 		})
 	}
@@ -4116,7 +4116,7 @@ func TestInterpretDictionary(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
-	actualDict := inter.Globals["x"].GetValue()
+	actualDict := inter.Globals.Get("x").GetValue()
 
 	AssertValuesEqual(
 		t,
@@ -4146,7 +4146,7 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
-	actualDict := inter.Globals["x"].GetValue()
+	actualDict := inter.Globals.Get("x").GetValue()
 
 	AssertValuesEqual(
 		t,
@@ -4173,7 +4173,7 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -4182,14 +4182,14 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 }
 
@@ -4209,7 +4209,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -4218,7 +4218,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 }
 
@@ -4239,7 +4239,7 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -4248,14 +4248,14 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 }
 
@@ -4286,39 +4286,39 @@ func TestInterpretDictionaryIndexingType(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("c"),
 		),
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 
 	// types need to match exactly, subtypes won't cut it
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("f"),
 		),
-		inter.Globals["f"].GetValue(),
+		inter.Globals.Get("f").GetValue(),
 	)
 }
 
@@ -4343,7 +4343,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 		value,
 	)
 
-	actualValue := inter.Globals["x"].GetValue()
+	actualValue := inter.Globals.Get("x").GetValue()
 	actualDict := actualValue.(*interpreter.DictionaryValue)
 
 	newValue := actualDict.GetKey(
@@ -4402,7 +4402,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
-	actualDict := inter.Globals["x"].GetValue().(*interpreter.DictionaryValue)
+	actualDict := inter.Globals.Get("x").GetValue().(*interpreter.DictionaryValue)
 
 	AssertValuesEqual(
 		t,
@@ -4468,7 +4468,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
-	actualDict := inter.Globals["x"].GetValue().(*interpreter.DictionaryValue)
+	actualDict := inter.Globals.Get("x").GetValue().(*interpreter.DictionaryValue)
 
 	RequireValuesEqual(
 		t,
@@ -4516,7 +4516,7 @@ func TestInterpretOptionalAnyStruct(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -4535,7 +4535,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -4544,7 +4544,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -4564,14 +4564,14 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(23),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -4580,7 +4580,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -4598,14 +4598,14 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -4614,7 +4614,7 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }
 
@@ -4845,7 +4845,7 @@ func TestInterpretArrayLength(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -4862,13 +4862,13 @@ func TestInterpretStringLength(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(4),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(4),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -4962,7 +4962,7 @@ func TestInterpretArrayAppend(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	actualArray := inter.Globals["xs"].GetValue()
+	actualArray := inter.Globals.Get("xs").GetValue()
 
 	arrayValue := actualArray.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5214,7 +5214,7 @@ func TestInterpretArrayInsert(t *testing.T) {
 			_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(int64(testCase.index)))
 			require.NoError(t, err)
 
-			actualArray := inter.Globals["x"].GetValue()
+			actualArray := inter.Globals.Get("x").GetValue()
 
 			require.IsType(t, &interpreter.ArrayValue{}, actualArray)
 
@@ -5278,7 +5278,7 @@ func TestInterpretArrayRemove(t *testing.T) {
       let y = x.remove(at: 1)
     `)
 
-	value := inter.Globals["x"].GetValue()
+	value := inter.Globals.Get("x").GetValue()
 
 	arrayValue := value.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5296,7 +5296,7 @@ func TestInterpretArrayRemove(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -5349,7 +5349,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
       let y = x.removeFirst()
     `)
 
-	value := inter.Globals["x"].GetValue()
+	value := inter.Globals.Get("x").GetValue()
 
 	arrayValue := value.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5367,7 +5367,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -5410,7 +5410,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
           let y = x.removeLast()
     `)
 
-	value := inter.Globals["x"].GetValue()
+	value := inter.Globals.Get("x").GetValue()
 
 	arrayValue := value.(*interpreter.ArrayValue)
 
@@ -5429,7 +5429,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 }
 
@@ -5738,7 +5738,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
       let removed = xs.remove(key: "abc")
     `)
 
-	actualValue := inter.Globals["xs"].GetValue()
+	actualValue := inter.Globals.Get("xs").GetValue()
 
 	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
 	actualDict := actualValue.(*interpreter.DictionaryValue)
@@ -5760,7 +5760,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["removed"].GetValue(),
+		inter.Globals.Get("removed").GetValue(),
 	)
 }
 
@@ -5773,7 +5773,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
       let inserted = xs.insert(key: "abc", 3)
     `)
 
-	actualValue := inter.Globals["xs"].GetValue()
+	actualValue := inter.Globals.Get("xs").GetValue()
 
 	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
 	actualDict := actualValue.(*interpreter.DictionaryValue)
@@ -5796,7 +5796,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["inserted"].GetValue(),
+		inter.Globals.Get("inserted").GetValue(),
 	)
 }
 
@@ -5998,7 +5998,7 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
-				inter.Globals["v"].GetValue(),
+				inter.Globals.Get("v").GetValue(),
 			)
 		})
 	}
@@ -6030,7 +6030,7 @@ func TestInterpretPathToString(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.NewUnmeteredStringValue(val),
-				inter.Globals["y"].GetValue(),
+				inter.Globals.Get("y").GetValue(),
 			)
 		})
 	}
@@ -6121,7 +6121,7 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["destroys"].GetValue(),
+		inter.Globals.Get("destroys").GetValue(),
 	)
 
 	value, err := inter.Invoke("test")
@@ -6138,7 +6138,7 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["destroys"].GetValue(),
+		inter.Globals.Get("destroys").GetValue(),
 	)
 }
 
@@ -6173,7 +6173,7 @@ func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["destroys"].GetValue(),
+		inter.Globals.Get("destroys").GetValue(),
 	)
 
 	_, err := inter.Invoke("test")
@@ -6183,7 +6183,7 @@ func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["destroys"].GetValue(),
+		inter.Globals.Get("destroys").GetValue(),
 	)
 }
 
@@ -6437,7 +6437,7 @@ func TestInterpretResourceDestroyExpressionDestructor(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["ranDestructor"].GetValue(),
+		inter.Globals.Get("ranDestructor").GetValue(),
 	)
 
 	_, err := inter.Invoke("test")
@@ -6447,7 +6447,7 @@ func TestInterpretResourceDestroyExpressionDestructor(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["ranDestructor"].GetValue(),
+		inter.Globals.Get("ranDestructor").GetValue(),
 	)
 }
 
@@ -6489,14 +6489,14 @@ func TestInterpretResourceDestroyExpressionNestedResources(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["ranDestructorA"].GetValue(),
+		inter.Globals.Get("ranDestructorA").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["ranDestructorB"].GetValue(),
+		inter.Globals.Get("ranDestructorB").GetValue(),
 	)
 
 	_, err := inter.Invoke("test")
@@ -6506,14 +6506,14 @@ func TestInterpretResourceDestroyExpressionNestedResources(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["ranDestructorA"].GetValue(),
+		inter.Globals.Get("ranDestructorA").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["ranDestructorB"].GetValue(),
+		inter.Globals.Get("ranDestructorB").GetValue(),
 	)
 }
 
@@ -6540,7 +6540,7 @@ func TestInterpretResourceDestroyArray(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 
 	_, err := inter.Invoke("test")
@@ -6550,7 +6550,7 @@ func TestInterpretResourceDestroyArray(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 }
 
@@ -6577,7 +6577,7 @@ func TestInterpretResourceDestroyDictionary(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 
 	_, err := inter.Invoke("test")
@@ -6587,7 +6587,7 @@ func TestInterpretResourceDestroyDictionary(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 }
 
@@ -6614,7 +6614,7 @@ func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 
 	_, err := inter.Invoke("test")
@@ -6624,7 +6624,7 @@ func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 }
 
@@ -6651,7 +6651,7 @@ func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 
 	_, err := inter.Invoke("test")
@@ -6661,7 +6661,7 @@ func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals["destructionCount"].GetValue(),
+		inter.Globals.Get("destructionCount").GetValue(),
 	)
 }
 
@@ -7732,7 +7732,7 @@ func TestInterpretCastingIntLiteralToInt8(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredInt8Value(42),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -7748,7 +7748,7 @@ func TestInterpretCastingIntLiteralToAnyStruct(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -7764,7 +7764,7 @@ func TestInterpretCastingIntLiteralToOptional(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewUnmeteredIntValueFromInt64(42)),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -7817,7 +7817,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["x1"].GetValue(),
+		inter.Globals.Get("x1").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -7826,7 +7826,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals["x2"].GetValue(),
+		inter.Globals.Get("x2").GetValue(),
 	)
 }
 
@@ -7854,17 +7854,17 @@ func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["x1"].GetValue(),
+		inter.Globals.Get("x1").GetValue(),
 	)
 
 	require.IsType(t,
 		&interpreter.SomeValue{},
-		inter.Globals["x2"].GetValue(),
+		inter.Globals.Get("x2").GetValue(),
 	)
 
 	assert.IsType(t,
 		interpreter.BoundFunctionValue{},
-		inter.Globals["x2"].GetValue().(*interpreter.SomeValue).
+		inter.Globals.Get("x2").GetValue().(*interpreter.SomeValue).
 			InnerValue(inter, interpreter.EmptyLocationRange),
 	)
 }
@@ -7893,7 +7893,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["x1"].GetValue(),
+		inter.Globals.Get("x1").GetValue(),
 	)
 
 	AssertValuesEqual(
@@ -7902,7 +7902,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals["x2"].GetValue(),
+		inter.Globals.Get("x2").GetValue(),
 	)
 }
 
@@ -7944,7 +7944,7 @@ func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -7984,7 +7984,7 @@ func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -8028,14 +8028,14 @@ func TestInterpretOptionalChainingArgumentEvaluation(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(nil, 2),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(nil, 1),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 }
 
@@ -8070,8 +8070,8 @@ func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	x1 := inter.Globals["x1"].GetValue()
-	x2 := inter.Globals["x2"].GetValue()
+	x1 := inter.Globals.Get("x1").GetValue()
+	x2 := inter.Globals.Get("x2").GetValue()
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -8115,7 +8115,7 @@ func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	x := inter.Globals["x"].GetValue()
+	x := inter.Globals.Get("x").GetValue()
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -8248,14 +8248,14 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 		t,
 		inter,
 		addressValue,
-		inter.Globals["address1"].GetValue(),
+		inter.Globals.Get("address1").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		addressValue,
-		inter.Globals["address2"].GetValue(),
+		inter.Globals.Get("address2").GetValue(),
 	)
 }
 
@@ -8383,7 +8383,7 @@ func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	i := inter.Globals["C"].GetValue().(interpreter.MemberAccessibleValue).
+	i := inter.Globals.Get("C").GetValue().(interpreter.MemberAccessibleValue).
 		GetMember(inter, interpreter.EmptyLocationRange, "i")
 
 	require.IsType(t,
@@ -8527,21 +8527,21 @@ func TestInterpretFix64(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredUFix64Value(78_900_123_010),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredUFix64Value(123_405_600_000),
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-1_234_500_678_900),
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 }
 
@@ -8559,7 +8559,7 @@ func TestInterpretFix64Mul(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-121000000),
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 }
 
@@ -8718,7 +8718,7 @@ func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 }
 
@@ -9243,14 +9243,14 @@ func TestInterpretForce(t *testing.T) {
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredIntValueFromInt64(1),
 			),
-			inter.Globals["x"].GetValue(),
+			inter.Globals.Get("x").GetValue(),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals["y"].GetValue(),
+			inter.Globals.Get("y").GetValue(),
 		)
 	})
 
@@ -9285,7 +9285,7 @@ func TestInterpretForce(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals["y"].GetValue(),
+			inter.Globals.Get("y").GetValue(),
 		)
 	})
 }
@@ -9465,7 +9465,7 @@ func TestInterpretCountDigits256(t *testing.T) {
 
 			assert.Equal(t,
 				bigInt,
-				inter.Globals["number"].GetValue().(interpreter.BigNumberValue).ToBigInt(nil),
+				inter.Globals.Get("number").GetValue().(interpreter.BigNumberValue).ToBigInt(nil),
 			)
 
 			expected := interpreter.NewUnmeteredUInt8Value(uint8(test.Count))
@@ -9476,7 +9476,7 @@ func TestInterpretCountDigits256(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals[variableName].GetValue(),
+					inter.Globals.Get(variableName).GetValue(),
 				)
 			}
 		})
@@ -9511,7 +9511,7 @@ func TestInterpretFailableCastingCompositeTypeConfusion(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals["s"].GetValue(),
+		inter.Globals.Get("s").GetValue(),
 	)
 }
 
@@ -9851,7 +9851,7 @@ func TestInterpretMissingMember(t *testing.T) {
 	)
 
 	// Remove field `y`
-	compositeValue := inter.Globals["x"].GetValue().(*interpreter.CompositeValue)
+	compositeValue := inter.Globals.Get("x").GetValue().(*interpreter.CompositeValue)
 	compositeValue.RemoveField(inter, interpreter.EmptyLocationRange, "y")
 
 	_, err := inter.Invoke("test")
@@ -9902,7 +9902,7 @@ func TestHostFunctionStaticType(t *testing.T) {
             let y = x.toString
         `)
 
-		value := inter.Globals["y"].GetValue()
+		value := inter.Globals.Get("y").GetValue()
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
@@ -9918,7 +9918,7 @@ func TestHostFunctionStaticType(t *testing.T) {
             let y = x<Int8>()
         `)
 
-		value := inter.Globals["x"].GetValue()
+		value := inter.Globals.Get("x").GetValue()
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(
@@ -9930,7 +9930,7 @@ func TestHostFunctionStaticType(t *testing.T) {
 			value.StaticType(inter),
 		)
 
-		value = inter.Globals["y"].GetValue()
+		value = inter.Globals.Get("y").GetValue()
 		assert.Equal(
 			t,
 			interpreter.PrimitiveStaticTypeMetaType,
@@ -9956,14 +9956,14 @@ func TestHostFunctionStaticType(t *testing.T) {
 		// Both `x` and `y` are two functions that returns a string.
 		// Hence, their types are equal. i.e: Receivers shouldn't matter.
 
-		xValue := inter.Globals["x"].GetValue()
+		xValue := inter.Globals.Get("x").GetValue()
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
 			xValue.StaticType(inter),
 		)
 
-		yValue := inter.Globals["y"].GetValue()
+		yValue := inter.Globals.Get("y").GetValue()
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
@@ -10127,8 +10127,8 @@ func TestInterpretCastingBoxing(t *testing.T) {
           let a = (1 as? Int?!)?.getType()
         `)
 
-		variable, ok := inter.Globals.Get("a")
-		require.True(t, ok)
+		variable := inter.Globals.Get("a")
+		require.NotNil(t, variable)
 
 		require.Equal(
 			t,
@@ -10149,8 +10149,8 @@ func TestInterpretCastingBoxing(t *testing.T) {
           let a = (1 as! Int?)?.getType()
         `)
 
-		variable, ok := inter.Globals.Get("a")
-		require.True(t, ok)
+		variable := inter.Globals.Get("a")
+		require.NotNil(t, variable)
 
 		require.Equal(
 			t,
@@ -10171,8 +10171,8 @@ func TestInterpretCastingBoxing(t *testing.T) {
           let a = (1 as Int?)?.getType()
         `)
 
-		variable, ok := inter.Globals.Get("a")
-		require.True(t, ok)
+		variable := inter.Globals.Get("a")
+		require.NotNil(t, variable)
 
 		require.Equal(
 			t,
@@ -10212,8 +10212,8 @@ func TestInterpretNilCoalesceReference(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	variable, ok := inter.Globals.Get("ref")
-	require.True(t, ok)
+	variable := inter.Globals.Get("ref")
+	require.NotNil(t, variable)
 
 	require.Equal(
 		t,

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -49,7 +49,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(true),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 
@@ -65,7 +65,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(false),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 
@@ -81,7 +81,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(false),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 
@@ -97,7 +97,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(true),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 
@@ -113,7 +113,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(false),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 
@@ -155,7 +155,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(false),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 
@@ -211,7 +211,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.BoolValue(false),
-			inter.Globals["result"].GetValue(),
+			inter.Globals.Get("result").GetValue(),
 		)
 	})
 }
@@ -233,7 +233,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("[Int]"),
-			inter.Globals["identifier"].GetValue(),
+			inter.Globals.Get("identifier").GetValue(),
 		)
 	})
 
@@ -252,7 +252,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("S.test.S"),
-			inter.Globals["identifier"].GetValue(),
+			inter.Globals.Get("identifier").GetValue(),
 		)
 	})
 
@@ -300,7 +300,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue(""),
-			inter.Globals["identifier"].GetValue(),
+			inter.Globals.Get("identifier").GetValue(),
 		)
 	})
 }
@@ -425,7 +425,7 @@ func TestInterpretIsInstance(t *testing.T) {
 				t,
 				inter,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals["result"].GetValue(),
+				inter.Globals.Get("result").GetValue(),
 			)
 		})
 	}
@@ -563,7 +563,7 @@ func TestInterpretIsSubtype(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals["result"].GetValue(),
+				inter.Globals.Get("result").GetValue(),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/path_test.go
+++ b/runtime/tests/interpreter/path_test.go
@@ -54,7 +54,7 @@ func TestInterpretPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "random",
 				},
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}
@@ -91,7 +91,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "foo",
 				},
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 
@@ -112,7 +112,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.Nil,
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 
@@ -133,7 +133,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.Nil,
-				inter.Globals["x"].GetValue(),
+				inter.Globals.Get("x").GetValue(),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -803,7 +803,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &r as &R?
         `)
 
-		value := inter.Globals["ref"].GetValue()
+		value := inter.Globals.Get("ref").GetValue()
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -822,7 +822,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &s as &S?
         `)
 
-		value := inter.Globals["ref"].GetValue()
+		value := inter.Globals.Get("ref").GetValue()
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -839,7 +839,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals["ref"].GetValue()
+		value := inter.Globals.Get("ref").GetValue()
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -856,7 +856,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals["ref"].GetValue()
+		value := inter.Globals.Get("ref").GetValue()
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -873,7 +873,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals["ref"].GetValue()
+		value := inter.Globals.Get("ref").GetValue()
 		require.IsType(t, interpreter.Nil, value)
 	})
 
@@ -886,7 +886,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals["ref"].GetValue()
+		value := inter.Globals.Get("ref").GetValue()
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -49,7 +49,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -58,7 +58,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -71,7 +71,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -82,12 +82,12 @@ func TestInterpretOptionalType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 }
 
@@ -112,7 +112,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -121,7 +121,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -134,7 +134,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -145,11 +145,11 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 }
 
@@ -175,7 +175,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(10),
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -185,7 +185,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(5),
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -199,7 +199,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(400),
 			},
 		},
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -212,12 +212,12 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(6),
 			},
 		},
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 }
 
@@ -245,7 +245,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -255,7 +255,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -269,7 +269,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -282,17 +282,17 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType: interpreter.PrimitiveStaticTypeBool,
 			},
 		},
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["f"].GetValue(),
+		inter.Globals.Get("f").GetValue(),
 	)
 }
 
@@ -326,7 +326,7 @@ func TestInterpretCompositeType(t *testing.T) {
 				TypeID:              "S.test.R",
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -337,22 +337,22 @@ func TestInterpretCompositeType(t *testing.T) {
 				TypeID:              "S.test.S",
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -363,7 +363,7 @@ func TestInterpretCompositeType(t *testing.T) {
 				TypeID:              "S.test.F",
 			},
 		},
-		inter.Globals["f"].GetValue(),
+		inter.Globals.Get("f").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -374,7 +374,7 @@ func TestInterpretCompositeType(t *testing.T) {
 				TypeID:              "PublicKey",
 			},
 		},
-		inter.Globals["g"].GetValue(),
+		inter.Globals.Get("g").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -385,7 +385,7 @@ func TestInterpretCompositeType(t *testing.T) {
 				TypeID:              "HashAlgorithm",
 			},
 		},
-		inter.Globals["h"].GetValue(),
+		inter.Globals.Get("h").GetValue(),
 	)
 }
 
@@ -411,7 +411,7 @@ func TestInterpretInterfaceType(t *testing.T) {
 				Location:            utils.TestLocation,
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -421,17 +421,17 @@ func TestInterpretInterfaceType(t *testing.T) {
 				Location:            utils.TestLocation,
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 }
 
@@ -456,7 +456,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -471,7 +471,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -483,12 +483,12 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 }
 
@@ -517,7 +517,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				Authorized: true,
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -527,7 +527,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				Authorized:   false,
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -541,12 +541,12 @@ func TestInterpretReferenceType(t *testing.T) {
 				Authorized: true,
 			},
 		},
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 }
 
@@ -597,7 +597,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -616,7 +616,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -631,7 +631,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["j"].GetValue(),
+		inter.Globals.Get("j").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -646,42 +646,42 @@ func TestInterpretRestrictedType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["k"].GetValue(),
+		inter.Globals.Get("k").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["f"].GetValue(),
+		inter.Globals.Get("f").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["g"].GetValue(),
+		inter.Globals.Get("g").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["h"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("h").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["b"].GetValue(),
-		inter.Globals["i"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("i").GetValue(),
 	)
 }
 
@@ -709,7 +709,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["a"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -721,7 +721,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["b"].GetValue(),
+		inter.Globals.Get("b").GetValue(),
 	)
 
 	assert.Equal(t,
@@ -737,16 +737,16 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals["c"].GetValue(),
+		inter.Globals.Get("c").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals["d"].GetValue(),
+		inter.Globals.Get("d").GetValue(),
 	)
 
 	assert.Equal(t,
-		inter.Globals["a"].GetValue(),
-		inter.Globals["e"].GetValue(),
+		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("e").GetValue(),
 	)
 }

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -424,20 +424,20 @@ func TestInterpretCompareCharacters(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["x"].GetValue(),
+		inter.Globals.Get("x").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(true),
-		inter.Globals["y"].GetValue(),
+		inter.Globals.Get("y").GetValue(),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.BoolValue(false),
-		inter.Globals["z"].GetValue(),
+		inter.Globals.Get("z").GetValue(),
 	)
 }

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -302,7 +302,7 @@ func TestInterpretTransactions(t *testing.T) {
 		err := inter.InvokeTransaction(0, arguments...)
 		assert.NoError(t, err)
 
-		values := inter.Globals["values"].GetValue()
+		values := inter.Globals.Get("values").GetValue()
 
 		require.IsType(t, &interpreter.ArrayValue{}, values)
 


### PR DESCRIPTION
Work towards #1883 

## Description

Reduce memory usage in the interpreter.

Instead of always allocating the globals map at interpreter construction time, delay it until a global is set.
This should reduce allocations for the case where the interpreter is used without a program, e.g. only for storage operations.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
