### PR TITLE
[v0.30] Skip broken values during storage iteration

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -771,6 +771,12 @@ account.forEachStored(fun (path: StoragePath, type: Type): Bool {
 ```
 </Callout>
 
+<Callout type="info">
+    The iteration will skip any broken elements in the storage.
+    An element could be broken due to invalid types associated with the stored value.
+    e.g: A value belongs to type `T` of a contract with syntax/semantic errors.
+</Callout>
+
 ## Storage limit
 
 An account's storage is limited by its storage capacity.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -320,7 +320,6 @@ func wrapPanic(f func()) {
 					Recovered: r,
 				})
 			}
-
 		}
 	}()
 	f()

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -3393,6 +3393,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 		runtime := newTestInterpreterRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
+		ledger := newTestLedger(nil, nil)
 		nextTransactionLocation := newTransactionLocationGenerator()
 		contractIsBroken := false
 
@@ -3404,7 +3405,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		newRuntimeInterface := func() Interface {
 			return &testRuntimeInterface{
-				storage: newTestLedger(nil, nil),
+				storage: ledger,
 				getSigningAccounts: func() ([]Address, error) {
 					return []Address{address}, nil
 				},
@@ -3520,6 +3521,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 		runtime := newTestInterpreterRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
+		ledger := newTestLedger(nil, nil)
 		nextTransactionLocation := newTransactionLocationGenerator()
 		contractIsBroken := false
 
@@ -3531,7 +3533,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		newRuntimeInterface := func() Interface {
 			return &testRuntimeInterface{
-				storage: newTestLedger(nil, nil),
+				storage: ledger,
 				getSigningAccounts: func() ([]Address, error) {
 					return []Address{address}, nil
 				},

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -3381,3 +3381,271 @@ func TestRuntimeStorageInternalAccess(t *testing.T) {
 	_, err = ExportValue(rValue, inter, interpreter.EmptyLocationRange)
 	require.NoError(t, err)
 }
+
+func TestRuntimeStorageIteration(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("non existing type", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := newTestInterpreterRuntime()
+		address := common.MustBytesToAddress([]byte{0x1})
+		accountCodes := map[common.Location][]byte{}
+		nextTransactionLocation := newTransactionLocationGenerator()
+		contractIsBroken := false
+
+		deployTx := DeploymentTransaction("Test", []byte(`
+            pub contract Test {
+                pub struct Foo {}
+            }
+        `))
+
+		newRuntimeInterface := func() Interface {
+			return &testRuntimeInterface{
+				storage: newTestLedger(nil, nil),
+				getSigningAccounts: func() ([]Address, error) {
+					return []Address{address}, nil
+				},
+				resolveLocation: singleIdentifierLocationResolver(t),
+				updateAccountContractCode: func(address Address, name string, code []byte) error {
+					location := common.AddressLocation{
+						Address: address,
+						Name:    name,
+					}
+					accountCodes[location] = code
+					return nil
+				},
+				getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+					location := common.AddressLocation{
+						Address: address,
+						Name:    name,
+					}
+
+					if contractIsBroken {
+						// Contract no longer has the type
+						return []byte(`pub contract Test {}`), nil
+					}
+
+					code = accountCodes[location]
+					return code, nil
+				},
+				emitEvent: func(event cadence.Event) error {
+					return nil
+				},
+			}
+		}
+
+		// Deploy contract
+
+		runtimeInterface := newRuntimeInterface()
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: deployTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Store value
+
+		runtimeInterface = newRuntimeInterface()
+
+		err = runtime.ExecuteTransaction(
+			Script{
+				Source: []byte(`
+                    import Test from 0x1
+
+                    transaction {
+                        prepare(signer: AuthAccount) {
+                            signer.save("Hello, World!", to: /storage/first)
+                            signer.save(["one", "two", "three"], to: /storage/second)
+                            signer.save(Test.Foo(), to: /storage/third)
+                            signer.save(1, to: /storage/fourth)
+                            signer.save(Test.Foo(), to: /storage/fifth)
+                            signer.save("two", to: /storage/sixth)
+                        }
+                    }
+                `),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
+		contractIsBroken = true
+
+		runtimeInterface = newRuntimeInterface()
+
+		// Read value
+		err = runtime.ExecuteTransaction(
+			Script{
+				Source: []byte(`
+                    transaction {
+                        prepare(account: AuthAccount) {
+                            var total = 0
+                            account.forEachStored(fun (path: StoragePath, type: Type): Bool {
+                                account.borrow<&AnyStruct>(from: path)!
+                                total = total + 1
+                                return true
+                            })
+
+                            // Total values iterated should be 4.
+                            // The two broken values must be skipped.
+                            assert(total == 4)
+                        }
+                    }
+                `),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("broken contract", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := newTestInterpreterRuntime()
+		address := common.MustBytesToAddress([]byte{0x1})
+		accountCodes := map[common.Location][]byte{}
+		nextTransactionLocation := newTransactionLocationGenerator()
+		contractIsBroken := false
+
+		deployTx := DeploymentTransaction("Test", []byte(`
+            pub contract Test {
+                pub struct Foo {}
+            }
+        `))
+
+		newRuntimeInterface := func() Interface {
+			return &testRuntimeInterface{
+				storage: newTestLedger(nil, nil),
+				getSigningAccounts: func() ([]Address, error) {
+					return []Address{address}, nil
+				},
+				resolveLocation: singleIdentifierLocationResolver(t),
+				updateAccountContractCode: func(address Address, name string, code []byte) error {
+					location := common.AddressLocation{
+						Address: address,
+						Name:    name,
+					}
+					accountCodes[location] = code
+					return nil
+				},
+				getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+					location := common.AddressLocation{
+						Address: address,
+						Name:    name,
+					}
+
+					if contractIsBroken {
+						// Contract has a semantic error. i.e: cannot find `Bar`
+						return []byte(`pub contract Test {
+                            pub struct Foo: Bar {}
+                        }`), nil
+					}
+
+					code = accountCodes[location]
+					return code, nil
+				},
+				emitEvent: func(event cadence.Event) error {
+					return nil
+				},
+			}
+		}
+
+		// Deploy contract
+
+		runtimeInterface := newRuntimeInterface()
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: deployTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Store values
+
+		runtimeInterface = newRuntimeInterface()
+
+		err = runtime.ExecuteTransaction(
+			Script{
+				Source: []byte(`
+                    import Test from 0x1
+
+                    transaction {
+                        prepare(signer: AuthAccount) {
+                            signer.save("Hello, World!", to: /storage/first)
+                            signer.save(["one", "two", "three"], to: /storage/second)
+                            signer.save(Test.Foo(), to: /storage/third)
+                            signer.save(1, to: /storage/fourth)
+                            signer.save(Test.Foo(), to: /storage/fifth)
+                            signer.save("two", to: /storage/sixth)
+
+                            signer.link<&String>(/private/a, target:/storage/first)
+                            signer.link<&[String]>(/private/b, target:/storage/second)
+                            signer.link<&Test.Foo>(/private/c, target:/storage/third)
+                            signer.link<&Int>(/private/d, target:/storage/fourth)
+                            signer.link<&Test.Foo>(/private/e, target:/storage/fifth)
+                            signer.link<&String>(/private/f, target:/storage/sixth)
+                        }
+                    }
+                `),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
+		contractIsBroken = true
+
+		runtimeInterface = newRuntimeInterface()
+
+		// Read value
+		err = runtime.ExecuteTransaction(
+			Script{
+				Source: []byte(`
+                    transaction {
+                        prepare(account: AuthAccount) {
+                            var total = 0
+                            account.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
+                                account.getCapability<&AnyStruct>(path).borrow()!
+                                total = total + 1
+                                return true
+                            })
+
+                            // Total values iterated should be 4.
+                            // The two broken values must be skipped.
+                            assert(total == 4)
+                        }
+                    }
+                `),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Port of #2202 to the `v0.30` branch

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
