### PR TITLE
Improve common supertype calculation

### DIFF
--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -1837,3 +1837,54 @@ func TestTypeInclusions(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func BenchmarkSuperTypeInference(b *testing.B) {
+
+	b.Run("integers", func(b *testing.B) {
+		types := []Type{
+			UInt8Type,
+			UInt256Type,
+			IntegerType,
+			Word64Type,
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			LeastCommonSuperType(types...)
+		}
+	})
+
+	b.Run("arrays", func(b *testing.B) {
+		types := []Type{
+			&VariableSizedType{
+				Type: IntType,
+			},
+			&VariableSizedType{
+				Type: Int8Type,
+			},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			LeastCommonSuperType(types...)
+		}
+	})
+
+	b.Run("composites", func(b *testing.B) {
+		types := []Type{
+			PublicKeyType,
+			AuthAccountType,
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			LeastCommonSuperType(types...)
+		}
+	})
+}

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -1004,10 +1004,15 @@ func TestCommonSuperType(t *testing.T) {
 					newCompositeWithInterfaces("Bar", interfaceType2, interfaceType3),
 					newCompositeWithInterfaces("Baz", interfaceType1, interfaceType2, interfaceType3),
 				},
-				expectedSuperType: &RestrictedType{
-					Type:         AnyStructType,
-					Restrictions: []*InterfaceType{interfaceType2},
-				},
+				expectedSuperType: func() Type {
+					typ := &RestrictedType{
+						Type:         AnyStructType,
+						Restrictions: []*InterfaceType{interfaceType2},
+					}
+					// just initialize for equality
+					typ.initializeRestrictionSet()
+					return typ
+				}(),
 			},
 			{
 				name: "multiple common interfaces",
@@ -1015,10 +1020,15 @@ func TestCommonSuperType(t *testing.T) {
 					newCompositeWithInterfaces("Foo", interfaceType1, interfaceType2),
 					newCompositeWithInterfaces("Baz", interfaceType1, interfaceType2, interfaceType3),
 				},
-				expectedSuperType: &RestrictedType{
-					Type:         AnyStructType,
-					Restrictions: []*InterfaceType{interfaceType1, interfaceType2},
-				},
+				expectedSuperType: func() Type {
+					typ := &RestrictedType{
+						Type:         AnyStructType,
+						Restrictions: []*InterfaceType{interfaceType1, interfaceType2},
+					}
+					// just initialize for equality
+					typ.initializeRestrictionSet()
+					return typ
+				}(),
 			},
 			{
 				name: "no common interfaces",
@@ -1513,6 +1523,8 @@ func TestCommonSuperType(t *testing.T) {
 	})
 
 	t.Run("Lower mask types", func(t *testing.T) {
+		t.Parallel()
+
 		for _, typeTag := range allLowerMaskedTypeTags {
 			// Upper mask must be zero
 			assert.Equal(t, uint64(0), typeTag.upperMask)
@@ -1537,6 +1549,8 @@ func TestCommonSuperType(t *testing.T) {
 	})
 
 	t.Run("Upper mask types", func(t *testing.T) {
+		t.Parallel()
+
 		for _, typeTag := range allUpperMaskedTypeTags {
 			// Lower mask must be zero
 			assert.Equal(t, uint64(0), typeTag.lowerMask)
@@ -1546,6 +1560,47 @@ func TestCommonSuperType(t *testing.T) {
 				typ := findSuperTypeFromUpperMask(typeTag, nil)
 				assert.NotNil(t, typ, fmt.Sprintf("not implemented %v", typeTag))
 			})
+		}
+	})
+
+	t.Run("Upper and lower mask types", func(t *testing.T) {
+		t.Parallel()
+
+		lowerMaskTypes := []Type{
+			NilType,
+			Int64Type,
+			AnyStructType,
+			AnyResourceType,
+		}
+
+		upperMaskTypes := []Type{
+			&CapabilityType{
+				BorrowType: AnyStructType,
+			},
+			&RestrictedType{
+				Type: AnyStructType,
+				Restrictions: []*InterfaceType{
+					{
+						Location:   common.StringLocation("test"),
+						Identifier: "Foo",
+					},
+				},
+			},
+		}
+
+		for _, firstType := range lowerMaskTypes {
+			for _, secondType := range upperMaskTypes {
+				superType := leastCommonSuperType(firstType, secondType)
+
+				switch firstType {
+				case AnyResourceType:
+					assert.Equal(t, InvalidType, superType)
+				case NilType:
+					assert.Equal(t, &OptionalType{Type: secondType}, superType)
+				default:
+					assert.Equal(t, AnyStructType, superType)
+				}
+			}
 		}
 	})
 

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -1183,3 +1183,42 @@ func TestCheckDictionarySupertypeInference(t *testing.T) {
 		require.IsType(t, &sema.TypeAnnotationRequiredError{}, errs[0])
 	})
 }
+
+func TestCheckTypeInferenceForTypesWithDifferentTypeMaskRanges(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("array expression", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            let x: @AnyResource{Foo} <- create Bar()
+            let y = [<-x, 6]
+
+            resource interface Foo {}
+
+            resource Bar: Foo {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.TypeAnnotationRequiredError{}, errs[0])
+	})
+
+	t.Run("conditional expression", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+            let x: AnyStruct{Foo} = Bar()
+            let y = true ? x : nil
+
+            struct interface Foo {}
+
+            struct Bar: Foo {}
+        `)
+
+		require.NoError(t, err)
+
+		xType := RequireGlobalValue(t, checker.Elaboration, "y")
+		require.IsType(t, &sema.OptionalType{Type: sema.AnyStructType}, xType)
+	})
+}


### PR DESCRIPTION
Required for https://github.com/onflow/cadence/pull/2099

## Description

Improve the supertype calculation to make it easy to add new types in the 'upper mask' section.

This does not change the behaviour for the existing types. Therefore not a breaking change.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
