### PR TITLE
Pretty print interpreter errors

### DIFF
--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -140,6 +140,44 @@ func TestRuntimeError(t *testing.T) {
 		)
 	})
 
+	t.Run("execution error with position", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := newTestInterpreterRuntime()
+
+		script := []byte(`
+			pub fun main() {
+				let x: AnyStruct? = nil
+				let y = x!
+			}
+        `)
+
+		runtimeInterface := &testRuntimeInterface{}
+
+		location := common.ScriptLocation{0x1}
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  location,
+			},
+		)
+		require.EqualError(
+			t,
+			err,
+			"Execution failed:\n"+
+				"error: unexpectedly found nil while forcing an Optional value\n"+
+				" --> 0100000000000000000000000000000000000000000000000000000000000000:4:12\n"+
+				"  |\n"+
+				"4 | 				let y = x!\n"+
+				"  | 				        ^^\n",
+		)
+	})
+
 	t.Run("parse error in import", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/pretty"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -60,7 +61,14 @@ func (e Error) Unwrap() error {
 }
 
 func (e Error) Error() string {
-	return e.Err.Error()
+	var sb strings.Builder
+	sb.WriteString("Execution failed:\n")
+	printErr := pretty.NewErrorPrettyPrinter(&sb, false).
+		PrettyPrintError(e.Err, e.Location, map[common.Location][]byte{})
+	if printErr != nil {
+		panic(printErr)
+	}
+	return sb.String()
 }
 
 func (e Error) ChildErrors() []error {

--- a/runtime/interpreter/errors_test.go
+++ b/runtime/interpreter/errors_test.go
@@ -44,7 +44,7 @@ func TestOverwriteError_Error(t *testing.T) {
 }
 
 func TestErrorOutputIncludesLocationRage(t *testing.T) {
-
+	t.Parallel()
 	require.Equal(t,
 		Error{
 			Location: utils.TestLocation,

--- a/runtime/interpreter/errors_test.go
+++ b/runtime/interpreter/errors_test.go
@@ -23,8 +23,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	. "github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestOverwriteError_Error(t *testing.T) {
@@ -38,5 +40,24 @@ func TestOverwriteError_Error(t *testing.T) {
 			},
 		},
 		"failed to save object: path /storage/test in account 0x0000000000000001 already stores an object",
+	)
+}
+
+func TestErrorOutputIncludesLocationRage(t *testing.T) {
+
+	require.Equal(t,
+		Error{
+			Location: utils.TestLocation,
+			Err: DereferenceError{
+				LocationRange: LocationRange{
+					Location: utils.TestLocation,
+					HasPosition: ast.Range{
+						StartPos: ast.Position{Offset: 0, Column: 0, Line: 0},
+						EndPos:   ast.Position{Offset: 0, Column: 0, Line: 0},
+					},
+				},
+			},
+		}.Error(),
+		"Execution failed:\nerror: dereference failed\n --> test:0:0\n",
 	)
 }


### PR DESCRIPTION
Part of https://github.com/onflow/cadence/issues/2050

We included `LocationRange` info in some interpreter errors, but didn't actually print that information. This should ensure that the location is included. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
