### PR TITLE
Forbid taking references of transaction roles

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2233,16 +2233,16 @@ func (checker *Checker) VisitExpressionWithForceType(expr ast.Expression, expect
 // visitExpressionWithForceType
 //
 // Parameters:
-// expr         - Expression to check
-// expectedType - Contextually expected type of the expression
-// forceType    - Specifies whether to use the expected type as a hard requirement (forceType = true)
-//
-//	or whether to use the expected type for type inferring only (forceType = false)
+//   - expr: Expression to check
+//   - expectedType: Contextually expected type of the expression
+//   - forceType:
+//     Specifies whether to use the expected type as a hard requirement (forceType = true)
+//     or whether to use the expected type for type inferring only (forceType = false)
 //
 // Return types:
-// visibleType - The type that others should 'see' as the type of this expression. This could be
-//
-//	used as the type of the expression to avoid the type errors being delegated up.
+//   - visibleType:
+//     The type that others should 'see' as the type of this expression.
+//     This could be used as the type of the expression to avoid the type errors being delegated up.
 //
 // actualType  - The actual type of the expression.
 func (checker *Checker) visitExpressionWithForceType(

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -2615,6 +2615,27 @@ func (e *NonReferenceTypeReferenceError) SecondaryError() string {
 	)
 }
 
+// InvalidReferenceTargetTypeError is reported when a reference expression
+// targets a type which may not be referenced.
+type InvalidReferenceTargetTypeError struct {
+	TargetType Type
+	ast.Range
+}
+
+var _ SemanticError = &InvalidReferenceTargetTypeError{}
+var _ errors.UserError = &InvalidReferenceTargetTypeError{}
+
+func (*InvalidReferenceTargetTypeError) isSemanticError() {}
+
+func (*InvalidReferenceTargetTypeError) IsUserError() {}
+
+func (e *InvalidReferenceTargetTypeError) Error() string {
+	return fmt.Sprintf(
+		"cannot create reference to `%s`",
+		e.TargetType.QualifiedString(),
+	)
+}
+
 // InvalidResourceCreationError
 
 type InvalidResourceCreationError struct {
@@ -2903,7 +2924,6 @@ func (e *ReadOnlyTargetAssignmentError) Error() string {
 }
 
 // MissingPrepareForFieldError
-//
 type MissingPrepareForFieldError struct {
 	FirstFieldName string
 	FirstFieldPos  ast.Position

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -1279,3 +1279,28 @@ func TestCheckReferenceTypeImplicitConformance(t *testing.T) {
 		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 }
+
+func TestCheckInvalidReferenceTargetType(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("transaction role", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          transaction {
+
+              role role1 {}
+
+              execute {
+                  &self.role1 as &AnyStruct
+              }
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.InvalidReferenceTargetTypeError{}, errs[0])
+	})
+}


### PR DESCRIPTION
Work towards #2177

## Description

As suggested in https://github.com/onflow/cadence/pull/2257#discussion_r1085598489, given that transaction roles are not first-class values, we should also forbid taking references to them.

Maybe we should also do this for other non-movable value types, like transactions, in Stable Cadence?

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
