### PR TITLE
Clean up function types and type annotations

### DIFF
--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -126,9 +126,11 @@ func TestExportValue(t *testing.T) {
 	testCharacter, _ := cadence.NewCharacter("a")
 
 	testFunction := &interpreter.InterpretedFunctionValue{
-		Type: &sema.FunctionType{
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
-		},
+		Type: sema.NewSimpleFunctionType(
+			sema.FunctionPurityImpure,
+			nil,
+			sema.NewTypeAnnotation(sema.VoidType),
+		),
 	}
 
 	testFunctionType := cadence.NewFunctionType(

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -129,7 +129,7 @@ func TestExportValue(t *testing.T) {
 		Type: sema.NewSimpleFunctionType(
 			sema.FunctionPurityImpure,
 			nil,
-			sema.NewTypeAnnotation(sema.VoidType),
+			sema.VoidTypeAnnotation,
 		),
 	}
 

--- a/runtime/interpreter/function_test.go
+++ b/runtime/interpreter/function_test.go
@@ -46,7 +46,7 @@ func TestFunctionStaticType(t *testing.T) {
 		hostFunctionType := sema.NewSimpleFunctionType(
 			sema.FunctionPurityImpure,
 			nil,
-			sema.NewTypeAnnotation(sema.BoolType),
+			sema.BoolTypeAnnotation,
 		)
 
 		hostFunctionValue := NewHostFunctionValue(
@@ -72,7 +72,7 @@ func TestFunctionStaticType(t *testing.T) {
 		hostFunctionType := sema.NewSimpleFunctionType(
 			sema.FunctionPurityImpure,
 			nil,
-			sema.NewTypeAnnotation(sema.BoolType),
+			sema.BoolTypeAnnotation,
 		)
 
 		hostFunctionValue := NewHostFunctionValue(

--- a/runtime/interpreter/function_test.go
+++ b/runtime/interpreter/function_test.go
@@ -43,10 +43,11 @@ func TestFunctionStaticType(t *testing.T) {
 			return TrueValue
 		}
 
-		hostFunctionType := &sema.FunctionType{
-			Parameters:           []*sema.Parameter{},
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
-		}
+		hostFunctionType := sema.NewSimpleFunctionType(
+			sema.FunctionPurityImpure,
+			nil,
+			sema.NewTypeAnnotation(sema.BoolType),
+		)
 
 		hostFunctionValue := NewHostFunctionValue(
 			inter,
@@ -68,10 +69,11 @@ func TestFunctionStaticType(t *testing.T) {
 			return TrueValue
 		}
 
-		hostFunctionType := &sema.FunctionType{
-			Parameters:           []*sema.Parameter{},
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
-		}
+		hostFunctionType := sema.NewSimpleFunctionType(
+			sema.FunctionPurityImpure,
+			nil,
+			sema.NewTypeAnnotation(sema.BoolType),
+		)
 
 		hostFunctionValue := NewHostFunctionValue(
 			inter,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -41,12 +41,13 @@ import (
 
 //
 
-var emptyImpureFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityImpure,
-	ReturnTypeAnnotation: &sema.TypeAnnotation{
+var emptyImpureFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityImpure,
+	nil,
+	&sema.TypeAnnotation{
 		Type: sema.VoidType,
 	},
-}
+)
 
 //
 
@@ -947,7 +948,6 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 		ReturnTypeAnnotation: &sema.TypeAnnotation{
 			Type: compositeType,
 		},
-		RequiredArgumentCount: nil,
 	}
 
 	var initializerFunction FunctionValue
@@ -2618,38 +2618,7 @@ func init() {
 		BaseActivation,
 		"DictionaryType",
 		NewUnmeteredHostFunctionValue(
-			func(invocation Invocation) Value {
-				keyTypeValue, ok := invocation.Arguments[0].(TypeValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				valueTypeValue, ok := invocation.Arguments[1].(TypeValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				keyType := keyTypeValue.Type
-				valueType := valueTypeValue.Type
-
-				// if the given key is not a valid dictionary key, it wouldn't make sense to create this type
-				if keyType == nil ||
-					!sema.IsValidDictionaryKeyType(invocation.Interpreter.MustConvertStaticToSemaType(keyType)) {
-					return Nil
-				}
-
-				return NewSomeValueNonCopying(
-					invocation.Interpreter,
-					NewTypeValue(
-						invocation.Interpreter,
-						NewDictionaryStaticType(
-							invocation.Interpreter,
-							keyType,
-							valueType,
-						),
-					),
-				)
-			},
+			dictionaryTypeFunction,
 			sema.DictionaryTypeFunctionType,
 		))
 
@@ -2657,26 +2626,7 @@ func init() {
 		BaseActivation,
 		"CompositeType",
 		NewUnmeteredHostFunctionValue(
-			func(invocation Invocation) Value {
-				typeIDValue, ok := invocation.Arguments[0].(*StringValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-				typeID := typeIDValue.Str
-
-				composite, err := lookupComposite(invocation.Interpreter, typeID)
-				if err != nil {
-					return Nil
-				}
-
-				return NewSomeValueNonCopying(
-					invocation.Interpreter,
-					NewTypeValue(
-						invocation.Interpreter,
-						ConvertSemaToStaticType(invocation.Interpreter, composite),
-					),
-				)
-			},
+			compositeTypeFunction,
 			sema.CompositeTypeFunctionType,
 		),
 	)
@@ -2685,26 +2635,7 @@ func init() {
 		BaseActivation,
 		"InterfaceType",
 		NewUnmeteredHostFunctionValue(
-			func(invocation Invocation) Value {
-				typeIDValue, ok := invocation.Arguments[0].(*StringValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-				typeID := typeIDValue.Str
-
-				interfaceType, err := lookupInterface(invocation.Interpreter, typeID)
-				if err != nil {
-					return Nil
-				}
-
-				return NewSomeValueNonCopying(
-					invocation.Interpreter,
-					NewTypeValue(
-						invocation.Interpreter,
-						ConvertSemaToStaticType(invocation.Interpreter, interfaceType),
-					),
-				)
-			},
+			interfaceTypeFunction,
 			sema.InterfaceTypeFunctionType,
 		),
 	)
@@ -2713,40 +2644,7 @@ func init() {
 		BaseActivation,
 		"FunctionType",
 		NewUnmeteredHostFunctionValue(
-			func(invocation Invocation) Value {
-				parameters, ok := invocation.Arguments[0].(*ArrayValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				typeValue, ok := invocation.Arguments[1].(TypeValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				returnType := invocation.Interpreter.MustConvertStaticToSemaType(typeValue.Type)
-				parameterTypes := make([]*sema.Parameter, 0, parameters.Count())
-				parameters.Iterate(invocation.Interpreter, func(param Value) bool {
-					semaType := invocation.Interpreter.MustConvertStaticToSemaType(param.(TypeValue).Type)
-					parameterTypes = append(
-						parameterTypes,
-						&sema.Parameter{
-							TypeAnnotation: sema.NewTypeAnnotation(semaType),
-						},
-					)
-
-					// Continue iteration
-					return true
-				})
-				functionStaticType := NewFunctionStaticType(
-					invocation.Interpreter,
-					&sema.FunctionType{
-						ReturnTypeAnnotation: sema.NewTypeAnnotation(returnType),
-						Parameters:           parameterTypes,
-					},
-				)
-				return NewUnmeteredTypeValue(functionStaticType)
-			},
+			functionTypeFunction,
 			sema.FunctionTypeFunctionType,
 		),
 	)
@@ -2755,13 +2653,127 @@ func init() {
 		BaseActivation,
 		"RestrictedType",
 		NewUnmeteredHostFunctionValue(
-			RestrictedTypeFunction,
+			restrictedTypeFunction,
 			sema.RestrictedTypeFunctionType,
 		),
 	)
 }
 
-func RestrictedTypeFunction(invocation Invocation) Value {
+func dictionaryTypeFunction(invocation Invocation) Value {
+	keyTypeValue, ok := invocation.Arguments[0].(TypeValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	valueTypeValue, ok := invocation.Arguments[1].(TypeValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	keyType := keyTypeValue.Type
+	valueType := valueTypeValue.Type
+
+	// if the given key is not a valid dictionary key, it wouldn't make sense to create this type
+	if keyType == nil ||
+		!sema.IsValidDictionaryKeyType(invocation.Interpreter.MustConvertStaticToSemaType(keyType)) {
+		return Nil
+	}
+
+	return NewSomeValueNonCopying(
+		invocation.Interpreter,
+		NewTypeValue(
+			invocation.Interpreter,
+			NewDictionaryStaticType(
+				invocation.Interpreter,
+				keyType,
+				valueType,
+			),
+		),
+	)
+}
+
+func compositeTypeFunction(invocation Invocation) Value {
+	typeIDValue, ok := invocation.Arguments[0].(*StringValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+	typeID := typeIDValue.Str
+
+	composite, err := lookupComposite(invocation.Interpreter, typeID)
+	if err != nil {
+		return Nil
+	}
+
+	return NewSomeValueNonCopying(
+		invocation.Interpreter,
+		NewTypeValue(
+			invocation.Interpreter,
+			ConvertSemaToStaticType(invocation.Interpreter, composite),
+		),
+	)
+}
+
+func interfaceTypeFunction(invocation Invocation) Value {
+	typeIDValue, ok := invocation.Arguments[0].(*StringValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+	typeID := typeIDValue.Str
+
+	interfaceType, err := lookupInterface(invocation.Interpreter, typeID)
+	if err != nil {
+		return Nil
+	}
+
+	return NewSomeValueNonCopying(
+		invocation.Interpreter,
+		NewTypeValue(
+			invocation.Interpreter,
+			ConvertSemaToStaticType(invocation.Interpreter, interfaceType),
+		),
+	)
+}
+
+func functionTypeFunction(invocation Invocation) Value {
+	parameters, ok := invocation.Arguments[0].(*ArrayValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	typeValue, ok := invocation.Arguments[1].(TypeValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	returnType := invocation.Interpreter.MustConvertStaticToSemaType(typeValue.Type)
+	parameterTypes := make([]*sema.Parameter, 0, parameters.Count())
+	parameters.Iterate(invocation.Interpreter, func(param Value) bool {
+		semaType := invocation.Interpreter.MustConvertStaticToSemaType(param.(TypeValue).Type)
+		parameterTypes = append(
+			parameterTypes,
+			&sema.Parameter{
+				TypeAnnotation: sema.NewTypeAnnotation(semaType),
+			},
+		)
+
+		// Continue iteration
+		return true
+	})
+
+	return NewTypeValue(
+		invocation.Interpreter,
+		NewFunctionStaticType(
+			invocation.Interpreter,
+			sema.NewSimpleFunctionType(
+				sema.FunctionPurityImpure,
+				parameterTypes,
+				sema.NewTypeAnnotation(returnType),
+			),
+		),
+	)
+}
+
+func restrictedTypeFunction(invocation Invocation) Value {
 	restrictionIDs, ok := invocation.Arguments[1].(*ArrayValue)
 	if !ok {
 		panic(errors.NewUnreachableError())

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2745,12 +2745,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					other,
 				)
 			},
-			&sema.FunctionType{
-				Purity: sema.FunctionPurityView,
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 		)
 
 	case sema.NumericTypeSaturatingSubtractFunctionName:
@@ -2766,12 +2761,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					other,
 				)
 			},
-			&sema.FunctionType{
-				Purity: sema.FunctionPurityView,
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 		)
 
 	case sema.NumericTypeSaturatingMultiplyFunctionName:
@@ -2787,12 +2777,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					other,
 				)
 			},
-			&sema.FunctionType{
-				Purity: sema.FunctionPurityView,
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 		)
 
 	case sema.NumericTypeSaturatingDivideFunctionName:
@@ -2808,12 +2793,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					other,
 				)
 			},
-			&sema.FunctionType{
-				Purity: sema.FunctionPurityView,
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 		)
 	}
 
@@ -16321,12 +16301,7 @@ var nilValueMapFunction = NewUnmeteredHostFunctionValue(
 	func(invocation Invocation) Value {
 		return Nil
 	},
-	&sema.FunctionType{
-		Purity: sema.FunctionPurityView,
-		ReturnTypeAnnotation: sema.NewTypeAnnotation(
-			sema.NeverType,
-		),
-	},
+	sema.OptionalTypeMapFunctionType(sema.NeverType),
 )
 
 func (v NilValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3717,14 +3717,15 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 
 		t.Parallel()
 
-		functionType := &sema.FunctionType{
-			Parameters: []*sema.Parameter{
+		functionType := sema.NewSimpleFunctionType(
+			sema.FunctionPurityImpure,
+			[]*sema.Parameter{
 				{
 					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
 				},
 			},
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
-		}
+			sema.NewTypeAnnotation(sema.BoolType),
+		)
 
 		for name, f := range map[string]Value{
 			"InterpretedFunctionValue": &InterpretedFunctionValue{

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3721,10 +3721,10 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			sema.FunctionPurityImpure,
 			[]*sema.Parameter{
 				{
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 			},
-			sema.NewTypeAnnotation(sema.BoolType),
+			sema.BoolTypeAnnotation,
 		)
 
 		for name, f := range map[string]Value{

--- a/runtime/sema/anystruct_type.go
+++ b/runtime/sema/anystruct_type.go
@@ -33,3 +33,5 @@ var AnyStructType = &SimpleType{
 	// The actual importability is checked at runtime
 	Importable: true,
 }
+
+var AnyStructTypeAnnotation = NewTypeAnnotation(AnyStructType)

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -142,9 +142,9 @@ or if the given name does not match the name of the contract/contract interface 
 Returns the deployed contract for the updated contract.
 `
 
-var AuthAccountContractsTypeUpdateExperimentalFunctionType = &FunctionType{
-	Purity: FunctionPurityImpure,
-	Parameters: []*Parameter{
+var AuthAccountContractsTypeUpdateExperimentalFunctionType = NewSimpleFunctionType(
+	FunctionPurityImpure,
+	[]*Parameter{
 		{
 			Identifier: "name",
 			TypeAnnotation: NewTypeAnnotation(
@@ -158,10 +158,10 @@ var AuthAccountContractsTypeUpdateExperimentalFunctionType = &FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		DeployedContractType,
 	),
-}
+)
 
 const authAccountContractsTypeGetFunctionDocString = `
 Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
@@ -169,9 +169,9 @@ Returns the deployed contract for the contract/contract interface with the given
 Returns nil if no contract/contract interface with the given name exists in the account.
 `
 
-var AuthAccountContractsTypeGetFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var AuthAccountContractsTypeGetFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier: "name",
 			TypeAnnotation: NewTypeAnnotation(
@@ -179,12 +179,12 @@ var AuthAccountContractsTypeGetFunctionType = &FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		&OptionalType{
 			Type: DeployedContractType,
 		},
 	),
-}
+)
 
 const authAccountContractsTypeRemoveFunctionDocString = `
 Removes the contract/contract interface from the account which has the given name, if any.
@@ -194,20 +194,20 @@ Returns the removed deployed contract, if any.
 Returns nil if no contract/contract interface with the given name exists in the account.
 `
 
-var AuthAccountContractsTypeRemoveFunctionType = &FunctionType{
-	Purity: FunctionPurityImpure,
-	Parameters: []*Parameter{
+var AuthAccountContractsTypeRemoveFunctionType = NewSimpleFunctionType(
+	FunctionPurityImpure,
+	[]*Parameter{
 		{
 			Identifier:     "name",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		&OptionalType{
 			Type: DeployedContractType,
 		},
 	),
-}
+)
 
 const authAccountContractsTypeGetNamesDocString = `
 Names of all contracts deployed in the account.

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -104,21 +104,15 @@ var AuthAccountContractsTypeAddFunctionType = &FunctionType{
 	Purity: FunctionPurityImpure,
 	Parameters: []*Parameter{
 		{
-			Identifier: "name",
-			TypeAnnotation: NewTypeAnnotation(
-				StringType,
-			),
+			Identifier:     "name",
+			TypeAnnotation: StringTypeAnnotation,
 		},
 		{
-			Identifier: "code",
-			TypeAnnotation: NewTypeAnnotation(
-				ByteArrayType,
-			),
+			Identifier:     "code",
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
-		DeployedContractType,
-	),
+	ReturnTypeAnnotation: DeployedContractTypeAnnotation,
 	// additional arguments are passed to the contract initializer
 	RequiredArgumentCount: RequiredArgumentCount(2),
 }
@@ -146,21 +140,15 @@ var AuthAccountContractsTypeUpdateExperimentalFunctionType = NewSimpleFunctionTy
 	FunctionPurityImpure,
 	[]*Parameter{
 		{
-			Identifier: "name",
-			TypeAnnotation: NewTypeAnnotation(
-				StringType,
-			),
+			Identifier:     "name",
+			TypeAnnotation: StringTypeAnnotation,
 		},
 		{
-			Identifier: "code",
-			TypeAnnotation: NewTypeAnnotation(
-				ByteArrayType,
-			),
+			Identifier:     "code",
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		DeployedContractType,
-	),
+	DeployedContractTypeAnnotation,
 )
 
 const authAccountContractsTypeGetFunctionDocString = `
@@ -169,21 +157,21 @@ Returns the deployed contract for the contract/contract interface with the given
 Returns nil if no contract/contract interface with the given name exists in the account.
 `
 
+var OptionalDeployedContractTypeAnnotation = NewTypeAnnotation(
+	&OptionalType{
+		Type: DeployedContractType,
+	},
+)
+
 var AuthAccountContractsTypeGetFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
-			Identifier: "name",
-			TypeAnnotation: NewTypeAnnotation(
-				StringType,
-			),
+			Identifier:     "name",
+			TypeAnnotation: StringTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		&OptionalType{
-			Type: DeployedContractType,
-		},
-	),
+	OptionalDeployedContractTypeAnnotation,
 )
 
 const authAccountContractsTypeRemoveFunctionDocString = `
@@ -199,14 +187,10 @@ var AuthAccountContractsTypeRemoveFunctionType = NewSimpleFunctionType(
 	[]*Parameter{
 		{
 			Identifier:     "name",
-			TypeAnnotation: NewTypeAnnotation(StringType),
+			TypeAnnotation: StringTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		&OptionalType{
-			Type: DeployedContractType,
-		},
-	),
+	OptionalDeployedContractTypeAnnotation,
 )
 
 const authAccountContractsTypeGetNamesDocString = `

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -215,6 +215,8 @@ var AuthAccountType = func() *CompositeType {
 	return authAccountType
 }()
 
+var AuthAccountTypeAnnotation = NewTypeAnnotation(AuthAccountType)
+
 var AuthAccountPublicPathsType = &VariableSizedType{
 	Type: PublicPathType,
 }
@@ -303,10 +305,10 @@ var AuthAccountTypeSaveFunctionType = func() *FunctionType {
 			{
 				Label:          "to",
 				Identifier:     "path",
-				TypeAnnotation: NewTypeAnnotation(StoragePathType),
+				TypeAnnotation: StoragePathTypeAnnotation,
 			},
 		},
-		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+		ReturnTypeAnnotation: VoidTypeAnnotation,
 	}
 }()
 
@@ -335,7 +337,7 @@ var AuthAccountTypeLoadFunctionType = func() *FunctionType {
 			{
 				Label:          "from",
 				Identifier:     "path",
-				TypeAnnotation: NewTypeAnnotation(StoragePathType),
+				TypeAnnotation: StoragePathTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(
@@ -362,7 +364,7 @@ var AuthAccountTypeTypeFunctionType = NewSimpleFunctionType(
 		{
 			Label:          "at",
 			Identifier:     "path",
-			TypeAnnotation: NewTypeAnnotation(StoragePathType),
+			TypeAnnotation: StoragePathTypeAnnotation,
 		},
 	},
 	NewTypeAnnotation(
@@ -402,7 +404,7 @@ var AuthAccountTypeCopyFunctionType = func() *FunctionType {
 			{
 				Label:          "from",
 				Identifier:     "path",
-				TypeAnnotation: NewTypeAnnotation(StoragePathType),
+				TypeAnnotation: StoragePathTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(
@@ -446,7 +448,7 @@ var AuthAccountTypeBorrowFunctionType = func() *FunctionType {
 			{
 				Label:          "from",
 				Identifier:     "path",
-				TypeAnnotation: NewTypeAnnotation(StoragePathType),
+				TypeAnnotation: StoragePathTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(
@@ -492,11 +494,11 @@ var AuthAccountTypeLinkFunctionType = func() *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "newCapabilityPath",
-				TypeAnnotation: NewTypeAnnotation(CapabilityPathType),
+				TypeAnnotation: CapabilityPathTypeAnnotation,
 			},
 			{
 				Identifier:     "target",
-				TypeAnnotation: NewTypeAnnotation(PathType),
+				TypeAnnotation: PathTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(
@@ -530,10 +532,10 @@ var AuthAccountTypeUnlinkFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "capabilityPath",
-			TypeAnnotation: NewTypeAnnotation(CapabilityPathType),
+			TypeAnnotation: CapabilityPathTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(VoidType),
+	VoidTypeAnnotation,
 )
 
 const authAccountTypeUnlinkFunctionDocString = `
@@ -559,7 +561,7 @@ var AuthAccountTypeGetCapabilityFunctionType = func() *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "capabilityPath",
-				TypeAnnotation: NewTypeAnnotation(CapabilityPathType),
+				TypeAnnotation: CapabilityPathTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(
@@ -582,7 +584,7 @@ var AccountTypeGetLinkTargetFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "capabilityPath",
-			TypeAnnotation: NewTypeAnnotation(CapabilityPathType),
+			TypeAnnotation: CapabilityPathTypeAnnotation,
 		},
 	},
 	NewTypeAnnotation(
@@ -644,18 +646,18 @@ var AuthAccountKeysTypeAddFunctionType = NewSimpleFunctionType(
 	[]*Parameter{
 		{
 			Identifier:     AccountKeyPublicKeyField,
-			TypeAnnotation: NewTypeAnnotation(PublicKeyType),
+			TypeAnnotation: PublicKeyTypeAnnotation,
 		},
 		{
 			Identifier:     AccountKeyHashAlgoField,
-			TypeAnnotation: NewTypeAnnotation(HashAlgorithmType),
+			TypeAnnotation: HashAlgorithmTypeAnnotation,
 		},
 		{
 			Identifier:     AccountKeyWeightField,
-			TypeAnnotation: NewTypeAnnotation(UFix64Type),
+			TypeAnnotation: UFix64TypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(AccountKeyType),
+	AccountKeyTypeAnnotation,
 )
 
 var AccountKeysTypeGetFunctionType = NewSimpleFunctionType(
@@ -663,7 +665,7 @@ var AccountKeysTypeGetFunctionType = NewSimpleFunctionType(
 	[]*Parameter{
 		{
 			Identifier:     AccountKeyKeyIndexField,
-			TypeAnnotation: NewTypeAnnotation(IntType),
+			TypeAnnotation: IntTypeAnnotation,
 		},
 	},
 	NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
@@ -678,10 +680,10 @@ var AccountKeysTypeForEachFunctionType = func() *FunctionType {
 		functionPurity,
 		[]*Parameter{
 			{
-				TypeAnnotation: NewTypeAnnotation(AccountKeyType),
+				TypeAnnotation: AccountKeyTypeAnnotation,
 			},
 		},
-		NewTypeAnnotation(BoolType),
+		BoolTypeAnnotation,
 	)
 
 	return NewSimpleFunctionType(
@@ -693,7 +695,7 @@ var AccountKeysTypeForEachFunctionType = func() *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(iterFunctionType),
 			},
 		},
-		NewTypeAnnotation(VoidType),
+		VoidTypeAnnotation,
 	)
 }()
 
@@ -704,7 +706,7 @@ var AuthAccountKeysTypeRevokeFunctionType = NewSimpleFunctionType(
 	[]*Parameter{
 		{
 			Identifier:     AccountKeyKeyIndexField,
-			TypeAnnotation: NewTypeAnnotation(IntType),
+			TypeAnnotation: IntTypeAnnotation,
 		},
 	},
 	NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
@@ -789,14 +791,14 @@ var AuthAccountTypeInboxPublishFunctionType = NewSimpleFunctionType(
 		},
 		{
 			Identifier:     "name",
-			TypeAnnotation: NewTypeAnnotation(StringType),
+			TypeAnnotation: StringTypeAnnotation,
 		},
 		{
 			Identifier:     "recipient",
 			TypeAnnotation: NewTypeAnnotation(&AddressType{}),
 		},
 	},
-	NewTypeAnnotation(VoidType),
+	VoidTypeAnnotation,
 )
 
 const authAccountTypeInboxUnpublishFunctionDocString = `
@@ -819,7 +821,7 @@ var AuthAccountTypeInboxUnpublishFunctionType = func() *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "name",
-				TypeAnnotation: NewTypeAnnotation(StringType),
+				TypeAnnotation: StringTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(
@@ -854,7 +856,7 @@ var AuthAccountTypeInboxClaimFunctionType = func() *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "name",
-				TypeAnnotation: NewTypeAnnotation(StringType),
+				TypeAnnotation: StringTypeAnnotation,
 			},
 			{
 				Identifier:     "provider",

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -356,21 +356,21 @@ If there is an object stored, the type of the object is returned without modifyi
 The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed
 `
 
-var AuthAccountTypeTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var AuthAccountTypeTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          "at",
 			Identifier:     "path",
 			TypeAnnotation: NewTypeAnnotation(StoragePathType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		&OptionalType{
 			Type: MetaType,
 		},
 	),
-}
+)
 
 const authAccountTypeLoadFunctionDocString = `
 Loads an object from the account's storage which is stored under the given path, or nil if no object is stored under the given path.
@@ -524,17 +524,17 @@ The link function does **not** check if the target path is valid/exists at the t
 The link is latent. The target value might be stored after the link is created, and the target value might be moved out after the link has been created.
 `
 
-var AuthAccountTypeUnlinkFunctionType = &FunctionType{
-	Purity: FunctionPurityImpure,
-	Parameters: []*Parameter{
+var AuthAccountTypeUnlinkFunctionType = NewSimpleFunctionType(
+	FunctionPurityImpure,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "capabilityPath",
 			TypeAnnotation: NewTypeAnnotation(CapabilityPathType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-}
+	NewTypeAnnotation(VoidType),
+)
 
 const authAccountTypeUnlinkFunctionDocString = `
 Removes the capability at the given public or private path
@@ -576,21 +576,21 @@ const authAccountTypeGetCapabilityFunctionDocString = `
 Returns the capability at the given private or public path, or nil if it does not exist
 `
 
-var AccountTypeGetLinkTargetFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var AccountTypeGetLinkTargetFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "capabilityPath",
 			TypeAnnotation: NewTypeAnnotation(CapabilityPathType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		&OptionalType{
 			Type: PathType,
 		},
 	),
-}
+)
 
 // AuthAccountKeysType represents the keys associated with an auth account.
 var AuthAccountKeysType = func() *CompositeType {
@@ -639,9 +639,9 @@ var AuthAccountKeysType = func() *CompositeType {
 	return accountKeys
 }()
 
-var AuthAccountKeysTypeAddFunctionType = &FunctionType{
-	Purity: FunctionPurityImpure,
-	Parameters: []*Parameter{
+var AuthAccountKeysTypeAddFunctionType = NewSimpleFunctionType(
+	FunctionPurityImpure,
+	[]*Parameter{
 		{
 			Identifier:     AccountKeyPublicKeyField,
 			TypeAnnotation: NewTypeAnnotation(PublicKeyType),
@@ -655,63 +655,60 @@ var AuthAccountKeysTypeAddFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(UFix64Type),
 		},
 	},
-	ReturnTypeAnnotation:  NewTypeAnnotation(AccountKeyType),
-	RequiredArgumentCount: RequiredArgumentCount(3),
-}
+	NewTypeAnnotation(AccountKeyType),
+)
 
-var AccountKeysTypeGetFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var AccountKeysTypeGetFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier:     AccountKeyKeyIndexField,
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},
-	ReturnTypeAnnotation:  NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
-	RequiredArgumentCount: RequiredArgumentCount(1),
-}
+	NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
+)
 
 // fun keys.forEach(_ function: ((AccountKey): Bool)): Void
 var AccountKeysTypeForEachFunctionType = func() *FunctionType {
 	const functionPurity = FunctionPurityImpure
 
 	// ((AccountKey): Bool)
-	iterFunctionType := &FunctionType{
-		Purity: functionPurity,
-		Parameters: []*Parameter{
+	iterFunctionType := NewSimpleFunctionType(
+		functionPurity,
+		[]*Parameter{
 			{
 				TypeAnnotation: NewTypeAnnotation(AccountKeyType),
 			},
 		},
-		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
-	}
+		NewTypeAnnotation(BoolType),
+	)
 
-	return &FunctionType{
-		Purity: functionPurity,
-		Parameters: []*Parameter{
+	return NewSimpleFunctionType(
+		functionPurity,
+		[]*Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "function",
 				TypeAnnotation: NewTypeAnnotation(iterFunctionType),
 			},
 		},
-		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-	}
+		NewTypeAnnotation(VoidType),
+	)
 }()
 
 var AccountKeysTypeCountFieldType = UInt64Type
 
-var AuthAccountKeysTypeRevokeFunctionType = &FunctionType{
-	Purity: FunctionPurityImpure,
-	Parameters: []*Parameter{
+var AuthAccountKeysTypeRevokeFunctionType = NewSimpleFunctionType(
+	FunctionPurityImpure,
+	[]*Parameter{
 		{
 			Identifier:     AccountKeyKeyIndexField,
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},
-	ReturnTypeAnnotation:  NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
-	RequiredArgumentCount: RequiredArgumentCount(1),
-}
+	NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
+)
 
 func init() {
 	// Set the container type after initializing the AccountKeysTypes, to avoid initializing loop.
@@ -782,9 +779,9 @@ const authAccountTypeInboxPublishFunctionDocString = `
 Publishes the argument value under the given name, to be later claimed by the specified recipient
 `
 
-var AuthAccountTypeInboxPublishFunctionType = &FunctionType{
-	Purity: FunctionPurityImpure,
-	Parameters: []*Parameter{
+var AuthAccountTypeInboxPublishFunctionType = NewSimpleFunctionType(
+	FunctionPurityImpure,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "value",
@@ -799,10 +796,8 @@ var AuthAccountTypeInboxPublishFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(&AddressType{}),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
-		VoidType,
-	),
-}
+	NewTypeAnnotation(VoidType),
+)
 
 const authAccountTypeInboxUnpublishFunctionDocString = `
 Unpublishes the value specified by the argument string

--- a/runtime/sema/block.go
+++ b/runtime/sema/block.go
@@ -89,6 +89,8 @@ var BlockType = &SimpleType{
 	},
 }
 
+var BlockTypeAnnotation = NewTypeAnnotation(BlockType)
+
 const BlockIDSize = 32
 
 var blockIDFieldType = &ConstantSizedType{

--- a/runtime/sema/bool_type.go
+++ b/runtime/sema/bool_type.go
@@ -31,3 +31,5 @@ var BoolType = &SimpleType{
 	ExternallyReturnable: true,
 	Importable:           true,
 }
+
+var BoolTypeAnnotation = NewTypeAnnotation(BoolType)

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1091,12 +1091,12 @@ func (checker *Checker) checkCompositeConformance(
 		initializerType := NewSimpleFunctionType(
 			compositeType.ConstructorPurity,
 			compositeType.ConstructorParameters,
-			NewTypeAnnotation(VoidType),
+			VoidTypeAnnotation,
 		)
 		interfaceInitializerType := NewSimpleFunctionType(
 			interfaceType.InitializerPurity,
 			interfaceType.InitializerParameters,
-			NewTypeAnnotation(VoidType),
+			VoidTypeAnnotation,
 		)
 
 		// TODO: subtype?
@@ -1485,7 +1485,7 @@ func CompositeConstructorType(
 			&FunctionType{
 				IsConstructor:        true,
 				Parameters:           constructorFunctionType.Parameters,
-				ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+				ReturnTypeAnnotation: VoidTypeAnnotation,
 			}
 	}
 
@@ -1899,7 +1899,7 @@ func (checker *Checker) checkSpecialFunction(
 	functionType := NewSimpleFunctionType(
 		purity,
 		parameters,
-		NewTypeAnnotation(VoidType),
+		VoidTypeAnnotation,
 	)
 
 	checker.checkFunction(

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1088,16 +1088,16 @@ func (checker *Checker) checkCompositeConformance(
 
 	if interfaceType.InitializerParameters != nil {
 
-		initializerType := &FunctionType{
-			Purity:               compositeType.ConstructorPurity,
-			Parameters:           compositeType.ConstructorParameters,
-			ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-		}
-		interfaceInitializerType := &FunctionType{
-			Purity:               interfaceType.InitializerPurity,
-			Parameters:           interfaceType.InitializerParameters,
-			ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-		}
+		initializerType := NewSimpleFunctionType(
+			compositeType.ConstructorPurity,
+			compositeType.ConstructorParameters,
+			NewTypeAnnotation(VoidType),
+		)
+		interfaceInitializerType := NewSimpleFunctionType(
+			interfaceType.InitializerPurity,
+			interfaceType.InitializerParameters,
+			NewTypeAnnotation(VoidType),
+		)
 
 		// TODO: subtype?
 		if !initializerType.Equal(interfaceInitializerType) {
@@ -1896,11 +1896,11 @@ func (checker *Checker) checkSpecialFunction(
 
 	checker.declareSelfValue(containerType, containerDocString)
 
-	functionType := &FunctionType{
-		Purity:               purity,
-		Parameters:           parameters,
-		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-	}
+	functionType := NewSimpleFunctionType(
+		purity,
+		parameters,
+		NewTypeAnnotation(VoidType),
+	)
 
 	checker.checkFunction(
 		specialFunction.FunctionDeclaration.ParameterList,

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -129,9 +129,11 @@ var _ ast.DeclarationVisitor[struct{}] = &Checker{}
 var _ ast.StatementVisitor[struct{}] = &Checker{}
 var _ ast.ExpressionVisitor[Type] = &Checker{}
 
-var baseFunctionType = &FunctionType{
-	ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-}
+var baseFunctionType = NewSimpleFunctionType(
+	FunctionPurityImpure,
+	nil,
+	NewTypeAnnotation(VoidType),
+)
 
 func NewChecker(
 	program *ast.Program,
@@ -1112,11 +1114,11 @@ func (checker *Checker) convertFunctionType(t *ast.FunctionType) Type {
 
 	purity := PurityFromAnnotation(t.PurityAnnotation)
 
-	return &FunctionType{
-		Purity:               purity,
-		Parameters:           parameters,
-		ReturnTypeAnnotation: returnTypeAnnotation,
-	}
+	return NewSimpleFunctionType(
+		purity,
+		parameters,
+		returnTypeAnnotation,
+	)
 }
 
 func (checker *Checker) convertConstantSizedType(t *ast.ConstantSizedType) Type {

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -132,7 +132,7 @@ var _ ast.ExpressionVisitor[Type] = &Checker{}
 var baseFunctionType = NewSimpleFunctionType(
 	FunctionPurityImpure,
 	nil,
-	NewTypeAnnotation(VoidType),
+	VoidTypeAnnotation,
 )
 
 func NewChecker(

--- a/runtime/sema/checker_test.go
+++ b/runtime/sema/checker_test.go
@@ -170,22 +170,18 @@ func TestFunctionSubtyping(t *testing.T) {
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(IntType),
+							TypeAnnotation: IntTypeAnnotation,
 						},
 					},
-					ReturnTypeAnnotation: NewTypeAnnotation(
-						VoidType,
-					),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(AnyStructType),
+							TypeAnnotation: AnyStructTypeAnnotation,
 						},
 					},
-					ReturnTypeAnnotation: NewTypeAnnotation(
-						VoidType,
-					),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 			),
 		)
@@ -197,22 +193,18 @@ func TestFunctionSubtyping(t *testing.T) {
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(AnyStructType),
+							TypeAnnotation: AnyStructTypeAnnotation,
 						},
 					},
-					ReturnTypeAnnotation: NewTypeAnnotation(
-						VoidType,
-					),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 				&FunctionType{
 					Parameters: []*Parameter{
 						{
-							TypeAnnotation: NewTypeAnnotation(IntType),
+							TypeAnnotation: IntTypeAnnotation,
 						},
 					},
-					ReturnTypeAnnotation: NewTypeAnnotation(
-						VoidType,
-					),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 			),
 		)
@@ -222,10 +214,10 @@ func TestFunctionSubtyping(t *testing.T) {
 		assert.True(t,
 			IsSubType(
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(IntType),
+					ReturnTypeAnnotation: IntTypeAnnotation,
 				},
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(AnyStructType),
+					ReturnTypeAnnotation: AnyStructTypeAnnotation,
 				},
 			),
 		)
@@ -235,10 +227,10 @@ func TestFunctionSubtyping(t *testing.T) {
 		assert.False(t,
 			IsSubType(
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(AnyStructType),
+					ReturnTypeAnnotation: AnyStructTypeAnnotation,
 				},
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(IntType),
+					ReturnTypeAnnotation: IntTypeAnnotation,
 				},
 			),
 		)
@@ -249,11 +241,11 @@ func TestFunctionSubtyping(t *testing.T) {
 			IsSubType(
 				&FunctionType{
 					IsConstructor:        false,
-					ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 				&FunctionType{
 					IsConstructor:        true,
-					ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 			),
 		)
@@ -264,10 +256,10 @@ func TestFunctionSubtyping(t *testing.T) {
 		assert.True(t,
 			IsSubType(
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 				&FunctionType{
-					ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+					ReturnTypeAnnotation: VoidTypeAnnotation,
 				},
 			),
 		)

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -106,19 +106,19 @@ func (algo SignatureAlgorithm) DocString() string {
 
 const HashAlgorithmTypeHashFunctionName = "hash"
 
-var HashAlgorithmTypeHashFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var HashAlgorithmTypeHashFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "data",
 			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		ByteArrayType,
 	),
-}
+)
 
 const HashAlgorithmTypeHashFunctionDocString = `
 Returns the hash of the given data
@@ -126,9 +126,9 @@ Returns the hash of the given data
 
 const HashAlgorithmTypeHashWithTagFunctionName = "hashWithTag"
 
-var HashAlgorithmTypeHashWithTagFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var HashAlgorithmTypeHashWithTagFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:      ArgumentLabelNotRequired,
 			Identifier: "data",
@@ -141,10 +141,10 @@ var HashAlgorithmTypeHashWithTagFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		ByteArrayType,
 	),
-}
+)
 
 const HashAlgorithmTypeHashWithTagFunctionDocString = `
 Returns the hash of the given data and tag

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -32,6 +32,8 @@ var SignatureAlgorithmType = newNativeEnumType(
 	nil,
 )
 
+var SignatureAlgorithmTypeAnnotation = NewTypeAnnotation(SignatureAlgorithmType)
+
 type SignatureAlgorithm uint8
 
 // NOTE: only add new algorithms, do *NOT* change existing items,
@@ -112,12 +114,10 @@ var HashAlgorithmTypeHashFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "data",
-			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		ByteArrayType,
-	),
+	ByteArrayTypeAnnotation,
 )
 
 const HashAlgorithmTypeHashFunctionDocString = `
@@ -130,20 +130,16 @@ var HashAlgorithmTypeHashWithTagFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
-			Label:      ArgumentLabelNotRequired,
-			Identifier: "data",
-			TypeAnnotation: NewTypeAnnotation(
-				ByteArrayType,
-			),
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "data",
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 		{
 			Identifier:     "tag",
-			TypeAnnotation: NewTypeAnnotation(StringType),
+			TypeAnnotation: StringTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		ByteArrayType,
-	),
+	ByteArrayTypeAnnotation,
 )
 
 const HashAlgorithmTypeHashWithTagFunctionDocString = `
@@ -170,6 +166,8 @@ var HashAlgorithmType = newNativeEnumType(
 		}
 	},
 )
+
+var HashAlgorithmTypeAnnotation = NewTypeAnnotation(HashAlgorithmType)
 
 type HashAlgorithm uint8
 

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -77,6 +77,8 @@ var DeployedContractType = &SimpleType{
 	},
 }
 
+var DeployedContractTypeAnnotation = NewTypeAnnotation(DeployedContractType)
+
 const DeployedContractTypeAddressFieldName = "address"
 
 const deployedContractTypeAddressFieldDocString = `

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -47,16 +47,18 @@ var MetaType = &SimpleType{
 	Importable:           true,
 }
 
+var MetaTypeAnnotation = NewTypeAnnotation(MetaType)
+
 var MetaTypeIsSubtypeFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
 			Label:          "of",
 			Identifier:     "otherType",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(BoolType),
+	BoolTypeAnnotation,
 )
 
 func init() {

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -47,19 +47,17 @@ var MetaType = &SimpleType{
 	Importable:           true,
 }
 
-var MetaTypeIsSubtypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var MetaTypeIsSubtypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          "of",
 			Identifier:     "otherType",
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
-		BoolType,
-	),
-}
+	NewTypeAnnotation(BoolType),
+)
 
 func init() {
 	MetaType.Members = func(t *SimpleType) map[string]MemberResolver {

--- a/runtime/sema/never_type.go
+++ b/runtime/sema/never_type.go
@@ -31,3 +31,5 @@ var NeverType = &SimpleType{
 	ExternallyReturnable: false,
 	Importable:           false,
 }
+
+var NeverTypeAnnotation = NewTypeAnnotation(NeverType)

--- a/runtime/sema/path_type.go
+++ b/runtime/sema/path_type.go
@@ -36,6 +36,8 @@ var PathType = &SimpleType{
 	},
 }
 
+var PathTypeAnnotation = NewTypeAnnotation(PathType)
+
 // StoragePathType
 var StoragePathType = &SimpleType{
 	Name:                 "StoragePath",
@@ -48,6 +50,8 @@ var StoragePathType = &SimpleType{
 	ExternallyReturnable: true,
 	Importable:           true,
 }
+
+var StoragePathTypeAnnotation = NewTypeAnnotation(StoragePathType)
 
 // CapabilityPathType
 var CapabilityPathType = &SimpleType{
@@ -66,6 +70,8 @@ var CapabilityPathType = &SimpleType{
 	},
 }
 
+var CapabilityPathTypeAnnotation = NewTypeAnnotation(CapabilityPathType)
+
 // PublicPathType
 var PublicPathType = &SimpleType{
 	Name:                 "PublicPath",
@@ -79,6 +85,8 @@ var PublicPathType = &SimpleType{
 	Importable:           true,
 }
 
+var PublicPathTypeAnnotation = NewTypeAnnotation(PublicPathType)
+
 // PrivatePathType
 var PrivatePathType = &SimpleType{
 	Name:                 "PrivatePath",
@@ -91,3 +99,5 @@ var PrivatePathType = &SimpleType{
 	ExternallyReturnable: true,
 	Importable:           true,
 }
+
+var PrivatePathTypeAnnotation = NewTypeAnnotation(PrivatePathType)

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -68,9 +68,9 @@ Returns the deployed contract for the contract/contract interface with the given
 Returns nil if no contract/contract interface with the given name exists in the account.
 `
 
-var publicAccountContractsTypeGetFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var publicAccountContractsTypeGetFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier: "name",
 			TypeAnnotation: NewTypeAnnotation(
@@ -78,12 +78,12 @@ var publicAccountContractsTypeGetFunctionType = &FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		&OptionalType{
 			Type: DeployedContractType,
 		},
 	),
-}
+)
 
 const publicAccountContractsTypeNamesDocString = `
 Names of all contracts deployed in the account.

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -72,17 +72,11 @@ var publicAccountContractsTypeGetFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
-			Identifier: "name",
-			TypeAnnotation: NewTypeAnnotation(
-				StringType,
-			),
+			Identifier:     "name",
+			TypeAnnotation: StringTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		&OptionalType{
-			Type: DeployedContractType,
-		},
-	),
+	OptionalDeployedContractTypeAnnotation,
 )
 
 const publicAccountContractsTypeNamesDocString = `

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -125,6 +125,8 @@ var PublicAccountType = func() *CompositeType {
 	return publicAccountType
 }()
 
+var PublicAccountTypeAnnotation = NewTypeAnnotation(PublicAccountType)
+
 var PublicAccountPathsType = &VariableSizedType{
 	Type: PublicPathType,
 }
@@ -147,10 +149,10 @@ func AccountForEachFunctionType(pathType Type) *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "type",
-				TypeAnnotation: NewTypeAnnotation(MetaType),
+				TypeAnnotation: MetaTypeAnnotation,
 			},
 		},
-		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
+		ReturnTypeAnnotation: BoolTypeAnnotation,
 	}
 	return &FunctionType{
 		Purity: functionPurity,
@@ -161,7 +163,7 @@ func AccountForEachFunctionType(pathType Type) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(iterFunctionType),
 			},
 		},
-		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+		ReturnTypeAnnotation: VoidTypeAnnotation,
 	}
 }
 
@@ -235,7 +237,7 @@ var PublicAccountTypeGetCapabilityFunctionType = func() *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "capabilityPath",
-				TypeAnnotation: NewTypeAnnotation(PublicPathType),
+				TypeAnnotation: PublicPathTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(

--- a/runtime/sema/runtime_type_constructors.go
+++ b/runtime/sema/runtime_type_constructors.go
@@ -27,7 +27,7 @@ type RuntimeTypeConstructor struct {
 var MetaTypeFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	nil,
-	NewTypeAnnotation(MetaType),
+	MetaTypeAnnotation,
 )
 
 var OptionalTypeFunctionType = NewSimpleFunctionType(
@@ -36,10 +36,10 @@ var OptionalTypeFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "type",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(MetaType),
+	MetaTypeAnnotation,
 )
 
 var VariableSizedArrayTypeFunctionType = NewSimpleFunctionType(
@@ -48,10 +48,10 @@ var VariableSizedArrayTypeFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "type",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(MetaType),
+	MetaTypeAnnotation,
 )
 
 var ConstantSizedArrayTypeFunctionType = NewSimpleFunctionType(
@@ -59,29 +59,31 @@ var ConstantSizedArrayTypeFunctionType = NewSimpleFunctionType(
 	[]*Parameter{
 		{
 			Identifier:     "type",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 		{
 			Identifier:     "size",
-			TypeAnnotation: NewTypeAnnotation(IntType),
+			TypeAnnotation: IntTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(MetaType),
+	MetaTypeAnnotation,
 )
+
+var OptionalMetaTypeAnnotation = NewTypeAnnotation(&OptionalType{MetaType})
 
 var DictionaryTypeFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
 			Identifier:     "key",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 		{
 			Identifier:     "value",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(&OptionalType{MetaType}),
+	OptionalMetaTypeAnnotation,
 )
 
 var CompositeTypeFunctionType = NewSimpleFunctionType(
@@ -90,10 +92,10 @@ var CompositeTypeFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "identifier",
-			TypeAnnotation: NewTypeAnnotation(StringType),
+			TypeAnnotation: StringTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(&OptionalType{MetaType}),
+	OptionalMetaTypeAnnotation,
 )
 
 var InterfaceTypeFunctionType = NewSimpleFunctionType(
@@ -102,10 +104,10 @@ var InterfaceTypeFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "identifier",
-			TypeAnnotation: NewTypeAnnotation(StringType),
+			TypeAnnotation: StringTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(&OptionalType{MetaType}),
+	OptionalMetaTypeAnnotation,
 )
 
 var FunctionTypeFunctionType = NewSimpleFunctionType(
@@ -117,10 +119,10 @@ var FunctionTypeFunctionType = NewSimpleFunctionType(
 		},
 		{
 			Identifier:     "return",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(MetaType),
+	MetaTypeAnnotation,
 )
 
 var RestrictedTypeFunctionType = NewSimpleFunctionType(
@@ -135,7 +137,7 @@ var RestrictedTypeFunctionType = NewSimpleFunctionType(
 			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{Type: StringType}),
 		},
 	},
-	NewTypeAnnotation(&OptionalType{MetaType}),
+	OptionalMetaTypeAnnotation,
 )
 
 var ReferenceTypeFunctionType = NewSimpleFunctionType(
@@ -143,14 +145,14 @@ var ReferenceTypeFunctionType = NewSimpleFunctionType(
 	[]*Parameter{
 		{
 			Identifier:     "authorized",
-			TypeAnnotation: NewTypeAnnotation(BoolType),
+			TypeAnnotation: BoolTypeAnnotation,
 		},
 		{
 			Identifier:     "type",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(MetaType),
+	MetaTypeAnnotation,
 )
 
 var CapabilityTypeFunctionType = NewSimpleFunctionType(
@@ -159,10 +161,10 @@ var CapabilityTypeFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "type",
-			TypeAnnotation: NewTypeAnnotation(MetaType),
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(&OptionalType{MetaType}),
+	OptionalMetaTypeAnnotation,
 )
 
 var runtimeTypeConstructors = []*RuntimeTypeConstructor{

--- a/runtime/sema/runtime_type_constructors.go
+++ b/runtime/sema/runtime_type_constructors.go
@@ -24,38 +24,39 @@ type RuntimeTypeConstructor struct {
 	DocString string
 }
 
-var MetaTypeFunctionType = &FunctionType{
-	Purity:               FunctionPurityView,
-	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
-}
+var MetaTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	nil,
+	NewTypeAnnotation(MetaType),
+)
 
-var OptionalTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var OptionalTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "type",
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
-}
+	NewTypeAnnotation(MetaType),
+)
 
-var VariableSizedArrayTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var VariableSizedArrayTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "type",
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
-}
+	NewTypeAnnotation(MetaType),
+)
 
-var ConstantSizedArrayTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var ConstantSizedArrayTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier:     "type",
 			TypeAnnotation: NewTypeAnnotation(MetaType),
@@ -65,12 +66,12 @@ var ConstantSizedArrayTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
-}
+	NewTypeAnnotation(MetaType),
+)
 
-var DictionaryTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var DictionaryTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier:     "key",
 			TypeAnnotation: NewTypeAnnotation(MetaType),
@@ -80,36 +81,36 @@ var DictionaryTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
-}
+	NewTypeAnnotation(&OptionalType{MetaType}),
+)
 
-var CompositeTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var CompositeTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "identifier",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
-}
+	NewTypeAnnotation(&OptionalType{MetaType}),
+)
 
-var InterfaceTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var InterfaceTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "identifier",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
-}
+	NewTypeAnnotation(&OptionalType{MetaType}),
+)
 
-var FunctionTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var FunctionTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier:     "parameters",
 			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{Type: MetaType}),
@@ -119,12 +120,12 @@ var FunctionTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
-}
+	NewTypeAnnotation(MetaType),
+)
 
-var RestrictedTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var RestrictedTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier:     "identifier",
 			TypeAnnotation: NewTypeAnnotation(&OptionalType{StringType}),
@@ -134,12 +135,12 @@ var RestrictedTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{Type: StringType}),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
-}
+	NewTypeAnnotation(&OptionalType{MetaType}),
+)
 
-var ReferenceTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var ReferenceTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier:     "authorized",
 			TypeAnnotation: NewTypeAnnotation(BoolType),
@@ -149,20 +150,20 @@ var ReferenceTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
-}
+	NewTypeAnnotation(MetaType),
+)
 
-var CapabilityTypeFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var CapabilityTypeFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "type",
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
-}
+	NewTypeAnnotation(&OptionalType{MetaType}),
+)
 
 var runtimeTypeConstructors = []*RuntimeTypeConstructor{
 	{

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -61,6 +61,8 @@ var StringType = &SimpleType{
 	},
 }
 
+var StringTypeAnnotation = NewTypeAnnotation(StringType)
+
 func init() {
 	StringType.Members = func(t *SimpleType) map[string]MemberResolver {
 		return map[string]MemberResolver{
@@ -146,12 +148,10 @@ var StringTypeConcatFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "other",
-			TypeAnnotation: NewTypeAnnotation(StringType),
+			TypeAnnotation: StringTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		StringType,
-	),
+	StringTypeAnnotation,
 )
 
 const stringTypeConcatFunctionDocString = `
@@ -163,16 +163,14 @@ var StringTypeSliceFunctionType = NewSimpleFunctionType(
 	[]*Parameter{
 		{
 			Identifier:     "from",
-			TypeAnnotation: NewTypeAnnotation(IntType),
+			TypeAnnotation: IntTypeAnnotation,
 		},
 		{
 			Identifier:     "upTo",
-			TypeAnnotation: NewTypeAnnotation(IntType),
+			TypeAnnotation: IntTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(
-		StringType,
-	),
+	StringTypeAnnotation,
 )
 
 const stringTypeSliceFunctionDocString = `
@@ -188,15 +186,19 @@ var ByteArrayType = &VariableSizedType{
 	Type: UInt8Type,
 }
 
+var ByteArrayTypeAnnotation = NewTypeAnnotation(ByteArrayType)
+
 // ByteArrayArrayType represents the type [[UInt8]]
 var ByteArrayArrayType = &VariableSizedType{
 	Type: ByteArrayType,
 }
 
+var ByteArrayArrayTypeAnnotation = NewTypeAnnotation(ByteArrayArrayType)
+
 var StringTypeDecodeHexFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	nil,
-	NewTypeAnnotation(ByteArrayType),
+	ByteArrayTypeAnnotation,
 )
 
 const stringTypeDecodeHexFunctionDocString = `
@@ -217,7 +219,7 @@ The byte array of the UTF-8 encoding
 var StringTypeToLowerFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	nil,
-	NewTypeAnnotation(StringType),
+	StringTypeAnnotation,
 )
 
 const stringTypeToLowerFunctionDocString = `
@@ -241,7 +243,7 @@ var StringFunctionType = func() *FunctionType {
 	functionType := NewSimpleFunctionType(
 		FunctionPurityView,
 		nil,
-		NewTypeAnnotation(StringType),
+		StringTypeAnnotation,
 	)
 
 	addMember := func(member *Member) {
@@ -292,14 +294,12 @@ var StringTypeEncodeHexFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
-			Label:      ArgumentLabelNotRequired,
-			Identifier: "data",
-			TypeAnnotation: NewTypeAnnotation(
-				ByteArrayType,
-			),
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "data",
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(StringType),
+	StringTypeAnnotation,
 )
 
 var StringTypeFromUtf8FunctionType = NewSimpleFunctionType(
@@ -308,7 +308,7 @@ var StringTypeFromUtf8FunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "bytes",
-			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 	},
 	NewTypeAnnotation(
@@ -329,5 +329,5 @@ var StringTypeFromCharactersFunctionType = NewSimpleFunctionType(
 			}),
 		},
 	},
-	NewTypeAnnotation(StringType),
+	StringTypeAnnotation,
 )

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -140,27 +140,27 @@ func init() {
 	}
 }
 
-var StringTypeConcatFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var StringTypeConcatFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "other",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		StringType,
 	),
-}
+)
 
 const stringTypeConcatFunctionDocString = `
 Returns a new string which contains the given string concatenated to the end of the original string, but does not modify the original string
 `
 
-var StringTypeSliceFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var StringTypeSliceFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Identifier:     "from",
 			TypeAnnotation: NewTypeAnnotation(IntType),
@@ -170,10 +170,10 @@ var StringTypeSliceFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		StringType,
 	),
-}
+)
 
 const stringTypeSliceFunctionDocString = `
 Returns a new string containing the slice of the characters in the given string from start index ` + "`from`" + ` up to, but not including, the end index ` + "`upTo`" + `.
@@ -193,10 +193,11 @@ var ByteArrayArrayType = &VariableSizedType{
 	Type: ByteArrayType,
 }
 
-var StringTypeDecodeHexFunctionType = &FunctionType{
-	Purity:               FunctionPurityView,
-	ReturnTypeAnnotation: NewTypeAnnotation(ByteArrayType),
-}
+var StringTypeDecodeHexFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	nil,
+	NewTypeAnnotation(ByteArrayType),
+)
 
 const stringTypeDecodeHexFunctionDocString = `
 Returns an array containing the bytes represented by the given hexadecimal string.
@@ -213,10 +214,11 @@ const stringTypeUtf8FieldDocString = `
 The byte array of the UTF-8 encoding
 `
 
-var StringTypeToLowerFunctionType = &FunctionType{
-	Purity:               FunctionPurityView,
-	ReturnTypeAnnotation: NewTypeAnnotation(StringType),
-}
+var StringTypeToLowerFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	nil,
+	NewTypeAnnotation(StringType),
+)
 
 const stringTypeToLowerFunctionDocString = `
 Returns the string with upper case letters replaced with lowercase
@@ -236,10 +238,11 @@ var StringFunctionType = func() *FunctionType {
 		panic(errors.NewUnreachableError())
 	}
 
-	functionType := &FunctionType{
-		Purity:               FunctionPurityView,
-		ReturnTypeAnnotation: NewTypeAnnotation(StringType),
-	}
+	functionType := NewSimpleFunctionType(
+		FunctionPurityView,
+		nil,
+		NewTypeAnnotation(StringType),
+	)
 
 	addMember := func(member *Member) {
 		if functionType.Members == nil {
@@ -285,9 +288,9 @@ var StringFunctionType = func() *FunctionType {
 	return functionType
 }()
 
-var StringTypeEncodeHexFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var StringTypeEncodeHexFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:      ArgumentLabelNotRequired,
 			Identifier: "data",
@@ -296,30 +299,28 @@ var StringTypeEncodeHexFunctionType = &FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
-		StringType,
-	),
-}
+	NewTypeAnnotation(StringType),
+)
 
-var StringTypeFromUtf8FunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var StringTypeFromUtf8FunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "bytes",
 			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
+	NewTypeAnnotation(
 		&OptionalType{
 			Type: StringType,
 		},
 	),
-}
+)
 
-var StringTypeFromCharactersFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
-	Parameters: []*Parameter{
+var StringTypeFromCharactersFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]*Parameter{
 		{
 			Label:      ArgumentLabelNotRequired,
 			Identifier: "characters",
@@ -328,7 +329,5 @@ var StringTypeFromCharactersFunctionType = &FunctionType{
 			}),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(
-		StringType,
-	),
-}
+	NewTypeAnnotation(StringType),
+)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -318,14 +318,12 @@ var IsInstanceFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
-			Label:      ArgumentLabelNotRequired,
-			Identifier: "type",
-			TypeAnnotation: NewTypeAnnotation(
-				MetaType,
-			),
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "type",
+			TypeAnnotation: MetaTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(BoolType),
+	BoolTypeAnnotation,
 )
 
 const isInstanceFunctionDocString = `
@@ -339,7 +337,7 @@ const GetTypeFunctionName = "getType"
 var GetTypeFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	nil,
-	NewTypeAnnotation(MetaType),
+	MetaTypeAnnotation,
 )
 
 const getTypeFunctionDocString = `
@@ -353,7 +351,7 @@ const ToStringFunctionName = "toString"
 var ToStringFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	nil,
-	NewTypeAnnotation(StringType),
+	StringTypeAnnotation,
 )
 
 const toStringFunctionDocString = `
@@ -393,7 +391,7 @@ func FromStringFunctionType(ty Type) *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "input",
-				TypeAnnotation: NewTypeAnnotation(StringType),
+				TypeAnnotation: StringTypeAnnotation,
 			},
 		},
 		NewTypeAnnotation(
@@ -409,7 +407,7 @@ const ToBigEndianBytesFunctionName = "toBigEndianBytes"
 var ToBigEndianBytesFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	nil,
-	NewTypeAnnotation(ByteArrayType),
+	ByteArrayTypeAnnotation,
 )
 
 const toBigEndianBytesFunctionDocString = `
@@ -1290,24 +1288,34 @@ var (
 			WithTag(NumberTypeTag).
 			AsSuperType()
 
+	NumberTypeAnnotation = NewTypeAnnotation(NumberType)
+
 	// SignedNumberType represents the super-type of all signed number types
 	SignedNumberType = NewNumericType(SignedNumberTypeName).
 				WithTag(SignedNumberTypeTag).
 				AsSuperType()
+
+	SignedNumberTypeAnnotation = NewTypeAnnotation(SignedNumberType)
 
 	// IntegerType represents the super-type of all integer types
 	IntegerType = NewNumericType(IntegerTypeName).
 			WithTag(IntegerTypeTag).
 			AsSuperType()
 
+	IntegerTypeAnnotation = NewTypeAnnotation(IntegerType)
+
 	// SignedIntegerType represents the super-type of all signed integer types
 	SignedIntegerType = NewNumericType(SignedIntegerTypeName).
 				WithTag(SignedIntegerTypeTag).
 				AsSuperType()
 
+	SignedIntegerTypeAnnotation = NewTypeAnnotation(SignedIntegerType)
+
 	// IntType represents the arbitrary-precision integer type `Int`
 	IntType = NewNumericType(IntTypeName).
 		WithTag(IntTypeTag)
+
+	IntTypeAnnotation = NewTypeAnnotation(IntType)
 
 	// Int8Type represents the 8-bit signed integer type `Int8`
 	Int8Type = NewNumericType(Int8TypeName).
@@ -1318,6 +1326,8 @@ var (
 			WithSaturatingMultiply().
 			WithSaturatingDivide()
 
+	Int8TypeAnnotation = NewTypeAnnotation(Int8Type)
+
 	// Int16Type represents the 16-bit signed integer type `Int16`
 	Int16Type = NewNumericType(Int16TypeName).
 			WithTag(Int16TypeTag).
@@ -1326,6 +1336,8 @@ var (
 			WithSaturatingSubtract().
 			WithSaturatingMultiply().
 			WithSaturatingDivide()
+
+	Int16TypeAnnotation = NewTypeAnnotation(Int16Type)
 
 	// Int32Type represents the 32-bit signed integer type `Int32`
 	Int32Type = NewNumericType(Int32TypeName).
@@ -1336,6 +1348,8 @@ var (
 			WithSaturatingMultiply().
 			WithSaturatingDivide()
 
+	Int32TypeAnnotation = NewTypeAnnotation(Int32Type)
+
 	// Int64Type represents the 64-bit signed integer type `Int64`
 	Int64Type = NewNumericType(Int64TypeName).
 			WithTag(Int64TypeTag).
@@ -1344,6 +1358,8 @@ var (
 			WithSaturatingSubtract().
 			WithSaturatingMultiply().
 			WithSaturatingDivide()
+
+	Int64TypeAnnotation = NewTypeAnnotation(Int64Type)
 
 	// Int128Type represents the 128-bit signed integer type `Int128`
 	Int128Type = NewNumericType(Int128TypeName).
@@ -1354,6 +1370,8 @@ var (
 			WithSaturatingMultiply().
 			WithSaturatingDivide()
 
+	Int128TypeAnnotation = NewTypeAnnotation(Int128Type)
+
 	// Int256Type represents the 256-bit signed integer type `Int256`
 	Int256Type = NewNumericType(Int256TypeName).
 			WithTag(Int256TypeTag).
@@ -1363,11 +1381,15 @@ var (
 			WithSaturatingMultiply().
 			WithSaturatingDivide()
 
+	Int256TypeAnnotation = NewTypeAnnotation(Int256Type)
+
 	// UIntType represents the arbitrary-precision unsigned integer type `UInt`
 	UIntType = NewNumericType(UIntTypeName).
 			WithTag(UIntTypeTag).
 			WithIntRange(UIntTypeMin, nil).
 			WithSaturatingSubtract()
+
+	UIntTypeAnnotation = NewTypeAnnotation(UIntType)
 
 	// UInt8Type represents the 8-bit unsigned integer type `UInt8`
 	// which checks for overflow and underflow
@@ -1378,6 +1400,8 @@ var (
 			WithSaturatingSubtract().
 			WithSaturatingMultiply()
 
+	UInt8TypeAnnotation = NewTypeAnnotation(UInt8Type)
+
 	// UInt16Type represents the 16-bit unsigned integer type `UInt16`
 	// which checks for overflow and underflow
 	UInt16Type = NewNumericType(UInt16TypeName).
@@ -1386,6 +1410,8 @@ var (
 			WithSaturatingAdd().
 			WithSaturatingSubtract().
 			WithSaturatingMultiply()
+
+	UInt16TypeAnnotation = NewTypeAnnotation(UInt16Type)
 
 	// UInt32Type represents the 32-bit unsigned integer type `UInt32`
 	// which checks for overflow and underflow
@@ -1396,6 +1422,8 @@ var (
 			WithSaturatingSubtract().
 			WithSaturatingMultiply()
 
+	UInt32TypeAnnotation = NewTypeAnnotation(UInt32Type)
+
 	// UInt64Type represents the 64-bit unsigned integer type `UInt64`
 	// which checks for overflow and underflow
 	UInt64Type = NewNumericType(UInt64TypeName).
@@ -1404,6 +1432,8 @@ var (
 			WithSaturatingAdd().
 			WithSaturatingSubtract().
 			WithSaturatingMultiply()
+
+	UInt64TypeAnnotation = NewTypeAnnotation(UInt64Type)
 
 	// UInt128Type represents the 128-bit unsigned integer type `UInt128`
 	// which checks for overflow and underflow
@@ -1414,6 +1444,8 @@ var (
 			WithSaturatingSubtract().
 			WithSaturatingMultiply()
 
+	UInt128TypeAnnotation = NewTypeAnnotation(UInt128Type)
+
 	// UInt256Type represents the 256-bit unsigned integer type `UInt256`
 	// which checks for overflow and underflow
 	UInt256Type = NewNumericType(UInt256TypeName).
@@ -1423,11 +1455,15 @@ var (
 			WithSaturatingSubtract().
 			WithSaturatingMultiply()
 
+	UInt256TypeAnnotation = NewTypeAnnotation(UInt256Type)
+
 	// Word8Type represents the 8-bit unsigned integer type `Word8`
 	// which does NOT check for overflow and underflow
 	Word8Type = NewNumericType(Word8TypeName).
 			WithTag(Word8TypeTag).
 			WithIntRange(Word8TypeMinInt, Word8TypeMaxInt)
+
+	Word8TypeAnnotation = NewTypeAnnotation(Word8Type)
 
 	// Word16Type represents the 16-bit unsigned integer type `Word16`
 	// which does NOT check for overflow and underflow
@@ -1435,11 +1471,15 @@ var (
 			WithTag(Word16TypeTag).
 			WithIntRange(Word16TypeMinInt, Word16TypeMaxInt)
 
+	Word16TypeAnnotation = NewTypeAnnotation(Word16Type)
+
 	// Word32Type represents the 32-bit unsigned integer type `Word32`
 	// which does NOT check for overflow and underflow
 	Word32Type = NewNumericType(Word32TypeName).
 			WithTag(Word32TypeTag).
 			WithIntRange(Word32TypeMinInt, Word32TypeMaxInt)
+
+	Word32TypeAnnotation = NewTypeAnnotation(Word32Type)
 
 	// Word64Type represents the 64-bit unsigned integer type `Word64`
 	// which does NOT check for overflow and underflow
@@ -1447,15 +1487,21 @@ var (
 			WithTag(Word64TypeTag).
 			WithIntRange(Word64TypeMinInt, Word64TypeMaxInt)
 
+	Word64TypeAnnotation = NewTypeAnnotation(Word64Type)
+
 	// FixedPointType represents the super-type of all fixed-point types
 	FixedPointType = NewNumericType(FixedPointTypeName).
 			WithTag(FixedPointTypeTag).
 			AsSuperType()
 
+	FixedPointTypeAnnotation = NewTypeAnnotation(FixedPointType)
+
 	// SignedFixedPointType represents the super-type of all signed fixed-point types
 	SignedFixedPointType = NewNumericType(SignedFixedPointTypeName).
 				WithTag(SignedFixedPointTypeTag).
 				AsSuperType()
+
+	SignedFixedPointTypeAnnotation = NewTypeAnnotation(SignedFixedPointType)
 
 	// Fix64Type represents the 64-bit signed decimal fixed-point type `Fix64`
 	// which has a scale of Fix64Scale, and checks for overflow and underflow
@@ -1469,6 +1515,8 @@ var (
 			WithSaturatingMultiply().
 			WithSaturatingDivide()
 
+	Fix64TypeAnnotation = NewTypeAnnotation(Fix64Type)
+
 	// UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
 	// which has a scale of 1E9, and checks for overflow and underflow
 	UFix64Type = NewFixedPointNumericType(UFix64TypeName).
@@ -1479,6 +1527,8 @@ var (
 			WithSaturatingAdd().
 			WithSaturatingSubtract().
 			WithSaturatingMultiply()
+
+	UFix64TypeAnnotation = NewTypeAnnotation(UFix64Type)
 )
 
 // Numeric type ranges
@@ -1978,7 +2028,7 @@ func ArrayRemoveFunctionType(elementType Type) *FunctionType {
 		[]*Parameter{
 			{
 				Identifier:     "at",
-				TypeAnnotation: NewTypeAnnotation(IntegerType),
+				TypeAnnotation: IntegerTypeAnnotation,
 			},
 		},
 		NewTypeAnnotation(elementType),
@@ -1991,7 +2041,7 @@ func ArrayInsertFunctionType(elementType Type) *FunctionType {
 		[]*Parameter{
 			{
 				Identifier:     "at",
-				TypeAnnotation: NewTypeAnnotation(IntegerType),
+				TypeAnnotation: IntegerTypeAnnotation,
 			},
 			{
 				Label:          ArgumentLabelNotRequired,
@@ -1999,7 +2049,7 @@ func ArrayInsertFunctionType(elementType Type) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(elementType),
 			},
 		},
-		NewTypeAnnotation(VoidType),
+		VoidTypeAnnotation,
 	)
 }
 
@@ -2042,7 +2092,7 @@ func ArrayContainsFunctionType(elementType Type) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(elementType),
 			},
 		},
-		NewTypeAnnotation(BoolType),
+		BoolTypeAnnotation,
 	)
 }
 
@@ -2056,7 +2106,7 @@ func ArrayAppendAllFunctionType(arrayType Type) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(arrayType),
 			},
 		},
-		NewTypeAnnotation(VoidType),
+		VoidTypeAnnotation,
 	)
 }
 
@@ -2070,7 +2120,7 @@ func ArrayAppendFunctionType(elementType Type) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(elementType),
 			},
 		},
-		NewTypeAnnotation(VoidType),
+		VoidTypeAnnotation,
 	)
 }
 
@@ -2080,11 +2130,11 @@ func ArraySliceFunctionType(elementType Type) *FunctionType {
 		[]*Parameter{
 			{
 				Identifier:     "from",
-				TypeAnnotation: NewTypeAnnotation(IntType),
+				TypeAnnotation: IntTypeAnnotation,
 			},
 			{
 				Identifier:     "upTo",
-				TypeAnnotation: NewTypeAnnotation(IntType),
+				TypeAnnotation: IntTypeAnnotation,
 			},
 		},
 		NewTypeAnnotation(&VariableSizedType{
@@ -3316,7 +3366,7 @@ func NumberConversionFunctionType(numberType Type) *FunctionType {
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "value",
-				TypeAnnotation: NewTypeAnnotation(NumberType),
+				TypeAnnotation: NumberTypeAnnotation,
 			},
 		},
 		ReturnTypeAnnotation:     NewTypeAnnotation(numberType),
@@ -3350,7 +3400,7 @@ var AddressConversionFunctionType = &FunctionType{
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "value",
-			TypeAnnotation: NewTypeAnnotation(IntegerType),
+			TypeAnnotation: IntegerTypeAnnotation,
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(&AddressType{}),
@@ -3428,7 +3478,7 @@ func pathConversionFunctionType(pathType Type) *FunctionType {
 		[]*Parameter{
 			{
 				Identifier:     "identifier",
-				TypeAnnotation: NewTypeAnnotation(StringType),
+				TypeAnnotation: StringTypeAnnotation,
 			},
 		},
 		NewTypeAnnotation(
@@ -3462,7 +3512,7 @@ func init() {
 			&FunctionType{
 				Purity:               FunctionPurityView,
 				TypeParameters:       []*TypeParameter{{Name: "T"}},
-				ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
+				ReturnTypeAnnotation: MetaTypeAnnotation,
 			},
 			"Creates a run-time type representing the given static type as a value",
 		),
@@ -4594,7 +4644,7 @@ func DictionaryContainsKeyFunctionType(t *DictionaryType) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(t.KeyType),
 			},
 		},
-		NewTypeAnnotation(BoolType),
+		BoolTypeAnnotation,
 	)
 }
 
@@ -4649,7 +4699,7 @@ func DictionaryForEachKeyFunctionType(t *DictionaryType) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(t.KeyType),
 			},
 		},
-		NewTypeAnnotation(BoolType),
+		BoolTypeAnnotation,
 	)
 
 	// fun forEachKey(_ function: ((K): Bool)): Void
@@ -4662,7 +4712,7 @@ func DictionaryForEachKeyFunctionType(t *DictionaryType) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(funcType),
 			},
 		},
-		NewTypeAnnotation(VoidType),
+		VoidTypeAnnotation,
 	)
 }
 
@@ -4963,7 +5013,7 @@ const AddressTypeToBytesFunctionName = `toBytes`
 var AddressTypeToBytesFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	nil,
-	NewTypeAnnotation(ByteArrayType),
+	ByteArrayTypeAnnotation,
 )
 
 const addressTypeToBytesFunctionDocString = `
@@ -5710,7 +5760,7 @@ func (t *TransactionType) EntryPointFunctionType() *FunctionType {
 	return NewSimpleFunctionType(
 		FunctionPurityImpure,
 		append(t.Parameters, t.PrepareParameters...),
-		NewTypeAnnotation(VoidType),
+		VoidTypeAnnotation,
 	)
 }
 
@@ -5719,14 +5769,14 @@ func (t *TransactionType) PrepareFunctionType() *FunctionType {
 		Purity:               FunctionPurityImpure,
 		IsConstructor:        true,
 		Parameters:           t.PrepareParameters,
-		ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+		ReturnTypeAnnotation: VoidTypeAnnotation,
 	}
 }
 
 var transactionTypeExecuteFunctionType = &FunctionType{
 	Purity:               FunctionPurityImpure,
 	IsConstructor:        true,
-	ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+	ReturnTypeAnnotation: VoidTypeAnnotation,
 }
 
 func (*TransactionType) ExecuteFunctionType() *FunctionType {
@@ -6276,7 +6326,7 @@ func CapabilityTypeCheckFunctionType(borrowType Type) *FunctionType {
 	return &FunctionType{
 		Purity:               FunctionPurityView,
 		TypeParameters:       typeParameters,
-		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
+		ReturnTypeAnnotation: BoolTypeAnnotation,
 	}
 }
 
@@ -6425,6 +6475,8 @@ var AccountKeyType = func() *CompositeType {
 	return accountKeyType
 }()
 
+var AccountKeyTypeAnnotation = NewTypeAnnotation(AccountKeyType)
+
 const PublicKeyTypeName = "PublicKey"
 const PublicKeyPublicKeyField = "publicKey"
 const PublicKeySignAlgoField = "signatureAlgorithm"
@@ -6494,31 +6546,35 @@ var PublicKeyType = func() *CompositeType {
 	return publicKeyType
 }()
 
+var PublicKeyTypeAnnotation = NewTypeAnnotation(PublicKeyType)
+
 var PublicKeyArrayType = &VariableSizedType{
 	Type: PublicKeyType,
 }
+
+var PublicKeyArrayTypeAnnotation = NewTypeAnnotation(PublicKeyArrayType)
 
 var PublicKeyVerifyFunctionType = NewSimpleFunctionType(
 	FunctionPurityView,
 	[]*Parameter{
 		{
 			Identifier:     "signature",
-			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 		{
 			Identifier:     "signedData",
-			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 		{
 			Identifier:     "domainSeparationTag",
-			TypeAnnotation: NewTypeAnnotation(StringType),
+			TypeAnnotation: StringTypeAnnotation,
 		},
 		{
 			Identifier:     "hashAlgorithm",
-			TypeAnnotation: NewTypeAnnotation(HashAlgorithmType),
+			TypeAnnotation: HashAlgorithmTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(BoolType),
+	BoolTypeAnnotation,
 )
 
 var PublicKeyVerifyPoPFunctionType = NewSimpleFunctionType(
@@ -6527,10 +6583,10 @@ var PublicKeyVerifyPoPFunctionType = NewSimpleFunctionType(
 		{
 			Label:          ArgumentLabelNotRequired,
 			Identifier:     "proof",
-			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+			TypeAnnotation: ByteArrayTypeAnnotation,
 		},
 	},
-	NewTypeAnnotation(BoolType),
+	BoolTypeAnnotation,
 )
 
 type CryptoAlgorithm interface {

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -54,12 +54,10 @@ func TestConstantSizedType_String_OfFunctionType(t *testing.T) {
 			Purity: FunctionPurityImpure,
 			Parameters: []*Parameter{
 				{
-					TypeAnnotation: NewTypeAnnotation(Int8Type),
+					TypeAnnotation: Int8TypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: NewTypeAnnotation(
-				Int16Type,
-			),
+			ReturnTypeAnnotation: Int16TypeAnnotation,
 		},
 		Size: 2,
 	}
@@ -79,12 +77,10 @@ func TestConstantSizedType_String_OfViewFunctionType(t *testing.T) {
 			Purity: FunctionPurityView,
 			Parameters: []*Parameter{
 				{
-					TypeAnnotation: NewTypeAnnotation(Int8Type),
+					TypeAnnotation: Int8TypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: NewTypeAnnotation(
-				Int16Type,
-			),
+			ReturnTypeAnnotation: Int16TypeAnnotation,
 		},
 		Size: 2,
 	}
@@ -120,12 +116,10 @@ func TestVariableSizedType_String_OfFunctionType(t *testing.T) {
 		Type: &FunctionType{
 			Parameters: []*Parameter{
 				{
-					TypeAnnotation: NewTypeAnnotation(Int8Type),
+					TypeAnnotation: Int8TypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: NewTypeAnnotation(
-				Int16Type,
-			),
+			ReturnTypeAnnotation: Int16TypeAnnotation,
 		},
 	}
 
@@ -1510,10 +1504,10 @@ func TestCommonSuperType(t *testing.T) {
 			Purity: FunctionPurityImpure,
 			Parameters: []*Parameter{
 				{
-					TypeAnnotation: NewTypeAnnotation(StringType),
+					TypeAnnotation: StringTypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: NewTypeAnnotation(Int8Type),
+			ReturnTypeAnnotation: Int8TypeAnnotation,
 			Members:              &StringMemberOrderedMap{},
 		}
 
@@ -1521,10 +1515,10 @@ func TestCommonSuperType(t *testing.T) {
 			Purity: FunctionPurityImpure,
 			Parameters: []*Parameter{
 				{
-					TypeAnnotation: NewTypeAnnotation(IntType),
+					TypeAnnotation: IntTypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: NewTypeAnnotation(Int8Type),
+			ReturnTypeAnnotation: Int8TypeAnnotation,
 			Members:              &StringMemberOrderedMap{},
 		}
 

--- a/runtime/sema/void_type.go
+++ b/runtime/sema/void_type.go
@@ -31,3 +31,5 @@ var VoidType = &SimpleType{
 	ExternallyReturnable: true,
 	Importable:           false,
 }
+
+var VoidTypeAnnotation = NewTypeAnnotation(VoidType)

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -40,15 +40,11 @@ var authAccountFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityImpure,
 	[]*sema.Parameter{
 		{
-			Identifier: "payer",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.AuthAccountType,
-			),
+			Identifier:     "payer",
+			TypeAnnotation: sema.AuthAccountTypeAnnotation,
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.AuthAccountType,
-	),
+	sema.AuthAccountTypeAnnotation,
 )
 
 type EventEmitter interface {
@@ -157,7 +153,7 @@ var getAuthAccountFunctionType = sema.NewSimpleFunctionType(
 			TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
 		},
 	},
-	sema.NewTypeAnnotation(sema.AuthAccountType),
+	sema.AuthAccountTypeAnnotation,
 )
 
 func NewGetAuthAccountFunction(handler AuthAccountHandler) StandardLibraryValue {
@@ -1795,9 +1791,7 @@ var getAccountFunctionType = sema.NewSimpleFunctionType(
 			),
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.PublicAccountType,
-	),
+	sema.PublicAccountTypeAnnotation,
 )
 
 type PublicAccountHandler interface {

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -36,9 +36,9 @@ const authAccountFunctionDocString = `
 Creates a new account, paid by the given existing account
 `
 
-var authAccountFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityImpure,
-	Parameters: []*sema.Parameter{
+var authAccountFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityImpure,
+	[]*sema.Parameter{
 		{
 			Identifier: "payer",
 			TypeAnnotation: sema.NewTypeAnnotation(
@@ -46,10 +46,10 @@ var authAccountFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.AuthAccountType,
 	),
-}
+)
 
 type EventEmitter interface {
 	EmitEvent(
@@ -148,15 +148,17 @@ const getAuthAccountDocString = `
 Returns the AuthAccount for the given address. Only available in scripts
 `
 
-var getAuthAccountFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{{
-		Label:          sema.ArgumentLabelNotRequired,
-		Identifier:     "address",
-		TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
-	}},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AuthAccountType),
-}
+var getAuthAccountFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
+		{
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "address",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
+		},
+	},
+	sema.NewTypeAnnotation(sema.AuthAccountType),
+)
 
 func NewGetAuthAccountFunction(handler AuthAccountHandler) StandardLibraryValue {
 	return NewStandardLibraryFunction(
@@ -1782,9 +1784,9 @@ const getAccountFunctionDocString = `
 Returns the public account for the given address
 `
 
-var getAccountFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var getAccountFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "address",
@@ -1793,10 +1795,10 @@ var getAccountFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.PublicAccountType,
 	),
-}
+)
 
 type PublicAccountHandler interface {
 	BalanceProvider

--- a/runtime/stdlib/assert.go
+++ b/runtime/stdlib/assert.go
@@ -41,16 +41,14 @@ var assertFunctionType = &sema.FunctionType{
 		{
 			Label:          sema.ArgumentLabelNotRequired,
 			Identifier:     "condition",
-			TypeAnnotation: sema.NewTypeAnnotation(sema.BoolType),
+			TypeAnnotation: sema.BoolTypeAnnotation,
 		},
 		{
 			Identifier:     "message",
-			TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
+			TypeAnnotation: sema.StringTypeAnnotation,
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
-		sema.VoidType,
-	),
+	ReturnTypeAnnotation:  sema.VoidTypeAnnotation,
 	RequiredArgumentCount: sema.RequiredArgumentCount(1),
 }
 

--- a/runtime/stdlib/block.go
+++ b/runtime/stdlib/block.go
@@ -32,20 +32,21 @@ const getCurrentBlockFunctionDocString = `
 Returns the current block, i.e. the block which contains the currently executed transaction
 `
 
-var getCurrentBlockFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+var getCurrentBlockFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	nil,
+	sema.NewTypeAnnotation(
 		sema.BlockType,
 	),
-}
+)
 
 const getBlockFunctionDocString = `
 Returns the block at the given height. If the given block does not exist the function returns nil
 `
 
-var getBlockFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var getBlockFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Label:      "at",
 			Identifier: "height",
@@ -54,12 +55,12 @@ var getBlockFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		&sema.OptionalType{
 			Type: sema.BlockType,
 		},
 	),
-}
+)
 
 const BlockHashLength = 32
 

--- a/runtime/stdlib/block.go
+++ b/runtime/stdlib/block.go
@@ -35,9 +35,7 @@ Returns the current block, i.e. the block which contains the currently executed 
 var getCurrentBlockFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityView,
 	nil,
-	sema.NewTypeAnnotation(
-		sema.BlockType,
-	),
+	sema.BlockTypeAnnotation,
 )
 
 const getBlockFunctionDocString = `
@@ -48,11 +46,9 @@ var getBlockFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityView,
 	[]*sema.Parameter{
 		{
-			Label:      "at",
-			Identifier: "height",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.UInt64Type,
-			),
+			Label:          "at",
+			Identifier:     "height",
+			TypeAnnotation: sema.UInt64TypeAnnotation,
 		},
 	},
 	sema.NewTypeAnnotation(

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -67,9 +67,9 @@ The function returns nil if the array is empty or if decoding one of the signatu
 
 const blsAggregateSignaturesFunctionName = "aggregateSignatures"
 
-var blsAggregateSignaturesFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var blsAggregateSignaturesFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "signatures",
@@ -78,12 +78,12 @@ var blsAggregateSignaturesFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		&sema.OptionalType{
 			Type: sema.ByteArrayType,
 		},
 	),
-}
+)
 
 const blsAggregatePublicKeysFunctionDocString = `
 Aggregates multiple BLS public keys into one.
@@ -95,9 +95,9 @@ The function returns nil if the array is empty or any of the input keys is not a
 
 const blsAggregatePublicKeysFunctionName = "aggregatePublicKeys"
 
-var blsAggregatePublicKeysFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var blsAggregatePublicKeysFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "keys",
@@ -106,12 +106,12 @@ var blsAggregatePublicKeysFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		&sema.OptionalType{
 			Type: sema.PublicKeyType,
 		},
 	),
-}
+)
 
 type BLSPublicKeyAggregator interface {
 	PublicKeySignatureVerifier

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -71,11 +71,9 @@ var blsAggregateSignaturesFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityView,
 	[]*sema.Parameter{
 		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "signatures",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.ByteArrayArrayType,
-			),
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "signatures",
+			TypeAnnotation: sema.ByteArrayArrayTypeAnnotation,
 		},
 	},
 	sema.NewTypeAnnotation(
@@ -99,11 +97,9 @@ var blsAggregatePublicKeysFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityView,
 	[]*sema.Parameter{
 		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "keys",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.PublicKeyArrayType,
-			),
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "keys",
+			TypeAnnotation: sema.PublicKeyArrayTypeAnnotation,
 		},
 	},
 	sema.NewTypeAnnotation(

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -113,7 +113,7 @@ func cryptoAlgorithmEnumConstructorType[T sema.CryptoAlgorithm](
 		)
 	}
 
-	constructorType := &sema.FunctionType{
+	return &sema.FunctionType{
 		Purity:        sema.FunctionPurityView,
 		IsConstructor: true,
 		Parameters: []*sema.Parameter{
@@ -129,8 +129,6 @@ func cryptoAlgorithmEnumConstructorType[T sema.CryptoAlgorithm](
 		),
 		Members: sema.GetMembersAsMap(members),
 	}
-
-	return constructorType
 }
 
 type enumCaseConstructor func(rawValue interpreter.UInt8Value) interpreter.MemberAccessibleValue

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -171,6 +171,8 @@ var HashType = &sema.ConstantSizedType{
 	Type: sema.UInt8Type,
 }
 
+var HashTypeAnnotation = sema.NewTypeAnnotation(HashType)
+
 var AccountEventAddressParameter = &sema.Parameter{
 	Identifier:     "address",
 	TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
@@ -178,19 +180,17 @@ var AccountEventAddressParameter = &sema.Parameter{
 
 var AccountEventCodeHashParameter = &sema.Parameter{
 	Identifier:     "codeHash",
-	TypeAnnotation: sema.NewTypeAnnotation(HashType),
+	TypeAnnotation: HashTypeAnnotation,
 }
 
 var AccountEventPublicKeyParameter = &sema.Parameter{
-	Identifier: "publicKey",
-	TypeAnnotation: sema.NewTypeAnnotation(
-		sema.ByteArrayType,
-	),
+	Identifier:     "publicKey",
+	TypeAnnotation: sema.ByteArrayTypeAnnotation,
 }
 
 var AccountEventContractParameter = &sema.Parameter{
 	Identifier:     "contract",
-	TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
+	TypeAnnotation: sema.StringTypeAnnotation,
 }
 
 var AccountCreatedEventType = newFlowEventType(
@@ -243,12 +243,12 @@ var AccountEventRecipientParameter = &sema.Parameter{
 
 var AccountEventNameParameter = &sema.Parameter{
 	Identifier:     "name",
-	TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
+	TypeAnnotation: sema.StringTypeAnnotation,
 }
 
 var AccountEventTypeParameter = &sema.Parameter{
 	Identifier:     "type",
-	TypeAnnotation: sema.NewTypeAnnotation(sema.MetaType),
+	TypeAnnotation: sema.MetaTypeAnnotation,
 }
 
 var AccountInboxPublishedEventType = newFlowEventType(

--- a/runtime/stdlib/log.go
+++ b/runtime/stdlib/log.go
@@ -23,9 +23,9 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-var LogFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityImpure,
-	Parameters: []*sema.Parameter{
+var LogFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityImpure,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "value",
@@ -34,10 +34,10 @@ var LogFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.VoidType,
 	),
-}
+)
 
 const logFunctionDocString = `
 Logs a string representation of the given value

--- a/runtime/stdlib/log.go
+++ b/runtime/stdlib/log.go
@@ -27,16 +27,12 @@ var LogFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityImpure,
 	[]*sema.Parameter{
 		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "value",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.AnyStructType,
-			),
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "value",
+			TypeAnnotation: sema.AnyStructTypeAnnotation,
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.VoidType,
-	),
+	sema.VoidTypeAnnotation,
 )
 
 const logFunctionDocString = `

--- a/runtime/stdlib/panic.go
+++ b/runtime/stdlib/panic.go
@@ -43,19 +43,19 @@ const panicFunctionDocString = `
 Terminates the program unconditionally and reports a message which explains why the unrecoverable error occurred.
 `
 
-var panicFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var panicFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Label:          sema.ArgumentLabelNotRequired,
 			Identifier:     "message",
 			TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.NeverType,
 	),
-}
+)
 
 var PanicFunction = NewStandardLibraryFunction(
 	"panic",

--- a/runtime/stdlib/panic.go
+++ b/runtime/stdlib/panic.go
@@ -49,12 +49,10 @@ var panicFunctionType = sema.NewSimpleFunctionType(
 		{
 			Label:          sema.ArgumentLabelNotRequired,
 			Identifier:     "message",
-			TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
+			TypeAnnotation: sema.StringTypeAnnotation,
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.NeverType,
-	),
+	sema.NeverTypeAnnotation,
 )
 
 var PanicFunction = NewStandardLibraryFunction(

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -34,14 +34,14 @@ var publicKeyConstructorFunctionType = sema.NewSimpleFunctionType(
 	[]*sema.Parameter{
 		{
 			Identifier:     sema.PublicKeyPublicKeyField,
-			TypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
+			TypeAnnotation: sema.ByteArrayTypeAnnotation,
 		},
 		{
 			Identifier:     sema.PublicKeySignAlgoField,
-			TypeAnnotation: sema.NewTypeAnnotation(sema.SignatureAlgorithmType),
+			TypeAnnotation: sema.SignatureAlgorithmTypeAnnotation,
 		},
 	},
-	sema.NewTypeAnnotation(sema.PublicKeyType),
+	sema.PublicKeyTypeAnnotation,
 )
 
 type PublicKey struct {

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -29,9 +29,9 @@ const publicKeyConstructorFunctionDocString = `
 Constructs a new public key
 `
 
-var publicKeyConstructorFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var publicKeyConstructorFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Identifier:     sema.PublicKeyPublicKeyField,
 			TypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
@@ -41,8 +41,8 @@ var publicKeyConstructorFunctionType = &sema.FunctionType{
 			TypeAnnotation: sema.NewTypeAnnotation(sema.SignatureAlgorithmType),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.PublicKeyType),
-}
+	sema.NewTypeAnnotation(sema.PublicKeyType),
+)
 
 type PublicKey struct {
 	PublicKey []byte

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -34,9 +34,7 @@ Follow best practices to prevent security issues when using this function
 var unsafeRandomFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityImpure,
 	nil,
-	sema.NewTypeAnnotation(
-		sema.UInt64Type,
-	),
+	sema.UInt64TypeAnnotation,
 )
 
 type UnsafeRandomGenerator interface {

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -31,12 +31,13 @@ NOTE: The use of this function is unsafe if not used correctly.
 Follow best practices to prevent security issues when using this function
 `
 
-var unsafeRandomFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityImpure,
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+var unsafeRandomFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityImpure,
+	nil,
+	sema.NewTypeAnnotation(
 		sema.UInt64Type,
 	),
-}
+)
 
 type UnsafeRandomGenerator interface {
 	// UnsafeRandom returns a random uint64,

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -72,16 +72,12 @@ var rlpDecodeStringFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityView,
 	[]*sema.Parameter{
 		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "input",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.ByteArrayType,
-			),
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "input",
+			TypeAnnotation: sema.ByteArrayTypeAnnotation,
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.ByteArrayType,
-	),
+	sema.ByteArrayTypeAnnotation,
 )
 
 type RLPDecodeStringError struct {
@@ -147,16 +143,12 @@ var rlpDecodeListFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityView,
 	[]*sema.Parameter{
 		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "input",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.ByteArrayType,
-			),
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "input",
+			TypeAnnotation: sema.ByteArrayTypeAnnotation,
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.ByteArrayArrayType,
-	),
+	sema.ByteArrayArrayTypeAnnotation,
 )
 
 type RLPDecodeListError struct {

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -68,9 +68,9 @@ If any error is encountered while decoding, the program aborts.
 
 const rlpDecodeStringFunctionName = "decodeString"
 
-var rlpDecodeStringFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var rlpDecodeStringFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "input",
@@ -79,10 +79,10 @@ var rlpDecodeStringFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.ByteArrayType,
 	),
-}
+)
 
 type RLPDecodeStringError struct {
 	Msg string
@@ -143,9 +143,9 @@ If any error is encountered while decoding, the program aborts.
 
 const rlpDecodeListFunctionName = "decodeList"
 
-var rlpDecodeListFunctionType = &sema.FunctionType{
-	Purity: sema.FunctionPurityView,
-	Parameters: []*sema.Parameter{
+var rlpDecodeListFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "input",
@@ -154,10 +154,10 @@ var rlpDecodeListFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.ByteArrayArrayType,
 	),
-}
+)
 
 type RLPDecodeListError struct {
 	Msg string

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -416,6 +416,9 @@ const testExpectFunctionName = "expect"
 
 var testExpectFunctionType = &sema.FunctionType{
 	Purity: matcherTestFunctionType.Purity,
+	TypeParameters: []*sema.TypeParameter{
+		typeParameter,
+	},
 	Parameters: []*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -431,9 +434,6 @@ var testExpectFunctionType = &sema.FunctionType{
 			Identifier:     "matcher",
 			TypeAnnotation: sema.NewTypeAnnotation(matcherType),
 		},
-	},
-	TypeParameters: []*sema.TypeParameter{
-		typeParameter,
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		sema.VoidType,
@@ -518,8 +518,9 @@ Read a local file, and return the content as a string.
 
 const testReadFileFunctionName = "readFile"
 
-var testReadFileFunctionType = &sema.FunctionType{
-	Parameters: []*sema.Parameter{
+var testReadFileFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityImpure,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "path",
@@ -528,10 +529,10 @@ var testReadFileFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.StringType,
 	),
-}
+)
 
 func testReadFileFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
@@ -560,12 +561,13 @@ Creates a blockchain which is backed by a new emulator instance.
 
 const testNewEmulatorBlockchainFunctionName = "newEmulatorBlockchain"
 
-var testNewEmulatorBlockchainFunctionType = &sema.FunctionType{
-	Parameters: []*sema.Parameter{},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+var testNewEmulatorBlockchainFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityView,
+	nil,
+	sema.NewTypeAnnotation(
 		blockchainType,
 	),
-}
+)
 
 func testNewEmulatorBlockchainFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
@@ -639,8 +641,9 @@ The test function is of type '((T): Bool)', where 'T' is bound to 'AnyStruct'.
 const newMatcherFunctionName = "newMatcher"
 
 // Type of the Matcher.test function: ((T): Bool)
-var matcherTestFunctionType = &sema.FunctionType{
-	Parameters: []*sema.Parameter{
+var matcherTestFunctionType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityImpure,
+	[]*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "value",
@@ -651,14 +654,17 @@ var matcherTestFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+	sema.NewTypeAnnotation(
 		sema.BoolType,
 	),
-}
+)
 
 var newMatcherFunctionType = &sema.FunctionType{
 	Purity:        sema.FunctionPurityView,
 	IsConstructor: true,
+	TypeParameters: []*sema.TypeParameter{
+		newMatcherFunctionTypeParameter,
+	},
 	Parameters: []*sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -669,9 +675,6 @@ var newMatcherFunctionType = &sema.FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(matcherType),
-	TypeParameters: []*sema.TypeParameter{
-		newMatcherFunctionTypeParameter,
-	},
 }
 
 var newMatcherFunctionTypeParameter = &sema.TypeParameter{

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -316,22 +316,16 @@ var testAssertFunctionType = &sema.FunctionType{
 	Purity: sema.FunctionPurityView,
 	Parameters: []*sema.Parameter{
 		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "condition",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.BoolType,
-			),
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "condition",
+			TypeAnnotation: sema.BoolTypeAnnotation,
 		},
 		{
-			Identifier: "message",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.StringType,
-			),
+			Identifier:     "message",
+			TypeAnnotation: sema.StringTypeAnnotation,
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
-		sema.VoidType,
-	),
+	ReturnTypeAnnotation:  sema.VoidTypeAnnotation,
 	RequiredArgumentCount: sema.RequiredArgumentCount(1),
 }
 
@@ -375,15 +369,11 @@ var testFailFunctionType = &sema.FunctionType{
 	Purity: sema.FunctionPurityView,
 	Parameters: []*sema.Parameter{
 		{
-			Identifier: "message",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.StringType,
-			),
+			Identifier:     "message",
+			TypeAnnotation: sema.StringTypeAnnotation,
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
-		sema.VoidType,
-	),
+	ReturnTypeAnnotation:  sema.VoidTypeAnnotation,
 	RequiredArgumentCount: sema.RequiredArgumentCount(0),
 }
 
@@ -435,9 +425,7 @@ var testExpectFunctionType = &sema.FunctionType{
 			TypeAnnotation: sema.NewTypeAnnotation(matcherType),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(
-		sema.VoidType,
-	),
+	ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 }
 
 var testExpectFunction = interpreter.NewUnmeteredHostFunctionValue(
@@ -522,16 +510,12 @@ var testReadFileFunctionType = sema.NewSimpleFunctionType(
 	sema.FunctionPurityImpure,
 	[]*sema.Parameter{
 		{
-			Label:      sema.ArgumentLabelNotRequired,
-			Identifier: "path",
-			TypeAnnotation: sema.NewTypeAnnotation(
-				sema.StringType,
-			),
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "path",
+			TypeAnnotation: sema.StringTypeAnnotation,
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.StringType,
-	),
+	sema.StringTypeAnnotation,
 )
 
 func testReadFileFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
@@ -654,9 +638,7 @@ var matcherTestFunctionType = sema.NewSimpleFunctionType(
 			),
 		},
 	},
-	sema.NewTypeAnnotation(
-		sema.BoolType,
-	),
+	sema.BoolTypeAnnotation,
 )
 
 var newMatcherFunctionType = &sema.FunctionType{

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -6055,8 +6055,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 							),
 						},
 					},
-					ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-					RequiredArgumentCount: nil,
+					ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 				},
 			)
 

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -6055,7 +6055,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 							),
 						},
 					},
-					ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+					ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 				},
 			)
 

--- a/runtime/tests/checker/entrypoint_test.go
+++ b/runtime/tests/checker/entrypoint_test.go
@@ -62,7 +62,7 @@ func TestEntryPointParameters(t *testing.T) {
 				{
 					Label:          "",
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 			},
 			parameters,
@@ -101,7 +101,7 @@ func TestEntryPointParameters(t *testing.T) {
 				{
 					Label:          "",
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 			},
 			parameters,
@@ -127,7 +127,7 @@ func TestEntryPointParameters(t *testing.T) {
 				{
 					Label:          "",
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 			},
 			parameters,
@@ -153,7 +153,7 @@ func TestEntryPointParameters(t *testing.T) {
 				{
 					Label:          "",
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 			},
 			parameters,

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -66,10 +66,7 @@ func TestCheckGenericFunction(t *testing.T) {
 					variant,
 				),
 				&sema.FunctionType{
-					TypeParameters:        nil,
-					Parameters:            nil,
-					ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-					RequiredArgumentCount: nil,
+					ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 				},
 			)
 
@@ -91,10 +88,7 @@ func TestCheckGenericFunction(t *testing.T) {
               let res = test<X>()
             `,
 			&sema.FunctionType{
-				TypeParameters:        nil,
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -120,9 +114,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -148,9 +140,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -199,8 +189,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -249,8 +238,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -288,8 +276,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -327,8 +314,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -372,8 +358,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -431,8 +416,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -465,7 +449,6 @@ func TestCheckGenericFunction(t *testing.T) {
 						TypeParameter: typeParameter,
 					},
 				),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -497,7 +480,6 @@ func TestCheckGenericFunction(t *testing.T) {
 						TypeParameter: typeParameter,
 					},
 				),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -556,7 +538,6 @@ func TestCheckGenericFunction(t *testing.T) {
 						TypeParameter: typeParameter,
 					},
 				),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -599,9 +580,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -639,9 +618,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -678,8 +655,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -757,7 +733,6 @@ func TestCheckGenericFunction(t *testing.T) {
 								},
 							),
 						),
-						RequiredArgumentCount: nil,
 					},
 				)
 
@@ -865,7 +840,6 @@ func TestCheckGenericFunction(t *testing.T) {
 								},
 							),
 						),
-						RequiredArgumentCount: nil,
 					},
 				)
 
@@ -905,8 +879,7 @@ func TestCheckGenericFunctionIsInvalid(t *testing.T) {
 				),
 			},
 		},
-		ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-		RequiredArgumentCount: nil,
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 	}
 
 	assert.False(t, genericFunctionType.IsInvalidType())

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -66,7 +66,7 @@ func TestCheckGenericFunction(t *testing.T) {
 					variant,
 				),
 				&sema.FunctionType{
-					ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+					ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 				},
 			)
 
@@ -88,7 +88,7 @@ func TestCheckGenericFunction(t *testing.T) {
               let res = test<X>()
             `,
 			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -114,7 +114,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -140,7 +140,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -189,7 +189,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -238,7 +238,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -276,7 +276,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -314,7 +314,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -358,7 +358,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -416,7 +416,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -580,7 +580,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -618,7 +618,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -655,7 +655,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 
@@ -879,7 +879,7 @@ func TestCheckGenericFunctionIsInvalid(t *testing.T) {
 				),
 			},
 		},
-		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+		ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 	}
 
 	assert.False(t, genericFunctionType.IsInvalidType())

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -684,7 +684,7 @@ func TestCheckImportVirtual(t *testing.T) {
 			fooType,
 			"bar",
 			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
+				ReturnTypeAnnotation: sema.UInt64TypeAnnotation,
 			},
 			"",
 		))

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -273,11 +273,9 @@ func TestCheckFunctionTypeReceiverType(t *testing.T) {
 
 		assert.Equal(t,
 			&sema.FunctionType{
-				Purity:     sema.FunctionPurityImpure,
-				Parameters: []*sema.Parameter{},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					sema.VoidType,
-				),
+				Purity:               sema.FunctionPurityImpure,
+				Parameters:           []*sema.Parameter{},
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 			RequireGlobalValue(t, checker.Elaboration, "f"),
 		)

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -116,7 +116,7 @@ func TestCheckStorable(t *testing.T) {
 	nonStorableTypes := []sema.Type{
 		&sema.FunctionType{
 			Purity:               sema.FunctionPurityImpure,
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+			ReturnTypeAnnotation: sema.IntTypeAnnotation,
 		},
 		sema.NeverType,
 		sema.VoidType,

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -363,7 +363,7 @@ func TestCheckFunctionArgumentTypeInference(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 		)
 

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -363,8 +363,7 @@ func TestCheckFunctionArgumentTypeInference(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -1093,16 +1093,12 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 		Purity: sema.FunctionPurityView,
 		Parameters: []*sema.Parameter{
 			{
-				Label:      sema.ArgumentLabelNotRequired,
-				Identifier: "value",
-				TypeAnnotation: sema.NewTypeAnnotation(
-					sema.AnyStructType,
-				),
+				Label:          sema.ArgumentLabelNotRequired,
+				Identifier:     "value",
+				TypeAnnotation: sema.AnyStructTypeAnnotation,
 			},
 		},
-		ReturnTypeAnnotation: sema.NewTypeAnnotation(
-			sema.VoidType,
-		),
+		ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 	}
 
 	valueDeclaration := stdlib.StandardLibraryValue{

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -50,7 +50,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 			fooType,
 			"bar",
 			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
+				ReturnTypeAnnotation: sema.UInt64TypeAnnotation,
 			},
 			"",
 		))
@@ -99,7 +99,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 								return interpreter.NewUnmeteredUInt64Value(42)
 							},
 							&sema.FunctionType{
-								ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UIntType),
+								ReturnTypeAnnotation: sema.UIntTypeAnnotation,
 							},
 						),
 					}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -1823,17 +1823,15 @@ func TestInterpretHostFunction(t *testing.T) {
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "a",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "b",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				sema.IntType,
-			),
+			ReturnTypeAnnotation: sema.IntTypeAnnotation,
 		},
 		``,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1907,12 +1905,10 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "value",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+					TypeAnnotation: sema.IntTypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				sema.VoidType,
-			),
+			ReturnTypeAnnotation:  sema.VoidTypeAnnotation,
 			RequiredArgumentCount: sema.RequiredArgumentCount(1),
 		},
 		``,
@@ -4711,16 +4707,12 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 		getStorageReferenceFunctionType := &sema.FunctionType{
 			Parameters: []*sema.Parameter{
 				{
-					Label:      "authorized",
-					Identifier: "authorized",
-					TypeAnnotation: sema.NewTypeAnnotation(
-						sema.BoolType,
-					),
+					Label:          "authorized",
+					Identifier:     "authorized",
+					TypeAnnotation: sema.BoolTypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				sema.AnyStructType,
-			),
+			ReturnTypeAnnotation: sema.AnyStructTypeAnnotation,
 		}
 
 		valueDeclaration := stdlib.NewStandardLibraryFunction(
@@ -9122,12 +9114,10 @@ func TestInterpretNestedDestroy(t *testing.T) {
 				{
 					Label:          sema.ArgumentLabelNotRequired,
 					Identifier:     "value",
-					TypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
+					TypeAnnotation: sema.AnyStructTypeAnnotation,
 				},
 			},
-			ReturnTypeAnnotation: sema.NewTypeAnnotation(
-				sema.VoidType,
-			),
+			ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 		},
 		``,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -9519,7 +9509,7 @@ func TestHostFunctionStaticType(t *testing.T) {
 				nil,
 				&sema.FunctionType{
 					Purity:               sema.FunctionPurityView,
-					ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.MetaType),
+					ReturnTypeAnnotation: sema.MetaTypeAnnotation,
 				},
 			),
 			value.StaticType(inter),

--- a/runtime/tests/interpreter/invocation_test.go
+++ b/runtime/tests/interpreter/invocation_test.go
@@ -55,9 +55,7 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 		checkFunction := stdlib.NewStandardLibraryFunction(
 			"check",
 			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					sema.VoidType,
-				),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 			``,
 			func(invocation interpreter.Invocation) interpreter.Value {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -9297,12 +9297,10 @@ func TestInterpretValueStringConversion(t *testing.T) {
 					{
 						Label:          sema.ArgumentLabelNotRequired,
 						Identifier:     "value",
-						TypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
+						TypeAnnotation: sema.AnyStructTypeAnnotation,
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					sema.VoidType,
-				),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 			``,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -9641,12 +9639,10 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 					{
 						Label:          sema.ArgumentLabelNotRequired,
 						Identifier:     "value",
-						TypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
+						TypeAnnotation: sema.AnyStructTypeAnnotation,
 					},
 				},
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					sema.VoidType,
-				),
+				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
 			},
 			``,
 			func(invocation interpreter.Invocation) interpreter.Value {


### PR DESCRIPTION

## Description

- Introduce `NewSimpleFunctionType` and use it where possible
- Fix some incorrect function types
- Create "constants" for common type annotations

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
