### PR TITLE
Correct definition of block view

### DIFF
--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -44,8 +44,7 @@ pub struct Block {
     /// The view of the block.
     ///
     /// It is a detail of the consensus algorithm. It is a monotonically increasing integer
-    /// and counts rounds in the consensus algorithm. Since not all rounds result in a finalized block,
-    /// the view number is strictly greater than or equal to the block height
+    /// and counts rounds in the consensus algorithm. It is reset to zero at each spork.
     ///
     pub let view: UInt64
 


### PR DESCRIPTION

## Description

The definition of block view did not consider the effects of sporks:
* block view is reset (not always increasing)
* after a spork, block view may be less than height
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
