### PR TITLE
Fix Capability example in JSON-Cadence Data Interchange Format specs

### DIFF
--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -364,11 +364,17 @@ Composite fields are encoded as a list of name-value pairs in the order in which
 {
   "type": "Capability",
   "value": {
-    "path": "/public/someInteger",
+    "path": {
+      "type": "Path",
+      "value": {
+        "domain": "public",
+        "identifier": "someInteger"
+      }
+    },
     "address": "0x1",
     "borrowType": {
       "kind": "Int"
-    },
+    }
   }
 }
 ```


### PR DESCRIPTION
## Description

This PR corrects an example by encoding Capability's path as path object instead of string.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
