### PR TITLE
Initialize the Crypto contract lazily

### DIFF
--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -99,9 +99,10 @@ func DefaultCheckerConfig(
 			importedLocation common.Location,
 			_ ast.Range,
 		) (sema.Import, error) {
-			if importedLocation == stdlib.CryptoChecker.Location {
+			cryptoChecker := stdlib.CryptoChecker()
+			if importedLocation == cryptoChecker.Location {
 				return sema.ElaborationImport{
-					Elaboration: stdlib.CryptoChecker.Elaboration,
+					Elaboration: cryptoChecker.Elaboration,
 				}, nil
 			}
 

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -99,8 +99,8 @@ func DefaultCheckerConfig(
 			importedLocation common.Location,
 			_ ast.Range,
 		) (sema.Import, error) {
-			cryptoChecker := stdlib.CryptoChecker()
-			if importedLocation == cryptoChecker.Location {
+			if importedLocation == stdlib.CryptoCheckerLocation {
+				cryptoChecker := stdlib.CryptoChecker()
 				return sema.ElaborationImport{
 					Elaboration: cryptoChecker.Elaboration,
 				}, nil

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -471,9 +471,9 @@ func (e *interpreterEnvironment) resolveImport(
 ) (sema.Import, error) {
 
 	var elaboration *sema.Elaboration
-	cryptoChecker := stdlib.CryptoChecker()
 	switch importedLocation {
-	case cryptoChecker.Location:
+	case stdlib.CryptoCheckerLocation:
+		cryptoChecker := stdlib.CryptoChecker()
 		elaboration = cryptoChecker.Elaboration
 
 	default:
@@ -752,10 +752,8 @@ func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter
 		compositeKind common.CompositeKind,
 	) map[string]interpreter.Value {
 
-		cryptoChecker := stdlib.CryptoChecker()
-
 		switch location {
-		case cryptoChecker.Location:
+		case stdlib.CryptoCheckerLocation:
 			return nil
 
 		default:
@@ -791,10 +789,10 @@ func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter
 
 func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLocationHandlerFunc {
 	return func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
-		cryptoChecker := stdlib.CryptoChecker()
 
 		switch location {
-		case cryptoChecker.Location:
+		case stdlib.CryptoCheckerLocation:
+			cryptoChecker := stdlib.CryptoChecker()
 			program := interpreter.ProgramFromChecker(cryptoChecker)
 			subInterpreter, err := inter.NewSubInterpreter(program, location)
 			if err != nil {
@@ -828,10 +826,8 @@ func (e *interpreterEnvironment) loadContract(
 	invocationRange ast.Range,
 ) *interpreter.CompositeValue {
 
-	cryptoChecker := stdlib.CryptoChecker()
-
 	switch compositeType.Location {
-	case cryptoChecker.Location:
+	case stdlib.CryptoCheckerLocation:
 		contract, err := stdlib.NewCryptoContract(
 			inter,
 			constructorGenerator(common.Address{}),

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -471,9 +471,10 @@ func (e *interpreterEnvironment) resolveImport(
 ) (sema.Import, error) {
 
 	var elaboration *sema.Elaboration
+	cryptoChecker := stdlib.CryptoChecker()
 	switch importedLocation {
-	case stdlib.CryptoChecker.Location:
-		elaboration = stdlib.CryptoChecker.Elaboration
+	case cryptoChecker.Location:
+		elaboration = cryptoChecker.Elaboration
 
 	default:
 
@@ -751,8 +752,10 @@ func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter
 		compositeKind common.CompositeKind,
 	) map[string]interpreter.Value {
 
+		cryptoChecker := stdlib.CryptoChecker()
+
 		switch location {
-		case stdlib.CryptoChecker.Location:
+		case cryptoChecker.Location:
 			return nil
 
 		default:
@@ -788,9 +791,11 @@ func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter
 
 func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLocationHandlerFunc {
 	return func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+		cryptoChecker := stdlib.CryptoChecker()
+
 		switch location {
-		case stdlib.CryptoChecker.Location:
-			program := interpreter.ProgramFromChecker(stdlib.CryptoChecker)
+		case cryptoChecker.Location:
+			program := interpreter.ProgramFromChecker(cryptoChecker)
 			subInterpreter, err := inter.NewSubInterpreter(program, location)
 			if err != nil {
 				panic(err)
@@ -823,8 +828,10 @@ func (e *interpreterEnvironment) loadContract(
 	invocationRange ast.Range,
 ) *interpreter.CompositeValue {
 
+	cryptoChecker := stdlib.CryptoChecker()
+
 	switch compositeType.Location {
-	case stdlib.CryptoChecker.Location:
+	case cryptoChecker.Location:
 		contract, err := stdlib.NewCryptoContract(
 			inter,
 			constructorGenerator(common.Address{}),

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7507,7 +7507,7 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 		Environment: environment,
 	}
 
-	require.NotNil(b, stdlib.CryptoChecker)
+	require.NotNil(b, stdlib.CryptoChecker())
 
 	runtime := newTestInterpreterRuntime()
 

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -31,6 +31,8 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
+const CryptoCheckerLocation = common.IdentifierLocation("Crypto")
+
 var cryptoOnce sync.Once
 
 // Deprecated: Use CryptoChecker instead
@@ -67,11 +69,9 @@ func initCrypto() {
 		panic(err)
 	}
 
-	location := common.IdentifierLocation("Crypto")
-
 	cryptoChecker, err = sema.NewChecker(
 		program,
-		location,
+		CryptoCheckerLocation,
 		nil,
 		&sema.Config{
 			AccessCheckMode: sema.AccessCheckModeStrict,

--- a/runtime/stdlib/crypto_test.go
+++ b/runtime/stdlib/crypto_test.go
@@ -27,5 +27,5 @@ import (
 )
 
 func TestCryptoContract(t *testing.T) {
-	require.IsType(t, &sema.Checker{}, CryptoChecker)
+	require.IsType(t, &sema.Checker{}, CryptoChecker())
 }

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1592,8 +1592,10 @@ func NewTestInterpreterContractValueHandler(
 		invocationRange ast.Range,
 	) interpreter.ContractValue {
 
+		cryptoChecker := CryptoChecker()
+
 		switch compositeType.Location {
-		case CryptoChecker.Location:
+		case cryptoChecker.Location:
 			contract, err := NewCryptoContract(
 				inter,
 				constructorGenerator(common.Address{}),

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1592,10 +1592,8 @@ func NewTestInterpreterContractValueHandler(
 		invocationRange ast.Range,
 	) interpreter.ContractValue {
 
-		cryptoChecker := CryptoChecker()
-
 		switch compositeType.Location {
-		case cryptoChecker.Location:
+		case CryptoCheckerLocation:
 			contract, err := NewCryptoContract(
 				inter,
 				constructorGenerator(common.Address{}),

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -110,9 +110,10 @@ func (programs Programs) check(
 			) (sema.Import, error) {
 
 				var elaboration *sema.Elaboration
+				cryptoChecker := stdlib.CryptoChecker()
 				switch importedLocation {
-				case stdlib.CryptoChecker.Location:
-					elaboration = stdlib.CryptoChecker.Elaboration
+				case cryptoChecker.Location:
+					elaboration = cryptoChecker.Elaboration
 
 				default:
 					err := programs.load(config, importedLocation, location, importRange)

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -110,9 +110,9 @@ func (programs Programs) check(
 			) (sema.Import, error) {
 
 				var elaboration *sema.Elaboration
-				cryptoChecker := stdlib.CryptoChecker()
 				switch importedLocation {
-				case cryptoChecker.Location:
+				case stdlib.CryptoCheckerLocation:
+					cryptoChecker := stdlib.CryptoChecker()
 					elaboration = cryptoChecker.Elaboration
 
 				default:


### PR DESCRIPTION
## Description

Instead of eagerly initializing the `Crypto` contract, initialize it lazily.

This is especially useful for development: Currently, when modifying the parser or checker, the eager initialization of the contract exercises the parser and checker before the test case runs.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
