### PR TITLE
Remove support for importing/exporting and JSON encoding/decoding path links and cadence type

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -215,8 +215,6 @@ func (d *Decoder) decodeJSON(v any) cadence.Value {
 		return d.decodeEvent(valueJSON)
 	case contractTypeStr:
 		return d.decodeContract(valueJSON)
-	case linkTypeStr:
-		return d.decodeLink(valueJSON)
 	case pathTypeStr:
 		return d.decodePath(valueJSON)
 	case typeTypeStr:
@@ -821,29 +819,6 @@ func (d *Decoder) decodeEnum(valueJSON any) cadence.Enum {
 		comp.fieldTypes,
 		nil,
 	))
-}
-
-func (d *Decoder) decodeLink(valueJSON any) cadence.PathLink {
-	obj := toObject(valueJSON)
-
-	targetPath, ok := d.decodeJSON(obj.Get(targetPathKey)).(cadence.Path)
-	if !ok {
-		panic(errors.NewDefaultUserError("invalid link: missing or invalid target path"))
-	}
-
-	borrowType := obj.GetString(borrowTypeKey)
-
-	common.UseMemory(d.gauge, common.MemoryUsage{
-		Kind: common.MemoryKindRawString,
-		// no need to add 1 to account for empty string: string is metered in Link struct
-		Amount: uint64(len(borrowType)),
-	})
-
-	return cadence.NewMeteredLink(
-		d.gauge,
-		targetPath,
-		borrowType,
-	)
 }
 
 func (d *Decoder) decodePath(valueJSON any) cadence.Path {

--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -126,11 +126,6 @@ type jsonCompositeField struct {
 	Name  string    `json:"name"`
 }
 
-type jsonPathLinkValue struct {
-	TargetPath jsonValue `json:"targetPath"`
-	BorrowType string    `json:"borrowType"`
-}
-
 type jsonPathValue struct {
 	Domain     string `json:"domain"`
 	Identifier string `json:"identifier"`
@@ -243,7 +238,6 @@ const (
 	resourceTypeStr   = "Resource"
 	eventTypeStr      = "Event"
 	contractTypeStr   = "Contract"
-	linkTypeStr       = "Link"
 	pathTypeStr       = "Path"
 	typeTypeStr       = "Type"
 	capabilityTypeStr = "Capability"
@@ -319,8 +313,6 @@ func Prepare(v cadence.Value) jsonValue {
 		return prepareEvent(x)
 	case cadence.Contract:
 		return prepareContract(x)
-	case cadence.PathLink:
-		return prepareLink(x)
 	case cadence.Path:
 		return preparePath(x)
 	case cadence.TypeValue:
@@ -596,16 +588,6 @@ func prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cade
 		Value: jsonCompositeValue{
 			ID:     id,
 			Fields: compositeFields,
-		},
-	}
-}
-
-func prepareLink(x cadence.PathLink) jsonValue {
-	return jsonValueObject{
-		Type: linkTypeStr,
-		Value: jsonPathLinkValue{
-			TargetPath: preparePath(x.TargetPath),
-			BorrowType: x.BorrowType,
 		},
 	}
 }

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1635,35 +1635,6 @@ func TestEncodeContract(t *testing.T) {
 	testAllEncodeAndDecode(t, simpleContract, resourceContract)
 }
 
-func TestEncodeLink(t *testing.T) {
-
-	t.Parallel()
-
-	testEncodeAndDecode(
-		t,
-		cadence.NewPathLink(
-			cadence.NewPath("storage", "foo"),
-			"Bar",
-		),
-		// language=json
-		`
-          {
-            "type": "Link",
-            "value": {
-              "targetPath": {
-                "type": "Path",
-                "value": {
-                  "domain": "storage",
-                  "identifier": "foo"
-                }
-              },
-              "borrowType": "Bar"
-            }
-          }
-        `,
-	)
-}
-
 func TestEncodeSimpleTypes(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -211,8 +211,6 @@ func exportValueWithInterpreter(
 		)
 	case interpreter.AddressValue:
 		return cadence.NewMeteredAddress(inter, v), nil
-	case interpreter.PathLinkValue:
-		return exportPathLinkValue(v, inter), nil
 	case interpreter.PathValue:
 		return exportPathValue(inter, v), nil
 	case interpreter.TypeValue:
@@ -557,12 +555,6 @@ func exportDictionaryValue(
 	return dictionary.WithType(exportType), err
 }
 
-func exportPathLinkValue(v interpreter.PathLinkValue, inter *interpreter.Interpreter) cadence.PathLink {
-	path := exportPathValue(inter, v.TargetPath)
-	ty := string(inter.MustConvertStaticToSemaType(v.Type).ID())
-	return cadence.NewMeteredLink(inter, path, ty)
-}
-
 func exportPathValue(gauge common.MemoryGauge, v interpreter.PathValue) cadence.Path {
 	domain := v.Domain.Identifier()
 	common.UseMemory(gauge, common.MemoryUsage{
@@ -782,8 +774,6 @@ func (i valueImporter) importValue(value cadence.Value, expectedType sema.Type) 
 		return nil, errors.NewDefaultUserError("cannot import contract")
 	case cadence.Function:
 		return nil, errors.NewDefaultUserError("cannot import function")
-	case cadence.PathLink:
-		return nil, errors.NewDefaultUserError("cannot import link")
 	default:
 		// This means the implementation has unhandled types.
 		// Hence, return an internal error

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -805,17 +805,6 @@ func TestImportValue(t *testing.T) {
 			},
 		},
 		{
-			label: "Link (invalid)",
-			value: cadence.PathLink{
-				TargetPath: cadence.Path{
-					Domain:     "storage",
-					Identifier: "test",
-				},
-				BorrowType: "Int",
-			},
-			expected: nil,
-		},
-		{
 			label: "Capability (invalid)",
 			value: cadence.StorageCapability{
 				Path: cadence.Path{
@@ -2061,91 +2050,6 @@ func TestExportStorageCapabilityValue(t *testing.T) {
 				Identifier: "foo",
 			},
 			Address: cadence.Address{0x1},
-		}
-
-		assert.Equal(t, expected, actual)
-	})
-}
-
-func TestExportPathLinkValue(t *testing.T) {
-
-	t.Parallel()
-
-	t.Run("Int", func(t *testing.T) {
-
-		link := interpreter.PathLinkValue{
-			TargetPath: interpreter.PathValue{
-				Domain:     common.PathDomainStorage,
-				Identifier: "foo",
-			},
-			Type: interpreter.PrimitiveStaticTypeInt,
-		}
-
-		actual, err := exportValueWithInterpreter(
-			link,
-			newTestInterpreter(t),
-			interpreter.EmptyLocationRange,
-			seenReferences{},
-		)
-		require.NoError(t, err)
-
-		expected := cadence.PathLink{
-			TargetPath: cadence.Path{
-				Domain:     "storage",
-				Identifier: "foo",
-			},
-			BorrowType: "Int",
-		}
-
-		assert.Equal(t, expected, actual)
-	})
-
-	t.Run("Struct", func(t *testing.T) {
-
-		const code = `
-          struct S {}
-        `
-		program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
-		require.NoError(t, err)
-
-		checker, err := sema.NewChecker(
-			program,
-			TestLocation,
-			nil,
-			&sema.Config{
-				AccessCheckMode: sema.AccessCheckModeNotSpecifiedUnrestricted,
-			},
-		)
-		require.NoError(t, err)
-
-		err = checker.Check()
-		require.NoError(t, err)
-
-		inter := newTestInterpreter(t)
-		inter.Program = interpreter.ProgramFromChecker(checker)
-
-		capability := interpreter.PathLinkValue{
-			TargetPath: interpreter.PathValue{
-				Domain:     common.PathDomainStorage,
-				Identifier: "foo",
-			},
-			Type: interpreter.NewCompositeStaticTypeComputeTypeID(inter, TestLocation, "S"),
-		}
-
-		actual, err := exportValueWithInterpreter(
-			capability,
-			inter,
-			interpreter.EmptyLocationRange,
-			seenReferences{},
-		)
-		require.NoError(t, err)
-
-		expected := cadence.PathLink{
-			TargetPath: cadence.Path{
-				Domain:     "storage",
-				Identifier: "foo",
-			},
-			BorrowType: "S.test.S",
 		}
 
 		assert.Equal(t, expected, actual)

--- a/values.go
+++ b/values.go
@@ -1758,49 +1758,6 @@ func (v Contract) String() string {
 	return formatComposite(v.ContractType.ID(), v.ContractType.Fields, v.Fields)
 }
 
-// PathLink
-
-type PathLink struct {
-	TargetPath Path
-	// TODO: a future version might want to export the whole type
-	BorrowType string
-}
-
-var _ Value = PathLink{}
-
-func NewPathLink(targetPath Path, borrowType string) PathLink {
-	return PathLink{
-		TargetPath: targetPath,
-		BorrowType: borrowType,
-	}
-}
-
-func NewMeteredLink(gauge common.MemoryGauge, targetPath Path, borrowType string) PathLink {
-	common.UseMemory(gauge, common.CadencePathLinkValueMemoryUsage)
-	return NewPathLink(targetPath, borrowType)
-}
-
-func (PathLink) isValue() {}
-
-func (v PathLink) Type() Type {
-	return nil
-}
-
-func (v PathLink) MeteredType(_ common.MemoryGauge) Type {
-	return v.Type()
-}
-
-func (v PathLink) ToGoValue() any {
-	return nil
-}
-
-func (v PathLink) String() string {
-	return format.PathLink(
-		v.BorrowType,
-		v.TargetPath.String(),
-	)
-}
-
 // Path
 
 type Path struct {

--- a/values_test.go
+++ b/values_test.go
@@ -233,16 +233,6 @@ func TestStringer(t *testing.T) {
 			}),
 			expected: "S.test.FooContract(y: \"bar\")",
 		},
-		"Link": {
-			value: NewPathLink(
-				Path{
-					Domain:     "storage",
-					Identifier: "foo",
-				},
-				"Int",
-			),
-			expected: "PathLink<Int>(/storage/foo)",
-		},
 		"Path": {
 			value: Path{
 				Domain:     "storage",


### PR DESCRIPTION
Closes #2208 
Closes #2167

## Description

#260 has added support for importing/exporting path link values into/from the interpreter, as well as encoding to/decoding from JSON.

This was likely only done because the Playground rendered storage contents in its UI by exporting stored values. Since then, storage inspection has changed and does not rely on this feature anymore.

Path links are only stored in storage, but are not first-class values. 
Remove
- `cadence` type definition
- Interpreter import/export
- JSON encoding/decoding

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
