### PR TITLE
Clear the test runtime program cache automatically after contract update

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -92,7 +92,7 @@ type Executor interface {
 
 // Runtime is a runtime capable of executing Cadence.
 type Runtime interface {
-	// Config() returns the runtime.Config this Runtime was instantiated with.
+	// Config returns the runtime.Config this Runtime was instantiated with.
 	Config() Config
 
 	// NewScriptExecutor returns an executor which executes the given script.
@@ -212,7 +212,7 @@ type interpreterRuntime struct {
 }
 
 // NewInterpreterRuntime returns a interpreter-based version of the Flow runtime.
-func NewInterpreterRuntime(defaultConfig Config) Runtime {
+func NewInterpreterRuntime(defaultConfig Config) *interpreterRuntime {
 	return &interpreterRuntime{
 		defaultConfig: defaultConfig,
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -212,7 +212,7 @@ type interpreterRuntime struct {
 }
 
 // NewInterpreterRuntime returns a interpreter-based version of the Flow runtime.
-func NewInterpreterRuntime(defaultConfig Config) *interpreterRuntime {
+func NewInterpreterRuntime(defaultConfig Config) Runtime {
 	return &interpreterRuntime{
 		defaultConfig: defaultConfig,
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -221,7 +221,7 @@ type testRuntimeInterface struct {
 	computationUsed            func() (uint64, error)
 	memoryUsed                 func() (uint64, error)
 	interactionUsed            func() (uint64, error)
-	updatedContractLocations   []common.AddressLocation
+	updatedContractCode        bool
 }
 
 // testRuntimeInterface should implement Interface
@@ -385,17 +385,7 @@ func (i *testRuntimeInterface) UpdateAccountContractCode(address Address, name s
 		return err
 	}
 
-	location := common.AddressLocation{
-		Name:    name,
-		Address: address,
-	}
-
-	if _, ok := i.programs[location]; ok {
-		i.updatedContractLocations = append(
-			i.updatedContractLocations,
-			location,
-		)
-	}
+	i.updatedContractCode = true
 
 	return nil
 }
@@ -675,10 +665,12 @@ func (i *testRuntimeInterface) onScriptExecutionStart() {
 }
 
 func (i *testRuntimeInterface) invalidateUpdatedPrograms() {
-	for _, location := range i.updatedContractLocations {
-		delete(i.programs, location)
+	if i.updatedContractCode {
+		for location := range i.programs {
+			delete(i.programs, location)
+		}
+		i.updatedContractCode = false
 	}
-	i.updatedContractLocations = i.updatedContractLocations[0:0]
 }
 
 func TestRuntimeImport(t *testing.T) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -138,7 +138,7 @@ func newTestInterpreterRuntime() testInterpreterRuntime {
 	return testInterpreterRuntime{
 		interpreterRuntime: NewInterpreterRuntime(Config{
 			AtreeValidationEnabled: true,
-		}),
+		}).(*interpreterRuntime),
 	}
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -128,10 +128,30 @@ func newTestLedger(
 	return storage
 }
 
-func newTestInterpreterRuntime() Runtime {
-	return NewInterpreterRuntime(Config{
-		AtreeValidationEnabled: true,
-	})
+type testInterpreterRuntime struct {
+	*interpreterRuntime
+}
+
+var _ Runtime = testInterpreterRuntime{}
+
+func newTestInterpreterRuntime() testInterpreterRuntime {
+	return testInterpreterRuntime{
+		interpreterRuntime: NewInterpreterRuntime(Config{
+			AtreeValidationEnabled: true,
+		}),
+	}
+}
+
+func (r testInterpreterRuntime) ExecuteTransaction(script Script, context Context) error {
+	i := context.Interface.(*testRuntimeInterface)
+	i.onTransactionExecutionStart()
+	return r.interpreterRuntime.ExecuteTransaction(script, context)
+}
+
+func (r testInterpreterRuntime) ExecuteScript(script Script, context Context) (cadence.Value, error) {
+	i := context.Interface.(*testRuntimeInterface)
+	i.onScriptExecutionStart()
+	return r.interpreterRuntime.ExecuteScript(script, context)
 }
 
 type testRuntimeInterface struct {
@@ -201,6 +221,7 @@ type testRuntimeInterface struct {
 	computationUsed            func() (uint64, error)
 	memoryUsed                 func() (uint64, error)
 	interactionUsed            func() (uint64, error)
+	updatedContractLocations   []common.AddressLocation
 }
 
 // testRuntimeInterface should implement Interface
@@ -358,7 +379,25 @@ func (i *testRuntimeInterface) UpdateAccountContractCode(address Address, name s
 	if i.updateAccountContractCode == nil {
 		panic("must specify testRuntimeInterface.updateAccountContractCode")
 	}
-	return i.updateAccountContractCode(address, name, code)
+
+	err = i.updateAccountContractCode(address, name, code)
+	if err != nil {
+		return err
+	}
+
+	location := common.AddressLocation{
+		Name:    name,
+		Address: address,
+	}
+
+	if _, ok := i.programs[location]; ok {
+		i.updatedContractLocations = append(
+			i.updatedContractLocations,
+			location,
+		)
+	}
+
+	return nil
 }
 
 func (i *testRuntimeInterface) GetAccountContractCode(address Address, name string) (code []byte, err error) {
@@ -625,6 +664,21 @@ func (i *testRuntimeInterface) InteractionUsed() (uint64, error) {
 	}
 
 	return i.interactionUsed()
+}
+
+func (i *testRuntimeInterface) onTransactionExecutionStart() {
+	i.invalidateUpdatedPrograms()
+}
+
+func (i *testRuntimeInterface) onScriptExecutionStart() {
+	i.invalidateUpdatedPrograms()
+}
+
+func (i *testRuntimeInterface) invalidateUpdatedPrograms() {
+	for _, location := range i.updatedContractLocations {
+		delete(i.programs, location)
+	}
+	i.updatedContractLocations = i.updatedContractLocations[0:0]
 }
 
 func TestRuntimeImport(t *testing.T) {
@@ -6198,6 +6252,16 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
         }
     `
 
+	const callHelloTransactionTemplate = `
+        import HelloWorld from 0x%s
+
+        transaction {
+            prepare(signer: AuthAccount) {
+                log(HelloWorld.hello())
+            }
+        }
+    `
+
 	createAccountTx := []byte(`
         transaction {
             prepare(signer: AuthAccount) {
@@ -6213,14 +6277,13 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
+	var loggedMessages []string
 
 	var accountCounter uint8 = 0
 
 	var signerAddresses []Address
 
 	var programHits []string
-
-	var codeChanged bool
 
 	runtimeInterface := &testRuntimeInterface{
 		createAccount: func(payer Address) (address Address, err error) {
@@ -6243,8 +6306,6 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			return accountCodes[location], nil
 		},
 		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			codeChanged = true
-
 			location := common.AddressLocation{
 				Address: address,
 				Name:    name,
@@ -6256,18 +6317,9 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 			events = append(events, event)
 			return nil
 		},
-	}
-
-	// When code is changed, the parsed+checked programs have to be invalidated
-
-	clearProgramsIfNeeded := func() {
-		if !codeChanged {
-			return
-		}
-
-		for location := range runtimeInterface.programs {
-			delete(runtimeInterface.programs, location)
-		}
+		log: func(message string) {
+			loggedMessages = append(loggedMessages, message)
+		},
 	}
 
 	nextTransactionLocation := newTransactionLocationGenerator()
@@ -6294,8 +6346,6 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	signerAddresses = []Address{{accountCounter}}
 
-	codeChanged = false
-
 	err = runtime.ExecuteTransaction(
 		Script{
 			Source: deployTx,
@@ -6314,8 +6364,6 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	}
 
 	require.NotContains(t, runtimeInterface.programs, location)
-
-	clearProgramsIfNeeded()
 
 	// call the initial hello function
 
@@ -6343,7 +6391,6 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	// update the contract
 
 	programHits = nil
-	codeChanged = false
 
 	err = runtime.ExecuteTransaction(
 		Script{
@@ -6366,9 +6413,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	)
 	require.NotNil(t, runtimeInterface.programs[location])
 
-	clearProgramsIfNeeded()
-
-	// call the new hello function
+	// call the new hello function from a script
 
 	result2, err := runtime.ExecuteScript(
 		Script{
@@ -6381,6 +6426,27 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, cadence.String("2"), result2)
+
+	// call the new hello function from a transaction
+
+	callTransaction := []byte(fmt.Sprintf(callHelloTransactionTemplate, Address{accountCounter}))
+
+	loggedMessages = nil
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: callTransaction,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{`"2"`},
+		loggedMessages,
+	)
 }
 
 func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
@@ -6635,8 +6701,6 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 	var accountCode []byte
 	var events []cadence.Event
 
-	var codeChanged bool
-
 	signerAddress := common.MustBytesToAddress([]byte{0x42})
 
 	runtimeInterface := &testRuntimeInterface{
@@ -6669,7 +6733,6 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 			return accountCode, nil
 		},
 		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
-			codeChanged = true
 			accountCode = code
 			return nil
 		},
@@ -6679,23 +6742,10 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		},
 	}
 
-	// When code is changed, the parsed+checked programs have to be invalidated
-
-	clearProgramsIfNeeded := func() {
-		if !codeChanged {
-			return
-		}
-
-		for location := range runtimeInterface.programs {
-			delete(runtimeInterface.programs, location)
-		}
-	}
-
 	nextTransactionLocation := newTransactionLocationGenerator()
 
 	// Deploy the Test contract
 
-	codeChanged = false
 	deployTx1 := DeploymentTransaction("Test", []byte(contract1))
 
 	err := runtime.ExecuteTransaction(
@@ -6715,8 +6765,6 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 	}
 
 	require.NotContains(t, runtimeInterface.programs, location)
-
-	clearProgramsIfNeeded()
 
 	// Use the Test contract
 
@@ -6758,8 +6806,6 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 	// Update the Test contract
 
-	codeChanged = false
-
 	deployTx2 := UpdateTransaction("Test", []byte(contract2))
 
 	err = runtime.ExecuteTransaction(
@@ -6781,8 +6827,6 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		runtimeInterface.programs[location],
 	)
 	require.NotNil(t, runtimeInterface.programs[location])
-
-	clearProgramsIfNeeded()
 
 	// Use the new Test contract
 
@@ -6919,12 +6963,9 @@ func TestRuntimeGetConfig(t *testing.T) {
 	t.Parallel()
 
 	rt := newTestInterpreterRuntime()
-	// depends on newTestInterpreterRuntime using the interpreterRuntime struct
-	underlying, ok := rt.(*interpreterRuntime)
-	require.True(t, ok)
 
 	config := rt.Config()
-	expected := underlying.defaultConfig
+	expected := rt.defaultConfig
 	require.Equal(t, expected, config)
 }
 


### PR DESCRIPTION
## Description

When a transaction updates a contract, the relevant programs must be cleared.

Currently tests have to implement this in the interface themselves and might forget.

Perform the program invalidation automatically. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
