### PR TITLE
Use a supertype to combine functionality of composite and attachment declarations

### DIFF
--- a/docs/flow-docs.json
+++ b/docs/flow-docs.json
@@ -10,7 +10,7 @@
          {
           "title": "Why Use Cadence?",
           "tags": ["reference", "patterns"],
-          "description":"Learn the main benefits of using Cadence for smart contract development."
+          "description":"Learn the main benefits of using Cadence for smart contract development.",
           "href": "/cadence/why-cadence"
         },
         {
@@ -172,6 +172,9 @@
           },
           {
             "href": "capability-based-access-control"
+          },
+          {
+            "href": "attachments"
           },
           {
             "href": "contracts"

--- a/docs/language/attachments.md
+++ b/docs/language/attachments.md
@@ -1,0 +1,270 @@
+---
+title: Attachments
+---
+
+<Callout type="warning">
+⚠️  This section describes a feature that is not yet released on Mainnet. 
+It will be available following the next Mainnet Spork. 
+</Callout>
+
+Attachments are a feature of Cadence designed to allow developers to extend a struct or resource type 
+(even one that they did not declare) with new functionality,
+without requiring the original author of the type to plan or account for the intended behavior. 
+
+## Declaring Attachments
+
+Attachments are declared with the `attachment` keyword, which would be declared using a new form of composite declaration:
+`pub attachment <Name> for <Type>: <Conformances> { ... }`, where the attachment functions and fields are declared in the body. 
+As such, the following would be examples of legal declarations of attachments:
+
+```cadence
+pub attachment Foo for MyStruct {
+    // ...
+}
+
+attachment Bar for MyResource: MyResourceInterface {
+    // ...
+}
+
+attachment Baz for MyInterface: MyOtherInterface {
+    // ...
+}
+```
+
+Specifying the kind (struct or resource) of an attachment is not necessary, as its kind will necessarily be the same as the type it is extending. 
+Note that the base type may be either a concrete composite type or an interface.
+In the former case, the attachment is only usable on values specifically of that base type, 
+while in the case of an interface the attachment is usable on any type that conforms to that interface. 
+
+As with other type declarations, attachments may only have a `pub` access modifier (if one is present). 
+
+The body of the attachment follows the same declaration rules as composites. 
+In particular, they may have both field and function members,
+and any field members must be initialized in an `init` function. 
+Only resource-kinded attachments may have resource members, 
+and such members must be explicitly handled in the `destroy` function. 
+The `self` keyword is available in attachment bodies, but unlike in a composite, 
+`self` is a **reference** type, rather than a composite type: 
+In an attachment declaration for `A`, the type of `self` would be `&A`, rather than `A` like in other composite declarations.
+
+If a resource with attachments on it is `destroy`ed, the `destroy` functions of all its attachments are all run in an unspecified order; 
+`destroy` should not rely on the presence of other attachments on the base type in its implementation. 
+The only guarantee about the order in which attachments are destroyed in this case is that the base resource will be the last thing destroyed. 
+
+Within the body of an attachment, there is also a `base` keyword available, 
+which contains a reference to the attachment's base value; 
+that is, the composite to which the attachment is attached.
+Its type, therefore, is a reference to the attachment's declared base type.
+So, for an attachment declared `pub attachment Foo for Bar`, the `base` field of `Foo` would have type `&Bar`.
+
+So, for example, this would be a valid declaration of an attachment:
+
+```
+pub resource R {
+    pub let x: Int
+
+    init (_ x: Int) {
+        self.x = x
+    }
+
+    pub fun foo() { ... }
+}
+
+pub attachment A for R {
+    pub let derivedX: Int 
+
+    init (_ scalar: Int) {
+        self.derivedX = base.x * scalar
+    }
+
+    pub fun foo() {
+        base.foo()
+    }
+}
+
+```
+
+For the purposes of external mutation checks or [access control](/access-control), 
+the attachment is considered a separate declaration from its base type. 
+A developer cannot, therefore, access any `priv` fields 
+(or `access(contract)` fields if the base was defined in a different contract to the attachment)
+on the `base` value, nor can they mutate any array or dictionary typed fields.
+
+```cadence
+pub resource interface SomeInterface {
+    pub let b: Bool
+    priv let i: Int
+    pub let a: [String]
+}
+pub attachment SomeAttachment for SomeContract.SomeStruct { 
+    pub let i: Int
+    init(i: Int) {
+        if base.b {
+            self.i = base.i // cannot access `i` on the `base` value
+        } else {
+            self.i = i
+        }
+    }
+    pub fun foo() {
+        base.a.append("hello") // cannot mutate `a` outside of the composite where it was defined
+    }
+}
+```
+
+### Attachment Types
+
+An attachment declared with `pub attachment A for C { ... }` will have a nominal type `A`.
+
+It is important to note that attachments are not first class values in Cadence, and as such their usage is limited in certain ways.  
+In particular, their types cannot appear outside of a reference type. 
+So, for example, given an  attachment declaration `attachment A for X {}`, the types `A`, `A?`, `[A]` and `((): A)` are not valid type annotations, 
+while `&A`, `&A?`, `[&A]` and `((): &A)` are valid. 
+
+## Creating Attachments
+
+An attachment is created using an `attach` expression, 
+where the attachment is both initialized and attached to the base value in a single operation. 
+Attachments are not first-class values in Cadence; they cannot exist independently of a base value, 
+nor can they be moved around on their own. 
+This means that an `attach` expression is the only place in which an attachment constructor can be called. 
+Tightly coupling the creation and attaching of attachment values helps to make reasoning about attachments simpler for the user. 
+Also for this reason, resource attachments do not need an expliict `<-` move operator when they appear in an `attach` expression. 
+
+An attach expression consists of the `attach` keyword, a constructor call for the attachment value, 
+the `to` keyword, and an expression that evaluates to the base value for that attachment. 
+Any arguments required by the attachment's `init` function are provided in its constructor call. 
+
+```cadence
+pub resource R {}
+pub attachment A for R {
+    init(x: Int) {
+        //...
+    }
+}
+
+// ...
+let r <- create R()
+let r2 <- attach A(x: 3) to <-r
+```
+
+The expression on the right-hand side of the `to` keyword must evaluate to a composite value whose type is a subtype of the attachment's base, 
+and is evaluated before the call to the constructor on the left side of `to`. 
+This means that the `base` value is available inside of the attachment's `init` function,
+but it is important to note that the attachment being created will not be accessible on the `base` 
+(see the accessing attachments section below) until after the constructor finishes executing. 
+
+
+```cadence
+pub resource interface I {}
+pub resource R: I {}
+pub attachment A for I {}
+
+// ...
+let r <- create R() // has type @R
+let r2 <- attach A() to <-r // ok, because `R` is a subtype of `I`, still has type @R
+```
+
+Because attachments are stored on their bases by type, there can only be one attachment of each type present on a value at a time.
+Cadence will raise a runtime error if a user attempts to add an attachment to a value when one it already exists on that value.
+The type returned by the `attach` expression is the same type as the expression on the right-hand side of the `to`; 
+attaching an attachment to a value does not change its type. 
+
+## Accessing Attachments
+
+Attachments are accessed on composites via type-indexing: 
+composite values function like a dictionary where the keys are types and the values are attachments. 
+So given a composite value `v`, one can look up the attachment named `A` on `v` using indexing syntax:
+
+```cadence
+let a = v[A] // has type `&A?`
+```
+
+This syntax requires that `A` is a nominal attachment type,
+and that `v` has a composite type that is a subtype of `A`'s declared base type. 
+As mentioned above, attachments are not first-class values in Cadence, 
+so this indexing returns a reference to the attachment on `v`, rather than the attachment itself. 
+If the attachment with the given type does not exist on `v`, this expression returns `nil`. 
+
+Because the indexed value must be a subtype of the indexing attachment's base type,
+the owner of a resource can restrict which attachments can be accessed on references to their resource using restricted types, 
+much like they would do with any other field or function. E.g.
+
+```cadence
+struct R: I {}
+struct interface I {}
+attachment A for R {}
+fun foo(r: &{I}) {
+    r[A] // fails to type check, because `{I}` is not a subtype of `R`
+}
+```
+
+Hence, if the owner of a resource wishes to allow others to use a subset of its attachments, 
+they can create a capability to that resource with a borrow type that only allows certain attachments to be accessed. 
+
+## Removing Attachments
+
+Attachments can be removed from a value with a `remove` statement. 
+The statement consists of the `remove` keyword, the nominal type for the attachment to be removed, 
+the `from` keyword, and the value from which the attachment is meant to be removed. 
+
+The value on the right-hand side of `from` must be a composite value whose type is a subtype of the attachment type's declared base. 
+
+Before the statement executes, the attachment's `destroy` function (if present) will be executed. 
+After the statement executes, the composite value on the right-hand side of `from` will no longer contain the attachment.
+If the value does not contain `t`, this statement has no effect. 
+
+Attachments may be removed from a type in any order,
+so users should take care not to design any attachments that rely on specific behaviors of other attachments, 
+as there is no to require that an attachment depend on another or to require that a type has a given attachment when another attachment is present. 
+
+If a resource containing attachments is `destroy`ed, all its attachments will be `destroy`ed in an arbitrary order. 
+
+### Iterating over Attachments
+
+All composite types contain a function `forEachAttachment` that iterates over all the attachments present on that composite. 
+On a resource-kinded composite, this function has the following signature:
+
+```cadence
+fun forEachAttachment(_ f: ((&AnyResourceAttachment): Void)): Void 
+```
+
+While on a struct-kinded composite, it has:
+
+```cadence
+fun forEachAttachment(_ f: ((&AnyStructAttachment): Void)): Void 
+```
+
+`AnyResourceAttachment`/`AnyStructAttachment` are express the supertypes of all struct/resource attachments.
+They contain two functions (that are implicitly present on all attachments): `getField` and `getFunction`, 
+with the following signatures:
+
+```cadence
+getField<T>(_  name: String): &T?
+getFunction<T>(_  name: String): T?
+```
+
+This functions takes the `name` of a member on an attachment and checks whether a member with that `name` exists on the attachment with the provided type argument.
+If it does, `getField` will return a reference to that member is it is a field, but `nil` if it is a function, 
+while `getFunction` will return that function if it is a function but `nil` if it is a field. 
+If the type does not match or the member is not present, then both will return nil. 
+
+So, for example, if the creator of a resource would like to have a function that returns the a descriptive string describing that resource and all its attachments, they may implement it this way:
+
+```
+pub resource R {
+    ...
+    priv let descriptionString: String
+    pub fun description(): String {
+        let description = descriptionString
+        self.forEachAttachment(f: fun (attachment: &AnyResourceAttachment) {
+            let descriptionFunction = attachment.getFunction<(():String)>("description")
+            if descriptionFunction != nil {
+                description.concat(descriptionFunction!())
+            }
+        }))
+    }
+}
+```
+
+Attempting to attach new attachments to a composite or remove attachments from it while iterating over it is a runtime error, 
+and the order of iteration over a composite's attachments is deterministic but undefined. 

--- a/runtime/ast/attachment.go
+++ b/runtime/ast/attachment.go
@@ -38,9 +38,7 @@ type AttachmentDeclaration struct {
 	Range
 }
 
-var _ Element = &AttachmentDeclaration{}
-var _ Declaration = &AttachmentDeclaration{}
-var _ Statement = &AttachmentDeclaration{}
+var _ CompositeLikeDeclaration = &AttachmentDeclaration{}
 
 func NewAttachmentDeclaration(
 	memoryGauge common.MemoryGauge,
@@ -97,6 +95,14 @@ func (d *AttachmentDeclaration) DeclarationMembers() *Members {
 
 func (d *AttachmentDeclaration) DeclarationDocString() string {
 	return d.DocString
+}
+
+func (*AttachmentDeclaration) Kind() common.CompositeKind {
+	return common.CompositeKindAttachment
+}
+
+func (d *AttachmentDeclaration) ConformanceList() []*NominalType {
+	return d.Conformances
 }
 
 const attachmentStatementDoc = prettier.Text("attachment")

--- a/runtime/ast/composite.go
+++ b/runtime/ast/composite.go
@@ -31,6 +31,14 @@ import (
 
 // NOTE: For events, only an empty initializer is declared
 
+type CompositeLikeDeclaration interface {
+	Element
+	Declaration
+	Statement
+	Kind() common.CompositeKind
+	ConformanceList() []*NominalType
+}
+
 type CompositeDeclaration struct {
 	Access        Access
 	CompositeKind common.CompositeKind
@@ -41,9 +49,7 @@ type CompositeDeclaration struct {
 	Range
 }
 
-var _ Element = &CompositeDeclaration{}
-var _ Declaration = &CompositeDeclaration{}
-var _ Statement = &CompositeDeclaration{}
+var _ CompositeLikeDeclaration = &CompositeDeclaration{}
 
 func NewCompositeDeclaration(
 	memoryGauge common.MemoryGauge,
@@ -255,6 +261,14 @@ func CompositeDocument(
 	}
 
 	return doc
+}
+
+func (d *CompositeDeclaration) Kind() common.CompositeKind {
+	return d.CompositeKind
+}
+
+func (d *CompositeDeclaration) ConformanceList() []*NominalType {
+	return d.Conformances
 }
 
 // FieldDeclaration

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -866,8 +866,7 @@ func (interpreter *Interpreter) declareAttachmentValue(
 	scope *VariableActivation,
 	variable *Variable,
 ) {
-	compositeDeclaration := sema.AttachmentAsComposite(interpreter, interpreter.Program.Elaboration, declaration)
-	return interpreter.declareCompositeValue(compositeDeclaration, lexicalScope)
+	return interpreter.declareCompositeValue(declaration, lexicalScope)
 }
 
 // declareCompositeValue creates and declares the value for
@@ -887,27 +886,27 @@ func (interpreter *Interpreter) declareAttachmentValue(
 //
 // For all other composite kinds the constructor function is declared.
 func (interpreter *Interpreter) declareCompositeValue(
-	declaration *ast.CompositeDeclaration,
+	declaration ast.CompositeLikeDeclaration,
 	lexicalScope *VariableActivation,
 ) (
 	scope *VariableActivation,
 	variable *Variable,
 ) {
-	if declaration.CompositeKind == common.CompositeKindEnum {
-		return interpreter.declareEnumConstructor(declaration, lexicalScope)
+	if declaration.Kind() == common.CompositeKindEnum {
+		return interpreter.declareEnumConstructor(declaration.(*ast.CompositeDeclaration), lexicalScope)
 	} else {
 		return interpreter.declareNonEnumCompositeValue(declaration, lexicalScope)
 	}
 }
 
 func (interpreter *Interpreter) declareNonEnumCompositeValue(
-	declaration *ast.CompositeDeclaration,
+	declaration ast.CompositeLikeDeclaration,
 	lexicalScope *VariableActivation,
 ) (
 	scope *VariableActivation,
 	variable *Variable,
 ) {
-	identifier := declaration.Identifier.Identifier
+	identifier := declaration.DeclarationIdentifier().Identifier
 	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
 	variable = interpreter.findOrDeclareVariable(identifier)
 
@@ -932,23 +931,25 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			)
 		}
 
-		for _, nestedInterfaceDeclaration := range declaration.Members.Interfaces() {
+		members := declaration.DeclarationMembers()
+
+		for _, nestedInterfaceDeclaration := range members.Interfaces() {
 			predeclare(nestedInterfaceDeclaration.Identifier)
 		}
 
-		for _, nestedCompositeDeclaration := range declaration.Members.Composites() {
+		for _, nestedCompositeDeclaration := range members.Composites() {
 			predeclare(nestedCompositeDeclaration.Identifier)
 		}
 
-		for _, nestedAttachmentDeclaration := range declaration.Members.Attachments() {
+		for _, nestedAttachmentDeclaration := range members.Attachments() {
 			predeclare(nestedAttachmentDeclaration.Identifier)
 		}
 
-		for _, nestedInterfaceDeclaration := range declaration.Members.Interfaces() {
+		for _, nestedInterfaceDeclaration := range members.Interfaces() {
 			interpreter.declareInterface(nestedInterfaceDeclaration, lexicalScope)
 		}
 
-		for _, nestedCompositeDeclaration := range declaration.Members.Composites() {
+		for _, nestedCompositeDeclaration := range members.Composites() {
 
 			// Pass the lexical scope, which has the containing composite's value declared,
 			// to the nested declarations so they can refer to it, and update the lexical scope
@@ -965,7 +966,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			nestedVariables[memberIdentifier] = nestedVariable
 		}
 
-		for _, nestedAttachmentDeclaration := range declaration.Members.Attachments() {
+		for _, nestedAttachmentDeclaration := range members.Attachments() {
 
 			// Pass the lexical scope, which has the containing composite's value declared,
 			// to the nested declarations so they can refer to it, and update the lexical scope
@@ -995,7 +996,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 	}
 
 	var initializerFunction FunctionValue
-	if declaration.CompositeKind == common.CompositeKindEvent {
+	if declaration.Kind() == common.CompositeKindEvent {
 		initializerFunction = NewHostFunctionValue(
 			interpreter,
 			func(invocation Invocation) Value {
@@ -1137,13 +1138,13 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 						interpreter,
 						location,
 						qualifiedIdentifier,
-						declaration.CompositeKind,
+						declaration.Kind(),
 					)
 				}
 
 				var fields []CompositeField
 
-				if declaration.CompositeKind == common.CompositeKindResource {
+				if declaration.Kind() == common.CompositeKindResource {
 
 					uuidHandler := config.UUIDHandler
 					if uuidHandler == nil {
@@ -1177,7 +1178,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 					locationRange,
 					location,
 					qualifiedIdentifier,
-					declaration.CompositeKind,
+					declaration.Kind(),
 					fields,
 					address,
 				)
@@ -1187,13 +1188,13 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 				value.Destructor = destructorFunction
 
 				var self MemberAccessibleValue = value
-				if declaration.CompositeKind == common.CompositeKindAttachment {
+				if declaration.Kind() == common.CompositeKindAttachment {
 					self = NewEphemeralReferenceValue(interpreter, false, value, interpreter.MustConvertStaticToSemaType(value.StaticType(interpreter)))
 					invocation.Base = interpreter.FindVariable(sema.BaseIdentifier).GetValue().(*EphemeralReferenceValue)
 				}
 				invocation.Self = &self
 
-				if declaration.CompositeKind == common.CompositeKindContract {
+				if declaration.Kind() == common.CompositeKindContract {
 					// NOTE: set the variable value immediately, as the contract value
 					// needs to be available for nested declarations
 
@@ -1219,9 +1220,9 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 	// Contract declarations declare a value / instance (singleton),
 	// for all other composite kinds, the constructor is declared
 
-	if declaration.CompositeKind == common.CompositeKindContract {
+	if declaration.Kind() == common.CompositeKindContract {
 		variable.getter = func() Value {
-			positioned := ast.NewRangeFromPositioned(interpreter, declaration.Identifier)
+			positioned := ast.NewRangeFromPositioned(interpreter, declaration.DeclarationIdentifier())
 
 			contractValue := config.ContractValueHandler(
 				interpreter,
@@ -1373,13 +1374,13 @@ func EnumConstructorFunction(
 }
 
 func (interpreter *Interpreter) compositeInitializerFunction(
-	compositeDeclaration *ast.CompositeDeclaration,
+	compositeDeclaration ast.CompositeLikeDeclaration,
 	lexicalScope *VariableActivation,
 ) *InterpretedFunctionValue {
 
 	// TODO: support multiple overloaded initializers
 
-	initializers := compositeDeclaration.Members.Initializers()
+	initializers := compositeDeclaration.DeclarationMembers().Initializers()
 	var initializer *ast.SpecialFunctionDeclaration
 	if len(initializers) == 0 {
 		return nil
@@ -1422,11 +1423,11 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 }
 
 func (interpreter *Interpreter) compositeDestructorFunction(
-	compositeDeclaration *ast.CompositeDeclaration,
+	compositeDeclaration ast.CompositeLikeDeclaration,
 	lexicalScope *VariableActivation,
 ) *InterpretedFunctionValue {
 
-	destructor := compositeDeclaration.Members.Destructor()
+	destructor := compositeDeclaration.DeclarationMembers().Destructor()
 	if destructor == nil {
 		return nil
 	}
@@ -1494,13 +1495,13 @@ func (interpreter *Interpreter) defaultFunctions(
 }
 
 func (interpreter *Interpreter) compositeFunctions(
-	compositeDeclaration *ast.CompositeDeclaration,
+	compositeDeclaration ast.CompositeLikeDeclaration,
 	lexicalScope *VariableActivation,
 ) map[string]FunctionValue {
 
 	functions := map[string]FunctionValue{}
 
-	for _, functionDeclaration := range compositeDeclaration.Members.Functions() {
+	for _, functionDeclaration := range compositeDeclaration.DeclarationMembers().Functions() {
 		name := functionDeclaration.Identifier.Identifier
 		functions[name] =
 			interpreter.compositeFunction(

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -121,7 +121,7 @@ func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDecl
 		// Composite declarations nested in interface declarations are type requirements,
 		// i.e. they should be checked like interfaces
 
-		checker.visitCompositeDeclaration(nestedComposite, kind)
+		checker.visitCompositeLikeDeclaration(nestedComposite, kind)
 	}
 
 	for _, nestedAttachments := range declaration.Members.Attachments() {
@@ -358,7 +358,7 @@ func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclar
 	}
 
 	for _, nestedCompositeDeclaration := range declaration.Members.Composites() {
-		checker.declareCompositeMembersAndValue(nestedCompositeDeclaration, ContainerKindInterface)
+		checker.declareCompositeLikeMembersAndValue(nestedCompositeDeclaration, ContainerKindInterface)
 	}
 
 	for _, nestedAttachmentDeclaration := range declaration.Members.Attachments() {

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -320,7 +320,7 @@ func (checker *Checker) CheckProgram(program *ast.Program) {
 	}
 
 	for _, declaration := range program.CompositeDeclarations() {
-		checker.declareCompositeMembersAndValue(declaration, ContainerKindComposite)
+		checker.declareCompositeLikeMembersAndValue(declaration, ContainerKindComposite)
 	}
 
 	for _, declaration := range program.AttachmentDeclarations() {

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -96,9 +96,8 @@ type Elaboration struct {
 	FunctionDeclarationFunctionTypes map[*ast.FunctionDeclaration]*FunctionType
 	VariableDeclarationTypes         map[*ast.VariableDeclaration]VariableDeclarationTypes
 	AssignmentStatementTypes         map[*ast.AssignmentStatement]AssignmentStatementTypes
-	CompositeDeclarationTypes        map[*ast.CompositeDeclaration]*CompositeType
-	CompositeTypeDeclarations        map[*CompositeType]*ast.CompositeDeclaration
-	AttachmentCompositeDeclarations  map[*ast.AttachmentDeclaration]*ast.CompositeDeclaration
+	CompositeDeclarationTypes        map[ast.CompositeLikeDeclaration]*CompositeType
+	CompositeTypeDeclarations        map[*CompositeType]ast.CompositeLikeDeclaration
 	InterfaceDeclarationTypes        map[*ast.InterfaceDeclaration]*InterfaceType
 	InterfaceTypeDeclarations        map[*InterfaceType]*ast.InterfaceDeclaration
 	ConstructorFunctionTypes         map[*ast.SpecialFunctionDeclaration]*FunctionType
@@ -120,7 +119,7 @@ type Elaboration struct {
 	// IsNestedResourceMoveExpression indicates if the access the index or member expression
 	// is implicitly moving a resource out of the container, e.g. in a shift or swap statement.
 	IsNestedResourceMoveExpression      map[ast.Expression]struct{}
-	CompositeNestedDeclarations         map[*ast.CompositeDeclaration]map[string]ast.Declaration
+	CompositeNestedDeclarations         map[ast.CompositeLikeDeclaration]map[string]ast.Declaration
 	InterfaceNestedDeclarations         map[*ast.InterfaceDeclaration]map[string]ast.Declaration
 	PostConditionsRewrite               map[*ast.Conditions]PostConditionsRewrite
 	EmitStatementEventTypes             map[*ast.EmitStatement]*CompositeType
@@ -152,9 +151,8 @@ func NewElaboration(gauge common.MemoryGauge, extendedElaboration bool) *Elabora
 		FunctionDeclarationFunctionTypes:    map[*ast.FunctionDeclaration]*FunctionType{},
 		VariableDeclarationTypes:            map[*ast.VariableDeclaration]VariableDeclarationTypes{},
 		AssignmentStatementTypes:            map[*ast.AssignmentStatement]AssignmentStatementTypes{},
-		CompositeDeclarationTypes:           map[*ast.CompositeDeclaration]*CompositeType{},
-		CompositeTypeDeclarations:           map[*CompositeType]*ast.CompositeDeclaration{},
-		AttachmentCompositeDeclarations:     map[*ast.AttachmentDeclaration]*ast.CompositeDeclaration{},
+		CompositeDeclarationTypes:           map[ast.CompositeLikeDeclaration]*CompositeType{},
+		CompositeTypeDeclarations:           map[*CompositeType]ast.CompositeLikeDeclaration{},
 		InterfaceDeclarationTypes:           map[*ast.InterfaceDeclaration]*InterfaceType{},
 		InterfaceTypeDeclarations:           map[*InterfaceType]*ast.InterfaceDeclaration{},
 		ConstructorFunctionTypes:            map[*ast.SpecialFunctionDeclaration]*FunctionType{},
@@ -174,7 +172,7 @@ func NewElaboration(gauge common.MemoryGauge, extendedElaboration bool) *Elabora
 		TransactionDeclarationTypes:         map[*ast.TransactionDeclaration]*TransactionType{},
 		SwapStatementTypes:                  map[*ast.SwapStatement]SwapStatementTypes{},
 		IsNestedResourceMoveExpression:      map[ast.Expression]struct{}{},
-		CompositeNestedDeclarations:         map[*ast.CompositeDeclaration]map[string]ast.Declaration{},
+		CompositeNestedDeclarations:         map[ast.CompositeLikeDeclaration]map[string]ast.Declaration{},
 		InterfaceNestedDeclarations:         map[*ast.InterfaceDeclaration]map[string]ast.Declaration{},
 		PostConditionsRewrite:               map[*ast.Conditions]PostConditionsRewrite{},
 		EmitStatementEventTypes:             map[*ast.EmitStatement]*CompositeType{},

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1141,7 +1141,7 @@ type InitializerMismatch struct {
 //  use `InitializerMismatch`, `MissingMembers`, `MemberMismatches`, etc
 
 type ConformanceError struct {
-	CompositeDeclaration           *ast.CompositeDeclaration
+	CompositeDeclaration           ast.CompositeLikeDeclaration
 	CompositeType                  *CompositeType
 	InterfaceType                  *InterfaceType
 	InitializerMismatch            *InitializerMismatch

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4008,16 +4008,16 @@ func (t *CompositeType) initializeMemberResolvers() {
 	})
 }
 
-func (t *CompositeType) FieldPosition(name string, declaration *ast.CompositeDeclaration) ast.Position {
+func (t *CompositeType) FieldPosition(name string, declaration ast.CompositeLikeDeclaration) ast.Position {
 	var pos ast.Position
 	if t.Kind == common.CompositeKindEnum &&
 		name == EnumRawValueFieldName {
 
-		if len(declaration.Conformances) > 0 {
-			pos = declaration.Conformances[0].StartPosition()
+		if len(declaration.ConformanceList()) > 0 {
+			pos = declaration.ConformanceList()[0].StartPosition()
 		}
 	} else {
-		pos = declaration.Members.FieldPosition(name, declaration.CompositeKind)
+		pos = declaration.DeclarationMembers().FieldPosition(name, declaration.Kind())
 	}
 	return pos
 }

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1564,7 +1564,7 @@ func TestCheckerContractValueHandler(
 	declaration *ast.CompositeDeclaration,
 	compositeType *sema.CompositeType,
 ) sema.ValueDeclaration {
-	constructorType, constructorArgumentLabels := sema.CompositeConstructorType(
+	constructorType, constructorArgumentLabels := sema.CompositeLikeConstructorType(
 		checker.Elaboration,
 		declaration,
 		compositeType,


### PR DESCRIPTION
This is a small improvement to the attachments code that uses a new `CompositeLikeDeclaration` type to reuse the composite code for attachments, instead of converting the latter into the former at runtime. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
