### PR TITLE
Add get or load program to the interface

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -34,36 +34,14 @@ type Interface interface {
 	ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
 	// GetCode returns the code at a given location
 	GetCode(location Location) ([]byte, error)
-	// GetProgram returns the program for the given location, if available.
-	//
-	// NOTE:
-	//
-	// For implementations:
-	// - During execution, this function MUST always return the *same* program,
-	//   i.e. it may NOT return a different program,
-	//   an elaboration in the program that is not annotating the AST in the program;
-	//   or a program/elaboration and then nothing in a subsequent call.
-	// - This function MUST also return what was set using SetProgram,
-	//   it may NOT return something different or nothing/nil (!) after SetProgram was called.
-	//   Do NOT implement this as a cache!
-	//
-	// For uses:
-	// - ONLY call this function when a program must be parsed and checked,
-	//   as an optimization to reuse the result of a potential previous parse and check.
-	// - If GetProgram returns nil, Cadence MUST call SetProgram:
-	//   There's an informal contract between Cadence and the implementer:
-	//   Cadence calls GetProgram to potentially avoid having to parse and check a program.
-	//   If the implementer returns nil from GetProgram,
-	//   it expects that Cadence sets the resulting parsed and checked program with SetProgram.
-	// - The behaviour after GetProgram returning nil or a program must be always deterministic:
-	//   As SetProgram is called when GetProgram is nil, then SetProgram MUST also be called when
-	//   GetProgram returns a program. This prevents nondeterministic behaviour
-	//
-	// Deprecated: This function should be refactored to ensure that SetProgram is always called
-	//
-	GetProgram(Location) (*interpreter.Program, error)
 	// SetProgram sets the program for the given location.
 	SetProgram(Location, *interpreter.Program) error
+	// GetOrLoadProgram gets the program for the given location. If the program was not loaded before,
+	// it uses the load function to load the program and caches it.
+	GetOrLoadProgram(
+		location Location,
+		load func(location Location) (*interpreter.Program, error),
+	) (*interpreter.Program, error)
 	// SetInterpreterSharedState sets the shared state of all interpreters.
 	SetInterpreterSharedState(state *interpreter.SharedState)
 	// GetInterpreterSharedState gets the shared state of all interpreters.


### PR DESCRIPTION
Related to https://github.com/onflow/flow-go/issues/3015

## Description

First step of changing the dangerous `GetProgram`, `SetProgram` to a `GetOrLoadProgram` that takes a closure doing the actual loading.

## Some concerns

1. I was not able to remove `SetProgram` due to some cases where set is used without first calling get (which I don't fully understand, but I think it relates to the non address location programs)

2. I duplicated some code from `parseAndCheckProgram`. This wouldn't have been needed if `runtimeInterface.SetProgram` could be removed from the function. But that is not possible due to the previous point.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
