### PR TITLE
add Config() method to runtime.Runtime interface

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -93,6 +93,9 @@ type Executor interface {
 
 // Runtime is a runtime capable of executing Cadence.
 type Runtime interface {
+	// Config() returns the runtime.Config this Runtime was instantiated with.
+	Config() Config
+
 	// NewScriptExecutor returns an executor which executes the given script.
 	NewScriptExecutor(Script, Context) Executor
 
@@ -214,6 +217,10 @@ func NewInterpreterRuntime(defaultConfig Config) Runtime {
 	return &interpreterRuntime{
 		defaultConfig: defaultConfig,
 	}
+}
+
+func (r *interpreterRuntime) Config() Config {
+	return r.defaultConfig
 }
 
 func (r *interpreterRuntime) Recover(onError func(Error), location Location, codesAndPrograms codesAndPrograms) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6863,6 +6863,19 @@ func singleIdentifierLocationResolver(t testing.TB) func(identifiers []Identifie
 	}
 }
 
+func TestRuntimeGetConfig(t *testing.T) {
+	t.Parallel()
+
+	rt := newTestInterpreterRuntime()
+	// depends on newTestInterpreterRuntime using the interpreterRuntime struct
+	underlying, ok := rt.(*interpreterRuntime)
+	require.True(t, ok)
+
+	config := rt.Config()
+	expected := underlying.defaultConfig
+	require.Equal(t, expected, config)
+}
+
 func TestRuntimePanics(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #2211

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This change exposes the underlying `Config` values for types that implement `Runtime`. This will require downstream changes for any consumers that depend on the cadence runtime.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
