### PR TITLE
Allow equality tests on arrays if their inner types support it

### DIFF
--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -290,7 +290,7 @@ Logical operators work with the boolean values `true` and `false`.
 
 Comparison operators work with boolean and integer values.
 
-- Equality: `==`, for booleans and integers. Optionals and arrays are equatable if their inner types support it.
+- Equality: `==`, is supported for booleans, numbers, addresses, strings, characters, enums, paths, `Type` values, references, and `Void` values (`()`). Variable-sized arrays, fixed-size arrays, and optionals also support equality tests if their inner types do.
 
   Both sides of the equality operator may be optional, even of different levels,
   so it is for example possible to compare a non-optional with a double-optional (`??`).
@@ -349,7 +349,7 @@ Comparison operators work with boolean and integer values.
   xs == ys // is `true`
   ```
 
-- Inequality: `!=`, for booleans and integers. Optionals and arrays can be tested for inequality if their inner types support it.
+- Inequality: `!=`, is supported for booleans, numbers, addresses, strings, characters, enums, paths, `Type` values, references, and `Void` values (`()`). Variable-sized arrays, fixed-size arrays, and optionals also support inequality tests if their inner types do.
 
   Both sides of the inequality operator may be optional, even of different levels,
   so it is for example possible to compare a non-optional with a double-optional (`??`).

--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -288,9 +288,9 @@ Logical operators work with the boolean values `true` and `false`.
 
 ## Comparison Operators
 
-Comparison operators work with boolean and integer values.
+Comparison operators work with boolean and integer values. Array types can be tested for equality if their inner types support it.
 
-- Equality: `==`, for booleans and integers
+- Equality: `==`, for booleans, integers, and arrays containing equatable values.
 
   Both sides of the equality operator may be optional, even of different levels,
   so it is for example possible to compare a non-optional with a double-optional (`??`).
@@ -329,6 +329,17 @@ Comparison operators work with boolean and integer values.
   let x: Int? = 2
   let y: Int?? = 2
   x == y  // is `true`
+  ```
+
+  ```cadence
+  // Equality tests of arrays are possible if their inner types are equatable.
+  let xs: [Int] = [1, 2, 3]
+  let ys: [Int] = [1, 2, 3]
+  xs == ys // is `true`
+
+  let xss: [[Int]] = [xs, xs, xs]
+  let yss: [[Int]] = [ys, ys, ys]
+  xss == yss // is `true`
   ```
 
 - Inequality: `!=`, for booleans and integers (possibly optional)
@@ -370,6 +381,13 @@ Comparison operators work with boolean and integer values.
   let x: Int? = 2
   let y: Int?? = 2
   x != y  // is `false`
+  ```
+
+  ```cadence
+  // Equality tests of arrays are possible if their inner types are equatable.
+  let xs: [Int] = [1, 2, 3]
+  let ys: [Int] = [4, 5, 6]
+  xs != ys // is `true`
   ```
 
 - Less than: `<`, for integers

--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -288,9 +288,9 @@ Logical operators work with the boolean values `true` and `false`.
 
 ## Comparison Operators
 
-Comparison operators work with boolean and integer values. Array types can be tested for equality if their inner types support it.
+Comparison operators work with boolean and integer values.
 
-- Equality: `==`, for booleans, integers, and arrays containing equatable values.
+- Equality: `==`, for booleans and integers. Optionals and arrays are equatable if their inner types support it.
 
   Both sides of the equality operator may be optional, even of different levels,
   so it is for example possible to compare a non-optional with a double-optional (`??`).
@@ -342,7 +342,14 @@ Comparison operators work with boolean and integer values. Array types can be te
   xss == yss // is `true`
   ```
 
-- Inequality: `!=`, for booleans and integers (possibly optional)
+  ```cadence
+  // Equality also applies to fixed-size arrays. If their lengths differ, the result is a type error.
+  let xs: [Int; 2] = [1, 2]
+  let ys: [Int; 2] = [0 + 1, 1 + 1]
+  xs == ys // is `true`
+  ```
+
+- Inequality: `!=`, for booleans and integers. Optionals and arrays can be tested for inequality if their inner types support it.
 
   Both sides of the inequality operator may be optional, even of different levels,
   so it is for example possible to compare a non-optional with a double-optional (`??`).
@@ -384,10 +391,17 @@ Comparison operators work with boolean and integer values. Array types can be te
   ```
 
   ```cadence
-  // Equality tests of arrays are possible if their inner types are equatable.
+  // Inequality tests of arrays are possible if their inner types are equatable.
   let xs: [Int] = [1, 2, 3]
   let ys: [Int] = [4, 5, 6]
   xs != ys // is `true`
+  ```
+
+  ```cadence
+  // Inequality also applies to fixed-size arrays. If their lengths differ, the result is a type error.
+  let xs: [Int; 2] = [1, 2]
+  let ys: [Int; 2] = [1, 2]
+  xs != ys // is `false`
   ```
 
 - Less than: `<`, for integers

--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -349,7 +349,8 @@ Comparison operators work with boolean and integer values.
   xs == ys // is `true`
   ```
 
-- Inequality: `!=`, is supported for booleans, numbers, addresses, strings, characters, enums, paths, `Type` values, references, and `Void` values (`()`). Variable-sized arrays, fixed-size arrays, and optionals also support inequality tests if their inner types do.
+- Inequality: `!=`, is supported for booleans, numbers, addresses, strings, characters, enums, paths, `Type` values, references, and `Void` values (`()`). 
+  Variable-sized arrays, fixed-size arrays, and optionals also support inequality tests if their inner types do.
 
   Both sides of the inequality operator may be optional, even of different levels,
   so it is for example possible to compare a non-optional with a double-optional (`??`).

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2153,9 +2153,9 @@ func (t *VariableSizedType) IsImportable(results map[*Member]bool) bool {
 	return t.Type.IsImportable(results)
 }
 
-func (*VariableSizedType) IsEquatable() bool {
+func (v *VariableSizedType) IsEquatable() bool {
 	// TODO:
-	return false
+	return v.Type.IsEquatable()
 }
 
 func (t *VariableSizedType) TypeAnnotationState() TypeAnnotationState {
@@ -2296,9 +2296,9 @@ func (t *ConstantSizedType) IsImportable(results map[*Member]bool) bool {
 	return t.Type.IsImportable(results)
 }
 
-func (*ConstantSizedType) IsEquatable() bool {
+func (t *ConstantSizedType) IsEquatable() bool {
 	// TODO:
-	return false
+	return t.Type.IsEquatable()
 }
 
 func (t *ConstantSizedType) TypeAnnotationState() TypeAnnotationState {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2154,7 +2154,6 @@ func (t *VariableSizedType) IsImportable(results map[*Member]bool) bool {
 }
 
 func (v *VariableSizedType) IsEquatable() bool {
-	// TODO:
 	return v.Type.IsEquatable()
 }
 
@@ -2297,7 +2296,6 @@ func (t *ConstantSizedType) IsImportable(results map[*Member]bool) bool {
 }
 
 func (t *ConstantSizedType) IsEquatable() bool {
-	// TODO:
 	return t.Type.IsEquatable()
 }
 

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -534,9 +534,11 @@ func TestCheckFixedSizedArrayEqual(t *testing.T) {
 func TestCheckInvalidArrayEqual(t *testing.T) {
 	t.Parallel()
 
-	assertInvalid := func(name, code string) {
+	assertInvalid := func(name, innerCode string) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			code := fmt.Sprintf("fun test(): Bool { \n %s \n}", innerCode)
 
 			_, err := ParseAndCheck(t, code)
 			errs := RequireCheckerErrors(t, err, 1)
@@ -544,15 +546,33 @@ func TestCheckInvalidArrayEqual(t *testing.T) {
 		})
 	}
 
-	assertInvalid("variable size array", `fun test(): Bool {
+	assertInvalid("variable size array", `
 		let xs = [fun(){}]
 		return xs == xs
-	}`)
+	`)
 
-	assertInvalid("fixed size array", `fun test(): Bool {
+	assertInvalid("fixed size array", `
 		let xs: [((): Void); 1] = [fun(){}]
 		return xs == xs
-	}`)
+	`)
+
+	assertInvalid("fixed size equaling variable-size", `
+		let xs: [Int; 3] = [1, 2, 3]
+		let ys: [Int] = [1, 2, 3]
+		return xs == ys
+	`)
+
+	assertInvalid("fixed size arrays of different lengths", `
+		let xs: [Int; 2] = [42, 1337]
+		let ys: [Int; 3] = [1, 2, 3]
+		return xs == ys
+	`)
+
+	assertInvalid("fixed size arrays of different types", `
+		let xs: [Int; 2] = [42, 1337]
+		let ys: [String; 3] = ["O", "w", "O"]
+		return xs != ys
+	`)
 }
 
 func TestCheckInvalidArrayConcat(t *testing.T) {

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -473,6 +474,34 @@ func TestCheckArrayConcat(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCheckArrayEqual(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 4; i++ {
+		nestingLevel := i
+		array := fmt.Sprintf("%s 42 %s", strings.Repeat("[", nestingLevel), strings.Repeat("]", nestingLevel))
+
+		for _, opStr := range []string{"==", "!="} {
+			op := opStr
+			testName := fmt.Sprintf("test array %s at nesting level %d", op, nestingLevel)
+
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				code := fmt.Sprintf(`
+					fun test(): Bool {
+						let xs = %s
+						return xs %s xs
+					}`,
+					array,
+					op,
+				)
+
+				_, err := ParseAndCheck(t, code)
+				require.NoError(t, err)
+			})
+		}
+	}
+}
 func TestCheckInvalidArrayConcat(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -772,8 +772,8 @@ func TestCheckArrayIndexOfNonEquatableValueArray(t *testing.T) {
 
 	_, err := ParseAndCheck(t, `
       fun test(): Int? {
-          let x = [[1, 2], [3]]
-          return x.firstIndex(of: [3])
+          let x = [[fun(){}, fun(){}], [fun(){}]]
+          return x.firstIndex(of: [fun(){}])
       }
     `)
 
@@ -851,8 +851,8 @@ func TestCheckInvalidArrayContainsNotEquatable(t *testing.T) {
 
 	_, err := ParseAndCheck(t, `
       fun test(): Bool {
-          let z = [[1], [2], [3]]
-          return z.contains([1, 2])
+          let z = [[fun(){}], [fun(){}], [fun(){}]]
+          return z.contains([fun(){}])
       }
     `)
 

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -502,6 +502,21 @@ func TestCheckArrayEqual(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckInvalidArrayEqual(t *testing.T) {
+	t.Parallel()
+
+	code := `fun test(): Bool {
+		let xs = [fun(){}]
+		return xs == xs
+	}`
+
+	_, err := ParseAndCheck(t, code)
+	errs := RequireCheckerErrors(t, err, 1)
+	fmt.Println(err.Error())
+	assert.IsType(t, &sema.InvalidBinaryOperandsError{}, errs[0])
+}
+
 func TestCheckInvalidArrayConcat(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -1655,7 +1655,6 @@ func TestCheckInvalidResourceLoss(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 2)
 
-		assert.IsType(t, &sema.InvalidBinaryOperandsError{}, errs[0])
 		assert.IsType(t, &sema.ResourceLossError{}, errs[1])
 	})
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -652,7 +652,7 @@ func TestInterpretArrayEquality(t *testing.T) {
 	testBooleanFunction(t, "fixed array [Int; 3] should be unequal to a different array", true, `
 		let xs: [Int; 3] = [1, 2, 3]
 		let ys: [Int; 3] = [4, 5, 6]
-		return xs != xs
+		return xs != ys
 	`)
 
 	testBooleanFunction(t, "fixed array [[Int; 2]; 1] should equal itself", true, `

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -643,13 +643,15 @@ func TestInterpretArrayEquality(t *testing.T) {
 
 	// fixed size arrays
 
-	testBooleanFunction(t, "fixed array [Int; 3] should equal itself", true, `
+	testBooleanFunction(t, "fixed array [Int; 3] should not equal a different array", false, `
 		let xs: [Int; 3] = [1, 2, 3]
-		return xs == xs
+		let ys: [Int; 3] = [4, 5, 6]
+		return xs == ys
 	`)
 
-	testBooleanFunction(t, "fixed array [Int; 3] should not be unequal to itself", false, `
+	testBooleanFunction(t, "fixed array [Int; 3] should be unequal to a different array", true, `
 		let xs: [Int; 3] = [1, 2, 3]
+		let ys: [Int; 3] = [4, 5, 6]
 		return xs != xs
 	`)
 


### PR DESCRIPTION
Closes #2235

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Turns out we already had this functionality implemented, but it was disallowed in the checker.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
