### PR TITLE
Use bitmasks for checking declaration kinds of top-level declarations

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -348,20 +348,20 @@ func (checker *Checker) checkTopLevelDeclarationValidity(declarations []ast.Decl
 		return
 	}
 
-	validDeclarationKinds := map[common.DeclarationKind]bool{}
-
 	validTopLevelDeclarations := validTopLevelDeclarationsHandler(checker.Location)
 	if validTopLevelDeclarations == nil {
 		return
 	}
 
+	validDeclarationKindMask := 0
+
 	for _, declarationKind := range validTopLevelDeclarations {
-		validDeclarationKinds[declarationKind] = true
+		validDeclarationKindMask |= 1 << declarationKind
 	}
 
 	for _, declaration := range declarations {
-		isValid := validDeclarationKinds[declaration.DeclarationKind()]
-		if isValid {
+		isValid := validDeclarationKindMask & (1 << declaration.DeclarationKind())
+		if isValid != 0 {
 			continue
 		}
 


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Draft PR to run benchstat and compare performance against master. This is a small microoptimization that switches the checker over to using a bitset instead of a hashset when checking the kinds of top-level declarations.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
