### PR TITLE
[no merge] Adds link to Playground on Cadence homepage

### DIFF
--- a/docs/flow-docs.json
+++ b/docs/flow-docs.json
@@ -24,6 +24,12 @@
           "tags": ["guide", "patterns"],
           "description": "Learn the key differences in the account models between Solidity and Cadence.",
           "href": "/cadence/msg-sender"
+        },
+        {
+          "title": "Flow Playground",
+          "tags": ["beginner", "advanced", "smart-contracts"],
+          "description": "Learn Cadence Smart Contract programming using our web-based Cadence IDE",
+          "href": "https://play.flow.com"
         }
       ]
     }


### PR DESCRIPTION
Reference issue: https://github.com/onflow/developer-portal/issues/719

Wait to merge this until signoff form Playground and Docs teams.
