### PR TITLE
Optimize resource tracking

### DIFF
--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -142,7 +142,9 @@ func (checker *Checker) checkConditionalBranches(
 
 	initialResources := checker.resources
 	thenResources := initialResources.Clone()
+	defer thenResources.Reclaim()
 	elseResources := initialResources.Clone()
+	defer elseResources.Reclaim()
 
 	thenType = checker.checkBranch(
 		checkThen,

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -235,6 +235,9 @@ func (checker *Checker) Check() error {
 
 		checker.Elaboration.setIsChecking(false)
 		checker.isChecked = true
+
+		checker.resources.Reclaim()
+		checker.resources = nil
 	}
 	err := checker.CheckerError()
 	if err != nil {
@@ -1578,6 +1581,7 @@ func (checker *Checker) checkPotentiallyUnevaluated(check TypeCheckFunc) Type {
 
 	initialResources := checker.resources
 	temporaryResources := initialResources.Clone()
+	defer temporaryResources.Reclaim()
 
 	result := checker.checkBranch(
 		check,


### PR DESCRIPTION
## Description

Add an object pool for `sema.Resources`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
