### PR TITLE
Transaction role prepare blocks take one signer each

### DIFF
--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -74,6 +74,28 @@ func (checker *Checker) VisitTransactionDeclaration(declaration *ast.Transaction
 		checker.checkRolePrepareParameterList(roleDeclaration, transactionType)
 	}
 
+	transactionPrepareParameterCount := len(transactionType.PrepareParameters)
+
+	// If the transaction has roles and the prepare block has parameters,
+	// then there should be exactly one role for each parameter
+	roleCount := len(declaration.Roles)
+	if roleCount > 0 &&
+		prepareFunctionDeclaration != nil &&
+		transactionPrepareParameterCount > 0 &&
+		roleCount != transactionPrepareParameterCount {
+
+		checker.report(
+			&RoleCountMismatchError{
+				ActualCount:   roleCount,
+				ExpectedCount: transactionPrepareParameterCount,
+				Range: ast.NewRangeFromPositioned(
+					checker.memoryGauge,
+					prepareFunctionDeclaration.FunctionDeclaration.ParameterList,
+				),
+			},
+		)
+	}
+
 	if declaration.PreConditions != nil {
 		checker.visitConditions(*declaration.PreConditions)
 	}
@@ -132,52 +154,46 @@ func (checker *Checker) checkRolePrepareParameterList(
 
 	transactionPrepareParameterCount := len(transactionType.PrepareParameters)
 	transactionRolePrepareParameterCount := len(transactionRoleType.PrepareParameters)
-	if transactionPrepareParameterCount != transactionRolePrepareParameterCount {
-		if roleDeclaration.Prepare == nil {
-			checker.report(
-				&MissingRolePrepareError{
-					Range: ast.NewRangeFromPositioned(
-						checker.memoryGauge,
-						roleDeclaration.Identifier,
-					),
-				},
-			)
-		} else {
+
+	// If the transaction declaration's prepare block has no parameters,
+	// then the roles should not have any either
+	if transactionPrepareParameterCount == 0 {
+		if transactionRolePrepareParameterCount != 0 {
 			checker.report(
 				&PrepareParameterCountMismatchError{
 					ActualCount:   transactionRolePrepareParameterCount,
 					ExpectedCount: transactionPrepareParameterCount,
 					Range: ast.NewRangeFromPositioned(
 						checker.memoryGauge,
-						roleDeclaration.Prepare,
+						roleDeclaration.Prepare.FunctionDeclaration.ParameterList,
 					),
 				},
 			)
 		}
-	}
+	} else {
+		// If the transaction declaration's prepare block has no parameters,
+		// then all roles should have exactly one parameter
+		const expectedPrepareParameterCount = 1
+		if transactionRolePrepareParameterCount != expectedPrepareParameterCount {
 
-	minPrepareParameterCount := transactionPrepareParameterCount
-	if transactionRolePrepareParameterCount < minPrepareParameterCount {
-		minPrepareParameterCount = transactionRolePrepareParameterCount
-	}
-
-	for prepareParameterIndex := 0; prepareParameterIndex < minPrepareParameterCount; prepareParameterIndex++ {
-		transactionPrepareParameter := transactionType.PrepareParameters[prepareParameterIndex]
-		transactionRolePrepareParameter := transactionRoleType.PrepareParameters[prepareParameterIndex]
-
-		if !transactionRolePrepareParameter.TypeAnnotation.
-			Equal(transactionPrepareParameter.TypeAnnotation) {
-
-			parameter := roleDeclaration.Prepare.FunctionDeclaration.ParameterList.Parameters[prepareParameterIndex]
+			var errorRange ast.Range
+			if roleDeclaration.Prepare == nil {
+				errorRange = ast.NewRangeFromPositioned(
+					checker.memoryGauge,
+					roleDeclaration.Identifier,
+				)
+			} else {
+				errorRange = ast.NewRangeFromPositioned(
+					checker.memoryGauge,
+					roleDeclaration.Prepare.FunctionDeclaration.ParameterList,
+				)
+			}
 
 			checker.report(
-				&TypeMismatchError{
-					ExpectedType: transactionPrepareParameter.TypeAnnotation.Type,
-					ActualType:   transactionRolePrepareParameter.TypeAnnotation.Type,
-					Range: ast.NewRangeFromPositioned(
-						checker.memoryGauge,
-						parameter.TypeAnnotation,
-					),
+				&PrepareParameterCountMismatchError{
+					ActualCount:   transactionRolePrepareParameterCount,
+					ExpectedCount: expectedPrepareParameterCount,
+					Range:         errorRange,
 				},
 			)
 		}

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -171,7 +171,7 @@ func (checker *Checker) checkRolePrepareParameterList(
 			)
 		}
 	} else {
-		// If the transaction declaration's prepare block has no parameters,
+		// If the transaction declaration's prepare block has parameters,
 		// then all roles should have exactly one parameter
 		const expectedPrepareParameterCount = 1
 		if transactionRolePrepareParameterCount != expectedPrepareParameterCount {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3094,20 +3094,26 @@ func (e *PrepareParameterCountMismatchError) Error() string {
 	)
 }
 
-// MissingRolePrepareError
-type MissingRolePrepareError struct {
+// RoleCountMismatchError
+type RoleCountMismatchError struct {
+	ActualCount   int
+	ExpectedCount int
 	ast.Range
 }
 
-var _ SemanticError = &MissingRolePrepareError{}
-var _ errors.UserError = &MissingRolePrepareError{}
+var _ SemanticError = &RoleCountMismatchError{}
+var _ errors.UserError = &RoleCountMismatchError{}
 
-func (*MissingRolePrepareError) isSemanticError() {}
+func (*RoleCountMismatchError) isSemanticError() {}
 
-func (*MissingRolePrepareError) IsUserError() {}
+func (*RoleCountMismatchError) IsUserError() {}
 
-func (e *MissingRolePrepareError) Error() string {
-	return "role is missing prepare block that matches transaction's"
+func (e *RoleCountMismatchError) Error() string {
+	return fmt.Sprintf(
+		"transaction must have one role for each prepare parameter: expected %d, got %d",
+		e.ExpectedCount,
+		e.ActualCount,
+	)
 }
 
 // InvalidNestedDeclarationError


### PR DESCRIPTION
Work towards #2177


## Description

As clarified in the [FLIP](https://github.com/onflow/flips/pull/41), a prepare block in a transaction role may have one parameter, and each role is passed one signer, sequentially from the full list of all signers.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
