### PR TITLE
Add additional metering methods to the interface

### DIFF
--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -30,6 +30,8 @@ import (
 )
 
 type Interface interface {
+	MeterInterface
+
 	// ResolveLocation resolves an import location.
 	ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
 	// GetCode returns the code at a given location
@@ -104,9 +106,6 @@ type Interface interface {
 	EmitEvent(cadence.Event) error
 	// GenerateUUID is called to generate a UUID.
 	GenerateUUID() (uint64, error)
-	// MeterComputation is a callback method for metering computation, it returns error
-	// when computation passes the limit (set by the environment)
-	MeterComputation(operationType common.ComputationKind, intensity uint) error
 	// DecodeArgument decodes a transaction/script argument against the given type.
 	DecodeArgument(argument []byte, argumentType cadence.Type) (cadence.Value, error)
 	// GetCurrentBlockHeight returns the current block height.
@@ -157,8 +156,20 @@ type Interface interface {
 		oldOwner common.Address,
 		newOwner common.Address,
 	)
+}
+
+type MeterInterface interface {
 	// MeterMemory gets called when new memory is allocated or used by the interpreter
 	MeterMemory(usage common.MemoryUsage) error
+	// MeterComputation is a callback method for metering computation, it returns error
+	// when computation passes the limit (set by the environment)
+	MeterComputation(operationType common.ComputationKind, intensity uint) error
+	// ComputationUsed returns the total computation used in the current runtime.
+	ComputationUsed() (uint64, error)
+	// MemoryUsed returns the total memory (estimate) used in the current runtime.
+	MemoryUsed() (uint64, error)
+	// InteractionUsed returns the total storage interaction used in the current runtime.
+	InteractionUsed() (uint64, error)
 }
 
 type Metrics interface {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -196,6 +196,9 @@ type testRuntimeInterface struct {
 	getAccountContractNames    func(address Address) ([]string, error)
 	recordTrace                func(operation string, location Location, duration time.Duration, attrs []attribute.KeyValue)
 	meterMemory                func(usage common.MemoryUsage) error
+	computationUsed            func() (uint64, error)
+	memoryUsed                 func() (uint64, error)
+	interactionUsed            func() (uint64, error)
 }
 
 // testRuntimeInterface should implement Interface
@@ -590,6 +593,30 @@ func (i *testRuntimeInterface) MeterMemory(usage common.MemoryUsage) error {
 	return i.meterMemory(usage)
 }
 
+func (i *testRuntimeInterface) ComputationUsed() (uint64, error) {
+	if i.computationUsed == nil {
+		return 0, nil
+	}
+
+	return i.computationUsed()
+}
+
+func (i *testRuntimeInterface) MemoryUsed() (uint64, error) {
+	if i.memoryUsed == nil {
+		return 0, nil
+	}
+
+	return i.memoryUsed()
+}
+
+func (i *testRuntimeInterface) InteractionUsed() (uint64, error) {
+	if i.interactionUsed == nil {
+		return 0, nil
+	}
+
+	return i.interactionUsed()
+}
+
 func TestRuntimeImport(t *testing.T) {
 
 	t.Parallel()
@@ -743,7 +770,7 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 	//   however, currently the imported program gets re-checked if it is currently being checked.
 	//   This can probably be optimized by synchronizing the checking of a program using `sync`.
 	//
-	//require.Equal(t, concurrency+1, checkCount)
+	// require.Equal(t, concurrency+1, checkCount)
 }
 
 func TestRuntimeProgramSetAndGet(t *testing.T) {


### PR DESCRIPTION
## Description

Add more metering methods to the interface.
This opens up two things:
- the ability to add more information when constructing things like coverage reports or resource usage profiles
- the ability to eventually add cadence methods that would tell you how much of one resource you have used so far.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 