### PR TITLE
Improve error messages for values/types that cannot be imported or exported

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -195,9 +195,7 @@ func (e *InvalidValueTypeError) Error() string {
 // InvalidScriptReturnTypeError is an error that is reported for
 // invalid script return types.
 //
-// For example, the type `Int` is valid,
-// whereas a function type is not,
-// because it cannot be exported/serialized.
+// A type is invalid if it cannot be exported / returned externally.
 type InvalidScriptReturnTypeError struct {
 	Type sema.Type
 }
@@ -210,6 +208,23 @@ func (e *InvalidScriptReturnTypeError) Error() string {
 	return fmt.Sprintf(
 		"invalid script return type: `%s`",
 		e.Type.QualifiedString(),
+	)
+}
+
+// ValueNotExportableError is an error that is reported for
+// values that cannot be exported.
+type ValueNotExportableError struct {
+	Type interpreter.StaticType
+}
+
+var _ errors.UserError = &ValueNotExportableError{}
+
+func (*ValueNotExportableError) IsUserError() {}
+
+func (e *ValueNotExportableError) Error() string {
+	return fmt.Sprintf(
+		"value of type `%s` cannot be exported",
+		e.Type.String(),
 	)
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7514,7 +7514,7 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 	}
 }
 
-func TestImportingTestStdlib(t *testing.T) {
+func TestRuntimeImportTestStdlib(t *testing.T) {
 
 	t.Parallel()
 
@@ -7545,4 +7545,32 @@ func TestImportingTestStdlib(t *testing.T) {
 	notDeclaredErr := &sema.NotDeclaredError{}
 	require.ErrorAs(t, errs[0], &notDeclaredErr)
 	assert.Equal(t, "Test", notDeclaredErr.Name)
+}
+
+func TestRuntime(t *testing.T) {
+
+	t.Parallel()
+
+	rt := newTestInterpreterRuntime()
+
+	runtimeInterface := &testRuntimeInterface{}
+
+	_, err := rt.ExecuteScript(
+		Script{
+			Source: []byte(`
+			    pub fun main(): AnyStruct {
+			        return getCurrentBlock()
+			    }
+			`),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  TestLocation,
+		},
+	)
+
+	RequireError(t, err)
+
+	var subErr *ValueNotExportableError
+	require.ErrorAs(t, err, &subErr)
 }

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -149,7 +149,7 @@ func (executor *interpreterScriptExecutor) preprocess() (err error) {
 
 	// Ensure the entry point's return type is valid
 	returnType := functionEntryPointType.ReturnTypeAnnotation.Type
-	if !returnType.IsExternallyReturnable(map[*sema.Member]bool{}) {
+	if !returnType.IsExportable(map[*sema.Member]bool{}) {
 		err = &InvalidScriptReturnTypeError{
 			Type: returnType,
 		}

--- a/runtime/sema/any_type.go
+++ b/runtime/sema/any_type.go
@@ -30,6 +30,6 @@ var AnyType = &SimpleType{
 	Storable:  true,
 	Equatable: false,
 	// `Any` is never a valid type in user programs
-	ExternallyReturnable: false,
-	Importable:           false,
+	Exportable: false,
+	Importable: false,
 }

--- a/runtime/sema/anyresource_type.go
+++ b/runtime/sema/anyresource_type.go
@@ -29,6 +29,6 @@ var AnyResourceType = &SimpleType{
 	Storable:  true,
 	Equatable: false,
 	// The actual returnability of a value is checked at run-time
-	ExternallyReturnable: true,
-	Importable:           false,
+	Exportable: true,
+	Importable: false,
 }

--- a/runtime/sema/anystruct_type.go
+++ b/runtime/sema/anystruct_type.go
@@ -26,9 +26,9 @@ var AnyStructType = &SimpleType{
 	tag:           AnyStructTypeTag,
 	IsResource:    false,
 	// The actual storability of a value is checked at run-time
-	Storable:             true,
-	Equatable:            false,
-	ExternallyReturnable: true,
+	Storable:   true,
+	Equatable:  false,
+	Exportable: true,
 	// The actual importability is checked at runtime
 	Importable: true,
 }

--- a/runtime/sema/block.go
+++ b/runtime/sema/block.go
@@ -25,15 +25,15 @@ import (
 
 // BlockType
 var BlockType = &SimpleType{
-	Name:                 "Block",
-	QualifiedName:        "Block",
-	TypeID:               "Block",
-	tag:                  BlockTypeTag,
-	IsResource:           false,
-	Storable:             false,
-	Equatable:            false,
-	ExternallyReturnable: false,
-	Importable:           false,
+	Name:          "Block",
+	QualifiedName: "Block",
+	TypeID:        "Block",
+	tag:           BlockTypeTag,
+	IsResource:    false,
+	Storable:      false,
+	Equatable:     false,
+	Exportable:    false,
+	Importable:    false,
 	Members: func(t *SimpleType) map[string]MemberResolver {
 		return map[string]MemberResolver{
 			BlockTypeHeightFieldName: {
@@ -79,7 +79,7 @@ var BlockType = &SimpleType{
 						memoryGauge,
 						t,
 						identifier,
-						blockIDFieldType,
+						BlockTypeIDFieldType,
 						blockTypeIDFieldDocString,
 					)
 				},
@@ -90,7 +90,7 @@ var BlockType = &SimpleType{
 
 const BlockIDSize = 32
 
-var blockIDFieldType = &ConstantSizedType{
+var BlockTypeIDFieldType = &ConstantSizedType{
 	Type: UInt8Type,
 	Size: BlockIDSize,
 }

--- a/runtime/sema/bool_type.go
+++ b/runtime/sema/bool_type.go
@@ -20,13 +20,13 @@ package sema
 
 // BoolType represents the boolean type
 var BoolType = &SimpleType{
-	Name:                 "Bool",
-	QualifiedName:        "Bool",
-	TypeID:               "Bool",
-	tag:                  BoolTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "Bool",
+	QualifiedName: "Bool",
+	TypeID:        "Bool",
+	tag:           BoolTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 }

--- a/runtime/sema/character_type.go
+++ b/runtime/sema/character_type.go
@@ -27,15 +27,15 @@ import (
 
 // CharacterType represents the character type
 var CharacterType = &SimpleType{
-	Name:                 "Character",
-	QualifiedName:        "Character",
-	TypeID:               "Character",
-	tag:                  CharacterTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "Character",
+	QualifiedName: "Character",
+	TypeID:        "Character",
+	tag:           CharacterTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 }
 
 func IsValidCharacter(s string) bool {

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -25,15 +25,15 @@ import (
 
 // DeployedContractType represents the type `DeployedContract`
 var DeployedContractType = &SimpleType{
-	Name:                 "DeployedContract",
-	QualifiedName:        "DeployedContract",
-	TypeID:               "DeployedContract",
-	tag:                  DeployedContractTypeTag,
-	IsResource:           false,
-	Storable:             false,
-	Equatable:            false,
-	ExternallyReturnable: false,
-	Importable:           false,
+	Name:          "DeployedContract",
+	QualifiedName: "DeployedContract",
+	TypeID:        "DeployedContract",
+	tag:           DeployedContractTypeTag,
+	IsResource:    false,
+	Storable:      false,
+	Equatable:     false,
+	Exportable:    false,
+	Importable:    false,
 	Members: func(t *SimpleType) map[string]MemberResolver {
 		return map[string]MemberResolver{
 			DeployedContractTypeAddressFieldName: {

--- a/runtime/sema/invalid_type.go
+++ b/runtime/sema/invalid_type.go
@@ -22,13 +22,13 @@ package sema
 // It is the result of type checking failing and
 // can't be expressed in programs.
 var InvalidType = &SimpleType{
-	Name:                 "<<invalid>>",
-	QualifiedName:        "<<invalid>>",
-	TypeID:               "<<invalid>>",
-	tag:                  InvalidTypeTag,
-	IsResource:           false,
-	Storable:             false,
-	Equatable:            false,
-	ExternallyReturnable: false,
-	Importable:           false,
+	Name:          "<<invalid>>",
+	QualifiedName: "<<invalid>>",
+	TypeID:        "<<invalid>>",
+	tag:           InvalidTypeTag,
+	IsResource:    false,
+	Storable:      false,
+	Equatable:     false,
+	Exportable:    false,
+	Importable:    false,
 }

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -35,15 +35,15 @@ const MetaTypeName = "Type"
 
 // MetaType represents the type of a type.
 var MetaType = &SimpleType{
-	Name:                 MetaTypeName,
-	QualifiedName:        MetaTypeName,
-	TypeID:               MetaTypeName,
-	tag:                  MetaTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          MetaTypeName,
+	QualifiedName: MetaTypeName,
+	TypeID:        MetaTypeName,
+	tag:           MetaTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 }
 
 var MetaTypeIsSubtypeFunctionType = &FunctionType{

--- a/runtime/sema/never_type.go
+++ b/runtime/sema/never_type.go
@@ -20,13 +20,13 @@ package sema
 
 // NeverType represents the bottom type
 var NeverType = &SimpleType{
-	Name:                 "Never",
-	QualifiedName:        "Never",
-	TypeID:               "Never",
-	tag:                  NeverTypeTag,
-	IsResource:           false,
-	Storable:             false,
-	Equatable:            false,
-	ExternallyReturnable: false,
-	Importable:           false,
+	Name:          "Never",
+	QualifiedName: "Never",
+	TypeID:        "Never",
+	tag:           NeverTypeTag,
+	IsResource:    false,
+	Storable:      false,
+	Equatable:     false,
+	Exportable:    false,
+	Importable:    false,
 }

--- a/runtime/sema/path_type.go
+++ b/runtime/sema/path_type.go
@@ -20,15 +20,15 @@ package sema
 
 // PathType
 var PathType = &SimpleType{
-	Name:                 "Path",
-	QualifiedName:        "Path",
-	TypeID:               "Path",
-	tag:                  PathTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "Path",
+	QualifiedName: "Path",
+	TypeID:        "Path",
+	tag:           PathTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 	IsSuperTypeOf: func(subType Type) bool {
 		return IsSubType(subType, StoragePathType) ||
 			IsSubType(subType, CapabilityPathType)
@@ -37,28 +37,28 @@ var PathType = &SimpleType{
 
 // StoragePathType
 var StoragePathType = &SimpleType{
-	Name:                 "StoragePath",
-	QualifiedName:        "StoragePath",
-	TypeID:               "StoragePath",
-	tag:                  StoragePathTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "StoragePath",
+	QualifiedName: "StoragePath",
+	TypeID:        "StoragePath",
+	tag:           StoragePathTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 }
 
 // CapabilityPathType
 var CapabilityPathType = &SimpleType{
-	Name:                 "CapabilityPath",
-	QualifiedName:        "CapabilityPath",
-	TypeID:               "CapabilityPath",
-	tag:                  CapabilityPathTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "CapabilityPath",
+	QualifiedName: "CapabilityPath",
+	TypeID:        "CapabilityPath",
+	tag:           CapabilityPathTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 	IsSuperTypeOf: func(subType Type) bool {
 		return IsSubType(subType, PrivatePathType) ||
 			IsSubType(subType, PublicPathType)
@@ -67,26 +67,26 @@ var CapabilityPathType = &SimpleType{
 
 // PublicPathType
 var PublicPathType = &SimpleType{
-	Name:                 "PublicPath",
-	QualifiedName:        "PublicPath",
-	TypeID:               "PublicPath",
-	tag:                  PublicPathTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "PublicPath",
+	QualifiedName: "PublicPath",
+	TypeID:        "PublicPath",
+	tag:           PublicPathTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 }
 
 // PrivatePathType
 var PrivatePathType = &SimpleType{
-	Name:                 "PrivatePath",
-	QualifiedName:        "PrivatePath",
-	TypeID:               "PrivatePath",
-	tag:                  PrivatePathTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "PrivatePath",
+	QualifiedName: "PrivatePath",
+	TypeID:        "PrivatePath",
+	tag:           PrivatePathTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 }

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -33,21 +33,21 @@ type ValueIndexingInfo struct {
 
 // SimpleType represents a simple nominal type.
 type SimpleType struct {
-	Name                 string
-	QualifiedName        string
-	TypeID               TypeID
-	tag                  TypeTag
-	IsResource           bool
-	Storable             bool
-	Equatable            bool
-	ExternallyReturnable bool
-	Importable           bool
-	IsSuperTypeOf        func(subType Type) bool
-	Members              func(*SimpleType) map[string]MemberResolver
-	members              map[string]MemberResolver
-	membersOnce          sync.Once
-	NestedTypes          *StringTypeOrderedMap
-	ValueIndexingInfo    ValueIndexingInfo
+	Name              string
+	QualifiedName     string
+	TypeID            TypeID
+	tag               TypeTag
+	IsResource        bool
+	Storable          bool
+	Equatable         bool
+	Exportable        bool
+	Importable        bool
+	IsSuperTypeOf     func(subType Type) bool
+	Members           func(*SimpleType) map[string]MemberResolver
+	members           map[string]MemberResolver
+	membersOnce       sync.Once
+	NestedTypes       *StringTypeOrderedMap
+	ValueIndexingInfo ValueIndexingInfo
 }
 
 func (*SimpleType) IsType() {}
@@ -88,8 +88,8 @@ func (t *SimpleType) IsEquatable() bool {
 	return t.Equatable
 }
 
-func (t *SimpleType) IsExternallyReturnable(_ map[*Member]bool) bool {
-	return t.ExternallyReturnable
+func (t *SimpleType) IsExportable(_ map[*Member]bool) bool {
+	return t.Exportable
 }
 
 func (t *SimpleType) IsImportable(_ map[*Member]bool) bool {

--- a/runtime/sema/storable_type.go
+++ b/runtime/sema/storable_type.go
@@ -33,11 +33,11 @@ var StorableType = &SimpleType{
 	// only used as e.g. a type bound, but is not accessible
 	// to user programs, i.e. can't be used in type annotations
 	// for e.g. parameters, return types, fields, etc.
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            false,
-	ExternallyReturnable: false,
-	Importable:           false,
+	IsResource: false,
+	Storable:   true,
+	Equatable:  false,
+	Exportable: false,
+	Importable: false,
 	IsSuperTypeOf: func(subType Type) bool {
 		storableResults := map[*Member]bool{}
 		return subType.IsStorable(storableResults)

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -41,15 +41,15 @@ Returns a string from the given array of characters
 
 // StringType represents the string type
 var StringType = &SimpleType{
-	Name:                 "String",
-	QualifiedName:        "String",
-	TypeID:               "String",
-	tag:                  StringTypeTag,
-	IsResource:           false,
-	Storable:             true,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           true,
+	Name:          "String",
+	QualifiedName: "String",
+	TypeID:        "String",
+	tag:           StringTypeTag,
+	IsResource:    false,
+	Storable:      true,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    true,
 	ValueIndexingInfo: ValueIndexingInfo{
 		IsValueIndexableType:          true,
 		AllowsValueIndexingAssignment: false,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -117,13 +117,13 @@ type Type interface {
 	// and pre-set before a recursive call.
 	IsStorable(results map[*Member]bool) bool
 
-	// IsExternallyReturnable returns true if a value of this type can be exported
+	// IsExportable returns true if a value of this type can be exported.
 	//
-	// The check if the type is externally returnable is recursive,
+	// The check if the type is exportable is recursive,
 	// the results parameter prevents cycles:
 	// it is checked at the start of the recursively called function,
 	// and pre-set before a recursive call.
-	IsExternallyReturnable(results map[*Member]bool) bool
+	IsExportable(results map[*Member]bool) bool
 
 	// IsImportable returns true if values of the type can be imported to a program as arguments
 	IsImportable(results map[*Member]bool) bool
@@ -548,8 +548,8 @@ func (t *OptionalType) IsStorable(results map[*Member]bool) bool {
 	return t.Type.IsStorable(results)
 }
 
-func (t *OptionalType) IsExternallyReturnable(results map[*Member]bool) bool {
-	return t.Type.IsExternallyReturnable(results)
+func (t *OptionalType) IsExportable(results map[*Member]bool) bool {
+	return t.Type.IsExportable(results)
 }
 
 func (t *OptionalType) IsImportable(results map[*Member]bool) bool {
@@ -726,7 +726,7 @@ func (*GenericType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
-func (*GenericType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (*GenericType) IsExportable(_ map[*Member]bool) bool {
 	return false
 }
 
@@ -1005,7 +1005,7 @@ func (*NumericType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
-func (*NumericType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (*NumericType) IsExportable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -1194,7 +1194,7 @@ func (*FixedPointNumericType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
-func (*FixedPointNumericType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (*FixedPointNumericType) IsExportable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -2122,8 +2122,8 @@ func (t *VariableSizedType) IsStorable(results map[*Member]bool) bool {
 	return t.Type.IsStorable(results)
 }
 
-func (t *VariableSizedType) IsExternallyReturnable(results map[*Member]bool) bool {
-	return t.Type.IsExternallyReturnable(results)
+func (t *VariableSizedType) IsExportable(results map[*Member]bool) bool {
+	return t.Type.IsExportable(results)
 }
 
 func (t *VariableSizedType) IsImportable(results map[*Member]bool) bool {
@@ -2261,7 +2261,7 @@ func (t *ConstantSizedType) IsStorable(results map[*Member]bool) bool {
 	return t.Type.IsStorable(results)
 }
 
-func (t *ConstantSizedType) IsExternallyReturnable(results map[*Member]bool) bool {
+func (t *ConstantSizedType) IsExportable(results map[*Member]bool) bool {
 	return t.Type.IsStorable(results)
 }
 
@@ -2717,7 +2717,7 @@ func (t *FunctionType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
-func (t *FunctionType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (t *FunctionType) IsExportable(_ map[*Member]bool) bool {
 	// Even though functions cannot be serialized,
 	// they are still treated as exportable,
 	// as values are simply omitted.
@@ -3646,7 +3646,7 @@ func (t *CompositeType) IsImportable(results map[*Member]bool) bool {
 	return true
 }
 
-func (t *CompositeType) IsExternallyReturnable(results map[*Member]bool) bool {
+func (t *CompositeType) IsExportable(results map[*Member]bool) bool {
 	// Only structures, resources, and enums can be stored
 
 	switch t.Kind {
@@ -3658,11 +3658,11 @@ func (t *CompositeType) IsExternallyReturnable(results map[*Member]bool) bool {
 		return false
 	}
 
-	// If this composite type has a member which is not externally returnable,
-	// then the composite type is not externally returnable.
+	// If this composite type has a member which is not exportable,
+	// then the composite type is not exportable.
 
 	for p := t.Members.Oldest(); p != nil; p = p.Next() {
-		if !p.Value.IsExternallyReturnable(results) {
+		if !p.Value.IsExportable(results) {
 			return false
 		}
 	}
@@ -3888,10 +3888,10 @@ func (m *Member) IsStorable(results map[*Member]bool) (result bool) {
 	return m.testType(test, results)
 }
 
-// IsExternallyReturnable returns whether a member is externally returnable
-func (m *Member) IsExternallyReturnable(results map[*Member]bool) (result bool) {
+// IsExportable returns whether a member is exportable
+func (m *Member) IsExportable(results map[*Member]bool) (result bool) {
 	test := func(t Type) bool {
-		return t.IsExternallyReturnable(results)
+		return t.IsExportable(results)
 	}
 	return m.testType(test, results)
 }
@@ -4109,17 +4109,17 @@ func (t *InterfaceType) IsStorable(results map[*Member]bool) bool {
 	return true
 }
 
-func (t *InterfaceType) IsExternallyReturnable(results map[*Member]bool) bool {
+func (t *InterfaceType) IsExportable(results map[*Member]bool) bool {
 
 	if t.CompositeKind != common.CompositeKindStructure {
 		return false
 	}
 
-	// If this interface type has a member which is not externally returnable,
-	// then the interface type is not externally returnable.
+	// If this interface type has a member which is not exportable,
+	// then the interface type is not exportable.
 
 	for pair := t.Members.Oldest(); pair != nil; pair = pair.Next() {
-		if !pair.Value.IsExternallyReturnable(results) {
+		if !pair.Value.IsExportable(results) {
 			return false
 		}
 	}
@@ -4268,9 +4268,9 @@ func (t *DictionaryType) IsStorable(results map[*Member]bool) bool {
 		t.ValueType.IsStorable(results)
 }
 
-func (t *DictionaryType) IsExternallyReturnable(results map[*Member]bool) bool {
-	return t.KeyType.IsExternallyReturnable(results) &&
-		t.ValueType.IsExternallyReturnable(results)
+func (t *DictionaryType) IsExportable(results map[*Member]bool) bool {
+	return t.KeyType.IsExportable(results) &&
+		t.ValueType.IsExportable(results)
 }
 
 func (t *DictionaryType) IsImportable(results map[*Member]bool) bool {
@@ -4692,7 +4692,7 @@ func (t *ReferenceType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
-func (t *ReferenceType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (t *ReferenceType) IsExportable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -4808,7 +4808,7 @@ func (*AddressType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
-func (*AddressType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (*AddressType) IsExportable(_ map[*Member]bool) bool {
 	return true
 }
 
@@ -5652,7 +5652,7 @@ func (*TransactionType) IsStorable(_ map[*Member]bool) bool {
 	return false
 }
 
-func (*TransactionType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (*TransactionType) IsExportable(_ map[*Member]bool) bool {
 	return false
 }
 
@@ -5838,13 +5838,13 @@ func (t *RestrictedType) IsStorable(results map[*Member]bool) bool {
 	return true
 }
 
-func (t *RestrictedType) IsExternallyReturnable(results map[*Member]bool) bool {
-	if t.Type != nil && !t.Type.IsExternallyReturnable(results) {
+func (t *RestrictedType) IsExportable(results map[*Member]bool) bool {
+	if t.Type != nil && !t.Type.IsExportable(results) {
 		return false
 	}
 
 	for _, restriction := range t.Restrictions {
-		if !restriction.IsExternallyReturnable(results) {
+		if !restriction.IsExportable(results) {
 			return false
 		}
 	}
@@ -6025,7 +6025,7 @@ func (*CapabilityType) IsStorable(_ map[*Member]bool) bool {
 	return true
 }
 
-func (*CapabilityType) IsExternallyReturnable(_ map[*Member]bool) bool {
+func (*CapabilityType) IsExportable(_ map[*Member]bool) bool {
 	return true
 }
 

--- a/runtime/sema/void_type.go
+++ b/runtime/sema/void_type.go
@@ -20,13 +20,13 @@ package sema
 
 // VoidType represents the void type
 var VoidType = &SimpleType{
-	Name:                 "Void",
-	QualifiedName:        "Void",
-	TypeID:               "Void",
-	tag:                  VoidTypeTag,
-	IsResource:           false,
-	Storable:             false,
-	Equatable:            true,
-	ExternallyReturnable: true,
-	Importable:           false,
+	Name:          "Void",
+	QualifiedName: "Void",
+	TypeID:        "Void",
+	tag:           VoidTypeTag,
+	IsResource:    false,
+	Storable:      false,
+	Equatable:     true,
+	Exportable:    true,
+	Importable:    false,
 }


### PR DESCRIPTION
## Description

Some values cannot be exported, like `Block`, and some values cannot be imported, like functions.

Report errors for exports of non-exportable values, and errors for imports of non-importable values as user errors, instead of implementation errors.

Also, simplify the export of composite and simple composite values, and naming.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
