### PR TITLE
Interpret transaction role declarations

### DIFF
--- a/runtime/activations/activations.go
+++ b/runtime/activations/activations.go
@@ -171,8 +171,8 @@ func (a *Activations[T]) PushNewWithParent(parent *Activation[T]) *Activation[T]
 // PushNewWithCurrent pushes a new empty activation
 // to the top of the activation stack.
 // The new activation has the current activation as its parent.
-func (a *Activations[T]) PushNewWithCurrent() {
-	a.PushNewWithParent(a.Current())
+func (a *Activations[T]) PushNewWithCurrent() *Activation[T] {
+	return a.PushNewWithParent(a.Current())
 }
 
 // Push pushes the given activation

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -206,6 +206,12 @@ func (interpreter *Interpreter) checkMemberAccess(
 
 		return
 
+	case *sema.TransactionRoleType:
+		// TODO: maybe also check transaction roles.
+		//   they are composites with a type ID which is not declared, i.e. no type is available
+
+		return
+
 	case *sema.CompositeType:
 		// TODO: also check built-in values.
 		//   blocked by standard library values (RLP, BLS, etc.),

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -93,7 +93,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 
 	transactionFunction := &HostFunctionValue{
 		Function: func(invocation Invocation) Value {
-			interpreter.activations.PushNewWithParent(lexicalScope)
+			transactionScope := interpreter.activations.PushNewWithParent(lexicalScope)
 			defer interpreter.activations.Pop()
 
 			self := MemberAccessibleValue(transactionValue)
@@ -113,10 +113,6 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 				interpreter.bindParameterArguments(declaration.ParameterList, transactionArguments)
 				invocation.Arguments = prepareArguments
 			}
-
-			// NOTE: get current scope instead of using `lexicalScope`,
-			// because current scope has `self` declared
-			transactionScope := interpreter.activations.CurrentOrNew()
 
 			if prepareFunction != nil {
 				prepare := interpreter.functionDeclarationValue(
@@ -219,14 +215,12 @@ func (interpreter *Interpreter) declareTransactionRole(
 
 	roleFunction = &HostFunctionValue{
 		Function: func(invocation Invocation) Value {
-			interpreter.activations.PushNewWithCurrent()
+			transactionRoleScope := interpreter.activations.PushNewWithCurrent()
 			defer interpreter.activations.Pop()
 
 			self := MemberAccessibleValue(roleValue)
 			invocation.Self = &self
 			interpreter.declareVariable(sema.SelfIdentifier, self)
-
-			transactionRoleScope := interpreter.activations.CurrentOrNew()
 
 			if prepareFunction != nil {
 				prepare := interpreter.functionDeclarationValue(

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -180,7 +180,7 @@ func (interpreter *Interpreter) declareTransactionRole(
 	declaration *ast.TransactionRoleDeclaration,
 ) (
 	roleValue *SimpleCompositeValue,
-	prepareFunctionValue *HostFunctionValue,
+	roleFunction *HostFunctionValue,
 ) {
 	transactionRoleType := interpreter.Program.Elaboration.TransactionRoleDeclarationType(declaration)
 
@@ -217,7 +217,7 @@ func (interpreter *Interpreter) declareTransactionRole(
 
 	common.UseMemory(interpreter, common.HostFunctionValueMemoryUsage)
 
-	prepareFunctionValue = &HostFunctionValue{
+	roleFunction = &HostFunctionValue{
 		Function: func(invocation Invocation) Value {
 			interpreter.activations.PushNewWithCurrent()
 			defer interpreter.activations.Pop()

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -37,7 +37,7 @@ func TestInterpretTransactions(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("NoPrepareFunction", func(t *testing.T) {
+	t.Run("no prepare function", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -53,7 +53,7 @@ func TestInterpretTransactions(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("SetTransactionField", func(t *testing.T) {
+	t.Run("field and prepare", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -76,7 +76,7 @@ func TestInterpretTransactions(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("PreConditions", func(t *testing.T) {
+	t.Run("succeeding pre-condition", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -99,7 +99,7 @@ func TestInterpretTransactions(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("FailingPreConditions", func(t *testing.T) {
+	t.Run("failing pre-condition", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -130,7 +130,7 @@ func TestInterpretTransactions(t *testing.T) {
 		)
 	})
 
-	t.Run("PostConditions", func(t *testing.T) {
+	t.Run("succeeding post-condition", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -157,7 +157,7 @@ func TestInterpretTransactions(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("FailingPostConditions", func(t *testing.T) {
+	t.Run("failing post-condition", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -192,7 +192,7 @@ func TestInterpretTransactions(t *testing.T) {
 		)
 	})
 
-	t.Run("MultipleTransactions", func(t *testing.T) {
+	t.Run("multiple transactions", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -223,7 +223,7 @@ func TestInterpretTransactions(t *testing.T) {
 		assert.IsType(t, interpreter.TransactionNotDeclaredError{}, err)
 	})
 
-	t.Run("TooFewArguments", func(t *testing.T) {
+	t.Run("invocation with too few arguments", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -237,7 +237,7 @@ func TestInterpretTransactions(t *testing.T) {
 		assert.IsType(t, interpreter.ArgumentCountError{}, err)
 	})
 
-	t.Run("TooManyArguments", func(t *testing.T) {
+	t.Run("invocation with too many arguments", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -271,7 +271,7 @@ func TestInterpretTransactions(t *testing.T) {
 		assert.IsType(t, interpreter.ArgumentCountError{}, err)
 	})
 
-	t.Run("Parameters", func(t *testing.T) {
+	t.Run("transaction parameters", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -326,7 +326,7 @@ func TestInterpretTransactionRoles(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("NoPrepareFunction", func(t *testing.T) {
+	t.Run("single role with field", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -438,7 +438,7 @@ func TestInterpretTransactionRoles(t *testing.T) {
 		)
 	})
 
-	t.Run("single role with field", func(t *testing.T) {
+	t.Run("multiple roles, each with a field", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -371,19 +371,20 @@ func TestInterpretTransactionRoles(t *testing.T) {
 
                       prepare(signer: AuthAccount) {
                           log("a 2")
-                          log(a)
-                          log("b 2")
-                          log(b)
-                          log("self.bar")
+                          //log(a)
+                          //log("b 2")
+                          //log(b)
                           self.bar = signer.address.toString()
+                          log("self.bar")
+                          log(self.bar)
                       }
                   }
 
                   execute {
                       log("self.foo 2")
                       log(self.foo)
-                      //log("self.buyer.bar")
-                      //log(self.buyer.bar)
+                      log("self.buyer.bar")
+                      log(self.buyer.bar)
                   }
               }
             `,
@@ -409,7 +410,7 @@ func TestInterpretTransactionRoles(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("B"),
 			signer,
 		)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		assert.Equal(t,
 			[]string{
@@ -420,15 +421,17 @@ func TestInterpretTransactionRoles(t *testing.T) {
 				"B",
 				"self.foo 1",
 				"0x0000000000000001",
-				//// role prepare
-				//"a 2",
+				// role prepare
+				"a 2",
 				//"A",
 				//"b 2",
 				//"B",
-				//"self.bar",
-				//"0x0000000000000001",
+				"self.bar",
+				"0x0000000000000001",
 				// execute
 				"self.foo 2",
+				"0x0000000000000001",
+				"self.buyer.bar",
 				"0x0000000000000001",
 			},
 			logs,

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -371,9 +371,9 @@ func TestInterpretTransactionRoles(t *testing.T) {
 
                       prepare(signer: AuthAccount) {
                           log("a 2")
-                          //log(a)
-                          //log("b 2")
-                          //log(b)
+                          log(a)
+                          log("b 2")
+                          log(b)
                           self.bar = signer.address.toString()
                           log("self.bar")
                           log(self.bar)
@@ -423,9 +423,9 @@ func TestInterpretTransactionRoles(t *testing.T) {
 				"0x0000000000000001",
 				// role prepare
 				"a 2",
-				//"A",
-				//"b 2",
-				//"B",
+				"A",
+				"b 2",
+				"B",
 				"self.bar",
 				"0x0000000000000001",
 				// execute


### PR DESCRIPTION
Work towards #2177

## Description

Interpret transaction roles. Call each role's prepare block just like the transaction's prepare block before.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
