### PR TITLE
Simplify lookaheads

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -709,7 +709,7 @@ func isNextTokenCommaOrFrom(p *parser) bool {
 	// Lookahead the next token
 	switch p.current.Type {
 	case lexer.TokenIdentifier:
-		return string(p.currentTokenSource()) == KeywordFrom
+		return string(p.currentTokenSource()) == keywordFrom
 
 	case lexer.TokenComma:
 		return true

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -709,7 +709,7 @@ func isNextTokenCommaOrFrom(p *parser) bool {
 	// Lookahead the next token
 	switch p.current.Type {
 	case lexer.TokenIdentifier:
-		isFrom := string(p.currentTokenSource()) == keywordFrom
+		isFrom := string(p.currentTokenSource()) == KeywordFrom
 		return isFrom
 
 	case lexer.TokenComma:

--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -709,8 +709,7 @@ func isNextTokenCommaOrFrom(p *parser) bool {
 	// Lookahead the next token
 	switch p.current.Type {
 	case lexer.TokenIdentifier:
-		isFrom := string(p.currentTokenSource()) == KeywordFrom
-		return isFrom
+		return string(p.currentTokenSource()) == KeywordFrom
 
 	case lexer.TokenComma:
 		return true

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -705,11 +705,10 @@ func defineGreaterThanOrBitwiseRightShiftExpression() {
 				return left, nil, true
 			}
 
-			// Start buffering before skipping the `>` token,
-			// so it can be replayed in case the right binding power
-			// was higher than the determined left binding power.
+			// Perform a lookahead for '>'
 
-			p.startBuffering()
+			current := p.current
+			cursor := p.tokens.Cursor()
 
 			// Skip the `>` token.
 			p.next()
@@ -731,14 +730,14 @@ func defineGreaterThanOrBitwiseRightShiftExpression() {
 				// was higher. In that case, replay the buffered tokens and stop.
 
 				if rightBindingPower >= exprLeftBindingPowerBitwiseShift {
-					err = p.replayBuffered()
-					return left, err, true
+					p.current = current
+					p.tokens.Revert(cursor)
+
+					return left, nil, true
 				}
 
 				// The previous attempt to parse a bitwise right shift succeeded,
 				// accept the buffered tokens.
-
-				p.acceptBuffered()
 
 				nextRightBindingPower = exprLeftBindingPowerBitwiseShift
 
@@ -749,10 +748,8 @@ func defineGreaterThanOrBitwiseRightShiftExpression() {
 				// The previous attempt to parse a bitwise right shift failed,
 				// replay the buffered tokens.
 
-				err = p.replayBuffered()
-				if err != nil {
-					return nil, err, true
-				}
+				p.current = current
+				p.tokens.Revert(cursor)
 
 				// The expression was determined to *not* be a bitwise shift,
 				// so it must be a comparison expression.

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -509,10 +509,10 @@ func defineRestrictedOrDictionaryType() {
 		lexer.TokenBraceOpen,
 		func(p *parser, rightBindingPower int, left ast.Type) (result ast.Type, err error, done bool) {
 
-			// Start buffering before skipping the `{` token,
-			// so it can be replayed in case the
+			// Perform a lookahead
 
-			p.startBuffering()
+			current := p.current
+			cursor := p.tokens.Cursor()
 
 			// Skip the `{` token.
 			p.next()
@@ -521,8 +521,10 @@ func defineRestrictedOrDictionaryType() {
 			// The buffered tokens are replayed to allow them to be re-parsed.
 
 			if p.current.Is(lexer.TokenSpace) {
-				err = p.replayBuffered()
-				return left, err, true
+				p.current = current
+				p.tokens.Revert(cursor)
+
+				return left, nil, true
 			}
 
 			// It was determined that a restricted type is parsed.
@@ -530,11 +532,10 @@ func defineRestrictedOrDictionaryType() {
 			// was higher. In that case, replay the buffered tokens and stop.
 
 			if rightBindingPower >= typeLeftBindingPowerRestriction {
-				err = p.replayBuffered()
-				return left, err, true
+				p.current = current
+				p.tokens.Revert(cursor)
+				return left, nil, true
 			}
-
-			p.acceptBuffered()
 
 			nominalTypes, endPos, err := parseNominalTypes(p, lexer.TokenBraceClose)
 			if err != nil {


### PR DESCRIPTION
## Description

The lookaheads do not need full buffering, as no nested parsing is performed, they can simply backup the current token and tokens cursor, like already done in some other parts of the parser.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
