### PR TITLE
Add invalidation info to the invalid reference usage error

### DIFF
--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -60,12 +60,14 @@ func (checker *Checker) checkReferenceValidity(variable *Variable, hasPosition a
 	// i.e: It is always the roots of the chain that is being stored as the `referencedResourceVariables`.
 	for _, referencedVar := range variable.referencedResourceVariables {
 		resourceInfo := checker.resources.Get(Resource{Variable: referencedVar})
-		if resourceInfo.Invalidation() == nil {
+		invalidation := resourceInfo.Invalidation()
+		if invalidation == nil {
 			continue
 		}
 
 		checker.report(&InvalidatedResourceReferenceError{
-			Range: ast.NewRangeFromPositioned(checker.memoryGauge, hasPosition),
+			Invalidation: *invalidation,
+			Range:        ast.NewRangeFromPositioned(checker.memoryGauge, hasPosition),
 		})
 	}
 }

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1900,13 +1900,7 @@ func (e *ResourceUseAfterInvalidationError) SecondaryError() string {
 func (e *ResourceUseAfterInvalidationError) ErrorNotes() []errors.ErrorNote {
 	invalidation := e.Invalidation
 	return []errors.ErrorNote{
-		PreviousResourceInvalidationNote{
-			ResourceInvalidation: invalidation,
-			Range: ast.NewUnmeteredRange(
-				invalidation.StartPos,
-				invalidation.EndPos,
-			),
-		},
+		newPreviousResourceInvalidationNote(invalidation),
 	}
 }
 
@@ -1915,6 +1909,16 @@ func (e *ResourceUseAfterInvalidationError) ErrorNotes() []errors.ErrorNote {
 type PreviousResourceInvalidationNote struct {
 	ResourceInvalidation
 	ast.Range
+}
+
+func newPreviousResourceInvalidationNote(invalidation ResourceInvalidation) PreviousResourceInvalidationNote {
+	return PreviousResourceInvalidationNote{
+		ResourceInvalidation: invalidation,
+		Range: ast.NewUnmeteredRange(
+			invalidation.StartPos,
+			invalidation.EndPos,
+		),
+	}
 }
 
 func (n PreviousResourceInvalidationNote) Message() string {
@@ -3728,6 +3732,7 @@ func (*PurityError) isSemanticError() {}
 // InvalidatedResourceReferenceError
 
 type InvalidatedResourceReferenceError struct {
+	Invalidation ResourceInvalidation
 	ast.Range
 }
 
@@ -3740,4 +3745,11 @@ func (*InvalidatedResourceReferenceError) IsUserError() {}
 
 func (e *InvalidatedResourceReferenceError) Error() string {
 	return "invalid reference: referenced resource may have been moved or destroyed"
+}
+
+func (e *InvalidatedResourceReferenceError) ErrorNotes() []errors.ErrorNote {
+	invalidation := e.Invalidation
+	return []errors.ErrorNote{
+		newPreviousResourceInvalidationNote(invalidation),
+	}
 }


### PR DESCRIPTION
## Description

Adds position info of the invalidation to the invalid resource-reference error.
 
Suggested in: https://github.com/onflow/cadence/pull/2037#discussion_r993960726.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
