### PR TITLE
Make compatibility checker workflow work with old tags

### DIFF
--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -31,7 +31,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ inputs.current-branch }}
+          # Checkout the branch where the workflow is available.
+          # Usually this is the master branch.
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-go@v3
         with:
@@ -42,7 +44,7 @@ jobs:
         run: |
           mkdir tmp
 
-      - name: Generate chache key
+      - name: Generate cache key
         id: cache-key-generator
         # cache key should include chain name
         run: echo "cache-key=${{ github.workflow }}-${{ inputs.chain }}-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -75,16 +77,17 @@ jobs:
       - name: Check contracts using current branch
         working-directory: ./tools/compatibility-check
         run: |
+          go get github.com/onflow/cadence@${{ inputs.current-branch }}
+          go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-new.txt
 
       # Check contracts using base branch
 
-      - name: Checkout base branch
-        run: git checkout ${{ inputs.base-branch }}
-
       - name: Check contracts using base branch
         working-directory: ./tools/compatibility-check
         run: |
+          go get github.com/onflow/cadence@${{ inputs.base-branch }}
+          go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-old.txt
 
       # Check Diff

--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -6,10 +6,10 @@ on:
       branch:
         description: 'Current branch/tag'
         required: true
+        default: 'master'
       base:
         description: 'Base branch/tag'
-        required: false
-        default: 'master'
+        required: true
 
 env:
   GO_VERSION: '1.19.2'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         required: true
       base:
         description: 'Base branch for the release'
-        required: false
+        required: true
         default: 'master'
 
 env:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -53,7 +53,7 @@ base branch (`master` in this case).
 
 ### Checking backward compatibility
 
-- Checkout the current branch (`master`) 
+- Checkout the `master` branch
   ```
   git checkout master
   ```
@@ -67,15 +67,23 @@ base branch (`master` in this case).
   go run ./cmd/get_contracts/main.go --chain=flow-mainnet --u=access.mainnet.nodes.onflow.org:9000 > ../../tmp/mainnet_contracts.csv
   cd ../..
   ```
+- Navigate to the `compatibility-check` tool and update it to use the Cadence branch from which the new release
+  would be created.
+  Here, since the release would also be done on the master branch, the current branch would also be `master`.
+  ```
+  cd ./tools/compatibility-check
+  go get github.com/onflow/cadence@master
+  go mod tidy
+  ```
 - Check the contracts using the current branch.
   This will write the parsing and checking errors to the `tmp/mainnet_output_new.txt` file.
   ```
-  cd ./tools/compatibility-check
   go run ./cmd/check_contracts/main.go ../../tmp/mainnet_contracts.csv ../../tmp/mainnet_output_new.txt
   ```
-- Checkout the Cadence version that is currently deployed on networks (`v0.21.0`), and repeat the previous step.
+- Update the tool to Cadence version that is currently deployed on networks (`v0.21.0`), and repeat the previous step.
   ```
-  git checkout v0.21.0
+  go get github.com/onflow/cadence@v0.21.0
+  go mod tidy
   go run ./cmd/check_contracts/main.go ../../tmp/mainnet_contracts.csv ../../tmp/mainnet_output_old.txt
   cd ../..
   ```

--- a/tools/compatibility-check/go.mod
+++ b/tools/compatibility-check/go.mod
@@ -3,8 +3,7 @@ module github.com/onflow/cadence/tools/compatibility_check
 go 1.19
 
 require (
-	github.com/kylelemons/godebug v1.1.0
-	github.com/onflow/cadence v0.31.2
+	github.com/onflow/cadence v0.31.2-0.20230201191829-559e775dc4af
 	github.com/rs/zerolog v1.26.1
 	github.com/sergi/go-diff v1.2.0
 )
@@ -28,6 +27,3 @@ require (
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )
-
-// Should always use the current version of cadence.
-replace github.com/onflow/cadence => ../../../cadence

--- a/tools/compatibility-check/go.sum
+++ b/tools/compatibility-check/go.sum
@@ -17,13 +17,13 @@ github.com/klauspost/cpuid/v2 v2.0.14/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuOb
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
-github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/onflow/atree v0.4.0 h1:+TbNisavAkukAKhgQ4plWnvR9o5+SkwPIsi3jaeAqKs=
 github.com/onflow/atree v0.4.0/go.mod h1:7Qe1xaW0YewvouLXrugzMFUYXNoRQ8MT/UsVAWx1Ndo=
+github.com/onflow/cadence v0.31.2-0.20230201191829-559e775dc4af h1:m+4LiQyhJrZ5VBYtGQvUqR7ng13vocbQBqniTYk+9QA=
+github.com/onflow/cadence v0.31.2-0.20230201191829-559e775dc4af/go.mod h1:Cq1ZtlAfoVEaR1+4n4Yrffpz7kGyIGTF9J4YJQarhRo=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Description

Instead of checking out the current/base branch/tag, just update the tool to use that particular version of cadence.
That way, the tool always stays the same (old tags don't need to have the tool), and only the cadence version is bumped.
Should have done it this way in the first place.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
