### PR TITLE
Correct example code link

### DIFF
--- a/docs/design-patterns.mdx
+++ b/docs/design-patterns.mdx
@@ -62,7 +62,7 @@ pub contract NamedFields {
 
 ```
 
-[Example Code](https://github.com/onflow/flow-core-contracts/blob/master/contracts/LockedTokens.cdc#L583)
+[Example Code](https://github.com/onflow/flow-core-contracts/blob/master/contracts/LockedTokens.cdc#L718)
 
 ## Script-Accessible public field/function
 


### PR DESCRIPTION
## Description

The link on the `Use named value fields for constants instead of hard-coding` section didn't point to the right line of code, pointing it to the init function of the same contract
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
