### PR TITLE
Avoid unnecessary use of any and casts, parse function is generic now

### DIFF
--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -340,13 +340,11 @@ func TestParseParameterList(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string) (any, []error) {
+	parse := func(input string) (*ast.ParameterList, []error) {
 		return Parse(
 			nil,
 			[]byte(input),
-			func(p *parser) (any, error) {
-				return parseParameterList(p)
-			},
+			parseParameterList,
 			Config{},
 		)
 	}
@@ -1350,13 +1348,11 @@ func TestParseAccess(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string) (any, []error) {
+	parse := func(input string) (ast.Access, []error) {
 		return Parse(
 			nil,
 			[]byte(input),
-			func(p *parser) (any, error) {
-				return parseAccess(p)
-			},
+			parseAccess,
 			Config{},
 		)
 	}
@@ -1403,7 +1399,7 @@ func TestParseAccess(t *testing.T) {
 		)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			ast.AccessNotSpecified,
 			result,
 		)
 	})
@@ -1424,7 +1420,7 @@ func TestParseAccess(t *testing.T) {
 		)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			ast.AccessNotSpecified,
 			result,
 		)
 	})
@@ -1445,7 +1441,7 @@ func TestParseAccess(t *testing.T) {
 		)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			ast.AccessNotSpecified,
 			result,
 		)
 	})
@@ -1531,7 +1527,7 @@ func TestParseAccess(t *testing.T) {
 		)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			ast.AccessNotSpecified,
 			result,
 		)
 	})
@@ -1552,7 +1548,7 @@ func TestParseAccess(t *testing.T) {
 		)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			ast.AccessNotSpecified,
 			result,
 		)
 	})
@@ -1573,7 +1569,7 @@ func TestParseAccess(t *testing.T) {
 		)
 
 		utils.AssertEqualWithDiff(t,
-			nil,
+			ast.AccessNotSpecified,
 			result,
 		)
 	})
@@ -2043,11 +2039,11 @@ func TestParseFieldWithVariableKind(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string) (any, []error) {
+	parse := func(input string) (*ast.FieldDeclaration, []error) {
 		return Parse(
 			nil,
 			[]byte(input),
-			func(p *parser) (any, error) {
+			func(p *parser) (*ast.FieldDeclaration, error) {
 				return parseFieldWithVariableKind(
 					p,
 					ast.AccessNotSpecified,
@@ -2134,11 +2130,11 @@ func TestParseField(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string, config Config) (any, []error) {
+	parse := func(input string, config Config) (ast.Declaration, []error) {
 		return Parse(
 			nil,
 			[]byte(input),
-			func(p *parser) (any, error) {
+			func(p *parser) (ast.Declaration, error) {
 				return parseMemberOrNestedDeclaration(
 					p,
 					"",
@@ -6174,11 +6170,11 @@ func TestParseNestedPragma(t *testing.T) {
 
 	t.Parallel()
 
-	parse := func(input string, config Config) (any, []error) {
+	parse := func(input string, config Config) (ast.Declaration, []error) {
 		return Parse(
 			nil,
 			[]byte(input),
-			func(p *parser) (any, error) {
+			func(p *parser) (ast.Declaration, error) {
 				return parseMemberOrNestedDeclaration(
 					p,
 					"",

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -526,24 +526,14 @@ func (p *parser) endAmbiguity() {
 }
 
 func ParseExpression(memoryGauge common.MemoryGauge, input []byte, config Config) (expression ast.Expression, errs []error) {
-	var res any
-	res, errs = Parse(
+	return Parse(
 		memoryGauge,
 		input,
-		func(p *parser) (any, error) {
+		func(p *parser) (ast.Expression, error) {
 			return parseExpression(p, lowestBindingPower)
 		},
 		config,
 	)
-	if res == nil {
-		expression = nil
-		return
-	}
-	expression, ok := res.(ast.Expression)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return
 }
 
 func ParseStatements(
@@ -554,47 +544,25 @@ func ParseStatements(
 	statements []ast.Statement,
 	errs []error,
 ) {
-	var res any
-	res, errs = Parse(
+	return Parse(
 		memoryGauge,
 		input,
-		func(p *parser) (any, error) {
+		func(p *parser) ([]ast.Statement, error) {
 			return parseStatements(p, nil)
 		},
 		config,
 	)
-	if res == nil {
-		statements = nil
-		return
-	}
-
-	statements, ok := res.([]ast.Statement)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return
 }
 
 func ParseType(memoryGauge common.MemoryGauge, input []byte, config Config) (ty ast.Type, errs []error) {
-	var res any
-	res, errs = Parse(
+	return Parse(
 		memoryGauge,
 		input,
-		func(p *parser) (any, error) {
+		func(p *parser) (ast.Type, error) {
 			return parseType(p, lowestBindingPower)
 		},
 		config,
 	)
-	if res == nil {
-		ty = nil
-		return
-	}
-
-	ty, ok := res.(ast.Type)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return
 }
 
 func ParseDeclarations(
@@ -605,25 +573,14 @@ func ParseDeclarations(
 	declarations []ast.Declaration,
 	errs []error,
 ) {
-	var res any
-	res, errs = Parse(
+	return Parse(
 		memoryGauge,
 		input,
-		func(p *parser) (any, error) {
+		func(p *parser) ([]ast.Declaration, error) {
 			return parseDeclarations(p, lexer.TokenEOF)
 		},
 		config,
 	)
-	if res == nil {
-		declarations = nil
-		return
-	}
-
-	declarations, ok := res.([]ast.Declaration)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return
 }
 
 func ParseArgumentList(
@@ -634,11 +591,10 @@ func ParseArgumentList(
 	arguments ast.Arguments,
 	errs []error,
 ) {
-	var res any
-	res, errs = Parse(
+	return Parse(
 		memoryGauge,
 		input,
-		func(p *parser) (any, error) {
+		func(p *parser) (ast.Arguments, error) {
 			p.skipSpaceAndComments()
 
 			_, err := p.mustOne(lexer.TokenParenOpen)
@@ -651,17 +607,6 @@ func ParseArgumentList(
 		},
 		config,
 	)
-	if res == nil {
-		arguments = nil
-		return
-	}
-
-	arguments, ok := res.([]*ast.Argument)
-
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return
 }
 
 func ParseProgram(memoryGauge common.MemoryGauge, code []byte, config Config) (program *ast.Program, err error) {
@@ -678,12 +623,10 @@ func ParseProgramFromTokenStream(
 	program *ast.Program,
 	err error,
 ) {
-	var res any
-	var errs []error
-	res, errs = ParseTokenStream(
+	declarations, errs := ParseTokenStream(
 		memoryGauge,
 		input,
-		func(p *parser) (any, error) {
+		func(p *parser) ([]ast.Declaration, error) {
 			return parseDeclarations(p, lexer.TokenEOF)
 		},
 		config,
@@ -693,15 +636,6 @@ func ParseProgramFromTokenStream(
 			Code:   input.Input(),
 			Errors: errs,
 		}
-	}
-	if res == nil {
-		program = nil
-		return
-	}
-
-	declarations, ok := res.([]ast.Declaration)
-	if !ok {
-		panic(errors.NewUnreachableError())
 	}
 
 	program = ast.NewProgram(memoryGauge, declarations)

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -140,47 +140,47 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			nil,
 			[]byte("a b c d"),
-			func(p *parser) (any, error) {
+			func(p *parser) (struct{}, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				p.startBuffering()
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				p.acceptBuffered()
 
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
-				return nil, nil
+				return struct{}{}, nil
 			},
 			Config{},
 		)
@@ -195,47 +195,47 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			nil,
 			[]byte("a b x d"),
-			func(p *parser) (any, error) {
+			func(p *parser) (struct{}, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				p.startBuffering()
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				p.acceptBuffered()
 
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
-				return nil, nil
+				return struct{}{}, nil
 			},
 			Config{},
 		)
@@ -258,58 +258,58 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			nil,
 			[]byte("a b c d"),
-			func(p *parser) (any, error) {
+			func(p *parser) (struct{}, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				p.startBuffering()
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				err = p.replayBuffered()
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
-				return nil, nil
+				return struct{}{}, nil
 			},
 			Config{},
 		)
@@ -324,14 +324,14 @@ func TestParseBuffering(t *testing.T) {
 		_, errs := Parse(
 			nil,
 			[]byte("a b c d"),
-			func(p *parser) (any, error) {
+			func(p *parser) (struct{}, error) {
 				_, err := p.mustToken(lexer.TokenIdentifier, "a")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				p.startBuffering()
@@ -370,31 +370,31 @@ func TestParseBuffering(t *testing.T) {
 
 				err = p.replayBuffered()
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				_, err = p.mustToken(lexer.TokenIdentifier, "b")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustToken(lexer.TokenIdentifier, "c")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustOne(lexer.TokenSpace)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 				_, err = p.mustToken(lexer.TokenIdentifier, "d")
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
-				return nil, nil
+				return struct{}{}, nil
 			},
 			Config{},
 		)
@@ -598,15 +598,15 @@ func TestParseEOF(t *testing.T) {
 	_, errs := Parse(
 		nil,
 		[]byte("a b"),
-		func(p *parser) (any, error) {
+		func(p *parser) (struct{}, error) {
 			_, err := p.mustToken(lexer.TokenIdentifier, "a")
 			if err != nil {
-				return nil, err
+				return struct{}{}, err
 			}
 			p.skipSpaceAndComments()
 			_, err = p.mustToken(lexer.TokenIdentifier, "b")
 			if err != nil {
-				return nil, err
+				return struct{}{}, err
 			}
 
 			p.next()
@@ -635,7 +635,7 @@ func TestParseEOF(t *testing.T) {
 				p.current,
 			)
 
-			return nil, nil
+			return struct{}{}, nil
 		},
 		Config{},
 	)
@@ -685,12 +685,11 @@ func TestParseNames(t *testing.T) {
 
 		actual, err := testParseProgram(code)
 
-		if validExpected {
-			assert.NotNil(t, actual)
-			assert.NoError(t, err)
+		assert.NotNil(t, actual)
 
+		if validExpected {
+			assert.NoError(t, err)
 		} else {
-			assert.Nil(t, actual)
 			assert.IsType(t, Error{}, err)
 		}
 	}
@@ -1004,7 +1003,7 @@ func TestParseWhitespaceAtEnd(t *testing.T) {
 	_, errs := Parse(
 		nil,
 		[]byte("a  "),
-		func(p *parser) (any, error) {
+		func(p *parser) (lexer.Token, error) {
 			return p.mustToken(lexer.TokenIdentifier, "a")
 		},
 		Config{},


### PR DESCRIPTION

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
