### PR TITLE
Prevent keywords from being used as names in function declarations

### DIFF
--- a/runtime/parser/statement.go
+++ b/runtime/parser/statement.go
@@ -176,7 +176,10 @@ func parseFunctionDeclarationOrFunctionExpressionStatement(
 	p.skipSpaceAndComments(true)
 
 	if p.current.Is(lexer.TokenIdentifier) {
-		identifier := p.tokenToIdentifier(p.current)
+		identifier, err := p.nonReservedIdentifier("after start of function declaration")
+		if err != nil {
+			return nil, err
+		}
 
 		p.next()
 

--- a/runtime/parser/statement_test.go
+++ b/runtime/parser/statement_test.go
@@ -1124,6 +1124,36 @@ func TestParseFunctionStatementOrExpression(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("function expression with keyword as name", func(t *testing.T) {
+		t.Parallel()
+
+		result, errs := testParseStatements("fun continue() {}")
+
+		require.Empty(t, result)
+
+		utils.AssertEqualWithDiff(t, []error{
+			&SyntaxError{
+				Message: "expected identifier after start of function declaration, got keyword continue",
+				Pos:     ast.Position{Line: 1, Column: 4, Offset: 4},
+			},
+		}, errs)
+	})
+
+	t.Run("function expression with purity, and keyword as name", func(t *testing.T) {
+		t.Parallel()
+
+		result, errs := testParseStatements("view fun break() {}")
+
+		require.Empty(t, result)
+
+		utils.AssertEqualWithDiff(t, []error{
+			&SyntaxError{
+				Message: "expected identifier after start of function declaration, got keyword break",
+				Pos:     ast.Position{Line: 1, Column: 9, Offset: 9},
+			},
+		}, errs)
+	})
 }
 
 func TestParseViewNonFunction(t *testing.T) {


### PR DESCRIPTION
Closes #2066

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Extends the keyword collision check to be used in `parseFunctionDeclarationOrFunctionExpressionStatement` from `statement.go`. This was something I missed in #1937.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
