### PR TITLE
Add support for resource-kinded fields in transaction roles

### DIFF
--- a/runtime/ast/transaction_declaration.go
+++ b/runtime/ast/transaction_declaration.go
@@ -198,10 +198,10 @@ func (d *TransactionDeclaration) String() string {
 // TransactionRoleDeclaration
 
 type TransactionRoleDeclaration struct {
-	Identifier Identifier
 	Prepare    *SpecialFunctionDeclaration
 	DocString  string
 	Fields     []*FieldDeclaration
+	Identifier Identifier
 	Range
 }
 

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -239,10 +239,10 @@ func (e RedeclarationError) Error() string {
 // DereferenceError
 
 type DereferenceError struct {
-	Cause        string
+	LocationRange
 	ExpectedType sema.Type
 	ActualType   sema.Type
-	LocationRange
+	Cause        string
 }
 
 var _ errors.UserError = DereferenceError{}

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -171,17 +171,22 @@ func (checker *Checker) visitCompositeDeclaration(declaration *ast.CompositeDecl
 
 	// NOTE: check destructors after initializer and functions
 
-	checker.withSelfResourceInvalidationAllowed(func() {
-		checker.checkDestructors(
-			declaration.Members.Destructors(),
-			declaration.Members.FieldsByIdentifier(),
-			compositeType.Members,
-			compositeType,
-			declaration.DeclarationKind(),
-			declaration.DeclarationDocString(),
-			kind,
-		)
-	})
+	checker.withResourceFieldInvalidationAllowed(
+		func(expression *ast.MemberExpression) *Member {
+			return checker.accessedSelfMember(expression)
+		},
+		func() {
+			checker.checkDestructors(
+				declaration.Members.Destructors(),
+				declaration.Members.FieldsByIdentifier(),
+				compositeType.Members,
+				compositeType,
+				declaration.DeclarationKind(),
+				declaration.DeclarationDocString(),
+				kind,
+			)
+		},
+	)
 
 	// NOTE: visit interfaces first
 	// DON'T use `nestedDeclarations`, because of non-deterministic order

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -83,9 +83,14 @@ func (checker *Checker) VisitTransactionDeclaration(declaration *ast.Transaction
 		declaration.PostConditions,
 		VoidType,
 		func() {
-			checker.withSelfResourceInvalidationAllowed(func() {
-				checker.visitTransactionExecuteFunction(declaration.Execute, transactionType)
-			})
+			checker.withResourceFieldInvalidationAllowed(
+				func(expression *ast.MemberExpression) *Member {
+					return checker.accessedSelfMember(expression)
+				},
+				func() {
+					checker.visitTransactionExecuteFunction(declaration.Execute, transactionType)
+				},
+			)
 		},
 	)
 

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -103,8 +103,15 @@ func (checker *Checker) VisitTransactionDeclaration(declaration *ast.Transaction
 
 	checker.checkResourceFieldsInvalidated(transactionType, members)
 
-	transactionType.Roles.Foreach(func(_ string, roleTye *TransactionRoleType) {
-		checker.checkResourceFieldsInvalidated(roleTye, roleTye.Members)
+	transactionType.Members.Foreach(func(_ string, member *Member) {
+		transactionRoleType, ok := member.TypeAnnotation.Type.(*TransactionRoleType)
+		if !ok {
+			return
+		}
+		checker.checkResourceFieldsInvalidated(
+			transactionRoleType,
+			transactionRoleType.Members,
+		)
 	})
 
 	return

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1407,8 +1407,9 @@ func (checker *Checker) recordResourceInvalidation(
 		})
 
 	case *ast.MemberExpression:
-		if checker.resourceFieldInvalidationAllowed != nil {
-			member := checker.resourceFieldInvalidationAllowed(expression)
+		resourceFieldInvalidationAllowed := checker.resourceFieldInvalidationAllowed
+		if resourceFieldInvalidationAllowed != nil {
+			member := resourceFieldInvalidationAllowed(expression)
 			if member != nil {
 				return getRecordedResourceInvalidation(Resource{
 					Member: member,

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -91,24 +91,24 @@ type ContractValueHandlerFunc func(
 
 type Checker struct {
 	// memoryGauge is used for metering memory usage
-	memoryGauge             common.MemoryGauge
-	Location                common.Location
-	expectedType            Type
-	resources               *Resources
-	valueActivations        *VariableActivations
-	currentMemberExpression *ast.MemberExpression
-	typeActivations         *VariableActivations
-	containerTypes          map[Type]struct{}
-	Program                 *ast.Program
-	PositionInfo            *PositionInfo
-	Config                  *Config
-	Elaboration             *Elaboration
+	memoryGauge  common.MemoryGauge
+	Location     common.Location
+	expectedType Type
+	Config       *Config
 	// initialized lazily. use beforeExtractor()
 	_beforeExtractor                 *BeforeExtractor
-	errors                           []error
-	functionActivations              *FunctionActivations
-	inCondition                      bool
+	currentMemberExpression          *ast.MemberExpression
+	typeActivations                  *VariableActivations
+	containerTypes                   map[Type]struct{}
+	Program                          *ast.Program
+	PositionInfo                     *PositionInfo
+	resources                        *Resources
+	Elaboration                      *Elaboration
+	valueActivations                 *VariableActivations
 	resourceFieldInvalidationAllowed func(*ast.MemberExpression) *Member
+	functionActivations              *FunctionActivations
+	errors                           []error
+	inCondition                      bool
 	inAssignment                     bool
 	inInvocation                     bool
 	inCreate                         bool

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1355,9 +1355,10 @@ func (checker *Checker) recordResourceInvalidation(
 		return nil
 	}
 
-	reportInvalidNestedMove := func() {
+	reportInvalidNestedMove := func(identifier *ast.Identifier) {
 		checker.report(
 			&InvalidNestedResourceMoveError{
+				Identifier: identifier,
 				Range: ast.NewRangeFromPositioned(
 					checker.memoryGauge,
 					expression,
@@ -1417,11 +1418,11 @@ func (checker *Checker) recordResourceInvalidation(
 			}
 		}
 
-		reportInvalidNestedMove()
+		reportInvalidNestedMove(&expression.Identifier)
 		return nil
 
 	case *ast.IndexExpression:
-		reportInvalidNestedMove()
+		reportInvalidNestedMove(nil)
 		return nil
 
 	default:

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -1860,6 +1860,7 @@ func (e *MissingResourceAnnotationError) Error() string {
 // InvalidNestedResourceMoveError
 
 type InvalidNestedResourceMoveError struct {
+	Identifier *ast.Identifier
 	ast.Range
 }
 
@@ -1871,6 +1872,11 @@ func (*InvalidNestedResourceMoveError) isSemanticError() {}
 func (*InvalidNestedResourceMoveError) IsUserError() {}
 
 func (e *InvalidNestedResourceMoveError) Error() string {
+	identifier := e.Identifier
+	if identifier != nil {
+		return fmt.Sprintf("cannot move nested resource-kinded field `%s`", identifier.Identifier)
+	}
+
 	return "cannot move nested resource"
 }
 
@@ -2903,7 +2909,6 @@ func (e *ReadOnlyTargetAssignmentError) Error() string {
 }
 
 // MissingPrepareForFieldError
-//
 type MissingPrepareForFieldError struct {
 	FirstFieldName string
 	FirstFieldPos  ast.Position

--- a/runtime/sema/resources.go
+++ b/runtime/sema/resources.go
@@ -57,7 +57,7 @@ import (
 
 */
 
-// A Resource is a variable or a member
+// A Resource is a variable OR a member
 type Resource struct {
 	Variable *Variable
 	Member   *Member

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -5649,7 +5648,6 @@ func IsNilType(ty Type) bool {
 
 type TransactionType struct {
 	Members           *StringMemberOrderedMap
-	Roles             *orderedmap.OrderedMap[string, *TransactionRoleType]
 	Fields            []string
 	PrepareParameters []Parameter
 	Parameters        []Parameter

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5649,10 +5649,10 @@ func IsNilType(ty Type) bool {
 
 type TransactionType struct {
 	Members           *StringMemberOrderedMap
+	Roles             *orderedmap.OrderedMap[string, *TransactionRoleType]
 	Fields            []string
 	PrepareParameters []Parameter
 	Parameters        []Parameter
-	Roles             *orderedmap.OrderedMap[string, *TransactionRoleType]
 }
 
 var _ Type = &TransactionType{}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/errors"
 )
 

--- a/runtime/tests/checker/transactions_test.go
+++ b/runtime/tests/checker/transactions_test.go
@@ -261,14 +261,14 @@ func TestCheckTransactions(t *testing.T) {
 
               transaction {
 
-                var x: @R
+                var r: @R
 
                 prepare() {
-                    self.x <- create R()
+                    self.r <- create R()
                 }
 
                 execute {
-                    destroy self.x
+                    destroy self.r
                 }
               }
             `,
@@ -283,10 +283,10 @@ func TestCheckTransactions(t *testing.T) {
 
               transaction {
 
-                  var x: @R
+                  var r: @R
 
                   prepare() {
-                      self.x <- create R()
+                      self.r <- create R()
                   }
 
                   execute {}
@@ -555,7 +555,7 @@ func TestCheckTransactionRoles(t *testing.T) {
 
                   prepare(signer: AuthAccount) {}
 
-                  role buyer {
+                  role role1 {
                       let foo: Int
 
                       prepare(foo: Int) {
@@ -579,7 +579,7 @@ func TestCheckTransactionRoles(t *testing.T) {
 
                   prepare(signer: AuthAccount) {}
 
-                  role buyer {
+                  role role1 {
                       prepare(signer: AuthAccount) {}
                   }
               }
@@ -596,7 +596,7 @@ func TestCheckTransactionRoles(t *testing.T) {
 
                   prepare(signer: AuthAccount) {}
 
-                  role buyer {}
+                  role role1 {}
               }
             `,
 			[]error{
@@ -613,7 +613,7 @@ func TestCheckTransactionRoles(t *testing.T) {
 
                   prepare(signer: AuthAccount) {}
 
-                  role buyer {
+                  role role1 {
                       prepare() {}
                   }
               }
@@ -632,7 +632,7 @@ func TestCheckTransactionRoles(t *testing.T) {
 
                   prepare(signer: AuthAccount) {}
 
-                  role buyer {
+                  role role1 {
                       prepare(firstSigner: AuthAccount, secondSigner: AuthAccount) {}
                   }
               }
@@ -649,7 +649,7 @@ func TestCheckTransactionRoles(t *testing.T) {
 			`
               transaction(foo: Int) {
 
-                  role buyer {
+                  role role1 {
                       let foo: Int
 
                       prepare() {
@@ -673,16 +673,16 @@ func TestCheckTransactionRoles(t *testing.T) {
 
               transaction {
 
-                  role buyer {
-                      var x: @R
+                  role role1 {
+                      var r: @R
 
                       prepare() {
-                          self.x <- create R()
+                          self.r <- create R()
                       }
                   }
 
                   execute {
-                      absorb(<-self.buyer.x)
+                      absorb(<-self.role1.r)
                   }
               }
             `,
@@ -697,11 +697,11 @@ func TestCheckTransactionRoles(t *testing.T) {
 
               transaction {
 
-                  role buyer {
-                      var x: @R
+                  role role1 {
+                      var r: @R
 
                       prepare() {
-                          self.x <- create R()
+                          self.r <- create R()
                       }
                   }
 
@@ -857,7 +857,7 @@ func TestCheckInvalidTransactionRoleSelfMove(t *testing.T) {
 
           transaction {
 
-              role buyer {
+              role role1 {
                   prepare() {
                       let x = self
                   }
@@ -878,7 +878,7 @@ func TestCheckInvalidTransactionRoleSelfMove(t *testing.T) {
 
           transaction {
 
-              role buyer {
+              role role1 {
                   prepare() {
                       let txs = [self]
                   }
@@ -899,7 +899,7 @@ func TestCheckInvalidTransactionRoleSelfMove(t *testing.T) {
 
           transaction {
 
-              role buyer {
+              role role1 {
                   prepare() {
                       let txs = {"self": self}
                   }

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -88,17 +88,17 @@ func ParseAndCheckWithOptionsAndMemoryMetering(
 		return nil, err
 	}
 
+	config := options.Config
+	if config == nil {
+		config = &sema.Config{}
+	}
+
+	if config.AccessCheckMode == sema.AccessCheckModeDefault {
+		config.AccessCheckMode = sema.AccessCheckModeNotSpecifiedUnrestricted
+	}
+	config.ExtendedElaborationEnabled = true
+
 	check := func() (*sema.Checker, error) {
-
-		config := options.Config
-		if config == nil {
-			config = &sema.Config{}
-		}
-
-		if config.AccessCheckMode == sema.AccessCheckModeDefault {
-			config.AccessCheckMode = sema.AccessCheckModeNotSpecifiedUnrestricted
-		}
-		config.ExtendedElaborationEnabled = true
 
 		checker, err := sema.NewChecker(
 			program,

--- a/types.go
+++ b/types.go
@@ -1769,10 +1769,10 @@ func (t ReferenceType) Equal(other Type) bool {
 type restrictionSet = map[Type]struct{}
 
 type RestrictedType struct {
-	typeID             string
 	Type               Type
-	Restrictions       []Type
 	restrictionSet     restrictionSet
+	typeID             string
+	Restrictions       []Type
 	restrictionSetOnce sync.Once
 }
 


### PR DESCRIPTION
Work towards #2177

## Description

Transaction roles may have resource-kinded fields.

Add dedicated support for allowing resource-kinded fields to get invalidated in a transaction's execute block, even though such invalidations are nested, which are not allowed in other contexts (composite destructors).

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
