### PR TITLE
[v0.31] Ensure SetProgram is called after GetProgram, even if there is an error

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -382,11 +382,7 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 		wrapPanic(func() {
 			err = e.runtimeInterface.SetProgram(location, program)
 		})
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 
 	wrapParsingCheckingError := func(err error) error {

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -348,6 +348,8 @@ func (e *interpreterEnvironment) ParseAndCheckProgram(
 	)
 }
 
+// parseAndCheckProgram parses and checks the given program.
+// If storeProgram is true, it calls Interface.SetProgram.
 func (e *interpreterEnvironment) parseAndCheckProgram(
 	code []byte,
 	location common.Location,
@@ -357,7 +359,37 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 	program *interpreter.Program,
 	err error,
 ) {
-	wrapError := func(err error) error {
+
+	// NOTE: Always ensure to call maybeSetProgram
+	// on all error paths of parseAndCheckProgram,
+	// except for once Interface.SetProgram was called!
+	//
+	// If the program is supposed to be stored,
+	// there was a call to Interface.GetProgram before.
+	// If an error occurs after calling Interface.GetProgram,
+	// then we *must* also call Interface.SetProgram, with nil.
+	//
+	// See the documentation for Interface.GetProgram
+	// for an explanation of this invariant.
+
+	maybeSetProgram := func() error {
+
+		if !storeProgram {
+			return nil
+		}
+
+		var err error
+		wrapPanic(func() {
+			err = e.runtimeInterface.SetProgram(location, program)
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	wrapParsingCheckingError := func(err error) error {
 		return &ParsingCheckingError{
 			Err:      err,
 			Location: location,
@@ -381,7 +413,14 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 		},
 	)
 	if err != nil {
-		return nil, wrapError(err)
+		// IMPORTANT: even when an error occurs,
+		// we still might need to set the program
+		setProgramErr := maybeSetProgram()
+		if setProgramErr != nil {
+			return nil, setProgramErr
+		}
+
+		return nil, wrapParsingCheckingError(err)
 	}
 
 	if storeProgram {
@@ -392,7 +431,14 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 
 	elaboration, err := e.check(location, parse, checkedImports)
 	if err != nil {
-		return nil, wrapError(err)
+		// IMPORTANT: even when an error occurs,
+		// we still might need to set the program
+		setProgramErr := maybeSetProgram()
+		if setProgramErr != nil {
+			return nil, setProgramErr
+		}
+
+		return nil, wrapParsingCheckingError(err)
 	}
 
 	// Return
@@ -402,13 +448,9 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 		Elaboration: elaboration,
 	}
 
-	if storeProgram {
-		wrapPanic(func() {
-			err = e.runtimeInterface.SetProgram(location, program)
-		})
-		if err != nil {
-			return nil, err
-		}
+	err = maybeSetProgram()
+	if err != nil {
+		return nil, err
 	}
 
 	return program, nil
@@ -527,9 +569,20 @@ func (e *interpreterEnvironment) getProgram(
 		var code []byte
 		code, err = e.getCode(location)
 		if err != nil {
+			var setProgramErr error
+			wrapPanic(func() {
+				setProgramErr = e.runtimeInterface.SetProgram(location, program)
+			})
+			if setProgramErr != nil {
+				return nil, setProgramErr
+			}
 			return nil, err
 		}
 
+		// NOTE: parseAndCheckProgram calls Interface.SetProgram on error, if needed.
+		// Do NOT call / move the calls of Interface.SetProgram here:
+		// The error returned from parseAndCheckProgram might be the result
+		// of a call to Interface.SetProgram, in which case it should not be called again.
 		program, err = e.parseAndCheckProgram(
 			code,
 			location,

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -3445,7 +3445,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Deploy contract
 
-		runtimeInterface, programStack := newRuntimeInterface()
+		runtimeInterface, _ := newRuntimeInterface()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -3460,7 +3460,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Store value
 
-		runtimeInterface, programStack = newRuntimeInterface()
+		runtimeInterface, _ = newRuntimeInterface()
 
 		err = runtime.ExecuteTransaction(
 			Script{
@@ -3488,6 +3488,8 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
 		contractIsBroken = true
+
+		var programStack *[]Location
 
 		runtimeInterface, programStack = newRuntimeInterface()
 
@@ -3602,7 +3604,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Deploy contract
 
-		runtimeInterface, programStack := newRuntimeInterface()
+		runtimeInterface, _ := newRuntimeInterface()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -3617,7 +3619,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Store values
 
-		runtimeInterface, programStack = newRuntimeInterface()
+		runtimeInterface, _ = newRuntimeInterface()
 
 		err = runtime.ExecuteTransaction(
 			Script{
@@ -3652,6 +3654,8 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
 		contractIsBroken = true
+
+		var programStack *[]Location
 
 		runtimeInterface, programStack = newRuntimeInterface()
 
@@ -3768,7 +3772,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Deploy contract
 
-		runtimeInterface, programStack := newRuntimeInterface()
+		runtimeInterface, _ := newRuntimeInterface()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -3783,7 +3787,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Store values
 
-		runtimeInterface, programStack = newRuntimeInterface()
+		runtimeInterface, _ = newRuntimeInterface()
 
 		err = runtime.ExecuteTransaction(
 			Script{
@@ -3818,6 +3822,8 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
 		contractIsBroken = true
+
+		var programStack *[]Location
 
 		runtimeInterface, programStack = newRuntimeInterface()
 


### PR DESCRIPTION
## Description

Calls to `runtime.Interface.GetProgram` and `SetProgram` need to be balanced.
So far this was not the case when an error occurred after `GetProgram` was called: 

A subsequent error, e.g. a parsing or type checking error, was bubbled up and lead to the failure of the whole program execution (e.g. when a static import fails).

However, since #2202, storage iteration skips type loading errors, which results in `GetProgram` calls without subsequent `SetProgram` calls.

Ensure `SetProgram` is always called after a call to `GetProgram`, even when an error occurs.

Test the pairing of `GetProgram`/`SetProgram` calls by re-implementing the defensive check FVM implements: Keep a stack of calls and ensure there are no outstanding calls to `SetProgram` at the end of execution.

We should maybe enable this check for all runtime tests in a subsequent PR.

This is a fix of the current runtime interface. We should aim to land #2180 next which should reduce/remove the possibility of incorrect uses of the get/set program functions.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
