### PR TITLE
Replace empty common.Address{} with singleton

### DIFF
--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -32,7 +32,7 @@ const AddressLength = 8
 type Address [AddressLength]byte
 
 // Singleton for address 0x0. This should be used in place of an empty initializer `Address{}`
-var NilAddress Address = Address{}
+var ZeroAddress Address = Address{}
 
 // MustBytesToAddress returns Address with value b.
 //

--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -31,6 +31,9 @@ const AddressLength = 8
 
 type Address [AddressLength]byte
 
+// Singleton for address 0x0. This should be used in place of an empty initializer `Address{}`
+var NilAddress Address = Address{}
+
 // MustBytesToAddress returns Address with value b.
 //
 // If the address is too large, then the function panics.

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -1143,7 +1143,7 @@ func (i valueImporter) importArrayValue(
 		inter,
 		locationRange,
 		staticArrayType,
-		common.NilAddress,
+		common.ZeroAddress,
 		values...,
 	), nil
 }
@@ -1311,7 +1311,7 @@ func (i valueImporter) importCompositeValue(
 		qualifiedIdentifier,
 		kind,
 		fields,
-		common.NilAddress,
+		common.ZeroAddress,
 	), nil
 }
 

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -1143,7 +1143,7 @@ func (i valueImporter) importArrayValue(
 		inter,
 		locationRange,
 		staticArrayType,
-		common.Address{},
+		common.NilAddress,
 		values...,
 	), nil
 }
@@ -1311,7 +1311,7 @@ func (i valueImporter) importCompositeValue(
 		qualifiedIdentifier,
 		kind,
 		fields,
-		common.Address{},
+		common.NilAddress,
 	), nil
 }
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -178,7 +178,7 @@ func TestExportValue(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
-					common.NilAddress,
+					common.ZeroAddress,
 				)
 			},
 			expected: cadence.NewArray([]cadence.Value{}).
@@ -195,7 +195,7 @@ func TestExportValue(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
-					common.NilAddress,
+					common.ZeroAddress,
 					interpreter.NewUnmeteredIntValueFromInt64(42),
 					interpreter.NewUnmeteredStringValue("foo"),
 				)
@@ -493,7 +493,7 @@ func TestExportValue(t *testing.T) {
 						inter,
 						interpreter.EmptyLocationRange,
 						interpreter.ByteArrayStaticType,
-						common.NilAddress,
+						common.ZeroAddress,
 					),
 				)
 			},
@@ -513,7 +513,7 @@ func TestExportValue(t *testing.T) {
 						inter,
 						interpreter.EmptyLocationRange,
 						blockIDStaticType,
-						common.NilAddress,
+						common.ZeroAddress,
 					),
 					interpreter.NewUnmeteredUFix64ValueWithInteger(1, interpreter.EmptyLocationRange),
 				)
@@ -612,7 +612,7 @@ func TestImportValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 			),
 			expectedType: &sema.VariableSizedType{
 				Type: sema.AnyStructType,
@@ -630,7 +630,7 @@ func TestImportValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredIntValueFromInt64(42),
 				interpreter.NewUnmeteredStringValue("foo"),
 			),
@@ -3102,7 +3102,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 		)
 
 		actual, err := exportValueWithInterpreter(
@@ -3148,7 +3148,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 			),
 			actual,
 		)
@@ -3166,7 +3166,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
@@ -3221,7 +3221,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredIntValueFromInt64(42),
 				interpreter.NewUnmeteredStringValue("foo"),
 			),
@@ -3266,14 +3266,14 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
-					common.NilAddress,
+					common.ZeroAddress,
 					interpreter.NewUnmeteredInt8Value(4),
 					interpreter.NewUnmeteredInt8Value(3),
 				),
@@ -3283,7 +3283,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
-					common.NilAddress,
+					common.ZeroAddress,
 					interpreter.NewUnmeteredInt8Value(42),
 					interpreter.NewUnmeteredInt8Value(54),
 				),
@@ -4693,7 +4693,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		inter,
 		interpreter.EmptyLocationRange,
 		staticArrayType,
-		common.NilAddress,
+		common.ZeroAddress,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
 		interpreter.NewUnmeteredStringValue("foo"),
 	)
@@ -4791,7 +4791,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		"Foo",
 		common.CompositeKindStructure,
 		internalCompositeValueFields,
-		common.NilAddress,
+		common.ZeroAddress,
 	)
 
 	externalCompositeValue := cadence.Struct{

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -178,7 +178,7 @@ func TestExportValue(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
-					common.Address{},
+					common.NilAddress,
 				)
 			},
 			expected: cadence.NewArray([]cadence.Value{}).
@@ -195,7 +195,7 @@ func TestExportValue(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
-					common.Address{},
+					common.NilAddress,
 					interpreter.NewUnmeteredIntValueFromInt64(42),
 					interpreter.NewUnmeteredStringValue("foo"),
 				)
@@ -493,7 +493,7 @@ func TestExportValue(t *testing.T) {
 						inter,
 						interpreter.EmptyLocationRange,
 						interpreter.ByteArrayStaticType,
-						common.Address{},
+						common.NilAddress,
 					),
 				)
 			},
@@ -513,7 +513,7 @@ func TestExportValue(t *testing.T) {
 						inter,
 						interpreter.EmptyLocationRange,
 						blockIDStaticType,
-						common.Address{},
+						common.NilAddress,
 					),
 					interpreter.NewUnmeteredUFix64ValueWithInteger(1, interpreter.EmptyLocationRange),
 				)
@@ -612,7 +612,7 @@ func TestImportValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
-				common.Address{},
+				common.NilAddress,
 			),
 			expectedType: &sema.VariableSizedType{
 				Type: sema.AnyStructType,
@@ -630,7 +630,7 @@ func TestImportValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredIntValueFromInt64(42),
 				interpreter.NewUnmeteredStringValue("foo"),
 			),
@@ -3102,7 +3102,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
-			common.Address{},
+			common.NilAddress,
 		)
 
 		actual, err := exportValueWithInterpreter(
@@ -3148,7 +3148,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
-				common.Address{},
+				common.NilAddress,
 			),
 			actual,
 		)
@@ -3166,7 +3166,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
@@ -3221,7 +3221,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredIntValueFromInt64(42),
 				interpreter.NewUnmeteredStringValue("foo"),
 			),
@@ -3266,14 +3266,14 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
-					common.Address{},
+					common.NilAddress,
 					interpreter.NewUnmeteredInt8Value(4),
 					interpreter.NewUnmeteredInt8Value(3),
 				),
@@ -3283,7 +3283,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
-					common.Address{},
+					common.NilAddress,
 					interpreter.NewUnmeteredInt8Value(42),
 					interpreter.NewUnmeteredInt8Value(54),
 				),
@@ -4693,7 +4693,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		inter,
 		interpreter.EmptyLocationRange,
 		staticArrayType,
-		common.Address{},
+		common.NilAddress,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
 		interpreter.NewUnmeteredStringValue("foo"),
 	)
@@ -4791,7 +4791,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		"Foo",
 		common.CompositeKindStructure,
 		internalCompositeValueFields,
-		common.Address{},
+		common.NilAddress,
 	)
 
 	externalCompositeValue := cadence.Struct{

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -880,7 +880,7 @@ func (e *interpreterEnvironment) loadContract(
 	case stdlib.CryptoCheckerLocation:
 		contract, err := stdlib.NewCryptoContract(
 			inter,
-			constructorGenerator(common.Address{}),
+			constructorGenerator(common.NilAddress),
 			invocationRange,
 		)
 		if err != nil {

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -880,7 +880,7 @@ func (e *interpreterEnvironment) loadContract(
 	case stdlib.CryptoCheckerLocation:
 		contract, err := stdlib.NewCryptoContract(
 			inter,
-			constructorGenerator(common.NilAddress),
+			constructorGenerator(common.ZeroAddress),
 			invocationRange,
 		)
 		if err != nil {

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -108,7 +108,7 @@ func ByteSliceToByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue
 		interpreter,
 		EmptyLocationRange,
 		ByteArrayStaticType,
-		common.Address{},
+		common.NilAddress,
 		values...,
 	)
 }

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -108,7 +108,7 @@ func ByteSliceToByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue
 		interpreter,
 		EmptyLocationRange,
 		ByteArrayStaticType,
-		common.NilAddress,
+		common.ZeroAddress,
 		values...,
 	)
 }

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -48,7 +48,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeUInt64,
 				},
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt64Value(500),
 			),
 			NewArrayValue(
@@ -57,7 +57,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt256,
 				},
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredInt256ValueFromBigInt(largeBigInt),
 			),
 			NewUnmeteredUInt64Value(500),
@@ -82,7 +82,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
-				common.Address{},
+				common.NilAddress,
 			): nil,
 			NewArrayValue(
 				inter,
@@ -90,7 +90,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt64Value(2),
 				NewUnmeteredUInt128ValueFromUint64(3),
 			): {2, 3},
@@ -100,7 +100,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt8Value(4),
 				NewUnmeteredIntValueFromInt64(5),
 			): {4, 5},

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -48,7 +48,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeUInt64,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt64Value(500),
 			),
 			NewArrayValue(
@@ -57,7 +57,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt256,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredInt256ValueFromBigInt(largeBigInt),
 			),
 			NewUnmeteredUInt64Value(500),
@@ -82,7 +82,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 			): nil,
 			NewArrayValue(
 				inter,
@@ -90,7 +90,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt64Value(2),
 				NewUnmeteredUInt128ValueFromUint64(3),
 			): {2, 3},
@@ -100,7 +100,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt8Value(4),
 				NewUnmeteredIntValueFromInt64(5),
 			): {4, 5},

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -70,7 +70,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 		VariableSizedStaticType{
 			Type: dictionaryStaticType,
 		},
-		common.Address{},
+		common.NilAddress,
 		dictValue,
 	)
 

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -70,7 +70,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 		VariableSizedStaticType{
 			Type: dictionaryStaticType,
 		},
-		common.NilAddress,
+		common.ZeroAddress,
 		dictValue,
 	)
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -276,7 +276,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 				Type: PrimitiveStaticTypeAnyStruct,
 				Size: 0,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 		)
 
 		testEncodeDecode(t,
@@ -307,7 +307,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeAnyStruct,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			expectedString,
 			TrueValue,
 		)

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -276,7 +276,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 				Type: PrimitiveStaticTypeAnyStruct,
 				Size: 0,
 			},
-			common.Address{},
+			common.NilAddress,
 		)
 
 		testEncodeDecode(t,
@@ -307,7 +307,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeAnyStruct,
 			},
-			common.Address{},
+			common.NilAddress,
 			expectedString,
 			TrueValue,
 		)

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -55,13 +55,13 @@ func TestInspectValue(t *testing.T) {
 			VariableSizedStaticType{
 				Type: dictionaryStaticType,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			dictValue,
 		)
 
 		optionalValue := NewUnmeteredSomeValueNonCopying(arrayValue)
 
-		compositeValue = newTestCompositeValue(inter, common.NilAddress)
+		compositeValue = newTestCompositeValue(inter, common.ZeroAddress)
 		compositeValue.SetMember(
 			inter,
 			EmptyLocationRange,

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -55,13 +55,13 @@ func TestInspectValue(t *testing.T) {
 			VariableSizedStaticType{
 				Type: dictionaryStaticType,
 			},
-			common.Address{},
+			common.NilAddress,
 			dictValue,
 		)
 
 		optionalValue := NewUnmeteredSomeValueNonCopying(arrayValue)
 
-		compositeValue = newTestCompositeValue(inter, common.Address{})
+		compositeValue = newTestCompositeValue(inter, common.NilAddress)
 		compositeValue.SetMember(
 			inter,
 			EmptyLocationRange,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1198,7 +1198,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			return contractValue
 		}
 	} else {
-		constructor := constructorGenerator(common.NilAddress)
+		constructor := constructorGenerator(common.ZeroAddress)
 		constructor.NestedVariables = nestedVariables
 		variable.SetValue(constructor)
 	}
@@ -1268,7 +1268,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 			qualifiedIdentifier,
 			declaration.CompositeKind,
 			caseValueFields,
-			common.NilAddress,
+			common.ZeroAddress,
 		)
 		caseValues[i] = EnumCase{
 			Value:    caseValue,
@@ -3216,7 +3216,7 @@ func (interpreter *Interpreter) accountPaths(addressValue AddressValue, location
 		interpreter,
 		locationRange,
 		NewVariableSizedStaticType(interpreter, pathType),
-		common.NilAddress,
+		common.ZeroAddress,
 		values...,
 	)
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1198,7 +1198,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 			return contractValue
 		}
 	} else {
-		constructor := constructorGenerator(common.Address{})
+		constructor := constructorGenerator(common.NilAddress)
 		constructor.NestedVariables = nestedVariables
 		variable.SetValue(constructor)
 	}
@@ -1268,7 +1268,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 			qualifiedIdentifier,
 			declaration.CompositeKind,
 			caseValueFields,
-			common.Address{},
+			common.NilAddress,
 		)
 		caseValues[i] = EnumCase{
 			Value:    caseValue,
@@ -3216,7 +3216,7 @@ func (interpreter *Interpreter) accountPaths(addressValue AddressValue, location
 		interpreter,
 		locationRange,
 		NewVariableSizedStaticType(interpreter, pathType),
-		common.Address{},
+		common.NilAddress,
 		values...,
 	)
 }

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -703,7 +703,7 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 		interpreter,
 		locationRange,
 		arrayStaticType,
-		common.NilAddress,
+		common.ZeroAddress,
 		copies...,
 	)
 }

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -703,7 +703,7 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 		interpreter,
 		locationRange,
 		arrayStaticType,
-		common.Address{},
+		common.NilAddress,
 		copies...,
 	)
 }

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -158,7 +158,7 @@ func TestInterpreterTracing(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			cloned,
 		)
 		require.NotNil(t, array)

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -158,7 +158,7 @@ func TestInterpreterTracing(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
-			common.Address{},
+			common.NilAddress,
 			cloned,
 		)
 		require.NotNil(t, array)

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -115,7 +115,7 @@ func TestArrayStorage(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		element := newTestCompositeValue(inter, common.NilAddress)
+		element := newTestCompositeValue(inter, common.ZeroAddress)
 
 		require.Equal(t, 1, storage.BasicSlabStorage.Count())
 
@@ -125,7 +125,7 @@ func TestArrayStorage(t *testing.T) {
 			VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 		)
 
 		require.NotEqual(t, atree.StorageIDUndefined, value.StorageID())
@@ -181,7 +181,7 @@ func TestArrayStorage(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		element := newTestCompositeValue(inter, common.NilAddress)
+		element := newTestCompositeValue(inter, common.ZeroAddress)
 
 		require.Equal(t, 1, storage.BasicSlabStorage.Count())
 
@@ -191,7 +191,7 @@ func TestArrayStorage(t *testing.T) {
 			VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			element,
 		)
 
@@ -449,7 +449,7 @@ func TestInterpretStorageOverwriteAndRemove(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	address := common.NilAddress
+	address := common.ZeroAddress
 
 	array1 := NewArrayValue(
 		inter,

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -115,7 +115,7 @@ func TestArrayStorage(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		element := newTestCompositeValue(inter, common.Address{})
+		element := newTestCompositeValue(inter, common.NilAddress)
 
 		require.Equal(t, 1, storage.BasicSlabStorage.Count())
 
@@ -125,7 +125,7 @@ func TestArrayStorage(t *testing.T) {
 			VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
-			common.Address{},
+			common.NilAddress,
 		)
 
 		require.NotEqual(t, atree.StorageIDUndefined, value.StorageID())
@@ -181,7 +181,7 @@ func TestArrayStorage(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		element := newTestCompositeValue(inter, common.Address{})
+		element := newTestCompositeValue(inter, common.NilAddress)
 
 		require.Equal(t, 1, storage.BasicSlabStorage.Count())
 
@@ -191,7 +191,7 @@ func TestArrayStorage(t *testing.T) {
 			VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
-			common.Address{},
+			common.NilAddress,
 			element,
 		)
 
@@ -449,7 +449,7 @@ func TestInterpretStorageOverwriteAndRemove(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	address := common.Address{}
+	address := common.NilAddress
 
 	array1 := NewArrayValue(
 		inter,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1300,7 +1300,7 @@ func (v *StringValue) DecodeHex(interpreter *Interpreter, locationRange Location
 	return NewArrayValueWithIterator(
 		interpreter,
 		ByteArrayStaticType,
-		common.NilAddress,
+		common.ZeroAddress,
 		uint64(len(bs)),
 		func() Value {
 			if i >= len(bs) {
@@ -1661,7 +1661,7 @@ func (v *ArrayValue) Concat(interpreter *Interpreter, locationRange LocationRang
 	return NewArrayValueWithIterator(
 		interpreter,
 		v.Type,
-		common.NilAddress,
+		common.ZeroAddress,
 		v.array.Count()+other.array.Count(),
 		func() Value {
 
@@ -2644,7 +2644,7 @@ func (v *ArrayValue) Slice(
 	return NewArrayValueWithIterator(
 		interpreter,
 		NewVariableSizedStaticType(interpreter, v.Type.ElementType()),
-		common.NilAddress,
+		common.ZeroAddress,
 		uint64(toIndex-fromIndex),
 		func() Value {
 
@@ -15032,7 +15032,7 @@ func NewEnumCaseValue(
 		enumType.QualifiedIdentifier(),
 		enumType.Kind,
 		fields,
-		common.NilAddress,
+		common.ZeroAddress,
 	)
 
 	v.Functions = functions
@@ -15061,7 +15061,7 @@ func NewDictionaryValue(
 		interpreter,
 		locationRange,
 		dictionaryType,
-		common.NilAddress,
+		common.ZeroAddress,
 		keysAndValues...,
 	)
 }
@@ -15542,7 +15542,7 @@ func (v *DictionaryValue) GetMember(
 		return NewArrayValueWithIterator(
 			interpreter,
 			NewVariableSizedStaticType(interpreter, v.Type.KeyType),
-			common.NilAddress,
+			common.ZeroAddress,
 			v.dictionary.Count(),
 			func() Value {
 
@@ -15569,7 +15569,7 @@ func (v *DictionaryValue) GetMember(
 		return NewArrayValueWithIterator(
 			interpreter,
 			NewVariableSizedStaticType(interpreter, v.Type.ValueType),
-			common.NilAddress,
+			common.ZeroAddress,
 			v.dictionary.Count(),
 			func() Value {
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1300,7 +1300,7 @@ func (v *StringValue) DecodeHex(interpreter *Interpreter, locationRange Location
 	return NewArrayValueWithIterator(
 		interpreter,
 		ByteArrayStaticType,
-		common.Address{},
+		common.NilAddress,
 		uint64(len(bs)),
 		func() Value {
 			if i >= len(bs) {
@@ -1661,7 +1661,7 @@ func (v *ArrayValue) Concat(interpreter *Interpreter, locationRange LocationRang
 	return NewArrayValueWithIterator(
 		interpreter,
 		v.Type,
-		common.Address{},
+		common.NilAddress,
 		v.array.Count()+other.array.Count(),
 		func() Value {
 
@@ -2644,7 +2644,7 @@ func (v *ArrayValue) Slice(
 	return NewArrayValueWithIterator(
 		interpreter,
 		NewVariableSizedStaticType(interpreter, v.Type.ElementType()),
-		common.Address{},
+		common.NilAddress,
 		uint64(toIndex-fromIndex),
 		func() Value {
 
@@ -15032,7 +15032,7 @@ func NewEnumCaseValue(
 		enumType.QualifiedIdentifier(),
 		enumType.Kind,
 		fields,
-		common.Address{},
+		common.NilAddress,
 	)
 
 	v.Functions = functions
@@ -15061,7 +15061,7 @@ func NewDictionaryValue(
 		interpreter,
 		locationRange,
 		dictionaryType,
-		common.Address{},
+		common.NilAddress,
 		keysAndValues...,
 	)
 }
@@ -15542,7 +15542,7 @@ func (v *DictionaryValue) GetMember(
 		return NewArrayValueWithIterator(
 			interpreter,
 			NewVariableSizedStaticType(interpreter, v.Type.KeyType),
-			common.Address{},
+			common.NilAddress,
 			v.dictionary.Count(),
 			func() Value {
 
@@ -15569,7 +15569,7 @@ func (v *DictionaryValue) GetMember(
 		return NewArrayValueWithIterator(
 			interpreter,
 			NewVariableSizedStaticType(interpreter, v.Type.ValueType),
-			common.Address{},
+			common.NilAddress,
 			v.dictionary.Count(),
 			func() Value {
 

--- a/runtime/interpreter/value_publickey.go
+++ b/runtime/interpreter/value_publickey.go
@@ -60,7 +60,7 @@ func NewPublicKeyValue(
 		sema.PublicKeyType.QualifiedIdentifier(),
 		sema.PublicKeyType.Kind,
 		fields,
-		common.Address{},
+		common.NilAddress,
 	)
 
 	publicKeyValue.ComputedFields = map[string]ComputedField{

--- a/runtime/interpreter/value_publickey.go
+++ b/runtime/interpreter/value_publickey.go
@@ -60,7 +60,7 @@ func NewPublicKeyValue(
 		sema.PublicKeyType.QualifiedIdentifier(),
 		sema.PublicKeyType.Kind,
 		fields,
-		common.NilAddress,
+		common.ZeroAddress,
 	)
 
 	publicKeyValue.ComputedFields = map[string]ComputedField{

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -111,14 +111,14 @@ func TestOwnerNewArray(t *testing.T) {
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
-		common.NilAddress,
+		common.ZeroAddress,
 		value,
 	)
 
 	value = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
-	assert.Equal(t, common.NilAddress, array.GetOwner())
-	assert.Equal(t, common.NilAddress, value.GetOwner())
+	assert.Equal(t, common.ZeroAddress, array.GetOwner())
+	assert.Equal(t, common.ZeroAddress, value.GetOwner())
 }
 
 func TestOwnerArrayDeepCopy(t *testing.T) {
@@ -165,7 +165,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
-		common.NilAddress,
+		common.ZeroAddress,
 		value,
 	)
 
@@ -415,7 +415,7 @@ func TestOwnerArrayRemove(t *testing.T) {
 	value = array.Remove(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, owner, array.GetOwner())
-	assert.Equal(t, common.NilAddress, value.GetOwner())
+	assert.Equal(t, common.ZeroAddress, value.GetOwner())
 }
 
 func TestOwnerNewDictionary(t *testing.T) {
@@ -461,8 +461,8 @@ func TestOwnerNewDictionary(t *testing.T) {
 	queriedValue, _ := dictionary.Get(inter, EmptyLocationRange, keyValue)
 	value = queriedValue.(*CompositeValue)
 
-	assert.Equal(t, common.NilAddress, dictionary.GetOwner())
-	assert.Equal(t, common.NilAddress, value.GetOwner())
+	assert.Equal(t, common.ZeroAddress, dictionary.GetOwner())
+	assert.Equal(t, common.ZeroAddress, value.GetOwner())
 }
 
 func TestOwnerDictionary(t *testing.T) {
@@ -579,8 +579,8 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 	)
 	value = queriedValue.(*CompositeValue)
 
-	assert.Equal(t, common.NilAddress, dictionaryCopy.GetOwner())
-	assert.Equal(t, common.NilAddress, value.GetOwner())
+	assert.Equal(t, common.ZeroAddress, dictionaryCopy.GetOwner())
+	assert.Equal(t, common.ZeroAddress, value.GetOwner())
 }
 
 func TestOwnerDictionarySetSome(t *testing.T) {
@@ -749,7 +749,7 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 	value2 = queriedValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
-	assert.Equal(t, common.NilAddress, value1.GetOwner())
+	assert.Equal(t, common.ZeroAddress, value1.GetOwner())
 	assert.Equal(t, newOwner, value2.GetOwner())
 }
 
@@ -804,7 +804,7 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 	value = innerValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
-	assert.Equal(t, common.NilAddress, value.GetOwner())
+	assert.Equal(t, common.ZeroAddress, value.GetOwner())
 }
 
 func TestOwnerNewComposite(t *testing.T) {
@@ -879,8 +879,8 @@ func TestOwnerCompositeCopy(t *testing.T) {
 		fieldName,
 	).(*CompositeValue)
 
-	assert.Equal(t, common.NilAddress, composite.GetOwner())
-	assert.Equal(t, common.NilAddress, value.GetOwner())
+	assert.Equal(t, common.ZeroAddress, composite.GetOwner())
+	assert.Equal(t, common.ZeroAddress, value.GetOwner())
 }
 
 func TestStringer(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestStringer(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeAnyStruct,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredIntValueFromInt64(10),
 				NewUnmeteredStringValue("TEST"),
 			),
@@ -1041,7 +1041,7 @@ func TestStringer(t *testing.T) {
 					"Foo",
 					common.CompositeKindResource,
 					fields,
-					common.NilAddress,
+					common.ZeroAddress,
 				)
 			}(),
 			expected: "S.test.Foo(y: \"bar\")",
@@ -1064,7 +1064,7 @@ func TestStringer(t *testing.T) {
 					"Foo",
 					common.CompositeKindResource,
 					fields,
-					common.NilAddress,
+					common.ZeroAddress,
 				)
 
 				compositeValue.Stringer = func(_ common.MemoryGauge, _ *CompositeValue, _ SeenReferences) string {
@@ -1125,7 +1125,7 @@ func TestStringer(t *testing.T) {
 					VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
-					common.NilAddress,
+					common.ZeroAddress,
 				)
 				arrayRef := &EphemeralReferenceValue{Value: array}
 				array.Insert(newTestInterpreter(t), EmptyLocationRange, 0, arrayRef)
@@ -1179,7 +1179,7 @@ func TestVisitor(t *testing.T) {
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
-		common.NilAddress,
+		common.ZeroAddress,
 		value,
 	)
 
@@ -1207,7 +1207,7 @@ func TestVisitor(t *testing.T) {
 		"Foo",
 		common.CompositeKindStructure,
 		fields,
-		common.NilAddress,
+		common.ZeroAddress,
 	)
 
 	value.Accept(inter, visitor)
@@ -1515,7 +1515,7 @@ func TestGetHashInput(t *testing.T) {
 					"Foo",
 					common.CompositeKindEnum,
 					fields,
-					common.NilAddress,
+					common.ZeroAddress,
 				)
 			}(),
 			expected: []byte{
@@ -1543,7 +1543,7 @@ func TestGetHashInput(t *testing.T) {
 					strings.Repeat("a", 32),
 					common.CompositeKindEnum,
 					fields,
-					common.NilAddress,
+					common.ZeroAddress,
 				)
 			}(),
 			expected: append(
@@ -1624,7 +1624,7 @@ func TestBlockValue(t *testing.T) {
 			inter,
 			EmptyLocationRange,
 			ByteArrayStaticType,
-			common.NilAddress,
+			common.ZeroAddress,
 		),
 		5.0,
 	)
@@ -2409,7 +2409,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
@@ -2419,7 +2419,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.NilAddress,
+					common.ZeroAddress,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredUInt8Value(2),
 				),
@@ -2438,7 +2438,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
@@ -2448,7 +2448,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.NilAddress,
+					common.ZeroAddress,
 					NewUnmeteredUInt8Value(2),
 					NewUnmeteredUInt8Value(3),
 				),
@@ -2467,7 +2467,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt8Value(1),
 			).Equal(
 				inter,
@@ -2476,7 +2476,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.NilAddress,
+					common.ZeroAddress,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredUInt8Value(2),
 				),
@@ -2495,7 +2495,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
@@ -2505,7 +2505,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.NilAddress,
+					common.ZeroAddress,
 					NewUnmeteredUInt8Value(1),
 				),
 			),
@@ -2527,7 +2527,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2535,7 +2535,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint16ArrayStaticType,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -2552,7 +2552,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				nil,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2560,7 +2560,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -2577,7 +2577,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2585,7 +2585,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					nil,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -2602,7 +2602,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				nil,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2610,7 +2610,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					nil,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -2627,7 +2627,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.NilAddress,
+				common.ZeroAddress,
 				NewUnmeteredUInt8Value(1),
 			).Equal(
 				inter,
@@ -2848,7 +2848,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					ByteArrayStaticType,
-					common.NilAddress,
+					common.ZeroAddress,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredUInt8Value(2),
 				),
@@ -2889,7 +2889,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2900,7 +2900,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -2934,7 +2934,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2945,7 +2945,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -2979,7 +2979,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2990,7 +2990,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"Y",
 					common.CompositeKindStructure,
 					fields2,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -3024,7 +3024,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3035,7 +3035,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -3073,7 +3073,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3084,7 +3084,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -3122,7 +3122,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3133,7 +3133,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -3167,7 +3167,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3178,7 +3178,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindResource,
 					fields2,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			),
 		)
@@ -3205,7 +3205,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.NilAddress,
+				common.ZeroAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3321,7 +3321,7 @@ func TestPublicKeyValue(t *testing.T) {
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			NewUnmeteredIntValueFromInt64(1),
 			NewUnmeteredIntValueFromInt64(7),
 			NewUnmeteredIntValueFromInt64(3),
@@ -3374,7 +3374,7 @@ func TestPublicKeyValue(t *testing.T) {
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[0])),
 			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[1])),
 			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[2])),

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -111,14 +111,14 @@ func TestOwnerNewArray(t *testing.T) {
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
-		common.Address{},
+		common.NilAddress,
 		value,
 	)
 
 	value = array.Get(inter, EmptyLocationRange, 0).(*CompositeValue)
 
-	assert.Equal(t, common.Address{}, array.GetOwner())
-	assert.Equal(t, common.Address{}, value.GetOwner())
+	assert.Equal(t, common.NilAddress, array.GetOwner())
+	assert.Equal(t, common.NilAddress, value.GetOwner())
 }
 
 func TestOwnerArrayDeepCopy(t *testing.T) {
@@ -165,7 +165,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
-		common.Address{},
+		common.NilAddress,
 		value,
 	)
 
@@ -415,7 +415,7 @@ func TestOwnerArrayRemove(t *testing.T) {
 	value = array.Remove(inter, EmptyLocationRange, 0).(*CompositeValue)
 
 	assert.Equal(t, owner, array.GetOwner())
-	assert.Equal(t, common.Address{}, value.GetOwner())
+	assert.Equal(t, common.NilAddress, value.GetOwner())
 }
 
 func TestOwnerNewDictionary(t *testing.T) {
@@ -461,8 +461,8 @@ func TestOwnerNewDictionary(t *testing.T) {
 	queriedValue, _ := dictionary.Get(inter, EmptyLocationRange, keyValue)
 	value = queriedValue.(*CompositeValue)
 
-	assert.Equal(t, common.Address{}, dictionary.GetOwner())
-	assert.Equal(t, common.Address{}, value.GetOwner())
+	assert.Equal(t, common.NilAddress, dictionary.GetOwner())
+	assert.Equal(t, common.NilAddress, value.GetOwner())
 }
 
 func TestOwnerDictionary(t *testing.T) {
@@ -579,8 +579,8 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 	)
 	value = queriedValue.(*CompositeValue)
 
-	assert.Equal(t, common.Address{}, dictionaryCopy.GetOwner())
-	assert.Equal(t, common.Address{}, value.GetOwner())
+	assert.Equal(t, common.NilAddress, dictionaryCopy.GetOwner())
+	assert.Equal(t, common.NilAddress, value.GetOwner())
 }
 
 func TestOwnerDictionarySetSome(t *testing.T) {
@@ -749,7 +749,7 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 	value2 = queriedValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
-	assert.Equal(t, common.Address{}, value1.GetOwner())
+	assert.Equal(t, common.NilAddress, value1.GetOwner())
 	assert.Equal(t, newOwner, value2.GetOwner())
 }
 
@@ -804,7 +804,7 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 	value = innerValue.(*CompositeValue)
 
 	assert.Equal(t, newOwner, dictionary.GetOwner())
-	assert.Equal(t, common.Address{}, value.GetOwner())
+	assert.Equal(t, common.NilAddress, value.GetOwner())
 }
 
 func TestOwnerNewComposite(t *testing.T) {
@@ -879,8 +879,8 @@ func TestOwnerCompositeCopy(t *testing.T) {
 		fieldName,
 	).(*CompositeValue)
 
-	assert.Equal(t, common.Address{}, composite.GetOwner())
-	assert.Equal(t, common.Address{}, value.GetOwner())
+	assert.Equal(t, common.NilAddress, composite.GetOwner())
+	assert.Equal(t, common.NilAddress, value.GetOwner())
 }
 
 func TestStringer(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestStringer(t *testing.T) {
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeAnyStruct,
 				},
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredIntValueFromInt64(10),
 				NewUnmeteredStringValue("TEST"),
 			),
@@ -1041,7 +1041,7 @@ func TestStringer(t *testing.T) {
 					"Foo",
 					common.CompositeKindResource,
 					fields,
-					common.Address{},
+					common.NilAddress,
 				)
 			}(),
 			expected: "S.test.Foo(y: \"bar\")",
@@ -1064,7 +1064,7 @@ func TestStringer(t *testing.T) {
 					"Foo",
 					common.CompositeKindResource,
 					fields,
-					common.Address{},
+					common.NilAddress,
 				)
 
 				compositeValue.Stringer = func(_ common.MemoryGauge, _ *CompositeValue, _ SeenReferences) string {
@@ -1125,7 +1125,7 @@ func TestStringer(t *testing.T) {
 					VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
-					common.Address{},
+					common.NilAddress,
 				)
 				arrayRef := &EphemeralReferenceValue{Value: array}
 				array.Insert(newTestInterpreter(t), EmptyLocationRange, 0, arrayRef)
@@ -1179,7 +1179,7 @@ func TestVisitor(t *testing.T) {
 		VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
-		common.Address{},
+		common.NilAddress,
 		value,
 	)
 
@@ -1207,7 +1207,7 @@ func TestVisitor(t *testing.T) {
 		"Foo",
 		common.CompositeKindStructure,
 		fields,
-		common.Address{},
+		common.NilAddress,
 	)
 
 	value.Accept(inter, visitor)
@@ -1515,7 +1515,7 @@ func TestGetHashInput(t *testing.T) {
 					"Foo",
 					common.CompositeKindEnum,
 					fields,
-					common.Address{},
+					common.NilAddress,
 				)
 			}(),
 			expected: []byte{
@@ -1543,7 +1543,7 @@ func TestGetHashInput(t *testing.T) {
 					strings.Repeat("a", 32),
 					common.CompositeKindEnum,
 					fields,
-					common.Address{},
+					common.NilAddress,
 				)
 			}(),
 			expected: append(
@@ -1624,7 +1624,7 @@ func TestBlockValue(t *testing.T) {
 			inter,
 			EmptyLocationRange,
 			ByteArrayStaticType,
-			common.Address{},
+			common.NilAddress,
 		),
 		5.0,
 	)
@@ -2409,7 +2409,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
@@ -2419,7 +2419,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.Address{},
+					common.NilAddress,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredUInt8Value(2),
 				),
@@ -2438,7 +2438,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
@@ -2448,7 +2448,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.Address{},
+					common.NilAddress,
 					NewUnmeteredUInt8Value(2),
 					NewUnmeteredUInt8Value(3),
 				),
@@ -2467,7 +2467,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt8Value(1),
 			).Equal(
 				inter,
@@ -2476,7 +2476,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.Address{},
+					common.NilAddress,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredUInt8Value(2),
 				),
@@ -2495,7 +2495,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt8Value(1),
 				NewUnmeteredUInt8Value(2),
 			).Equal(
@@ -2505,7 +2505,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.Address{},
+					common.NilAddress,
 					NewUnmeteredUInt8Value(1),
 				),
 			),
@@ -2527,7 +2527,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2535,7 +2535,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint16ArrayStaticType,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -2552,7 +2552,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				nil,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2560,7 +2560,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					uint8ArrayStaticType,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -2577,7 +2577,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2585,7 +2585,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					nil,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -2602,7 +2602,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				nil,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2610,7 +2610,7 @@ func TestArrayValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					nil,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -2627,7 +2627,7 @@ func TestArrayValue_Equal(t *testing.T) {
 				inter,
 				EmptyLocationRange,
 				uint8ArrayStaticType,
-				common.Address{},
+				common.NilAddress,
 				NewUnmeteredUInt8Value(1),
 			).Equal(
 				inter,
@@ -2848,7 +2848,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 					inter,
 					EmptyLocationRange,
 					ByteArrayStaticType,
-					common.Address{},
+					common.NilAddress,
 					NewUnmeteredUInt8Value(1),
 					NewUnmeteredUInt8Value(2),
 				),
@@ -2889,7 +2889,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2900,7 +2900,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -2934,7 +2934,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2945,7 +2945,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -2979,7 +2979,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -2990,7 +2990,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"Y",
 					common.CompositeKindStructure,
 					fields2,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -3024,7 +3024,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3035,7 +3035,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -3073,7 +3073,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3084,7 +3084,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -3122,7 +3122,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3133,7 +3133,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindStructure,
 					fields2,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -3167,7 +3167,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3178,7 +3178,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 					"X",
 					common.CompositeKindResource,
 					fields2,
-					common.Address{},
+					common.NilAddress,
 				),
 			),
 		)
@@ -3205,7 +3205,7 @@ func TestCompositeValue_Equal(t *testing.T) {
 				"X",
 				common.CompositeKindStructure,
 				fields1,
-				common.Address{},
+				common.NilAddress,
 			).Equal(
 				inter,
 				EmptyLocationRange,
@@ -3321,7 +3321,7 @@ func TestPublicKeyValue(t *testing.T) {
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			NewUnmeteredIntValueFromInt64(1),
 			NewUnmeteredIntValueFromInt64(7),
 			NewUnmeteredIntValueFromInt64(3),
@@ -3374,7 +3374,7 @@ func TestPublicKeyValue(t *testing.T) {
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[0])),
 			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[1])),
 			NewUnmeteredIntValueFromInt64(int64(publicKeyBytes[2])),

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1222,7 +1222,7 @@ func newAccountContractsGetNamesFunction(
 			inter,
 			locationRange,
 			arrayType,
-			common.NilAddress,
+			common.ZeroAddress,
 			values...,
 		)
 	}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1222,7 +1222,7 @@ func newAccountContractsGetNamesFunction(
 			inter,
 			locationRange,
 			arrayType,
-			common.Address{},
+			common.NilAddress,
 			values...,
 		)
 	}

--- a/runtime/stdlib/block.go
+++ b/runtime/stdlib/block.go
@@ -145,7 +145,7 @@ func NewBlockValue(
 		inter,
 		locationRange,
 		BlockIDStaticType,
-		common.Address{},
+		common.NilAddress,
 		values...,
 	)
 

--- a/runtime/stdlib/block.go
+++ b/runtime/stdlib/block.go
@@ -145,7 +145,7 @@ func NewBlockValue(
 		inter,
 		locationRange,
 		BlockIDStaticType,
-		common.NilAddress,
+		common.ZeroAddress,
 		values...,
 	)
 

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -217,7 +217,7 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
 				invocation.Interpreter,
 				interpreter.ByteArrayStaticType,
 			),
-			common.Address{},
+			common.NilAddress,
 			values...,
 		)
 	},

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -217,7 +217,7 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
 				invocation.Interpreter,
 				interpreter.ByteArrayStaticType,
 			),
-			common.NilAddress,
+			common.ZeroAddress,
 			values...,
 		)
 	},

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -822,7 +822,7 @@ func newEmulatorBackend(
 		emulatorBackendTypeName,
 		common.CompositeKindStructure,
 		fields,
-		common.NilAddress,
+		common.ZeroAddress,
 	)
 }
 
@@ -1611,7 +1611,7 @@ func NewTestInterpreterContractValueHandler(
 		case CryptoCheckerLocation:
 			contract, err := NewCryptoContract(
 				inter,
-				constructorGenerator(common.NilAddress),
+				constructorGenerator(common.ZeroAddress),
 				invocationRange,
 			)
 			if err != nil {
@@ -1623,7 +1623,7 @@ func NewTestInterpreterContractValueHandler(
 			contract, err := NewTestContract(
 				inter,
 				testFramework,
-				constructorGenerator(common.NilAddress),
+				constructorGenerator(common.ZeroAddress),
 				invocationRange,
 			)
 			if err != nil {
@@ -1634,7 +1634,7 @@ func NewTestInterpreterContractValueHandler(
 		default:
 			// During tests, imported contracts can be constructed using the constructor,
 			// similar to structs. Therefore, generate a constructor function.
-			return constructorGenerator(common.NilAddress)
+			return constructorGenerator(common.ZeroAddress)
 		}
 	}
 }

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -822,7 +822,7 @@ func newEmulatorBackend(
 		emulatorBackendTypeName,
 		common.CompositeKindStructure,
 		fields,
-		common.Address{},
+		common.NilAddress,
 	)
 }
 
@@ -1611,7 +1611,7 @@ func NewTestInterpreterContractValueHandler(
 		case CryptoCheckerLocation:
 			contract, err := NewCryptoContract(
 				inter,
-				constructorGenerator(common.Address{}),
+				constructorGenerator(common.NilAddress),
 				invocationRange,
 			)
 			if err != nil {
@@ -1623,7 +1623,7 @@ func NewTestInterpreterContractValueHandler(
 			contract, err := NewTestContract(
 				inter,
 				testFramework,
-				constructorGenerator(common.Address{}),
+				constructorGenerator(common.NilAddress),
 				invocationRange,
 			)
 			if err != nil {
@@ -1634,7 +1634,7 @@ func NewTestInterpreterContractValueHandler(
 		default:
 			// During tests, imported contracts can be constructed using the constructor,
 			// similar to structs. Therefore, generate a constructor function.
-			return constructorGenerator(common.Address{})
+			return constructorGenerator(common.NilAddress)
 		}
 	}
 }

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -132,7 +132,7 @@ func TestInterpretToBytes(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredUInt8Value(0x0),
 				interpreter.NewUnmeteredUInt8Value(0x0),
 				interpreter.NewUnmeteredUInt8Value(0x0),

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -132,7 +132,7 @@ func TestInterpretToBytes(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredUInt8Value(0x0),
 				interpreter.NewUnmeteredUInt8Value(0x0),
 				interpreter.NewUnmeteredUInt8Value(0x0),

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -64,7 +64,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredStringValue("baz"),
 				interpreter.NewUnmeteredStringValue("bar"),
 			),
@@ -138,7 +138,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredStringValue("foo"),
 				interpreter.NewUnmeteredStringValue("bar"),
 				interpreter.NewUnmeteredStringValue("baz"),
@@ -213,7 +213,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredStringValue("foo"),
 				interpreter.NewUnmeteredStringValue("baz"),
 				interpreter.NewUnmeteredStringValue("bar"),
@@ -274,7 +274,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredStringValue("foo"),
 				interpreter.NewUnmeteredStringValue("bar"),
 			),

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -64,7 +64,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredStringValue("baz"),
 				interpreter.NewUnmeteredStringValue("bar"),
 			),
@@ -138,7 +138,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredStringValue("foo"),
 				interpreter.NewUnmeteredStringValue("bar"),
 				interpreter.NewUnmeteredStringValue("baz"),
@@ -213,7 +213,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredStringValue("foo"),
 				interpreter.NewUnmeteredStringValue("baz"),
 				interpreter.NewUnmeteredStringValue("bar"),
@@ -274,7 +274,7 @@ func TestArrayMutation(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredStringValue("foo"),
 				interpreter.NewUnmeteredStringValue("bar"),
 			),

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -139,7 +139,7 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
@@ -175,7 +175,7 @@ func TestInterpretEnumConstructor(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
@@ -210,7 +210,7 @@ func TestInterpretEnumInstance(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -139,7 +139,7 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
@@ -175,7 +175,7 @@ func TestInterpretEnumConstructor(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
@@ -210,7 +210,7 @@ func TestInterpretEnumInstance(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -248,7 +248,7 @@ func TestInterpretForString(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeCharacter,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredCharacterValue("👪"),
 			interpreter.NewUnmeteredCharacterValue("❤️"),
 		),

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -248,7 +248,7 @@ func TestInterpretForString(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeCharacter,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredCharacterValue("👪"),
 			interpreter.NewUnmeteredCharacterValue("❤️"),
 		),

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -89,7 +89,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 						"Foo",
 						common.CompositeKindContract,
 						nil,
-						common.NilAddress,
+						common.ZeroAddress,
 					)
 
 					value.Functions = map[string]interpreter.FunctionValue{

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -89,7 +89,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 						"Foo",
 						common.CompositeKindContract,
 						nil,
-						common.Address{},
+						common.NilAddress,
 					)
 
 					value.Functions = map[string]interpreter.FunctionValue{

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -209,7 +209,7 @@ func makeContractValueHandler(
 		invocationRange ast.Range,
 	) interpreter.ContractValue {
 
-		constructor := constructorGenerator(common.Address{})
+		constructor := constructorGenerator(common.NilAddress)
 
 		value, err := inter.InvokeFunctionValue(
 			constructor,
@@ -276,7 +276,7 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
@@ -681,7 +681,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 		interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeInt,
 		},
-		common.Address{},
+		common.NilAddress,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
 		interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
@@ -2420,7 +2420,7 @@ func TestInterpretStructCopyOnDeclaration(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2465,7 +2465,7 @@ func TestInterpretStructCopyOnDeclarationModifiedWithStructFunction(t *testing.T
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2507,7 +2507,7 @@ func TestInterpretStructCopyOnIdentifierAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2549,7 +2549,7 @@ func TestInterpretStructCopyOnIndexingAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2598,7 +2598,7 @@ func TestInterpretStructCopyOnMemberAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2674,7 +2674,7 @@ func TestInterpretArrayCopy(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(0),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
@@ -2715,7 +2715,7 @@ func TestInterpretStructCopyInArray(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
@@ -6348,7 +6348,7 @@ func TestInterpretSwapVariables(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
@@ -6389,7 +6389,7 @@ func TestInterpretSwapArrayAndField(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
@@ -6819,7 +6819,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
 			fields1,
-			common.Address{},
+			common.NilAddress,
 		),
 		interpreter.NewCompositeValue(
 			inter,
@@ -6828,7 +6828,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
 			fields2,
-			common.Address{},
+			common.NilAddress,
 		),
 		interpreter.NewCompositeValue(
 			inter,
@@ -6837,7 +6837,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 			TestLocation.QualifiedIdentifier(transferAmountEventType.ID()),
 			common.CompositeKindEvent,
 			fields3,
-			common.Address{},
+			common.NilAddress,
 		),
 	}
 
@@ -6895,7 +6895,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		"S",
 		common.CompositeKindStructure,
 		nil,
-		common.Address{},
+		common.NilAddress,
 	)
 	sValue.Functions = map[string]interpreter.FunctionValue{}
 
@@ -7054,7 +7054,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 					},
-					common.Address{},
+					common.NilAddress,
 					testCase.value,
 				),
 				literal: fmt.Sprintf("[%s as %s]", testCase, validType),
@@ -7069,7 +7069,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 						Size: 1,
 					},
-					common.Address{},
+					common.NilAddress,
 					testCase.value,
 				),
 				literal: fmt.Sprintf("[%s as %s]", testCase, validType),
@@ -7170,7 +7170,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 					TestLocation.QualifiedIdentifier(testType.ID()),
 					common.CompositeKindEvent,
 					fields,
-					common.Address{},
+					common.NilAddress,
 				),
 			}
 
@@ -7357,7 +7357,7 @@ func TestInterpretReferenceUse(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
@@ -7409,7 +7409,7 @@ func TestInterpretReferenceUseAccess(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(0),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
@@ -7587,7 +7587,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 						Type: interpreter.PrimitiveStaticTypeString,
 					},
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
@@ -7674,7 +7674,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 						Type: interpreter.PrimitiveStaticTypeString,
 					},
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
@@ -8193,7 +8193,7 @@ func TestInterpretFungibleTokenContract(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 				Size: 2,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(40),
 			interpreter.NewUnmeteredIntValueFromInt64(60),
 		),
@@ -8939,7 +8939,7 @@ func TestInterpretReferenceUseAfterCopy(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredStringValue("2"),
 				interpreter.NewUnmeteredStringValue("3"),
 			),
@@ -9058,7 +9058,7 @@ func newTestAuthAccountValue(gauge common.MemoryGauge, addressValue interpreter.
 						interpreter.VariableSizedStaticType{
 							Type: interpreter.PrimitiveStaticTypeString,
 						},
-						common.Address{},
+						common.NilAddress,
 					)
 				},
 			)
@@ -9126,7 +9126,7 @@ func newTestPublicAccountValue(gauge common.MemoryGauge, addressValue interprete
 						interpreter.VariableSizedStaticType{
 							Type: interpreter.PrimitiveStaticTypeString,
 						},
-						common.Address{},
+						common.NilAddress,
 					)
 				},
 			)
@@ -9688,7 +9688,7 @@ func TestInterpretInternalAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: stringIntDictionaryStaticType,
 			},
-			common.Address{},
+			common.NilAddress,
 			interpreter.NewDictionaryValue(
 				inter,
 				interpreter.EmptyLocationRange,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -209,7 +209,7 @@ func makeContractValueHandler(
 		invocationRange ast.Range,
 	) interpreter.ContractValue {
 
-		constructor := constructorGenerator(common.NilAddress)
+		constructor := constructorGenerator(common.ZeroAddress)
 
 		value, err := inter.InvokeFunctionValue(
 			constructor,
@@ -276,7 +276,7 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
@@ -681,7 +681,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 		interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeInt,
 		},
-		common.NilAddress,
+		common.ZeroAddress,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
 		interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
@@ -2420,7 +2420,7 @@ func TestInterpretStructCopyOnDeclaration(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2465,7 +2465,7 @@ func TestInterpretStructCopyOnDeclarationModifiedWithStructFunction(t *testing.T
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2507,7 +2507,7 @@ func TestInterpretStructCopyOnIdentifierAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2549,7 +2549,7 @@ func TestInterpretStructCopyOnIndexingAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2598,7 +2598,7 @@ func TestInterpretStructCopyOnMemberAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.FalseValue,
 			interpreter.TrueValue,
 		),
@@ -2674,7 +2674,7 @@ func TestInterpretArrayCopy(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(0),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
@@ -2715,7 +2715,7 @@ func TestInterpretStructCopyInArray(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
@@ -6348,7 +6348,7 @@ func TestInterpretSwapVariables(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
@@ -6389,7 +6389,7 @@ func TestInterpretSwapArrayAndField(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
@@ -6819,7 +6819,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
 			fields1,
-			common.NilAddress,
+			common.ZeroAddress,
 		),
 		interpreter.NewCompositeValue(
 			inter,
@@ -6828,7 +6828,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 			TestLocation.QualifiedIdentifier(transferEventType.ID()),
 			common.CompositeKindEvent,
 			fields2,
-			common.NilAddress,
+			common.ZeroAddress,
 		),
 		interpreter.NewCompositeValue(
 			inter,
@@ -6837,7 +6837,7 @@ func TestInterpretEmitEvent(t *testing.T) {
 			TestLocation.QualifiedIdentifier(transferAmountEventType.ID()),
 			common.CompositeKindEvent,
 			fields3,
-			common.NilAddress,
+			common.ZeroAddress,
 		),
 	}
 
@@ -6895,7 +6895,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		"S",
 		common.CompositeKindStructure,
 		nil,
-		common.NilAddress,
+		common.ZeroAddress,
 	)
 	sValue.Functions = map[string]interpreter.FunctionValue{}
 
@@ -7054,7 +7054,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 					interpreter.VariableSizedStaticType{
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 					},
-					common.NilAddress,
+					common.ZeroAddress,
 					testCase.value,
 				),
 				literal: fmt.Sprintf("[%s as %s]", testCase, validType),
@@ -7069,7 +7069,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 						Size: 1,
 					},
-					common.NilAddress,
+					common.ZeroAddress,
 					testCase.value,
 				),
 				literal: fmt.Sprintf("[%s as %s]", testCase, validType),
@@ -7170,7 +7170,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 					TestLocation.QualifiedIdentifier(testType.ID()),
 					common.CompositeKindEvent,
 					fields,
-					common.NilAddress,
+					common.ZeroAddress,
 				),
 			}
 
@@ -7357,7 +7357,7 @@ func TestInterpretReferenceUse(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
@@ -7409,7 +7409,7 @@ func TestInterpretReferenceUseAccess(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(0),
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
@@ -7587,7 +7587,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 						Type: interpreter.PrimitiveStaticTypeString,
 					},
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
@@ -7674,7 +7674,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 						Type: interpreter.PrimitiveStaticTypeString,
 					},
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
@@ -8193,7 +8193,7 @@ func TestInterpretFungibleTokenContract(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 				Size: 2,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewUnmeteredIntValueFromInt64(40),
 			interpreter.NewUnmeteredIntValueFromInt64(60),
 		),
@@ -8939,7 +8939,7 @@ func TestInterpretReferenceUseAfterCopy(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredStringValue("2"),
 				interpreter.NewUnmeteredStringValue("3"),
 			),
@@ -9058,7 +9058,7 @@ func newTestAuthAccountValue(gauge common.MemoryGauge, addressValue interpreter.
 						interpreter.VariableSizedStaticType{
 							Type: interpreter.PrimitiveStaticTypeString,
 						},
-						common.NilAddress,
+						common.ZeroAddress,
 					)
 				},
 			)
@@ -9126,7 +9126,7 @@ func newTestPublicAccountValue(gauge common.MemoryGauge, addressValue interprete
 						interpreter.VariableSizedStaticType{
 							Type: interpreter.PrimitiveStaticTypeString,
 						},
-						common.NilAddress,
+						common.ZeroAddress,
 					)
 				},
 			)
@@ -9688,7 +9688,7 @@ func TestInterpretInternalAssignment(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: stringIntDictionaryStaticType,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			interpreter.NewDictionaryValue(
 				inter,
 				interpreter.EmptyLocationRange,

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -106,7 +106,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
-				common.Address{},
+				common.NilAddress,
 				interpreter.NewUnmeteredUInt8Value(1),
 				interpreter.NewUnmeteredUInt8Value(0xCA),
 				interpreter.NewUnmeteredUInt8Value(0xDE),
@@ -272,7 +272,7 @@ func TestInterpretStringUtf8Field(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeUInt8,
 			},
-			common.Address{},
+			common.NilAddress,
 			// Flowers
 			interpreter.NewUnmeteredUInt8Value(70),
 			interpreter.NewUnmeteredUInt8Value(108),

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -106,7 +106,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 				interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
-				common.NilAddress,
+				common.ZeroAddress,
 				interpreter.NewUnmeteredUInt8Value(1),
 				interpreter.NewUnmeteredUInt8Value(0xCA),
 				interpreter.NewUnmeteredUInt8Value(0xDE),
@@ -272,7 +272,7 @@ func TestInterpretStringUtf8Field(t *testing.T) {
 			interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeUInt8,
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 			// Flowers
 			interpreter.NewUnmeteredUInt8Value(70),
 			interpreter.NewUnmeteredUInt8Value(108),

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1263,7 +1263,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 					Value: rawValue,
 				},
 			},
-			common.NilAddress,
+			common.ZeroAddress,
 		)
 
 		if enum.GetField(inter, interpreter.EmptyLocationRange, sema.EnumRawValueFieldName) == nil {
@@ -1323,7 +1323,7 @@ func randomDictionaryValue(
 			KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 			ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 		},
-		common.NilAddress,
+		common.ZeroAddress,
 		keyValues...,
 	)
 }
@@ -1347,7 +1347,7 @@ func randomArrayValue(inter *interpreter.Interpreter, currentDepth int) interpre
 		interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeAnyStruct,
 		},
-		common.NilAddress,
+		common.ZeroAddress,
 		elements...,
 	)
 }
@@ -1412,7 +1412,7 @@ func randomCompositeValue(
 		identifier,
 		kind,
 		fields,
-		common.NilAddress,
+		common.ZeroAddress,
 	)
 }
 

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1263,7 +1263,7 @@ func generateRandomHashableValue(inter *interpreter.Interpreter, n int) interpre
 					Value: rawValue,
 				},
 			},
-			common.Address{},
+			common.NilAddress,
 		)
 
 		if enum.GetField(inter, interpreter.EmptyLocationRange, sema.EnumRawValueFieldName) == nil {
@@ -1323,7 +1323,7 @@ func randomDictionaryValue(
 			KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 			ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 		},
-		common.Address{},
+		common.NilAddress,
 		keyValues...,
 	)
 }
@@ -1347,7 +1347,7 @@ func randomArrayValue(inter *interpreter.Interpreter, currentDepth int) interpre
 		interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeAnyStruct,
 		},
-		common.Address{},
+		common.NilAddress,
 		elements...,
 	)
 }
@@ -1412,7 +1412,7 @@ func randomCompositeValue(
 		identifier,
 		kind,
 		fields,
-		common.Address{},
+		common.NilAddress,
 	)
 }
 

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -71,7 +71,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 					cadence.Struct{}.
 						WithType(&cadence.StructType{
 							Location: common.AddressLocation{
-								Address: common.Address{},
+								Address: common.NilAddress,
 								Name:    "Foo",
 							},
 							QualifiedIdentifier: "Foo.Bar",
@@ -122,7 +122,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 					cadence.Struct{}.
 						WithType(&cadence.StructType{
 							Location: common.AddressLocation{
-								Address: common.Address{},
+								Address: common.NilAddress,
 								Name:    "Foo",
 							},
 							QualifiedIdentifier: "Foo.Bar",

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -71,7 +71,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 					cadence.Struct{}.
 						WithType(&cadence.StructType{
 							Location: common.AddressLocation{
-								Address: common.NilAddress,
+								Address: common.ZeroAddress,
 								Name:    "Foo",
 							},
 							QualifiedIdentifier: "Foo.Bar",
@@ -122,7 +122,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 					cadence.Struct{}.
 						WithType(&cadence.StructType{
 							Location: common.AddressLocation{
-								Address: common.NilAddress,
+								Address: common.ZeroAddress,
 								Name:    "Foo",
 							},
 							QualifiedIdentifier: "Foo.Bar",


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Introduces a global singleton `common.ZeroAddress` to be used in place of the empty constructor `common.Address{}` that pops up a bunch. This helps with code clarity and robustness in case we change the internal implementation of `Address`.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
