### PR TITLE
DO NOT MERGE: Revert skipping broken contracts when iterating over storage

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3278,13 +3278,6 @@ func (interpreter *Interpreter) newStorageIterationFunction(
 			for key, value := storageIterator.Next(); key != "" && value != nil; key, value = storageIterator.Next() {
 				staticType := value.StaticType(inter)
 
-				// Perform a forced type loading to see if the underlying type is not broken.
-				// If broken, skip this value from the iteration.
-				typeError := inter.checkTypeLoading(staticType)
-				if typeError != nil {
-					continue
-				}
-
 				pathValue := NewPathValue(inter, domain, key)
 				runtimeType := NewTypeValue(inter, staticType)
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3318,24 +3318,6 @@ func (interpreter *Interpreter) newStorageIterationFunction(
 	)
 }
 
-func (interpreter *Interpreter) checkTypeLoading(staticType StaticType) (typeError error) {
-	defer func() {
-		if r := recover(); r != nil {
-			switch r := r.(type) {
-			case errors.UserError, errors.ExternalError:
-				typeError = r.(error)
-			default:
-				panic(r)
-			}
-		}
-	}()
-
-	// Here it is only interested in whether the type can be properly loaded.
-	_, typeError = interpreter.ConvertStaticToSemaType(staticType)
-
-	return
-}
-
 func (interpreter *Interpreter) authAccountSaveFunction(addressValue AddressValue) *HostFunctionValue {
 
 	// Converted addresses can be cached and don't have to be recomputed on each function invocation

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/checker"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
@@ -3511,7 +3513,9 @@ func TestRuntimeStorageIteration(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(t, err)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.TypeLoadingError{})
 	})
 
 	t.Run("broken contract", func(t *testing.T) {
@@ -3648,6 +3652,11 @@ func TestRuntimeStorageIteration(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		require.NoError(t, err)
+		RequireError(t, err)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+
+		notDeclaredErr := &sema.NotDeclaredError{}
+		require.ErrorAs(t, errs[0], &notDeclaredErr)
 	})
 }


### PR DESCRIPTION
## Description

This currently breaks the requirement that `GetProgram`/`SetProgram` calls are in pairs.

This is just a backup solution, we are aiming to get in the fix #2241 first.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
