### PR TITLE
Transaction pre-conditions must also be `view`

### DIFF
--- a/runtime/sema/check_conditions.go
+++ b/runtime/sema/check_conditions.go
@@ -21,23 +21,25 @@ package sema
 import "github.com/onflow/cadence/runtime/ast"
 
 func (checker *Checker) visitConditions(conditions []*ast.Condition) {
+	// all condition blocks are `view`
+	checker.InNewPurityScope(true, func() {
+		// flag the checker to be inside a condition.
+		// this flag is used to detect illegal expressions,
+		// see e.g. VisitFunctionExpression
 
-	// flag the checker to be inside a condition.
-	// this flag is used to detect illegal expressions,
-	// see e.g. VisitFunctionExpression
+		wasInCondition := checker.inCondition
+		checker.inCondition = true
+		defer func() {
+			checker.inCondition = wasInCondition
+		}()
 
-	wasInCondition := checker.inCondition
-	checker.inCondition = true
-	defer func() {
-		checker.inCondition = wasInCondition
-	}()
+		// check all conditions: check the expression
+		// and ensure the result is boolean
 
-	// check all conditions: check the expression
-	// and ensure the result is boolean
-
-	for _, condition := range conditions {
-		checker.checkCondition(condition)
-	}
+		for _, condition := range conditions {
+			checker.checkCondition(condition)
+		}
+	})
 }
 
 func (checker *Checker) checkCondition(condition *ast.Condition) Type {

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -362,9 +362,7 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 	}
 
 	if rewrittenPostConditions != nil {
-		checker.InNewPurityScope(true, func() {
-			checker.visitConditions(rewrittenPostConditions.RewrittenPostConditions)
-		})
+		checker.visitConditions(rewrittenPostConditions.RewrittenPostConditions)
 	}
 }
 
@@ -377,9 +375,7 @@ func (checker *Checker) visitFunctionBlock(
 	defer checker.leaveValueScope(functionBlock.EndPosition, checkResourceLoss)
 
 	if functionBlock.PreConditions != nil {
-		checker.InNewPurityScope(true, func() {
-			checker.visitConditions(*functionBlock.PreConditions)
-		})
+		checker.visitConditions(*functionBlock.PreConditions)
 	}
 
 	checker.visitWithPostConditions(

--- a/runtime/tests/checker/transactions_test.go
+++ b/runtime/tests/checker/transactions_test.go
@@ -175,6 +175,29 @@ func TestCheckTransactions(t *testing.T) {
 		)
 	})
 
+	t.Run("PreConditions must be view", func(t *testing.T) {
+		test(t,
+			`
+              transaction {
+				  var foo: ((): Int)
+
+                  prepare() {
+					  self.foo = fun (): Int {
+						return 40
+					  }
+                  }
+
+                  pre {
+					  self.foo() > 30
+                  }
+              }
+            `,
+			[]error{
+				&sema.PurityError{},
+			},
+		)
+	})
+
 	t.Run("PostConditions", func(t *testing.T) {
 		test(t,
 			`
@@ -196,6 +219,29 @@ func TestCheckTransactions(t *testing.T) {
               }
             `,
 			nil,
+		)
+	})
+
+	t.Run("PostConditions must be view", func(t *testing.T) {
+		test(t,
+			`
+              transaction {
+				  var foo: ((): Int)
+
+                  prepare() {
+					  self.foo = fun (): Int {
+						return 40
+					  }
+                  }
+
+                  post {
+					  self.foo() > 30
+                  }
+              }
+            `,
+			[]error{
+				&sema.PurityError{},
+			},
 		)
 	})
 

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.29.0-stable-cadence-4"
+const Version = "v0.29.0-stable-cadence-5"


### PR DESCRIPTION
While reading over https://github.com/onflow/flips/pull/41 I realized that we did not properly enforce that transaction pre-conditions were `view`. This refactors the checking to push the purity scope in all condition checking locations, covering the missed case. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
