### PR TITLE
Fix function activations

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -105,7 +105,7 @@ type Checker struct {
 	// initialized lazily. use beforeExtractor()
 	_beforeExtractor                   *BeforeExtractor
 	errors                             []error
-	functionActivations                FunctionActivations
+	functionActivations                *FunctionActivations
 	inCondition                        bool
 	allowSelfResourceFieldInvalidation bool
 	inAssignment                       bool
@@ -133,9 +133,9 @@ func NewChecker(
 		return nil, errors.NewDefaultUserError("invalid default access check mode")
 	}
 
-	functionActivations := FunctionActivations{
+	functionActivations := &FunctionActivations{
 		// Pre-allocate a common function depth
-		activations: make([]FunctionActivation, 0, 2),
+		activations: make([]*FunctionActivation, 0, 2),
 	}
 	functionActivations.EnterFunction(
 		&FunctionType{

--- a/runtime/sema/function_activations.go
+++ b/runtime/sema/function_activations.go
@@ -49,7 +49,7 @@ func (a *FunctionActivation) WithSwitch(f func()) {
 }
 
 type FunctionActivations struct {
-	activations []FunctionActivation
+	activations []*FunctionActivation
 }
 
 func (a *FunctionActivations) IsLocal() bool {
@@ -64,19 +64,18 @@ func (a *FunctionActivations) IsLocal() bool {
 }
 
 func (a *FunctionActivations) EnterFunction(functionType *FunctionType, valueActivationDepth int) *FunctionActivation {
-	activation := FunctionActivation{
+	activation := &FunctionActivation{
 		ReturnType:           functionType.ReturnTypeAnnotation.Type,
 		ValueActivationDepth: valueActivationDepth,
 		ReturnInfo:           NewReturnInfo(),
 	}
-	lastIndex := len(a.activations)
 	a.activations = append(a.activations, activation)
-	return &a.activations[lastIndex]
+	return activation
 }
 
 func (a *FunctionActivations) LeaveFunction() {
 	lastIndex := len(a.activations) - 1
-	a.activations[lastIndex] = FunctionActivation{}
+	a.activations[lastIndex] = nil
 	a.activations = a.activations[:lastIndex]
 }
 
@@ -95,5 +94,5 @@ func (a *FunctionActivations) Current() *FunctionActivation {
 	if lastIndex < 0 {
 		return nil
 	}
-	return &a.activations[lastIndex]
+	return a.activations[lastIndex]
 }

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -506,3 +506,28 @@ func TestCheckNestedFunctionExits(t *testing.T) {
 		exits: false,
 	})
 }
+
+func TestCheckFunctionExpressionReturnStatementInfluence(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test(): Int {
+          if false {
+              // should not influence definite halt of outer function (test)
+              fun() { return }
+              return 1
+          }
+
+          if false {
+              return 2
+          }
+
+          return 3
+      }
+    `)
+
+	// If this test fails, there is likely something wrong in the definite halt analysis,
+	// or in the function activation stack
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Closes #2210

## Description

Revert commit 55acc03 which was introduced in #2127.

It broke the function activation stack, which resulted in a weird definite return analysis bug.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
