### PR TITLE
Add missing PathLink in JSON-Cadence Data Interchange Format Specs

### DIFF
--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -319,6 +319,38 @@ Composite fields are encoded as a list of name-value pairs in the order in which
 
 ---
 
+## PathLink
+
+```json
+{
+  "type": "Link",
+  "value": {
+    "TargetPath": <path>,
+    "BorrowType": "..."
+  }
+}
+```
+
+### Example
+
+```json
+{
+  "type": "Link",
+  "value": {
+    "TargetPath": {
+      "type": "Path",
+      "value": {
+        "domain": "public",
+        "identifier": "someInteger"
+      }
+    },
+    "BorrowType": "Int"
+  }
+}
+```
+
+---
+
 ## Type Value
 
 ```json


### PR DESCRIPTION
## Description

The JSON-Cadence Data Interchange Format specification is missing PathLink.

This PR adds PathLink to the specs.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
