### PR TITLE
Automate the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+      base:
+        description: 'Base branch create the release'
+        required: false
+        default: 'master'
+
+env:
+  GO_VERSION: '1.19.2'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release branch
+        run: |
+          git checkout ${{ github.event.inputs.base }}
+          git checkout -b release/${{ github.event.inputs.version }}
+          git push origin release/${{ github.event.inputs.version }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,12 @@
-name: CI
+# This workflow automates the release process.
+# It follows the below steps:
+#   - Bump the version to the target release version
+#   - Run tests and lint
+#   - Create and push a branch `release/v<version>` with version bump changes
+#   - Open a PR from `release/<version>` branch to `master`
+#   - Create and push a release tag with name `v<version>`
+
+name: Release
 
 on:
   workflow_dispatch:
@@ -7,7 +15,7 @@ on:
         description: 'Release version'
         required: true
       base:
-        description: 'Base branch create the release'
+        description: 'Base branch for the release'
         required: false
         default: 'master'
 
@@ -19,13 +27,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  release:
+    name: "${{ github.event.inputs.version }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Create release branch
-        run: |
-          git checkout ${{ github.event.inputs.base }}
-          git checkout -b release/${{ github.event.inputs.version }}
-          git push origin release/${{ github.event.inputs.version }}
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install wabt
 
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.base }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Bump Version
+        run: make release bump=${{ github.event.inputs.version }}
+
+      - name: Run Tests
+        run: |
+          make test
+          make lint-github-actions
+
+      - name: Config git
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Open Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: release/v${{ github.event.inputs.version }}
+          title: 'Merge `release/v${{ github.event.inputs.version }}` to `${{ inputs.base }}`'
+          commit-message: v${{ github.event.inputs.version }}
+          body: |
+            Merge `release/v${{ github.event.inputs.version }}` branch to `${{ inputs.base }}`
+
+      - name: Tag and Push
+        run: |
+          git checkout release/v${{ github.event.inputs.version }}
+          git tag v${{ github.event.inputs.version }}
+          git push origin v${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ check-tidy: generate
 release:
 	@(VERSIONED_FILES="version.go \
 	npm-packages/cadence-parser/package.json" \
-	./bump-version.sh $(bump))
+	bash ./bump-version.sh $(bump))
 
 .PHONY: check-capabilities
 check-capabilities:

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -24,5 +24,9 @@ echo "$v => $v2"
 
 for f in $VERSIONED_FILES; do \
   echo "- $f"; \
-  sed -i '' "s/$v/$v2/g" "$f"; \
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/$v/$v2/g" "$f"; \
+  else
+    sed -i "s/$v/$v2/g" "$f"; \
+  fi
 done

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 v=$(git describe --tags --abbrev=0 | sed -Ee 's/^v|-.*//')
 


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2244

## Description

Add a GH workflow to automate the release process. Can be triggered manually. Inputs are the release version and the base from which the release should be created. Once completed it will:
- Create a release tag (Sample: https://github.com/SupunS/cadence/releases/tag/v0.1.4-test)
- Open a PR from the release-branch to master with the version bump changes (Sample: https://github.com/SupunS/cadence/pull/12)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
