### PR TITLE
Replace interface GetProgram and SetProgram with GetAndSetProgram

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -29,6 +29,9 @@ type Context struct {
 	CoverageReport *CoverageReport
 }
 
+// codesAndPrograms collects the source code and AST for each location.
+// It is purely used for debugging: Both the codes and the programs
+// are provided in runtime errors.
 type codesAndPrograms struct {
 	codes    map[Location][]byte
 	programs map[Location]*ast.Program

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -283,7 +283,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 					"  |\n"+
 					"4 |               fun testCase() {}\n"+
 					"  |               ^\n",
-				1,
+				2,
 			),
 		})
 	})
@@ -333,7 +333,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 					"  |\n"+
 					"3 |                   pub fun test() { X }\n"+
 					"  |                                    ^ not found in this scope\n",
-				1,
+				2,
 			),
 		})
 	})

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -355,38 +355,12 @@ func (e *interpreterEnvironment) ParseAndCheckProgram(
 func (e *interpreterEnvironment) parseAndCheckProgram(
 	code []byte,
 	location common.Location,
-	storeProgram bool,
 	checkedImports importResolutionResults,
 ) (
-	program *interpreter.Program,
+	program *ast.Program,
+	elaboration *sema.Elaboration,
 	err error,
 ) {
-
-	// NOTE: Always ensure to call maybeSetProgram
-	// on all error paths of parseAndCheckProgram,
-	// except for once Interface.SetProgram was called!
-	//
-	// If the program is supposed to be stored,
-	// there was a call to Interface.GetProgram before.
-	// If an error occurs after calling Interface.GetProgram,
-	// then we *must* also call Interface.SetProgram, with nil.
-	//
-	// See the documentation for Interface.GetProgram
-	// for an explanation of this invariant.
-
-	maybeSetProgram := func() error {
-
-		if !storeProgram {
-			return nil
-		}
-
-		var err error
-		wrapPanic(func() {
-			err = e.runtimeInterface.SetProgram(location, program)
-		})
-		return err
-	}
-
 	wrapParsingCheckingError := func(err error) error {
 		return &ParsingCheckingError{
 			Err:      err,
@@ -394,16 +368,11 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 		}
 	}
 
-	if storeProgram {
-		e.codesAndPrograms.setCode(location, code)
-	}
-
 	// Parse
 
-	var parse *ast.Program
 	reportMetric(
 		func() {
-			parse, err = parser.ParseProgram(e, code, parser.Config{})
+			program, err = parser.ParseProgram(e, code, parser.Config{})
 		},
 		e.runtimeInterface,
 		func(metrics Metrics, duration time.Duration) {
@@ -411,47 +380,17 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 		},
 	)
 	if err != nil {
-		// IMPORTANT: even when an error occurs,
-		// we still might need to set the program
-		setProgramErr := maybeSetProgram()
-		if setProgramErr != nil {
-			return nil, setProgramErr
-		}
-
-		return nil, wrapParsingCheckingError(err)
-	}
-
-	if storeProgram {
-		e.codesAndPrograms.setProgram(location, parse)
+		return nil, nil, wrapParsingCheckingError(err)
 	}
 
 	// Check
 
-	elaboration, err := e.check(location, parse, checkedImports)
+	elaboration, err = e.check(location, program, checkedImports)
 	if err != nil {
-		// IMPORTANT: even when an error occurs,
-		// we still might need to set the program
-		setProgramErr := maybeSetProgram()
-		if setProgramErr != nil {
-			return nil, setProgramErr
-		}
-
-		return nil, wrapParsingCheckingError(err)
+		return program, nil, wrapParsingCheckingError(err)
 	}
 
-	// Return
-
-	program = &interpreter.Program{
-		Program:     parse,
-		Elaboration: elaboration,
-	}
-
-	err = maybeSetProgram()
-	if err != nil {
-		return nil, err
-	}
-
-	return program, nil
+	return program, elaboration, nil
 }
 
 func (e *interpreterEnvironment) check(
@@ -577,48 +516,51 @@ func (e *interpreterEnvironment) getProgram(
 	program *interpreter.Program,
 	err error,
 ) {
-	if getAndSetProgram {
-		wrapPanic(func() {
-			program, err = e.runtimeInterface.GetProgram(location)
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if program == nil {
+	load := func() (*interpreter.Program, error) {
 		code, err := getCode()
 		if err != nil {
-			if getAndSetProgram {
-				var setProgramErr error
-				wrapPanic(func() {
-					setProgramErr = e.runtimeInterface.SetProgram(location, program)
-				})
-				if setProgramErr != nil {
-					return nil, setProgramErr
-				}
-			}
 			return nil, err
 		}
 
-		// NOTE: parseAndCheckProgram calls Interface.SetProgram on error, if needed.
-		// Do NOT call / move the calls of Interface.SetProgram here:
-		// The error returned from parseAndCheckProgram might be the result
-		// of a call to Interface.SetProgram, in which case it should not be called again.
-		program, err = e.parseAndCheckProgram(
+		e.codesAndPrograms.setCode(location, code)
+
+		parsedProgram, elaboration, err := e.parseAndCheckProgram(
 			code,
 			location,
-			getAndSetProgram,
 			checkedImports,
 		)
+		if parsedProgram != nil {
+			e.codesAndPrograms.setProgram(location, parsedProgram)
+		}
 		if err != nil {
 			return nil, err
 		}
+
+		return &interpreter.Program{
+			Program:     parsedProgram,
+			Elaboration: elaboration,
+		}, nil
 	}
 
-	e.codesAndPrograms.setProgram(location, program.Program)
-
-	return program, nil
+	if getAndSetProgram {
+		wrapPanic(func() {
+			program, err = e.runtimeInterface.GetAndSetProgram(location, func() (program *interpreter.Program, err error) {
+				// Loading is done by Cadence.
+				// If it panics with a user error, e.g. when parsing fails due to a memory metering error,
+				// then do not treat it as an external error (the load callback is called by the embedder)
+				panicErr := userPanicToError(func() {
+					program, err = load()
+				})
+				if panicErr != nil {
+					return nil, panicErr
+				}
+				return
+			})
+		})
+	} else {
+		program, err = load()
+	}
+	return
 }
 
 func (e *interpreterEnvironment) getCode(location common.Location) (code []byte, err error) {

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -542,24 +542,25 @@ func (e *interpreterEnvironment) getProgram(
 		}, nil
 	}
 
-	if getAndSetProgram {
-		wrapPanic(func() {
-			program, err = e.runtimeInterface.GetAndSetProgram(location, func() (program *interpreter.Program, err error) {
-				// Loading is done by Cadence.
-				// If it panics with a user error, e.g. when parsing fails due to a memory metering error,
-				// then do not treat it as an external error (the load callback is called by the embedder)
-				panicErr := userPanicToError(func() {
-					program, err = load()
-				})
-				if panicErr != nil {
-					return nil, panicErr
-				}
-				return
-			})
-		})
-	} else {
-		program, err = load()
+	if !getAndSetProgram {
+		return load()
 	}
+
+	wrapPanic(func() {
+		program, err = e.runtimeInterface.GetAndSetProgram(location, func() (program *interpreter.Program, err error) {
+			// Loading is done by Cadence.
+			// If it panics with a user error, e.g. when parsing fails due to a memory metering error,
+			// then do not treat it as an external error (the load callback is called by the embedder)
+			panicErr := userPanicToError(func() {
+				program, err = load()
+			})
+			if panicErr != nil {
+				return nil, panicErr
+			}
+			return
+		})
+	})
+
 	return
 }
 

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -46,8 +46,9 @@ type Interface interface {
 	//   i.e. it may NOT return a different program,
 	//   an elaboration in the program that is not annotating the AST in the program;
 	//   or a program/elaboration and then nothing in a subsequent call.
-	// - This function MUST also return what was previously loaded,
-	//   it may NOT return something different or nothing/nil (!) after load was called.
+	// - This function MUST also return exactly what was previously returned from load,
+	//   *EVEN IF loading failed* (program is nil / error is non-nil),
+	//   and it may NOT return something different
 	// - Do NOT implement this as a cache!
 	GetAndSetProgram(
 		location Location,

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -34,36 +34,25 @@ type Interface interface {
 	ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
 	// GetCode returns the code at a given location
 	GetCode(location Location) ([]byte, error)
-	// GetProgram returns the program for the given location, if available.
-	//
-	// NOTE:
+	// GetAndSetProgram returns the program for the given location, if available,
+	// or sets the program by calling the given load function.
 	//
 	// For implementations:
-	// - During execution, this function MUST always return the *same* program,
+	// - Perform a lookup for the location and return the program if it exists.
+	// - If the program does not exist, call load, and store the result,
+	//   *EVEN IF loading failed* (program is nil / error is non-nil)!
+	// - During execution of a high-level program (e.g. script, transaction, etc.),
+	//   this function MUST always return the *same* program,
 	//   i.e. it may NOT return a different program,
 	//   an elaboration in the program that is not annotating the AST in the program;
 	//   or a program/elaboration and then nothing in a subsequent call.
-	// - This function MUST also return what was set using SetProgram,
-	//   it may NOT return something different or nothing/nil (!) after SetProgram was called.
-	//   Do NOT implement this as a cache!
-	//
-	// For uses:
-	// - ONLY call this function when a program must be parsed and checked,
-	//   as an optimization to reuse the result of a potential previous parse and check.
-	// - If GetProgram returns nil, Cadence MUST call SetProgram:
-	//   There's an informal contract between Cadence and the implementer:
-	//   Cadence calls GetProgram to potentially avoid having to parse and check a program.
-	//   If the implementer returns nil from GetProgram,
-	//   it expects that Cadence sets the resulting parsed and checked program with SetProgram.
-	// - The behaviour after GetProgram returning nil or a program must be always deterministic:
-	//   As SetProgram is called when GetProgram is nil, then SetProgram MUST also be called when
-	//   GetProgram returns a program. This prevents nondeterministic behaviour
-	//
-	// Deprecated: This function should be refactored to ensure that SetProgram is always called
-	//
-	GetProgram(Location) (*interpreter.Program, error)
-	// SetProgram sets the program for the given location.
-	SetProgram(Location, *interpreter.Program) error
+	// - This function MUST also return what was previously loaded,
+	//   it may NOT return something different or nothing/nil (!) after load was called.
+	// - Do NOT implement this as a cache!
+	GetAndSetProgram(
+		location Location,
+		load func() (*interpreter.Program, error),
+	) (*interpreter.Program, error)
 	// SetInterpreterSharedState sets the shared state of all interpreters.
 	SetInterpreterSharedState(state *interpreter.SharedState)
 	// GetInterpreterSharedState gets the shared state of all interpreters.

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -135,10 +135,12 @@ func newTestInterpreterRuntime() Runtime {
 }
 
 type testRuntimeInterface struct {
-	resolveLocation           func(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
-	getCode                   func(_ Location) ([]byte, error)
-	getProgram                func(Location) (*interpreter.Program, error)
-	setProgram                func(Location, *interpreter.Program) error
+	resolveLocation  func(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
+	getCode          func(_ Location) ([]byte, error)
+	getAndSetProgram func(
+		location Location,
+		load func() (*interpreter.Program, error),
+	) (*interpreter.Program, error)
 	setInterpreterSharedState func(state *interpreter.SharedState)
 	getInterpreterSharedState func() *interpreter.SharedState
 	storage                   testLedger
@@ -220,27 +222,35 @@ func (i *testRuntimeInterface) GetCode(location Location) ([]byte, error) {
 	return i.getCode(location)
 }
 
-func (i *testRuntimeInterface) GetProgram(location Location) (*interpreter.Program, error) {
-	if i.getProgram == nil {
+func (i *testRuntimeInterface) GetAndSetProgram(
+	location Location,
+	load func() (*interpreter.Program, error),
+) (
+	program *interpreter.Program,
+	err error,
+) {
+	if i.getAndSetProgram == nil {
 		if i.programs == nil {
 			i.programs = map[Location]*interpreter.Program{}
 		}
-		return i.programs[location], nil
-	}
 
-	return i.getProgram(location)
-}
-
-func (i *testRuntimeInterface) SetProgram(location Location, program *interpreter.Program) error {
-	if i.setProgram == nil {
-		if i.programs == nil {
-			i.programs = map[Location]*interpreter.Program{}
+		var ok bool
+		program, ok = i.programs[location]
+		if ok {
+			return
 		}
+
+		program, err = load()
+
+		// NOTE: important: still set empty program,
+		// even if error occurred
+
 		i.programs[location] = program
-		return nil
+
+		return
 	}
 
-	return i.setProgram(location, program)
+	return i.getAndSetProgram(location, load)
 }
 
 func (i *testRuntimeInterface) SetInterpreterSharedState(state *interpreter.SharedState) {
@@ -676,8 +686,8 @@ func TestRuntimeConcurrentImport(t *testing.T) {
     `)
 
 	var checkCount uint64
-	var programsLock sync.RWMutex
-	programs := map[Location]*interpreter.Program{}
+
+	var programs sync.Map
 
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
@@ -691,21 +701,27 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 		programChecked: func(location Location, duration time.Duration) {
 			atomic.AddUint64(&checkCount, 1)
 		},
-		setProgram: func(location Location, program *interpreter.Program) error {
-			programsLock.Lock()
-			defer programsLock.Unlock()
+		getAndSetProgram: func(
+			location Location,
+			load func() (*interpreter.Program, error),
+		) (
+			program *interpreter.Program,
+			err error,
+		) {
+			item, ok := programs.Load(location)
+			if ok {
+				program = item.(*interpreter.Program)
+				return
+			}
 
-			programs[location] = program
+			program, err = load()
 
-			return nil
-		},
-		getProgram: func(location Location) (*interpreter.Program, error) {
-			programsLock.RLock()
-			defer programsLock.RUnlock()
+			// NOTE: important: still set empty program,
+			// even if error occurred
 
-			program := programs[location]
+			programs.Store(location, program)
 
-			return program, nil
+			return
 		},
 	}
 
@@ -764,17 +780,30 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 	runtimeInterface := &testRuntimeInterface{
-		getProgram: func(location Location) (*interpreter.Program, error) {
-			program, found := programs[location]
-			programsHits[location] = found
-			if !found {
-				return nil, nil
+		getAndSetProgram: func(
+			location Location,
+			load func() (*interpreter.Program, error),
+		) (
+			program *interpreter.Program,
+			err error,
+		) {
+			var ok bool
+			program, ok = programs[location]
+
+			programsHits[location] = ok
+
+			if ok {
+				return
 			}
-			return program, nil
-		},
-		setProgram: func(location Location, program *interpreter.Program) error {
+
+			program, err = load()
+
+			// NOTE: important: still set empty program,
+			// even if error occurred
+
 			programs[location] = program
-			return nil
+
+			return
 		},
 		getCode: func(location Location) ([]byte, error) {
 			switch location {
@@ -6338,13 +6367,29 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 		getCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		setProgram: func(location Location, program *interpreter.Program) error {
-			programs[location] = program
-			return nil
-		},
-		getProgram: func(location Location) (*interpreter.Program, error) {
+		getAndSetProgram: func(
+			location Location,
+			load func() (*interpreter.Program, error),
+		) (
+			program *interpreter.Program,
+			err error,
+		) {
 			programsHits = append(programsHits, location)
-			return programs[location], nil
+
+			var ok bool
+			program, ok = programs[location]
+			if ok {
+				return
+			}
+
+			program, err = load()
+
+			// NOTE: important: still set empty program,
+			// even if error occurred
+
+			programs[location] = program
+
+			return
 		},
 		storage: newTestLedger(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
@@ -7231,8 +7276,8 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		runtime := newTestInterpreterRuntime()
 
 		runtimeInterface := &testRuntimeInterface{
-			setProgram: func(location Location, program *interpreter.Program) error {
-				panic(errors.New("crash while setting program"))
+			getAndSetProgram: func(_ Location, _ func() (*interpreter.Program, error)) (*interpreter.Program, error) {
+				panic(errors.New("crash while getting/setting program"))
 			},
 		}
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -3403,34 +3403,13 @@ func TestRuntimeStorageIteration(t *testing.T) {
             }
         `))
 
-		newRuntimeInterface := func() (Interface, *[]Location) {
-			programs := map[Location]*interpreter.Program{}
-
-			var programStack []Location
-
-			runtimeInterface := &testRuntimeInterface{
+		newRuntimeInterface := func() Interface {
+			return &testRuntimeInterface{
 				storage: ledger,
 				getSigningAccounts: func() ([]Address, error) {
 					return []Address{address}, nil
 				},
 				resolveLocation: singleIdentifierLocationResolver(t),
-				getProgram: func(location Location) (*interpreter.Program, error) {
-					programStack = append(programStack, location)
-					return programs[location], nil
-				},
-				setProgram: func(location Location, program *interpreter.Program) error {
-					programs[location] = program
-
-					require.NotEmpty(t, programStack)
-					lastIndex := len(programStack) - 1
-					lastLocation := programStack[lastIndex]
-					require.Equal(t, lastLocation, location)
-
-					programStack[lastIndex] = nil
-					programStack = programStack[:lastIndex]
-
-					return nil
-				},
 				updateAccountContractCode: func(address Address, name string, code []byte) error {
 					location := common.AddressLocation{
 						Address: address,
@@ -3457,13 +3436,11 @@ func TestRuntimeStorageIteration(t *testing.T) {
 					return nil
 				},
 			}
-
-			return runtimeInterface, &programStack
 		}
 
 		// Deploy contract
 
-		runtimeInterface, _ := newRuntimeInterface()
+		runtimeInterface := newRuntimeInterface()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -3478,7 +3455,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Store value
 
-		runtimeInterface, _ = newRuntimeInterface()
+		runtimeInterface = newRuntimeInterface()
 
 		err = runtime.ExecuteTransaction(
 			Script{
@@ -3507,9 +3484,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
 		contractIsBroken = true
 
-		var programStack *[]Location
-
-		runtimeInterface, programStack = newRuntimeInterface()
+		runtimeInterface = newRuntimeInterface()
 
 		// Read value
 		err = runtime.ExecuteTransaction(
@@ -3537,8 +3512,6 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-
-		require.Empty(t, *programStack)
 	})
 
 	t.Run("broken contract, parsing problem", func(t *testing.T) {
@@ -3558,34 +3531,13 @@ func TestRuntimeStorageIteration(t *testing.T) {
             }
         `))
 
-		newRuntimeInterface := func() (Interface, *[]Location) {
-			programs := map[Location]*interpreter.Program{}
-
-			var programStack []Location
-
-			runtimeInterface := &testRuntimeInterface{
+		newRuntimeInterface := func() Interface {
+			return &testRuntimeInterface{
 				storage: ledger,
 				getSigningAccounts: func() ([]Address, error) {
 					return []Address{address}, nil
 				},
 				resolveLocation: singleIdentifierLocationResolver(t),
-				getProgram: func(location Location) (*interpreter.Program, error) {
-					programStack = append(programStack, location)
-					return programs[location], nil
-				},
-				setProgram: func(location Location, program *interpreter.Program) error {
-					programs[location] = program
-
-					require.NotEmpty(t, programStack)
-					lastIndex := len(programStack) - 1
-					lastLocation := programStack[lastIndex]
-					require.Equal(t, lastLocation, location)
-
-					programStack[lastIndex] = nil
-					programStack = programStack[:lastIndex]
-
-					return nil
-				},
 				updateAccountContractCode: func(address Address, name string, code []byte) error {
 					location := common.AddressLocation{
 						Address: address,
@@ -3613,12 +3565,11 @@ func TestRuntimeStorageIteration(t *testing.T) {
 				},
 			}
 
-			return runtimeInterface, &programStack
 		}
 
 		// Deploy contract
 
-		runtimeInterface, _ := newRuntimeInterface()
+		runtimeInterface := newRuntimeInterface()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -3633,7 +3584,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Store values
 
-		runtimeInterface, _ = newRuntimeInterface()
+		runtimeInterface = newRuntimeInterface()
 
 		err = runtime.ExecuteTransaction(
 			Script{
@@ -3669,9 +3620,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
 		contractIsBroken = true
 
-		var programStack *[]Location
-
-		runtimeInterface, programStack = newRuntimeInterface()
+		runtimeInterface = newRuntimeInterface()
 
 		// Read value
 		err = runtime.ExecuteTransaction(
@@ -3699,8 +3648,6 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-
-		require.Empty(t, *programStack)
 	})
 
 	t.Run("broken contract, type checking problem", func(t *testing.T) {
@@ -3720,34 +3667,13 @@ func TestRuntimeStorageIteration(t *testing.T) {
             }
         `))
 
-		newRuntimeInterface := func() (Interface, *[]Location) {
-			programs := map[Location]*interpreter.Program{}
-
-			var programStack []Location
-
-			runtimeInterface := &testRuntimeInterface{
+		newRuntimeInterface := func() Interface {
+			return &testRuntimeInterface{
 				storage: ledger,
 				getSigningAccounts: func() ([]Address, error) {
 					return []Address{address}, nil
 				},
 				resolveLocation: singleIdentifierLocationResolver(t),
-				getProgram: func(location Location) (*interpreter.Program, error) {
-					programStack = append(programStack, location)
-					return programs[location], nil
-				},
-				setProgram: func(location Location, program *interpreter.Program) error {
-					programs[location] = program
-
-					require.NotEmpty(t, programStack)
-					lastIndex := len(programStack) - 1
-					lastLocation := programStack[lastIndex]
-					require.Equal(t, lastLocation, location)
-
-					programStack[lastIndex] = nil
-					programStack = programStack[:lastIndex]
-
-					return nil
-				},
 				updateAccountContractCode: func(address Address, name string, code []byte) error {
 					location := common.AddressLocation{
 						Address: address,
@@ -3776,13 +3702,11 @@ func TestRuntimeStorageIteration(t *testing.T) {
 					return nil
 				},
 			}
-
-			return runtimeInterface, &programStack
 		}
 
 		// Deploy contract
 
-		runtimeInterface, _ := newRuntimeInterface()
+		runtimeInterface := newRuntimeInterface()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -3797,7 +3721,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		// Store values
 
-		runtimeInterface, _ = newRuntimeInterface()
+		runtimeInterface = newRuntimeInterface()
 
 		err = runtime.ExecuteTransaction(
 			Script{
@@ -3833,9 +3757,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 		// Make the `Test` contract broken. i.e: `Test.Foo` type is broken
 		contractIsBroken = true
 
-		var programStack *[]Location
-
-		runtimeInterface, programStack = newRuntimeInterface()
+		runtimeInterface = newRuntimeInterface()
 
 		// Read value
 		err = runtime.ExecuteTransaction(
@@ -3863,7 +3785,5 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-
-		require.Empty(t, *programStack)
 	})
 }


### PR DESCRIPTION
⚠️ Depends on #2249
Closes #2247
Closes #2180 (replacement)

## Description

Bases on the great start by @janezpodhostnik  in #2180 🙏 

With #2249, all `GetProgram` and `SetProgram` calls are now balanced.
Finally, replace both functions with a single function `GetAndSetProgram`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
