### PR TITLE
Fix confusion of return type of checker's visitExpression methods

### DIFF
--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -71,7 +71,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 
 	referencedExpression := referenceExpression.Expression
 
-	_, _ = checker.visitExpression(referencedExpression, targetType)
+	_ = checker.VisitExpression(referencedExpression, targetType)
 
 	if referenceType == nil {
 		return InvalidType

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2194,8 +2194,10 @@ func (checker *Checker) convertInstantiationType(t *ast.InstantiationType) Type 
 }
 
 func (checker *Checker) VisitExpression(expr ast.Expression, expectedType Type) Type {
-	actualType, _ := checker.visitExpression(expr, expectedType)
-	return actualType
+	// Always return 'visibleType' as the type of the expression,
+	// to avoid bubbling up type-errors of inner expressions.
+	visibleType, _ := checker.visitExpression(expr, expectedType)
+	return visibleType
 }
 
 func (checker *Checker) visitExpression(expr ast.Expression, expectedType Type) (visibleType Type, actualType Type) {
@@ -2203,8 +2205,10 @@ func (checker *Checker) visitExpression(expr ast.Expression, expectedType Type) 
 }
 
 func (checker *Checker) VisitExpressionWithForceType(expr ast.Expression, expectedType Type, forceType bool) Type {
-	actualType, _ := checker.visitExpressionWithForceType(expr, expectedType, forceType)
-	return actualType
+	// Always return 'visibleType' as the type of the expression,
+	// to avoid bubbling up type-errors of inner expressions.
+	visibleType, _ := checker.visitExpressionWithForceType(expr, expectedType, forceType)
+	return visibleType
 }
 
 // visitExpressionWithForceType
@@ -2257,6 +2261,7 @@ func (checker *Checker) visitExpressionWithForceType(
 
 		// If there are type mismatch errors, return the expected type as the visible-type of the expression.
 		// This is done to avoid the same error getting delegated up.
+		// i.e: Impact of the mismatched type would be local to that expression only.
 		return expectedType, actualType
 	}
 


### PR DESCRIPTION
## Description

Cleans up the confusion about the return type

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
