### PR TITLE
Improve JSON decoding error messages, add utility

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -102,7 +102,7 @@ func (d *Decoder) Decode() (value cadence.Value, err error) {
 				panic(r)
 			}
 
-			err = errors.NewDefaultUserError("failed to decode JSON-CDC: %w", panicErr)
+			err = errors.NewDefaultUserError("failed to decode JSON-Cadence value: %w", panicErr)
 		}
 	}()
 

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"math/big"
 	"strconv"
@@ -92,7 +91,7 @@ func (d *Decoder) Decode() (value cadence.Value, err error) {
 
 	err = d.dec.Decode(&jsonMap)
 	if err != nil {
-		return nil, fmt.Errorf("json-cdc: failed to decode valid JSON structure: %w", err)
+		return nil, errors.NewDefaultUserError("failed to decode JSON: %w", err)
 	}
 
 	// capture panics that occur during decoding
@@ -103,7 +102,7 @@ func (d *Decoder) Decode() (value cadence.Value, err error) {
 				panic(r)
 			}
 
-			err = errors.NewDefaultUserError("failed to decode value: %w", panicErr)
+			err = errors.NewDefaultUserError("failed to decode JSON-CDC: %w", panicErr)
 		}
 	}()
 
@@ -136,8 +135,6 @@ const (
 	returnKey       = "return"
 )
 
-var ErrInvalidJSONCadence = errors.NewDefaultUserError("invalid JSON Cadence structure")
-
 func (d *Decoder) decodeJSON(v any) cadence.Value {
 	obj := toObject(v)
 
@@ -150,7 +147,7 @@ func (d *Decoder) decodeJSON(v any) cadence.Value {
 
 	// object should only contain two keys: "type", "value"
 	if len(obj) != 2 {
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("expected JSON object with keys `s` and `%s`", typeKey, valueKey))
 	}
 
 	valueJSON := obj.Get(valueKey)
@@ -230,14 +227,13 @@ func (d *Decoder) decodeJSON(v any) cadence.Value {
 		return d.decodeEnum(valueJSON)
 	}
 
-	panic(ErrInvalidJSONCadence)
+	panic(errors.NewDefaultUserError("invalid type: %s", typeStr))
 }
 
 func (d *Decoder) decodeVoid(m map[string]any) cadence.Void {
 	// object should not contain fields other than "type"
 	if len(m) != 1 {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid additional fields in void value"))
 	}
 
 	return cadence.NewMeteredVoid(d.gauge)
@@ -284,19 +280,29 @@ func (d *Decoder) decodeString(valueJSON any) cadence.String {
 	return str
 }
 
+const addressPrefix = "0x"
+
 func (d *Decoder) decodeAddress(valueJSON any) cadence.Address {
 	v := toString(valueJSON)
 
-	// must include 0x prefix
-	if v[:2] != "0x" {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+	prefixLength := len(addressPrefix)
+	if len(v) < prefixLength {
+		panic(errors.NewDefaultUserError("missing address prefix: `%s`"))
 	}
 
-	b, err := hex.DecodeString(v[2:])
+	// must include 0x prefix
+	actualPrefix := v[:prefixLength]
+	if actualPrefix != addressPrefix {
+		panic(errors.NewDefaultUserError(
+			"invalid address prefix: expected `%s`, got `%s`",
+			addressPrefix,
+			actualPrefix,
+		))
+	}
+
+	b, err := hex.DecodeString(v[prefixLength:])
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid address: %w", err))
 	}
 
 	return cadence.BytesToMeteredAddress(d.gauge, b)
@@ -308,8 +314,7 @@ func (d *Decoder) decodeBigInt(valueJSON any) *big.Int {
 	i := new(big.Int)
 	i, ok := i.SetString(v, 10)
 	if !ok {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		return nil
 	}
 
 	return i
@@ -317,6 +322,11 @@ func (d *Decoder) decodeBigInt(valueJSON any) *big.Int {
 
 func (d *Decoder) decodeInt(valueJSON any) cadence.Int {
 	bigInt := d.decodeBigInt(valueJSON)
+	if bigInt == nil {
+		// TODO: propagate toString error from decodeBigInt
+		panic(errors.NewDefaultUserError("invalid Int: %s", valueJSON))
+	}
+
 	return cadence.NewMeteredIntFromBig(
 		d.gauge,
 		common.NewCadenceIntMemoryUsage(
@@ -333,8 +343,7 @@ func (d *Decoder) decodeInt8(valueJSON any) cadence.Int8 {
 
 	i, err := strconv.ParseInt(v, 10, 8)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Int8: %s", v))
 	}
 
 	return cadence.NewMeteredInt8(d.gauge, int8(i))
@@ -345,8 +354,7 @@ func (d *Decoder) decodeInt16(valueJSON any) cadence.Int16 {
 
 	i, err := strconv.ParseInt(v, 10, 16)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Int16: %s", v))
 	}
 
 	return cadence.NewMeteredInt16(d.gauge, int16(i))
@@ -357,8 +365,7 @@ func (d *Decoder) decodeInt32(valueJSON any) cadence.Int32 {
 
 	i, err := strconv.ParseInt(v, 10, 32)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Int32: %s", v))
 	}
 
 	return cadence.NewMeteredInt32(d.gauge, int32(i))
@@ -369,8 +376,7 @@ func (d *Decoder) decodeInt64(valueJSON any) cadence.Int64 {
 
 	i, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Int64: %s", v))
 	}
 
 	return cadence.NewMeteredInt64(d.gauge, i)
@@ -380,13 +386,17 @@ func (d *Decoder) decodeInt128(valueJSON any) cadence.Int128 {
 	value, err := cadence.NewMeteredInt128FromBig(
 		d.gauge,
 		func() *big.Int {
-			return d.decodeBigInt(valueJSON)
+			bigInt := d.decodeBigInt(valueJSON)
+			if bigInt == nil {
+				// TODO: propagate toString error from decodeBigInt
+				panic(errors.NewDefaultUserError("invalid Int128: %s", valueJSON))
+			}
+			return bigInt
 		},
 	)
 
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Int128: %w", err))
 	}
 	return value
 }
@@ -395,19 +405,27 @@ func (d *Decoder) decodeInt256(valueJSON any) cadence.Int256 {
 	value, err := cadence.NewMeteredInt256FromBig(
 		d.gauge,
 		func() *big.Int {
-			return d.decodeBigInt(valueJSON)
+			bigInt := d.decodeBigInt(valueJSON)
+			if bigInt == nil {
+				// TODO: propagate toString error from decodeBigInt
+				panic(errors.NewDefaultUserError("invalid Int256: %s", valueJSON))
+			}
+			return bigInt
 		},
 	)
 
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Int256: %w", err))
 	}
 	return value
 }
 
 func (d *Decoder) decodeUInt(valueJSON any) cadence.UInt {
 	bigInt := d.decodeBigInt(valueJSON)
+	if bigInt == nil {
+		// TODO: propagate toString error from decodeBigInt
+		panic(errors.NewDefaultUserError("invalid UInt: %s", valueJSON))
+	}
 	value, err := cadence.NewMeteredUIntFromBig(
 		d.gauge,
 		common.NewCadenceIntMemoryUsage(
@@ -419,8 +437,7 @@ func (d *Decoder) decodeUInt(valueJSON any) cadence.UInt {
 	)
 
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UInt: %w", err))
 	}
 	return value
 }
@@ -430,8 +447,7 @@ func (d *Decoder) decodeUInt8(valueJSON any) cadence.UInt8 {
 
 	i, err := strconv.ParseUint(v, 10, 8)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UInt8: %w", err))
 	}
 
 	return cadence.NewMeteredUInt8(d.gauge, uint8(i))
@@ -442,8 +458,7 @@ func (d *Decoder) decodeUInt16(valueJSON any) cadence.UInt16 {
 
 	i, err := strconv.ParseUint(v, 10, 16)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UInt16: %w", err))
 	}
 
 	return cadence.NewMeteredUInt16(d.gauge, uint16(i))
@@ -454,8 +469,7 @@ func (d *Decoder) decodeUInt32(valueJSON any) cadence.UInt32 {
 
 	i, err := strconv.ParseUint(v, 10, 32)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UInt32: %w", err))
 	}
 
 	return cadence.NewMeteredUInt32(d.gauge, uint32(i))
@@ -466,8 +480,7 @@ func (d *Decoder) decodeUInt64(valueJSON any) cadence.UInt64 {
 
 	i, err := strconv.ParseUint(v, 10, 64)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UInt64: %w", err))
 	}
 
 	return cadence.NewMeteredUInt64(d.gauge, i)
@@ -477,12 +490,16 @@ func (d *Decoder) decodeUInt128(valueJSON any) cadence.UInt128 {
 	value, err := cadence.NewMeteredUInt128FromBig(
 		d.gauge,
 		func() *big.Int {
-			return d.decodeBigInt(valueJSON)
+			bigInt := d.decodeBigInt(valueJSON)
+			if bigInt == nil {
+				// TODO: propagate toString error from decodeBigInt
+				panic(errors.NewDefaultUserError("invalid UInt128: %s", valueJSON))
+			}
+			return bigInt
 		},
 	)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UInt128: %w", err))
 	}
 	return value
 }
@@ -491,12 +508,15 @@ func (d *Decoder) decodeUInt256(valueJSON any) cadence.UInt256 {
 	value, err := cadence.NewMeteredUInt256FromBig(
 		d.gauge,
 		func() *big.Int {
-			return d.decodeBigInt(valueJSON)
+			bigInt := d.decodeBigInt(valueJSON)
+			if bigInt == nil {
+				panic(errors.NewDefaultUserError("invalid UInt256: %s", valueJSON))
+			}
+			return bigInt
 		},
 	)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UInt256: %w", err))
 	}
 	return value
 }
@@ -506,8 +526,7 @@ func (d *Decoder) decodeWord8(valueJSON any) cadence.Word8 {
 
 	i, err := strconv.ParseUint(v, 10, 8)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Word8: %w", err))
 	}
 
 	return cadence.NewMeteredWord8(d.gauge, uint8(i))
@@ -518,8 +537,7 @@ func (d *Decoder) decodeWord16(valueJSON any) cadence.Word16 {
 
 	i, err := strconv.ParseUint(v, 10, 16)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Word16: %w", err))
 	}
 
 	return cadence.NewMeteredWord16(d.gauge, uint16(i))
@@ -530,8 +548,7 @@ func (d *Decoder) decodeWord32(valueJSON any) cadence.Word32 {
 
 	i, err := strconv.ParseUint(v, 10, 32)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Word32: %w", err))
 	}
 
 	return cadence.NewMeteredWord32(d.gauge, uint32(i))
@@ -542,8 +559,7 @@ func (d *Decoder) decodeWord64(valueJSON any) cadence.Word64 {
 
 	i, err := strconv.ParseUint(v, 10, 64)
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Word64: %w", err))
 	}
 
 	return cadence.NewMeteredWord64(d.gauge, i)
@@ -554,8 +570,7 @@ func (d *Decoder) decodeFix64(valueJSON any) cadence.Fix64 {
 		return toString(valueJSON), nil
 	})
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid Fix64: %w", err))
 	}
 	return v
 }
@@ -565,8 +580,7 @@ func (d *Decoder) decodeUFix64(valueJSON any) cadence.UFix64 {
 		return toString(valueJSON), nil
 	})
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid UFix64: %w", err))
 	}
 	return v
 }
@@ -587,8 +601,7 @@ func (d *Decoder) decodeArray(valueJSON any) cadence.Array {
 	)
 
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid array: %w", err))
 	}
 	return value
 }
@@ -611,8 +624,7 @@ func (d *Decoder) decodeDictionary(valueJSON any) cadence.Dictionary {
 	)
 
 	if err != nil {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid dictionary: %w", err))
 	}
 
 	return value
@@ -644,12 +656,13 @@ func (d *Decoder) decodeComposite(valueJSON any) composite {
 	typeID := obj.GetString(idKey)
 	location, qualifiedIdentifier, err := common.DecodeTypeID(d.gauge, typeID)
 
-	if err != nil ||
-		location == nil && sema.NativeCompositeTypes[typeID] == nil {
+	if err != nil {
+		panic(errors.NewDefaultUserError("invalid type ID `%s`: %w", typeID, err))
+	} else if location == nil && sema.NativeCompositeTypes[typeID] == nil {
 
 		// If the location is nil, and there is no native composite type with this ID, then it's an invalid type.
 		// Note: This is moved out from the common.DecodeTypeID() to avoid the circular dependency.
-		panic(errors.NewDefaultUserError("%s. invalid type ID: `%s`", ErrInvalidJSONCadence, typeID))
+		panic(errors.NewDefaultUserError("invalid type ID for built-in: `%s`", typeID))
 	}
 
 	fields := obj.GetSlice(fieldsKey)
@@ -702,7 +715,7 @@ func (d *Decoder) decodeStruct(valueJSON any) cadence.Struct {
 	)
 
 	if err != nil {
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid struct: %w", err))
 	}
 
 	return structure.WithType(cadence.NewMeteredStructType(
@@ -726,7 +739,7 @@ func (d *Decoder) decodeResource(valueJSON any) cadence.Resource {
 	)
 
 	if err != nil {
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid resource: %w", err))
 	}
 	return resource.WithType(cadence.NewMeteredResourceType(
 		d.gauge,
@@ -749,7 +762,7 @@ func (d *Decoder) decodeEvent(valueJSON any) cadence.Event {
 	)
 
 	if err != nil {
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid event: %w", err))
 	}
 
 	return event.WithType(cadence.NewMeteredEventType(
@@ -773,7 +786,7 @@ func (d *Decoder) decodeContract(valueJSON any) cadence.Contract {
 	)
 
 	if err != nil {
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid contract: %w", err))
 	}
 
 	return contract.WithType(cadence.NewMeteredContractType(
@@ -797,7 +810,7 @@ func (d *Decoder) decodeEnum(valueJSON any) cadence.Enum {
 	)
 
 	if err != nil {
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid enum: %w", err))
 	}
 
 	return enum.WithType(cadence.NewMeteredEnumType(
@@ -815,8 +828,7 @@ func (d *Decoder) decodeLink(valueJSON any) cadence.Link {
 
 	targetPath, ok := d.decodeJSON(obj.Get(targetPathKey)).(cadence.Path)
 	if !ok {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid link: missing or invalid target path"))
 	}
 
 	borrowType := obj.GetString(borrowTypeKey)
@@ -937,7 +949,7 @@ func (d *Decoder) decodeNominalType(
 
 	location, qualifiedIdentifier, err := common.DecodeTypeID(d.gauge, typeID)
 	if err != nil {
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid type ID in nominal type: %w", err))
 	}
 
 	var result cadence.Type
@@ -1019,7 +1031,7 @@ func (d *Decoder) decodeNominalType(
 		)
 		result = compositeType
 	default:
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid kind: %s", kind))
 	}
 
 	results[typeID] = result
@@ -1260,8 +1272,7 @@ func (d *Decoder) decodeCapability(valueJSON any) cadence.Capability {
 
 	path, ok := d.decodeJSON(obj.Get(pathKey)).(cadence.Path)
 	if !ok {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("invalid capability: missing or invalid path"))
 	}
 
 	return cadence.NewMeteredCapability(
@@ -1279,8 +1290,7 @@ type jsonObject map[string]any
 func (obj jsonObject) Get(key string) any {
 	v, hasKey := obj[key]
 	if !hasKey {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("missing property: %s", key))
 	}
 
 	return v
@@ -1311,8 +1321,7 @@ func (obj jsonObject) GetValue(d *Decoder, key string) cadence.Value {
 func toBool(valueJSON any) bool {
 	v, isBool := valueJSON.(bool)
 	if !isBool {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("expected JSON bool, got %s", valueJSON))
 	}
 
 	return v
@@ -1321,8 +1330,7 @@ func toBool(valueJSON any) bool {
 func toUInt(valueJSON any) uint {
 	v, isNum := valueJSON.(float64)
 	if !isNum {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("expected JSON number, got %s", valueJSON))
 	}
 
 	return uint(v)
@@ -1331,8 +1339,8 @@ func toUInt(valueJSON any) uint {
 func toString(valueJSON any) string {
 	v, isString := valueJSON.(string)
 	if !isString {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("expected JSON string, got %s", valueJSON))
+
 	}
 
 	return v
@@ -1341,8 +1349,7 @@ func toString(valueJSON any) string {
 func toSlice(valueJSON any) []any {
 	v, isSlice := valueJSON.([]any)
 	if !isSlice {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("expected JSON array, got %s", valueJSON))
 	}
 
 	return v
@@ -1351,8 +1358,7 @@ func toSlice(valueJSON any) []any {
 func toObject(valueJSON any) jsonObject {
 	v, isMap := valueJSON.(map[string]any)
 	if !isMap {
-		// TODO: improve error message
-		panic(ErrInvalidJSONCadence)
+		panic(errors.NewDefaultUserError("expecte JSON object, got %s", valueJSON))
 	}
 
 	return v

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -147,7 +147,7 @@ func (d *Decoder) decodeJSON(v any) cadence.Value {
 
 	// object should only contain two keys: "type", "value"
 	if len(obj) != 2 {
-		panic(errors.NewDefaultUserError("expected JSON object with keys `s` and `%s`", typeKey, valueKey))
+		panic(errors.NewDefaultUserError("expected JSON object with keys `%s` and `%s`", typeKey, valueKey))
 	}
 
 	valueJSON := obj.Get(valueKey)
@@ -287,7 +287,7 @@ func (d *Decoder) decodeAddress(valueJSON any) cadence.Address {
 
 	prefixLength := len(addressPrefix)
 	if len(v) < prefixLength {
-		panic(errors.NewDefaultUserError("missing address prefix: `%s`"))
+		panic(errors.NewDefaultUserError("missing address prefix: `%s`", addressPrefix))
 	}
 
 	// must include 0x prefix

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1931,7 +1931,7 @@ func TestDecodeInvalidType(t *testing.T) {
 	`
 		_, err := json.Decode(nil, []byte(encodedValue))
 		require.Error(t, err)
-		assert.Equal(t, "failed to decode value: invalid JSON Cadence structure. invalid type ID: ``", err.Error())
+		assert.Equal(t, "failed to decode JSON-Cadence value: invalid type ID for built-in: ``", err.Error())
 	})
 
 	t.Run("undefined type", func(t *testing.T) {
@@ -1948,7 +1948,7 @@ func TestDecodeInvalidType(t *testing.T) {
 	`
 		_, err := json.Decode(nil, []byte(encodedValue))
 		require.Error(t, err)
-		assert.Equal(t, "failed to decode value: invalid JSON Cadence structure. invalid type ID: `I.Foo`", err.Error())
+		assert.Equal(t, "failed to decode JSON-Cadence value: invalid type ID `I.Foo`: invalid identifier location type ID: missing qualified identifier", err.Error())
 	})
 
 	t.Run("unknown location prefix", func(t *testing.T) {
@@ -1965,7 +1965,7 @@ func TestDecodeInvalidType(t *testing.T) {
 	`
 		_, err := json.Decode(nil, []byte(encodedValue))
 		require.Error(t, err)
-		assert.Equal(t, "failed to decode value: invalid JSON Cadence structure. invalid type ID: `N.PublicKey`", err.Error())
+		assert.Equal(t, "failed to decode JSON-Cadence value: invalid type ID for built-in: `N.PublicKey`", err.Error())
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f
 	github.com/go-test/deep v1.0.5
+	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/leanovate/gopter v0.2.9
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/onflow/atree v0.4.0
@@ -27,6 +28,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fxamacker/circlehash v0.3.0 // indirect
+	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.14 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,11 @@ github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
+github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
+github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.0.14 h1:QRqdp6bb9M9S5yyKeYteXKuoKE4p0tGlra81fKOpWH8=
 github.com/klauspost/cpuid/v2 v2.0.14/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=

--- a/runtime/cmd/json-cdc/main.go
+++ b/runtime/cmd/json-cdc/main.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (

--- a/runtime/cmd/json-cdc/main.go
+++ b/runtime/cmd/json-cdc/main.go
@@ -36,7 +36,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	switch os.Args[1] {
+	command := os.Args[1]
+	switch command {
 	case "decode":
 		var data bytes.Buffer
 		reader := bufio.NewReader(os.Stdin)
@@ -51,5 +52,9 @@ func main() {
 		}
 
 		_, _ = pp.Print(value)
+
+	default:
+		_, _ = fmt.Fprintf(os.Stderr, "unsupported command: %s", command)
+		os.Exit(1)
 	}
 }

--- a/runtime/cmd/json-cdc/main.go
+++ b/runtime/cmd/json-cdc/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/k0kubun/pp"
+
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		_, _ = fmt.Fprintf(os.Stderr, "expected command\n")
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "decode":
+		var data bytes.Buffer
+		reader := bufio.NewReader(os.Stdin)
+		_, err := io.Copy(&data, reader)
+		if err != nil {
+			panic(err)
+		}
+
+		value, err := jsoncdc.Decode(nil, data.Bytes())
+		if err != nil {
+			panic(err)
+		}
+
+		_, _ = pp.Print(value)
+	}
+}


### PR DESCRIPTION
## Description

Triggered by https://dapperlabs.slack.com/archives/CSE8F45PT/p1666651547642259

- Make the error messages of the JSON decoder more useful
- Add a utility which can be used to validate JSON-CDC

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
