### PR TITLE
Update Stable Cadence branch, fix view function expression parsing

### DIFF
--- a/docs/testing-framework.mdx
+++ b/docs/testing-framework.mdx
@@ -9,10 +9,6 @@ This functionality is provided by the built-in `Test` contract.
 The testing framework can only be used off-chain, e.g. by using the [Flow CLI](https://developers.flow.com/tools/flow-cli).
 </Callout>
 
-<Callout type="info">
-🚧 Status: This will be available in a future version of the CLI.
-</Callout>
-
 Tests must be written in the form of a Cadence script.
 A test script may contain testing functions that starts with the `test` prefix,
 a `setup` function that will always run before the tests,

--- a/fuzz.go
+++ b/fuzz.go
@@ -32,7 +32,7 @@ func Fuzz(data []byte) int {
 		return 0
 	}
 
-	program, err := parser.ParseProgram(data, nil)
+	program, err := parser.ParseProgram(nil, data, parser.Config{})
 
 	if err != nil {
 		return 0

--- a/runtime/ast/composite_test.go
+++ b/runtime/ast/composite_test.go
@@ -35,6 +35,7 @@ func TestFieldDeclaration_MarshalJSON(t *testing.T) {
 
 	decl := &FieldDeclaration{
 		Access:       AccessPublic,
+		Flags:        FieldDeclarationFlagsIsStatic | FieldDeclarationFlagsIsNative,
 		VariableKind: VariableKindConstant,
 		Identifier: Identifier{
 			Identifier: "xyz",
@@ -61,10 +62,13 @@ func TestFieldDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "FieldDeclaration",
             "Access": "AccessPublic",
+            "IsStatic": true,
+            "IsNative": true,
             "VariableKind": "VariableKindConstant",
             "Identifier": {
                 "Identifier": "xyz",
@@ -99,13 +103,14 @@ func TestFieldDeclaration_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("with access, with kind", func(t *testing.T) {
+	t.Run("with access, with kind, with static, with native", func(t *testing.T) {
 
 		t.Parallel()
 
 		decl := &FieldDeclaration{
 			Access:       AccessPublic,
 			VariableKind: VariableKindConstant,
+			Flags:        FieldDeclarationFlagsIsNative | FieldDeclarationFlagsIsStatic,
 			Identifier: Identifier{
 				Identifier: "xyz",
 			},
@@ -124,6 +129,10 @@ func TestFieldDeclaration_Doc(t *testing.T) {
 			prettier.Group{
 				Doc: prettier.Concat{
 					prettier.Text("pub"),
+					prettier.Text(" "),
+					prettier.Text("static"),
+					prettier.Text(" "),
+					prettier.Text("native"),
 					prettier.Text(" "),
 					prettier.Text("let"),
 					prettier.Text(" "),
@@ -403,6 +412,7 @@ func TestCompositeDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "CompositeDeclaration",

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1395,6 +1395,8 @@ var functionExpressionEmptyBlockDoc prettier.Doc = prettier.Text(" {}")
 func FunctionDocument(
 	access Access,
 	purity FunctionPurity,
+	isStatic bool,
+	isNative bool,
 	includeKeyword bool,
 	identifier string,
 	parameterList *ParameterList,
@@ -1434,6 +1436,22 @@ func FunctionDocument(
 		doc = append(
 			doc,
 			prettier.Text(purity.Keyword()),
+			prettier.Space,
+		)
+	}
+
+	if isStatic {
+		doc = append(
+			doc,
+			staticKeywordDoc,
+			prettier.Space,
+		)
+	}
+
+	if isNative {
+		doc = append(
+			doc,
+			nativeKeywordDoc,
 			prettier.Space,
 		)
 	}
@@ -1478,6 +1496,8 @@ func (e *FunctionExpression) Doc() prettier.Doc {
 	return FunctionDocument(
 		AccessNotSpecified,
 		e.Purity,
+		false,
+		false,
 		true,
 		"",
 		e.ParameterList,

--- a/runtime/ast/function_declaration_test.go
+++ b/runtime/ast/function_declaration_test.go
@@ -35,6 +35,7 @@ func TestFunctionDeclaration_MarshalJSON(t *testing.T) {
 
 	decl := &FunctionDeclaration{
 		Access: AccessPublic,
+		Flags:  FunctionDeclarationFlagsIsStatic | FunctionDeclarationFlagsIsNative,
 		Identifier: Identifier{
 			Identifier: "xyz",
 			Pos:        Position{Offset: 37, Line: 38, Column: 39},
@@ -94,10 +95,13 @@ func TestFunctionDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "FunctionDeclaration",
             "Access": "AccessPublic",
+            "IsStatic": true,
+            "IsNative": true,
             "Identifier": {
                 "Identifier": "xyz",
 				"StartPos": {"Offset": 37, "Line": 38, "Column": 39},
@@ -177,6 +181,7 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 	decl := &FunctionDeclaration{
 		Access: AccessPublic,
 		Purity: FunctionPurityView,
+		Flags:  FunctionDeclarationFlagsIsStatic | FunctionDeclarationFlagsIsNative,
 		Identifier: Identifier{
 			Identifier: "xyz",
 		},
@@ -217,6 +222,10 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 			prettier.Text("pub"),
 			prettier.Space,
 			prettier.Text("view"),
+			prettier.Space,
+			prettier.Text("static"),
+			prettier.Space,
+			prettier.Text("native"),
 			prettier.Space,
 			prettier.Text("fun "),
 			prettier.Text("xyz"),
@@ -309,6 +318,7 @@ func TestSpecialFunctionDeclaration_MarshalJSON(t *testing.T) {
 		Kind: common.DeclarationKindInitializer,
 		FunctionDeclaration: &FunctionDeclaration{
 			Access: AccessNotSpecified,
+			Flags:  FunctionDeclarationFlagsIsNative,
 			Identifier: Identifier{
 				Identifier: "xyz",
 				Pos:        Position{Offset: 37, Line: 38, Column: 39},
@@ -369,6 +379,7 @@ func TestSpecialFunctionDeclaration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
+		// language=json
 		`
         {
             "Type": "SpecialFunctionDeclaration",
@@ -376,6 +387,8 @@ func TestSpecialFunctionDeclaration_MarshalJSON(t *testing.T) {
             "FunctionDeclaration": {
                 "Type": "FunctionDeclaration",
                 "Access": "AccessNotSpecified",
+                "IsStatic": false,
+                "IsNative": true,
                 "Identifier": {
                     "Identifier": "xyz",
 		    		"StartPos": {"Offset": 37, "Line": 38, "Column": 39},

--- a/runtime/ast/inspector_test.go
+++ b/runtime/ast/inspector_test.go
@@ -33,7 +33,11 @@ func TestInspector_Elements(t *testing.T) {
 
 	t.Parallel()
 
-	program, err := parser.ParseProgram([]byte(examples.FungibleTokenContractInterface), nil)
+	program, err := parser.ParseProgram(
+		nil,
+		[]byte(examples.FungibleTokenContractInterface),
+		parser.Config{},
+	)
 	require.NoError(t, err)
 
 	inspector := ast.NewInspector(program)
@@ -102,7 +106,11 @@ func TestInspectorTypeFiltering(t *testing.T) {
       }
     `
 
-	program, err := parser.ParseProgram([]byte(code), nil)
+	program, err := parser.ParseProgram(
+		nil,
+		[]byte(code),
+		parser.Config{},
+	)
 	require.NoError(t, err)
 
 	inspector := ast.NewInspector(program)

--- a/runtime/ast/position.go
+++ b/runtime/ast/position.go
@@ -92,6 +92,16 @@ func EndPosition(memoryGauge common.MemoryGauge, startPosition Position, end int
 	return startPosition.Shifted(memoryGauge, length)
 }
 
+func EarliestPosition(p Position, ps ...*Position) (earliest Position) {
+	earliest = p
+	for _, pos := range ps {
+		if pos != nil && pos.Compare(earliest) < 0 {
+			earliest = *pos
+		}
+	}
+	return
+}
+
 // HasPosition
 
 type HasPosition interface {

--- a/runtime/ast/string_test.go
+++ b/runtime/ast/string_test.go
@@ -79,7 +79,11 @@ func TestStringQuick(t *testing.T) {
 	t.Parallel()
 
 	f := func(text string) bool {
-		res, errs := parser.ParseExpression([]byte(ast.QuoteString(text)), nil)
+		res, errs := parser.ParseExpression(
+			nil,
+			[]byte(ast.QuoteString(text)),
+			parser.Config{},
+		)
 		if len(errs) > 0 {
 			return false
 		}

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -63,7 +63,7 @@ func PrepareProgramFromFile(location common.StringLocation, codes map[common.Loc
 func PrepareProgram(code []byte, location common.Location, codes map[common.Location][]byte) (*ast.Program, func(error)) {
 	must := mustClosure(location, codes)
 
-	program, err := parser.ParseProgram(code, nil)
+	program, err := parser.ParseProgram(nil, code, parser.Config{})
 	codes[location] = code
 	must(err)
 

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -175,7 +175,7 @@ func runPath(path string, bench bool) (res result, succeeded bool) {
 			}
 		}()
 
-		program, err = parser.ParseProgram(code, nil)
+		program, err = parser.ParseProgram(nil, code, parser.Config{})
 		if !bench {
 			res.Program = program
 		}
@@ -189,7 +189,7 @@ func runPath(path string, bench bool) (res result, succeeded bool) {
 
 	if bench {
 		benchRes := benchParse(func() (err error) {
-			_, err = parser.ParseProgram(code, nil)
+			_, err = parser.ParseProgram(nil, code, parser.Config{})
 			return
 		})
 		res.Bench = &benchResult{

--- a/runtime/cmd/parse/main_wasm.go
+++ b/runtime/cmd/parse/main_wasm.go
@@ -68,7 +68,7 @@ func parse(code string) string {
 			}
 		}()
 
-		res.Program, res.Error = parser.ParseProgram([]byte(code), nil)
+		res.Program, res.Error = parser.ParseProgram(nil, []byte(code), parser.Config{})
 	}()
 
 	serialized, err := json.Marshal(res)

--- a/runtime/common/intervalst/node.go
+++ b/runtime/common/intervalst/node.go
@@ -54,7 +54,7 @@ func (MinPosition) Compare(other Position) int {
 	return -1
 }
 
-var minPosition = MinPosition{}
+var minPosition Position = MinPosition{}
 
 func (n *node[T]) Max() Position {
 	if n == nil {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1884,7 +1884,7 @@ func TestExportTypeValue(t *testing.T) {
           pub struct S: SI {}
 
         `
-		program, err := parser.ParseProgram([]byte(code), nil)
+		program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 		require.NoError(t, err)
 
 		checker, err := sema.NewChecker(
@@ -1982,7 +1982,7 @@ func TestExportCapabilityValue(t *testing.T) {
 		const code = `
           struct S {}
         `
-		program, err := parser.ParseProgram([]byte(code), nil)
+		program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 		require.NoError(t, err)
 
 		checker, err := sema.NewChecker(
@@ -2102,7 +2102,7 @@ func TestExportLinkValue(t *testing.T) {
 		const code = `
           struct S {}
         `
-		program, err := parser.ParseProgram([]byte(code), nil)
+		program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 		require.NoError(t, err)
 
 		checker, err := sema.NewChecker(

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -362,7 +362,7 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 	var parse *ast.Program
 	reportMetric(
 		func() {
-			parse, err = parser.ParseProgram(code, e)
+			parse, err = parser.ParseProgram(e, code, parser.Config{})
 		},
 		e.runtimeInterface,
 		func(metrics Metrics, duration time.Duration) {

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -57,7 +57,7 @@ func ParseLiteral(
 ) {
 	code := []byte(literal)
 
-	expression, errs := parser.ParseExpression(code, inter)
+	expression, errs := parser.ParseExpression(inter, code, parser.Config{})
 	if len(errs) > 0 {
 		return nil, parser.Error{
 			Code:   code,
@@ -82,7 +82,7 @@ func ParseLiteralArgumentList(
 	error,
 ) {
 	code := []byte(argumentList)
-	arguments, errs := parser.ParseArgumentList(code, inter)
+	arguments, errs := parser.ParseArgumentList(inter, code, parser.Config{})
 	if len(errs) > 0 {
 		return nil, parser.Error{
 			Errors: errs,

--- a/runtime/parser/benchmark_test.go
+++ b/runtime/parser/benchmark_test.go
@@ -54,7 +54,7 @@ func BenchmarkParseDeploy(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, err := ParseProgram(transaction, nil)
+			_, err := ParseProgram(nil, transaction, Config{})
 			if err != nil {
 				b.FailNow()
 			}
@@ -81,7 +81,7 @@ func BenchmarkParseDeploy(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, err := ParseProgram(transaction, nil)
+			_, err := ParseProgram(nil, transaction, Config{})
 			if err != nil {
 				b.FailNow()
 			}
@@ -205,7 +205,7 @@ func BenchmarkParseFungibleToken(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, err := ParseProgram(code, nil)
+			_, err := ParseProgram(nil, code, Config{})
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -221,7 +221,7 @@ func BenchmarkParseFungibleToken(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, err := ParseProgram(code, meter)
+			_, err := ParseProgram(meter, code, Config{})
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -276,6 +276,82 @@ func TestParseVariableDeclaration(t *testing.T) {
 			errs,
 		)
 	})
+
+	t.Run("static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte("static var x = 1"),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier for variable",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("static var x = 1")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte("native var x = 1"),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid native modifier for variable",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("native var x = 1")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseParameterList(t *testing.T) {
@@ -284,11 +360,12 @@ func TestParseParameterList(t *testing.T) {
 
 	parse := func(input string) (any, []error) {
 		return Parse(
+			nil,
 			[]byte(input),
 			func(p *parser) (any, error) {
 				return parseParameterList(p)
 			},
-			nil,
+			Config{},
 		)
 	}
 
@@ -1021,6 +1098,59 @@ func TestParseFunctionDeclaration(t *testing.T) {
 		)
 	})
 
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations(
+			nil,
+			[]byte("native fun foo() {}"),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.FunctionDeclaration{
+					Flags: ast.FunctionDeclarationFlagsIsNative,
+					Identifier: ast.Identifier{
+						Identifier: "foo",
+						Pos:        ast.Position{Line: 1, Column: 11, Offset: 11},
+					},
+					ParameterList: &ast.ParameterList{
+						Parameters: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
+							EndPos:   ast.Position{Line: 1, Column: 15, Offset: 15},
+						},
+					},
+					ReturnTypeAnnotation: &ast.TypeAnnotation{
+						IsResource: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "",
+								Pos:        ast.Position{Line: 1, Column: 15, Offset: 15},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 15, Offset: 15},
+					},
+					FunctionBlock: &ast.FunctionBlock{
+						Block: &ast.Block{
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 17, Offset: 17},
+								EndPos:   ast.Position{Line: 1, Column: 18, Offset: 18},
+							},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+				},
+			},
+			result,
+		)
+	})
+
 	t.Run("double purity annot", func(t *testing.T) {
 
 		t.Parallel()
@@ -1032,6 +1162,277 @@ func TestParseFunctionDeclaration(t *testing.T) {
 			Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
 		})
 	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("native fun foo() {}")
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations(
+			nil,
+			[]byte("static fun foo() {}"),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.FunctionDeclaration{
+					Flags: ast.FunctionDeclarationFlagsIsStatic,
+					Identifier: ast.Identifier{
+						Identifier: "foo",
+						Pos:        ast.Position{Line: 1, Column: 11, Offset: 11},
+					},
+					ParameterList: &ast.ParameterList{
+						Parameters: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
+							EndPos:   ast.Position{Line: 1, Column: 15, Offset: 15},
+						},
+					},
+					ReturnTypeAnnotation: &ast.TypeAnnotation{
+						IsResource: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "",
+								Pos:        ast.Position{Line: 1, Column: 15, Offset: 15},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 15, Offset: 15},
+					},
+					FunctionBlock: &ast.FunctionBlock{
+						Block: &ast.Block{
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 17, Offset: 17},
+								EndPos:   ast.Position{Line: 1, Column: 18, Offset: 18},
+							},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("static fun foo() {}")
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations(
+			nil,
+			[]byte("static native fun foo() {}"),
+			Config{
+				StaticModifierEnabled: true,
+				NativeModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.FunctionDeclaration{
+					Flags: ast.FunctionDeclarationFlagsIsStatic | ast.FunctionDeclarationFlagsIsNative,
+					Identifier: ast.Identifier{
+						Identifier: "foo",
+						Pos:        ast.Position{Line: 1, Column: 18, Offset: 18},
+					},
+					ParameterList: &ast.ParameterList{
+						Parameters: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 21, Offset: 21},
+							EndPos:   ast.Position{Line: 1, Column: 22, Offset: 22},
+						},
+					},
+					ReturnTypeAnnotation: &ast.TypeAnnotation{
+						IsResource: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "",
+								Pos:        ast.Position{Line: 1, Column: 22, Offset: 22},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 22, Offset: 22},
+					},
+					FunctionBlock: &ast.FunctionBlock{
+						Block: &ast.Block{
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 24, Offset: 24},
+								EndPos:   ast.Position{Line: 1, Column: 25, Offset: 25},
+							},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("static native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("static native fun foo() {}")
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte("native static fun foo() {}"),
+			Config{
+				StaticModifierEnabled: true,
+				NativeModifierEnabled: true,
+			},
+		)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier after native modifier",
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("native static fun foo() {}")
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("pub static native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := ParseDeclarations(
+			nil,
+			[]byte("pub static native fun foo() {}"),
+			Config{
+				StaticModifierEnabled: true,
+				NativeModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.FunctionDeclaration{
+					Access: ast.AccessPublic,
+					Flags:  ast.FunctionDeclarationFlagsIsStatic | ast.FunctionDeclarationFlagsIsNative,
+					Identifier: ast.Identifier{
+						Identifier: "foo",
+						Pos:        ast.Position{Line: 1, Column: 22, Offset: 22},
+					},
+					ParameterList: &ast.ParameterList{
+						Parameters: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 25, Offset: 25},
+							EndPos:   ast.Position{Line: 1, Column: 26, Offset: 26},
+						},
+					},
+					ReturnTypeAnnotation: &ast.TypeAnnotation{
+						IsResource: false,
+						Type: &ast.NominalType{
+							Identifier: ast.Identifier{
+								Identifier: "",
+								Pos:        ast.Position{Line: 1, Column: 26, Offset: 26},
+							},
+						},
+						StartPos: ast.Position{Line: 1, Column: 26, Offset: 26},
+					},
+					FunctionBlock: &ast.FunctionBlock{
+						Block: &ast.Block{
+							Range: ast.Range{
+								StartPos: ast.Position{Line: 1, Column: 28, Offset: 28},
+								EndPos:   ast.Position{Line: 1, Column: 29, Offset: 29},
+							},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("pub static native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("pub static native fun foo() {}")
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
+			},
+			errs,
+		)
+	})
+
 }
 
 func TestParseAccess(t *testing.T) {
@@ -1040,11 +1441,12 @@ func TestParseAccess(t *testing.T) {
 
 	parse := func(input string) (any, []error) {
 		return Parse(
+			nil,
 			[]byte(input),
 			func(p *parser) (any, error) {
 				return parseAccess(p)
 			},
-			nil,
+			Config{},
 		)
 	}
 
@@ -1780,11 +2182,19 @@ func TestParseFieldWithVariableKind(t *testing.T) {
 
 	parse := func(input string) (any, []error) {
 		return Parse(
+			nil,
 			[]byte(input),
 			func(p *parser) (any, error) {
-				return parseFieldWithVariableKind(p, ast.AccessNotSpecified, nil, "")
+				return parseFieldWithVariableKind(
+					p,
+					ast.AccessNotSpecified,
+					nil,
+					nil,
+					nil,
+					"",
+				)
 			},
-			nil,
+			Config{},
 		)
 	}
 
@@ -1855,6 +2265,275 @@ func TestParseFieldWithVariableKind(t *testing.T) {
 			result,
 		)
 	})
+}
+
+func TestParseField(t *testing.T) {
+
+	t.Parallel()
+
+	parse := func(input string, config Config) (any, []error) {
+		return Parse(
+			nil,
+			[]byte(input),
+			func(p *parser) (any, error) {
+				return parseMemberOrNestedDeclaration(
+					p,
+					"",
+				)
+			},
+			config,
+		)
+	}
+
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := parse(
+			"native let foo: Int",
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.FieldDeclaration{
+				Flags:        ast.FieldDeclarationFlagsIsNative,
+				VariableKind: ast.VariableKindConstant,
+				Identifier: ast.Identifier{
+					Identifier: "foo",
+					Pos:        ast.Position{Line: 1, Column: 11, Offset: 11},
+				},
+				TypeAnnotation: &ast.TypeAnnotation{
+					Type: &ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: "Int",
+							Pos:        ast.Position{Line: 1, Column: 16, Offset: 16},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 16, Offset: 16},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 18, Offset: 18},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := parse("native let foo: Int", Config{})
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := parse(
+			"static let foo: Int",
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.FieldDeclaration{
+				Flags:        ast.FieldDeclarationFlagsIsStatic,
+				VariableKind: ast.VariableKindConstant,
+				Identifier: ast.Identifier{
+					Identifier: "foo",
+					Pos:        ast.Position{Line: 1, Column: 11, Offset: 11},
+				},
+				TypeAnnotation: &ast.TypeAnnotation{
+					Type: &ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: "Int",
+							Pos:        ast.Position{Line: 1, Column: 16, Offset: 16},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 16, Offset: 16},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 18, Offset: 18},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := parse(
+			"static let foo: Int",
+			Config{},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := parse(
+			"static native let foo: Int",
+			Config{
+				StaticModifierEnabled: true,
+				NativeModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.FieldDeclaration{
+				Flags:        ast.FieldDeclarationFlagsIsStatic | ast.FieldDeclarationFlagsIsNative,
+				VariableKind: ast.VariableKindConstant,
+				Identifier: ast.Identifier{
+					Identifier: "foo",
+					Pos:        ast.Position{Line: 1, Column: 18, Offset: 18},
+				},
+				TypeAnnotation: &ast.TypeAnnotation{
+					Type: &ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: "Int",
+							Pos:        ast.Position{Line: 1, Column: 23, Offset: 23},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 23, Offset: 23},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 25, Offset: 25},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("static native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := parse("static native let foo: Int", Config{})
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := parse(
+			"native static let foo: Int",
+			Config{
+				StaticModifierEnabled: true,
+				NativeModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier after native modifier",
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("pub static native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := parse(
+			"pub static native let foo: Int",
+			Config{
+				StaticModifierEnabled: true,
+				NativeModifierEnabled: true,
+			},
+		)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			&ast.FieldDeclaration{
+				Access:       ast.AccessPublic,
+				Flags:        ast.FieldDeclarationFlagsIsStatic | ast.FieldDeclarationFlagsIsNative,
+				VariableKind: ast.VariableKindConstant,
+				Identifier: ast.Identifier{
+					Identifier: "foo",
+					Pos:        ast.Position{Line: 1, Column: 22, Offset: 22},
+				},
+				TypeAnnotation: &ast.TypeAnnotation{
+					Type: &ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: "Int",
+							Pos:        ast.Position{Line: 1, Column: 27, Offset: 27},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 27, Offset: 27},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 29, Offset: 29},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("pub static native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := parse("pub static native let foo: Int", Config{})
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
+			},
+			errs,
+		)
+	})
+
 }
 
 func TestParseCompositeDeclaration(t *testing.T) {
@@ -2696,6 +3375,82 @@ func TestParseEnumDeclaration(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid view modifier for enum case",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("enum case with static modifier, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(" enum E { static case e }"),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier for enum case",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("enum case with static modifier, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(" enum E { static case e }")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("enum case with native modifier, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(" enum E { native case e }"),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid native modifier for enum case",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("enum case with native modifier, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(" enum E { native case e }")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
 					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
 				},
 			},
@@ -3896,6 +4651,30 @@ func TestParseStructureWithConformances(t *testing.T) {
 	)
 }
 
+func TestParseInvalidMember(t *testing.T) {
+
+	t.Parallel()
+
+	const code = `
+        struct Test {
+            foo let x: Int
+        }
+	`
+
+	_, errs := testParseDeclarations(code)
+
+	utils.AssertEqualWithDiff(t,
+		[]error{
+			&SyntaxError{
+				Message: "unexpected token: identifier",
+				Pos:     ast.Position{Offset: 35, Line: 3, Column: 12},
+			},
+		},
+		errs,
+	)
+
+}
+
 func TestParsePreAndPostConditions(t *testing.T) {
 
 	t.Parallel()
@@ -4355,6 +5134,82 @@ func TestParsePragmaNoArguments(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "invalid view modifier for pragma",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte("static #foo"),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier for pragma",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("static #foo")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte("native #foo"),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid native modifier for pragma",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("native #foo")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
 					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
 				},
 			},
@@ -5363,6 +6218,7 @@ func TestParseInvalidCompositeFunctionNames(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 
 				_, err := ParseProgram(
+					nil,
 					[]byte(fmt.Sprintf(
 						`
                           %[1]s %[2]s Test {
@@ -5374,7 +6230,7 @@ func TestParseInvalidCompositeFunctionNames(t *testing.T) {
 						interfaceKeyword,
 						body,
 					)),
-					nil,
+					Config{},
 				)
 
 				errs, ok := err.(Error)
@@ -5608,6 +6464,379 @@ func TestParseInvalidAccessModifiers(t *testing.T) {
 				&SyntaxError{
 					Message: "invalid second access modifier",
 					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				},
+			},
+			errs,
+		)
+	})
+}
+
+func TestParseInvalidImportWithModifier(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                static import x from 0x1
+	        `),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier for import",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            static import x from 0x1
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                native import x from 0x1
+	        `),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid native modifier for import",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            native import x from 0x1
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
+}
+
+func TestParseInvalidEventWithModifier(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                static event Foo()
+	        `),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier for event",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            static event Foo()
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                native event Foo()
+	        `),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid native modifier for event",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            native event Foo()
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
+
+}
+
+func TestParseCompositeWithModifier(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                static struct Foo()
+	        `),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier for composite",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            static struct Foo()
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                native struct Foo()
+	        `),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid native modifier for composite",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            native struct Foo()
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
+}
+
+func TestParseTransactionWithModifier(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("static, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                static transaction {}
+	        `),
+			Config{
+				StaticModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid static modifier for transaction",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("static, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            static transaction {}
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, enabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := ParseDeclarations(
+			nil,
+			[]byte(`
+                native transaction {}
+	        `),
+			Config{
+				NativeModifierEnabled: true,
+			},
+		)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid native modifier for transaction",
+					Pos:     ast.Position{Offset: 17, Line: 2, Column: 16},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("native, disabled", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(`
+            native transaction {}
+	    `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token: identifier",
+					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
 				},
 			},
 			errs,

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -816,9 +816,18 @@ func defineIdentifierExpression() {
 
 			case KeywordView:
 				// if `view` is followed by `fun`, then it denotes a view function expression
-				if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
-					p.nextSemanticToken()
-					return parseFunctionExpression(p, token, ast.FunctionPurityView)
+
+				current := p.current
+				if current.Is(lexer.TokenSpace) {
+					cursor := p.tokens.Cursor()
+					p.next()
+					if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
+						p.nextSemanticToken()
+						return parseFunctionExpression(p, token, ast.FunctionPurityView)
+					} else {
+						p.tokens.Revert(cursor)
+						p.current = current
+					}
 				}
 
 				// otherwise, we treat it as an identifier called "view"

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -329,7 +329,7 @@ func TestParseAdvancedExpression(t *testing.T) {
 			defer func() {
 				panicMsg = recover()
 			}()
-			ParseExpression([]byte("1 < 2"), gauge)
+			ParseExpression(gauge, []byte("1 < 2"), Config{})
 		})()
 
 		require.IsType(t, errors.MemoryError{}, panicMsg)
@@ -352,7 +352,7 @@ func TestParseAdvancedExpression(t *testing.T) {
 				panicMsg = recover()
 			}()
 
-			ParseExpression([]byte("1 < 2 > 3"), gauge)
+			ParseExpression(gauge, []byte("1 < 2 > 3"), Config{})
 		})()
 
 		require.IsType(t, errors.MemoryError{}, panicMsg)
@@ -2139,9 +2139,14 @@ func TestParseBlockComment(t *testing.T) {
 			input: []byte(`/*foo`),
 		}
 
-		_, errs := ParseTokenStream(nil, tokens, func(p *parser) (ast.Expression, error) {
-			return parseExpression(p, lowestBindingPower)
-		})
+		_, errs := ParseTokenStream(
+			nil,
+			tokens,
+			func(p *parser) (ast.Expression, error) {
+				return parseExpression(p, lowestBindingPower)
+			},
+			Config{},
+		)
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{

--- a/runtime/parser/function.go
+++ b/runtime/parser/function.go
@@ -185,10 +185,13 @@ func parseFunctionDeclaration(
 	accessPos *ast.Position,
 	purity ast.FunctionPurity,
 	purityPos *ast.Position,
+	staticPos *ast.Position,
+	nativePos *ast.Position,
 	docString string,
 ) (*ast.FunctionDeclaration, error) {
 
-	startPos := *ast.EarlierPosition(ast.EarlierPosition(purityPos, accessPos), &p.current.StartPos)
+	startPos := ast.EarliestPosition(p.current.StartPos, accessPos, purityPos, staticPos, nativePos)
+
 	// Skip the `fun` keyword
 	p.nextSemanticToken()
 
@@ -212,6 +215,8 @@ func parseFunctionDeclaration(
 		p.memoryGauge,
 		access,
 		purity,
+		staticPos != nil,
+		nativePos != nil,
 		identifier,
 		parameterList,
 		returnTypeAnnotation,

--- a/runtime/parser/keyword.go
+++ b/runtime/parser/keyword.go
@@ -64,6 +64,8 @@ const (
 	KeywordDefault     = "default"
 	KeywordEnum        = "enum"
 	KeywordView        = "view"
+	KeywordStatic      = "static"
+	KeywordNative      = "native"
 	// NOTE: ensure to update allKeywords when adding a new keyword
 )
 

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -81,27 +81,27 @@ func (*testTokenStream) Reclaim() {
 }
 
 func testParseStatements(s string) ([]ast.Statement, []error) {
-	return ParseStatements([]byte(s), nil)
+	return ParseStatements(nil, []byte(s), Config{})
 }
 
 func testParseDeclarations(s string) ([]ast.Declaration, []error) {
-	return ParseDeclarations([]byte(s), nil)
+	return ParseDeclarations(nil, []byte(s), Config{})
 }
 
 func testParseProgram(s string) (*ast.Program, error) {
-	return ParseProgram([]byte(s), nil)
+	return ParseProgram(nil, []byte(s), Config{})
 }
 
 func testParseExpression(s string) (ast.Expression, []error) {
-	return ParseExpression([]byte(s), nil)
+	return ParseExpression(nil, []byte(s), Config{})
 }
 
 func testParseArgumentList(s string) (ast.Arguments, []error) {
-	return ParseArgumentList([]byte(s), nil)
+	return ParseArgumentList(nil, []byte(s), Config{})
 }
 
 func testParseType(s string) (ast.Type, []error) {
-	return ParseType([]byte(s), nil)
+	return ParseType(nil, []byte(s), Config{})
 }
 
 func TestParseInvalid(t *testing.T) {
@@ -138,6 +138,7 @@ func TestParseBuffering(t *testing.T) {
 		t.Parallel()
 
 		_, errs := Parse(
+			nil,
 			[]byte("a b c d"),
 			func(p *parser) (any, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
@@ -181,7 +182,7 @@ func TestParseBuffering(t *testing.T) {
 
 				return nil, nil
 			},
-			nil,
+			Config{},
 		)
 
 		assert.Empty(t, errs)
@@ -192,6 +193,7 @@ func TestParseBuffering(t *testing.T) {
 		t.Parallel()
 
 		_, errs := Parse(
+			nil,
 			[]byte("a b x d"),
 			func(p *parser) (any, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
@@ -235,7 +237,7 @@ func TestParseBuffering(t *testing.T) {
 
 				return nil, nil
 			},
-			nil,
+			Config{},
 		)
 
 		utils.AssertEqualWithDiff(t,
@@ -254,6 +256,7 @@ func TestParseBuffering(t *testing.T) {
 		t.Parallel()
 
 		_, errs := Parse(
+			nil,
 			[]byte("a b c d"),
 			func(p *parser) (any, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
@@ -308,7 +311,7 @@ func TestParseBuffering(t *testing.T) {
 
 				return nil, nil
 			},
-			nil,
+			Config{},
 		)
 
 		assert.Empty(t, errs)
@@ -319,6 +322,7 @@ func TestParseBuffering(t *testing.T) {
 		t.Parallel()
 
 		_, errs := Parse(
+			nil,
 			[]byte("a b c d"),
 			func(p *parser) (any, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
@@ -392,7 +396,7 @@ func TestParseBuffering(t *testing.T) {
 
 				return nil, nil
 			},
-			nil,
+			Config{},
 		)
 
 		assert.Empty(t, errs)
@@ -403,6 +407,7 @@ func TestParseBuffering(t *testing.T) {
 		t.Parallel()
 
 		_, errs := Parse(
+			nil,
 			[]byte("a b c x"),
 			func(p *parser) (any, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
@@ -475,7 +480,7 @@ func TestParseBuffering(t *testing.T) {
 
 				return nil, nil
 			},
-			nil,
+			Config{},
 		)
 
 		utils.AssertEqualWithDiff(t,
@@ -591,6 +596,7 @@ func TestParseEOF(t *testing.T) {
 	t.Parallel()
 
 	_, errs := Parse(
+		nil,
 		[]byte("a b"),
 		func(p *parser) (any, error) {
 			_, err := p.mustToken(lexer.TokenIdentifier, "a")
@@ -631,7 +637,7 @@ func TestParseEOF(t *testing.T) {
 
 			return nil, nil
 		},
-		nil,
+		Config{},
 	)
 
 	assert.Empty(t, errs)
@@ -733,7 +739,7 @@ func TestParseArgumentList(t *testing.T) {
 				panicMsg = recover()
 			}()
 
-			ParseArgumentList([]byte(`(1, b: true)`), gauge)
+			ParseArgumentList(gauge, []byte(`(1, b: true)`), Config{})
 		})()
 
 		require.IsType(t, errors.MemoryError{}, panicMsg)
@@ -934,7 +940,7 @@ func TestParseLocalReplayLimit(t *testing.T) {
 	builder.WriteString(">()")
 
 	code := []byte(builder.String())
-	_, err := ParseProgram(code, nil)
+	_, err := ParseProgram(nil, code, Config{})
 	utils.AssertEqualWithDiff(t,
 		Error{
 			Code: code,
@@ -969,7 +975,7 @@ func TestParseGlobalReplayLimit(t *testing.T) {
 	}
 
 	code := []byte(builder.String())
-	_, err := ParseProgram(code, nil)
+	_, err := ParseProgram(nil, code, Config{})
 	utils.AssertEqualWithDiff(t,
 		Error{
 			Code: code,
@@ -996,11 +1002,12 @@ func TestParseWhitespaceAtEnd(t *testing.T) {
 	t.Parallel()
 
 	_, errs := Parse(
+		nil,
 		[]byte("a  "),
 		func(p *parser) (any, error) {
 			return p.mustToken(lexer.TokenIdentifier, "a")
 		},
-		nil,
+		Config{},
 	)
 
 	assert.Empty(t, errs)

--- a/runtime/parser/statement.go
+++ b/runtime/parser/statement.go
@@ -201,6 +201,8 @@ func parseFunctionDeclarationOrFunctionExpressionStatement(
 			p.memoryGauge,
 			ast.AccessNotSpecified,
 			purity,
+			false,
+			false,
 			identifier,
 			parameterList,
 			returnTypeAnnotation,

--- a/runtime/parser/transaction.go
+++ b/runtime/parser/transaction.go
@@ -93,6 +93,8 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 				nil,
 				ast.FunctionPurityUnspecified,
 				nil,
+				nil,
+				nil,
 				identifier,
 			)
 			if err != nil {
@@ -229,7 +231,14 @@ func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration, err erro
 		case lexer.TokenIdentifier:
 			switch string(p.currentTokenSource()) {
 			case KeywordLet, KeywordVar:
-				field, err := parseFieldWithVariableKind(p, ast.AccessNotSpecified, nil, docString)
+				field, err := parseFieldWithVariableKind(
+					p,
+					ast.AccessNotSpecified,
+					nil,
+					nil,
+					nil,
+					docString,
+				)
 				if err != nil {
 					return nil, err
 				}
@@ -265,6 +274,8 @@ func parseTransactionExecute(p *parser) (*ast.SpecialFunctionDeclaration, error)
 			p.memoryGauge,
 			ast.AccessNotSpecified,
 			ast.FunctionPurityUnspecified,
+			false,
+			false,
 			identifier,
 			nil,
 			nil,

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -193,7 +193,7 @@ func (r *REPL) Accept(code []byte) (inputIsComplete bool, err error) {
 	// TODO: detect if the input is complete
 	inputIsComplete = true
 
-	result, errs := parser.ParseStatements(code, nil)
+	result, errs := parser.ParseStatements(nil, code, parser.Config{})
 	if len(errs) > 0 {
 		err = parser.Error{
 			Code:   code,

--- a/runtime/sema/any_type.go
+++ b/runtime/sema/any_type.go
@@ -25,7 +25,6 @@ var AnyType = &SimpleType{
 	QualifiedName: "Any",
 	TypeID:        "Any",
 	tag:           AnyTypeTag,
-	IsInvalid:     false,
 	IsResource:    false,
 	// `Any` is never a valid type in user programs
 	Storable:  true,

--- a/runtime/sema/anyresource_type.go
+++ b/runtime/sema/anyresource_type.go
@@ -24,7 +24,6 @@ var AnyResourceType = &SimpleType{
 	QualifiedName: "AnyResource",
 	TypeID:        "AnyResource",
 	tag:           AnyResourceTypeTag,
-	IsInvalid:     false,
 	IsResource:    true,
 	// The actual storability of a value is checked at run-time
 	Storable:  true,

--- a/runtime/sema/anystruct_type.go
+++ b/runtime/sema/anystruct_type.go
@@ -24,7 +24,6 @@ var AnyStructType = &SimpleType{
 	QualifiedName: "AnyStruct",
 	TypeID:        "AnyStruct",
 	tag:           AnyStructTypeTag,
-	IsInvalid:     false,
 	IsResource:    false,
 	// The actual storability of a value is checked at run-time
 	Storable:             true,

--- a/runtime/sema/before_extractor_test.go
+++ b/runtime/sema/before_extractor_test.go
@@ -32,9 +32,13 @@ func TestBeforeExtractor(t *testing.T) {
 
 	t.Parallel()
 
-	expression, errs := parser.ParseExpression([]byte(`
+	expression, errs := parser.ParseExpression(
+		nil,
+		[]byte(`
         before(x + before(y)) + z
-    `), nil)
+    `),
+		parser.Config{},
+	)
 
 	require.Empty(t, errs)
 

--- a/runtime/sema/block.go
+++ b/runtime/sema/block.go
@@ -29,7 +29,6 @@ var BlockType = &SimpleType{
 	QualifiedName:        "Block",
 	TypeID:               "Block",
 	tag:                  BlockTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             false,
 	Equatable:            false,
@@ -114,17 +113,17 @@ The view of the block.
 It is a detail of the consensus algorithm. It is a monotonically increasing integer and counts rounds in the consensus algorithm. Since not all rounds result in a finalized block, the view number is strictly greater than or equal to the block height
 `
 
-const BlockTypeTimestampFieldName = "timestamp"
+const BlockTypeIDFieldName = "id"
 
-const blockTypeTimestampFieldDocString = `
+const blockTypeIDFieldDocString = `
 The ID of the block.
 
 It is essentially the hash of the block
 `
 
-const BlockTypeIDFieldName = "id"
+const BlockTypeTimestampFieldName = "timestamp"
 
-const blockTypeIDFieldDocString = `
+const blockTypeTimestampFieldDocString = `
 The timestamp of the block.
 
 Unix timestamp of when the proposer claims it constructed the block.

--- a/runtime/sema/bool_type.go
+++ b/runtime/sema/bool_type.go
@@ -24,7 +24,6 @@ var BoolType = &SimpleType{
 	QualifiedName:        "Bool",
 	TypeID:               "Bool",
 	tag:                  BoolTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             true,
 	Equatable:            true,

--- a/runtime/sema/character_type.go
+++ b/runtime/sema/character_type.go
@@ -31,7 +31,6 @@ var CharacterType = &SimpleType{
 	QualifiedName:        "Character",
 	TypeID:               "Character",
 	tag:                  CharacterTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             true,
 	Equatable:            true,

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -74,6 +74,16 @@ func (checker *Checker) visitFunctionDeclaration(
 		true,
 	)
 
+	checker.checkStaticModifier(
+		declaration.IsStatic(),
+		declaration.Identifier,
+	)
+
+	checker.checkNativeModifier(
+		declaration.IsNative(),
+		declaration.Identifier,
+	)
+
 	// global functions were previously declared, see `declareFunctionDeclaration`
 
 	functionType := checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -69,7 +69,6 @@ func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDecl
 		declaration.Members.Initializers(),
 		declaration.Members.Fields(),
 		interfaceType,
-		declaration.DeclarationKind(),
 		declaration.DeclarationDocString(),
 		interfaceType.InitializerPurity,
 		interfaceType.InitializerParameters,
@@ -172,7 +171,7 @@ func (checker *Checker) checkInterfaceFunctions(
 	for _, function := range functions {
 		// NOTE: new activation, as function declarations
 		// shouldn't be visible in other function declarations,
-		// and `self` is is only visible inside function
+		// and `self` is only visible inside function
 
 		func() {
 			checker.enterValueScope()

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2404,3 +2404,23 @@ func wrapWithOptionalIfNotNil(typ Type) Type {
 func (checker *Checker) CheckStatement(element ast.Statement) {
 	ast.AcceptStatement[struct{}](element, checker)
 }
+
+func (checker *Checker) checkStaticModifier(isStatic bool, position ast.HasPosition) {
+	if isStatic && !checker.Config.AllowStaticDeclarations {
+		checker.report(
+			&InvalidStaticModifierError{
+				Range: ast.NewRangeFromPositioned(checker.memoryGauge, position),
+			},
+		)
+	}
+}
+
+func (checker *Checker) checkNativeModifier(isNative bool, position ast.HasPosition) {
+	if isNative && !checker.Config.AllowNativeDeclarations {
+		checker.report(
+			&InvalidNativeModifierError{
+				Range: ast.NewRangeFromPositioned(checker.memoryGauge, position),
+			},
+		)
+	}
+}

--- a/runtime/sema/config.go
+++ b/runtime/sema/config.go
@@ -46,4 +46,8 @@ type Config struct {
 	MemberAccountAccessHandler MemberAccountAccessHandlerFunc
 	// ContractValueHandler is used to construct the contract variable
 	ContractValueHandler ContractValueHandlerFunc
+	// AllowNativeDeclarations determines if declarations may be native
+	AllowNativeDeclarations bool
+	// AllowStaticDeclarations determined if declarations may be static
+	AllowStaticDeclarations bool
 }

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -29,7 +29,6 @@ var DeployedContractType = &SimpleType{
 	QualifiedName:        "DeployedContract",
 	TypeID:               "DeployedContract",
 	tag:                  DeployedContractTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             false,
 	Equatable:            false,

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -677,6 +677,40 @@ func (e *MissingAccessModifierError) EndPosition(common.MemoryGauge) ast.Positio
 	return e.Pos
 }
 
+// InvalidStaticModifierError
+
+type InvalidStaticModifierError struct {
+	ast.Range
+}
+
+var _ SemanticError = &InvalidStaticModifierError{}
+var _ errors.UserError = &InvalidStaticModifierError{}
+
+func (*InvalidStaticModifierError) isSemanticError() {}
+
+func (*InvalidStaticModifierError) IsUserError() {}
+
+func (e *InvalidStaticModifierError) Error() string {
+	return "invalid static modifier for declaration"
+}
+
+// InvalidNativeModifierError
+
+type InvalidNativeModifierError struct {
+	ast.Range
+}
+
+var _ SemanticError = &InvalidNativeModifierError{}
+var _ errors.UserError = &InvalidNativeModifierError{}
+
+func (*InvalidNativeModifierError) isSemanticError() {}
+
+func (*InvalidNativeModifierError) IsUserError() {}
+
+func (e *InvalidNativeModifierError) Error() string {
+	return "invalid native modifier for declaration"
+}
+
 // InvalidNameError
 
 type InvalidNameError struct {

--- a/runtime/sema/invalid_type.go
+++ b/runtime/sema/invalid_type.go
@@ -26,7 +26,6 @@ var InvalidType = &SimpleType{
 	QualifiedName:        "<<invalid>>",
 	TypeID:               "<<invalid>>",
 	tag:                  InvalidTypeTag,
-	IsInvalid:            true,
 	IsResource:           false,
 	Storable:             false,
 	Equatable:            false,

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -39,7 +39,6 @@ var MetaType = &SimpleType{
 	QualifiedName:        MetaTypeName,
 	TypeID:               MetaTypeName,
 	tag:                  MetaTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             true,
 	Equatable:            true,

--- a/runtime/sema/never_type.go
+++ b/runtime/sema/never_type.go
@@ -24,7 +24,6 @@ var NeverType = &SimpleType{
 	QualifiedName:        "Never",
 	TypeID:               "Never",
 	tag:                  NeverTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             false,
 	Equatable:            false,

--- a/runtime/sema/path_type.go
+++ b/runtime/sema/path_type.go
@@ -24,7 +24,6 @@ var PathType = &SimpleType{
 	QualifiedName:        "Path",
 	TypeID:               "Path",
 	tag:                  PathTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             true,
 	Equatable:            true,

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -37,7 +37,6 @@ type SimpleType struct {
 	QualifiedName        string
 	TypeID               TypeID
 	tag                  TypeTag
-	IsInvalid            bool
 	IsResource           bool
 	Storable             bool
 	Equatable            bool
@@ -78,7 +77,7 @@ func (t *SimpleType) IsResourceType() bool {
 }
 
 func (t *SimpleType) IsInvalidType() bool {
-	return t.IsInvalid
+	return t == InvalidType
 }
 
 func (t *SimpleType) IsStorable(_ map[*Member]bool) bool {

--- a/runtime/sema/storable_type.go
+++ b/runtime/sema/storable_type.go
@@ -27,7 +27,6 @@ var StorableType = &SimpleType{
 	Name:          "Storable",
 	QualifiedName: "Storable",
 	TypeID:        "Storable",
-	IsInvalid:     false,
 	// NOTE: Subtypes may be either resource types or not.
 	//
 	// Returning false here is safe, because this type is

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -45,7 +45,6 @@ var StringType = &SimpleType{
 	QualifiedName:        "String",
 	TypeID:               "String",
 	tag:                  StringTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             true,
 	Equatable:            true,

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -670,7 +670,7 @@ func TestIdentifierCacheUpdate(t *testing.T) {
           }
 	`
 
-	program, err := parser.ParseProgram([]byte(code), nil)
+	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 	require.NoError(t, err)
 
 	checker, err := NewChecker(

--- a/runtime/sema/void_type.go
+++ b/runtime/sema/void_type.go
@@ -24,7 +24,6 @@ var VoidType = &SimpleType{
 	QualifiedName:        "Void",
 	TypeID:               "Void",
 	tag:                  VoidTypeTag,
-	IsInvalid:            false,
 	IsResource:           false,
 	Storable:             false,
 	Equatable:            true,

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1365,7 +1365,11 @@ func newAuthAccountContractsChangeFunction(
 				oldCode, err := handler.GetAccountContractCode(address, contractName)
 				handleContractUpdateError(err)
 
-				oldProgram, err := parser.ParseProgram(oldCode, gauge)
+				oldProgram, err := parser.ParseProgram(
+					gauge,
+					oldCode,
+					parser.Config{},
+				)
 
 				if !ignoreUpdatedProgramParserError(err) {
 					handleContractUpdateError(err)
@@ -1705,7 +1709,7 @@ func newAuthAccountContractsRemoveFunction(
 				// NOTE: *DO NOT* call setProgram – the program removal
 				// should not be effective during the execution, only after
 
-				existingProgram, err := parser.ParseProgram(code, gauge)
+				existingProgram, err := parser.ParseProgram(gauge, code, parser.Config{})
 
 				// If the existing code is not parsable (i.e: `err != nil`),
 				// that shouldn't be a reason to fail the contract removal.

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -38,8 +38,9 @@ func newUnmeteredInMemoryStorage() interpreter.InMemoryStorage {
 
 func newInterpreter(t *testing.T, code string, valueDeclarations ...StandardLibraryValue) *interpreter.Interpreter {
 	program, err := parser.ParseProgram(
-		[]byte(code),
 		nil,
+		[]byte(code),
+		parser.Config{},
 	)
 	require.NoError(t, err)
 

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -30,7 +30,11 @@ import (
 
 var CryptoChecker = func() *sema.Checker {
 
-	program, err := parser.ParseProgram(contracts.Crypto, nil)
+	program, err := parser.ParseProgram(
+		nil,
+		contracts.Crypto,
+		parser.Config{},
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -62,7 +62,7 @@ var TestContractLocation = common.IdentifierLocation(testContractTypeName)
 
 var TestContractChecker = func() *sema.Checker {
 
-	program, err := parser.ParseProgram(contracts.TestContract, nil)
+	program, err := parser.ParseProgram(nil, contracts.TestContract, parser.Config{})
 	if err != nil {
 		panic(err)
 	}

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -36,8 +36,9 @@ import (
 
 func newTestContractInterpreter(t *testing.T, code string) (*interpreter.Interpreter, error) {
 	program, err := parser.ParseProgram(
-		[]byte(code),
 		nil,
+		[]byte(code),
+		parser.Config{},
 	)
 	require.NoError(t, err)
 

--- a/runtime/tests/checker/composite_test.go
+++ b/runtime/tests/checker/composite_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -2261,4 +2262,52 @@ func TestCheckInvalidMissingMember(t *testing.T) {
 			notDeclaredMemberErr.SecondaryError(),
 		)
 	})
+}
+
+func TestCheckStaticFieldDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+          struct S {
+              static let foo: Int
+          }
+        `,
+		ParseAndCheckOptions{
+			ParseOptions: parser.Config{
+				StaticModifierEnabled: true,
+			},
+		},
+	)
+
+	errs := RequireCheckerErrors(t, err, 2)
+
+	assert.IsType(t, &sema.InvalidStaticModifierError{}, errs[0])
+	// TODO: static fields must be native and need no initializer
+	assert.IsType(t, &sema.MissingInitializerError{}, errs[1])
+}
+
+func TestCheckNativeFieldDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+          struct S {
+              native let foo: Int
+          }
+        `,
+		ParseAndCheckOptions{
+			ParseOptions: parser.Config{
+				NativeModifierEnabled: true,
+			},
+		},
+	)
+
+	errs := RequireCheckerErrors(t, err, 2)
+
+	assert.IsType(t, &sema.InvalidNativeModifierError{}, errs[0])
+	// TODO: native fields need no initializer
+	assert.IsType(t, &sema.MissingInitializerError{}, errs[1])
 }

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -414,4 +415,44 @@ func TestCheckFunctionNonExistingField(t *testing.T) {
 	errs := RequireCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.NotDeclaredMemberError{}, errs[0])
+}
+
+func TestCheckStaticFunctionDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+          static fun test() {}
+        `,
+		ParseAndCheckOptions{
+			ParseOptions: parser.Config{
+				StaticModifierEnabled: true,
+			},
+		},
+	)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidStaticModifierError{}, errs[0])
+}
+
+func TestCheckNativeFunctionDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheckWithOptions(t,
+		`
+          native fun test() {}
+        `,
+		ParseAndCheckOptions{
+			ParseOptions: parser.Config{
+				NativeModifierEnabled: true,
+			},
+		},
+	)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidNativeModifierError{}, errs[0])
 }

--- a/runtime/tests/checker/import_test.go
+++ b/runtime/tests/checker/import_test.go
@@ -510,7 +510,11 @@ func TestCheckInvalidImportCycleSelf(t *testing.T) {
 	// it will be checked by checker that is checking the importing program
 
 	const code = `import "test"`
-	importedProgram, err := parser.ParseProgram([]byte(code), nil)
+	importedProgram, err := parser.ParseProgram(
+		nil,
+		[]byte(code),
+		parser.Config{},
+	)
 
 	require.NoError(t, err)
 
@@ -578,7 +582,7 @@ func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
           return odd(n - 1)
       }
     `
-	programEven, err := parser.ParseProgram([]byte(codeEven), nil)
+	programEven, err := parser.ParseProgram(nil, []byte(codeEven), parser.Config{})
 	require.NoError(t, err)
 
 	const codeOdd = `
@@ -591,7 +595,7 @@ func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
           return even(n - 1)
       }
     `
-	programOdd, err := parser.ParseProgram([]byte(codeOdd), nil)
+	programOdd, err := parser.ParseProgram(nil, []byte(codeOdd), parser.Config{})
 	require.NoError(t, err)
 
 	getProgram := func(location common.Location) *ast.Program {

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -1856,7 +1856,7 @@ func BenchmarkContractInterfaceFungibleToken(b *testing.B) {
 
 	const code = examples.FungibleTokenContractInterface
 
-	program, err := parser.ParseProgram([]byte(code), nil)
+	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1887,7 +1887,7 @@ func BenchmarkCheckContractInterfaceFungibleTokenConformance(b *testing.B) {
 
 	code := examples.FungibleTokenContractInterface + "\n" + examples.ExampleFungibleTokenContract
 
-	program, err := parser.ParseProgram([]byte(code), nil)
+	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -47,6 +47,7 @@ type ParseAndCheckOptions struct {
 	Location         common.Location
 	IgnoreParseError bool
 	Config           *sema.Config
+	ParseOptions     parser.Config
 }
 
 var checkConcurrently = flag.Int(
@@ -74,8 +75,8 @@ func ParseAndCheckWithOptionsAndMemoryMetering(
 		options.Location = utils.TestLocation
 	}
 
-	program, err := parser.ParseProgram([]byte(code), memoryGauge)
-	if !(options.IgnoreParseError || assert.NoError(t, err)) {
+	program, err := parser.ParseProgram(memoryGauge, []byte(code), options.ParseOptions)
+	if !options.IgnoreParseError && !assert.NoError(t, err) {
 		var sb strings.Builder
 		location := options.Location
 		printErr := pretty.NewErrorPrettyPrinter(&sb, true).

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -1812,7 +1812,7 @@ func TestInterpretHostFunction(t *testing.T) {
 	const code = `
       pub let a = test(1, 2)
     `
-	program, err := parser.ParseProgram([]byte(code), nil)
+	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 
 	require.NoError(t, err)
 
@@ -1892,7 +1892,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 	const code = `
       pub let nothing = test(1, true, "test")
     `
-	program, err := parser.ParseProgram([]byte(code), nil)
+	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 
 	require.NoError(t, err)
 

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -55,7 +55,7 @@ func (programs Programs) load(
 		return err
 	}
 
-	program, err := parser.ParseProgram(code, nil)
+	program, err := parser.ParseProgram(nil, code, parser.Config{})
 	if err != nil {
 		return wrapError(err)
 	}

--- a/tools/astexplorer/main.go
+++ b/tools/astexplorer/main.go
@@ -53,7 +53,7 @@ func main() {
 		}
 
 		var response Response
-		program, err := parser.ParseProgram([]byte(req.Code), nil)
+		program, err := parser.ParseProgram(nil, []byte(req.Code), parser.Config{})
 		if err != nil {
 			response.Error = err.Error()
 		} else {

--- a/tools/pretty/main.go
+++ b/tools/pretty/main.go
@@ -33,7 +33,7 @@ import (
 )
 
 func pretty(code string, maxLineWidth int) string {
-	program, err := parser.ParseProgram([]byte(code), nil)
+	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 	if err != nil {
 		return err.Error()
 	}


### PR DESCRIPTION
## Description

Quite a few conflicts due to Stable Cadence having support for the `view` modifier, and `master` having `native` and `static`.

Also, fix view function expression parsing by fixing the lookahead, whitespace is not skipped automatically anymore since #2115: https://github.com/onflow/cadence/pull/2141/files#diff-176a1c27185333df9a8b12d7551f33577326d9a715aab2abf203c8227574391bL819-R830

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
