### PR TITLE
Optimize sema

### DIFF
--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -307,7 +307,7 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 		return sema.BoolType
 
 	case PrimitiveStaticTypeAddress:
-		return &sema.AddressType{}
+		return sema.TheAddressType
 
 	case PrimitiveStaticTypeString:
 		return sema.StringType

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16313,7 +16313,7 @@ var nilValueMapFunction = NewUnmeteredHostFunctionValue(
 
 func (v NilValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
 	switch name {
-	case "map":
+	case sema.OptionalTypeMapFunctionName:
 		return nilValueMapFunction
 	}
 
@@ -16498,7 +16498,7 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, locationRange LocationRa
 		v.checkInvalidatedResourceUse(locationRange)
 	}
 	switch name {
-	case "map":
+	case sema.OptionalTypeMapFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
 			func(invocation Invocation) Value {

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -448,7 +448,7 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("Address, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`0x1`, &sema.AddressType{}, newTestInterpreter(t))
+		value, err := ParseLiteral(`0x1`, sema.TheAddressType, newTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 0, 0, 1}),
@@ -457,7 +457,7 @@ func TestLiteralValue(t *testing.T) {
 	})
 
 	t.Run("Address, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, &sema.AddressType{}, newTestInterpreter(t))
+		value, err := ParseLiteral(`1`, sema.TheAddressType, newTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3377,7 +3377,7 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 			[]sema.Type{
 				sema.StringType,
 				sema.IntType,
-				&sema.AddressType{},
+				sema.TheAddressType,
 			},
 			Context{
 				Interface: runtimeInterface,

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -75,7 +75,7 @@ var AuthAccountType = func() *CompositeType {
 		NewUnmeteredPublicConstantFieldMember(
 			authAccountType,
 			AuthAccountAddressField,
-			&AddressType{},
+			TheAddressType,
 			accountTypeAddressFieldDocString,
 		),
 		NewUnmeteredPublicConstantFieldMember(
@@ -831,7 +831,7 @@ var AuthAccountTypeInboxPublishFunctionType = &FunctionType{
 		},
 		{
 			Identifier:     "recipient",
-			TypeAnnotation: NewTypeAnnotation(&AddressType{}),
+			TypeAnnotation: NewTypeAnnotation(TheAddressType),
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(
@@ -896,7 +896,7 @@ var AuthAccountTypeInboxClaimFunctionType = func() *FunctionType {
 			},
 			{
 				Identifier:     "provider",
-				TypeAnnotation: NewTypeAnnotation(&AddressType{}),
+				TypeAnnotation: NewTypeAnnotation(TheAddressType),
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -174,7 +174,7 @@ func (checker *Checker) VisitIntegerExpression(expression *ast.IntegerExpression
 	// If the contextually expected type is a subtype of Integer or Address, then take that.
 	if IsSameTypeKind(expectedType, IntegerType) {
 		actualType = expectedType
-	} else if IsSameTypeKind(expectedType, &AddressType{}) {
+	} else if IsSameTypeKind(expectedType, TheAddressType) {
 		isAddress = true
 		CheckAddressLiteral(checker.memoryGauge, expression, checker.report)
 		actualType = expectedType

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -434,7 +434,7 @@ func (checker *Checker) checkTypeCompatibility(expression ast.Expression, valueT
 
 			return true
 
-		} else if IsSameTypeKind(unwrappedTargetType, &AddressType{}) {
+		} else if IsSameTypeKind(unwrappedTargetType, TheAddressType) {
 			CheckAddressLiteral(checker.memoryGauge, typedExpression, checker.report)
 
 			return true

--- a/runtime/sema/deployed_contract.go
+++ b/runtime/sema/deployed_contract.go
@@ -43,7 +43,7 @@ var DeployedContractType = &SimpleType{
 						memoryGauge,
 						t,
 						identifier,
-						&AddressType{},
+						TheAddressType,
 						deployedContractTypeAddressFieldDocString,
 					)
 				},

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -55,7 +55,7 @@ var PublicAccountType = func() *CompositeType {
 		NewUnmeteredPublicConstantFieldMember(
 			publicAccountType,
 			PublicAccountAddressField,
-			&AddressType{},
+			TheAddressType,
 			accountTypeAddressFieldDocString,
 		),
 		NewUnmeteredPublicConstantFieldMember(

--- a/runtime/sema/runtime_type_constructors.go
+++ b/runtime/sema/runtime_type_constructors.go
@@ -71,7 +71,11 @@ var DictionaryTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: MetaType,
+		},
+	),
 }
 
 var CompositeTypeFunctionType = &FunctionType{
@@ -82,7 +86,11 @@ var CompositeTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: MetaType,
+		},
+	),
 }
 
 var InterfaceTypeFunctionType = &FunctionType{
@@ -93,14 +101,22 @@ var InterfaceTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: MetaType,
+		},
+	),
 }
 
 var FunctionTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
-			Identifier:     "parameters",
-			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{Type: MetaType}),
+			Identifier: "parameters",
+			TypeAnnotation: NewTypeAnnotation(
+				&VariableSizedType{
+					Type: MetaType,
+				},
+			),
 		},
 		{
 			Identifier:     "return",
@@ -113,15 +129,27 @@ var FunctionTypeFunctionType = &FunctionType{
 var RestrictedTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
-			Identifier:     "identifier",
-			TypeAnnotation: NewTypeAnnotation(&OptionalType{StringType}),
+			Identifier: "identifier",
+			TypeAnnotation: NewTypeAnnotation(
+				&OptionalType{
+					Type: StringType,
+				},
+			),
 		},
 		{
-			Identifier:     "restrictions",
-			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{Type: StringType}),
+			Identifier: "restrictions",
+			TypeAnnotation: NewTypeAnnotation(
+				&VariableSizedType{
+					Type: StringType,
+				},
+			),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: MetaType,
+		},
+	),
 }
 
 var ReferenceTypeFunctionType = &FunctionType{
@@ -146,7 +174,11 @@ var CapabilityTypeFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(MetaType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&OptionalType{MetaType}),
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: MetaType,
+		},
+	),
 }
 
 var runtimeTypeConstructors = []*RuntimeTypeConstructor{

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -48,7 +48,6 @@ type SimpleType struct {
 	memberResolversOnce sync.Once
 	NestedTypes         *StringTypeOrderedMap
 	ValueIndexingInfo   ValueIndexingInfo
-	MemberAvailable     func(name string, config *Config) bool
 }
 
 func (*SimpleType) IsType() {}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -609,6 +609,8 @@ with the value of this optional when it is not nil.
 Returns nil if this optional is nil
 `
 
+const OptionalTypeMapFunctionName = "map"
+
 func (t *OptionalType) GetMembers() map[string]MemberResolver {
 
 	members := map[string]MemberResolver{

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -447,7 +447,7 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 
 	// All number types, addresses, and path types have a `toString` function
 
-	if IsSubType(ty, NumberType) || IsSubType(ty, &AddressType{}) || IsSubType(ty, PathType) {
+	if IsSubType(ty, NumberType) || IsSubType(ty, TheAddressType) || IsSubType(ty, PathType) {
 
 		members[ToStringFunctionName] = MemberResolver{
 			Kind: common.DeclarationKindFunction,
@@ -2988,7 +2988,7 @@ func init() {
 		BoolType,
 		CharacterType,
 		StringType,
-		&AddressType{},
+		TheAddressType,
 		AuthAccountType,
 		PublicAccountType,
 		PathType,
@@ -3266,7 +3266,7 @@ var AddressConversionFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(IntegerType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(&AddressType{}),
+	ReturnTypeAnnotation: NewTypeAnnotation(TheAddressType),
 	ArgumentExpressionsCheck: func(checker *Checker, argumentExpressions []ast.Expression, _ ast.Range) {
 		if len(argumentExpressions) < 1 {
 			return
@@ -4774,6 +4774,8 @@ const AddressTypeName = "Address"
 // AddressType represents the address type
 type AddressType struct{}
 
+var TheAddressType = &AddressType{}
+
 var _ IntegerRangedType = &AddressType{}
 
 func (*AddressType) IsType() {}
@@ -6220,7 +6222,7 @@ func (t *CapabilityType) initializeMemberResolvers() {
 						memoryGauge,
 						t,
 						identifier,
-						&AddressType{},
+						TheAddressType,
 						capabilityTypeAddressFieldDocString,
 					)
 				},

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -570,7 +570,7 @@ func findSuperTypeFromLowerMask(joinedTypeTag TypeTag, types []Type) Type {
 	case voidTypeMask:
 		return VoidType
 	case addressTypeMask:
-		return &AddressType{}
+		return TheAddressType
 	case metaTypeMask:
 		return MetaType
 	case blockTypeMask:

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -740,7 +740,9 @@ func TestCommonSuperType(t *testing.T) {
 		_ = newTypeTagFromLowerMask(32)
 	})
 
-	nilType := &OptionalType{NeverType}
+	nilType := &OptionalType{
+		Type: NeverType,
+	}
 
 	resourceType := &CompositeType{
 		Location:   nil,

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -153,7 +153,7 @@ var getAuthAccountFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{{
 		Label:          sema.ArgumentLabelNotRequired,
 		Identifier:     "address",
-		TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
+		TypeAnnotation: sema.NewTypeAnnotation(sema.TheAddressType),
 	}},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AuthAccountType),
 }
@@ -1993,7 +1993,7 @@ var getAccountFunctionType = &sema.FunctionType{
 			Label:      sema.ArgumentLabelNotRequired,
 			Identifier: "address",
 			TypeAnnotation: sema.NewTypeAnnotation(
-				&sema.AddressType{},
+				sema.TheAddressType,
 			),
 		},
 	},

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -173,7 +173,7 @@ var HashType = &sema.ConstantSizedType{
 
 var AccountEventAddressParameter = sema.Parameter{
 	Identifier:     "address",
-	TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
+	TypeAnnotation: sema.NewTypeAnnotation(sema.TheAddressType),
 }
 
 var AccountEventCodeHashParameter = sema.Parameter{
@@ -233,12 +233,12 @@ var AccountContractRemovedEventType = newFlowEventType(
 
 var AccountEventProviderParameter = sema.Parameter{
 	Identifier:     "provider",
-	TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
+	TypeAnnotation: sema.NewTypeAnnotation(sema.TheAddressType),
 }
 
 var AccountEventRecipientParameter = sema.Parameter{
 	Identifier:     "recipient",
-	TypeAnnotation: sema.NewTypeAnnotation(&sema.AddressType{}),
+	TypeAnnotation: sema.NewTypeAnnotation(sema.TheAddressType),
 }
 
 var AccountEventNameParameter = sema.Parameter{

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -33,7 +33,7 @@ func TestCheckToString(t *testing.T) {
 
 	for _, numberOrAddressType := range append(
 		sema.AllNumberTypes[:],
-		&sema.AddressType{},
+		sema.TheAddressType,
 	) {
 
 		ty := numberOrAddressType

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -448,6 +448,6 @@ func TestCheckCapability_address(t *testing.T) {
 		require.NoError(t, err)
 
 		addrType := RequireGlobalValue(t, checker.Elaboration, "addr")
-		require.Equal(t, &sema.AddressType{}, addrType)
+		require.Equal(t, sema.TheAddressType, addrType)
 	})
 }

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -463,7 +463,7 @@ func TestCheckDynamicCastingAddress(t *testing.T) {
 
 	types := []sema.Type{
 		sema.AnyStructType,
-		&sema.AddressType{},
+		sema.TheAddressType,
 	}
 
 	for _, operation := range dynamicCastingOperations {

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -100,7 +100,7 @@ func TestCheckEventDeclaration(t *testing.T) {
 				sema.StringType,
 				sema.CharacterType,
 				sema.BoolType,
-				&sema.AddressType{},
+				sema.TheAddressType,
 				sema.MetaType,
 				sema.PathType,
 				sema.StoragePathType,

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -31,7 +31,7 @@ import (
 
 var allIntegerTypesAndAddressType = append(
 	sema.AllIntegerTypes[:],
-	&sema.AddressType{},
+	sema.TheAddressType,
 )
 
 func TestCheckIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -95,7 +95,7 @@ func TestCheckStorable(t *testing.T) {
 	storableTypes := sema.AllNumberTypes[:]
 	storableTypes = append(
 		storableTypes,
-		&sema.AddressType{},
+		sema.TheAddressType,
 		sema.PathType,
 		&sema.CapabilityType{},
 		sema.StringType,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -469,7 +469,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 
 	types := []sema.Type{
 		sema.AnyStructType,
-		&sema.AddressType{},
+		sema.TheAddressType,
 	}
 
 	for operation, returnsOptional := range dynamicCastingOperations {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -6915,7 +6915,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		"Address": {
 			literal: `0x1`,
 			value:   interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
-			ty:      &sema.AddressType{},
+			ty:      sema.TheAddressType,
 		},
 		// Int*
 		"Int": {


### PR DESCRIPTION

## Description

- Add and use singleton for `Address` type. Unlike other singletons for types (like `IntType`), naming is hard, because the Go type itself is already named `AddressType`. Suggestions welcome
- Add and use constant for Optional `map` function
- Optimize Optional type members
- Make naming consistent for cached members
- Optimize members of Address type by caching them, like done for other types already

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
