### PR TITLE
Reject cyclic imports during contract deployment

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -338,7 +338,11 @@ func (e *interpreterEnvironment) ParseAndCheckProgram(
 			return code, nil
 		},
 		getAndSetProgram,
-		importResolutionResults{},
+		importResolutionResults{
+			// Current program is already in check.
+			// So mark it also as 'already seen'.
+			location: true,
+		},
 	)
 }
 

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/checker"
@@ -109,5 +111,110 @@ func TestRuntimeCyclicImport(t *testing.T) {
 
 	errs = checker.RequireCheckerErrors(t, checkerErr3, 1)
 
+	require.IsType(t, &sema.CyclicImportsError{}, errs[0])
+}
+
+func TestCheckCyclicImports(t *testing.T) {
+
+	runtime := newTestInterpreterRuntime()
+
+	contractsAddress := common.MustBytesToAddress([]byte{0x1})
+
+	accountCodes := map[Location][]byte{}
+
+	signerAccount := contractsAddress
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(location Location) ([]byte, error) {
+			return accountCodes[location], nil
+		},
+		storage: newTestLedger(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{signerAccount}, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+		getAccountContractCode: func(address Address, name string) ([]byte, error) {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			return accountCodes[location], nil
+		},
+		updateAccountContractCode: func(address Address, name string, code []byte) error {
+			location := common.AddressLocation{
+				Address: address,
+				Name:    name,
+			}
+			accountCodes[location] = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) error {
+			return nil
+		},
+	}
+	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
+		return json.Decode(runtimeInterface, b)
+	}
+
+	environment := NewBaseInterpreterEnvironment(Config{})
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	deploy := func(name string, contract string, update bool) error {
+		var txSource = DeploymentTransaction
+		if update {
+			txSource = UpdateTransaction
+		}
+
+		return runtime.ExecuteTransaction(
+			Script{
+				Source: txSource(
+					name,
+					[]byte(contract),
+				),
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
+			},
+		)
+	}
+
+	const fooContract = `
+        pub contract Foo {}
+    `
+
+	const barContract = `
+        import Foo from 0x0000000000000001
+        pub contract Bar {}
+    `
+
+	const updatedFooContract = `
+        import Bar from 0x0000000000000001
+        pub contract Foo {}
+    `
+
+	err := deploy("Foo", fooContract, false)
+	require.NoError(t, err)
+
+	err = deploy("Bar", barContract, false)
+	require.NoError(t, err)
+
+	// Update `Foo` contract creating a cycle.
+	err = deploy("Foo", updatedFooContract, true)
+
+	var checkerErr *sema.CheckerError
+	require.ErrorAs(t, err, &checkerErr)
+
+	errs := checker.RequireCheckerErrors(t, checkerErr, 1)
+
+	var importedProgramErr *sema.ImportedProgramError
+	require.ErrorAs(t, errs[0], &importedProgramErr)
+
+	var nestedCheckerErr *sema.CheckerError
+	require.ErrorAs(t, importedProgramErr.Err, &nestedCheckerErr)
+
+	errs = checker.RequireCheckerErrors(t, nestedCheckerErr, 1)
 	require.IsType(t, &sema.CyclicImportsError{}, errs[0])
 }


### PR DESCRIPTION
Closes #2304

## Description

Currently, cyclic imports are not rejected during contract updates, but are only rejected once the contract is deployed and is imported/used by another program (contract/script/transaction).

This PR rejects creating cyclic contracts early on, at the time of deployment. i.e: Fails early.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
