### PR TITLE
Report preceding identifier in member declaration

### DIFF
--- a/runtime/contract_update_test.go
+++ b/runtime/contract_update_test.go
@@ -19,8 +19,6 @@
 package runtime
 
 import (
-	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -170,18 +168,7 @@ func TestContractUpdateWithDependencies(t *testing.T) {
 	signerAccount = common.MustBytesToAddress([]byte{0x1})
 	err = runtime.ExecuteTransaction(
 		Script{
-			Source: []byte(fmt.Sprintf(
-				`
-	             transaction {
-	                 prepare(signer: AuthAccount) {
-	                     signer.contracts.update__experimental(name: "Foo", code: "%s".decodeHex())
-	                 }
-	             }
-	           `,
-				hex.EncodeToString(
-					[]byte(fooContractV2),
-				),
-			)),
+			Source: utils.UpdateTransaction("Foo", []byte(fooContractV2)),
 		},
 		Context{
 			Interface: runtimeInterface,
@@ -199,18 +186,7 @@ func TestContractUpdateWithDependencies(t *testing.T) {
 
 	err = runtime.ExecuteTransaction(
 		Script{
-			Source: []byte(fmt.Sprintf(
-				`
-	             transaction {
-	                 prepare(signer: AuthAccount) {
-	                     signer.contracts.update__experimental(name: "Bar", code: "%s".decodeHex())
-	                 }
-	             }
-	           `,
-				hex.EncodeToString(
-					[]byte(barContractV2),
-				),
-			)),
+			Source: utils.UpdateTransaction("Bar", []byte(barContractV2)),
 		},
 		Context{
 			Interface: runtimeInterface,
@@ -218,4 +194,92 @@ func TestContractUpdateWithDependencies(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+}
+
+func TestContractUpdateWithPrecedingIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	signerAccount := common.MustBytesToAddress([]byte{0x1})
+
+	fooLocation := common.AddressLocation{
+		Address: signerAccount,
+		Name:    "Foo",
+	}
+
+	const fooContractV1 = `
+        pub contract Foo {
+            // NOTE: invalid preceding identifier in member declaration
+            bar pub let foo: Int
+
+            init() {
+                self.foo = 1
+            }
+        }
+    `
+
+	const fooContractV2 = `
+        pub contract Foo {
+            pub let foo: Int
+
+            init() {
+                self.foo = 1
+            }
+        }
+    `
+
+	// Assume contract with deprecated syntax is already deployed
+
+	accountCodes := map[common.Location][]byte{
+		fooLocation: []byte(fooContractV1),
+	}
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(location Location) (bytes []byte, err error) {
+			return accountCodes[location], nil
+		},
+		storage: newTestLedger(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{signerAccount}, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			return accountCodes[location], nil
+		},
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			accountCodes[location] = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) error {
+			return nil
+		},
+		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	// Update contract
+
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: utils.UpdateTransaction("Foo", []byte(fooContractV2)),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
 }

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -1168,6 +1168,16 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
 
+			if !p.config.IgnoreLeadingIdentifierEnabled &&
+				previousIdentifierToken != nil {
+
+				return nil, NewSyntaxError(
+					previousIdentifierToken.StartPos,
+					"unexpected %s",
+					previousIdentifierToken.Type,
+				)
+			}
+
 			switch string(p.currentTokenSource()) {
 			case KeywordLet, KeywordVar:
 				if purity != ast.FunctionPurityUnspecified {
@@ -1313,7 +1323,9 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				continue
 			}
 
-			if previousIdentifierToken != nil {
+			if p.config.IgnoreLeadingIdentifierEnabled &&
+				previousIdentifierToken != nil {
+
 				return nil, p.syntaxError("unexpected %s", p.current.Type)
 			}
 

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -2311,10 +2311,15 @@ func TestParseField(t *testing.T) {
 
 		_, errs := parse("native let foo: Int", Config{})
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
-		require.Empty(t, errs)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
 	})
 
 	t.Run("static", func(t *testing.T) {
@@ -2364,10 +2369,15 @@ func TestParseField(t *testing.T) {
 			Config{},
 		)
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
-		require.Empty(t, errs)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
+				},
+			},
+			errs,
+		)
 	})
 
 	t.Run("static native, enabled", func(t *testing.T) {
@@ -2415,14 +2425,11 @@ func TestParseField(t *testing.T) {
 
 		_, errs := parse("static native let foo: Int", Config{})
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: "unexpected identifier",
-					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
 				},
 			},
 			errs,
@@ -2498,14 +2505,11 @@ func TestParseField(t *testing.T) {
 
 		_, errs := parse("pub static native let foo: Int", Config{})
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: "unexpected identifier",
-					Pos:     ast.Position{Offset: 11, Line: 1, Column: 11},
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
 				},
 			},
 			errs,
@@ -3382,10 +3386,15 @@ func TestParseEnumDeclaration(t *testing.T) {
 
 		_, errs := testParseDeclarations(" enum E { static case e }")
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
-		require.Empty(t, errs)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
+			},
+			errs,
+		)
 	})
 
 	t.Run("enum case with native modifier, enabled", func(t *testing.T) {
@@ -3416,10 +3425,15 @@ func TestParseEnumDeclaration(t *testing.T) {
 
 		_, errs := testParseDeclarations(" enum E { native case e }")
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
-		require.Empty(t, errs)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
+			},
+			errs,
+		)
 	})
 }
 
@@ -4599,9 +4613,6 @@ func TestParseStructureWithConformances(t *testing.T) {
 
 func TestParseInvalidMember(t *testing.T) {
 
-	// For now, leading unknown identifiers are valid.
-	// This will be rejected in Stable Cadence.
-
 	t.Parallel()
 
 	const code = `
@@ -4610,9 +4621,33 @@ func TestParseInvalidMember(t *testing.T) {
         }
 	`
 
-	_, errs := testParseDeclarations(code)
+	t.Run("ignore", func(t *testing.T) {
+		t.Parallel()
 
-	require.Empty(t, errs)
+		_, errs := ParseDeclarations(nil, []byte(code), Config{
+			IgnoreLeadingIdentifierEnabled: true,
+		})
+		require.Empty(t, errs)
+
+	})
+
+	t.Run("report", func(t *testing.T) {
+		t.Parallel()
+
+		_, errs := ParseDeclarations(nil, []byte(code), Config{
+			IgnoreLeadingIdentifierEnabled: false,
+		})
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected identifier",
+					Pos:     ast.Position{Offset: 35, Line: 3, Column: 12},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParsePreAndPostConditions(t *testing.T) {
@@ -6889,14 +6924,11 @@ func TestParseNestedPragma(t *testing.T) {
 
 		_, errs := parse("static native #pragma", Config{})
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: "unexpected identifier",
-					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
+					Pos:     ast.Position{Offset: 0, Line: 1, Column: 0},
 				},
 			},
 			errs,
@@ -6971,14 +7003,11 @@ func TestParseNestedPragma(t *testing.T) {
 
 		_, errs := parse("pub static native #pragma", Config{})
 
-		// For now, leading unknown identifiers are valid.
-		// This will be rejected in Stable Cadence.
-
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: "unexpected identifier",
-					Pos:     ast.Position{Offset: 11, Line: 1, Column: 11},
+					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
 				},
 			},
 			errs,

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -46,6 +46,15 @@ type Config struct {
 	StaticModifierEnabled bool
 	// NativeModifierEnabled determines if the static modifier is enabled
 	NativeModifierEnabled bool
+	// Deprecated: IgnoreLeadingIdentifierEnabled determines
+	// if leading identifiers are ignored.
+	//
+	// Pre-Stable Cadence, identifiers preceding keywords were (incorrectly) ignored,
+	// instead of being reported as invalid, e.g. `foo let bar: Int` was valid.
+	// The new default behaviour is to report an error, e.g. for `foo` in the example above.
+	//
+	// This option exists so the old behaviour can be enabled to allow developers to update their code.
+	IgnoreLeadingIdentifierEnabled bool
 }
 
 type parser struct {

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1457,7 +1457,9 @@ func newAuthAccountContractsChangeFunction(
 				oldProgram, err := parser.ParseProgram(
 					gauge,
 					oldCode,
-					parser.Config{},
+					parser.Config{
+						IgnoreLeadingIdentifierEnabled: true,
+					},
 				)
 
 				if !ignoreUpdatedProgramParserError(err) {


### PR DESCRIPTION
## Description

Bring back #2134, which is a breaking change: 
Currently, identifiers preceding member declarations are simply ignored.
Instead, report them as an error.

Allow existing code to be updated / parsed through a feature flag in the parser config.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
