### PR TITLE
Improve view modifier parsing and printing

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1394,6 +1394,7 @@ var functionExpressionEmptyBlockDoc prettier.Doc = prettier.Text(" {}")
 
 func FunctionDocument(
 	access Access,
+	purity FunctionPurity,
 	includeKeyword bool,
 	identifier string,
 	parameterList *ParameterList,
@@ -1425,6 +1426,14 @@ func FunctionDocument(
 		doc = append(
 			doc,
 			prettier.Text(access.Keyword()),
+			prettier.Space,
+		)
+	}
+
+	if purity != FunctionPurityUnspecified {
+		doc = append(
+			doc,
+			prettier.Text(purity.Keyword()),
 			prettier.Space,
 		)
 	}
@@ -1468,6 +1477,7 @@ func FunctionDocument(
 func (e *FunctionExpression) Doc() prettier.Doc {
 	return FunctionDocument(
 		AccessNotSpecified,
+		e.Purity,
 		true,
 		"",
 		e.ParameterList,

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4722,6 +4722,35 @@ func TestFunctionExpression_Doc(t *testing.T) {
 
 		assert.Equal(t, expected, expr.Doc())
 	})
+
+	t.Run("view", func(t *testing.T) {
+
+		t.Parallel()
+
+		expr := &FunctionExpression{
+			Purity:        FunctionPurityView,
+			ParameterList: &ParameterList{},
+			FunctionBlock: &FunctionBlock{
+				Block: &Block{
+					Statements: []Statement{},
+				},
+			},
+		}
+
+		expected := prettier.Concat{
+			prettier.Text("view"),
+			prettier.Space,
+			prettier.Text("fun "),
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("()"),
+				},
+			},
+			prettier.Text(" {}"),
+		}
+
+		assert.Equal(t, expected, expr.Doc())
+	})
 }
 
 func TestFunctionExpression_String(t *testing.T) {

--- a/runtime/ast/function_declaration.go
+++ b/runtime/ast/function_declaration.go
@@ -24,6 +24,7 @@ import (
 	"github.com/turbolent/prettier"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
 )
 
 type FunctionPurity int
@@ -33,11 +34,26 @@ const (
 	FunctionPurityView
 )
 
-func (p FunctionPurity) MarshalJSON() ([]byte, error) {
-	if p == FunctionPurityUnspecified {
-		return json.Marshal("Unspecified")
+func (p FunctionPurity) Keyword() string {
+	switch p {
+	case FunctionPurityUnspecified:
+		return ""
+	case FunctionPurityView:
+		return "view"
+	default:
+		panic(errors.NewUnreachableError())
 	}
-	return json.Marshal("View")
+}
+
+func (p FunctionPurity) MarshalJSON() ([]byte, error) {
+	switch p {
+	case FunctionPurityUnspecified:
+		return json.Marshal("Unspecified")
+	case FunctionPurityView:
+		return json.Marshal("View")
+	default:
+		panic(errors.NewUnreachableError())
+	}
 }
 
 type FunctionDeclaration struct {
@@ -144,6 +160,7 @@ func (d *FunctionDeclaration) DeclarationDocString() string {
 func (d *FunctionDeclaration) Doc() prettier.Doc {
 	return FunctionDocument(
 		d.Access,
+		d.Purity,
 		true,
 		d.Identifier.Identifier,
 		d.ParameterList,
@@ -236,6 +253,7 @@ func (d *SpecialFunctionDeclaration) DeclarationDocString() string {
 func (d *SpecialFunctionDeclaration) Doc() prettier.Doc {
 	return FunctionDocument(
 		d.FunctionDeclaration.Access,
+		d.FunctionDeclaration.Purity,
 		false,
 		d.Kind.Keywords(),
 		d.FunctionDeclaration.ParameterList,

--- a/runtime/ast/function_declaration_test.go
+++ b/runtime/ast/function_declaration_test.go
@@ -176,6 +176,7 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 
 	decl := &FunctionDeclaration{
 		Access: AccessPublic,
+		Purity: FunctionPurityView,
 		Identifier: Identifier{
 			Identifier: "xyz",
 		},
@@ -214,6 +215,8 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 	require.Equal(t,
 		prettier.Concat{
 			prettier.Text("pub"),
+			prettier.Space,
+			prettier.Text("view"),
 			prettier.Space,
 			prettier.Text("fun "),
 			prettier.Text("xyz"),

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -471,6 +471,10 @@ func (t *FunctionType) Doc() prettier.Doc {
 		prettier.SoftLine{},
 	}
 
+	result := prettier.Concat{
+		functionTypeStartDoc,
+	}
+
 	for i, parameterTypeAnnotation := range t.ParameterTypeAnnotations {
 		if i > 0 {
 			parametersDoc = append(
@@ -485,8 +489,16 @@ func (t *FunctionType) Doc() prettier.Doc {
 		)
 	}
 
-	return prettier.Concat{
-		functionTypeStartDoc,
+	if t.PurityAnnotation != FunctionPurityUnspecified {
+		result = append(
+			result,
+			prettier.Text(t.PurityAnnotation.Keyword()),
+			prettier.Space,
+		)
+	}
+
+	result = append(
+		result,
 		prettier.Group{
 			Doc: prettier.Concat{
 				functionTypeStartDoc,
@@ -500,7 +512,9 @@ func (t *FunctionType) Doc() prettier.Doc {
 		typeSeparatorSpaceDoc,
 		t.ReturnTypeAnnotation.Doc(),
 		functionTypeEndDoc,
-	}
+	)
+
+	return result
 }
 
 func (t *FunctionType) MarshalJSON() ([]byte, error) {

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -659,6 +659,7 @@ func TestFunctionType_Doc(t *testing.T) {
 	t.Parallel()
 
 	ty := &FunctionType{
+		PurityAnnotation: FunctionPurityView,
 		ParameterTypeAnnotations: []*TypeAnnotation{
 			{
 				IsResource: true,
@@ -689,6 +690,8 @@ func TestFunctionType_Doc(t *testing.T) {
 	assert.Equal(t,
 		prettier.Concat{
 			prettier.Text("("),
+			prettier.Text("view"),
+			prettier.Space,
 			prettier.Group{
 				Doc: prettier.Concat{
 					prettier.Text("("),

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -75,6 +75,9 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 		switch p.current.Type {
 		case lexer.TokenPragma:
+			if purity != ast.FunctionPurityUnspecified {
+				return nil, p.syntaxError("invalid view modifier for pragma")
+			}
 			if access != ast.AccessNotSpecified {
 				return nil, p.syntaxError("invalid access modifier for pragma")
 			}

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -76,17 +76,17 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 		switch p.current.Type {
 		case lexer.TokenPragma:
 			if purity != ast.FunctionPurityUnspecified {
-				return nil, p.syntaxError("invalid view modifier for pragma")
+				return nil, NewSyntaxError(*purityPos, "invalid view modifier for pragma")
 			}
 			if access != ast.AccessNotSpecified {
-				return nil, p.syntaxError("invalid access modifier for pragma")
+				return nil, NewSyntaxError(*accessPos, "invalid access modifier for pragma")
 			}
 			return parsePragmaDeclaration(p)
 		case lexer.TokenIdentifier:
 			switch string(p.currentTokenSource()) {
 			case keywordLet, keywordVar:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for variable")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for variable")
 				}
 				return parseVariableDeclaration(p, access, accessPos, docString)
 
@@ -95,28 +95,28 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 			case keywordImport:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for import")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for import")
 				}
 				return parseImportDeclaration(p)
 
 			case keywordEvent:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for event")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for event")
 				}
 				return parseEventDeclaration(p, access, accessPos, docString)
 
 			case keywordStruct, keywordResource, keywordContract, keywordEnum:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for composite")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for composite")
 				}
 				return parseCompositeOrInterfaceDeclaration(p, access, accessPos, docString)
 
 			case keywordTransaction:
 				if access != ast.AccessNotSpecified {
-					return nil, p.syntaxError("invalid access modifier for transaction")
+					return nil, NewSyntaxError(*accessPos, "invalid access modifier for transaction")
 				}
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for transaction")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for transaction")
 				}
 
 				return parseTransactionDeclaration(p, docString)
@@ -1058,13 +1058,13 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 			switch string(p.currentTokenSource()) {
 			case keywordLet, keywordVar:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for variable")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for variable")
 				}
 				return parseFieldWithVariableKind(p, access, accessPos, docString)
 
 			case keywordCase:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for case")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for case")
 				}
 				return parseEnumCase(p, access, accessPos, docString)
 
@@ -1073,13 +1073,13 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 
 			case keywordEvent:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for event")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for event")
 				}
 				return parseEventDeclaration(p, access, accessPos, docString)
 
 			case keywordStruct, keywordResource, keywordContract, keywordEnum:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, p.syntaxError("invalid view modifier for composite")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for composite")
 				}
 				return parseCompositeOrInterfaceDeclaration(p, access, accessPos, docString)
 
@@ -1123,7 +1123,7 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				return nil, p.syntaxError("unexpected %s", p.current.Type)
 			}
 			if purity != ast.FunctionPurityUnspecified {
-				return nil, p.syntaxError("invalid view modifier for variable")
+				return nil, NewSyntaxError(*purityPos, "invalid view modifier for variable")
 			}
 			identifier := p.tokenToIdentifier(*previousIdentifierToken)
 			return parseFieldDeclarationWithoutVariableKind(p, access, accessPos, identifier, docString)

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -1064,7 +1064,7 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 
 			case keywordCase:
 				if purity != ast.FunctionPurityUnspecified {
-					return nil, NewSyntaxError(*purityPos, "invalid view modifier for case")
+					return nil, NewSyntaxError(*purityPos, "invalid view modifier for enum case")
 				}
 				return parseEnumCase(p, access, accessPos, docString)
 

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -4299,27 +4299,47 @@ func TestParsePragmaNoArguments(t *testing.T) {
 
 	t.Parallel()
 
-	const code = `#pedantic`
-	result, err := testParseProgram(code)
-	require.NoError(t, err)
+	t.Run("identifier", func(t *testing.T) {
 
-	utils.AssertEqualWithDiff(t,
-		[]ast.Declaration{
-			&ast.PragmaDeclaration{
-				Expression: &ast.IdentifierExpression{
-					Identifier: ast.Identifier{
-						Identifier: "pedantic",
-						Pos:        ast.Position{Offset: 1, Line: 1, Column: 1},
+		t.Parallel()
+
+		result, errs := testParseDeclarations(`#pedantic`)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.PragmaDeclaration{
+					Expression: &ast.IdentifierExpression{
+						Identifier: ast.Identifier{
+							Identifier: "pedantic",
+							Pos:        ast.Position{Offset: 1, Line: 1, Column: 1},
+						},
+					},
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+						EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},
 					},
 				},
-				Range: ast.Range{
-					StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
-					EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},
+			},
+			result,
+		)
+	})
+
+	t.Run("with purity", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("view #foo")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid view modifier for pragma",
+					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
 				},
 			},
-		},
-		result.Declarations(),
-	)
+			errs,
+		)
+	})
 }
 
 func TestParsePragmaArguments(t *testing.T) {

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -2681,6 +2681,22 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("enum case with view modifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(" enum E { view case e }")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid view modifier for enum case",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseTransactionDeclaration(t *testing.T) {
@@ -4576,7 +4592,7 @@ func TestParseImportWithFromIdentifier(t *testing.T) {
 	)
 }
 
-func TestParseImportWithPurity(t *testing.T) {
+func TestParseInvalidImportWithPurity(t *testing.T) {
 
 	t.Parallel()
 
@@ -4596,7 +4612,7 @@ func TestParseImportWithPurity(t *testing.T) {
 	)
 }
 
-func TestParseEventWithPurity(t *testing.T) {
+func TestParseInvalidEventWithPurity(t *testing.T) {
 
 	t.Parallel()
 
@@ -4616,7 +4632,7 @@ func TestParseEventWithPurity(t *testing.T) {
 	)
 }
 
-func TestParseCompositeWithPurity(t *testing.T) {
+func TestParseInvalidCompositeWithPurity(t *testing.T) {
 
 	t.Parallel()
 
@@ -4636,7 +4652,7 @@ func TestParseCompositeWithPurity(t *testing.T) {
 	)
 }
 
-func TestParseTransactionWithPurity(t *testing.T) {
+func TestParseInvalidTransactionWithPurity(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -2573,52 +2573,6 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 		}, errs)
 	})
 
-	t.Run("enum, two cases one one line", func(t *testing.T) {
-
-		t.Parallel()
-
-		result, errs := testParseDeclarations(" pub enum E { case c ; pub case d }")
-		require.Empty(t, errs)
-
-		utils.AssertEqualWithDiff(t,
-			[]ast.Declaration{
-				&ast.CompositeDeclaration{
-					Access:        ast.AccessPublic,
-					CompositeKind: common.CompositeKindEnum,
-					Identifier: ast.Identifier{
-						Identifier: "E",
-						Pos:        ast.Position{Line: 1, Column: 10, Offset: 10},
-					},
-					Members: ast.NewUnmeteredMembers(
-						[]ast.Declaration{
-							&ast.EnumCaseDeclaration{
-								Access: ast.AccessNotSpecified,
-								Identifier: ast.Identifier{
-									Identifier: "c",
-									Pos:        ast.Position{Line: 1, Column: 19, Offset: 19},
-								},
-								StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
-							},
-							&ast.EnumCaseDeclaration{
-								Access: ast.AccessPublic,
-								Identifier: ast.Identifier{
-									Identifier: "d",
-									Pos:        ast.Position{Line: 1, Column: 32, Offset: 32},
-								},
-								StartPos: ast.Position{Line: 1, Column: 23, Offset: 23},
-							},
-						},
-					),
-					Range: ast.Range{
-						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-						EndPos:   ast.Position{Line: 1, Column: 34, Offset: 34},
-					},
-				},
-			},
-			result,
-		)
-	})
-
 	t.Run("struct with view member", func(t *testing.T) {
 
 		t.Parallel()
@@ -2675,6 +2629,57 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 						EndPos:   ast.Position{Line: 3, Column: 2, Offset: 45},
+					},
+				},
+			},
+			result,
+		)
+	})
+}
+
+func TestParseEnumDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("enum, two cases one one line", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseDeclarations(" pub enum E { case c ; pub case d }")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.CompositeDeclaration{
+					Access:        ast.AccessPublic,
+					CompositeKind: common.CompositeKindEnum,
+					Identifier: ast.Identifier{
+						Identifier: "E",
+						Pos:        ast.Position{Line: 1, Column: 10, Offset: 10},
+					},
+					Members: ast.NewUnmeteredMembers(
+						[]ast.Declaration{
+							&ast.EnumCaseDeclaration{
+								Access: ast.AccessNotSpecified,
+								Identifier: ast.Identifier{
+									Identifier: "c",
+									Pos:        ast.Position{Line: 1, Column: 19, Offset: 19},
+								},
+								StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
+							},
+							&ast.EnumCaseDeclaration{
+								Access: ast.AccessPublic,
+								Identifier: ast.Identifier{
+									Identifier: "d",
+									Pos:        ast.Position{Line: 1, Column: 32, Offset: 32},
+								},
+								StartPos: ast.Position{Line: 1, Column: 23, Offset: 23},
+							},
+						},
+					),
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						EndPos:   ast.Position{Line: 1, Column: 34, Offset: 34},
 					},
 				},
 			},

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -270,7 +270,7 @@ func TestParseVariableDeclaration(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid view modifier for variable",
-					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
 				},
 			},
 			errs,
@@ -2263,7 +2263,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid view modifier for variable",
-					Pos:     ast.Position{Offset: 23, Line: 2, Column: 11},
+					Pos:     ast.Position{Offset: 15, Line: 2, Column: 3},
 				},
 			},
 			errs,
@@ -4334,7 +4334,7 @@ func TestParsePragmaNoArguments(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid view modifier for pragma",
-					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
 				},
 			},
 			errs,
@@ -4589,7 +4589,7 @@ func TestParseImportWithPurity(t *testing.T) {
 		[]error{
 			&SyntaxError{
 				Message: "invalid view modifier for import",
-				Pos:     ast.Position{Offset: 14, Line: 2, Column: 13},
+				Pos:     ast.Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
 		errs,
@@ -4609,7 +4609,7 @@ func TestParseEventWithPurity(t *testing.T) {
 		[]error{
 			&SyntaxError{
 				Message: "invalid view modifier for event",
-				Pos:     ast.Position{Offset: 14, Line: 2, Column: 13},
+				Pos:     ast.Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
 		errs,
@@ -4629,7 +4629,7 @@ func TestParseCompositeWithPurity(t *testing.T) {
 		[]error{
 			&SyntaxError{
 				Message: "invalid view modifier for composite",
-				Pos:     ast.Position{Offset: 14, Line: 2, Column: 13},
+				Pos:     ast.Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
 		errs,
@@ -4649,7 +4649,7 @@ func TestParseTransactionWithPurity(t *testing.T) {
 		[]error{
 			&SyntaxError{
 				Message: "invalid view modifier for transaction",
-				Pos:     ast.Position{Offset: 14, Line: 2, Column: 13},
+				Pos:     ast.Position{Offset: 9, Line: 2, Column: 8},
 			},
 		},
 		errs,
@@ -5554,7 +5554,7 @@ func TestParseInvalidAccessModifiers(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid access modifier for pragma",
-					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
 				},
 			},
 			errs,
@@ -5570,7 +5570,7 @@ func TestParseInvalidAccessModifiers(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid access modifier for transaction",
-					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
 				},
 			},
 			errs,

--- a/runtime/parser/keyword.go
+++ b/runtime/parser/keyword.go
@@ -18,6 +18,7 @@
 
 package parser
 
+// NOTE: ensure to update allKeywords when adding a new keyword
 const (
 	keywordIf          = "if"
 	keywordElse        = "else"
@@ -63,6 +64,7 @@ const (
 	keywordDefault     = "default"
 	keywordEnum        = "enum"
 	keywordView        = "view"
+	// NOTE: ensure to update allKeywords when adding a new keyword
 )
 
 var allKeywords = map[string]struct{}{
@@ -109,6 +111,7 @@ var allKeywords = map[string]struct{}{
 	keywordSwitch:      {},
 	keywordDefault:     {},
 	keywordEnum:        {},
+	keywordView:        {},
 }
 
 // Keywords that can be used in identifier position without ambiguity.
@@ -120,7 +123,7 @@ var softKeywords = map[string]struct{}{
 }
 
 // Keywords that aren't allowed in identifier position.
-var hardKeywords map[string]struct{} = mapDiff(allKeywords, softKeywords)
+var hardKeywords = mapDiff(allKeywords, softKeywords)
 
 // take the boolean difference of two maps
 func mapDiff[T comparable, U any](minuend map[T]U, subtrahend map[T]U) map[T]U {

--- a/types.go
+++ b/types.go
@@ -1399,7 +1399,7 @@ func (t *ContractInterfaceType) InterfaceInitializers() [][]Parameter {
 type FunctionPurity int
 
 const (
-	FunctionPurityUnspecified = iota
+	FunctionPurityUnspecified FunctionPurity = iota
 	FunctionPurityView
 )
 


### PR DESCRIPTION
## Description

Noticed this while working on related code:

- Forbid `view` modifier for pragmas
- Ensure `view` keyword is declared as such
- Update pretty-printing of function declarations, expressions, and types to include `view` modifier

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
