### PR TITLE
Bypass go-proxy to always pick the latest commit

### DIFF
--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Check contracts using ${{ inputs.current-branch }}
         working-directory: ./tools/compatibility-check
         run: |
-          go get github.com/onflow/cadence@${{ inputs.current-branch }}
+          GOPROXY=direct go get github.com/onflow/cadence@${{ inputs.current-branch }}
           go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-new.txt
 
@@ -86,7 +86,7 @@ jobs:
       - name: Check contracts using ${{ inputs.base-branch }}
         working-directory: ./tools/compatibility-check
         run: |
-          go get github.com/onflow/cadence@${{ inputs.base-branch }}
+          GOPROXY=direct go get github.com/onflow/cadence@${{ inputs.base-branch }}
           go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-old.txt
 


### PR DESCRIPTION
## Description

The `go get` command by default uses the [go module proxy](https://proxy.golang.org/). However, sometimes the proxy may not reflect the latest commits on a branch immediately.

As a result, when we use `go get github.com/onflow/cadence@master` it may sometimes not pick the latest commit on the `master` branch. This can impact the compatibility check, since the latest commits may get skipped from the check.

Hence, bypass the proxy and directly pull the commit from the source repo.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
