### PR TITLE
Add link to style guide

### DIFF
--- a/docs/flow-docs.json
+++ b/docs/flow-docs.json
@@ -90,6 +90,15 @@
           }
         ]
       },
+        {
+          "title": "Project and Style Guides",
+          "items": [
+            {
+              "title": "Project Management Guide",
+              "href": "style-guide"
+            }
+          ]
+        },      
       {
         "title": "Cadence",
         "items": [


### PR DESCRIPTION
Need to add link to style guide

Here is the original PR, original PR added style guide repo configuration to developer portal. This step was missed with new nav changes to developer portal
https://github.com/onflow/developer-portal/pull/727
following limited documentation on how to [add a link](https://developers.flow.com/flow/developer-portal/contribution-guidelines#basic-contribution-workflow)



## Description

Add a link to cadence style guide on cadence side menu
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
