### PR TITLE
Export all keywords

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -84,34 +84,34 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 			return parsePragmaDeclaration(p)
 		case lexer.TokenIdentifier:
 			switch string(p.currentTokenSource()) {
-			case keywordLet, keywordVar:
+			case KeywordLet, KeywordVar:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for variable")
 				}
 				return parseVariableDeclaration(p, access, accessPos, docString)
 
-			case keywordFun:
+			case KeywordFun:
 				return parseFunctionDeclaration(p, false, access, accessPos, purity, purityPos, docString)
 
-			case keywordImport:
+			case KeywordImport:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for import")
 				}
 				return parseImportDeclaration(p)
 
-			case keywordEvent:
+			case KeywordEvent:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for event")
 				}
 				return parseEventDeclaration(p, access, accessPos, docString)
 
-			case keywordStruct, keywordResource, keywordContract, keywordEnum:
+			case KeywordStruct, KeywordResource, KeywordContract, KeywordEnum:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for composite")
 				}
 				return parseCompositeOrInterfaceDeclaration(p, access, accessPos, docString)
 
-			case keywordTransaction:
+			case KeywordTransaction:
 				if access != ast.AccessNotSpecified {
 					return nil, NewSyntaxError(*accessPos, "invalid access modifier for transaction")
 				}
@@ -121,7 +121,7 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 				return parseTransactionDeclaration(p, docString)
 
-			case keywordView:
+			case KeywordView:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, p.syntaxError("invalid second view modifier")
 				}
@@ -131,7 +131,7 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 				purity = parsePurityAnnotation(p)
 				continue
 
-			case keywordPriv, keywordPub, keywordAccess:
+			case KeywordPriv, KeywordPub, KeywordAccess:
 				if access != ast.AccessNotSpecified {
 					return nil, p.syntaxError("invalid second access modifier")
 				}
@@ -153,10 +153,10 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 var enumeratedAccessModifierKeywords = common.EnumerateWords(
 	[]string{
-		strconv.Quote(keywordAll),
-		strconv.Quote(keywordAccount),
-		strconv.Quote(keywordContract),
-		strconv.Quote(keywordSelf),
+		strconv.Quote(KeywordAll),
+		strconv.Quote(KeywordAccount),
+		strconv.Quote(KeywordContract),
+		strconv.Quote(KeywordSelf),
 	},
 	"or",
 )
@@ -170,12 +170,12 @@ var enumeratedAccessModifierKeywords = common.EnumerateWords(
 func parseAccess(p *parser) (ast.Access, error) {
 
 	switch string(p.currentTokenSource()) {
-	case keywordPriv:
+	case KeywordPriv:
 		// Skip the `priv` keyword
 		p.next()
 		return ast.AccessPrivate, nil
 
-	case keywordPub:
+	case KeywordPub:
 		// Skip the `pub` keyword
 		p.nextSemanticToken()
 		if !p.current.Is(lexer.TokenParenOpen) {
@@ -188,16 +188,16 @@ func parseAccess(p *parser) (ast.Access, error) {
 		if !p.current.Is(lexer.TokenIdentifier) {
 			return ast.AccessNotSpecified, p.syntaxError(
 				"expected keyword %q, got %s",
-				keywordSet,
+				KeywordSet,
 				p.current.Type,
 			)
 		}
 
 		keyword := p.currentTokenSource()
-		if string(keyword) != keywordSet {
+		if string(keyword) != KeywordSet {
 			return ast.AccessNotSpecified, p.syntaxError(
 				"expected keyword %q, got %q",
-				keywordSet,
+				KeywordSet,
 				keyword,
 			)
 		}
@@ -212,7 +212,7 @@ func parseAccess(p *parser) (ast.Access, error) {
 
 		return ast.AccessPublicSettable, nil
 
-	case keywordAccess:
+	case KeywordAccess:
 		// Skip the `access` keyword
 		p.nextSemanticToken()
 
@@ -235,16 +235,16 @@ func parseAccess(p *parser) (ast.Access, error) {
 
 		keyword := p.currentTokenSource()
 		switch string(keyword) {
-		case keywordAll:
+		case KeywordAll:
 			access = ast.AccessPublic
 
-		case keywordAccount:
+		case KeywordAccount:
 			access = ast.AccessAccount
 
-		case keywordContract:
+		case KeywordContract:
 			access = ast.AccessContract
 
-		case keywordSelf:
+		case KeywordSelf:
 			access = ast.AccessPrivate
 
 		default:
@@ -290,7 +290,7 @@ func parseVariableDeclaration(
 		startPos = *accessPos
 	}
 
-	isLet := string(p.currentTokenSource()) == keywordLet
+	isLet := string(p.currentTokenSource()) == KeywordLet
 
 	// Skip the `let` or `var` keyword
 	p.nextSemanticToken()
@@ -487,7 +487,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 					return p.syntaxError(
 						"expected %s or keyword %q, got %s",
 						lexer.TokenIdentifier,
-						keywordFrom,
+						KeywordFrom,
 						p.current.Type,
 					)
 				}
@@ -496,7 +496,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 			case lexer.TokenIdentifier:
 
 				keyword := p.currentTokenSource()
-				if string(keyword) == keywordFrom {
+				if string(keyword) == KeywordFrom {
 					if expectCommaOrFrom {
 						atEnd = true
 
@@ -544,7 +544,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 				return p.syntaxError(
 					"unexpected token in import declaration: got %s, expected keyword %q or %s",
 					p.current.Type,
-					keywordFrom,
+					KeywordFrom,
 					lexer.TokenComma,
 				)
 			}
@@ -561,7 +561,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 		// If it is not the `from` keyword,
 		// the given (previous) identifier is the import location.
 
-		if string(p.currentTokenSource()) == keywordFrom {
+		if string(p.currentTokenSource()) == KeywordFrom {
 			identifiers = append(identifiers, identifier)
 			// Skip the `from` keyword
 			p.nextSemanticToken()
@@ -611,7 +611,7 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 			return nil, p.syntaxError(
 				"unexpected token in import declaration: got %s, expected keyword %q or %s",
 				p.current.Type,
-				keywordFrom,
+				KeywordFrom,
 				lexer.TokenComma,
 			)
 		}
@@ -652,7 +652,7 @@ func isNextTokenCommaOrFrom(p *parser) (b bool, err error) {
 	// Lookahead the next token
 	switch p.current.Type {
 	case lexer.TokenIdentifier:
-		isFrom := string(p.currentTokenSource()) == keywordFrom
+		isFrom := string(p.currentTokenSource()) == KeywordFrom
 		return isFrom, nil
 	case lexer.TokenComma:
 		return true, nil
@@ -765,16 +765,16 @@ func parseCompositeKind(p *parser) common.CompositeKind {
 
 	if p.current.Is(lexer.TokenIdentifier) {
 		switch string(p.currentTokenSource()) {
-		case keywordStruct:
+		case KeywordStruct:
 			return common.CompositeKindStructure
 
-		case keywordResource:
+		case KeywordResource:
 			return common.CompositeKindResource
 
-		case keywordContract:
+		case KeywordContract:
 			return common.CompositeKindContract
 
-		case keywordEnum:
+		case KeywordEnum:
 			return common.CompositeKindEnum
 		}
 	}
@@ -801,10 +801,10 @@ func parseFieldWithVariableKind(
 
 	var variableKind ast.VariableKind
 	switch string(p.currentTokenSource()) {
-	case keywordLet:
+	case KeywordLet:
 		variableKind = ast.VariableKindConstant
 
-	case keywordVar:
+	case KeywordVar:
 		variableKind = ast.VariableKindVariable
 	}
 
@@ -889,12 +889,12 @@ func parseCompositeOrInterfaceDeclaration(
 
 		wasInterface := isInterface
 
-		if string(p.currentTokenSource()) == keywordInterface {
+		if string(p.currentTokenSource()) == KeywordInterface {
 			isInterface = true
 			if wasInterface {
 				return nil, p.syntaxError(
 					"expected interface name, got keyword %q",
-					keywordInterface,
+					KeywordInterface,
 				)
 			}
 			// Skip the `interface` keyword
@@ -1057,34 +1057,34 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
 			switch string(p.currentTokenSource()) {
-			case keywordLet, keywordVar:
+			case KeywordLet, KeywordVar:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for variable")
 				}
 				return parseFieldWithVariableKind(p, access, accessPos, docString)
 
-			case keywordCase:
+			case KeywordCase:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for enum case")
 				}
 				return parseEnumCase(p, access, accessPos, docString)
 
-			case keywordFun:
+			case KeywordFun:
 				return parseFunctionDeclaration(p, functionBlockIsOptional, access, accessPos, purity, purityPos, docString)
 
-			case keywordEvent:
+			case KeywordEvent:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for event")
 				}
 				return parseEventDeclaration(p, access, accessPos, docString)
 
-			case keywordStruct, keywordResource, keywordContract, keywordEnum:
+			case KeywordStruct, KeywordResource, KeywordContract, KeywordEnum:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, NewSyntaxError(*purityPos, "invalid view modifier for composite")
 				}
 				return parseCompositeOrInterfaceDeclaration(p, access, accessPos, docString)
 
-			case keywordView:
+			case KeywordView:
 				if purity != ast.FunctionPurityUnspecified {
 					return nil, p.syntaxError("invalid second view modifier")
 				}
@@ -1093,7 +1093,7 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				purity = parsePurityAnnotation(p)
 				continue
 
-			case keywordPriv, keywordPub, keywordAccess:
+			case KeywordPriv, KeywordPub, KeywordAccess:
 				if access != ast.AccessNotSpecified {
 					return nil, p.syntaxError("unexpected access modifier")
 				}
@@ -1217,16 +1217,16 @@ func parseSpecialFunctionDeclaration(
 
 	declarationKind := common.DeclarationKindUnknown
 	switch identifier.Identifier {
-	case keywordInit:
+	case KeywordInit:
 		declarationKind = common.DeclarationKindInitializer
 
-	case keywordDestroy:
+	case KeywordDestroy:
 		if purity == ast.FunctionPurityView {
 			return nil, NewSyntaxError(*purityPos, "invalid view annotation on destructor")
 		}
 		declarationKind = common.DeclarationKindDestructor
 
-	case keywordPrepare:
+	case KeywordPrepare:
 		declarationKind = common.DeclarationKindPrepare
 	}
 

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -790,19 +790,19 @@ func defineIdentifierExpression() {
 		tokenType: lexer.TokenIdentifier,
 		nullDenotation: func(p *parser, token lexer.Token) (ast.Expression, error) {
 			switch string(p.tokenSource(token)) {
-			case keywordTrue:
+			case KeywordTrue:
 				return ast.NewBoolExpression(p.memoryGauge, true, token.Range), nil
 
-			case keywordFalse:
+			case KeywordFalse:
 				return ast.NewBoolExpression(p.memoryGauge, false, token.Range), nil
 
-			case keywordNil:
+			case KeywordNil:
 				return ast.NewNilExpression(p.memoryGauge, token.Range.StartPos), nil
 
-			case keywordCreate:
+			case KeywordCreate:
 				return parseCreateExpressionRemainder(p, token)
 
-			case keywordDestroy:
+			case KeywordDestroy:
 				expression, err := parseExpression(p, lowestBindingPower)
 				if err != nil {
 					return nil, err
@@ -814,16 +814,16 @@ func defineIdentifierExpression() {
 					token.Range.StartPos,
 				), nil
 
-			case keywordView:
+			case KeywordView:
 				// if `view` is followed by `fun`, then it denotes a view function expression
-				if p.isToken(p.current, lexer.TokenIdentifier, keywordFun) {
+				if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
 					p.nextSemanticToken()
 					return parseFunctionExpression(p, token, ast.FunctionPurityView)
 				}
 
 				// otherwise, we treat it as an identifier called "view"
 				break
-			case keywordFun:
+			case KeywordFun:
 				return parseFunctionExpression(p, token, ast.FunctionPurityUnspecified)
 			}
 
@@ -854,7 +854,7 @@ func parseFunctionExpression(p *parser, token lexer.Token, purity ast.FunctionPu
 
 func defineIdentifierLeftDenotations() {
 
-	setExprIdentifierLeftBindingPower(keywordAs, exprLeftBindingPowerCasting)
+	setExprIdentifierLeftBindingPower(KeywordAs, exprLeftBindingPowerCasting)
 	setExprLeftDenotation(
 		lexer.TokenIdentifier,
 		func(parser *parser, t lexer.Token, left ast.Expression) (ast.Expression, error) {
@@ -862,7 +862,7 @@ func defineIdentifierLeftDenotations() {
 			// as this function is called for *any identifier left denotation ("postfix keyword"),
 			// not just for `as`, it might be extended with more cases (keywords) in the future
 			switch string(parser.tokenSource(t)) {
-			case keywordAs:
+			case KeywordAs:
 				right, err := parseTypeAnnotation(parser)
 				if err != nil {
 					return nil, err

--- a/runtime/parser/function.go
+++ b/runtime/parser/function.go
@@ -25,7 +25,7 @@ import (
 
 func parsePurityAnnotation(p *parser) ast.FunctionPurity {
 	// get the purity annotation (if one exists) and skip it
-	if p.isToken(p.current, lexer.TokenIdentifier, keywordView) {
+	if p.isToken(p.current, lexer.TokenIdentifier, KeywordView) {
 		p.nextSemanticToken()
 		return ast.FunctionPurityView
 	}

--- a/runtime/parser/keyword.go
+++ b/runtime/parser/keyword.go
@@ -20,107 +20,107 @@ package parser
 
 // NOTE: ensure to update allKeywords when adding a new keyword
 const (
-	keywordIf          = "if"
-	keywordElse        = "else"
-	keywordWhile       = "while"
-	keywordBreak       = "break"
-	keywordContinue    = "continue"
-	keywordReturn      = "return"
-	keywordTrue        = "true"
-	keywordFalse       = "false"
-	keywordNil         = "nil"
-	keywordLet         = "let"
-	keywordVar         = "var"
-	keywordFun         = "fun"
-	keywordAs          = "as"
-	keywordCreate      = "create"
-	keywordDestroy     = "destroy"
-	keywordFor         = "for"
-	keywordIn          = "in"
-	keywordEmit        = "emit"
-	keywordAuth        = "auth"
-	keywordPriv        = "priv"
-	keywordPub         = "pub"
-	keywordAccess      = "access"
-	keywordSet         = "set"
-	keywordAll         = "all"
-	keywordSelf        = "self"
-	keywordInit        = "init"
-	keywordContract    = "contract"
-	keywordAccount     = "account"
-	keywordImport      = "import"
-	keywordFrom        = "from"
-	keywordPre         = "pre"
-	keywordPost        = "post"
-	keywordEvent       = "event"
-	keywordStruct      = "struct"
-	keywordResource    = "resource"
-	keywordInterface   = "interface"
-	keywordTransaction = "transaction"
-	keywordPrepare     = "prepare"
-	keywordExecute     = "execute"
-	keywordCase        = "case"
-	keywordSwitch      = "switch"
-	keywordDefault     = "default"
-	keywordEnum        = "enum"
-	keywordView        = "view"
+	KeywordIf          = "if"
+	KeywordElse        = "else"
+	KeywordWhile       = "while"
+	KeywordBreak       = "break"
+	KeywordContinue    = "continue"
+	KeywordReturn      = "return"
+	KeywordTrue        = "true"
+	KeywordFalse       = "false"
+	KeywordNil         = "nil"
+	KeywordLet         = "let"
+	KeywordVar         = "var"
+	KeywordFun         = "fun"
+	KeywordAs          = "as"
+	KeywordCreate      = "create"
+	KeywordDestroy     = "destroy"
+	KeywordFor         = "for"
+	KeywordIn          = "in"
+	KeywordEmit        = "emit"
+	KeywordAuth        = "auth"
+	KeywordPriv        = "priv"
+	KeywordPub         = "pub"
+	KeywordAccess      = "access"
+	KeywordSet         = "set"
+	KeywordAll         = "all"
+	KeywordSelf        = "self"
+	KeywordInit        = "init"
+	KeywordContract    = "contract"
+	KeywordAccount     = "account"
+	KeywordImport      = "import"
+	KeywordFrom        = "from"
+	KeywordPre         = "pre"
+	KeywordPost        = "post"
+	KeywordEvent       = "event"
+	KeywordStruct      = "struct"
+	KeywordResource    = "resource"
+	KeywordInterface   = "interface"
+	KeywordTransaction = "transaction"
+	KeywordPrepare     = "prepare"
+	KeywordExecute     = "execute"
+	KeywordCase        = "case"
+	KeywordSwitch      = "switch"
+	KeywordDefault     = "default"
+	KeywordEnum        = "enum"
+	KeywordView        = "view"
 	// NOTE: ensure to update allKeywords when adding a new keyword
 )
 
 var allKeywords = map[string]struct{}{
-	keywordIf:          {},
-	keywordElse:        {},
-	keywordWhile:       {},
-	keywordBreak:       {},
-	keywordContinue:    {},
-	keywordReturn:      {},
-	keywordTrue:        {},
-	keywordFalse:       {},
-	keywordNil:         {},
-	keywordLet:         {},
-	keywordVar:         {},
-	keywordFun:         {},
-	keywordAs:          {},
-	keywordCreate:      {},
-	keywordDestroy:     {},
-	keywordFor:         {},
-	keywordIn:          {},
-	keywordEmit:        {},
-	keywordAuth:        {},
-	keywordPriv:        {},
-	keywordPub:         {},
-	keywordAccess:      {},
-	keywordSet:         {},
-	keywordAll:         {},
-	keywordSelf:        {},
-	keywordInit:        {},
-	keywordContract:    {},
-	keywordAccount:     {},
-	keywordImport:      {},
-	keywordFrom:        {},
-	keywordPre:         {},
-	keywordPost:        {},
-	keywordEvent:       {},
-	keywordStruct:      {},
-	keywordResource:    {},
-	keywordInterface:   {},
-	keywordTransaction: {},
-	keywordPrepare:     {},
-	keywordExecute:     {},
-	keywordCase:        {},
-	keywordSwitch:      {},
-	keywordDefault:     {},
-	keywordEnum:        {},
-	keywordView:        {},
+	KeywordIf:          {},
+	KeywordElse:        {},
+	KeywordWhile:       {},
+	KeywordBreak:       {},
+	KeywordContinue:    {},
+	KeywordReturn:      {},
+	KeywordTrue:        {},
+	KeywordFalse:       {},
+	KeywordNil:         {},
+	KeywordLet:         {},
+	KeywordVar:         {},
+	KeywordFun:         {},
+	KeywordAs:          {},
+	KeywordCreate:      {},
+	KeywordDestroy:     {},
+	KeywordFor:         {},
+	KeywordIn:          {},
+	KeywordEmit:        {},
+	KeywordAuth:        {},
+	KeywordPriv:        {},
+	KeywordPub:         {},
+	KeywordAccess:      {},
+	KeywordSet:         {},
+	KeywordAll:         {},
+	KeywordSelf:        {},
+	KeywordInit:        {},
+	KeywordContract:    {},
+	KeywordAccount:     {},
+	KeywordImport:      {},
+	KeywordFrom:        {},
+	KeywordPre:         {},
+	KeywordPost:        {},
+	KeywordEvent:       {},
+	KeywordStruct:      {},
+	KeywordResource:    {},
+	KeywordInterface:   {},
+	KeywordTransaction: {},
+	KeywordPrepare:     {},
+	KeywordExecute:     {},
+	KeywordCase:        {},
+	KeywordSwitch:      {},
+	KeywordDefault:     {},
+	KeywordEnum:        {},
+	KeywordView:        {},
 }
 
 // Keywords that can be used in identifier position without ambiguity.
 var softKeywords = map[string]struct{}{
-	keywordFrom:    {},
-	keywordAccount: {},
-	keywordSet:     {},
-	keywordAll:     {},
-	keywordView:    {},
+	KeywordFrom:    {},
+	KeywordAccount: {},
+	KeywordSet:     {},
+	KeywordAll:     {},
+	KeywordView:    {},
 }
 
 // Keywords that aren't allowed in identifier position.

--- a/runtime/parser/statement.go
+++ b/runtime/parser/statement.go
@@ -81,30 +81,30 @@ func parseStatement(p *parser) (ast.Statement, error) {
 	switch p.current.Type {
 	case lexer.TokenIdentifier:
 		switch string(p.currentTokenSource()) {
-		case keywordReturn:
+		case KeywordReturn:
 			return parseReturnStatement(p)
-		case keywordBreak:
+		case KeywordBreak:
 			return parseBreakStatement(p), nil
-		case keywordContinue:
+		case KeywordContinue:
 			return parseContinueStatement(p), nil
-		case keywordIf:
+		case KeywordIf:
 			return parseIfStatement(p)
-		case keywordSwitch:
+		case KeywordSwitch:
 			return parseSwitchStatement(p)
-		case keywordWhile:
+		case KeywordWhile:
 			return parseWhileStatement(p)
-		case keywordFor:
+		case KeywordFor:
 			return parseForStatement(p)
-		case keywordEmit:
+		case KeywordEmit:
 			return parseEmitStatement(p)
-		case keywordView:
+		case KeywordView:
 			// save current stream state before looking ahead for the `fun` keyword
 			cursor := p.tokens.Cursor()
 			current := p.current
 			purityPos := current.StartPos
 
 			p.nextSemanticToken()
-			if p.isToken(p.current, lexer.TokenIdentifier, keywordFun) {
+			if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
 				return parseFunctionDeclarationOrFunctionExpressionStatement(p, ast.FunctionPurityView, &purityPos)
 			}
 
@@ -113,7 +113,7 @@ func parseStatement(p *parser) (ast.Statement, error) {
 			p.current = current
 			tokenIsIdentifier = true
 
-		case keywordFun:
+		case KeywordFun:
 			// The `fun` keyword is ambiguous: it either introduces a function expression
 			// or a function declaration, depending on if an identifier follows, or not.
 			return parseFunctionDeclarationOrFunctionExpressionStatement(p, ast.FunctionPurityUnspecified, nil)
@@ -292,7 +292,7 @@ func parseIfStatement(p *parser) (*ast.IfStatement, error) {
 
 		if p.current.Type == lexer.TokenIdentifier {
 			switch string(p.currentTokenSource()) {
-			case keywordLet, keywordVar:
+			case KeywordLet, KeywordVar:
 				variableDeclaration, err =
 					parseVariableDeclaration(p, ast.AccessNotSpecified, nil, "")
 				if err != nil {
@@ -320,9 +320,9 @@ func parseIfStatement(p *parser) (*ast.IfStatement, error) {
 		parseNested := false
 
 		p.skipSpaceAndComments()
-		if p.isToken(p.current, lexer.TokenIdentifier, keywordElse) {
+		if p.isToken(p.current, lexer.TokenIdentifier, KeywordElse) {
 			p.nextSemanticToken()
-			if p.isToken(p.current, lexer.TokenIdentifier, keywordIf) {
+			if p.isToken(p.current, lexer.TokenIdentifier, KeywordIf) {
 				parseNested = true
 			} else {
 				elseBlock, err = parseBlock(p)
@@ -401,10 +401,10 @@ func parseForStatement(p *parser) (*ast.ForStatement, error) {
 	startPos := p.current.StartPos
 	p.nextSemanticToken()
 
-	if p.isToken(p.current, lexer.TokenIdentifier, keywordIn) {
+	if p.isToken(p.current, lexer.TokenIdentifier, KeywordIn) {
 		p.reportSyntaxError(
 			"expected identifier, got keyword %q",
-			keywordIn,
+			KeywordIn,
 		)
 		p.next()
 	}
@@ -432,10 +432,10 @@ func parseForStatement(p *parser) (*ast.ForStatement, error) {
 		identifier = firstValue
 	}
 
-	if !p.isToken(p.current, lexer.TokenIdentifier, keywordIn) {
+	if !p.isToken(p.current, lexer.TokenIdentifier, KeywordIn) {
 		p.reportSyntaxError(
 			"expected keyword %q, got %s",
-			keywordIn,
+			KeywordIn,
 			p.current.Type,
 		)
 	}
@@ -502,7 +502,7 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	p.skipSpaceAndComments()
 
 	var preConditions *ast.Conditions
-	if p.isToken(p.current, lexer.TokenIdentifier, keywordPre) {
+	if p.isToken(p.current, lexer.TokenIdentifier, KeywordPre) {
 		p.next()
 		conditions, err := parseConditions(p, ast.ConditionKindPre)
 		if err != nil {
@@ -515,7 +515,7 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	p.skipSpaceAndComments()
 
 	var postConditions *ast.Conditions
-	if p.isToken(p.current, lexer.TokenIdentifier, keywordPost) {
+	if p.isToken(p.current, lexer.TokenIdentifier, KeywordPost) {
 		p.next()
 		conditions, err := parseConditions(p, ast.ConditionKindPost)
 		if err != nil {
@@ -678,8 +678,8 @@ func parseSwitchCases(p *parser) (cases []*ast.SwitchCase, err error) {
 		p.reportSyntaxError(
 			"unexpected token: got %s, expected %q or %q",
 			p.current.Type,
-			keywordCase,
-			keywordDefault,
+			KeywordCase,
+			KeywordDefault,
 		)
 		p.next()
 	}
@@ -692,10 +692,10 @@ func parseSwitchCases(p *parser) (cases []*ast.SwitchCase, err error) {
 
 			var switchCase *ast.SwitchCase
 			switch string(p.currentTokenSource()) {
-			case keywordCase:
+			case KeywordCase:
 				switchCase, err = parseSwitchCase(p, true)
 
-			case keywordDefault:
+			case KeywordDefault:
 				switchCase, err = parseSwitchCase(p, false)
 
 			default:
@@ -761,7 +761,7 @@ func parseSwitchCase(p *parser, hasExpression bool) (*ast.SwitchCase, error) {
 
 		case lexer.TokenIdentifier:
 			switch string(p.currentTokenSource()) {
-			case keywordCase, keywordDefault:
+			case KeywordCase, KeywordDefault:
 				return true
 			default:
 				return false

--- a/runtime/parser/transaction.go
+++ b/runtime/parser/transaction.go
@@ -82,7 +82,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 		keyword := p.currentTokenSource()
 
 		switch string(keyword) {
-		case keywordPrepare:
+		case KeywordPrepare:
 			identifier := p.tokenToIdentifier(p.current)
 			// Skip the `prepare` keyword
 			p.next()
@@ -99,7 +99,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 				return nil, err
 			}
 
-		case keywordExecute:
+		case KeywordExecute:
 			execute, err = parseTransactionExecute(p)
 			if err != nil {
 				return nil, err
@@ -108,8 +108,8 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 		default:
 			return nil, p.syntaxError(
 				"unexpected identifier, expected keyword %q or %q, got %q",
-				keywordPrepare,
-				keywordExecute,
+				KeywordPrepare,
+				KeywordExecute,
 				keyword,
 			)
 		}
@@ -121,7 +121,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 
 	if execute == nil {
 		p.skipSpaceAndComments()
-		if p.isToken(p.current, lexer.TokenIdentifier, keywordPre) {
+		if p.isToken(p.current, lexer.TokenIdentifier, KeywordPre) {
 			// Skip the `pre` keyword
 			p.next()
 			conditions, err := parseConditions(p, ast.ConditionKindPre)
@@ -149,9 +149,9 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 
 			keyword := p.currentTokenSource()
 			switch string(keyword) {
-			case keywordExecute:
+			case KeywordExecute:
 				if execute != nil {
-					return nil, p.syntaxError("unexpected second %q block", keywordExecute)
+					return nil, p.syntaxError("unexpected second %q block", KeywordExecute)
 				}
 
 				execute, err = parseTransactionExecute(p)
@@ -159,7 +159,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 					return nil, err
 				}
 
-			case keywordPost:
+			case KeywordPost:
 				if sawPost {
 					return nil, p.syntaxError("unexpected second post-conditions")
 				}
@@ -176,8 +176,8 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 			default:
 				return nil, p.syntaxError(
 					"unexpected identifier, expected keyword %q or %q, got %q",
-					keywordExecute,
-					keywordPost,
+					KeywordExecute,
+					KeywordPost,
 					keyword,
 				)
 			}
@@ -228,7 +228,7 @@ func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration, err erro
 
 		case lexer.TokenIdentifier:
 			switch string(p.currentTokenSource()) {
-			case keywordLet, keywordVar:
+			case KeywordLet, KeywordVar:
 				field, err := parseFieldWithVariableKind(p, ast.AccessNotSpecified, nil, docString)
 				if err != nil {
 					return nil, err

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -156,7 +156,7 @@ func init() {
 		func(p *parser, token lexer.Token) (ast.Type, error) {
 
 			switch string(p.tokenSource(token)) {
-			case keywordAuth:
+			case KeywordAuth:
 				p.skipSpaceAndComments()
 
 				_, err := p.mustOne(lexer.TokenAmpersand)


### PR DESCRIPTION
Work towards #2084 

## Description

#1937 accidentally unexported the `transaction` keyword:
https://github.com/onflow/cadence/pull/1937/files#diff-d4f2e1652a85c54fe0afb9d6c1ae50164d96d7051160e201669e9d6699e5bc2eL58-R58

Bring the export back and export all other keywords.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
