### PR TITLE
Remove outdated callout from the testing-framework docs

### DIFF
--- a/docs/testing-framework.mdx
+++ b/docs/testing-framework.mdx
@@ -9,10 +9,6 @@ This functionality is provided by the built-in `Test` contract.
 The testing framework can only be used off-chain, e.g. by using the [Flow CLI](https://developers.flow.com/tools/flow-cli).
 </Callout>
 
-<Callout type="info">
-🚧 Status: This will be available in a future version of the CLI.
-</Callout>
-
 Tests must be written in the form of a Cadence script.
 A test script may contain testing functions that starts with the `test` prefix,
 a `setup` function that will always run before the tests,


### PR DESCRIPTION
## Description

Testing framework is now available in the latest version of the CLI. Hence remove the callout.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
