### PR TITLE
Improve type inference for case expressions in switch statement

### DIFF
--- a/runtime/sema/check_switch.go
+++ b/runtime/sema/check_switch.go
@@ -87,7 +87,12 @@ func (checker *Checker) checkSwitchCaseExpression(
 	testTypeIsValid bool,
 ) {
 
-	caseType := checker.VisitExpression(caseExpression, nil)
+	var caseExprExpectedType Type
+	if testTypeIsValid {
+		caseExprExpectedType = testType
+	}
+
+	caseType := checker.VisitExpression(caseExpression, caseExprExpectedType)
 
 	if caseType.IsInvalidType() {
 		return
@@ -96,21 +101,7 @@ func (checker *Checker) checkSwitchCaseExpression(
 	// The type of each case expression must be the same
 	// as the type of the test expression
 
-	if testTypeIsValid {
-		// If the test type is valid,
-		// the case type can be checked to be equatable and compatible in one go
-
-		if !AreCompatibleEquatableTypes(testType, caseType) {
-			checker.report(
-				&InvalidBinaryOperandsError{
-					Operation: ast.OperationEqual,
-					LeftType:  testType,
-					RightType: caseType,
-					Range:     ast.NewRangeFromPositioned(checker.memoryGauge, caseExpression),
-				},
-			)
-		}
-	} else {
+	if !testTypeIsValid {
 		// If the test type is invalid,
 		// at least the case type can be checked to be equatable
 

--- a/runtime/tests/checker/switch_test.go
+++ b/runtime/tests/checker/switch_test.go
@@ -462,4 +462,23 @@ func TestCheckCaseExpressionTypeInference(t *testing.T) {
 		errs := RequireCheckerErrors(t, err, 1)
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 	})
+
+	t.Run("character literal", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            fun test(): Int {
+                let c: Character = "a"
+                switch c {
+                case "b": return 0
+                case "c": return 1
+                case "d": return 2
+                case "a": return 1337
+                default: return -1
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Closes #2077

## Description

Pass the type of condition-expression as the expected-type of the case-expressions.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
