### PR TITLE
Optimize elaboration

### DIFF
--- a/runtime/compiler/compiler.go
+++ b/runtime/compiler/compiler.go
@@ -110,7 +110,7 @@ func (compiler *Compiler) VisitVariableDeclaration(declaration *ast.VariableDecl
 	// TODO: second value
 
 	identifier := declaration.Identifier.Identifier
-	targetType := compiler.Checker.Elaboration.VariableDeclarationTypes[declaration].TargetType
+	targetType := compiler.Checker.Elaboration.VariableDeclarationTypes(declaration).TargetType
 	valType := compileValueType(targetType)
 	local := compiler.declareLocal(identifier, valType)
 	exp := ast.AcceptExpression[ir.Expr](declaration.Value, compiler)
@@ -294,7 +294,7 @@ func (compiler *Compiler) VisitFunctionDeclaration(declaration *ast.FunctionDecl
 
 	// Declare a local for each parameter
 
-	functionType := compiler.Checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]
+	functionType := compiler.Checker.Elaboration.FunctionDeclarationFunctionType(declaration)
 
 	parameters := declaration.ParameterList.Parameters
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -4847,7 +4847,10 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		Fields:     []string{"dictionary"},
 	}
 
-	program.Elaboration.CompositeTypes[semaCompositeType.ID()] = semaCompositeType
+	program.Elaboration.SetCompositeType(
+		semaCompositeType.ID(),
+		semaCompositeType,
+	)
 
 	semaCompositeType.Members.Set(
 		"dictionary",
@@ -4923,7 +4926,10 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		inter := newTestInterpreter(t)
 		inter.Program = &program
 
-		program.Elaboration.CompositeTypes[semaCompositeType.ID()] = semaCompositeType
+		program.Elaboration.SetCompositeType(
+			semaCompositeType.ID(),
+			semaCompositeType,
+		)
 
 		actual, err := ImportValue(
 			inter,

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -4765,7 +4765,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 	t.Parallel()
 
 	program := interpreter.Program{
-		Elaboration: sema.NewElaboration(nil, false),
+		Elaboration: sema.NewElaboration(nil),
 	}
 
 	inter := newTestInterpreter(t)
@@ -4920,7 +4920,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		t.Parallel()
 
 		program := interpreter.Program{
-			Elaboration: sema.NewElaboration(nil, false),
+			Elaboration: sema.NewElaboration(nil),
 		}
 
 		inter := newTestInterpreter(t)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -631,7 +631,7 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 
 	identifier := declaration.Identifier.Identifier
 
-	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[declaration]
+	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionType(declaration)
 
 	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
 	variable := interpreter.findOrDeclareVariable(identifier)
@@ -943,7 +943,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 		}
 	})()
 
-	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationType(declaration)
 
 	constructorType := &sema.FunctionType{
 		IsConstructor: true,
@@ -1218,7 +1218,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 
 	lexicalScope.Set(identifier, variable)
 
-	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationType(declaration)
 	qualifiedIdentifier := compositeType.QualifiedIdentifier()
 
 	location := interpreter.Location
@@ -1344,7 +1344,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 	}
 
 	initializer = initializers[0]
-	functionType := interpreter.Program.Elaboration.ConstructorFunctionTypes[initializer]
+	functionType := interpreter.Program.Elaboration.ConstructorFunctionType(initializer)
 
 	parameterList := initializer.FunctionDeclaration.ParameterList
 
@@ -1479,7 +1479,7 @@ func (interpreter *Interpreter) functionWrappers(
 
 	for _, functionDeclaration := range members.Functions() {
 
-		functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+		functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionType(functionDeclaration)
 
 		name := functionDeclaration.Identifier.Identifier
 		functionWrapper := interpreter.functionConditionsWrapper(
@@ -1501,7 +1501,7 @@ func (interpreter *Interpreter) compositeFunction(
 	lexicalScope *VariableActivation,
 ) *InterpretedFunctionValue {
 
-	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionType(functionDeclaration)
 
 	var preConditions ast.Conditions
 
@@ -1801,7 +1801,7 @@ func (interpreter *Interpreter) declareInterface(
 		}
 	})()
 
-	interfaceType := interpreter.Program.Elaboration.InterfaceDeclarationTypes[declaration]
+	interfaceType := interpreter.Program.Elaboration.InterfaceDeclarationType(declaration)
 	typeID := interfaceType.ID()
 
 	initializerFunctionWrapper := interpreter.initializerFunctionWrapper(declaration.Members, lexicalScope)
@@ -1837,7 +1837,7 @@ func (interpreter *Interpreter) declareTypeRequirement(
 		}
 	})()
 
-	compositeType := interpreter.Program.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := interpreter.Program.Elaboration.CompositeDeclarationType(declaration)
 	typeID := compositeType.ID()
 
 	initializerFunctionWrapper := interpreter.initializerFunctionWrapper(declaration.Members, lexicalScope)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -356,7 +356,7 @@ func (interpreter *Interpreter) invokeVariable(
 		}
 	}
 
-	functionVariable, ok := interpreter.Program.Elaboration.GlobalValues.Get(functionName)
+	functionVariable, ok := interpreter.Program.Elaboration.GetGlobalValue(functionName)
 	if !ok {
 		panic(errors.NewUnreachableError())
 	}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -669,7 +669,7 @@ func (interpreter *Interpreter) functionDeclarationValue(
 
 	if declaration.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Program.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite(declaration.FunctionBlock.PostConditions)
 
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
 		beforeStatements = postConditionsRewrite.BeforeStatements
@@ -1361,7 +1361,7 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 	postConditions := initializer.FunctionDeclaration.FunctionBlock.PostConditions
 	if postConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Program.Elaboration.PostConditionsRewrite[postConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite(postConditions)
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -1404,7 +1404,7 @@ func (interpreter *Interpreter) compositeDestructorFunction(
 	postConditions := destructor.FunctionDeclaration.FunctionBlock.PostConditions
 	if postConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Program.Elaboration.PostConditionsRewrite[postConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite(postConditions)
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -1510,15 +1510,15 @@ func (interpreter *Interpreter) compositeFunction(
 	}
 
 	var beforeStatements []ast.Statement
-	var postConditions ast.Conditions
+	var rewrittenPostConditions ast.Conditions
 
 	if functionDeclaration.FunctionBlock.PostConditions != nil {
 
 		postConditionsRewrite :=
-			interpreter.Program.Elaboration.PostConditionsRewrite[functionDeclaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite(functionDeclaration.FunctionBlock.PostConditions)
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
-		postConditions = postConditionsRewrite.RewrittenPostConditions
+		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
 	}
 
 	parameterList := functionDeclaration.ParameterList
@@ -1532,7 +1532,7 @@ func (interpreter *Interpreter) compositeFunction(
 		beforeStatements,
 		preConditions,
 		statements,
-		postConditions,
+		rewrittenPostConditions,
 	)
 }
 
@@ -1915,7 +1915,7 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 	if declaration.FunctionBlock.PostConditions != nil {
 
 		postConditionsRewrite :=
-			interpreter.Program.Elaboration.PostConditionsRewrite[declaration.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite(declaration.FunctionBlock.PostConditions)
 
 		beforeStatements = postConditionsRewrite.BeforeStatements
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
@@ -4040,7 +4040,7 @@ func (interpreter *Interpreter) getUserCompositeType(location common.Location, t
 		}
 	}
 
-	ty := elaboration.CompositeTypes[typeID]
+	ty := elaboration.CompositeType(typeID)
 	if ty == nil {
 		return nil, TypeLoadingError{
 			TypeID: typeID,
@@ -4075,7 +4075,7 @@ func (interpreter *Interpreter) getInterfaceType(location common.Location, quali
 		}
 	}
 
-	ty := elaboration.InterfaceTypes[typeID]
+	ty := elaboration.InterfaceType(typeID)
 	if ty == nil {
 		return nil, TypeLoadingError{
 			TypeID: typeID,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -921,7 +921,7 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 
 	if expression.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=
-			interpreter.Program.Elaboration.PostConditionsRewrite[expression.FunctionBlock.PostConditions]
+			interpreter.Program.Elaboration.PostConditionsRewrite(expression.FunctionBlock.PostConditions)
 
 		rewrittenPostConditions = postConditionsRewrite.RewrittenPostConditions
 		beforeStatements = postConditionsRewrite.BeforeStatements

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -91,7 +91,7 @@ func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast
 
 	elaboration := interpreter.Program.Elaboration
 
-	indexExpressionTypes := elaboration.IndexExpressionTypes[indexExpression]
+	indexExpressionTypes := elaboration.IndexExpressionTypes(indexExpression)
 	indexedType := indexExpressionTypes.IndexedType
 	indexingType := indexExpressionTypes.IndexingType
 
@@ -1021,7 +1021,7 @@ func (interpreter *Interpreter) VisitDestroyExpression(expression *ast.DestroyEx
 
 func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *ast.ReferenceExpression) Value {
 
-	borrowType := interpreter.Program.Elaboration.ReferenceExpressionBorrowTypes[referenceExpression]
+	borrowType := interpreter.Program.Elaboration.ReferenceExpressionBorrowType(referenceExpression)
 
 	result := interpreter.evalExpression(referenceExpression.Expression)
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -196,7 +196,7 @@ func (interpreter *Interpreter) checkMemberAccess(
 	target Value,
 	locationRange LocationRange,
 ) {
-	memberInfo := interpreter.Program.Elaboration.MemberExpressionMemberInfos[memberExpression]
+	memberInfo, _ := interpreter.Program.Elaboration.MemberExpressionMemberInfo(memberExpression)
 	expectedType := memberInfo.AccessedType
 
 	switch expectedType := expectedType.(type) {
@@ -625,7 +625,7 @@ func (interpreter *Interpreter) NewIntegerValueFromBigInt(value *big.Int, intege
 func (interpreter *Interpreter) VisitFixedPointExpression(expression *ast.FixedPointExpression) Value {
 	// TODO: adjust once/if we support more fixed point types
 
-	fixedPointSubType := interpreter.Program.Elaboration.FixedPointExpression[expression]
+	fixedPointSubType := interpreter.Program.Elaboration.FixedPointExpression(expression)
 
 	value := fixedpoint.ConvertToFixedPointBigInt(
 		expression.Negative,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -105,7 +105,7 @@ func (interpreter *Interpreter) indexExpressionGetterSetter(indexExpression *ast
 		},
 	)
 
-	_, isNestedResourceMove := elaboration.IsNestedResourceMoveExpression[indexExpression]
+	isNestedResourceMove := elaboration.IsNestedResourceMoveExpression(indexExpression)
 
 	return getterSetter{
 		target: target,
@@ -136,7 +136,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 		HasPosition: memberExpression,
 	}
 
-	_, isNestedResourceMove := interpreter.Program.Elaboration.IsNestedResourceMoveExpression[memberExpression]
+	isNestedResourceMove := interpreter.Program.Elaboration.IsNestedResourceMoveExpression(memberExpression)
 
 	return getterSetter{
 		target: target,
@@ -441,7 +441,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 
 		value := rightValue()
 
-		binaryExpressionTypes := interpreter.Program.Elaboration.BinaryExpressionTypes[expression]
+		binaryExpressionTypes := interpreter.Program.Elaboration.BinaryExpressionTypes(expression)
 		rightType := binaryExpressionTypes.RightType
 		resultType := binaryExpressionTypes.ResultType
 
@@ -533,7 +533,7 @@ func (interpreter *Interpreter) VisitNilExpression(_ *ast.NilExpression) Value {
 }
 
 func (interpreter *Interpreter) VisitIntegerExpression(expression *ast.IntegerExpression) Value {
-	typ := interpreter.Program.Elaboration.IntegerExpressionType[expression]
+	typ := interpreter.Program.Elaboration.IntegerExpressionType(expression)
 
 	value := expression.Value
 
@@ -651,7 +651,7 @@ func (interpreter *Interpreter) VisitFixedPointExpression(expression *ast.FixedP
 }
 
 func (interpreter *Interpreter) VisitStringExpression(expression *ast.StringExpression) Value {
-	stringType := interpreter.Program.Elaboration.StringExpressionType[expression]
+	stringType := interpreter.Program.Elaboration.StringExpressionType(expression)
 
 	switch stringType {
 	case sema.CharacterType:
@@ -665,7 +665,7 @@ func (interpreter *Interpreter) VisitStringExpression(expression *ast.StringExpr
 func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpression) Value {
 	values := interpreter.visitExpressionsNonCopying(expression.Values)
 
-	arrayExpressionTypes := interpreter.Program.Elaboration.ArrayExpressionTypes[expression]
+	arrayExpressionTypes := interpreter.Program.Elaboration.ArrayExpressionTypes(expression)
 	argumentTypes := arrayExpressionTypes.ArgumentTypes
 	arrayType := arrayExpressionTypes.ArrayType
 	elementType := arrayType.ElementType(false)
@@ -701,7 +701,7 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.DictionaryExpression) Value {
 	values := interpreter.visitEntries(expression.Entries)
 
-	dictionaryExpressionTypes := interpreter.Program.Elaboration.DictionaryExpressionTypes[expression]
+	dictionaryExpressionTypes := interpreter.Program.Elaboration.DictionaryExpressionTypes(expression)
 	entryTypes := dictionaryExpressionTypes.EntryTypes
 	dictionaryType := dictionaryExpressionTypes.DictionaryType
 
@@ -949,7 +949,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		HasPosition: expression.Expression,
 	}
 
-	expectedType := interpreter.Program.Elaboration.CastingTargetTypes[expression]
+	expectedType := interpreter.Program.Elaboration.CastingExpressionTypes(expression).TargetType
 
 	switch expression.Operation {
 	case ast.OperationFailableCast, ast.OperationForceCast:
@@ -991,7 +991,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		}
 
 	case ast.OperationCast:
-		staticValueType := interpreter.Program.Elaboration.CastingStaticValueTypes[expression]
+		staticValueType := interpreter.Program.Elaboration.CastingExpressionTypes(expression).StaticValueType
 		// The cast may upcast to an optional type, e.g. `1 as Int?`, so box
 		return interpreter.ConvertAndBox(locationRange, value, staticValueType, expectedType)
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -845,7 +845,7 @@ func (interpreter *Interpreter) VisitInvocationExpression(invocationExpression *
 
 	elaboration := interpreter.Program.Elaboration
 
-	invocationExpressionTypes := elaboration.InvocationExpressionTypes[invocationExpression]
+	invocationExpressionTypes := elaboration.InvocationExpressionTypes(invocationExpression)
 
 	typeParameterTypes := invocationExpressionTypes.TypeArguments
 	argumentTypes := invocationExpressionTypes.ArgumentTypes
@@ -909,7 +909,7 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 	// lexical scope: variables in functions are bound to what is visible at declaration time
 	lexicalScope := interpreter.activations.CurrentOrNew()
 
-	functionType := interpreter.Program.Elaboration.FunctionExpressionFunctionType[expression]
+	functionType := interpreter.Program.Elaboration.FunctionExpressionFunctionType(expression)
 
 	var preConditions ast.Conditions
 	if expression.FunctionBlock.PreConditions != nil {

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -28,7 +28,7 @@ import (
 
 func (interpreter *Interpreter) VisitImportDeclaration(declaration *ast.ImportDeclaration) StatementResult {
 
-	resolvedLocations := interpreter.Program.Elaboration.ImportDeclarationsResolvedLocations[declaration]
+	resolvedLocations := interpreter.Program.Elaboration.ImportDeclarationsResolvedLocations(declaration)
 
 	for _, resolvedLocation := range resolvedLocations {
 		interpreter.importResolvedLocation(resolvedLocation)

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -377,7 +377,7 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 		panic(errors.NewUnreachableError())
 	}
 
-	eventType := interpreter.Program.Elaboration.EmitStatementEventTypes[statement]
+	eventType := interpreter.Program.Elaboration.EmitStatementEventType(statement)
 
 	locationRange := LocationRange{
 		Location:    interpreter.Location,

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -502,7 +502,7 @@ func (interpreter *Interpreter) VisitAssignmentStatement(assignment *ast.Assignm
 }
 
 func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) StatementResult {
-	swapStatementTypes := interpreter.Program.Elaboration.SwapStatementTypes[swap]
+	swapStatementTypes := interpreter.Program.Elaboration.SwapStatementTypes(swap)
 	leftType := swapStatementTypes.LeftType
 	rightType := swapStatementTypes.RightType
 

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -78,7 +78,7 @@ func (interpreter *Interpreter) VisitReturnStatement(statement *ast.ReturnStatem
 	} else {
 		value = interpreter.evalExpression(statement.Expression)
 
-		returnStatementTypes := interpreter.Program.Elaboration.ReturnStatementTypes[statement]
+		returnStatementTypes := interpreter.Program.Elaboration.ReturnStatementTypes(statement)
 		valueType := returnStatementTypes.ValueType
 		returnType := returnStatementTypes.ReturnType
 

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -159,7 +159,7 @@ func (interpreter *Interpreter) visitIfStatementWithVariableDeclaration(
 		panic(errors.NewUnreachableError())
 	}
 
-	variableDeclarationTypes := interpreter.Program.Elaboration.VariableDeclarationTypes[declaration]
+	variableDeclarationTypes := interpreter.Program.Elaboration.VariableDeclarationTypes(declaration)
 	valueType := variableDeclarationTypes.ValueType
 
 	if declaration.SecondValue != nil {
@@ -431,7 +431,7 @@ func (interpreter *Interpreter) visitVariableDeclaration(
 	valueCallback func(identifier string, value Value),
 ) {
 
-	variableDeclarationTypes := interpreter.Program.Elaboration.VariableDeclarationTypes[declaration]
+	variableDeclarationTypes := interpreter.Program.Elaboration.VariableDeclarationTypes(declaration)
 	targetType := variableDeclarationTypes.TargetType
 	valueType := variableDeclarationTypes.ValueType
 	secondValueType := variableDeclarationTypes.SecondValueType
@@ -484,7 +484,7 @@ func (interpreter *Interpreter) visitVariableDeclaration(
 }
 
 func (interpreter *Interpreter) VisitAssignmentStatement(assignment *ast.AssignmentStatement) StatementResult {
-	assignmentStatementTypes := interpreter.Program.Elaboration.AssignmentStatementTypes[assignment]
+	assignmentStatementTypes := interpreter.Program.Elaboration.AssignmentStatementTypes(assignment)
 	targetType := assignmentStatementTypes.TargetType
 	valueType := assignmentStatementTypes.ValueType
 

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -49,7 +49,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 	}
 
 	postConditionsRewrite :=
-		interpreter.Program.Elaboration.PostConditionsRewrite[declaration.PostConditions]
+		interpreter.Program.Elaboration.PostConditionsRewrite(declaration.PostConditions)
 
 	staticType := NewCompositeStaticTypeComputeTypeID(interpreter, interpreter.Location, "")
 

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -30,7 +30,7 @@ func (interpreter *Interpreter) VisitTransactionDeclaration(declaration *ast.Tra
 }
 
 func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.TransactionDeclaration) {
-	transactionType := interpreter.Program.Elaboration.TransactionDeclarationTypes[declaration]
+	transactionType := interpreter.Program.Elaboration.TransactionDeclarationType(declaration)
 
 	lexicalScope := interpreter.activations.CurrentOrNew()
 

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -91,7 +91,7 @@ func TestArrayStorage(t *testing.T) {
 	t.Parallel()
 
 	importLocationHandlerFunc := func(inter *Interpreter, location common.Location) Import {
-		elaboration := sema.NewElaboration(nil, false)
+		elaboration := sema.NewElaboration(nil)
 		elaboration.SetCompositeType(
 			testCompositeValueType.ID(),
 			testCompositeValueType,

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -92,7 +92,10 @@ func TestArrayStorage(t *testing.T) {
 
 	importLocationHandlerFunc := func(inter *Interpreter, location common.Location) Import {
 		elaboration := sema.NewElaboration(nil, false)
-		elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+		elaboration.SetCompositeType(
+			testCompositeValueType.ID(),
+			testCompositeValueType,
+		)
 		return VirtualImport{Elaboration: elaboration}
 	}
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -85,7 +85,10 @@ func TestOwnerNewArray(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -125,7 +128,10 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -189,7 +195,10 @@ func TestOwnerArrayElement(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -228,7 +237,10 @@ func TestOwnerArraySetIndex(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -277,7 +289,10 @@ func TestOwnerArrayAppend(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -320,7 +335,10 @@ func TestOwnerArrayInsert(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -363,7 +381,10 @@ func TestOwnerArrayRemove(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -404,7 +425,10 @@ func TestOwnerNewDictionary(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -448,7 +472,10 @@ func TestOwnerDictionary(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -492,7 +519,10 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -560,7 +590,10 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -611,7 +644,10 @@ func TestOwnerDictionaryInsertNonExisting(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -663,7 +699,10 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -721,7 +760,10 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 	storage := newUnmeteredInMemoryStorage()
 
 	elaboration := sema.NewElaboration(nil, false)
-	elaboration.CompositeTypes[testCompositeValueType.ID()] = testCompositeValueType
+	elaboration.SetCompositeType(
+		testCompositeValueType.ID(),
+		testCompositeValueType,
+	)
 
 	inter, err := NewInterpreter(
 		&Program{
@@ -3676,7 +3718,10 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		members.Set("foo", fooField)
 
 		elaboration := sema.NewElaboration(nil, false)
-		elaboration.CompositeTypes[compositeType.ID()] = compositeType
+		elaboration.SetCompositeType(
+			compositeType.ID(),
+			compositeType,
+		)
 
 		inter, err := NewInterpreter(
 			&Program{

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -84,7 +84,7 @@ func TestOwnerNewArray(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -127,7 +127,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -194,7 +194,7 @@ func TestOwnerArrayElement(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -236,7 +236,7 @@ func TestOwnerArraySetIndex(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -288,7 +288,7 @@ func TestOwnerArrayAppend(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -334,7 +334,7 @@ func TestOwnerArrayInsert(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -380,7 +380,7 @@ func TestOwnerArrayRemove(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -424,7 +424,7 @@ func TestOwnerNewDictionary(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -471,7 +471,7 @@ func TestOwnerDictionary(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -518,7 +518,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -589,7 +589,7 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -643,7 +643,7 @@ func TestOwnerDictionaryInsertNonExisting(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -698,7 +698,7 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -759,7 +759,7 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 
 	storage := newUnmeteredInMemoryStorage()
 
-	elaboration := sema.NewElaboration(nil, false)
+	elaboration := sema.NewElaboration(nil)
 	elaboration.SetCompositeType(
 		testCompositeValueType.ID(),
 		testCompositeValueType,
@@ -3717,7 +3717,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		)
 		members.Set("foo", fooField)
 
-		elaboration := sema.NewElaboration(nil, false)
+		elaboration := sema.NewElaboration(nil)
 		elaboration.SetCompositeType(
 			compositeType.ID(),
 			compositeType,

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -258,7 +258,7 @@ type REPLSuggestion struct {
 func (r *REPL) Suggestions() (result []REPLSuggestion) {
 	names := map[string]string{}
 
-	r.checker.Elaboration.GlobalValues.Foreach(func(name string, variable *sema.Variable) {
+	r.checker.Elaboration.ForEachGlobalValue(func(name string, variable *sema.Variable) {
 		if names[name] != "" {
 			return
 		}

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -94,11 +94,13 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 		}
 	}
 
-	checker.Elaboration.ArrayExpressionTypes[expression] =
+	checker.Elaboration.SetArrayExpressionTypes(
+		expression,
 		ArrayExpressionTypes{
 			ArgumentTypes: argumentTypes,
 			ArrayType:     resultType,
-		}
+		},
+	)
 
 	return resultType
 }

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -32,11 +32,13 @@ func (checker *Checker) VisitAssignmentStatement(assignment *ast.AssignmentState
 		false,
 	)
 
-	checker.Elaboration.AssignmentStatementTypes[assignment] =
+	checker.Elaboration.SetAssignmentStatementTypes(
+		assignment,
 		AssignmentStatementTypes{
 			ValueType:  valueType,
 			TargetType: targetType,
-		}
+		},
+	)
 
 	return
 }

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -28,12 +28,14 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 
 	var leftType, rightType, resultType Type
 	defer func() {
-		elaboration := checker.Elaboration
-		elaboration.BinaryExpressionTypes[expression] = BinaryExpressionTypes{
-			LeftType:   leftType,
-			RightType:  rightType,
-			ResultType: resultType,
-		}
+		checker.Elaboration.SetBinaryExpressionTypes(
+			expression,
+			BinaryExpressionTypes{
+				LeftType:   leftType,
+				RightType:  rightType,
+				ResultType: resultType,
+			},
+		)
 	}()
 
 	// The left-hand side is always evaluated.

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -32,8 +32,6 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 
 	rightHandType := rightHandTypeAnnotation.Type
 
-	checker.Elaboration.CastingTargetTypes[expression] = rightHandType
-
 	// visit the expression
 
 	leftHandExpression := expression.Expression
@@ -50,7 +48,13 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 
 	hasErrors := len(checker.errors) > beforeErrors
 
-	checker.Elaboration.CastingStaticValueTypes[expression] = leftHandType
+	checker.Elaboration.SetCastingExpressionTypes(
+		expression,
+		CastingExpressionTypes{
+			StaticValueType: leftHandType,
+			TargetType:      rightHandType,
+		},
+	)
 
 	if leftHandType.IsResourceType() {
 		checker.recordResourceInvalidation(

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -129,11 +129,13 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 					},
 				)
 			} else if checker.Config.ExtendedElaborationEnabled {
-				checker.Elaboration.RuntimeCastTypes[expression] =
+				checker.Elaboration.SetRuntimeCastTypes(
+					expression,
 					RuntimeCastTypes{
 						Left:  leftHandType,
 						Right: rightHandType,
-					}
+					},
+				)
 			}
 		}
 
@@ -149,12 +151,14 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 		// Then, it is not possible to determine whether the target type is redundant.
 		// Therefore, don't check for redundant casts, if there are errors.
 		if checker.Config.ExtendedElaborationEnabled && !hasErrors {
-			checker.Elaboration.StaticCastTypes[expression] =
+			checker.Elaboration.SetStaticCastTypes(
+				expression,
 				CastTypes{
 					ExprActualType: exprActualType,
 					TargetType:     rightHandType,
 					ExpectedType:   checker.expectedType,
-				}
+				},
+			)
 		}
 
 		return rightHandType

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -220,7 +220,7 @@ func (checker *Checker) declareCompositeNestedTypes(
 	declareConstructors bool,
 ) {
 	compositeType := checker.Elaboration.CompositeDeclarationType(declaration)
-	nestedDeclarations := checker.Elaboration.CompositeNestedDeclarations[declaration]
+	nestedDeclarations := checker.Elaboration.CompositeNestedDeclarations(declaration)
 
 	compositeType.NestedTypes.Foreach(func(name string, nestedType Type) {
 
@@ -477,7 +477,7 @@ func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclarati
 			declaration.Members.Interfaces(),
 		)
 
-	checker.Elaboration.CompositeNestedDeclarations[declaration] = nestedDeclarations
+	checker.Elaboration.SetCompositeNestedDeclarations(declaration, nestedDeclarations)
 
 	for _, nestedInterfaceType := range nestedInterfaceTypes {
 		compositeType.NestedTypes.Set(nestedInterfaceType.Identifier, nestedInterfaceType)

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -41,7 +41,7 @@ func (checker *Checker) VisitCompositeDeclaration(declaration *ast.CompositeDecl
 // through `declareCompositeMembersAndValue`.
 func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDeclaration, kind ContainerKind) {
 
-	compositeType := checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := checker.Elaboration.CompositeDeclarationType(declaration)
 	if compositeType == nil {
 		panic(errors.NewUnreachableError())
 	}
@@ -219,7 +219,7 @@ func (checker *Checker) declareCompositeNestedTypes(
 	kind ContainerKind,
 	declareConstructors bool,
 ) {
-	compositeType := checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := checker.Elaboration.CompositeDeclarationType(declaration)
 	nestedDeclarations := checker.Elaboration.CompositeNestedDeclarations[declaration]
 
 	compositeType.NestedTypes.Foreach(func(name string, nestedType Type) {
@@ -456,8 +456,8 @@ func (checker *Checker) declareCompositeType(declaration *ast.CompositeDeclarati
 
 	// Register in elaboration
 
-	checker.Elaboration.CompositeDeclarationTypes[declaration] = compositeType
-	checker.Elaboration.CompositeTypeDeclarations[compositeType] = declaration
+	checker.Elaboration.SetCompositeDeclarationType(declaration, compositeType)
+	checker.Elaboration.SetCompositeTypeDeclaration(compositeType, declaration)
 
 	// Activate new scope for nested declarations
 
@@ -502,7 +502,7 @@ func (checker *Checker) declareCompositeMembersAndValue(
 	declaration *ast.CompositeDeclaration,
 	kind ContainerKind,
 ) {
-	compositeType := checker.Elaboration.CompositeDeclarationTypes[declaration]
+	compositeType := checker.Elaboration.CompositeDeclarationType(declaration)
 	if compositeType == nil {
 		panic(errors.NewUnreachableError())
 	}
@@ -1454,12 +1454,14 @@ func CompositeConstructorType(
 		// NOTE: Don't use `constructorFunctionType`, as it has a return type.
 		//   The initializer itself has a `Void` return type.
 
-		elaboration.ConstructorFunctionTypes[firstInitializer] =
+		elaboration.SetConstructorFunctionType(
+			firstInitializer,
 			&FunctionType{
 				IsConstructor:        true,
 				Parameters:           constructorFunctionType.Parameters,
 				ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
-			}
+			},
+		)
 	}
 
 	return constructorFunctionType, argumentLabels

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -96,11 +96,13 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 		ValueType: valueType,
 	}
 
-	checker.Elaboration.DictionaryExpressionTypes[expression] =
+	checker.Elaboration.SetDictionaryExpressionTypes(
+		expression,
 		DictionaryExpressionTypes{
 			EntryTypes:     entryTypes,
 			DictionaryType: dictionaryType,
-		}
+		},
+	)
 
 	return dictionaryType
 }

--- a/runtime/sema/check_emit_statement.go
+++ b/runtime/sema/check_emit_statement.go
@@ -45,7 +45,7 @@ func (checker *Checker) VisitEmitStatement(statement *ast.EmitStatement) (_ stru
 		return
 	}
 
-	checker.Elaboration.EmitStatementEventTypes[statement] = compositeType
+	checker.Elaboration.SetEmitStatementEventType(statement, compositeType)
 
 	// Check that the emitted event is declared in the same location
 

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -212,7 +212,7 @@ func (checker *Checker) VisitFixedPointExpression(expression *ast.FixedPointExpr
 
 	CheckFixedPointLiteral(checker.memoryGauge, expression, actualType, checker.report)
 
-	checker.Elaboration.FixedPointExpression[expression] = actualType
+	checker.Elaboration.SetFixedPointExpression(expression, actualType)
 
 	return actualType
 }

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -41,7 +41,7 @@ func (checker *Checker) VisitIdentifierExpression(expression *ast.IdentifierExpr
 	checker.checkSelfVariableUseInInitializer(variable, identifier.Pos)
 
 	if checker.inInvocation {
-		checker.Elaboration.IdentifierInInvocationTypes[expression] = valueType
+		checker.Elaboration.SetIdentifierInInvocationType(expression, valueType)
 	}
 
 	return valueType
@@ -291,10 +291,13 @@ func (checker *Checker) visitIndexExpression(
 
 	checker.checkUnusedExpressionResourceLoss(elementType, targetExpression)
 
-	checker.Elaboration.IndexExpressionTypes[indexExpression] = IndexExpressionTypes{
-		IndexedType:  indexedType,
-		IndexingType: indexingType,
-	}
+	checker.Elaboration.SetIndexExpressionTypes(
+		indexExpression,
+		IndexExpressionTypes{
+			IndexedType:  indexedType,
+			IndexingType: indexingType,
+		},
+	)
 
 	return elementType
 }

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -187,7 +187,7 @@ func (checker *Checker) VisitIntegerExpression(expression *ast.IntegerExpression
 		CheckIntegerLiteral(checker.memoryGauge, expression, actualType, checker.report)
 	}
 
-	checker.Elaboration.IntegerExpressionType[expression] = actualType
+	checker.Elaboration.SetIntegerExpressionType(expression, actualType)
 
 	return actualType
 }
@@ -227,7 +227,7 @@ func (checker *Checker) VisitStringExpression(expression *ast.StringExpression) 
 		actualType = expectedType
 	}
 
-	checker.Elaboration.StringExpressionType[expression] = actualType
+	checker.Elaboration.SetStringExpressionType(expression, actualType)
 
 	return actualType
 }

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -41,7 +41,7 @@ func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) Ty
 	)
 
 	if checker.Config.ExtendedElaborationEnabled {
-		checker.Elaboration.ForceExpressionTypes[expression] = valueType
+		checker.Elaboration.SetForceExpressionType(expression, valueType)
 	}
 
 	optionalType, ok := valueType.(*OptionalType)

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -78,7 +78,7 @@ func (checker *Checker) visitFunctionDeclaration(
 
 	// global functions were previously declared, see `declareFunctionDeclaration`
 
-	functionType := checker.Elaboration.FunctionDeclarationFunctionTypes[declaration]
+	functionType := checker.Elaboration.FunctionDeclarationFunctionType(declaration)
 	if functionType == nil {
 		functionType = checker.functionType(declaration.ParameterList, declaration.ReturnTypeAnnotation)
 
@@ -87,7 +87,7 @@ func (checker *Checker) visitFunctionDeclaration(
 		}
 	}
 
-	checker.Elaboration.FunctionDeclarationFunctionTypes[declaration] = functionType
+	checker.Elaboration.SetFunctionDeclarationFunctionType(declaration, functionType)
 
 	checker.checkFunction(
 		declaration.ParameterList,
@@ -407,7 +407,7 @@ func (checker *Checker) VisitFunctionExpression(expression *ast.FunctionExpressi
 	// TODO: infer
 	functionType := checker.functionType(expression.ParameterList, expression.ReturnTypeAnnotation)
 
-	checker.Elaboration.FunctionExpressionFunctionType[expression] = functionType
+	checker.Elaboration.SetFunctionExpressionFunctionType(expression, functionType)
 
 	checker.checkFunction(
 		expression.ParameterList,

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -320,7 +320,7 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 		rewriteResult := checker.rewritePostConditions(*postConditions)
 		rewrittenPostConditions = &rewriteResult
 
-		checker.Elaboration.PostConditionsRewrite[postConditions] = rewriteResult
+		checker.Elaboration.SetPostConditionsRewrite(postConditions, rewriteResult)
 
 		checker.visitStatements(rewriteResult.BeforeStatements)
 	}

--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -59,7 +59,7 @@ func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclarat
 		return nil
 	}
 
-	checker.Elaboration.ImportDeclarationsResolvedLocations[declaration] = resolvedLocations
+	checker.Elaboration.SetImportDeclarationsResolvedLocations(declaration, resolvedLocations)
 
 	for _, resolvedLocation := range resolvedLocations {
 		checker.importResolvedLocation(resolvedLocation, locationRange)

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -34,7 +34,7 @@ func (checker *Checker) VisitInterfaceDeclaration(declaration *ast.InterfaceDecl
 
 	const kind = ContainerKindInterface
 
-	interfaceType := checker.Elaboration.InterfaceDeclarationTypes[declaration]
+	interfaceType := checker.Elaboration.InterfaceDeclarationType(declaration)
 	if interfaceType == nil {
 		panic(errors.NewUnreachableError())
 	}
@@ -135,7 +135,7 @@ func (checker *Checker) declareInterfaceNestedTypes(
 	declaration *ast.InterfaceDeclaration,
 ) {
 
-	interfaceType := checker.Elaboration.InterfaceDeclarationTypes[declaration]
+	interfaceType := checker.Elaboration.InterfaceDeclarationType(declaration)
 	nestedDeclarations := checker.Elaboration.InterfaceNestedDeclarations[declaration]
 
 	interfaceType.NestedTypes.Foreach(func(name string, nestedType Type) {
@@ -247,8 +247,8 @@ func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclarati
 		)
 	}
 
-	checker.Elaboration.InterfaceDeclarationTypes[declaration] = interfaceType
-	checker.Elaboration.InterfaceTypeDeclarations[interfaceType] = declaration
+	checker.Elaboration.SetInterfaceDeclarationType(declaration, interfaceType)
+	checker.Elaboration.SetInterfaceTypeDeclaration(interfaceType, declaration)
 
 	if !declaration.CompositeKind.SupportsInterfaces() {
 		checker.report(
@@ -300,7 +300,7 @@ func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclarati
 // in the elaboration's `InterfaceDeclarationTypes` and `InterfaceNestedDeclarations` fields.
 func (checker *Checker) declareInterfaceMembers(declaration *ast.InterfaceDeclaration) {
 
-	interfaceType := checker.Elaboration.InterfaceDeclarationTypes[declaration]
+	interfaceType := checker.Elaboration.InterfaceDeclarationType(declaration)
 	if interfaceType == nil {
 		panic(errors.NewUnreachableError())
 	}

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -136,7 +136,7 @@ func (checker *Checker) declareInterfaceNestedTypes(
 ) {
 
 	interfaceType := checker.Elaboration.InterfaceDeclarationType(declaration)
-	nestedDeclarations := checker.Elaboration.InterfaceNestedDeclarations[declaration]
+	nestedDeclarations := checker.Elaboration.InterfaceNestedDeclarations(declaration)
 
 	interfaceType.NestedTypes.Foreach(func(name string, nestedType Type) {
 		nestedDeclaration := nestedDeclarations[name]
@@ -277,7 +277,7 @@ func (checker *Checker) declareInterfaceType(declaration *ast.InterfaceDeclarati
 			declaration.Members.Interfaces(),
 		)
 
-	checker.Elaboration.InterfaceNestedDeclarations[declaration] = nestedDeclarations
+	checker.Elaboration.SetInterfaceNestedDeclarations(declaration, nestedDeclarations)
 
 	for _, nestedInterfaceType := range nestedInterfaceTypes {
 		interfaceType.NestedTypes.Set(nestedInterfaceType.Identifier, nestedInterfaceType)

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -99,11 +99,13 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 			argumentTypes = append(argumentTypes, argumentType)
 		}
 
-		checker.Elaboration.InvocationExpressionTypes[invocationExpression] =
+		checker.Elaboration.SetInvocationExpressionTypes(
+			invocationExpression,
 			InvocationExpressionTypes{
 				ArgumentTypes: argumentTypes,
 				ReturnType:    checker.expectedType,
-			}
+			},
+		)
 
 		return InvalidType
 	}
@@ -470,12 +472,15 @@ func (checker *Checker) checkInvocation(
 
 	// Save types in the elaboration
 
-	checker.Elaboration.InvocationExpressionTypes[invocationExpression] = InvocationExpressionTypes{
-		TypeArguments:      typeArguments,
-		TypeParameterTypes: parameterTypes,
-		ReturnType:         returnType,
-		ArgumentTypes:      argumentTypes,
-	}
+	checker.Elaboration.SetInvocationExpressionTypes(
+		invocationExpression,
+		InvocationExpressionTypes{
+			TypeArguments:      typeArguments,
+			TypeParameterTypes: parameterTypes,
+			ReturnType:         returnType,
+			ArgumentTypes:      argumentTypes,
+		},
+	)
 
 	return argumentTypes, returnType
 }

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -209,8 +209,8 @@ func (checker *Checker) checkMemberInvocationResourceInvalidation(invokedExpress
 	// Check that an entry for `IdentifierInInvocationTypes` exists,
 	// because the entry might be missing if the invocation was on a non-existent variable
 
-	valueType, ok := checker.Elaboration.IdentifierInInvocationTypes[invocationIdentifierExpression]
-	if !ok {
+	valueType := checker.Elaboration.IdentifierInInvocationType(invocationIdentifierExpression)
+	if valueType == nil {
 		return
 	}
 

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -77,7 +77,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 		return InvalidType
 	}
 
-	checker.Elaboration.ReferenceExpressionBorrowTypes[referenceExpression] = returnType
+	checker.Elaboration.SetReferenceExpressionBorrowType(referenceExpression, returnType)
 
 	return returnType
 }

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -56,11 +56,13 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) (_ 
 
 	valueType := checker.VisitExpression(statement.Expression, returnType)
 
-	checker.Elaboration.ReturnStatementTypes[statement] =
+	checker.Elaboration.SetReturnStatementTypes(
+		statement,
 		ReturnStatementTypes{
 			ValueType:  valueType,
 			ReturnType: returnType,
-		}
+		},
+	)
 
 	if returnType == VoidType {
 		return

--- a/runtime/sema/check_swap.go
+++ b/runtime/sema/check_swap.go
@@ -28,11 +28,13 @@ func (checker *Checker) VisitSwapStatement(swap *ast.SwapStatement) (_ struct{})
 	leftType := checker.VisitExpression(swap.Left, nil)
 	rightType := checker.VisitExpression(swap.Right, nil)
 
-	checker.Elaboration.SwapStatementTypes[swap] =
+	checker.Elaboration.SetSwapStatementTypes(
+		swap,
 		SwapStatementTypes{
 			LeftType:  leftType,
 			RightType: rightType,
-		}
+		},
+	)
 
 	lhsValid := checker.checkSwapStatementExpression(swap.Left, leftType, common.OperandSideLeft)
 	rhsValid := checker.checkSwapStatementExpression(swap.Right, rightType, common.OperandSideRight)

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (checker *Checker) VisitTransactionDeclaration(declaration *ast.TransactionDeclaration) (_ struct{}) {
-	transactionType := checker.Elaboration.TransactionDeclarationTypes[declaration]
+	transactionType := checker.Elaboration.TransactionDeclarationType(declaration)
 	if transactionType == nil {
 		panic(errors.NewUnreachableError())
 	}
@@ -273,6 +273,6 @@ func (checker *Checker) declareTransactionDeclaration(declaration *ast.Transacti
 		transactionType.PrepareParameters = checker.parameters(parameterList)
 	}
 
-	checker.Elaboration.TransactionDeclarationTypes[declaration] = transactionType
+	checker.Elaboration.SetTransactionDeclarationType(declaration, transactionType)
 	checker.Elaboration.TransactionTypes = append(checker.Elaboration.TransactionTypes, transactionType)
 }

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -232,6 +232,6 @@ func (checker *Checker) recordVariableDeclarationRange(
 func (checker *Checker) elaborateNestedResourceMoveExpression(expression ast.Expression) {
 	switch expression.(type) {
 	case *ast.IndexExpression, *ast.MemberExpression:
-		checker.Elaboration.IsNestedResourceMoveExpression[expression] = struct{}{}
+		checker.Elaboration.SetIsNestedResourceMoveExpression(expression)
 	}
 }

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -169,12 +169,14 @@ func (checker *Checker) visitVariableDeclaration(declaration *ast.VariableDeclar
 		}
 	}
 
-	checker.Elaboration.VariableDeclarationTypes[declaration] =
+	checker.Elaboration.SetVariableDeclarationTypes(
+		declaration,
 		VariableDeclarationTypes{
 			TargetType:      declarationType,
 			ValueType:       valueType,
 			SecondValueType: secondValueType,
-		}
+		},
+	)
 
 	// Finally, declare the variable in the current value activation
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -664,7 +664,7 @@ func (checker *Checker) declareGlobalValue(name string) {
 	if variable == nil {
 		return
 	}
-	checker.Elaboration.GlobalValues.Set(name, variable)
+	checker.Elaboration.SetGlobalValue(name, variable)
 }
 
 func (checker *Checker) declareGlobalType(name string) {
@@ -672,7 +672,7 @@ func (checker *Checker) declareGlobalType(name string) {
 	if ty == nil {
 		return
 	}
-	checker.Elaboration.GlobalTypes.Set(name, ty)
+	checker.Elaboration.SetGlobalType(name, ty)
 }
 
 func (checker *Checker) checkResourceMoveOperation(valueExpression ast.Expression, valueType Type) {
@@ -2273,11 +2273,11 @@ func (checker *Checker) declareGlobalRanges() {
 		return nil
 	})
 
-	checker.Elaboration.GlobalTypes.Foreach(func(name string, variable *Variable) {
+	checker.Elaboration.ForEachGlobalType(func(name string, variable *Variable) {
 		checker.PositionInfo.recordGlobalRange(memoryGauge, name, variable)
 	})
 
-	checker.Elaboration.GlobalValues.Foreach(func(name string, variable *Variable) {
+	checker.Elaboration.ForEachGlobalValue(func(name string, variable *Variable) {
 		checker.PositionInfo.recordGlobalRange(memoryGauge, name, variable)
 	})
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -393,7 +393,7 @@ func (checker *Checker) checkTopLevelDeclarationValidity(declarations []ast.Decl
 
 func (checker *Checker) declareGlobalFunctionDeclaration(declaration *ast.FunctionDeclaration) {
 	functionType := checker.functionType(declaration.ParameterList, declaration.ReturnTypeAnnotation)
-	checker.Elaboration.FunctionDeclarationFunctionTypes[declaration] = functionType
+	checker.Elaboration.SetFunctionDeclarationFunctionType(declaration, functionType)
 	checker.declareFunctionDeclaration(declaration, functionType)
 }
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -144,10 +144,7 @@ func NewChecker(
 		0,
 	)
 
-	elaboration := NewElaboration(
-		memoryGauge,
-		config.ExtendedElaborationEnabled,
-	)
+	elaboration := NewElaboration(memoryGauge)
 
 	checker := &Checker{
 		Program:             program,

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -280,9 +280,9 @@ func (checker *Checker) CheckProgram(program *ast.Program) {
 	registerInElaboration := func(ty Type) {
 		switch typedType := ty.(type) {
 		case *InterfaceType:
-			checker.Elaboration.InterfaceTypes[typedType.ID()] = typedType
+			checker.Elaboration.SetInterfaceType(typedType.ID(), typedType)
 		case *CompositeType:
-			checker.Elaboration.CompositeTypes[typedType.ID()] = typedType
+			checker.Elaboration.SetCompositeType(typedType.ID(), typedType)
 		default:
 			panic(errors.NewUnreachableError())
 		}

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -123,8 +123,8 @@ type Elaboration struct {
 	integerExpressionTypes           map[*ast.IntegerExpression]Type
 	stringExpressionTypes            map[*ast.StringExpression]Type
 	fixedPointExpressionTypes        map[*ast.FixedPointExpression]Type
-	TransactionDeclarationTypes      map[*ast.TransactionDeclaration]*TransactionType
-	SwapStatementTypes               map[*ast.SwapStatement]SwapStatementTypes
+	transactionDeclarationTypes      map[*ast.TransactionDeclaration]*TransactionType
+	swapStatementTypes               map[*ast.SwapStatement]SwapStatementTypes
 	// nestedResourceMoveExpressions indicates the index or member expression
 	// is implicitly moving a resource out of the container, e.g. in a shift or swap statement.
 	nestedResourceMoveExpressions       map[ast.Expression]struct{}
@@ -152,8 +152,6 @@ func NewElaboration(gauge common.MemoryGauge, extendedElaboration bool) *Elabora
 	common.UseMemory(gauge, common.ElaborationMemoryUsage)
 	elaboration := &Elaboration{
 		lock:                                new(sync.RWMutex),
-		TransactionDeclarationTypes:         map[*ast.TransactionDeclaration]*TransactionType{},
-		SwapStatementTypes:                  map[*ast.SwapStatement]SwapStatementTypes{},
 		CompositeNestedDeclarations:         map[*ast.CompositeDeclaration]map[string]ast.Declaration{},
 		InterfaceNestedDeclarations:         map[*ast.InterfaceDeclaration]map[string]ast.Declaration{},
 		PostConditionsRewrite:               map[*ast.Conditions]PostConditionsRewrite{},
@@ -620,4 +618,32 @@ func (e *Elaboration) SetFixedPointExpression(expression *ast.FixedPointExpressi
 		e.fixedPointExpressionTypes = map[*ast.FixedPointExpression]Type{}
 	}
 	e.fixedPointExpressionTypes[expression] = ty
+}
+
+func (e *Elaboration) TransactionDeclarationType(declaration *ast.TransactionDeclaration) *TransactionType {
+	if e.transactionDeclarationTypes == nil {
+		return nil
+	}
+	return e.transactionDeclarationTypes[declaration]
+}
+
+func (e *Elaboration) SetTransactionDeclarationType(declaration *ast.TransactionDeclaration, ty *TransactionType) {
+	if e.transactionDeclarationTypes == nil {
+		e.transactionDeclarationTypes = map[*ast.TransactionDeclaration]*TransactionType{}
+	}
+	e.transactionDeclarationTypes[declaration] = ty
+}
+
+func (e *Elaboration) SetSwapStatementTypes(statement *ast.SwapStatement, types SwapStatementTypes) {
+	if e.swapStatementTypes == nil {
+		e.swapStatementTypes = map[*ast.SwapStatement]SwapStatementTypes{}
+	}
+	e.swapStatementTypes[statement] = types
+}
+
+func (e *Elaboration) SwapStatementTypes(statement *ast.SwapStatement) (types SwapStatementTypes) {
+	if e.swapStatementTypes == nil {
+		return
+	}
+	return e.swapStatementTypes[statement]
 }

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -128,12 +128,12 @@ type Elaboration struct {
 	// nestedResourceMoveExpressions indicates the index or member expression
 	// is implicitly moving a resource out of the container, e.g. in a shift or swap statement.
 	nestedResourceMoveExpressions       map[ast.Expression]struct{}
-	CompositeNestedDeclarations         map[*ast.CompositeDeclaration]map[string]ast.Declaration
-	InterfaceNestedDeclarations         map[*ast.InterfaceDeclaration]map[string]ast.Declaration
-	PostConditionsRewrite               map[*ast.Conditions]PostConditionsRewrite
-	EmitStatementEventTypes             map[*ast.EmitStatement]*CompositeType
-	CompositeTypes                      map[TypeID]*CompositeType
-	InterfaceTypes                      map[TypeID]*InterfaceType
+	compositeNestedDeclarations         map[*ast.CompositeDeclaration]map[string]ast.Declaration
+	interfaceNestedDeclarations         map[*ast.InterfaceDeclaration]map[string]ast.Declaration
+	postConditionsRewrites              map[*ast.Conditions]PostConditionsRewrite
+	emitStatementEventTypes             map[*ast.EmitStatement]*CompositeType
+	compositeTypes                      map[TypeID]*CompositeType
+	interfaceTypes                      map[TypeID]*InterfaceType
 	IdentifierInInvocationTypes         map[*ast.IdentifierExpression]Type
 	ImportDeclarationsResolvedLocations map[*ast.ImportDeclaration][]ResolvedLocation
 	globalValues                        *StringVariableOrderedMap
@@ -152,12 +152,6 @@ func NewElaboration(gauge common.MemoryGauge, extendedElaboration bool) *Elabora
 	common.UseMemory(gauge, common.ElaborationMemoryUsage)
 	elaboration := &Elaboration{
 		lock:                                new(sync.RWMutex),
-		CompositeNestedDeclarations:         map[*ast.CompositeDeclaration]map[string]ast.Declaration{},
-		InterfaceNestedDeclarations:         map[*ast.InterfaceDeclaration]map[string]ast.Declaration{},
-		PostConditionsRewrite:               map[*ast.Conditions]PostConditionsRewrite{},
-		EmitStatementEventTypes:             map[*ast.EmitStatement]*CompositeType{},
-		CompositeTypes:                      map[TypeID]*CompositeType{},
-		InterfaceTypes:                      map[TypeID]*InterfaceType{},
 		IdentifierInInvocationTypes:         map[*ast.IdentifierExpression]Type{},
 		ImportDeclarationsResolvedLocations: map[*ast.ImportDeclaration][]ResolvedLocation{},
 		ReferenceExpressionBorrowTypes:      map[*ast.ReferenceExpression]Type{},
@@ -646,4 +640,94 @@ func (e *Elaboration) SwapStatementTypes(statement *ast.SwapStatement) (types Sw
 		return
 	}
 	return e.swapStatementTypes[statement]
+}
+
+func (e *Elaboration) CompositeNestedDeclarations(declaration *ast.CompositeDeclaration) map[string]ast.Declaration {
+	if e.compositeNestedDeclarations == nil {
+		return nil
+	}
+	return e.compositeNestedDeclarations[declaration]
+}
+
+func (e *Elaboration) SetCompositeNestedDeclarations(
+	declaration *ast.CompositeDeclaration,
+	nestedDeclaration map[string]ast.Declaration,
+) {
+	if e.compositeNestedDeclarations == nil {
+		e.compositeNestedDeclarations = map[*ast.CompositeDeclaration]map[string]ast.Declaration{}
+	}
+	e.compositeNestedDeclarations[declaration] = nestedDeclaration
+}
+
+func (e *Elaboration) InterfaceNestedDeclarations(declaration *ast.InterfaceDeclaration) map[string]ast.Declaration {
+	if e.interfaceNestedDeclarations == nil {
+		return nil
+	}
+	return e.interfaceNestedDeclarations[declaration]
+}
+
+func (e *Elaboration) SetInterfaceNestedDeclarations(
+	declaration *ast.InterfaceDeclaration,
+	nestedDeclaration map[string]ast.Declaration,
+) {
+	if e.interfaceNestedDeclarations == nil {
+		e.interfaceNestedDeclarations = map[*ast.InterfaceDeclaration]map[string]ast.Declaration{}
+	}
+	e.interfaceNestedDeclarations[declaration] = nestedDeclaration
+}
+
+func (e *Elaboration) PostConditionsRewrite(conditions *ast.Conditions) (rewrite PostConditionsRewrite) {
+	if e.postConditionsRewrites == nil {
+		return
+	}
+	return e.postConditionsRewrites[conditions]
+}
+
+func (e *Elaboration) SetPostConditionsRewrite(conditions *ast.Conditions, rewrite PostConditionsRewrite) {
+	if e.postConditionsRewrites == nil {
+		e.postConditionsRewrites = map[*ast.Conditions]PostConditionsRewrite{}
+	}
+	e.postConditionsRewrites[conditions] = rewrite
+}
+
+func (e *Elaboration) EmitStatementEventType(statement *ast.EmitStatement) *CompositeType {
+	if e.emitStatementEventTypes == nil {
+		return nil
+	}
+	return e.emitStatementEventTypes[statement]
+}
+
+func (e *Elaboration) SetEmitStatementEventType(statement *ast.EmitStatement, compositeType *CompositeType) {
+	if e.emitStatementEventTypes == nil {
+		e.emitStatementEventTypes = map[*ast.EmitStatement]*CompositeType{}
+	}
+	e.emitStatementEventTypes[statement] = compositeType
+}
+
+func (e *Elaboration) CompositeType(typeID common.TypeID) *CompositeType {
+	if e.compositeTypes == nil {
+		return nil
+	}
+	return e.compositeTypes[typeID]
+}
+
+func (e *Elaboration) SetCompositeType(typeID TypeID, ty *CompositeType) {
+	if e.compositeTypes == nil {
+		e.compositeTypes = map[TypeID]*CompositeType{}
+	}
+	e.compositeTypes[typeID] = ty
+}
+
+func (e *Elaboration) InterfaceType(typeID common.TypeID) *InterfaceType {
+	if e.interfaceTypes == nil {
+		return nil
+	}
+	return e.interfaceTypes[typeID]
+}
+
+func (e *Elaboration) SetInterfaceType(typeID TypeID, ty *InterfaceType) {
+	if e.interfaceTypes == nil {
+		e.interfaceTypes = map[TypeID]*InterfaceType{}
+	}
+	e.interfaceTypes[typeID] = ty
 }

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -116,13 +116,13 @@ type Elaboration struct {
 	castingExpressionTypes           map[*ast.CastingExpression]CastingExpressionTypes
 	returnStatementTypes             map[*ast.ReturnStatement]ReturnStatementTypes
 	binaryExpressionTypes            map[*ast.BinaryExpression]BinaryExpressionTypes
-	MemberExpressionMemberInfos      map[*ast.MemberExpression]MemberInfo
-	MemberExpressionExpectedTypes    map[*ast.MemberExpression]Type
+	memberExpressionMemberInfos      map[*ast.MemberExpression]MemberInfo
+	memberExpressionExpectedTypes    map[*ast.MemberExpression]Type
 	arrayExpressionTypes             map[*ast.ArrayExpression]ArrayExpressionTypes
 	dictionaryExpressionTypes        map[*ast.DictionaryExpression]DictionaryExpressionTypes
 	integerExpressionTypes           map[*ast.IntegerExpression]Type
 	stringExpressionTypes            map[*ast.StringExpression]Type
-	FixedPointExpression             map[*ast.FixedPointExpression]Type
+	fixedPointExpressionTypes        map[*ast.FixedPointExpression]Type
 	TransactionDeclarationTypes      map[*ast.TransactionDeclaration]*TransactionType
 	SwapStatementTypes               map[*ast.SwapStatement]SwapStatementTypes
 	// nestedResourceMoveExpressions indicates the index or member expression
@@ -152,9 +152,6 @@ func NewElaboration(gauge common.MemoryGauge, extendedElaboration bool) *Elabora
 	common.UseMemory(gauge, common.ElaborationMemoryUsage)
 	elaboration := &Elaboration{
 		lock:                                new(sync.RWMutex),
-		MemberExpressionMemberInfos:         map[*ast.MemberExpression]MemberInfo{},
-		MemberExpressionExpectedTypes:       map[*ast.MemberExpression]Type{},
-		FixedPointExpression:                map[*ast.FixedPointExpression]Type{},
 		TransactionDeclarationTypes:         map[*ast.TransactionDeclaration]*TransactionType{},
 		SwapStatementTypes:                  map[*ast.SwapStatement]SwapStatementTypes{},
 		CompositeNestedDeclarations:         map[*ast.CompositeDeclaration]map[string]ast.Declaration{},
@@ -569,4 +566,58 @@ func (e *Elaboration) SetIntegerExpressionType(expression *ast.IntegerExpression
 		e.integerExpressionTypes = map[*ast.IntegerExpression]Type{}
 	}
 	e.integerExpressionTypes[expression] = actualType
+}
+
+func (e *Elaboration) MemberExpressionMemberInfo(expression *ast.MemberExpression) (memberInfo MemberInfo, ok bool) {
+	if e.memberExpressionMemberInfos == nil {
+		ok = false
+		return
+	}
+	memberInfo, ok = e.memberExpressionMemberInfos[expression]
+	return
+}
+
+func (e *Elaboration) SetMemberExpressionMemberInfo(expression *ast.MemberExpression, memberInfo MemberInfo) {
+	if e.memberExpressionMemberInfos == nil {
+		e.memberExpressionMemberInfos = map[*ast.MemberExpression]MemberInfo{}
+	}
+	e.memberExpressionMemberInfos[expression] = memberInfo
+}
+
+func (e *Elaboration) MemberExpressionExpectedType(expression *ast.MemberExpression) Type {
+	if e.memberExpressionExpectedTypes == nil {
+		return nil
+	}
+	return e.memberExpressionExpectedTypes[expression]
+}
+
+func (e *Elaboration) SetMemberExpressionExpectedType(expression *ast.MemberExpression, expectedType Type) {
+	if e.memberExpressionExpectedTypes == nil {
+		e.memberExpressionExpectedTypes = map[*ast.MemberExpression]Type{}
+	}
+	e.memberExpressionExpectedTypes[expression] = expectedType
+}
+
+var defaultElaborationFixedPointExpressionType = UFix64Type
+
+func (e *Elaboration) FixedPointExpression(expression *ast.FixedPointExpression) Type {
+	if e.fixedPointExpressionTypes != nil {
+		result, ok := e.fixedPointExpressionTypes[expression]
+		if ok {
+			return result
+		}
+	}
+	// default, Elaboration.SetFixedPointExpressionType
+	return defaultElaborationFixedPointExpressionType
+}
+
+func (e *Elaboration) SetFixedPointExpression(expression *ast.FixedPointExpression, ty Type) {
+	if ty == defaultElaborationFixedPointExpressionType {
+		// default, see Elaboration.FixedPointExpressionType
+		return
+	}
+	if e.fixedPointExpressionTypes == nil {
+		e.fixedPointExpressionTypes = map[*ast.FixedPointExpression]Type{}
+	}
+	e.fixedPointExpressionTypes[expression] = ty
 }

--- a/runtime/sema/entrypoint.go
+++ b/runtime/sema/entrypoint.go
@@ -60,7 +60,7 @@ func FunctionEntryPointDeclaration(program *ast.Program) *ast.FunctionDeclaratio
 func (checker *Checker) EntryPointParameters() []Parameter {
 	transactionDeclaration := checker.Program.SoleTransactionDeclaration()
 	if transactionDeclaration != nil {
-		transactionType := checker.Elaboration.TransactionDeclarationTypes[transactionDeclaration]
+		transactionType := checker.Elaboration.TransactionDeclarationType(transactionDeclaration)
 		return transactionType.Parameters
 	}
 

--- a/runtime/sema/entrypoint.go
+++ b/runtime/sema/entrypoint.go
@@ -66,7 +66,7 @@ func (checker *Checker) EntryPointParameters() []Parameter {
 
 	functionDeclaration := FunctionEntryPointDeclaration(checker.Program)
 	if functionDeclaration != nil {
-		functionType := checker.Elaboration.FunctionDeclarationFunctionTypes[functionDeclaration]
+		functionType := checker.Elaboration.FunctionDeclarationFunctionType(functionDeclaration)
 		return functionType.Parameters
 	}
 

--- a/runtime/sema/import.go
+++ b/runtime/sema/import.go
@@ -44,13 +44,11 @@ type ElaborationImport struct {
 	Elaboration *Elaboration
 }
 
-func variablesToImportElements(
-	variables *StringVariableOrderedMap,
-) *StringImportElementOrderedMap {
+func variablesToImportElements(f func(func(name string, variable *Variable))) *StringImportElementOrderedMap {
 
 	elements := &StringImportElementOrderedMap{}
 
-	variables.Foreach(func(name string, variable *Variable) {
+	f(func(name string, variable *Variable) {
 
 		elements.Set(name, ImportElement{
 			DeclarationKind: variable.DeclarationKind,
@@ -64,11 +62,11 @@ func variablesToImportElements(
 }
 
 func (i ElaborationImport) AllValueElements() *StringImportElementOrderedMap {
-	return variablesToImportElements(i.Elaboration.GlobalValues)
+	return variablesToImportElements(i.Elaboration.ForEachGlobalValue)
 }
 
 func (i ElaborationImport) AllTypeElements() *StringImportElementOrderedMap {
-	return variablesToImportElements(i.Elaboration.GlobalTypes)
+	return variablesToImportElements(i.Elaboration.ForEachGlobalType)
 }
 
 func (i ElaborationImport) IsChecking() bool {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3344,20 +3344,26 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 		case *ast.IntegerExpression:
 			if CheckIntegerLiteral(nil, argument, targetType, checker.report) {
 				if checker.Config.ExtendedElaborationEnabled {
-					checker.Elaboration.NumberConversionArgumentTypes[argument] = struct {
-						Type  Type
-						Range ast.Range
-					}{Type: targetType, Range: invocationRange}
+					checker.Elaboration.SetNumberConversionArgumentTypes(
+						argument,
+						NumberConversionArgumentTypes{
+							Type: targetType,
+							Range: invocationRange,
+						},
+					)
 				}
 			}
 
 		case *ast.FixedPointExpression:
 			if CheckFixedPointLiteral(nil, argument, targetType, checker.report) {
 				if checker.Config.ExtendedElaborationEnabled {
-					checker.Elaboration.NumberConversionArgumentTypes[argument] = struct {
-						Type  Type
-						Range ast.Range
-					}{Type: targetType, Range: invocationRange}
+					checker.Elaboration.SetNumberConversionArgumentTypes(
+						argument,
+						NumberConversionArgumentTypes{
+							Type: targetType,
+							Range: invocationRange,
+						},
+					)
 				}
 			}
 		}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3347,7 +3347,7 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 					checker.Elaboration.SetNumberConversionArgumentTypes(
 						argument,
 						NumberConversionArgumentTypes{
-							Type: targetType,
+							Type:  targetType,
 							Range: invocationRange,
 						},
 					)
@@ -3360,7 +3360,7 @@ func numberFunctionArgumentExpressionsChecker(targetType Type) ArgumentExpressio
 					checker.Elaboration.SetNumberConversionArgumentTypes(
 						argument,
 						NumberConversionArgumentTypes{
-							Type: targetType,
+							Type:  targetType,
 							Range: invocationRange,
 						},
 					)

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1500,7 +1500,7 @@ func newAuthAccountContractsChangeFunction(
 			var contractTypes []*sema.CompositeType
 			var contractInterfaceTypes []*sema.InterfaceType
 
-			program.Elaboration.GlobalTypes.Foreach(func(_ string, variable *sema.Variable) {
+			program.Elaboration.ForEachGlobalType(func(_ string, variable *sema.Variable) {
 				switch ty := variable.Type.(type) {
 				case *sema.CompositeType:
 					if ty.Kind == common.CompositeKindContract {

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -63,7 +63,7 @@ var CryptoChecker = func() *sema.Checker {
 }()
 
 var cryptoContractType = func() *sema.CompositeType {
-	variable, ok := CryptoChecker.Elaboration.GlobalTypes.Get("Crypto")
+	variable, ok := CryptoChecker.Elaboration.GetGlobalType("Crypto")
 	if !ok {
 		panic(errors2.NewUnreachableError())
 	}

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -301,7 +301,10 @@ func init() {
 
 	// Enrich 'Test' contract elaboration with natively implemented composite types.
 	// e.g: 'EmulatorBackend' type.
-	TestContractChecker.Elaboration.CompositeTypes[EmulatorBackendType.ID()] = EmulatorBackendType
+	TestContractChecker.Elaboration.SetCompositeType(
+		EmulatorBackendType.ID(),
+		EmulatorBackendType,
+	)
 }
 
 var blockchainType = func() sema.Type {

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -129,7 +129,7 @@ func NewTestContract(
 }
 
 var testContractType = func() *sema.CompositeType {
-	variable, ok := TestContractChecker.Elaboration.GlobalTypes.Get(testContractTypeName)
+	variable, ok := TestContractChecker.Elaboration.GetGlobalType(testContractTypeName)
 	if !ok {
 		panic(errors.NewUnreachableError())
 	}

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -5943,8 +5943,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Int8Type, cast.TargetType)
 			}
 		})
@@ -5958,8 +5958,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Int8Type, cast.TargetType)
 			}
 		})
@@ -5973,8 +5973,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Int8Type, cast.TargetType)
 			}
 		})
@@ -5988,8 +5988,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.CharacterType, cast.TargetType)
 			}
 		})
@@ -6003,8 +6003,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.UInt8Type, cast.TargetType)
 			}
 		})
@@ -6020,7 +6020,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 			assert.IsType(t, &sema.NotDeclaredError{}, errors[0])
 			assert.IsType(t, &sema.NotDeclaredError{}, errors[1])
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
 		})
 
 		t.Run("with generics", func(t *testing.T) {
@@ -6055,7 +6055,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 			)
 
 			require.NoError(t, err)
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
 		})
 	})
 
@@ -6071,8 +6071,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.StringType, cast.TargetType)
 			}
 		})
@@ -6086,8 +6086,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.BoolType, cast.TargetType)
 			}
 		})
@@ -6101,8 +6101,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.OptionalType{
 					Type: sema.NeverType,
 				}, cast.TargetType)
@@ -6120,8 +6120,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Int8Type, cast.ExprActualType)
 			}
 		})
@@ -6137,8 +6137,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Int8Type, cast.ExprActualType)
 			}
 		})
@@ -6153,8 +6153,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			RequireCheckerErrors(t, err, 1)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Int8Type, cast.TargetType)
 			}
 		})
@@ -6169,8 +6169,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.AnyStructType, cast.ExpectedType)
 			}
 		})
@@ -6184,8 +6184,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.UFix64Type, cast.TargetType)
 			}
 
@@ -6195,8 +6195,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Fix64Type, cast.TargetType)
 			}
 		})
@@ -6210,8 +6210,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.VariableSizedType{
 					Type: sema.IntType,
 				}, cast.TargetType)
@@ -6227,8 +6227,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.VariableSizedType{
 					Type: sema.UInt8Type,
 				}, cast.TargetType)
@@ -6247,8 +6247,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.VariableSizedType{
 					Type: sema.Int8Type,
 				}, cast.TargetType)
@@ -6271,7 +6271,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 			assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
 			assert.IsType(t, &sema.TypeMismatchError{}, errs[2])
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 0)
 		})
 
 		t.Run("Nested array, all elements self typed", func(t *testing.T) {
@@ -6286,8 +6286,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.VariableSizedType{
 					Type: &sema.VariableSizedType{
 						Type: sema.Int8Type,
@@ -6307,8 +6307,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.VariableSizedType{
 					Type: &sema.VariableSizedType{
 						Type: sema.Int8Type,
@@ -6333,7 +6333,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 			assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
 			assert.IsType(t, &sema.TypeMismatchError{}, errs[2])
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 0)
 		})
 
 		t.Run("Nested dictionary, all entries self typed", func(t *testing.T) {
@@ -6348,8 +6348,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.DictionaryType{
 					KeyType: sema.Int8Type,
 					ValueType: &sema.DictionaryType{
@@ -6372,8 +6372,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.DictionaryType{
 					KeyType: sema.Int8Type,
 					ValueType: &sema.DictionaryType{
@@ -6394,7 +6394,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 0)
 		})
 
 		t.Run("Reference, with type", func(t *testing.T) {
@@ -6407,7 +6407,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 0)
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 0)
 		})
 
 		t.Run("Conditional expr valid", func(t *testing.T) {
@@ -6419,8 +6419,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.OptionalType{
 					Type: sema.UFix64Type,
 				}, cast.TargetType)
@@ -6436,8 +6436,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, &sema.OptionalType{
 					Type: sema.Fix64Type,
 				}, cast.TargetType)
@@ -6453,8 +6453,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.UFix64Type, cast.TargetType)
 			}
 		})
@@ -6472,8 +6472,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.UIntType, cast.TargetType)
 			}
 		})
@@ -6496,8 +6496,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.StringType, cast.TargetType)
 			}
 		})
@@ -6512,8 +6512,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.IntType, cast.TargetType)
 			}
 		})
@@ -6529,8 +6529,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.IsType(t, &sema.CompositeType{}, cast.TargetType)
 				compositeType := cast.TargetType.(*sema.CompositeType)
 				assert.Equal(t, "Foo", compositeType.Identifier)
@@ -6547,8 +6547,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.IntType, cast.TargetType)
 			}
 		})
@@ -6563,8 +6563,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.PublicPathType, cast.TargetType)
 			}
 		})
@@ -6578,8 +6578,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.BoolType, cast.TargetType)
 			}
 
@@ -6590,8 +6590,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.Equal(t, sema.Fix64Type, cast.TargetType)
 			}
 		})
@@ -6606,7 +6606,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 2)
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 2)
 		})
 
 		t.Run("Function expr", func(t *testing.T) {
@@ -6621,8 +6621,8 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Len(t, checker.Elaboration.StaticCastTypes, 1)
-			for _, cast := range checker.Elaboration.StaticCastTypes { // nolint:maprangecheck
+			require.Len(t, checker.Elaboration.AllStaticCastTypes(), 1)
+			for _, cast := range checker.Elaboration.AllStaticCastTypes() { // nolint:maprangecheck
 				assert.IsType(t, &sema.FunctionType{}, cast.TargetType)
 			}
 		})

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -55,8 +55,6 @@ func TestCheckCastingIntLiteralToIntegerType(t *testing.T) {
 				integerType,
 				xType,
 			)
-
-			assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
 		})
 	}
 
@@ -94,15 +92,13 @@ func TestCheckCastingIntLiteralToAnyStruct(t *testing.T) {
 		sema.AnyStructType,
 		xType,
 	)
-
-	assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
 }
 
 func TestCheckCastingResourceToAnyResource(t *testing.T) {
 
 	t.Parallel()
 
-	checker, err := ParseAndCheck(t, `
+	_, err := ParseAndCheck(t, `
       resource R {}
 
       fun test() {
@@ -113,8 +109,6 @@ func TestCheckCastingResourceToAnyResource(t *testing.T) {
     `)
 
 	require.NoError(t, err)
-
-	assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
 }
 
 func TestCheckCastingArrayLiteral(t *testing.T) {

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -110,7 +110,7 @@ func TestCheckFunctionPostConditionWithBefore(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Len(t, checker.Elaboration.VariableDeclarationTypes, 1)
+	assert.Equal(t, 1, checker.Elaboration.VariableDeclarationTypesCount())
 }
 
 func TestCheckFunctionPostConditionWithBeforeNotDeclaredUse(t *testing.T) {

--- a/runtime/tests/checker/dynamic_casting_test.go
+++ b/runtime/tests/checker/dynamic_casting_test.go
@@ -45,7 +45,7 @@ func TestCheckDynamicCastingAnyStruct(t *testing.T) {
 		t.Run(operation.Symbol(), func(t *testing.T) {
 
 			t.Run("struct", func(t *testing.T) {
-				checker, err := ParseAndCheck(t,
+				_, err := ParseAndCheck(t,
 					fmt.Sprintf(
 						`
                           struct S {}
@@ -59,7 +59,6 @@ func TestCheckDynamicCastingAnyStruct(t *testing.T) {
 
 				require.NoError(t, err)
 
-				assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
 			})
 
 			t.Run("resource", func(t *testing.T) {
@@ -91,9 +90,11 @@ func TestCheckDynamicCastingAnyResource(t *testing.T) {
 
 	t.Run("resource", func(t *testing.T) {
 
+		t.Parallel()
+
 		t.Run("as?", func(t *testing.T) {
 
-			checker, err := ParseAndCheck(t, `
+			_, err := ParseAndCheck(t, `
 
               resource R {}
 
@@ -108,13 +109,11 @@ func TestCheckDynamicCastingAnyResource(t *testing.T) {
             `)
 
 			require.NoError(t, err)
-
-			assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
 		})
 
 		t.Run("as!", func(t *testing.T) {
 
-			checker, err := ParseAndCheck(t, `
+			_, err := ParseAndCheck(t, `
 
               resource R {}
 
@@ -126,12 +125,12 @@ func TestCheckDynamicCastingAnyResource(t *testing.T) {
             `)
 
 			require.NoError(t, err)
-
-			assert.NotEmpty(t, checker.Elaboration.CastingTargetTypes)
 		})
 	})
 
 	t.Run("struct", func(t *testing.T) {
+
+		t.Parallel()
 
 		t.Run("as?", func(t *testing.T) {
 

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -164,7 +164,7 @@ func TestCheckGenericFunction(t *testing.T) {
 		require.IsType(t, &ast.InvocationExpression{}, variableDeclaration.Value)
 		invocationExpression := variableDeclaration.Value.(*ast.InvocationExpression)
 
-		typeArguments := checker.Elaboration.InvocationExpressionTypes[invocationExpression].TypeArguments
+		typeArguments := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for parameter %#+v", typeParameter)
@@ -214,7 +214,7 @@ func TestCheckGenericFunction(t *testing.T) {
 		require.IsType(t, &ast.InvocationExpression{}, variableDeclaration.Value)
 		invocationExpression := variableDeclaration.Value.(*ast.InvocationExpression)
 
-		typeArguments := checker.Elaboration.InvocationExpressionTypes[invocationExpression].TypeArguments
+		typeArguments := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
@@ -387,7 +387,7 @@ func TestCheckGenericFunction(t *testing.T) {
 		require.IsType(t, &ast.InvocationExpression{}, variableDeclaration.Value)
 		invocationExpression := variableDeclaration.Value.(*ast.InvocationExpression)
 
-		typeParameterTypes := checker.Elaboration.InvocationExpressionTypes[invocationExpression].TypeArguments
+		typeParameterTypes := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
 
 		ty, present := typeParameterTypes.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
@@ -511,7 +511,7 @@ func TestCheckGenericFunction(t *testing.T) {
 		require.IsType(t, &ast.InvocationExpression{}, variableDeclaration.Value)
 		invocationExpression := variableDeclaration.Value.(*ast.InvocationExpression)
 
-		typeArguments := checker.Elaboration.InvocationExpressionTypes[invocationExpression].TypeArguments
+		typeArguments := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
@@ -570,7 +570,7 @@ func TestCheckGenericFunction(t *testing.T) {
 		require.IsType(t, &ast.InvocationExpression{}, variableDeclaration.Value)
 		invocationExpression := variableDeclaration.Value.(*ast.InvocationExpression)
 
-		typeArguments := checker.Elaboration.InvocationExpressionTypes[invocationExpression].TypeArguments
+		typeArguments := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
@@ -615,7 +615,7 @@ func TestCheckGenericFunction(t *testing.T) {
 		require.IsType(t, &ast.InvocationExpression{}, variableDeclaration.Value)
 		invocationExpression := variableDeclaration.Value.(*ast.InvocationExpression)
 
-		typeArguments := checker.Elaboration.InvocationExpressionTypes[invocationExpression].TypeArguments
+		typeArguments := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
 
 		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)

--- a/runtime/tests/checker/range_test.go
+++ b/runtime/tests/checker/range_test.go
@@ -110,19 +110,19 @@ func TestCheckRange(t *testing.T) {
 	ranges = checker.PositionInfo.Ranges.All()
 	sortAndFilterRanges()
 
-	barTypeVariable, ok := checker.Elaboration.GlobalTypes.Get("_TEST_Bar")
+	barTypeVariable, ok := checker.Elaboration.GetGlobalType("_TEST_Bar")
 	require.True(t, ok, "missing global type _TEST_Bar")
 
-	barValueVariable, ok := checker.Elaboration.GlobalValues.Get("_TEST_Bar")
+	barValueVariable, ok := checker.Elaboration.GetGlobalValue("_TEST_Bar")
 	require.True(t, ok, "missing global value _TEST_Bar")
 
-	bazTypeVariable, ok := checker.Elaboration.GlobalTypes.Get("_TEST_Baz")
+	bazTypeVariable, ok := checker.Elaboration.GetGlobalType("_TEST_Baz")
 	require.True(t, ok, "missing global type _TEST_Baz")
 
-	bazValueVariable, ok := checker.Elaboration.GlobalValues.Get("_TEST_Baz")
+	bazValueVariable, ok := checker.Elaboration.GetGlobalValue("_TEST_Baz")
 	require.True(t, ok, "missing global value _TEST_Baz")
 
-	fooValueVariable, ok := checker.Elaboration.GlobalValues.Get("_TEST_foo")
+	fooValueVariable, ok := checker.Elaboration.GetGlobalValue("_TEST_foo")
 	require.True(t, ok, "missing global value _TEST_foo")
 
 	assert.Equal(t,

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -192,13 +192,13 @@ func RequireCheckerErrors(t *testing.T, err error, count int) []error {
 }
 
 func RequireGlobalType(t *testing.T, elaboration *sema.Elaboration, name string) sema.Type {
-	variable, ok := elaboration.GlobalTypes.Get(name)
+	variable, ok := elaboration.GetGlobalType(name)
 	require.True(t, ok, "global type '%s' missing", name)
 	return variable.Type
 }
 
 func RequireGlobalValue(t *testing.T, elaboration *sema.Elaboration, name string) sema.Type {
-	variable, ok := elaboration.GlobalValues.Get(name)
+	variable, ok := elaboration.GetGlobalValue(name)
 	require.True(t, ok, "global value '%s' missing", name)
 	return variable.Type
 }

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -149,7 +149,10 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 				BaseTypeActivation:  baseTypeActivation,
 				CheckHandler: func(checker *sema.Checker, check func()) {
 					if checker.Location == TestLocation {
-						checker.Elaboration.CompositeTypes[fruitType.ID()] = fruitType
+						checker.Elaboration.SetCompositeType(
+							fruitType.ID(),
+							fruitType,
+						)
 					}
 					check()
 				},

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -104,7 +104,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 						),
 					}
 
-					elaboration := sema.NewElaboration(nil, false)
+					elaboration := sema.NewElaboration(nil)
 					elaboration.SetCompositeType(
 						fooType.ID(),
 						fooType,

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -105,7 +105,10 @@ func TestInterpretVirtualImport(t *testing.T) {
 					}
 
 					elaboration := sema.NewElaboration(nil, false)
-					elaboration.CompositeTypes[fooType.ID()] = fooType
+					elaboration.SetCompositeType(
+						fooType.ID(),
+						fooType,
+					)
 
 					return interpreter.VirtualImport{
 						Globals: []struct {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4690,7 +4690,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 		var inter *interpreter.Interpreter
 
 		getType := func(name string) sema.Type {
-			variable, ok := inter.Program.Elaboration.GlobalTypes.Get(name)
+			variable, ok := inter.Program.Elaboration.GetGlobalType(name)
 			require.True(t, ok, "missing global type %s", name)
 			return variable.Type
 		}

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1070,7 +1070,10 @@ func newCompositeValue(
 	}
 
 	// Add the type to the elaboration, to short-circuit the type-lookup
-	inter.Program.Elaboration.CompositeTypes[compositeType.ID()] = compositeType
+	inter.Program.Elaboration.SetCompositeType(
+		compositeType.ID(),
+		compositeType,
+	)
 
 	testComposite := interpreter.NewCompositeValue(
 		inter,
@@ -1242,7 +1245,10 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 			Location:    location,
 		}
 
-		inter.Program.Elaboration.CompositeTypes[enumType.ID()] = enumType
+		inter.Program.Elaboration.SetCompositeType(
+			enumType.ID(),
+			enumType,
+		)
 
 		enum := interpreter.NewCompositeValue(
 			inter,
@@ -1393,7 +1399,10 @@ func randomCompositeValue(
 	}
 
 	// Add the type to the elaboration, to short-circuit the type-lookup
-	inter.Program.Elaboration.CompositeTypes[compositeType.ID()] = compositeType
+	inter.Program.Elaboration.SetCompositeType(
+		compositeType.ID(),
+		compositeType,
+	)
 
 	return interpreter.NewCompositeValue(
 		inter,

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -63,7 +63,7 @@ func TestRandomMapOperations(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		&interpreter.Program{
 			Program:     ast.NewProgram(nil, []ast.Declaration{}),
-			Elaboration: sema.NewElaboration(nil, false),
+			Elaboration: sema.NewElaboration(nil),
 		},
 		utils.TestLocation,
 		&interpreter.Config{
@@ -508,7 +508,7 @@ func TestRandomArrayOperations(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		&interpreter.Program{
 			Program:     ast.NewProgram(nil, []ast.Declaration{}),
-			Elaboration: sema.NewElaboration(nil, false),
+			Elaboration: sema.NewElaboration(nil),
 		},
 		utils.TestLocation,
 		&interpreter.Config{
@@ -872,7 +872,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 	inter, err := interpreter.NewInterpreter(
 		&interpreter.Program{
 			Program:     ast.NewProgram(nil, []ast.Declaration{}),
-			Elaboration: sema.NewElaboration(nil, false),
+			Elaboration: sema.NewElaboration(nil),
 		},
 		utils.TestLocation,
 		&interpreter.Config{

--- a/tools/analysis/analysis_test.go
+++ b/tools/analysis/analysis_test.go
@@ -112,8 +112,9 @@ func TestNeedSyntaxAndImport(t *testing.T) {
 				return true
 			}
 
-			leftHandType := program.Elaboration.CastingStaticValueTypes[castingExpression]
-			rightHandType := program.Elaboration.CastingTargetTypes[castingExpression]
+			types := program.Elaboration.CastingExpressionTypes(castingExpression)
+			leftHandType := types.StaticValueType
+			rightHandType := types.TargetType
 
 			if !sema.IsSubType(leftHandType, rightHandType) {
 				return true


### PR DESCRIPTION
## Description

Lazily allocate the many maps of an elaboration. In many cases, especially for smaller scripts, the allocations are unnecessary.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
