### PR TITLE
Add more purity annotations to built-in and standard library function types

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -41,7 +41,7 @@ import (
 
 //
 
-var emptyFunctionType = &sema.FunctionType{
+var emptyImpureFunctionType = &sema.FunctionType{
 	Purity: sema.FunctionPurityImpure,
 	ReturnTypeAnnotation: &sema.TypeAnnotation{
 		Type: sema.VoidType,
@@ -1407,7 +1407,7 @@ func (interpreter *Interpreter) compositeDestructorFunction(
 	return NewInterpretedFunctionValue(
 		interpreter,
 		nil,
-		emptyFunctionType,
+		emptyImpureFunctionType,
 		lexicalScope,
 		beforeStatements,
 		preConditions,
@@ -3059,10 +3059,7 @@ var typeFunction = NewUnmeteredHostFunctionValue(
 		staticType := ConvertSemaToStaticType(invocation.Interpreter, ty)
 		return NewTypeValue(invocation.Interpreter, staticType)
 	},
-	&sema.FunctionType{
-		Purity:               sema.FunctionPurityView,
-		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.MetaType),
-	},
+	sema.MetaTypeFunctionType,
 )
 
 func defineTypeFunction(activation *VariableActivation) {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2729,12 +2729,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					v.ToBigEndianBytes(),
 				)
 			},
-			&sema.FunctionType{
-				Purity: sema.FunctionPurityView,
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					sema.ByteArrayType,
-				),
-			},
+			sema.ToBigEndianBytesFunctionType,
 		)
 
 	case sema.NumericTypeSaturatingAddFunctionName:

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -101,6 +101,7 @@ Returns the deployed contract.
 `
 
 var AuthAccountContractsTypeAddFunctionType = &FunctionType{
+	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
 			Identifier: "name",
@@ -142,6 +143,7 @@ Returns the deployed contract for the updated contract.
 `
 
 var AuthAccountContractsTypeUpdateExperimentalFunctionType = &FunctionType{
+	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
 			Identifier: "name",
@@ -193,6 +195,7 @@ Returns nil if no contract/contract interface with the given name exists in the 
 `
 
 var AuthAccountContractsTypeRemoveFunctionType = &FunctionType{
+	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
 			Identifier:     "name",

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -286,6 +286,7 @@ var AuthAccountTypeSaveFunctionType = func() *FunctionType {
 	}
 
 	return &FunctionType{
+		Purity: FunctionPurityImpure,
 		TypeParameters: []*TypeParameter{
 			typeParameter,
 		},
@@ -326,6 +327,7 @@ var AuthAccountTypeLoadFunctionType = func() *FunctionType {
 	}
 
 	return &FunctionType{
+		Purity: FunctionPurityImpure,
 		TypeParameters: []*TypeParameter{
 			typeParameter,
 		},
@@ -523,6 +525,7 @@ The link is latent. The target value might be stored after the link is created, 
 `
 
 var AuthAccountTypeUnlinkFunctionType = &FunctionType{
+	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
@@ -637,6 +640,7 @@ var AuthAccountKeysType = func() *CompositeType {
 }()
 
 var AuthAccountKeysTypeAddFunctionType = &FunctionType{
+	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
 			Identifier:     AccountKeyPublicKeyField,
@@ -669,8 +673,11 @@ var AccountKeysTypeGetFunctionType = &FunctionType{
 
 // fun keys.forEach(_ function: ((AccountKey): Bool)): Void
 var AccountKeysTypeForEachFunctionType = func() *FunctionType {
+	const functionPurity = FunctionPurityImpure
+
 	// ((AccountKey): Bool)
 	iterFunctionType := &FunctionType{
+		Purity: functionPurity,
 		Parameters: []*Parameter{
 			{
 				TypeAnnotation: NewTypeAnnotation(AccountKeyType),
@@ -680,6 +687,7 @@ var AccountKeysTypeForEachFunctionType = func() *FunctionType {
 	}
 
 	return &FunctionType{
+		Purity: functionPurity,
 		Parameters: []*Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
@@ -694,6 +702,7 @@ var AccountKeysTypeForEachFunctionType = func() *FunctionType {
 var AccountKeysTypeCountFieldType = UInt64Type
 
 var AuthAccountKeysTypeRevokeFunctionType = &FunctionType{
+	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
 			Identifier:     AccountKeyKeyIndexField,
@@ -774,6 +783,7 @@ Publishes the argument value under the given name, to be later claimed by the sp
 `
 
 var AuthAccountTypeInboxPublishFunctionType = &FunctionType{
+	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
@@ -806,6 +816,7 @@ var AuthAccountTypeInboxUnpublishFunctionType = func() *FunctionType {
 		},
 	}
 	return &FunctionType{
+		Purity: FunctionPurityImpure,
 		TypeParameters: []*TypeParameter{
 			typeParameter,
 		},
@@ -840,6 +851,7 @@ var AuthAccountTypeInboxClaimFunctionType = func() *FunctionType {
 		},
 	}
 	return &FunctionType{
+		Purity: FunctionPurityImpure,
 		TypeParameters: []*TypeParameter{
 			typeParameter,
 		},

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -129,6 +129,10 @@ var _ ast.DeclarationVisitor[struct{}] = &Checker{}
 var _ ast.StatementVisitor[struct{}] = &Checker{}
 var _ ast.ExpressionVisitor[Type] = &Checker{}
 
+var baseFunctionType = &FunctionType{
+	ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+}
+
 func NewChecker(
 	program *ast.Program,
 	location common.Location,
@@ -145,8 +149,8 @@ func NewChecker(
 	}
 
 	functionActivations := &FunctionActivations{}
-	functionActivations.EnterFunction(&FunctionType{
-		ReturnTypeAnnotation: NewTypeAnnotation(VoidType)},
+	functionActivations.EnterFunction(
+		baseFunctionType,
 		0,
 	)
 

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -134,7 +134,10 @@ All the public paths of an account
 `
 
 func AccountForEachFunctionType(pathType Type) *FunctionType {
+	const functionPurity = FunctionPurityImpure
+
 	iterFunctionType := &FunctionType{
+		Purity: functionPurity,
 		Parameters: []*Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
@@ -150,6 +153,7 @@ func AccountForEachFunctionType(pathType Type) *FunctionType {
 		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
 	}
 	return &FunctionType{
+		Purity: functionPurity,
 		Parameters: []*Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,

--- a/runtime/sema/runtime_type_constructors.go
+++ b/runtime/sema/runtime_type_constructors.go
@@ -24,6 +24,11 @@ type RuntimeTypeConstructor struct {
 	DocString string
 }
 
+var MetaTypeFunctionType = &FunctionType{
+	Purity:               FunctionPurityView,
+	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
+}
+
 var OptionalTypeFunctionType = &FunctionType{
 	Purity: FunctionPurityView,
 	Parameters: []*Parameter{

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -392,6 +392,7 @@ func FromStringFunctionDocstring(ty Type) string {
 
 func FromStringFunctionType(ty Type) *FunctionType {
 	return &FunctionType{
+		Purity: FunctionPurityView,
 		Parameters: []*Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
@@ -409,7 +410,7 @@ func FromStringFunctionType(ty Type) *FunctionType {
 
 const ToBigEndianBytesFunctionName = "toBigEndianBytes"
 
-var toBigEndianBytesFunctionType = &FunctionType{
+var ToBigEndianBytesFunctionType = &FunctionType{
 	Purity: FunctionPurityView,
 	ReturnTypeAnnotation: NewTypeAnnotation(
 		ByteArrayType,
@@ -484,7 +485,7 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 					memoryGauge,
 					ty,
 					identifier,
-					toBigEndianBytesFunctionType,
+					ToBigEndianBytesFunctionType,
 					toBigEndianBytesFunctionDocString,
 				)
 			},
@@ -661,8 +662,10 @@ func OptionalTypeMapFunctionType(typ Type) *FunctionType {
 		TypeParameter: typeParameter,
 	}
 
+	const functionPurity = FunctionPurityImpure
+
 	return &FunctionType{
-		Purity: FunctionPurityImpure,
+		Purity: functionPurity,
 		TypeParameters: []*TypeParameter{
 			typeParameter,
 		},
@@ -672,7 +675,7 @@ func OptionalTypeMapFunctionType(typ Type) *FunctionType {
 				Identifier: "transform",
 				TypeAnnotation: NewTypeAnnotation(
 					&FunctionType{
-						Purity: FunctionPurityImpure,
+						Purity: functionPurity,
 						Parameters: []*Parameter{
 							{
 								Label:          ArgumentLabelNotRequired,
@@ -4636,9 +4639,7 @@ func DictionaryRemoveFunctionType(t *DictionaryType) *FunctionType {
 }
 
 func DictionaryForEachKeyFunctionType(t *DictionaryType) *FunctionType {
-	// fun forEachKey(_ function: ((K): Bool)): Void
-
-	// funcType: K -> Bool
+	// ((K): Bool)
 	funcType := &FunctionType{
 		Parameters: []*Parameter{
 			{
@@ -4649,6 +4650,7 @@ func DictionaryForEachKeyFunctionType(t *DictionaryType) *FunctionType {
 		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
 	}
 
+	// fun forEachKey(_ function: ((K): Bool)): Void
 	return &FunctionType{
 		Parameters: []*Parameter{
 			{
@@ -5719,13 +5721,15 @@ func (t *TransactionType) PrepareFunctionType() *FunctionType {
 	}
 }
 
+var transactionTypeExecuteFunctionType = &FunctionType{
+	Purity:               FunctionPurityImpure,
+	IsConstructor:        true,
+	Parameters:           []*Parameter{},
+	ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+}
+
 func (*TransactionType) ExecuteFunctionType() *FunctionType {
-	return &FunctionType{
-		Purity:               FunctionPurityImpure,
-		IsConstructor:        true,
-		Parameters:           []*Parameter{},
-		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-	}
+	return transactionTypeExecuteFunctionType
 }
 
 func (*TransactionType) IsType() {}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -37,6 +37,7 @@ Creates a new account, paid by the given existing account
 `
 
 var authAccountFunctionType = &sema.FunctionType{
+	Purity: sema.FunctionPurityImpure,
 	Parameters: []*sema.Parameter{
 		{
 			Identifier: "payer",
@@ -1782,6 +1783,7 @@ Returns the public account for the given address
 `
 
 var getAccountFunctionType = &sema.FunctionType{
+	Purity: sema.FunctionPurityView,
 	Parameters: []*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,

--- a/runtime/stdlib/block.go
+++ b/runtime/stdlib/block.go
@@ -33,6 +33,7 @@ Returns the current block, i.e. the block which contains the currently executed 
 `
 
 var getCurrentBlockFunctionType = &sema.FunctionType{
+	Purity: sema.FunctionPurityView,
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		sema.BlockType,
 	),

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -32,6 +32,7 @@ Follow best practices to prevent security issues when using this function
 `
 
 var unsafeRandomFunctionType = &sema.FunctionType{
+	Purity: sema.FunctionPurityImpure,
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		sema.UInt64Type,
 	),


### PR DESCRIPTION
Work towards #2084 

## Description

Updating the NFT Storefront contracts identified that some more built-in and standard library functions are impure, but could be view: https://github.com/onflow/nft-storefront/pull/74#discussion_r1015633981

Add explicit purity annotations to more built-in and standard library function types, make functions view when possible.
 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
