### PR TITLE
Update docs to reflect Account inbox live after MN21 spork

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -364,11 +364,6 @@ However, this method is deprecated and is available only for the backward compat
 
 ## Account Inbox
 
-<Callout type="warning">
-⚠️  This section describes a feature that is not yet released on Mainnet. 
-It will be available following the next Mainnet Spork. 
-</Callout>
-
 Accounts also possess an `Inbox` that can be used to make [Capabilities](capability-based-access-control) available to specific accounts. 
 The functions in this `Inbox` provide a convenient means to "bootstrap" Capabilities, 
 setting up an initial connection between two accounts that will later allow them to transfer data or permissions through a Capability.


### PR DESCRIPTION
Account inbox section of docs have this callout: "⚠️ This section describes a feature that is not yet released on Mainnet. It will be available following the next Mainnet Spork."

Remove the callout now that this has been deployed on MN21.

______


- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
