### PR TITLE
Fix docstring parsing for functions

### DIFF
--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -6657,3 +6657,130 @@ func TestParseNestedPragma(t *testing.T) {
 	})
 
 }
+
+func TestParseMemberDocStrings(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("functions", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseDeclarations(`
+          struct Test {
+
+              /// noReturnNoBlock
+              fun noReturnNoBlock()
+
+              /// returnNoBlock
+              fun returnNoBlock(): Int
+
+              /// returnAndBlock
+              fun returnAndBlock(): String {}
+          }
+	    `)
+
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.CompositeDeclaration{
+					CompositeKind: common.CompositeKindStructure,
+					Identifier: ast.Identifier{
+						Identifier: "Test",
+						Pos:        ast.Position{Offset: 18, Line: 2, Column: 17},
+					},
+					Members: ast.NewUnmeteredMembers(
+						[]ast.Declaration{
+							&ast.FunctionDeclaration{
+								DocString: " noReturnNoBlock",
+								Identifier: ast.Identifier{
+									Identifier: "noReturnNoBlock",
+									Pos:        ast.Position{Offset: 78, Line: 5, Column: 18},
+								},
+								ParameterList: &ast.ParameterList{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 93, Line: 5, Column: 33},
+										EndPos:   ast.Position{Offset: 94, Line: 5, Column: 34},
+									},
+								},
+								ReturnTypeAnnotation: &ast.TypeAnnotation{
+									IsResource: false,
+									Type: &ast.NominalType{
+										Identifier: ast.Identifier{
+											Identifier: "",
+											Pos:        ast.Position{Offset: 94, Line: 5, Column: 34},
+										},
+									},
+									StartPos: ast.Position{Offset: 94, Line: 5, Column: 34},
+								},
+								StartPos: ast.Position{Offset: 74, Line: 5, Column: 14},
+							},
+							&ast.FunctionDeclaration{
+								DocString: " returnNoBlock",
+								Identifier: ast.Identifier{
+									Identifier: "returnNoBlock",
+									Pos:        ast.Position{Offset: 147, Line: 8, Column: 18},
+								},
+								ParameterList: &ast.ParameterList{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 160, Line: 8, Column: 31},
+										EndPos:   ast.Position{Offset: 161, Line: 8, Column: 32},
+									},
+								},
+								ReturnTypeAnnotation: &ast.TypeAnnotation{
+									IsResource: false,
+									Type: &ast.NominalType{
+										Identifier: ast.Identifier{
+											Identifier: "Int",
+											Pos:        ast.Position{Offset: 164, Line: 8, Column: 35},
+										},
+									},
+									StartPos: ast.Position{Offset: 164, Line: 8, Column: 35},
+								},
+								StartPos: ast.Position{Offset: 143, Line: 8, Column: 14},
+							},
+							&ast.FunctionDeclaration{
+								DocString: " returnAndBlock",
+								Identifier: ast.Identifier{
+									Identifier: "returnAndBlock",
+									Pos:        ast.Position{Offset: 220, Line: 11, Column: 18},
+								},
+								ParameterList: &ast.ParameterList{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 234, Line: 11, Column: 32},
+										EndPos:   ast.Position{Offset: 235, Line: 11, Column: 33},
+									},
+								},
+								ReturnTypeAnnotation: &ast.TypeAnnotation{
+									IsResource: false,
+									Type: &ast.NominalType{
+										Identifier: ast.Identifier{
+											Identifier: "String",
+											Pos:        ast.Position{Offset: 238, Line: 11, Column: 36},
+										},
+									},
+									StartPos: ast.Position{Offset: 238, Line: 11, Column: 36},
+								},
+								FunctionBlock: &ast.FunctionBlock{
+									Block: &ast.Block{
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 245, Line: 11, Column: 43},
+											EndPos:   ast.Position{Offset: 246, Line: 11, Column: 44},
+										},
+									},
+								},
+								StartPos: ast.Position{Offset: 216, Line: 11, Column: 14},
+							},
+						},
+					),
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 11, Line: 2, Column: 10},
+						EndPos:   ast.Position{Offset: 258, Line: 12, Column: 10},
+					},
+				},
+			},
+			result,
+		)
+	})
+}

--- a/runtime/parser/function.go
+++ b/runtime/parser/function.go
@@ -357,17 +357,21 @@ func parseFunctionParameterListAndRest(
 		return
 	}
 
+	current := p.current
+	cursor := p.tokens.Cursor()
 	p.skipSpaceAndComments()
 	if p.current.Is(lexer.TokenColon) {
 		// Skip the colon
 		p.nextSemanticToken()
+
 		returnTypeAnnotation, err = parseTypeAnnotation(p)
 		if err != nil {
 			return
 		}
-
-		p.skipSpaceAndComments()
 	} else {
+		p.tokens.Revert(cursor)
+		p.current = current
+
 		positionBeforeMissingReturnType := parameterList.EndPos
 		returnType := ast.NewNominalType(
 			p.memoryGauge,
@@ -385,15 +389,20 @@ func parseFunctionParameterListAndRest(
 		)
 	}
 
-	p.skipSpaceAndComments()
-
-	if !functionBlockIsOptional ||
-		p.current.Is(lexer.TokenBraceOpen) {
-
-		functionBlock, err = parseFunctionBlock(p)
-		if err != nil {
+	if functionBlockIsOptional {
+		current = p.current
+		cursor := p.tokens.Cursor()
+		p.skipSpaceAndComments()
+		if !p.current.Is(lexer.TokenBraceOpen) {
+			p.tokens.Revert(cursor)
+			p.current = current
 			return
 		}
+	}
+
+	functionBlock, err = parseFunctionBlock(p)
+	if err != nil {
+		return
 	}
 
 	return


### PR DESCRIPTION
## Description

Currently, docstrings for member declarations after functions are not retained correctly when the function does not have a return type annotation or body, because the parsing function always skips trivia (whitespace and comments).

Fix this by performing a lookahead for the optional return type start, and for the (potentially) optional block by performing a look.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
