### PR TITLE
Allow embedders to reuse interpreter shared state

### DIFF
--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -543,13 +543,12 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			events = append(events, event)
 			return nil
 		},
-		meterMemory: func(_ common.MemoryUsage) error {
-			return nil
-		},
 	}
 	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 		return json.Decode(runtimeInterface, b)
 	}
+
+	environment := NewBaseInterpreterEnvironment(Config{})
 
 	nextTransactionLocation := newTransactionLocationGenerator()
 
@@ -563,8 +562,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
 		},
 	)
 	require.NoError(b, err)
@@ -586,8 +586,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			)),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
 		},
 	)
 	require.NoError(b, err)
@@ -606,8 +607,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				Source: []byte(realSetupFlowTokenAccountTransaction),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
 			},
 		)
 		require.NoError(b, err)
@@ -631,8 +633,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			}),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
 		},
 	)
 	require.NoError(b, err)
@@ -643,8 +646,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 	require.NoError(b, err)
 
 	signerAccount = senderAddress
-
-	environment := NewBaseInterpreterEnvironment(Config{})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -689,8 +690,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
 			},
 		)
 		require.NoError(b, err)

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -64,6 +64,11 @@ type Interface interface {
 	GetProgram(Location) (*interpreter.Program, error)
 	// SetProgram sets the program for the given location.
 	SetProgram(Location, *interpreter.Program) error
+	// SetInterpreterSharedState sets the shared state of all interpreters.
+	SetInterpreterSharedState(state *interpreter.SharedState)
+	// GetInterpreterSharedState gets the shared state of all interpreters.
+	// May return nil if none is available or use is not applicable.
+	GetInterpreterSharedState() *interpreter.SharedState
 	// GetValue gets a value for the given key in the storage, owned by the given account.
 	GetValue(owner, key []byte) (value []byte, err error)
 	// SetValue sets a value for the given key in the storage, owned by the given account.

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -550,7 +550,7 @@ func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerEx
 // NewIntegerValueFromBigInt creates a Cadence interpreter value of a given subtype.
 // This method assumes the range validations are done prior to calling this method. (i.e: at semantic level)
 func (interpreter *Interpreter) NewIntegerValueFromBigInt(value *big.Int, integerSubType sema.Type) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	memoryGauge := config.MemoryGauge
 
 	// NOTE: cases meter manually and call the unmetered constructors to avoid allocating closures
@@ -794,7 +794,7 @@ func (interpreter *Interpreter) VisitConditionalExpression(expression *ast.Condi
 }
 
 func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *ast.InvocationExpression) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	// tracing
 	if config.TracingEnabled {

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -38,7 +38,7 @@ func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDe
 }
 
 func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.ResolvedLocation) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	// tracing
 	if config.TracingEnabled {

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -127,7 +127,7 @@ func (interpreter *Interpreter) invokeInterpretedFunction(
 	current := interpreter.activations.PushNewWithParent(function.Activation)
 	current.IsFunction = true
 
-	interpreter.sharedState.callStack.Push(invocation)
+	interpreter.SharedState.callStack.Push(invocation)
 
 	// Make `self` available, if any
 	if invocation.Self != nil {
@@ -147,7 +147,7 @@ func (interpreter *Interpreter) invokeInterpretedFunctionActivated(
 		if r := recover(); r != nil {
 			panic(r)
 		}
-		interpreter.sharedState.callStack.Pop()
+		interpreter.SharedState.callStack.Pop()
 	}()
 	defer interpreter.activations.Pop()
 

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -37,7 +37,7 @@ func (interpreter *Interpreter) evalStatement(statement ast.Statement) Statement
 
 	interpreter.statement = statement
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	onMeterComputation := config.OnMeterComputation
 	if onMeterComputation != nil {
@@ -384,7 +384,7 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 		HasPosition: statement,
 	}
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	onEventEmitted := config.OnEventEmitted
 	if onEventEmitted == nil {

--- a/runtime/interpreter/interpreter_tracing.go
+++ b/runtime/interpreter/interpreter_tracing.go
@@ -48,12 +48,12 @@ const (
 )
 
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(interpreter, tracingFunctionPrefix+functionName, duration, nil)
 }
 
 func (interpreter *Interpreter) reportImportTrace(importPath string, duration time.Duration) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(interpreter, tracingImportPrefix+importPath, duration, nil)
 }
 
@@ -69,7 +69,7 @@ func (interpreter *Interpreter) reportArrayValueConstructTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingArrayPrefix+tracingConstructPostfix,
@@ -83,7 +83,7 @@ func (interpreter *Interpreter) reportArrayValueDeepRemoveTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingArrayPrefix+tracingDeepRemovePostfix,
@@ -97,7 +97,7 @@ func (interpreter *Interpreter) reportArrayValueDestroyTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingArrayPrefix+tracingDestroyPostfix,
@@ -111,7 +111,7 @@ func (interpreter *Interpreter) reportArrayValueTransferTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingArrayPrefix+tracingTransferPostfix,
@@ -125,7 +125,7 @@ func (interpreter *Interpreter) reportArrayValueConformsToStaticTypeTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingArrayPrefix+tracingConformsToStaticTypePostfix,
@@ -139,7 +139,7 @@ func (interpreter *Interpreter) reportDictionaryValueConstructTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingDictionaryPrefix+tracingConstructPostfix,
@@ -153,7 +153,7 @@ func (interpreter *Interpreter) reportDictionaryValueDeepRemoveTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingDictionaryPrefix+tracingDeepRemovePostfix,
@@ -167,7 +167,7 @@ func (interpreter *Interpreter) reportDictionaryValueDestroyTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingDictionaryPrefix+tracingDestroyPostfix,
@@ -181,7 +181,7 @@ func (interpreter *Interpreter) reportDictionaryValueTransferTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingDictionaryPrefix+tracingTransferPostfix,
@@ -195,7 +195,7 @@ func (interpreter *Interpreter) reportDictionaryValueConformsToStaticTypeTrace(
 	count int,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingDictionaryPrefix+tracingConformsToStaticTypePostfix,
@@ -210,7 +210,7 @@ func (interpreter *Interpreter) reportDictionaryValueGetMemberTrace(
 	name string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingDictionaryPrefix+tracingGetMemberPrefix+name,
@@ -233,7 +233,7 @@ func (interpreter *Interpreter) reportCompositeValueConstructTrace(
 	kind string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingConstructPostfix,
@@ -248,7 +248,7 @@ func (interpreter *Interpreter) reportCompositeValueDeepRemoveTrace(
 	kind string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingDeepRemovePostfix,
@@ -263,7 +263,7 @@ func (interpreter *Interpreter) reportCompositeValueDestroyTrace(
 	kind string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingDestroyPostfix,
@@ -278,7 +278,7 @@ func (interpreter *Interpreter) reportCompositeValueTransferTrace(
 	kind string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingTransferPostfix,
@@ -293,7 +293,7 @@ func (interpreter *Interpreter) reportCompositeValueConformsToStaticTypeTrace(
 	kind string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingConformsToStaticTypePostfix,
@@ -309,7 +309,7 @@ func (interpreter *Interpreter) reportCompositeValueGetMemberTrace(
 	name string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingGetMemberPrefix+name,
@@ -325,7 +325,7 @@ func (interpreter *Interpreter) reportCompositeValueSetMemberTrace(
 	name string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingSetMemberPrefix+name,
@@ -341,7 +341,7 @@ func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(
 	name string,
 	duration time.Duration,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	config.OnRecordTrace(
 		interpreter,
 		tracingCompositePrefix+tracingRemoveMemberPrefix+name,

--- a/runtime/interpreter/sharedstate.go
+++ b/runtime/interpreter/sharedstate.go
@@ -25,8 +25,8 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-type sharedState struct {
-	config                        *Config
+type SharedState struct {
+	Config                        *Config
 	allInterpreters               map[common.Location]*Interpreter
 	callStack                     *CallStack
 	typeCodes                     TypeCodes
@@ -37,9 +37,9 @@ type sharedState struct {
 	resourceVariables              map[ResourceKindedValue]*Variable
 }
 
-func newSharedState(config *Config) *sharedState {
-	return &sharedState{
-		config:          config,
+func NewSharedState(config *Config) *SharedState {
+	return &SharedState{
+		Config:          config,
 		allInterpreters: map[common.Location]*Interpreter{},
 		callStack:       &CallStack{},
 		typeCodes: TypeCodes{

--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -124,7 +124,7 @@ func (s StorageMap) SetValue(interpreter *Interpreter, key string, value atree.V
 	interpreter.maybeValidateAtreeValue(s.orderedMap)
 
 	if existingStorable != nil {
-		config := interpreter.sharedState.config
+		config := interpreter.SharedState.Config
 		existingValue := StoredValue(interpreter, existingStorable, config.Storage)
 		existingValue.DeepRemove(interpreter)
 		interpreter.RemoveReferencedSlab(existingStorable)
@@ -155,7 +155,7 @@ func (s StorageMap) RemoveValue(interpreter *Interpreter, key string) {
 	// Value
 
 	if existingValueStorable != nil {
-		config := interpreter.sharedState.config
+		config := interpreter.SharedState.Config
 		existingValue := StoredValue(interpreter, existingValueStorable, config.Storage)
 		existingValue.DeepRemove(interpreter)
 		interpreter.RemoveReferencedSlab(existingValueStorable)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1433,7 +1433,7 @@ func NewArrayValueWithIterator(
 ) *ArrayValue {
 	interpreter.ReportComputation(common.ComputationKindCreateArrayValue, 1)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	var v *ArrayValue
 
@@ -1583,7 +1583,7 @@ func (v *ArrayValue) Destroy(interpreter *Interpreter, locationRange LocationRan
 
 	interpreter.ReportComputation(common.ComputationKindDestroyArrayValue, 1)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -1705,7 +1705,7 @@ func (v *ArrayValue) Concat(interpreter *Interpreter, locationRange LocationRang
 }
 
 func (v *ArrayValue) GetKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -1745,13 +1745,13 @@ func (v *ArrayValue) Get(interpreter *Interpreter, locationRange LocationRange, 
 		panic(errors.NewExternalError(err))
 	}
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	return StoredValue(interpreter, storable, config.Storage)
 }
 
 func (v *ArrayValue) SetKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -1794,7 +1794,7 @@ func (v *ArrayValue) Set(interpreter *Interpreter, locationRange LocationRange, 
 	}
 	interpreter.maybeValidateAtreeValue(v.array)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	existingValue := StoredValue(interpreter, existingStorable, config.Storage)
 
 	existingValue.DeepRemove(interpreter)
@@ -1870,7 +1870,7 @@ func (v *ArrayValue) AppendAll(interpreter *Interpreter, locationRange LocationR
 }
 
 func (v *ArrayValue) InsertKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -1923,7 +1923,7 @@ func (v *ArrayValue) Insert(interpreter *Interpreter, locationRange LocationRang
 }
 
 func (v *ArrayValue) RemoveKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -1954,7 +1954,7 @@ func (v *ArrayValue) Remove(interpreter *Interpreter, locationRange LocationRang
 	}
 	interpreter.maybeValidateAtreeValue(v.array)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	value := StoredValue(interpreter, storable, config.Storage)
 
 	return value.Transfer(
@@ -2027,7 +2027,7 @@ func (v *ArrayValue) Contains(
 }
 
 func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -2226,7 +2226,7 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 }
 
 func (v *ArrayValue) RemoveMember(interpreter *Interpreter, locationRange LocationRange, _ string) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -2237,7 +2237,7 @@ func (v *ArrayValue) RemoveMember(interpreter *Interpreter, locationRange Locati
 }
 
 func (v *ArrayValue) SetMember(interpreter *Interpreter, locationRange LocationRange, _ string, _ Value) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -2256,7 +2256,7 @@ func (v *ArrayValue) ConformsToStaticType(
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	count := v.Count()
 
@@ -2368,7 +2368,7 @@ func (v *ArrayValue) Transfer(
 	common.UseMemory(interpreter, dataSlabs)
 	common.UseMemory(interpreter, metaDataSlabs)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -2488,7 +2488,7 @@ func (v *ArrayValue) Transfer(
 }
 
 func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	iterator, err := v.array.Iterator()
 	if err != nil {
@@ -2533,7 +2533,7 @@ func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
 }
 
 func (v *ArrayValue) DeepRemove(interpreter *Interpreter) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
 		startTime := time.Now()
@@ -13864,7 +13864,7 @@ func NewCompositeValue(
 
 	interpreter.ReportComputation(common.ComputationKindCreateCompositeValue, 1)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	var v *CompositeValue
 
@@ -14012,7 +14012,7 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, locationRange Locatio
 
 	interpreter.ReportComputation(common.ComputationKindDestroyCompositeValue, 1)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -14042,7 +14042,7 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, locationRange Locatio
 
 	// if composite was deserialized, dynamically link in the destructor
 	if v.Destructor == nil {
-		v.Destructor = interpreter.sharedState.typeCodes.CompositeCodes[v.TypeID()].DestructorFunction
+		v.Destructor = interpreter.SharedState.typeCodes.CompositeCodes[v.TypeID()].DestructorFunction
 	}
 
 	destructor := v.Destructor
@@ -14085,7 +14085,7 @@ func (v *CompositeValue) Destroy(interpreter *Interpreter, locationRange Locatio
 }
 
 func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -14201,7 +14201,7 @@ func (v *CompositeValue) InitializeFunctions(interpreter *Interpreter) {
 		return
 	}
 
-	v.Functions = interpreter.sharedState.typeCodes.CompositeCodes[v.TypeID()].CompositeFunctions
+	v.Functions = interpreter.SharedState.typeCodes.CompositeCodes[v.TypeID()].CompositeFunctions
 }
 
 func (v *CompositeValue) OwnerValue(interpreter *Interpreter, locationRange LocationRange) OptionalValue {
@@ -14211,7 +14211,7 @@ func (v *CompositeValue) OwnerValue(interpreter *Interpreter, locationRange Loca
 		return NilOptionalValue
 	}
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	ownerAccount := config.PublicAccountHandler(AddressValue(address))
 
@@ -14227,7 +14227,7 @@ func (v *CompositeValue) RemoveMember(
 	name string,
 ) Value {
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -14292,7 +14292,7 @@ func (v *CompositeValue) SetMember(
 	name string,
 	value Value,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -14422,7 +14422,7 @@ func formatComposite(memoryGauge common.MemoryGauge, typeId string, fields []Com
 }
 
 func (v *CompositeValue) GetField(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -14533,7 +14533,7 @@ func (v *CompositeValue) ConformsToStaticType(
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
 		startTime := time.Now()
@@ -14665,7 +14665,7 @@ func (v *CompositeValue) Transfer(
 
 	interpreter.ReportComputation(common.ComputationKindTransferCompositeValue, 1)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -14842,7 +14842,7 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 		panic(errors.NewExternalError(err))
 	}
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	elementMemoryUse := common.NewAtreeMapPreAllocatedElementsMemoryUsage(v.dictionary.Count(), 0)
 	common.UseMemory(config.MemoryGauge, elementMemoryUse)
@@ -14893,7 +14893,7 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 }
 
 func (v *CompositeValue) DeepRemove(interpreter *Interpreter) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
 		startTime := time.Now()
@@ -14981,7 +14981,7 @@ func (v *CompositeValue) RemoveField(
 	interpreter.RemoveReferencedSlab(existingKeyStorable)
 
 	// Value
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	existingValue := StoredValue(interpreter, existingValueStorable, config.Storage)
 	existingValue.DeepRemove(interpreter)
 	interpreter.RemoveReferencedSlab(existingValueStorable)
@@ -15059,7 +15059,7 @@ func NewDictionaryValueWithAddress(
 
 	var v *DictionaryValue
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
 		startTime := time.Now()
@@ -15246,7 +15246,7 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, locationRange Locati
 
 	interpreter.ReportComputation(common.ComputationKindDestroyDictionaryValue, 1)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -15387,7 +15387,7 @@ func (v *DictionaryValue) Get(
 }
 
 func (v *DictionaryValue) GetKey(interpreter *Interpreter, locationRange LocationRange, keyValue Value) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -15407,7 +15407,7 @@ func (v *DictionaryValue) SetKey(
 	keyValue Value,
 	value Value,
 ) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -15486,7 +15486,7 @@ func (v *DictionaryValue) GetMember(
 	locationRange LocationRange,
 	name string,
 ) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -15642,7 +15642,7 @@ func (v *DictionaryValue) GetMember(
 }
 
 func (v *DictionaryValue) RemoveMember(interpreter *Interpreter, locationRange LocationRange, _ string) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -15653,7 +15653,7 @@ func (v *DictionaryValue) RemoveMember(interpreter *Interpreter, locationRange L
 }
 
 func (v *DictionaryValue) SetMember(interpreter *Interpreter, locationRange LocationRange, _ string, _ Value) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -15672,7 +15672,7 @@ func (v *DictionaryValue) RemoveKey(
 	locationRange LocationRange,
 	key Value,
 ) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -15705,7 +15705,7 @@ func (v *DictionaryValue) Remove(
 	}
 	interpreter.maybeValidateAtreeValue(v.dictionary)
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	storage := config.Storage
 
 	// Key
@@ -15789,7 +15789,7 @@ func (v *DictionaryValue) Insert(
 		return NilOptionalValue
 	}
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 	storage := config.Storage
 
 	existingValue := StoredValue(
@@ -15820,7 +15820,7 @@ func (v *DictionaryValue) ConformsToStaticType(
 
 	count := v.Count()
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
 		startTime := time.Now()
@@ -15969,7 +15969,7 @@ func (v *DictionaryValue) Transfer(
 
 	interpreter.ReportComputation(common.ComputationKindTransferDictionaryValue, uint(v.Count()))
 
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(interpreter, locationRange)
@@ -16102,7 +16102,7 @@ func (v *DictionaryValue) Transfer(
 }
 
 func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	valueComparator := newValueComparator(interpreter, EmptyLocationRange)
 	hashInputProvider := newHashInputProvider(interpreter, EmptyLocationRange)
@@ -16156,7 +16156,7 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 }
 
 func (v *DictionaryValue) DeepRemove(interpreter *Interpreter) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
 		startTime := time.Now()
@@ -16458,7 +16458,7 @@ func (v *SomeValue) IsDestroyed() bool {
 }
 
 func (v *SomeValue) Destroy(interpreter *Interpreter, locationRange LocationRange) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -16487,7 +16487,7 @@ func (v SomeValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences 
 }
 
 func (v *SomeValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -16536,7 +16536,7 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, locationRange LocationRa
 }
 
 func (v *SomeValue) RemoveMember(interpreter *Interpreter, locationRange LocationRange, _ string) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -16546,7 +16546,7 @@ func (v *SomeValue) RemoveMember(interpreter *Interpreter, locationRange Locatio
 }
 
 func (v *SomeValue) SetMember(interpreter *Interpreter, locationRange LocationRange, _ string, _ Value) {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -16641,7 +16641,7 @@ func (v *SomeValue) Transfer(
 	remove bool,
 	storable atree.Storable,
 ) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)
@@ -16706,7 +16706,7 @@ func (v *SomeValue) DeepRemove(interpreter *Interpreter) {
 }
 
 func (v *SomeValue) InnerValue(interpreter *Interpreter, locationRange LocationRange) Value {
-	config := interpreter.sharedState.config
+	config := interpreter.SharedState.Config
 
 	if config.InvalidatedResourceValidationEnabled {
 		v.checkInvalidatedResourceUse(locationRange)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -140,7 +140,7 @@ type testRuntimeInterface struct {
 	getProgram                func(Location) (*interpreter.Program, error)
 	setProgram                func(Location, *interpreter.Program) error
 	setInterpreterSharedState func(state *interpreter.SharedState)
-	getInterpreterShareState  func() *interpreter.SharedState
+	getInterpreterSharedState func() *interpreter.SharedState
 	storage                   testLedger
 	createAccount             func(payer Address) (address Address, err error)
 	addEncodedAccountKey      func(address Address, publicKey []byte) error
@@ -252,11 +252,11 @@ func (i *testRuntimeInterface) SetInterpreterSharedState(state *interpreter.Shar
 }
 
 func (i *testRuntimeInterface) GetInterpreterSharedState() *interpreter.SharedState {
-	if i.getInterpreterShareState == nil {
+	if i.getInterpreterSharedState == nil {
 		return nil
 	}
 
-	return i.getInterpreterShareState()
+	return i.getInterpreterSharedState()
 }
 
 func (i *testRuntimeInterface) ValueExists(owner, key []byte) (exists bool, err error) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -135,15 +135,17 @@ func newTestInterpreterRuntime() Runtime {
 }
 
 type testRuntimeInterface struct {
-	resolveLocation         func(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
-	getCode                 func(_ Location) ([]byte, error)
-	getProgram              func(Location) (*interpreter.Program, error)
-	setProgram              func(Location, *interpreter.Program) error
-	storage                 testLedger
-	createAccount           func(payer Address) (address Address, err error)
-	addEncodedAccountKey    func(address Address, publicKey []byte) error
-	removeEncodedAccountKey func(address Address, index int) (publicKey []byte, err error)
-	addAccountKey           func(
+	resolveLocation           func(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
+	getCode                   func(_ Location) ([]byte, error)
+	getProgram                func(Location) (*interpreter.Program, error)
+	setProgram                func(Location, *interpreter.Program) error
+	setInterpreterSharedState func(state *interpreter.SharedState)
+	getInterpreterShareState  func() *interpreter.SharedState
+	storage                   testLedger
+	createAccount             func(payer Address) (address Address, err error)
+	addEncodedAccountKey      func(address Address, publicKey []byte) error
+	removeEncodedAccountKey   func(address Address, index int) (publicKey []byte, err error)
+	addAccountKey             func(
 		address Address,
 		publicKey *stdlib.PublicKey,
 		hashAlgo HashAlgorithm,
@@ -239,6 +241,22 @@ func (i *testRuntimeInterface) SetProgram(location Location, program *interprete
 	}
 
 	return i.setProgram(location, program)
+}
+
+func (i *testRuntimeInterface) SetInterpreterSharedState(state *interpreter.SharedState) {
+	if i.setInterpreterSharedState == nil {
+		return
+	}
+
+	i.setInterpreterSharedState(state)
+}
+
+func (i *testRuntimeInterface) GetInterpreterSharedState() *interpreter.SharedState {
+	if i.getInterpreterShareState == nil {
+		return nil
+	}
+
+	return i.getInterpreterShareState()
 }
 
 func (i *testRuntimeInterface) ValueExists(owner, key []byte) (exists bool, err error) {
@@ -5471,11 +5489,11 @@ func TestRuntimeMetrics(t *testing.T) {
 	)
 }
 
-type testWrite struct {
+type ownerKeyPair struct {
 	owner, key []byte
 }
 
-func (w testWrite) String() string {
+func (w ownerKeyPair) String() string {
 	return string(w.key)
 }
 
@@ -5525,10 +5543,10 @@ func TestRuntimeContractWriteback(t *testing.T) {
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
-	var writes []testWrite
+	var writes []ownerKeyPair
 
 	onWrite := func(owner, key, value []byte) {
-		writes = append(writes, testWrite{
+		writes = append(writes, ownerKeyPair{
 			owner,
 			key,
 		})
@@ -5575,7 +5593,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 	assert.NotNil(t, accountCode)
 
 	assert.Equal(t,
-		[]testWrite{
+		[]ownerKeyPair{
 			// storage index to contract domain storage map
 			{
 				addressValue[:],
@@ -5624,7 +5642,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]testWrite{
+		[]ownerKeyPair{
 			// contract value
 			{
 				addressValue[:],
@@ -5667,10 +5685,10 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	var accountCode []byte
 	var events []cadence.Event
 	var loggedMessages []string
-	var writes []testWrite
+	var writes []ownerKeyPair
 
 	onWrite := func(owner, key, _ []byte) {
-		writes = append(writes, testWrite{
+		writes = append(writes, ownerKeyPair{
 			owner,
 			key,
 		})
@@ -5717,7 +5735,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	assert.NotNil(t, accountCode)
 
 	assert.Equal(t,
-		[]testWrite{
+		[]ownerKeyPair{
 			// storage index to contract domain storage map
 			{
 				addressValue[:],
@@ -5760,7 +5778,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]testWrite{
+		[]ownerKeyPair{
 			// storage index to storage domain storage map
 			{
 				addressValue[:],
@@ -5832,7 +5850,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]testWrite{
+		[]ownerKeyPair{
 			// resource value
 			{
 				addressValue[:],

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -1,0 +1,259 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	. "github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestRuntimeSharedState(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	signerAddress := common.MustBytesToAddress([]byte{0x1})
+
+	deploy1 := DeploymentTransaction("C1", []byte(`
+        pub contract C1 {
+            pub fun hello() {
+                log("Hello from C1!")
+            }
+        }
+    `))
+
+	deploy2 := DeploymentTransaction("C2", []byte(`
+        pub contract C2 {
+            pub fun hello() {
+                log("Hello from C2!")
+            }
+        }
+    `))
+
+	accountCodes := map[common.Location][]byte{}
+
+	var events []cadence.Event
+	var loggedMessages []string
+
+	var interpreterState *interpreter.SharedState
+
+	var ledgerReads []ownerKeyPair
+
+	ledger := newTestLedger(
+		func(owner, key, value []byte) {
+			ledgerReads = append(
+				ledgerReads,
+				ownerKeyPair{
+					owner: owner,
+					key:   key,
+				},
+			)
+		},
+		nil,
+	)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: ledger,
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{signerAddress}, nil
+		},
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			accountCodes[location] = code
+			return nil
+		},
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			code = accountCodes[location]
+			return code, nil
+		},
+		removeAccountContractCode: func(address Address, name string) error {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			delete(accountCodes, location)
+			return nil
+		},
+		resolveLocation: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
+
+			// Resolve each identifier as an address location
+
+			for _, identifier := range identifiers {
+				result = append(result, sema.ResolvedLocation{
+					Location: common.AddressLocation{
+						Address: location.(common.AddressLocation).Address,
+						Name:    identifier.Identifier,
+					},
+					Identifiers: []ast.Identifier{
+						identifier,
+					},
+				})
+			}
+
+			return
+		},
+		log: func(message string) {
+			loggedMessages = append(loggedMessages, message)
+		},
+		emitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
+		},
+		setInterpreterSharedState: func(state *interpreter.SharedState) {
+			interpreterState = state
+		},
+		getInterpreterShareState: func() *interpreter.SharedState {
+			return interpreterState
+		},
+	}
+
+	environment := NewBaseInterpreterEnvironment(Config{})
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	// Deploy contracts
+
+	for _, source := range [][]byte{
+		deploy1,
+		deploy2,
+	} {
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: source,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	assert.NotEmpty(t, accountCodes)
+
+	// Call C1.hello using transaction
+
+	loggedMessages = nil
+
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: []byte(`
+                import C1 from 0x1
+
+                transaction {
+                    prepare(signer: AuthAccount) {
+                        C1.hello()
+                    }
+                }
+            `),
+			Arguments: nil,
+		},
+		Context{
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{`"Hello from C1!"`}, loggedMessages)
+
+	// Call C1.hello manually
+
+	loggedMessages = nil
+
+	_, err = runtime.InvokeContractFunction(
+		common.AddressLocation{
+			Address: signerAddress,
+			Name:    "C1",
+		},
+		"hello",
+		nil,
+		nil,
+		Context{
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{`"Hello from C1!"`}, loggedMessages)
+
+	// Call C2.hello manually
+
+	loggedMessages = nil
+
+	_, err = runtime.InvokeContractFunction(
+		common.AddressLocation{
+			Address: signerAddress,
+			Name:    "C2",
+		},
+		"hello",
+		nil,
+		nil,
+		Context{
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{`"Hello from C2!"`}, loggedMessages)
+
+	// Assert shared state was used,
+	// i.e. data was not re-read
+
+	require.Equal(t,
+		[]ownerKeyPair{
+			{
+				owner: signerAddress[:],
+				key:   []byte(StorageDomainContract),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(StorageDomainContract),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			},
+		},
+		ledgerReads,
+	)
+}

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -135,7 +135,7 @@ func TestRuntimeSharedState(t *testing.T) {
 		setInterpreterSharedState: func(state *interpreter.SharedState) {
 			interpreterState = state
 		},
-		getInterpreterShareState: func() *interpreter.SharedState {
+		getInterpreterSharedState: func() *interpreter.SharedState {
 			return interpreterState
 		},
 	}

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -107,15 +107,15 @@ func TestRuntimeStorageWriteCachedIsDeterministic(t *testing.T) {
 
 	t.Parallel()
 
-	var previousWrites []testWrite
+	var previousWrites []ownerKeyPair
 
 	// verify for 10 times and check the writes are always deterministic
 	for i := 0; i < 10; i++ {
 
-		var writes []testWrite
+		var writes []ownerKeyPair
 
 		onWrite := func(owner, key, _ []byte) {
-			writes = append(writes, testWrite{
+			writes = append(writes, ownerKeyPair{
 				owner: owner,
 				key:   key,
 			})
@@ -164,10 +164,10 @@ func TestRuntimeStorageWrite(t *testing.T) {
        }
     `)
 
-	var writes []testWrite
+	var writes []ownerKeyPair
 
 	onWrite := func(owner, key, _ []byte) {
-		writes = append(writes, testWrite{
+		writes = append(writes, ownerKeyPair{
 			owner,
 			key,
 		})
@@ -194,7 +194,7 @@ func TestRuntimeStorageWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]testWrite{
+		[]ownerKeyPair{
 			// storage index to storage domain storage map
 			{
 				[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},


### PR DESCRIPTION
Closes #2048 


## Description

Based on @janezpodhostnik's idea and [proof-of-concept](https://github.com/onflow/cadence/commit/4ac0d1bb126a14b889c319a36e990489bf2e3628):
Allow the embedder, e.g. FVM, to reuse the shared state across multiple runtime top-level entry calls (e.g. transaction invocation, contract function invocation).

If the embedder, through the new interface functions `SetInterpreterSharedState` and `GetInterpreterSharedState`, saves the state and re-supplies it in a subsequent top-level entry call, interpreters for imported contracts are re-used – contract data does not need to be re-read from storage, and contract values do not need to be recreated by the interpreter.

When enabling this optimization for `BenchmarkRuntimeFungibleTokenTransfer`, this optimization improves performance and allocations by ca ~16%:

```
6878	    172776 ns/op	  106226 B/op	    2002 allocs/op
8194	    145198 ns/op	   81168 B/op	    1645 allocs/op
```
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
