### PR TITLE
Move test framework tests to Cadence

### DIFF
--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -36,7 +36,7 @@ func newUnmeteredInMemoryStorage() interpreter.InMemoryStorage {
 	return interpreter.NewInMemoryStorage(nil)
 }
 
-func testInterpreter(t *testing.T, code string, valueDeclaration StandardLibraryValue) *interpreter.Interpreter {
+func newInterpreter(t *testing.T, code string, valueDeclarations ...StandardLibraryValue) *interpreter.Interpreter {
 	program, err := parser.ParseProgram(
 		[]byte(code),
 		nil,
@@ -44,8 +44,9 @@ func testInterpreter(t *testing.T, code string, valueDeclaration StandardLibrary
 	require.NoError(t, err)
 
 	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
-
-	baseValueActivation.DeclareValue(valueDeclaration)
+	for _, valueDeclaration := range valueDeclarations {
+		baseValueActivation.DeclareValue(valueDeclaration)
+	}
 
 	checker, err := sema.NewChecker(
 		program,
@@ -64,7 +65,9 @@ func testInterpreter(t *testing.T, code string, valueDeclaration StandardLibrary
 	storage := newUnmeteredInMemoryStorage()
 
 	baseActivation := activations.NewActivation[*interpreter.Variable](nil, interpreter.BaseActivation)
-	interpreter.Declare(baseActivation, valueDeclaration)
+	for _, valueDeclaration := range valueDeclarations {
+		interpreter.Declare(baseActivation, valueDeclaration)
+	}
 
 	inter, err := interpreter.NewInterpreter(
 		interpreter.ProgramFromChecker(checker),
@@ -86,7 +89,7 @@ func TestAssert(t *testing.T) {
 
 	t.Parallel()
 
-	inter := testInterpreter(t,
+	inter := newInterpreter(t,
 		`pub let test = assert`,
 		AssertFunction,
 	)
@@ -131,7 +134,7 @@ func TestPanic(t *testing.T) {
 
 	t.Parallel()
 
-	inter := testInterpreter(t,
+	inter := newInterpreter(t,
 		`pub let test = panic`,
 		PanicFunction,
 	)

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -103,7 +103,7 @@ func NewTestContract(
 ) {
 	value, err := inter.InvokeFunctionValue(
 		constructor,
-		[]interpreter.Value{},
+		nil,
 		testContractInitializerTypes,
 		testContractInitializerTypes,
 		invocationRange,
@@ -694,7 +694,7 @@ var newMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		return newMatcherWithGenericTestFunction(invocation, test)
 	},
-	equalMatcherFunctionType,
+	newMatcherFunctionType,
 )
 
 // 'EmulatorBackend' struct.
@@ -1557,4 +1557,67 @@ func newMatcherWithGenericTestFunction(
 	}
 
 	return matcher
+}
+
+func TestCheckerContractValueHandler(
+	checker *sema.Checker,
+	declaration *ast.CompositeDeclaration,
+	compositeType *sema.CompositeType,
+) sema.ValueDeclaration {
+	constructorType, constructorArgumentLabels := sema.CompositeConstructorType(
+		checker.Elaboration,
+		declaration,
+		compositeType,
+	)
+
+	return StandardLibraryValue{
+		Name:           declaration.Identifier.Identifier,
+		Type:           constructorType,
+		DocString:      declaration.DocString,
+		Kind:           declaration.DeclarationKind(),
+		Position:       &declaration.Identifier.Pos,
+		ArgumentLabels: constructorArgumentLabels,
+	}
+}
+
+func NewTestInterpreterContractValueHandler(
+	testFramework TestFramework,
+) interpreter.ContractValueHandlerFunc {
+	return func(
+		inter *interpreter.Interpreter,
+		compositeType *sema.CompositeType,
+		constructorGenerator func(common.Address) *interpreter.HostFunctionValue,
+		invocationRange ast.Range,
+	) interpreter.ContractValue {
+
+		switch compositeType.Location {
+		case CryptoChecker.Location:
+			contract, err := NewCryptoContract(
+				inter,
+				constructorGenerator(common.Address{}),
+				invocationRange,
+			)
+			if err != nil {
+				panic(err)
+			}
+			return contract
+
+		case TestContractLocation:
+			contract, err := NewTestContract(
+				inter,
+				testFramework,
+				constructorGenerator(common.Address{}),
+				invocationRange,
+			)
+			if err != nil {
+				panic(err)
+			}
+			return contract
+
+		default:
+			// During tests, imported contracts can be constructed using the constructor,
+			// similar to structs. Therefore, generate a constructor function.
+			return constructorGenerator(common.Address{})
+		}
+	}
 }

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -1,0 +1,759 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdlib
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/checker"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func newTestContractInterpreter(t *testing.T, code string) (*interpreter.Interpreter, error) {
+	program, err := parser.ParseProgram(
+		[]byte(code),
+		nil,
+	)
+	require.NoError(t, err)
+
+	checker, err := sema.NewChecker(
+		program,
+		utils.TestLocation,
+		nil,
+		&sema.Config{
+			AccessCheckMode: sema.AccessCheckModeStrict,
+			ImportHandler: func(
+				checker *sema.Checker,
+				importedLocation common.Location,
+				importRange ast.Range,
+			) (
+				sema.Import,
+				error,
+			) {
+				if importedLocation == TestContractLocation {
+					return sema.ElaborationImport{
+						Elaboration: TestContractChecker.Elaboration,
+					}, nil
+				}
+
+				return nil, errors.New("invalid import")
+			},
+			ContractValueHandler: TestCheckerContractValueHandler,
+		},
+	)
+	require.NoError(t, err)
+
+	err = checker.Check()
+	if err != nil {
+		return nil, err
+	}
+
+	storage := newUnmeteredInMemoryStorage()
+
+	var uuid uint64 = 0
+
+	inter, err := interpreter.NewInterpreter(
+		interpreter.ProgramFromChecker(checker),
+		checker.Location,
+		&interpreter.Config{
+			Storage: storage,
+			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+				if location == TestContractLocation {
+					program := interpreter.ProgramFromChecker(TestContractChecker)
+					subInterpreter, err := inter.NewSubInterpreter(program, location)
+					if err != nil {
+						panic(err)
+					}
+					return interpreter.InterpreterImport{
+						Interpreter: subInterpreter,
+					}
+				}
+
+				return nil
+			},
+			ContractValueHandler: NewTestInterpreterContractValueHandler(nil),
+			UUIDHandler: func() (uint64, error) {
+				uuid++
+				return uuid, nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	err = inter.Interpret()
+	require.NoError(t, err)
+
+	return inter, nil
+}
+
+func TestTestNewMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom matcher", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            import Test
+
+            pub fun test(): Bool {
+                let matcher = Test.newMatcher(fun (_ value: AnyStruct): Bool {
+                     if !value.getType().isSubtype(of: Type<Int>()) {
+                        return false
+                    }
+
+                    return (value as! Int) > 5
+                })
+
+                return matcher.test(8)
+            }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("custom matcher primitive type", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+
+               let matcher = Test.newMatcher(fun (_ value: Int): Bool {
+                    return value == 7
+               })
+
+               return matcher.test(7)
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("custom matcher invalid type usage", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+
+               let matcher = Test.newMatcher(fun (_ value: Int): Bool {
+                    return (value + 7) == 4
+               })
+
+               // Invoke with an incorrect type
+               matcher.test("Hello")
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &interpreter.TypeMismatchError{})
+	})
+
+	t.Run("custom resource matcher", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+
+               let matcher = Test.newMatcher(fun (_ value: &Foo): Bool {
+                   return value.a == 4
+               })
+
+               let f <-create Foo(4)
+
+               let res = matcher.test(&f as &Foo)
+
+               destroy f
+
+               return res
+           }
+
+           pub resource Foo {
+               pub let a: Int
+
+               init(_ a: Int) {
+                   self.a = a
+               }
+            }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("custom resource matcher invalid type", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+	       import Test
+
+	       pub fun test() {
+
+	           let matcher = Test.newMatcher(fun (_ value: @Foo): Bool {
+	                destroy value
+	                return true
+	           })
+	       }
+
+	       pub resource Foo {}
+	    `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
+
+	t.Run("custom matcher with explicit type", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+	       import Test
+
+	       pub fun test(): Bool {
+
+	           let matcher = Test.newMatcher<Int>(fun (_ value: Int): Bool {
+	                return value == 7
+	           })
+
+	           return matcher.test(7)
+	       }
+	    `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("custom matcher with mismatching types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+	       import Test
+
+	       pub fun test() {
+
+	           let matcher = Test.newMatcher<String>(fun (_ value: Int): Bool {
+	                return value == 7
+	           })
+	       }
+	    `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+	})
+
+	t.Run("combined matcher mismatching types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+	       import Test
+
+	       pub fun test() {
+
+	           let matcher1 = Test.newMatcher(fun (_ value: Int): Bool {
+	                return (value + 5) == 10
+	           })
+
+	           let matcher2 = Test.newMatcher(fun (_ value: String): Bool {
+	                return value.length == 10
+	           })
+
+	           let matcher3 = matcher1.and(matcher2)
+
+	           // Invoke with a type that matches to only one matcher
+	           matcher3.test(5)
+	       }
+	    `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &interpreter.TypeMismatchError{})
+	})
+}
+
+func TestTestEqualMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("equal matcher with primitive", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let matcher = Test.equal(1)
+               return matcher.test(1)
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("equal matcher with struct", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let f = Foo()
+               let matcher = Test.equal(f)
+               return matcher.test(f)
+           }
+
+           pub struct Foo {}
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("equal matcher with resource", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let f <- create Foo()
+               let matcher = Test.equal(<-f)
+               return matcher.test(<- create Foo())
+           }
+
+           pub resource Foo {}
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+		require.Error(t, err)
+
+		errs := checker.RequireCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+	})
+
+	t.Run("with explicit types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               let matcher = Test.equal<String>("hello")
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+	})
+
+	t.Run("with incorrect types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               let matcher = Test.equal<String>(1)
+           }
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+	})
+
+	t.Run("matcher or", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let one = Test.equal(1)
+               let two = Test.equal(2)
+
+               let oneOrTwo = one.or(two)
+
+               return oneOrTwo.test(1)
+                   && oneOrTwo.test(2)
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("matcher or fail", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let one = Test.equal(1)
+               let two = Test.equal(2)
+
+               let oneOrTwo = one.or(two)
+
+               return oneOrTwo.test(3)
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher and", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let one = Test.equal(1)
+               let two = Test.equal(2)
+
+               let oneAndTwo = one.and(two)
+
+               return oneAndTwo.test(1)
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("chained matchers", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let one = Test.equal(1)
+               let two = Test.equal(2)
+               let three = Test.equal(3)
+
+               let oneOrTwoOrThree = one.or(two).or(three)
+
+               return oneOrTwoOrThree.test(3)
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+	})
+
+	t.Run("resource matcher or", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let foo <- create Foo()
+               let bar <- create Bar()
+
+               let fooMatcher = Test.equal(<-foo)
+               let barMatcher = Test.equal(<-bar)
+
+               let matcher = fooMatcher.or(barMatcher)
+
+               return matcher.test(<-create Foo())
+                   && matcher.test(<-create Bar())
+           }
+
+           pub resource Foo {}
+           pub resource Bar {}
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 4)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[2])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[3])
+	})
+
+	t.Run("resource matcher and", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test(): Bool {
+               let foo <- create Foo()
+               let bar <- create Bar()
+
+               let fooMatcher = Test.equal(<-foo)
+               let barMatcher = Test.equal(<-bar)
+
+               let matcher = fooMatcher.and(barMatcher)
+
+               return matcher.test(<-create Foo())
+           }
+
+           pub resource Foo {}
+           pub resource Bar {}
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 3)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[2])
+	})
+}
+
+func TestTestExpect(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               Test.expect("this string", Test.equal("this string"))
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               Test.expect("this string", Test.equal("other string"))
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &AssertionError{})
+	})
+
+	t.Run("different types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               Test.expect("string", Test.equal(1))
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &AssertionError{})
+	})
+
+	t.Run("with explicit types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               Test.expect<String>("hello", Test.equal("hello"))
+           }
+        `
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+	})
+
+	t.Run("mismatching types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               Test.expect<Int>("string", Test.equal(1))
+           }
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+	})
+
+	t.Run("resource with resource matcher", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               let f1 <- create Foo()
+               let f2 <- create Foo()
+               Test.expect(<-f1, Test.equal(<-f2))
+           }
+
+           pub resource Foo {}
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+	})
+
+	t.Run("resource with struct matcher", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               let foo <- create Foo()
+               let bar = Bar()
+               Test.expect(<-foo, Test.equal(bar))
+           }
+
+           pub resource Foo {}
+           pub struct Bar {}
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
+
+	t.Run("struct with resource matcher", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+           import Test
+
+           pub fun test() {
+               let foo = Foo()
+               let bar <- create Bar()
+               Test.expect(foo, Test.equal(<-bar))
+           }
+
+           pub struct Foo {}
+           pub resource Bar {}
+        `
+
+		_, err := newTestContractInterpreter(t, script)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
+}


### PR DESCRIPTION
Work towards #2084 

## Description

When updating the Test framework, `cadence-tools/test`, to Stable Cadence, I realized I had broken it in #2125.
This was not catched, as all tests for the standard library test contract are in the downstream repo.

To avoid future breakage, move some of the functionality and tests to the Cadence repo.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
