### PR TITLE
Reject cyclic imports during contract deployment

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -336,7 +336,11 @@ func (e *interpreterEnvironment) ParseAndCheckProgram(
 		code,
 		location,
 		storeProgram,
-		importResolutionResults{},
+		importResolutionResults{
+			// Current program is already in check.
+			// So mark it also as 'already seen'.
+			location: true,
+		},
 	)
 }
 


### PR DESCRIPTION
Closes #2304

## Description

Currently, cyclic imports are not rejected during contract updates, but are only rejected once the contract is deployed and is imported/used by another program (contract/script/transaction).

This PR rejects creating cyclic contracts early on, at the time of deployment. i.e: Fails early.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
