### PR TITLE
Add documentation for String.fromUTF8, numeric types' fromString

### DIFF
--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -168,7 +168,19 @@ Integers have multiple built-in functions you can use.
   answer.toString()  // is "42"
   ```
 
-- `cadence•fun fromString(_ input: String): T?`
+- `cadence•fun toBigEndianBytes(): [UInt8]`
+
+  Returns the byte array representation (`[UInt8]`) in big-endian order of the integer.
+
+  ```cadence
+  let largeNumber = 1234567890
+
+  largeNumber.toBigEndianBytes()  // is `[73, 150, 2, 210]`
+  ```
+
+All integer types support the following functions:
+
+- `cadence•fun T.fromString(_ input: String): T?`
 
   Attempts to parse an integer value from a base-10 encoded string, returning `nil` if the string is invalid.
 
@@ -182,14 +194,16 @@ Integers have multiple built-in functions you can use.
 
   For unsigned integer types like `Word64`, `UInt64`, and `UInt`, sign prefices are not allowed.
 
-- `cadence•fun toBigEndianBytes(): [UInt8]`
-
-  Returns the byte array representation (`[UInt8]`) in big-endian order of the integer.
+  Examples:
 
   ```cadence
-  let largeNumber = 1234567890
+  let fortyTwo: Int64? = Int64.fromString("42") // ok
 
-  largeNumber.toBigEndianBytes()  // is `[73, 150, 2, 210]`
+  let twenty: UInt? = UInt.fromString("20") // ok
+
+  let nilWord: Word8? = Word8.fromString("1024") // nil, out of bounds
+
+  let negTwenty: Int? = Int.fromString("-20") // ok
   ```
 
 ## Fixed-Point Numbers
@@ -236,7 +250,19 @@ Fixed-Point numbers have multiple built-in functions you can use.
   fix.toString()  // is "1.23000000"
   ```
 
-- `cadence•fun fromString(_ input: String): T?`
+- `cadence•fun toBigEndianBytes(): [UInt8]`
+
+  Returns the byte array representation (`[UInt8]`) in big-endian order of the fixed-point number.
+
+  ```cadence
+  let fix = 1.23
+
+  fix.toBigEndianBytes()  // is `[0, 0, 0, 0, 7, 84, 212, 192]`
+  ```
+
+All fixed-point types support the following functions:
+
+- `cadence•fun T.fromString(_ input: String): T?`
 
   Attempts to parse a fixed-point value from a base-10 encoded string, returning `nil` if the string is invalid.
 
@@ -251,14 +277,20 @@ Fixed-Point numbers have multiple built-in functions you can use.
 
   For unsigned types like `UFix64`, sign prefices are not allowed.
 
-- `cadence•fun toBigEndianBytes(): [UInt8]`
-
-  Returns the byte array representation (`[UInt8]`) in big-endian order of the fixed-point number.
+  Examples:
 
   ```cadence
-  let fix = 1.23
+  let nil1: UFix64? = UFix64.fromString("0.") // nil, fractional part is required
 
-  fix.toBigEndianBytes()  // is `[0, 0, 0, 0, 7, 84, 212, 192]`
+  let nil2: UFix64? = UFix64.fromString(".1") // nil, decimal part is required
+
+  let smol: UFix64? = UFix64.fromString("0.1") // ok
+
+  let smolString: String = "-0.1"
+
+  let nil3: UFix64? = UFix64.fromString(smolString) // nil, unsigned types don't allow a sign prefix
+
+  let smolFix64: Fix64? = Fix64.fromString(smolString) // ok
   ```
 
 ## Minimum and maximum values

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -172,7 +172,7 @@ Integers have multiple built-in functions you can use.
 
   Attempts to parse an integer value from a base-10 encoded string, returning `nil` if the string is invalid.
 
-  For a given integer `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an `Optional`.
+  For a given integer `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an [optional](#optionals).
 
   Strings are invalid if:
     - they contain non-digit characters
@@ -240,7 +240,7 @@ Fixed-Point numbers have multiple built-in functions you can use.
 
   Attempts to parse a fixed-point value from a base-10 encoded string, returning `nil` if the string is invalid.
 
-  For a given fixed-point numeral `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an `Optional`.
+  For a given fixed-point numeral `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an `optional`.
 
   Strings are invalid if:
     - they contain non-digit characters.
@@ -679,6 +679,13 @@ Strings have multiple built-in functions you can use:
   let bytes = flowers.utf8
   // `bytes` is `[70, 108, 111, 119, 101, 114, 115, 32, 240, 159, 146, 144]`
   ```
+
+- `cadence•fun fromUTF8(_ input: [UInt8]): String?`
+
+  Attempts to convert a UTF-8 encoded byte array into a `String`. This function returns `nil` if the byte array contains invalid UTF-8,
+  such as incomplete codepoint sequences or undefined graphemes.
+
+  For a given string `s`, `String.fromUTF8(s.utf8)` is equivalent to wrapping `s` up in an [optional](#optionals).
 
 - `cadence•fun concat(_ other: String): String`
 

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -168,6 +168,20 @@ Integers have multiple built-in functions you can use.
   answer.toString()  // is "42"
   ```
 
+- `cadence•fun fromString(_ input: String): T?`
+
+  Attempts to parse an integer value from a base-10 encoded string, returning `nil` if the string is invalid.
+
+  For a given integer `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an `Optional`.
+
+  Strings are invalid if:
+    - they contain non-digit characters
+    - they don't fit in the target type
+  
+  For signed integer types like `Int64`, and `Int`, the string may optionally begin with `+` or `-` sign prefix.
+
+  For unsigned integer types like `Word64`, `UInt64`, and `UInt`, sign prefices are not allowed.
+
 - `cadence•fun toBigEndianBytes(): [UInt8]`
 
   Returns the byte array representation (`[UInt8]`) in big-endian order of the integer.
@@ -221,6 +235,21 @@ Fixed-Point numbers have multiple built-in functions you can use.
 
   fix.toString()  // is "1.23000000"
   ```
+
+- `cadence•fun fromString(_ input: String): T?`
+
+  Attempts to parse a fixed-point value from a base-10 encoded string, returning `nil` if the string is invalid.
+
+  For a given fixed-point numeral `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an `Optional`.
+
+  Strings are invalid if:
+    - they contain non-digit characters.
+    - they don't fit in the target type.
+    - they're missing a decimal or fractional component. For example, both "0." and ".1" are invalid strings, but "0.1" is accepted.
+
+  For signed types like `Fix64`, the string may optionally begin with `+` or `-` sign prefix.
+
+  For unsigned types like `UFix64`, sign prefices are not allowed.
 
 - `cadence•fun toBigEndianBytes(): [UInt8]`
 

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -712,13 +712,6 @@ Strings have multiple built-in functions you can use:
   // `bytes` is `[70, 108, 111, 119, 101, 114, 115, 32, 240, 159, 146, 144]`
   ```
 
-- `cadence•fun fromUTF8(_ input: [UInt8]): String?`
-
-  Attempts to convert a UTF-8 encoded byte array into a `String`. This function returns `nil` if the byte array contains invalid UTF-8,
-  such as incomplete codepoint sequences or undefined graphemes.
-
-  For a given string `s`, `String.fromUTF8(s.utf8)` is equivalent to wrapping `s` up in an [optional](#optionals).
-
 - `cadence•fun concat(_ other: String): String`
 
   Concatenates the string `other` to the end of the original string,
@@ -800,6 +793,13 @@ let str = "abc"
 let c = str[0] // is the Character "a"
 ```
 
+- `cadence•fun String.fromUTF8(_ input: [UInt8]): String?`
+
+  Attempts to convert a UTF-8 encoded byte array into a `String`. This function returns `nil` if the byte array contains invalid UTF-8,
+  such as incomplete codepoint sequences or undefined graphemes.
+
+  For a given string `s`, `String.fromUTF8(s.utf8)` is equivalent to wrapping `s` up in an [optional](#optionals).
+
 ### Character Fields and Functions
 
 `Character` values can be converted into `String` values using the `toString` function:
@@ -812,6 +812,15 @@ let c = str[0] // is the Character "a"
   let c: Character = "x"
 
   c.toString()  // is "x"
+  ```
+
+- `cadence•fun String.fromCharacters(_ characters: [Character]): String`
+
+  Builds a new `String` value from an array of `Character`s. Because `String`s are immutable, this operation makes a copy of the input array.
+
+  ```cadence
+  let rawUwU: [Character] = ["U", "w", "U"]
+  let uwu: String = String.fromCharacters(rawUwU) // "UwU"
   ```
 
 ## Arrays


### PR DESCRIPTION
Closes #2056

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

New standard library functions were introduced in #1927 and #1982, but ~~i was too lazy to write docs~~ they were omitted from the Cadence language reference. This PR extends our docs to cover the new functionality. 
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
