### PR TITLE
Allow for-loops over strings

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1377,6 +1377,10 @@ func (i ArrayValueIterator) Next(interpreter *Interpreter) Value {
 		panic(errors.NewExternalError(err))
 	}
 
+	if atreeValue == nil {
+		return nil
+	}
+
 	// atree.Array iterator returns low-level atree.Value,
 	// convert to high-level interpreter.Value
 	return MustConvertStoredValue(interpreter, atreeValue)

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -60,6 +60,8 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 			)
 		} else if arrayType, ok := valueType.(ArrayType); ok {
 			elementType = arrayType.ElementType(false)
+		} else if valueType == StringType {
+			elementType = CharacterType
 		} else {
 			checker.report(
 				&TypeMismatchWithDescriptionError{

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -58,6 +58,24 @@ func TestCheckForConstantSized(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCheckForString(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test(): [Character] {
+          let characters: [Character] = []
+          let hello = "hello"
+          for c in hello {
+              characters.append(c)
+          }
+          return characters
+      }
+    `)
+
+	assert.NoError(t, err)
+}
+
 func TestCheckForEmpty(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -216,6 +217,41 @@ func TestInterpretForStatementEmpty(t *testing.T) {
 		t,
 		inter,
 		interpreter.BoolValue(false),
+		value,
+	)
+}
+
+func TestInterpretForString(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      fun test(): [Character] {
+          let characters: [Character] = []
+          let hello = "👪❤️"
+          for c in hello {
+              characters.append(c)
+          }
+          return characters
+      }
+    `)
+
+	value, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	RequireValuesEqual(
+		t,
+		inter,
+		interpreter.NewArrayValue(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.PrimitiveStaticTypeCharacter,
+			},
+			common.Address{},
+			interpreter.NewUnmeteredCharacterValue("👪"),
+			interpreter.NewUnmeteredCharacterValue("❤️"),
+		),
 		value,
 	)
 }


### PR DESCRIPTION
## Description

For-loops currently only allow iteration over arrays.

Generalize iteration to any value that is iterable and make `String` iterable.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
