### PR TITLE
Revert "don't ignore invalid identifier" / PR 

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -1120,14 +1120,6 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
 
-			if previousIdentifierToken != nil {
-				return nil, NewSyntaxError(
-					previousIdentifierToken.StartPos,
-					"unexpected token: %s",
-					previousIdentifierToken.Type,
-				)
-			}
-
 			switch string(p.currentTokenSource()) {
 			case keywordLet, keywordVar:
 				return parseFieldWithVariableKind(
@@ -1239,6 +1231,10 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				nativePos = &pos
 				p.next()
 				continue
+			}
+
+			if previousIdentifierToken != nil {
+				return nil, p.syntaxError("unexpected %s", p.current.Type)
 			}
 
 			t := p.current

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -4167,6 +4167,9 @@ func TestParseStructureWithConformances(t *testing.T) {
 
 func TestParseInvalidMember(t *testing.T) {
 
+	// For now, leading unknown identifiers are valid.
+	// This will be rejected in Stable Cadence.
+
 	t.Parallel()
 
 	const code = `
@@ -4177,16 +4180,7 @@ func TestParseInvalidMember(t *testing.T) {
 
 	_, errs := testParseDeclarations(code)
 
-	utils.AssertEqualWithDiff(t,
-		[]error{
-			&SyntaxError{
-				Message: "unexpected token: identifier",
-				Pos:     ast.Position{Offset: 35, Line: 3, Column: 12},
-			},
-		},
-		errs,
-	)
-
+	require.Empty(t, errs)
 }
 
 func TestParsePreAndPostConditions(t *testing.T) {

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -2192,15 +2192,10 @@ func TestParseField(t *testing.T) {
 
 		_, errs := parse("native let foo: Int", Config{})
 
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
-				},
-			},
-			errs,
-		)
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
+		require.Empty(t, errs)
 	})
 
 	t.Run("static", func(t *testing.T) {
@@ -2250,15 +2245,10 @@ func TestParseField(t *testing.T) {
 			Config{},
 		)
 
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
-				},
-			},
-			errs,
-		)
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
+		require.Empty(t, errs)
 	})
 
 	t.Run("static native, enabled", func(t *testing.T) {
@@ -2306,11 +2296,14 @@ func TestParseField(t *testing.T) {
 
 		_, errs := parse("static native let foo: Int", Config{})
 
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
 				},
 			},
 			errs,
@@ -2386,11 +2379,14 @@ func TestParseField(t *testing.T) {
 
 		_, errs := parse("pub static native let foo: Int", Config{})
 
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 11, Line: 1, Column: 11},
 				},
 			},
 			errs,
@@ -2966,15 +2962,11 @@ func TestParseEnumDeclaration(t *testing.T) {
 		t.Parallel()
 
 		_, errs := testParseDeclarations(" enum E { static case e }")
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
-				},
-			},
-			errs,
-		)
+
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
+		require.Empty(t, errs)
 	})
 
 	t.Run("enum case with native modifier, enabled", func(t *testing.T) {
@@ -3004,15 +2996,11 @@ func TestParseEnumDeclaration(t *testing.T) {
 		t.Parallel()
 
 		_, errs := testParseDeclarations(" enum E { native case e }")
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
-				},
-			},
-			errs,
-		)
+
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
+		require.Empty(t, errs)
 	})
 }
 
@@ -6308,11 +6296,14 @@ func TestParseNestedPragma(t *testing.T) {
 
 		_, errs := parse("static native #pragma", Config{})
 
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
 				},
 			},
 			errs,
@@ -6387,11 +6378,14 @@ func TestParseNestedPragma(t *testing.T) {
 
 		_, errs := parse("pub static native #pragma", Config{})
 
+		// For now, leading unknown identifiers are valid.
+		// This will be rejected in Stable Cadence.
+
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected token: identifier",
-					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 11, Line: 1, Column: 11},
 				},
 			},
 			errs,


### PR DESCRIPTION
Work towards #2217

## Description

This reverts commit fc536667bef6ef7668981b685d6815865fcfb8e5 / PR #2134, I missed this is a breaking change. 

I'm going to port the rejection of leading non-keyword identifiers to the Stable Cadence branch, while allowing keeping support for the current parsing behaviour when updating contracts.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
