### PR TITLE
refactor AccountKeysCount to expect an error too

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -224,10 +224,8 @@ func TestRuntimeReturnPublicAccount(t *testing.T) {
 		getAccountAvailableBalance: noopRuntimeUInt64Getter,
 		getStorageUsed:             noopRuntimeUInt64Getter,
 		getStorageCapacity:         noopRuntimeUInt64Getter,
-		accountKeysCount: func(_ common.Address) uint64 {
-			return 0
-		},
-		storage: newTestLedger(nil, nil),
+		accountKeysCount:           noopRuntimeUInt64Getter,
+		storage:                    newTestLedger(nil, nil),
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -262,7 +260,7 @@ func TestRuntimeReturnAuthAccount(t *testing.T) {
 		getAccountAvailableBalance: noopRuntimeUInt64Getter,
 		getStorageUsed:             noopRuntimeUInt64Getter,
 		getStorageCapacity:         noopRuntimeUInt64Getter,
-		accountKeysCount:           func(_ common.Address) uint64 { return 0 },
+		accountKeysCount:           noopRuntimeUInt64Getter,
 		storage:                    newTestLedger(nil, nil),
 	}
 
@@ -1105,8 +1103,8 @@ func getAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *testRunt
 
 			return accountKey, nil
 		},
-		accountKeysCount: func(address Address) uint64 {
-			return uint64(storage.unrevokedKeyCount)
+		accountKeysCount: func(address Address) (uint64, error) {
+			return uint64(storage.unrevokedKeyCount), nil
 		},
 		log: func(message string) {
 			storage.logs = append(storage.logs, message)

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -245,7 +245,7 @@ func (e *interpreterEnvironment) GetAccountKey(address common.Address, index int
 	return e.runtimeInterface.GetAccountKey(address, index)
 }
 
-func (e *interpreterEnvironment) AccountKeysCount(address common.Address) uint64 {
+func (e *interpreterEnvironment) AccountKeysCount(address common.Address) (uint64, error) {
 	return e.runtimeInterface.AccountKeysCount(address)
 }
 

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -82,7 +82,7 @@ type Interface interface {
 	AddAccountKey(address Address, publicKey *PublicKey, hashAlgo HashAlgorithm, weight int) (*AccountKey, error)
 	// GetAccountKey retrieves a key from an account by index.
 	GetAccountKey(address Address, index int) (*AccountKey, error)
-	AccountKeysCount(address Address) uint64
+	AccountKeysCount(address Address) (uint64, error)
 	// RevokeAccountKey removes a key from an account by index.
 	RevokeAccountKey(address Address, index int) (*AccountKey, error)
 	// UpdateAccountContractCode updates the code associated with an account contract.

--- a/runtime/interpreter/accountkeys.go
+++ b/runtime/interpreter/accountkeys.go
@@ -38,7 +38,7 @@ func NewAuthAccountKeysValue(
 	getFunction FunctionValue,
 	revokeFunction FunctionValue,
 	forEachFunction FunctionValue,
-	getKeysCount AccountKeysCountConstructor,
+	getKeysCount AccountKeysCountGetter,
 ) Value {
 
 	fields := map[string]Value{
@@ -89,7 +89,7 @@ func NewPublicAccountKeysValue(
 	address AddressValue,
 	getFunction FunctionValue,
 	forEachFunction FunctionValue,
-	getKeysCount AccountKeysCountConstructor,
+	getKeysCount AccountKeysCountGetter,
 ) Value {
 
 	fields := map[string]Value{
@@ -126,4 +126,4 @@ func NewPublicAccountKeysValue(
 	)
 }
 
-type AccountKeysCountConstructor func() UInt64Value
+type AccountKeysCountGetter func() UInt64Value

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -151,7 +151,7 @@ type testRuntimeInterface struct {
 	) (*stdlib.AccountKey, error)
 	getAccountKey             func(address Address, index int) (*stdlib.AccountKey, error)
 	removeAccountKey          func(address Address, index int) (*stdlib.AccountKey, error)
-	accountKeysCount          func(address Address) uint64
+	accountKeysCount          func(address Address) (uint64, error)
 	updateAccountContractCode func(address Address, name string, code []byte) error
 	getAccountContractCode    func(address Address, name string) (code []byte, err error)
 	removeAccountContractCode func(address Address, name string) (err error)
@@ -309,7 +309,7 @@ func (i *testRuntimeInterface) GetAccountKey(address Address, index int) (*stdli
 	return i.getAccountKey(address, index)
 }
 
-func (i *testRuntimeInterface) AccountKeysCount(address Address) uint64 {
+func (i *testRuntimeInterface) AccountKeysCount(address Address) (uint64, error) {
 	if i.accountKeysCount == nil {
 		panic("must specify testRuntimeInterface.accountKeysCount")
 	}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -787,7 +787,7 @@ func newAccountKeysCountGetter(
 	gauge common.MemoryGauge,
 	provider AccountKeyProvider,
 	addressValue interpreter.AddressValue,
-) interpreter.AccountKeysCountConstructor {
+) interpreter.AccountKeysCountGetter {
 	address := addressValue.ToAddress()
 
 	return func() interpreter.UInt64Value {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -9068,7 +9068,7 @@ func newTestAuthAccountValue(gauge common.MemoryGauge, addressValue interpreter.
 				panicFunctionValue,
 				panicFunctionValue,
 				panicFunctionValue,
-				interpreter.AccountKeysCountConstructor(func() interpreter.UInt64Value {
+				interpreter.AccountKeysCountGetter(func() interpreter.UInt64Value {
 					panic(errors.NewUnreachableError())
 				}),
 			)
@@ -9102,7 +9102,7 @@ func newTestPublicAccountValue(gauge common.MemoryGauge, addressValue interprete
 				addressValue,
 				panicFunctionValue,
 				panicFunctionValue,
-				interpreter.AccountKeysCountConstructor(func() interpreter.UInt64Value {
+				interpreter.AccountKeysCountGetter(func() interpreter.UInt64Value {
 					panic(errors.NewUnreachableError())
 				}),
 			)


### PR DESCRIPTION
Required for #1388.

## Description
<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

There are a few places in the FVM where errors can occur while fetching the total number of account keys, but the method `AccountKeysCount` doesn't currently expect an error. This PR changes the type signature to accommodate this fact.

Currently a blocker for implementing `AccountKeysCount` in the FVM.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
