### PR TITLE
Re-use interpreter for value decoding in test-framework

### DIFF
--- a/runtime/stdlib/test-framework.go
+++ b/runtime/stdlib/test-framework.go
@@ -28,11 +28,12 @@ import (
 // Cadence standard library talks to test providers via this interface.
 // This is used as a way to inject test provider dependencies dynamically.
 type TestFramework interface {
-	RunScript(code string, arguments []interpreter.Value) *ScriptResult
+	RunScript(inter *interpreter.Interpreter, code string, arguments []interpreter.Value) *ScriptResult
 
 	CreateAccount() (*Account, error)
 
 	AddTransaction(
+		inter *interpreter.Interpreter,
 		code string,
 		authorizers []common.Address,
 		signers []*Account,
@@ -44,6 +45,7 @@ type TestFramework interface {
 	CommitBlock() error
 
 	DeployContract(
+		inter *interpreter.Interpreter,
 		name string,
 		code string,
 		account *Account,

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -836,9 +836,11 @@ func emulatorBackendExecuteScriptFunction(testFramework TestFramework) *interpre
 				panic(errors.NewUnexpectedErrorFromCause(err))
 			}
 
-			result := testFramework.RunScript(script.Str, args)
+			inter := invocation.Interpreter
 
-			return newScriptResult(invocation.Interpreter, result.Value, result)
+			result := testFramework.RunScript(inter, script.Str, args)
+
+			return newScriptResult(inter, result.Value, result)
 		},
 		emulatorBackendExecuteScriptFunctionType,
 	)
@@ -1054,7 +1056,14 @@ func emulatorBackendAddTransactionFunction(testFramework TestFramework) *interpr
 				panic(errors.NewUnexpectedErrorFromCause(err))
 			}
 
-			err = testFramework.AddTransaction(code.Str, authorizers, signerAccounts, args)
+			err = testFramework.AddTransaction(
+				invocation.Interpreter,
+				code.Str,
+				authorizers,
+				signerAccounts,
+				args,
+			)
+
 			if err != nil {
 				panic(err)
 			}
@@ -1381,6 +1390,7 @@ func emulatorBackendDeployContractFunction(testFramework TestFramework) *interpr
 			}
 
 			err = testFramework.DeployContract(
+				inter,
 				name.Str,
 				code.Str,
 				account,


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence-tools/issues/33

## Description

Pass the interpreter instance which is used to run the test-script, for also decoding values (return values, arguments).
See: https://github.com/onflow/cadence-tools/pull/34

This avoids having to instantiate a new interpreter instance just for decoding values. Also avoids any potential misconfigurations of the interpreter.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
