### PR TITLE
Improve parameter AST node

### DIFF
--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4464,10 +4464,7 @@ func TestFunctionExpression_MarshalJSON(t *testing.T) {
 						},
 						StartPos: Position{Offset: 7, Line: 8, Column: 9},
 					},
-					Range: Range{
-						StartPos: Position{Offset: 10, Line: 11, Column: 12},
-						EndPos:   Position{Offset: 13, Line: 14, Column: 15},
-					},
+					StartPos: Position{Offset: 10, Line: 11, Column: 12},
 				},
 			},
 			Range: Range{
@@ -4530,7 +4527,7 @@ func TestFunctionExpression_MarshalJSON(t *testing.T) {
                             "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
                         },
                         "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
-                        "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+                        "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
                     }
                 ],
                 "StartPos": {"Offset": 16, "Line": 17, "Column": 18},

--- a/runtime/ast/function_declaration_test.go
+++ b/runtime/ast/function_declaration_test.go
@@ -57,10 +57,7 @@ func TestFunctionDeclaration_MarshalJSON(t *testing.T) {
 						},
 						StartPos: Position{Offset: 7, Line: 8, Column: 9},
 					},
-					Range: Range{
-						StartPos: Position{Offset: 10, Line: 11, Column: 12},
-						EndPos:   Position{Offset: 13, Line: 14, Column: 15},
-					},
+					StartPos: Position{Offset: 10, Line: 11, Column: 12},
 				},
 			},
 			Range: Range{
@@ -132,7 +129,7 @@ func TestFunctionDeclaration_MarshalJSON(t *testing.T) {
                             "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
                         },
                         "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
-                        "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+                        "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
                     }
                 ],
                 "StartPos": {"Offset": 16, "Line": 17, "Column": 18},
@@ -336,10 +333,7 @@ func TestSpecialFunctionDeclaration_MarshalJSON(t *testing.T) {
 							},
 							StartPos: Position{Offset: 7, Line: 8, Column: 9},
 						},
-						Range: Range{
-							StartPos: Position{Offset: 10, Line: 11, Column: 12},
-							EndPos:   Position{Offset: 13, Line: 14, Column: 15},
-						},
+						StartPos: Position{Offset: 10, Line: 11, Column: 12},
 					},
 				},
 				Range: Range{
@@ -415,7 +409,7 @@ func TestSpecialFunctionDeclaration_MarshalJSON(t *testing.T) {
                                 "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
                             },
                             "StartPos": {"Offset": 10, "Line": 11, "Column": 12},
-                            "EndPos": {"Offset": 13, "Line": 14, "Column": 15}
+                            "EndPos": {"Offset": 5, "Line": 5, "Column": 7}
                         }
                     ],
                     "StartPos": {"Offset": 16, "Line": 17, "Column": 18},

--- a/runtime/ast/parameter.go
+++ b/runtime/ast/parameter.go
@@ -28,7 +28,7 @@ type Parameter struct {
 	Label          string
 	Identifier     Identifier
 	TypeAnnotation *TypeAnnotation
-	StartPos       Position
+	StartPos       Position `json:"-"`
 }
 
 func NewParameter(
@@ -71,10 +71,10 @@ func (p *Parameter) EndPosition(memoryGauge common.MemoryGauge) Position {
 func (p *Parameter) MarshalJSON() ([]byte, error) {
 	type Alias Parameter
 	return json.Marshal(&struct {
-		EndPos Position
+		Range
 		*Alias
 	}{
-		EndPos: p.EndPosition(nil),
-		Alias:  (*Alias)(p),
+		Range: NewUnmeteredRangeFromPositioned(p),
+		Alias: (*Alias)(p),
 	})
 }

--- a/runtime/ast/parameter.go
+++ b/runtime/ast/parameter.go
@@ -18,13 +18,17 @@
 
 package ast
 
-import "github.com/onflow/cadence/runtime/common"
+import (
+	"encoding/json"
+
+	"github.com/onflow/cadence/runtime/common"
+)
 
 type Parameter struct {
 	Label          string
 	Identifier     Identifier
 	TypeAnnotation *TypeAnnotation
-	Range
+	StartPos       Position
 }
 
 func NewParameter(
@@ -32,24 +36,45 @@ func NewParameter(
 	label string,
 	identifier Identifier,
 	typeAnnotation *TypeAnnotation,
-	astRange Range,
+	startPos Position,
 ) *Parameter {
 	common.UseMemory(gauge, common.ParameterMemoryUsage)
 	return &Parameter{
 		Label:          label,
 		Identifier:     identifier,
 		TypeAnnotation: typeAnnotation,
-		Range:          astRange,
+		StartPos:       startPos,
 	}
 }
+
+var _ HasPosition = &Parameter{}
 
 // EffectiveArgumentLabel returns the effective argument label that
 // an argument in a call must use:
 // If no argument label is declared for parameter,
 // the parameter name is used as the argument label
-func (p Parameter) EffectiveArgumentLabel() string {
+func (p *Parameter) EffectiveArgumentLabel() string {
 	if p.Label != "" {
 		return p.Label
 	}
 	return p.Identifier.Identifier
+}
+
+func (p *Parameter) StartPosition() Position {
+	return p.StartPos
+}
+
+func (p *Parameter) EndPosition(memoryGauge common.MemoryGauge) Position {
+	return p.TypeAnnotation.EndPosition(memoryGauge)
+}
+
+func (p *Parameter) MarshalJSON() ([]byte, error) {
+	type Alias Parameter
+	return json.Marshal(&struct {
+		EndPos Position
+		*Alias
+	}{
+		EndPos: p.EndPosition(nil),
+		Alias:  (*Alias)(p),
+	})
 }

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -413,10 +413,7 @@ func TestParseParameterList(t *testing.T) {
 							},
 							StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
 						},
-						Range: ast.Range{
-							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 8, Offset: 8},
-						},
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
 					},
 				},
 				Range: ast.Range{
@@ -454,10 +451,7 @@ func TestParseParameterList(t *testing.T) {
 							},
 							StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 						},
-						Range: ast.Range{
-							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
-						},
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
 					},
 				},
 				Range: ast.Range{
@@ -495,10 +489,7 @@ func TestParseParameterList(t *testing.T) {
 							},
 							StartPos: ast.Position{Line: 1, Column: 8, Offset: 8},
 						},
-						Range: ast.Range{
-							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
-							EndPos:   ast.Position{Line: 1, Column: 10, Offset: 10},
-						},
+						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
 					},
 					{
 						Label: "",
@@ -516,10 +507,7 @@ func TestParseParameterList(t *testing.T) {
 							},
 							StartPos: ast.Position{Line: 1, Column: 18, Offset: 18},
 						},
-						Range: ast.Range{
-							StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
-							EndPos:   ast.Position{Line: 1, Column: 20, Offset: 20},
-						},
+						StartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
 					},
 				},
 				Range: ast.Range{
@@ -2009,10 +1997,7 @@ func TestParseEvent(t *testing.T) {
 													},
 													StartPos: ast.Position{Offset: 21, Line: 1, Column: 21},
 												},
-												Range: ast.Range{
-													StartPos: ast.Position{Offset: 17, Line: 1, Column: 17},
-													EndPos:   ast.Position{Offset: 23, Line: 1, Column: 23},
-												},
+												StartPos: ast.Position{Offset: 17, Line: 1, Column: 17},
 											},
 											{
 												Label: "",
@@ -2030,10 +2015,7 @@ func TestParseEvent(t *testing.T) {
 													},
 													StartPos: ast.Position{Offset: 31, Line: 1, Column: 31},
 												},
-												Range: ast.Range{
-													StartPos: ast.Position{Offset: 27, Line: 1, Column: 27},
-													EndPos:   ast.Position{Offset: 36, Line: 1, Column: 36},
-												},
+												StartPos: ast.Position{Offset: 27, Line: 1, Column: 27},
 											},
 										},
 										Range: ast.Range{
@@ -2560,10 +2542,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 													},
 													StartPos: ast.Position{Offset: 86, Line: 5, Column: 24},
 												},
-												Range: ast.Range{
-													StartPos: ast.Position{Offset: 81, Line: 5, Column: 19},
-													EndPos:   ast.Position{Offset: 88, Line: 5, Column: 26},
-												},
+												StartPos: ast.Position{Offset: 81, Line: 5, Column: 19},
 											},
 										},
 										Range: ast.Range{
@@ -2806,10 +2785,7 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 													},
 													StartPos: ast.Position{Offset: 96, Line: 5, Column: 24},
 												},
-												Range: ast.Range{
-													StartPos: ast.Position{Offset: 91, Line: 5, Column: 19},
-													EndPos:   ast.Position{Offset: 98, Line: 5, Column: 26},
-												},
+												StartPos: ast.Position{Offset: 91, Line: 5, Column: 19},
 											},
 										},
 										Range: ast.Range{
@@ -3180,10 +3156,7 @@ func TestParseTransactionDeclaration(t *testing.T) {
 											},
 											StartPos: ast.Position{Offset: 60, Line: 6, Column: 22},
 										},
-										Range: ast.Range{
-											StartPos: ast.Position{Offset: 52, Line: 6, Column: 14},
-											EndPos:   ast.Position{Offset: 70, Line: 6, Column: 32},
-										},
+										StartPos: ast.Position{Offset: 52, Line: 6, Column: 14},
 									},
 								},
 								Range: ast.Range{
@@ -3376,10 +3349,7 @@ func TestParseTransactionDeclaration(t *testing.T) {
 											},
 											StartPos: ast.Position{Offset: 60, Line: 6, Column: 22},
 										},
-										Range: ast.Range{
-											StartPos: ast.Position{Offset: 52, Line: 6, Column: 14},
-											EndPos:   ast.Position{Offset: 70, Line: 6, Column: 32},
-										},
+										StartPos: ast.Position{Offset: 52, Line: 6, Column: 14},
 									},
 								},
 								Range: ast.Range{
@@ -3616,10 +3586,7 @@ func TestParseTransactionDeclaration(t *testing.T) {
 											},
 											StartPos: ast.Position{Offset: 60, Line: 6, Column: 22},
 										},
-										Range: ast.Range{
-											StartPos: ast.Position{Offset: 52, Line: 6, Column: 14},
-											EndPos:   ast.Position{Offset: 70, Line: 6, Column: 32},
-										},
+										StartPos: ast.Position{Offset: 52, Line: 6, Column: 14},
 									},
 								},
 								Range: ast.Range{
@@ -3868,10 +3835,7 @@ func TestParseFunctionParameterWithoutLabel(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 15, Line: 2, Column: 14},
-								EndPos:   ast.Position{Offset: 20, Line: 2, Column: 19},
-							},
+							StartPos: ast.Position{Offset: 15, Line: 2, Column: 14},
 						},
 					},
 					Range: ast.Range{
@@ -3938,10 +3902,7 @@ func TestParseFunctionParameterWithLabel(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 20, Line: 2, Column: 19},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 15, Line: 2, Column: 14},
-								EndPos:   ast.Position{Offset: 22, Line: 2, Column: 21},
-							},
+							StartPos: ast.Position{Offset: 15, Line: 2, Column: 14},
 						},
 					},
 					Range: ast.Range{
@@ -4050,10 +4011,7 @@ func TestParseStructure(t *testing.T) {
 												},
 												StartPos: ast.Position{Offset: 80, Line: 5, Column: 22},
 											},
-											Range: ast.Range{
-												StartPos: ast.Position{Offset: 75, Line: 5, Column: 17},
-												EndPos:   ast.Position{Offset: 82, Line: 5, Column: 24},
-											},
+											StartPos: ast.Position{Offset: 75, Line: 5, Column: 17},
 										},
 									},
 									Range: ast.Range{
@@ -4276,10 +4234,7 @@ func TestParsePreAndPostConditions(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 21, Line: 2, Column: 20},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
-								EndPos:   ast.Position{Offset: 23, Line: 2, Column: 22},
-							},
+							StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
 						},
 					},
 					Range: ast.Range{
@@ -4436,10 +4391,7 @@ func TestParseConditionMessage(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 21, Line: 2, Column: 20},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
-								EndPos:   ast.Position{Offset: 23, Line: 2, Column: 22},
-							},
+							StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
 						},
 					},
 					Range: ast.Range{
@@ -4596,10 +4548,7 @@ func TestParseInterface(t *testing.T) {
 											},
 											StartPos: ast.Position{Offset: 89, Line: 5, Column: 26},
 										},
-										Range: ast.Range{
-											StartPos: ast.Position{Offset: 84, Line: 5, Column: 21},
-											EndPos:   ast.Position{Offset: 91, Line: 5, Column: 28},
-										},
+										StartPos: ast.Position{Offset: 84, Line: 5, Column: 21},
 									},
 								},
 								Range: ast.Range{
@@ -5074,10 +5023,7 @@ func TestParseEventDeclaration(t *testing.T) {
 												},
 												StartPos: ast.Position{Offset: 28, Line: 2, Column: 27},
 											},
-											Range: ast.Range{
-												StartPos: ast.Position{Offset: 24, Line: 2, Column: 23},
-												EndPos:   ast.Position{Offset: 34, Line: 2, Column: 33},
-											},
+											StartPos: ast.Position{Offset: 24, Line: 2, Column: 23},
 										},
 										{
 											Label: "",
@@ -5095,10 +5041,7 @@ func TestParseEventDeclaration(t *testing.T) {
 												},
 												StartPos: ast.Position{Offset: 43, Line: 2, Column: 42},
 											},
-											Range: ast.Range{
-												StartPos: ast.Position{Offset: 37, Line: 2, Column: 36},
-												EndPos:   ast.Position{Offset: 49, Line: 2, Column: 48},
-											},
+											StartPos: ast.Position{Offset: 37, Line: 2, Column: 36},
 										},
 									},
 									Range: ast.Range{
@@ -5347,10 +5290,7 @@ func TestParseResourceParameterType(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 21, Line: 2, Column: 20},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
-								EndPos:   ast.Position{Offset: 22, Line: 2, Column: 21},
-							},
+							StartPos: ast.Position{Offset: 18, Line: 2, Column: 17},
 						},
 					},
 					Range: ast.Range{
@@ -5593,10 +5533,7 @@ func TestParseCompositeDeclarationWithSemicolonSeparatedMembers(t *testing.T) {
 												},
 												StartPos: ast.Position{Offset: 47, Line: 2, Column: 46},
 											},
-											Range: ast.Range{
-												StartPos: ast.Position{Offset: 43, Line: 2, Column: 42},
-												EndPos:   ast.Position{Offset: 49, Line: 2, Column: 48},
-											},
+											StartPos: ast.Position{Offset: 43, Line: 2, Column: 42},
 										},
 									},
 									Range: ast.Range{

--- a/runtime/parser/function.go
+++ b/runtime/parser/function.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/runtime/parser/lexer"
 )
 
-func parseParameterList(p *parser) (parameterList *ast.ParameterList, err error) {
+func parseParameterList(p *parser) (*ast.ParameterList, error) {
 	var parameters []*ast.Parameter
 
 	p.skipSpaceAndComments()
@@ -108,7 +108,7 @@ func parseParameterList(p *parser) (parameterList *ast.ParameterList, err error)
 			startPos,
 			endPos,
 		),
-	), err
+	), nil
 }
 
 func parseParameter(p *parser) (*ast.Parameter, error) {
@@ -156,8 +156,6 @@ func parseParameter(p *parser) (*ast.Parameter, error) {
 		return nil, err
 	}
 
-	endPos := typeAnnotation.EndPosition(p.memoryGauge)
-
 	return ast.NewParameter(
 		p.memoryGauge,
 		argumentLabel,
@@ -167,11 +165,7 @@ func parseParameter(p *parser) (*ast.Parameter, error) {
 			parameterPos,
 		),
 		typeAnnotation,
-		ast.NewRange(
-			p.memoryGauge,
-			startPos,
-			endPos,
-		),
+		startPos,
 	), nil
 }
 

--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -1355,10 +1355,7 @@ func TestParseParametersAndArrayTypes(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 19, Line: 2, Column: 18},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 16, Line: 2, Column: 15},
-								EndPos:   ast.Position{Offset: 23, Line: 2, Column: 22},
-							},
+							StartPos: ast.Position{Offset: 16, Line: 2, Column: 15},
 						},
 						{
 							Identifier: ast.Identifier{
@@ -1390,10 +1387,7 @@ func TestParseParametersAndArrayTypes(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 29, Line: 2, Column: 28},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 26, Line: 2, Column: 25},
-								EndPos:   ast.Position{Offset: 38, Line: 2, Column: 37},
-							},
+							StartPos: ast.Position{Offset: 26, Line: 2, Column: 25},
 						},
 						{
 							Identifier: ast.Identifier{
@@ -1431,10 +1425,7 @@ func TestParseParametersAndArrayTypes(t *testing.T) {
 								},
 								StartPos: ast.Position{Offset: 44, Line: 2, Column: 43},
 							},
-							Range: ast.Range{
-								StartPos: ast.Position{Offset: 41, Line: 2, Column: 40},
-								EndPos:   ast.Position{Offset: 55, Line: 2, Column: 54},
-							},
+							StartPos: ast.Position{Offset: 41, Line: 2, Column: 40},
 						},
 					},
 					Range: ast.Range{

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -9099,8 +9099,8 @@ func TestInterpretASTMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(231), meter.getMemory(common.MemoryKindPosition))
-		assert.Equal(t, uint64(126), meter.getMemory(common.MemoryKindRange))
+		assert.Equal(t, uint64(229), meter.getMemory(common.MemoryKindPosition))
+		assert.Equal(t, uint64(124), meter.getMemory(common.MemoryKindRange))
 	})
 
 	t.Run("locations", func(t *testing.T) {


### PR DESCRIPTION
## Description

Replace the full range with just the start position.
Compute the end position only if needed, from the parameter's type annotation.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
