### PR TITLE
Improve the definite return analysis

### DIFF
--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -211,8 +211,8 @@ func (checker *Checker) checkFunctionExits(functionBlock *ast.FunctionBlock, ret
 	functionActivation := checker.functionActivations.Current()
 
 	// NOTE: intentionally NOT DefinitelyReturned || DefinitelyHalted,
-	// see DefinitelyReturnedOrHalted
-	if functionActivation.ReturnInfo.DefinitelyReturnedOrHalted {
+	// see DefinitelyExited
+	if functionActivation.ReturnInfo.DefinitelyExited {
 		return
 	}
 

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -210,11 +210,9 @@ func (checker *Checker) checkFunctionExits(functionBlock *ast.FunctionBlock, ret
 
 	functionActivation := checker.functionActivations.Current()
 
-	definitelyReturnedOrHalted :=
-		functionActivation.ReturnInfo.DefinitelyReturned ||
-			functionActivation.ReturnInfo.DefinitelyHalted
-
-	if definitelyReturnedOrHalted {
+	// NOTE: intentionally NOT DefinitelyReturned || DefinitelyHalted,
+	// see DefinitelyReturnedOrHalted
+	if functionActivation.ReturnInfo.DefinitelyReturnedOrHalted {
 		return
 	}
 

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -174,7 +174,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	if returnType == NeverType {
 		returnInfo := checker.functionActivations.Current().ReturnInfo
 		returnInfo.DefinitelyHalted = true
-		returnInfo.DefinitelyReturned = true
+		returnInfo.DefinitelyReturnedOrHalted = true
 	}
 
 	if isOptionalChainingResult {

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -174,6 +174,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	if returnType == NeverType {
 		returnInfo := checker.functionActivations.Current().ReturnInfo
 		returnInfo.DefinitelyHalted = true
+		returnInfo.DefinitelyReturned = true
 	}
 
 	if isOptionalChainingResult {

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -174,7 +174,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	if returnType == NeverType {
 		returnInfo := checker.functionActivations.Current().ReturnInfo
 		returnInfo.DefinitelyHalted = true
-		returnInfo.DefinitelyReturnedOrHalted = true
+		returnInfo.DefinitelyExited = true
 	}
 
 	if isOptionalChainingResult {

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -29,7 +29,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) (_ 
 		checker.checkResourceLossForFunction()
 		functionActivation.ReturnInfo.MaybeReturned = true
 		functionActivation.ReturnInfo.DefinitelyReturned = true
-		functionActivation.ReturnInfo.DefinitelyReturnedOrHalted = true
+		functionActivation.ReturnInfo.DefinitelyExited = true
 	}()
 
 	returnType := functionActivation.ReturnType

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -29,6 +29,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) (_ 
 		checker.checkResourceLossForFunction()
 		functionActivation.ReturnInfo.MaybeReturned = true
 		functionActivation.ReturnInfo.DefinitelyReturned = true
+		functionActivation.ReturnInfo.DefinitelyReturnedOrHalted = true
 	}()
 
 	returnType := functionActivation.ReturnType

--- a/runtime/sema/return_info.go
+++ b/runtime/sema/return_info.go
@@ -41,9 +41,10 @@ type ReturnInfo struct {
 	// DefinitelyHalted indicates that (the branch of) the function
 	// contains a definite halt (a function call with a Never return type)
 	DefinitelyHalted bool
-	// DefinitelyReturnedOrHalted indicates that (the branch of)
-	// the function contains a definite return statement
-	// or a definite halt (a function call with a Never return type).
+	// DefinitelyExited indicates that (the branch of)
+	// the function either contains a definite return statement,
+	// contains a definite halt (a function call with a Never return type),
+	// or both.
 	//
 	// NOTE: this is NOT the same DefinitelyReturned || DefinitelyHalted:
 	// For example, for the following program:
@@ -53,19 +54,19 @@ type ReturnInfo struct {
 	//
 	//       // DefinitelyReturned = true
 	//	     // DefinitelyHalted = false
-	//	     // DefinitelyReturnedOrHalted = true
+	//	     // DefinitelyExited = true
 	//   } else {
 	//       panic(...)
 	//
 	//       // DefinitelyReturned = false
 	//	     // DefinitelyHalted = true
-	//	     // DefinitelyReturnedOrHalted = true
+	//	     // DefinitelyExited = true
 	//   }
 	//
 	//   // DefinitelyReturned = false
 	//   // DefinitelyHalted = false
-	//   // DefinitelyReturnedOrHalted = true
-	DefinitelyReturnedOrHalted bool
+	//   // DefinitelyExited = true
+	DefinitelyExited bool
 	// DefinitelyJumped indicates that (the branch of) the function
 	// contains a definite break or continue statement
 	DefinitelyJumped bool
@@ -99,9 +100,9 @@ func (ri *ReturnInfo) MergeBranches(thenReturnInfo *ReturnInfo, elseReturnInfo *
 		(thenReturnInfo.DefinitelyHalted &&
 			elseReturnInfo.DefinitelyHalted)
 
-	ri.DefinitelyReturnedOrHalted = ri.DefinitelyReturnedOrHalted ||
-		(thenReturnInfo.DefinitelyReturnedOrHalted &&
-			elseReturnInfo.DefinitelyReturnedOrHalted)
+	ri.DefinitelyExited = ri.DefinitelyExited ||
+		(thenReturnInfo.DefinitelyExited &&
+			elseReturnInfo.DefinitelyExited)
 }
 
 func (ri *ReturnInfo) MergePotentiallyUnevaluated(temporaryReturnInfo *ReturnInfo) {
@@ -119,8 +120,8 @@ func (ri *ReturnInfo) Clone() *ReturnInfo {
 
 func (ri *ReturnInfo) IsUnreachable() bool {
 	// NOTE: intentionally NOT DefinitelyReturned || DefinitelyHalted,
-	// see DefinitelyReturnedOrHalted
-	return ri.DefinitelyReturnedOrHalted ||
+	// see DefinitelyExited
+	return ri.DefinitelyExited ||
 		ri.DefinitelyJumped
 }
 


### PR DESCRIPTION
Closes #1516

## Description

Improve the definite-return check by considering definite halts as definite returns.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
