### PR TITLE
Report invalid identifier preceding a member or nested declaration

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -1020,6 +1020,14 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
+			if previousIdentifierToken != nil {
+				return nil, NewSyntaxError(
+					previousIdentifierToken.StartPos,
+					"unexpected %s",
+					previousIdentifierToken.Type,
+				)
+			}
+
 			switch string(p.currentTokenSource()) {
 			case keywordLet, keywordVar:
 				return parseFieldWithVariableKind(p, access, accessPos, docString)
@@ -1051,10 +1059,6 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				continue
 
 			default:
-				if previousIdentifierToken != nil {
-					return nil, p.syntaxError("unexpected %s", p.current.Type)
-				}
-
 				t := p.current
 				previousIdentifierToken = &t
 				// Skip the identifier

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -3448,6 +3448,30 @@ func TestParseStructureWithConformances(t *testing.T) {
 	)
 }
 
+func TestParseInvalidMember(t *testing.T) {
+
+	t.Parallel()
+
+	const code = `
+        struct Test {
+            foo let x: Int
+        }
+	`
+
+	_, errs := testParseDeclarations(code)
+
+	utils.AssertEqualWithDiff(t,
+		[]error{
+			&SyntaxError{
+				Message: "unexpected identifier",
+				Pos:     ast.Position{Offset: 35, Line: 3, Column: 12},
+			},
+		},
+		errs,
+	)
+
+}
+
 func TestParsePreAndPostConditions(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
## Description

While working on #2119 I noticed that the parser currently ignores an invalid identifier preceding a member or nested declaration.

Report the invalid identifier instead of ignoring it.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
