### PR TITLE
Make view a soft keyword

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -62,7 +62,7 @@ func parseDeclarations(p *parser, endTokenType lexer.TokenType) (declarations []
 	}
 }
 
-func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
+func parseDeclaration(p *parser, docString string) (declaration ast.Declaration, err error) {
 
 	access := ast.AccessNotSpecified
 	var accessPos *ast.Position
@@ -78,7 +78,11 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 	defer func() {
 		if noDeclarationFound {
-			p.replayBuffered()
+			bufferErr := p.replayBuffered()
+			if bufferErr != nil && err == nil {
+				declaration = nil
+				err = bufferErr
+			}
 		} else {
 			p.acceptBuffered()
 		}
@@ -151,10 +155,9 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 				}
 				pos := p.current.StartPos
 				accessPos = &pos
-				var err error
 				access, err = parseAccess(p)
 				if err != nil {
-					return nil, err
+					return
 				}
 
 				continue
@@ -162,7 +165,7 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 		}
 
 		noDeclarationFound = true
-		return nil, nil
+		return
 	}
 }
 

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -70,7 +70,7 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 	purity := ast.FunctionPurityUnspecified
 	var purityPos *ast.Position
 
-	// access modifiers/purity annotations are soft keywords
+	// some access modifiers/purity annotations are soft keywords
 	// in which case, parsing them as semantic tokens might mangle the
 	// parser state before they can parsed as identifiers
 	noDeclarationFound := false

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -62,31 +62,13 @@ func parseDeclarations(p *parser, endTokenType lexer.TokenType) (declarations []
 	}
 }
 
-func parseDeclaration(p *parser, docString string) (declaration ast.Declaration, err error) {
+func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 	access := ast.AccessNotSpecified
 	var accessPos *ast.Position
 
 	purity := ast.FunctionPurityUnspecified
 	var purityPos *ast.Position
-
-	// some access modifiers/purity annotations are soft keywords
-	// in which case, parsing them as semantic tokens might mangle the
-	// parser state before they can parsed as identifiers
-	noDeclarationFound := false
-	p.startBuffering()
-
-	defer func() {
-		if noDeclarationFound {
-			bufferErr := p.replayBuffered()
-			if bufferErr != nil && err == nil {
-				declaration = nil
-				err = bufferErr
-			}
-		} else {
-			p.acceptBuffered()
-		}
-	}()
 
 	for {
 		p.skipSpaceAndComments()
@@ -155,17 +137,17 @@ func parseDeclaration(p *parser, docString string) (declaration ast.Declaration,
 				}
 				pos := p.current.StartPos
 				accessPos = &pos
+				var err error
 				access, err = parseAccess(p)
 				if err != nil {
-					return
+					return nil, err
 				}
 
 				continue
 			}
 		}
 
-		noDeclarationFound = true
-		return
+		return nil, nil
 	}
 }
 

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -2573,52 +2573,6 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 		}, errs)
 	})
 
-	t.Run("enum, two cases one one line", func(t *testing.T) {
-
-		t.Parallel()
-
-		result, errs := testParseDeclarations(" pub enum E { case c ; pub case d }")
-		require.Empty(t, errs)
-
-		utils.AssertEqualWithDiff(t,
-			[]ast.Declaration{
-				&ast.CompositeDeclaration{
-					Access:        ast.AccessPublic,
-					CompositeKind: common.CompositeKindEnum,
-					Identifier: ast.Identifier{
-						Identifier: "E",
-						Pos:        ast.Position{Line: 1, Column: 10, Offset: 10},
-					},
-					Members: ast.NewUnmeteredMembers(
-						[]ast.Declaration{
-							&ast.EnumCaseDeclaration{
-								Access: ast.AccessNotSpecified,
-								Identifier: ast.Identifier{
-									Identifier: "c",
-									Pos:        ast.Position{Line: 1, Column: 19, Offset: 19},
-								},
-								StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
-							},
-							&ast.EnumCaseDeclaration{
-								Access: ast.AccessPublic,
-								Identifier: ast.Identifier{
-									Identifier: "d",
-									Pos:        ast.Position{Line: 1, Column: 32, Offset: 32},
-								},
-								StartPos: ast.Position{Line: 1, Column: 23, Offset: 23},
-							},
-						},
-					),
-					Range: ast.Range{
-						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
-						EndPos:   ast.Position{Line: 1, Column: 34, Offset: 34},
-					},
-				},
-			},
-			result,
-		)
-	})
-
 	t.Run("struct with view member", func(t *testing.T) {
 
 		t.Parallel()
@@ -2675,6 +2629,57 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 					Range: ast.Range{
 						StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 						EndPos:   ast.Position{Line: 3, Column: 2, Offset: 45},
+					},
+				},
+			},
+			result,
+		)
+	})
+}
+
+func TestParseEnumDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("enum, two cases one one line", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseDeclarations(" pub enum E { case c ; pub case d }")
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.CompositeDeclaration{
+					Access:        ast.AccessPublic,
+					CompositeKind: common.CompositeKindEnum,
+					Identifier: ast.Identifier{
+						Identifier: "E",
+						Pos:        ast.Position{Line: 1, Column: 10, Offset: 10},
+					},
+					Members: ast.NewUnmeteredMembers(
+						[]ast.Declaration{
+							&ast.EnumCaseDeclaration{
+								Access: ast.AccessNotSpecified,
+								Identifier: ast.Identifier{
+									Identifier: "c",
+									Pos:        ast.Position{Line: 1, Column: 19, Offset: 19},
+								},
+								StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
+							},
+							&ast.EnumCaseDeclaration{
+								Access: ast.AccessPublic,
+								Identifier: ast.Identifier{
+									Identifier: "d",
+									Pos:        ast.Position{Line: 1, Column: 32, Offset: 32},
+								},
+								StartPos: ast.Position{Line: 1, Column: 23, Offset: 23},
+							},
+						},
+					),
+					Range: ast.Range{
+						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						EndPos:   ast.Position{Line: 1, Column: 34, Offset: 34},
 					},
 				},
 			},

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -822,20 +822,15 @@ func defineIdentifierExpression() {
 				}
 
 				// otherwise, we treat it as an identifier called "view"
-				return ast.NewIdentifierExpression(
-					p.memoryGauge,
-					p.tokenToIdentifier(token),
-				), nil
-
+				break
 			case keywordFun:
 				return parseFunctionExpression(p, token, ast.FunctionPurityUnspecified)
-
-			default:
-				return ast.NewIdentifierExpression(
-					p.memoryGauge,
-					p.tokenToIdentifier(token),
-				), nil
 			}
+
+			return ast.NewIdentifierExpression(
+				p.memoryGauge,
+				p.tokenToIdentifier(token),
+			), nil
 		},
 	})
 }

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -815,15 +815,18 @@ func defineIdentifierExpression() {
 				), nil
 
 			case keywordView:
-				if !p.isToken(p.current, lexer.TokenIdentifier, keywordFun) {
-					return nil, p.syntaxError(
-						"expected fun keyword, but got %s",
-						string(p.tokenSource(p.current)),
-					)
+				// if `view` is followed by `fun`, then it denotes a pure function expression
+				if p.isToken(p.current, lexer.TokenIdentifier, keywordFun) {
+					p.nextSemanticToken()
+					return parseFunctionExpression(p, token, ast.FunctionPurityView)
 				}
-				p.nextSemanticToken()
 
-				return parseFunctionExpression(p, token, ast.FunctionPurityView)
+				// otherwise, we treat it as an identifier called "view"
+				return ast.NewIdentifierExpression(
+					p.memoryGauge,
+					p.tokenToIdentifier(token),
+				), nil
+
 			case keywordFun:
 				return parseFunctionExpression(p, token, ast.FunctionPurityUnspecified)
 

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -2799,7 +2799,7 @@ func TestParseFunctionExpression(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "expected fun keyword, but got for",
+					Message: "unexpected token: identifier",
 					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
 				},
 			},
@@ -5900,6 +5900,7 @@ func TestParseIdentifiers(t *testing.T) {
 		"foo________",
 		"FOO_______",
 		"Fo123__21341278AAAAAAAAAAAAA",
+		"view",
 	}
 	for _, name := range names {
 		t.Run(name, func(t *testing.T) {

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -5890,7 +5890,9 @@ func TestParseCasting(t *testing.T) {
 }
 
 func testParseIdentifiersWith(t *testing.T, identifiers []string, condition func(*testing.T, string, error)) {
-	for _, name := range identifiers {
+	for _, identifier := range identifiers {
+		// to ensure proper name capture
+		name := identifier
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -5922,8 +5924,7 @@ func TestParseIdentifiers(t *testing.T) {
 func TestParseHardKeywords(t *testing.T) {
 	t.Parallel()
 
-	// seriously why doesn't golang have iterators
-	hardKeywordList := make([]string, len(hardKeywords))
+	hardKeywordList := make([]string, 0, len(hardKeywords))
 	for kw := range hardKeywords {
 		hardKeywordList = append(hardKeywordList, kw)
 	}
@@ -5944,7 +5945,7 @@ func TestParseHardKeywords(t *testing.T) {
 func TestParseSoftKeywords(t *testing.T) {
 	t.Parallel()
 
-	softKeywordList := make([]string, len(softKeywords))
+	softKeywordList := make([]string, 0, len(softKeywords))
 	for kw := range softKeywords {
 		softKeywordList = append(softKeywordList, kw)
 	}

--- a/runtime/parser/keyword.go
+++ b/runtime/parser/keyword.go
@@ -120,6 +120,7 @@ var softKeywords = map[string]struct{}{
 	keywordAccount: {},
 	keywordSet:     {},
 	keywordAll:     {},
+	keywordView:    {},
 }
 
 // Keywords that aren't allowed in identifier position.

--- a/runtime/parser/statement_test.go
+++ b/runtime/parser/statement_test.go
@@ -2651,9 +2651,7 @@ func TestSoftKeywordsInStatement(t *testing.T) {
 		}
 	}
 
-	for keyword := range softKeywords {
-		// haha scoping
-		name := keyword
+	testSoftKeyword := func(name string) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2686,6 +2684,11 @@ func TestSoftKeywordsInStatement(t *testing.T) {
 				},
 			}
 			utils.AssertEqualWithDiff(t, expected, result)
+
 		})
+	}
+
+	for keyword := range softKeywords {
+		testSoftKeyword(keyword)
 	}
 }


### PR DESCRIPTION
Closes #2120

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Modifies the parser to allow the `view` keyword to be used as an identifier. The keyword has been added to the `SoftKeywords` set in `runtime/parser/keyword.go`.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
