### PR TITLE
Update Stable Cadence feature branches in downstream dependencies

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'onflow/flow-go'
+          ref: ${{ github.base_ref == 'feature/stable-cadence' && 'feature/stable-cadence' || 'master' }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -55,6 +56,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'onflow/flow-emulator'
+          ref: ${{ github.base_ref == 'feature/stable-cadence' && 'feature/stable-cadence' || 'master' }}
 
       - name: Setup Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
## Description

The downstream dependencies are only updated to Stable Cadence on feature branches, so update those and not `master`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
