### PR TITLE
fix view parsing for expressions

### DIFF
--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -818,17 +818,18 @@ func defineIdentifierExpression() {
 				// if `view` is followed by `fun`, then it denotes a view function expression
 
 				current := p.current
-				if current.Is(lexer.TokenSpace) {
-					cursor := p.tokens.Cursor()
-					p.next()
-					if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
-						p.nextSemanticToken()
-						return parseFunctionExpression(p, token, ast.FunctionPurityView)
-					} else {
-						p.tokens.Revert(cursor)
-						p.current = current
-					}
+				cursor := p.tokens.Cursor()
+
+				p.skipSpaceAndComments()
+
+				if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
+					// skip the `fun` keyword
+					p.nextSemanticToken()
+					return parseFunctionExpression(p, token, ast.FunctionPurityView)
 				}
+
+				p.tokens.Revert(cursor)
+				p.current = current
 
 				// otherwise, we treat it as an identifier called "view"
 				break

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -2977,6 +2977,49 @@ func TestParseFunctionExpression(t *testing.T) {
 	})
 }
 
+func TestParseAdjacentViewKeyword(t *testing.T) {
+	// ensure that spaces and comments between adjacent keywords are treated the same, i.e. ignored
+
+	t.Parallel()
+
+	code := `
+		view /* UwU */ fun(){}
+	`
+
+	result, errs := testParseExpression(code)
+
+	require.Empty(t, errs)
+
+	expected := &ast.FunctionExpression{
+		Purity: ast.FunctionPurityView,
+		ParameterList: &ast.ParameterList{
+			Range: ast.NewUnmeteredRange(
+				ast.Position{Line: 2, Column: 20, Offset: 21},
+				ast.Position{Line: 2, Column: 21, Offset: 22},
+			),
+		},
+		ReturnTypeAnnotation: &ast.TypeAnnotation{
+			Type: &ast.NominalType{
+				Identifier: ast.Identifier{
+					Pos: ast.Position{Line: 2, Column: 21, Offset: 22},
+				},
+			},
+			StartPos: ast.Position{Line: 2, Column: 21, Offset: 22},
+		},
+		FunctionBlock: &ast.FunctionBlock{
+			Block: &ast.Block{
+				Range: ast.NewUnmeteredRange(
+					ast.Position{Line: 2, Column: 22, Offset: 23},
+					ast.Position{Line: 2, Column: 23, Offset: 24},
+				),
+			},
+		},
+		StartPos: ast.Position{Line: 2, Column: 2, Offset: 3},
+	}
+	utils.AssertEqualWithDiff(t, expected, result)
+
+}
+
 func TestParseIntegerLiterals(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Noticed a small bug when implementing #2140 - we don't currently skip comments when parsing the `view` keyword in expressions, just a single space token. Therefore, code like this:

```cadence
let x = view /* UwU */ fun() {}
```

throws an error when the block comment should have been ignored. 

Pushing this as a separate PR as per [request](https://github.com/onflow/cadence/pull/2140#discussion_r1025839150)
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
