### PR TITLE
Add JSON language annotations to expected JSON encodings in AST tests

### DIFF
--- a/runtime/ast/argument_test.go
+++ b/runtime/ast/argument_test.go
@@ -50,6 +50,7 @@ func TestArgument_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
+			// language=json
 			`
             {
                 "Expression": {
@@ -89,6 +90,7 @@ func TestArgument_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
+			// language=json
 			`
             {
                 "Label": "ok",

--- a/runtime/ast/block_test.go
+++ b/runtime/ast/block_test.go
@@ -53,6 +53,7 @@ func TestBlock_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "Block",
@@ -176,6 +177,7 @@ func TestFunctionBlock_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
+			// language=json
 			`
             {
                 "Type": "FunctionBlock",
@@ -261,6 +263,7 @@ func TestFunctionBlock_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
+			// language=json
 			`
             {
                 "Type": "FunctionBlock",

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -44,6 +44,7 @@ func TestBoolExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "BoolExpression",
@@ -98,6 +99,7 @@ func TestNilExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "NilExpression",
@@ -145,6 +147,7 @@ func TestStringExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "StringExpression",
@@ -195,6 +198,7 @@ func TestIntegerExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "IntegerExpression",
@@ -399,6 +403,7 @@ func TestFixedPointExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "FixedPointExpression",
@@ -518,6 +523,7 @@ func TestArrayExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ArrayExpression",
@@ -661,6 +667,7 @@ func TestDictionaryExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "DictionaryExpression",
@@ -818,6 +825,7 @@ func TestIdentifierExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "IdentifierExpression",
@@ -882,6 +890,7 @@ func TestPathExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "PathExpression",
@@ -970,6 +979,7 @@ func TestMemberExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "MemberExpression",
@@ -1304,6 +1314,7 @@ func TestIndexExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "IndexExpression",
@@ -1611,6 +1622,7 @@ func TestUnaryExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "UnaryExpression",
@@ -1843,6 +1855,7 @@ func TestBinaryExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "BinaryExpression",
@@ -2337,6 +2350,7 @@ func TestDestroyExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "DestroyExpression",
@@ -2552,6 +2566,7 @@ func TestForceExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ForceExpression",
@@ -2764,6 +2779,7 @@ func TestConditionalExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ConditionalExpression",
@@ -3306,6 +3322,7 @@ func TestInvocationExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "InvocationExpression",
@@ -3625,6 +3642,7 @@ func TestCastingExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "CastingExpression",
@@ -3976,6 +3994,7 @@ func TestCreateExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "CreateExpression",
@@ -4106,6 +4125,7 @@ func TestReferenceExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ReferenceExpression",
@@ -4481,6 +4501,7 @@ func TestFunctionExpression_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "FunctionExpression",

--- a/runtime/ast/import_test.go
+++ b/runtime/ast/import_test.go
@@ -52,6 +52,7 @@ func TestImportDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ImportDeclaration", 

--- a/runtime/ast/interface_test.go
+++ b/runtime/ast/interface_test.go
@@ -52,6 +52,7 @@ func TestInterfaceDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "InterfaceDeclaration",

--- a/runtime/ast/members_test.go
+++ b/runtime/ast/members_test.go
@@ -36,6 +36,7 @@ func TestMembers_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Declarations": []

--- a/runtime/ast/pragma_test.go
+++ b/runtime/ast/pragma_test.go
@@ -49,6 +49,7 @@ func TestPragmaDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "PragmaDeclaration",

--- a/runtime/ast/program_test.go
+++ b/runtime/ast/program_test.go
@@ -36,6 +36,7 @@ func TestProgram_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "Program",

--- a/runtime/ast/statement_test.go
+++ b/runtime/ast/statement_test.go
@@ -45,6 +45,7 @@ func TestExpressionStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ExpressionStatement",
@@ -116,6 +117,7 @@ func TestReturnStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ReturnStatement",
@@ -217,6 +219,7 @@ func TestBreakStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "BreakStatement",
@@ -263,6 +266,7 @@ func TestContinueStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ContinueStatement",
@@ -327,6 +331,7 @@ func TestIfStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "IfStatement",
@@ -523,6 +528,7 @@ func TestWhileStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "WhileStatement",
@@ -625,6 +631,7 @@ func TestForStatement_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
+			// language=json
 			`
             {
                 "Type": "ForStatement",
@@ -688,6 +695,7 @@ func TestForStatement_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.JSONEq(t,
+			// language=json
 			`
             {
                 "Type": "ForStatement",
@@ -875,6 +883,7 @@ func TestAssignmentStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "AssignmentStatement",
@@ -992,6 +1001,7 @@ func TestSwapStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "SwapStatement",
@@ -1116,6 +1126,7 @@ func TestEmitStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "EmitStatement",
@@ -1284,6 +1295,7 @@ func TestSwitchStatement_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "SwitchStatement",

--- a/runtime/ast/transaction_declaration_test.go
+++ b/runtime/ast/transaction_declaration_test.go
@@ -57,6 +57,7 @@ func TestTransactionDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "TransactionDeclaration",

--- a/runtime/ast/transfer_test.go
+++ b/runtime/ast/transfer_test.go
@@ -39,6 +39,7 @@ func TestTransfer_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "Transfer",

--- a/runtime/ast/type_test.go
+++ b/runtime/ast/type_test.go
@@ -88,6 +88,7 @@ func TestTypeAnnotation_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "IsResource": true,
@@ -232,6 +233,7 @@ func TestNominalType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "NominalType",
@@ -312,6 +314,7 @@ func TestOptionalType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "OptionalType",
@@ -400,6 +403,7 @@ func TestVariableSizedType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "VariableSizedType",
@@ -509,6 +513,7 @@ func TestConstantSizedType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ConstantSizedType",
@@ -623,6 +628,7 @@ func TestDictionaryType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "DictionaryType",
@@ -794,6 +800,7 @@ func TestFunctionType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "FunctionType",
@@ -948,6 +955,7 @@ func TestReferenceType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "ReferenceType",
@@ -1083,6 +1091,7 @@ func TestRestrictedType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "RestrictedType",
@@ -1260,6 +1269,7 @@ func TestInstantiationType_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "InstantiationType",

--- a/runtime/ast/variable_declaration_test.go
+++ b/runtime/ast/variable_declaration_test.go
@@ -78,6 +78,7 @@ func TestVariableDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "VariableDeclaration",


### PR DESCRIPTION
## Description

Make it easier to edit expected JSON encodings in AST tests by adding [language injection](https://www.jetbrains.com/help/go/using-language-injections.html#use-language-injection-comments) annotations.


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
