### PR TITLE
Fix loop variables being captured in closures

### DIFF
--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -314,15 +314,16 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 		t.Parallel()
 
 		for _, typ := range sema.AllNumberTypes {
+			typString := typ.QualifiedString()
 
-			t.Run(typ.QualifiedString(), func(t *testing.T) {
+			t.Run(typString, func(t *testing.T) {
 				t.Parallel()
 
 				script := fmt.Sprintf(`
                         pub fun main(arg: %s?) {
                         }
                     `,
-					typ.QualifiedString(),
+					typString,
 				)
 
 				err := executeScript(t, script, cadence.NewOptional(nil))
@@ -830,15 +831,16 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 		t.Parallel()
 
 		for _, typ := range sema.AllNumberTypes {
+			typString := typ.QualifiedString()
 
-			t.Run(typ.QualifiedString(), func(t *testing.T) {
+			t.Run(typString, func(t *testing.T) {
 				t.Parallel()
 
 				script := fmt.Sprintf(`
                         transaction(arg: %s?) {
                         }
                     `,
-					typ.QualifiedString(),
+					typString,
 				)
 
 				err := executeTransaction(t, script, cadence.NewOptional(nil))


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Small fix to remove loopclosure warnings. A few loop variables were being captured in parallel tests, which adds nondeterminism and subtly reduces test coverage due to unchecked mutation.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
