### PR TITLE
swap arguments of NewHostFunctionValue to put the fn type first

### DIFF
--- a/runtime/interpreter/deployedcontract.go
+++ b/runtime/interpreter/deployedcontract.go
@@ -62,7 +62,7 @@ func newPublicTypesFunctionValue(inter *Interpreter, addressValue AddressValue, 
 	var publicTypes *ArrayValue
 
 	address := addressValue.ToAddress()
-	return NewHostFunctionValue(inter, func(inv Invocation) Value {
+	return NewHostFunctionValue(inter, sema.DeployedContractTypePublicTypesFunctionType, func(inv Invocation) Value {
 		if publicTypes == nil {
 			innerInter := inv.Interpreter
 			contractLocation := common.NewAddressLocation(innerInter, address, name.Str)
@@ -97,5 +97,5 @@ func newPublicTypesFunctionValue(inter *Interpreter, addressValue AddressValue, 
 		}
 
 		return publicTypes
-	}, sema.DeployedContractTypePublicTypesFunctionType)
+	})
 }

--- a/runtime/interpreter/function.go
+++ b/runtime/interpreter/function.go
@@ -191,8 +191,8 @@ func (f *HostFunctionValue) MeteredString(memoryGauge common.MemoryGauge, _ Seen
 }
 
 func NewUnmeteredHostFunctionValue(
-	function HostFunction,
 	funcType *sema.FunctionType,
+	function HostFunction,
 ) *HostFunctionValue {
 	// Host functions can be passed by value,
 	// so for the interpreter value transfer check to work,
@@ -209,13 +209,13 @@ func NewUnmeteredHostFunctionValue(
 
 func NewHostFunctionValue(
 	gauge common.MemoryGauge,
-	function HostFunction,
 	funcType *sema.FunctionType,
+	function HostFunction,
 ) *HostFunctionValue {
 
 	common.UseMemory(gauge, common.HostFunctionValueMemoryUsage)
 
-	return NewUnmeteredHostFunctionValue(function, funcType)
+	return NewUnmeteredHostFunctionValue(funcType, function)
 }
 
 var _ Value = &HostFunctionValue{}

--- a/runtime/interpreter/function_test.go
+++ b/runtime/interpreter/function_test.go
@@ -49,8 +49,8 @@ func TestFunctionStaticType(t *testing.T) {
 
 		hostFunctionValue := NewHostFunctionValue(
 			inter,
-			hostFunction,
 			hostFunctionType,
+			hostFunction,
 		)
 
 		staticType := hostFunctionValue.StaticType(inter)
@@ -73,8 +73,8 @@ func TestFunctionStaticType(t *testing.T) {
 
 		hostFunctionValue := NewHostFunctionValue(
 			inter,
-			hostFunction,
 			hostFunctionType,
+			hostFunction,
 		)
 
 		compositeValue := NewCompositeValue(

--- a/runtime/interpreter/string.go
+++ b/runtime/interpreter/string.go
@@ -111,10 +111,10 @@ func stringFunctionFromCharacters(invocation Invocation) Value {
 // stringFunction is the `String` function. It is stateless, hence it can be re-used across interpreters.
 var stringFunction = func() Value {
 	functionValue := NewUnmeteredHostFunctionValue(
+		sema.StringFunctionType,
 		func(invocation Invocation) Value {
 			return emptyString
 		},
-		sema.StringFunctionType,
 	)
 
 	addMember := func(name string, value Value) {
@@ -129,24 +129,24 @@ var stringFunction = func() Value {
 	addMember(
 		sema.StringTypeEncodeHexFunctionName,
 		NewUnmeteredHostFunctionValue(
-			stringFunctionEncodeHex,
 			sema.StringTypeEncodeHexFunctionType,
+			stringFunctionEncodeHex,
 		),
 	)
 
 	addMember(
 		sema.StringTypeFromUtf8FunctionName,
 		NewUnmeteredHostFunctionValue(
-			stringFunctionFromUtf8,
 			sema.StringTypeFromUtf8FunctionType,
+			stringFunctionFromUtf8,
 		),
 	)
 
 	addMember(
 		sema.StringTypeFromCharactersFunctionName,
 		NewUnmeteredHostFunctionValue(
-			stringFunctionFromCharacters,
 			sema.StringTypeFromCharactersFunctionType,
+			stringFunctionFromCharacters,
 		),
 	)
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -358,6 +358,7 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 	case "isSubtype":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.MetaTypeIsSubtypeFunctionType,
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 
@@ -379,7 +380,6 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 				)
 				return AsBoolValue(result)
 			},
-			sema.MetaTypeIsSubtypeFunctionType,
 		)
 	}
 
@@ -858,6 +858,7 @@ func (v CharacterValue) GetMember(interpreter *Interpreter, _ LocationRange, nam
 	case sema.ToStringFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ToStringFunctionType,
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 
@@ -871,7 +872,6 @@ func (v CharacterValue) GetMember(interpreter *Interpreter, _ LocationRange, nam
 					},
 				)
 			},
-			sema.ToStringFunctionType,
 		)
 	}
 	return nil
@@ -1123,6 +1123,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 	case "concat":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.StringTypeConcatFunctionType,
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 				otherArray, ok := invocation.Arguments[0].(*StringValue)
@@ -1131,12 +1132,12 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 				}
 				return v.Concat(interpreter, otherArray, locationRange)
 			},
-			sema.StringTypeConcatFunctionType,
 		)
 
 	case "slice":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.StringTypeSliceFunctionType,
 			func(invocation Invocation) Value {
 				from, ok := invocation.Arguments[0].(IntValue)
 				if !ok {
@@ -1150,28 +1151,27 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 				return v.Slice(from, to, invocation.LocationRange)
 			},
-			sema.StringTypeSliceFunctionType,
 		)
 
 	case "decodeHex":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.StringTypeDecodeHexFunctionType,
 			func(invocation Invocation) Value {
 				return v.DecodeHex(
 					invocation.Interpreter,
 					invocation.LocationRange,
 				)
 			},
-			sema.StringTypeDecodeHexFunctionType,
 		)
 
 	case "toLower":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.StringTypeToLowerFunctionType,
 			func(invocation Invocation) Value {
 				return v.ToLower(invocation.Interpreter)
 			},
-			sema.StringTypeToLowerFunctionType,
 		)
 	}
 
@@ -2043,6 +2043,9 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 	case "append":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayAppendFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				v.Append(
 					invocation.Interpreter,
@@ -2051,14 +2054,14 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 				)
 				return Void
 			},
-			sema.ArrayAppendFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 
 	case "appendAll":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayAppendAllFunctionType(
+				v.SemaType(interpreter),
+			),
 			func(invocation Invocation) Value {
 				otherArray, ok := invocation.Arguments[0].(*ArrayValue)
 				if !ok {
@@ -2071,14 +2074,14 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 				)
 				return Void
 			},
-			sema.ArrayAppendAllFunctionType(
-				v.SemaType(interpreter),
-			),
 		)
 
 	case "concat":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayConcatFunctionType(
+				v.SemaType(interpreter),
+			),
 			func(invocation Invocation) Value {
 				otherArray, ok := invocation.Arguments[0].(*ArrayValue)
 				if !ok {
@@ -2090,14 +2093,14 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 					otherArray,
 				)
 			},
-			sema.ArrayConcatFunctionType(
-				v.SemaType(interpreter),
-			),
 		)
 
 	case "insert":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayInsertFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				indexValue, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2115,14 +2118,14 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 				)
 				return Void
 			},
-			sema.ArrayInsertFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 
 	case "remove":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayRemoveFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				indexValue, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2136,42 +2139,42 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 					index,
 				)
 			},
-			sema.ArrayRemoveFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 
 	case "removeFirst":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayRemoveFirstFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				return v.RemoveFirst(
 					invocation.Interpreter,
 					invocation.LocationRange,
 				)
 			},
-			sema.ArrayRemoveFirstFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 
 	case "removeLast":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayRemoveLastFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				return v.RemoveLast(
 					invocation.Interpreter,
 					invocation.LocationRange,
 				)
 			},
-			sema.ArrayRemoveLastFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 
 	case "firstIndex":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayFirstIndexFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				return v.FirstIndex(
 					invocation.Interpreter,
@@ -2179,14 +2182,14 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 					invocation.Arguments[0],
 				)
 			},
-			sema.ArrayFirstIndexFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 
 	case "contains":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArrayContainsFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				return v.Contains(
 					invocation.Interpreter,
@@ -2194,14 +2197,14 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 					invocation.Arguments[0],
 				)
 			},
-			sema.ArrayContainsFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 
 	case "slice":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ArraySliceFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
 			func(invocation Invocation) Value {
 				from, ok := invocation.Arguments[0].(IntValue)
 				if !ok {
@@ -2220,9 +2223,6 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 					invocation.LocationRange,
 				)
 			},
-			sema.ArraySliceFunctionType(
-				v.SemaType(interpreter).ElementType(false),
-			),
 		)
 	}
 
@@ -2701,6 +2701,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 	case sema.ToStringFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ToStringFunctionType,
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 				memoryUsage := common.NewStringMemoryUsage(
@@ -2714,28 +2715,32 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					},
 				)
 			},
-			sema.ToStringFunctionType,
 		)
 
 	case sema.ToBigEndianBytesFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			&sema.FunctionType{
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(
+					sema.ByteArrayType,
+				),
+			},
 			func(invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(
 					invocation.Interpreter,
 					v.ToBigEndianBytes(),
 				)
 			},
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					sema.ByteArrayType,
-				),
-			},
 		)
 
 	case sema.NumericTypeSaturatingAddFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			&sema.FunctionType{
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(
+					typ,
+				),
+			},
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2747,16 +2752,16 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					locationRange,
 				)
 			},
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
 		)
 
 	case sema.NumericTypeSaturatingSubtractFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			&sema.FunctionType{
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(
+					typ,
+				),
+			},
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2768,16 +2773,16 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					locationRange,
 				)
 			},
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
 		)
 
 	case sema.NumericTypeSaturatingMultiplyFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			&sema.FunctionType{
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(
+					typ,
+				),
+			},
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2789,16 +2794,16 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					locationRange,
 				)
 			},
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
 		)
 
 	case sema.NumericTypeSaturatingDivideFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			&sema.FunctionType{
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(
+					typ,
+				),
+			},
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2809,11 +2814,6 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 					other,
 					locationRange,
 				)
-			},
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
 			},
 		)
 	}
@@ -15588,6 +15588,9 @@ func (v *DictionaryValue) GetMember(
 	case "remove":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.DictionaryRemoveFunctionType(
+				v.SemaType(interpreter),
+			),
 			func(invocation Invocation) Value {
 				keyValue := invocation.Arguments[0]
 
@@ -15597,14 +15600,14 @@ func (v *DictionaryValue) GetMember(
 					keyValue,
 				)
 			},
-			sema.DictionaryRemoveFunctionType(
-				v.SemaType(interpreter),
-			),
 		)
 
 	case "insert":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.DictionaryInsertFunctionType(
+				v.SemaType(interpreter),
+			),
 			func(invocation Invocation) Value {
 				keyValue := invocation.Arguments[0]
 				newValue := invocation.Arguments[1]
@@ -15616,14 +15619,14 @@ func (v *DictionaryValue) GetMember(
 					newValue,
 				)
 			},
-			sema.DictionaryInsertFunctionType(
-				v.SemaType(interpreter),
-			),
 		)
 
 	case "containsKey":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.DictionaryContainsKeyFunctionType(
+				v.SemaType(interpreter),
+			),
 			func(invocation Invocation) Value {
 				return v.ContainsKey(
 					invocation.Interpreter,
@@ -15631,13 +15634,13 @@ func (v *DictionaryValue) GetMember(
 					invocation.Arguments[0],
 				)
 			},
-			sema.DictionaryContainsKeyFunctionType(
-				v.SemaType(interpreter),
-			),
 		)
 	case "forEachKey":
 		return NewHostFunctionValue(
 			interpreter,
+			sema.DictionaryForEachKeyFunctionType(
+				v.SemaType(interpreter),
+			),
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 
@@ -15654,9 +15657,6 @@ func (v *DictionaryValue) GetMember(
 
 				return Void
 			},
-			sema.DictionaryForEachKeyFunctionType(
-				v.SemaType(interpreter),
-			),
 		)
 	}
 
@@ -16319,13 +16319,13 @@ func (v NilValue) MeteredString(memoryGauge common.MemoryGauge, _ SeenReferences
 // nilValueMapFunction is created only once per interpreter.
 // Hence, no need to meter, as it's a constant.
 var nilValueMapFunction = NewUnmeteredHostFunctionValue(
-	func(invocation Invocation) Value {
-		return Nil
-	},
 	&sema.FunctionType{
 		ReturnTypeAnnotation: sema.NewTypeAnnotation(
 			sema.NeverType,
 		),
+	},
+	func(invocation Invocation) Value {
+		return Nil
 	},
 )
 
@@ -16519,6 +16519,11 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, locationRange LocationRa
 	case sema.OptionalTypeMapFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			sema.OptionalTypeMapFunctionType(
+				interpreter.MustConvertStaticToSemaType(
+					v.value.StaticType(interpreter),
+				),
+			),
 			func(invocation Invocation) Value {
 
 				transformFunction, ok := invocation.Arguments[0].(FunctionValue)
@@ -16547,11 +16552,6 @@ func (v *SomeValue) GetMember(interpreter *Interpreter, locationRange LocationRa
 
 				return v.fmap(invocation.Interpreter, f)
 			},
-			sema.OptionalTypeMapFunctionType(
-				interpreter.MustConvertStaticToSemaType(
-					v.value.StaticType(interpreter),
-				),
-			),
 		)
 	}
 
@@ -17609,6 +17609,7 @@ func (v AddressValue) GetMember(interpreter *Interpreter, locationRange Location
 	case sema.ToStringFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			sema.ToStringFunctionType,
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 				memoryUsage := common.NewStringMemoryUsage(
@@ -17622,18 +17623,17 @@ func (v AddressValue) GetMember(interpreter *Interpreter, locationRange Location
 					},
 				)
 			},
-			sema.ToStringFunctionType,
 		)
 
 	case sema.AddressTypeToBytesFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
+			sema.AddressTypeToBytesFunctionType,
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 				address := common.Address(v)
 				return ByteSliceToByteArrayValue(interpreter, address[:])
 			},
-			sema.AddressTypeToBytesFunctionType,
 		)
 	}
 
@@ -17716,6 +17716,7 @@ func accountGetCapabilityFunction(
 
 	return NewHostFunctionValue(
 		gauge,
+		funcType,
 		func(invocation Invocation) Value {
 
 			path, ok := invocation.Arguments[0].(PathValue)
@@ -17759,7 +17760,6 @@ func accountGetCapabilityFunction(
 				borrowStaticType,
 			)
 		},
-		funcType,
 	)
 }
 
@@ -17851,6 +17851,7 @@ func (v PathValue) GetMember(inter *Interpreter, locationRange LocationRange, na
 	case sema.ToStringFunctionName:
 		return NewHostFunctionValue(
 			inter,
+			sema.ToStringFunctionType,
 			func(invocation Invocation) Value {
 				interpreter := invocation.Interpreter
 
@@ -17867,7 +17868,6 @@ func (v PathValue) GetMember(inter *Interpreter, locationRange LocationRange, na
 					v.String,
 				)
 			},
-			sema.ToStringFunctionType,
 		)
 	}
 

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -455,6 +455,7 @@ func newAddPublicKeyFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountTypeAddPublicKeyFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			publicKeyValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -488,7 +489,6 @@ func newAddPublicKeyFunction(
 
 			return interpreter.Void
 		},
-		sema.AuthAccountTypeAddPublicKeyFunctionType,
 	)
 }
 
@@ -509,6 +509,7 @@ func newRemovePublicKeyFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountTypeRemovePublicKeyFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			index, ok := invocation.Arguments[0].(interpreter.IntValue)
 			if !ok {
@@ -544,7 +545,6 @@ func newRemovePublicKeyFunction(
 
 			return interpreter.Void
 		},
-		sema.AuthAccountTypeRemovePublicKeyFunctionType,
 	)
 }
 
@@ -569,6 +569,7 @@ func newAccountKeysAddFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountKeysTypeAddFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			publicKeyValue, ok := invocation.Arguments[0].(*interpreter.CompositeValue)
 			if !ok {
@@ -617,7 +618,6 @@ func newAccountKeysAddFunction(
 				handler,
 			)
 		},
-		sema.AuthAccountKeysTypeAddFunctionType,
 	)
 }
 
@@ -650,6 +650,7 @@ func newAccountKeysGetFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AccountKeysTypeGetFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			indexValue, ok := invocation.Arguments[0].(interpreter.IntValue)
 			if !ok {
@@ -689,7 +690,6 @@ func newAccountKeysGetFunction(
 				),
 			)
 		},
-		sema.AccountKeysTypeGetFunctionType,
 	)
 }
 
@@ -705,6 +705,7 @@ func newAccountKeysForEachFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AccountKeysTypeForEachFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			fnValue, ok := invocation.Arguments[0].(interpreter.FunctionValue)
 
@@ -788,7 +789,6 @@ func newAccountKeysForEachFunction(
 
 			return interpreter.Void
 		},
-		sema.AccountKeysTypeForEachFunctionType,
 	)
 }
 
@@ -839,6 +839,7 @@ func newAccountKeysRevokeFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountKeysTypeRevokeFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			indexValue, ok := invocation.Arguments[0].(interpreter.IntValue)
 			if !ok {
@@ -887,7 +888,6 @@ func newAccountKeysRevokeFunction(
 				),
 			)
 		},
-		sema.AuthAccountKeysTypeRevokeFunctionType,
 	)
 }
 
@@ -961,6 +961,7 @@ func accountInboxPublishFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountTypeInboxPublishFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			value, ok := invocation.Arguments[0].(*interpreter.StorageCapabilityValue)
 			if !ok {
@@ -1004,7 +1005,6 @@ func accountInboxPublishFunction(
 
 			return interpreter.Void
 		},
-		sema.AuthAccountTypeInboxPublishFunctionType,
 	)
 }
 
@@ -1016,6 +1016,7 @@ func accountInboxUnpublishFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountTypeInboxPublishFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -1071,7 +1072,6 @@ func accountInboxUnpublishFunction(
 
 			return interpreter.NewSomeValueNonCopying(inter, value)
 		},
-		sema.AuthAccountTypeInboxPublishFunctionType,
 	)
 }
 
@@ -1082,6 +1082,7 @@ func accountInboxClaimFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountTypeInboxPublishFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -1150,7 +1151,6 @@ func accountInboxClaimFunction(
 
 			return interpreter.NewSomeValueNonCopying(inter, value)
 		},
-		sema.AuthAccountTypeInboxPublishFunctionType,
 	)
 }
 
@@ -1244,6 +1244,7 @@ func newAccountContractsGetFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AccountContractsTypeGetFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -1277,7 +1278,6 @@ func newAccountContractsGetFunction(
 				return interpreter.Nil
 			}
 		},
-		sema.AccountContractsTypeGetFunctionType,
 	)
 }
 
@@ -1292,6 +1292,7 @@ func newAccountContractsBorrowFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AccountContractsTypeBorrowFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			inter := invocation.Interpreter
@@ -1356,7 +1357,6 @@ func newAccountContractsBorrowFunction(
 			)
 
 		},
-		sema.AccountContractsTypeBorrowFunctionType,
 	)
 }
 
@@ -1394,6 +1394,7 @@ func newAuthAccountContractsChangeFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountContractsTypeAddFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			locationRange := invocation.LocationRange
@@ -1641,7 +1642,6 @@ func newAuthAccountContractsChangeFunction(
 				newCodeValue,
 			)
 		},
-		sema.AuthAccountContractsTypeAddFunctionType,
 	)
 }
 
@@ -1907,6 +1907,7 @@ func newAuthAccountContractsRemoveFunction(
 
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.AuthAccountContractsTypeRemoveFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			inter := invocation.Interpreter
@@ -1989,7 +1990,6 @@ func newAuthAccountContractsRemoveFunction(
 				return interpreter.Nil
 			}
 		},
-		sema.AuthAccountContractsTypeRemoveFunctionType,
 	)
 }
 

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -124,6 +124,7 @@ func newBLSAggregatePublicKeysFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		blsAggregatePublicKeysFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			publicKeysValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -181,7 +182,6 @@ func newBLSAggregatePublicKeysFunction(
 				aggregatedPublicKeyValue,
 			)
 		},
-		blsAggregatePublicKeysFunctionType,
 	)
 }
 
@@ -196,6 +196,7 @@ func newBLSAggregateSignaturesFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		blsAggregateSignaturesFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			signaturesValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -247,7 +248,6 @@ func newBLSAggregateSignaturesFunction(
 				aggregatedSignatureValue,
 			)
 		},
-		blsAggregateSignaturesFunctionType,
 	)
 }
 

--- a/runtime/stdlib/functions.go
+++ b/runtime/stdlib/functions.go
@@ -39,7 +39,7 @@ func NewStandardLibraryFunction(
 		argumentLabels[i] = parameter.EffectiveArgumentLabel()
 	}
 
-	functionValue := interpreter.NewUnmeteredHostFunctionValue(function, functionType)
+	functionValue := interpreter.NewUnmeteredHostFunctionValue(functionType, function)
 
 	return StandardLibraryValue{
 		Name:           name,

--- a/runtime/stdlib/hashalgorithm.go
+++ b/runtime/stdlib/hashalgorithm.go
@@ -73,6 +73,7 @@ func newHashAlgorithmHashFunction(
 	hasher Hasher,
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		sema.HashAlgorithmTypeHashFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			dataValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -92,7 +93,6 @@ func newHashAlgorithmHashFunction(
 				hashAlgoValue,
 			)
 		},
-		sema.HashAlgorithmTypeHashFunctionType,
 	)
 }
 
@@ -101,6 +101,7 @@ func newHashAlgorithmHashWithTagFunction(
 	hasher Hasher,
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		sema.HashAlgorithmTypeHashWithTagFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			dataValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
@@ -126,7 +127,6 @@ func newHashAlgorithmHashWithTagFunction(
 				hashAlgorithmValue,
 			)
 		},
-		sema.HashAlgorithmTypeHashWithTagFunctionType,
 	)
 }
 

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -224,6 +224,7 @@ func newPublicKeyVerifySignatureFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.PublicKeyVerifyFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			signatureValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -294,7 +295,6 @@ func newPublicKeyVerifySignatureFunction(
 
 			return interpreter.AsBoolValue(valid)
 		},
-		sema.PublicKeyVerifyFunctionType,
 	)
 }
 
@@ -309,6 +309,7 @@ func newPublicKeyVerifyPoPFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		sema.PublicKeyVerifyPoPFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			signatureValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -346,6 +347,5 @@ func newPublicKeyVerifyPoPFunction(
 			}
 			return interpreter.AsBoolValue(valid)
 		},
-		sema.PublicKeyVerifyPoPFunctionType,
 	)
 }

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -97,6 +97,7 @@ func (e RLPDecodeStringError) Error() string {
 }
 
 var rlpDecodeStringFunction = interpreter.NewUnmeteredHostFunctionValue(
+	rlpDecodeStringFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		input, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 		if !ok {
@@ -129,7 +130,6 @@ var rlpDecodeStringFunction = interpreter.NewUnmeteredHostFunctionValue(
 		}
 		return interpreter.ByteSliceToByteArrayValue(invocation.Interpreter, output)
 	},
-	rlpDecodeStringFunctionType,
 )
 
 const rlpDecodeListFunctionDocString = `
@@ -171,6 +171,7 @@ func (e RLPDecodeListError) Error() string {
 }
 
 var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
+	rlpDecodeListFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		input, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 		if !ok {
@@ -221,7 +222,6 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
 			values...,
 		)
 	},
-	rlpDecodeListFunctionType,
 )
 
 var rlpContractFields = map[string]interpreter.Value{

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -349,6 +349,7 @@ var testAssertFunctionType = &sema.FunctionType{
 }
 
 var testAssertFunction = interpreter.NewUnmeteredHostFunctionValue(
+	testAssertFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		condition, ok := invocation.Arguments[0].(interpreter.BoolValue)
 		if !ok {
@@ -373,7 +374,6 @@ var testAssertFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		return interpreter.Void
 	},
-	testAssertFunctionType,
 )
 
 // 'Test.fail' function
@@ -400,6 +400,7 @@ var testFailFunctionType = &sema.FunctionType{
 }
 
 var testFailFunction = interpreter.NewUnmeteredHostFunctionValue(
+	testFailFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		var message string
 		if len(invocation.Arguments) > 0 {
@@ -415,7 +416,6 @@ var testFailFunction = interpreter.NewUnmeteredHostFunctionValue(
 			LocationRange: invocation.LocationRange,
 		})
 	},
-	testFailFunctionType,
 )
 
 // 'Test.expect' function
@@ -461,6 +461,7 @@ var testExpectFunctionType = func() *sema.FunctionType {
 }()
 
 var testExpectFunction = interpreter.NewUnmeteredHostFunctionValue(
+	testExpectFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		value := invocation.Arguments[0]
 
@@ -485,7 +486,6 @@ var testExpectFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		return interpreter.Void
 	},
-	testExpectFunctionType,
 )
 
 func invokeMatcherTest(
@@ -555,6 +555,7 @@ var testReadFileFunctionType = &sema.FunctionType{
 
 func testReadFileFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		testReadFileFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			pathString, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -568,7 +569,6 @@ func testReadFileFunction(testFramework TestFramework) *interpreter.HostFunction
 
 			return interpreter.NewUnmeteredStringValue(content)
 		},
-		testReadFileFunctionType,
 	)
 }
 
@@ -588,6 +588,7 @@ var testNewEmulatorBlockchainFunctionType = &sema.FunctionType{
 
 func testNewEmulatorBlockchainFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		testNewEmulatorBlockchainFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			inter := invocation.Interpreter
 			locationRange := invocation.LocationRange
@@ -621,7 +622,6 @@ func testNewEmulatorBlockchainFunction(testFramework TestFramework) *interpreter
 
 			return blockchain
 		},
-		testNewEmulatorBlockchainFunctionType,
 	)
 }
 
@@ -700,6 +700,7 @@ var newMatcherFunctionType = func() *sema.FunctionType {
 }()
 
 var newMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
+	newMatcherFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		test, ok := invocation.Arguments[0].(interpreter.FunctionValue)
 		if !ok {
@@ -708,7 +709,6 @@ var newMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		return newMatcherWithGenericTestFunction(invocation, test)
 	},
-	newMatcherFunctionType,
 )
 
 // 'EmulatorBackend' struct.
@@ -842,6 +842,7 @@ var emulatorBackendExecuteScriptFunctionType = interfaceFunctionType(
 
 func emulatorBackendExecuteScriptFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		emulatorBackendExecuteScriptFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			script, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -859,7 +860,6 @@ func emulatorBackendExecuteScriptFunction(testFramework TestFramework) *interpre
 
 			return newScriptResult(inter, result.Value, result)
 		},
-		emulatorBackendExecuteScriptFunctionType,
 	)
 }
 
@@ -949,6 +949,7 @@ var emulatorBackendCreateAccountFunctionType = interfaceFunctionType(
 
 func emulatorBackendCreateAccountFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		emulatorBackendCreateAccountFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			account, err := testFramework.CreateAccount()
 			if err != nil {
@@ -965,7 +966,6 @@ func emulatorBackendCreateAccountFunction(testFramework TestFramework) *interpre
 				account,
 			)
 		},
-		emulatorBackendCreateAccountFunctionType,
 	)
 }
 
@@ -1022,6 +1022,7 @@ var emulatorBackendAddTransactionFunctionType = interfaceFunctionType(
 
 func emulatorBackendAddTransactionFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		emulatorBackendAddTransactionFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			inter := invocation.Interpreter
 			locationRange := invocation.LocationRange
@@ -1089,7 +1090,6 @@ func emulatorBackendAddTransactionFunction(testFramework TestFramework) *interpr
 
 			return interpreter.Void
 		},
-		emulatorBackendAddTransactionFunctionType,
 	)
 }
 
@@ -1199,6 +1199,7 @@ var emulatorBackendExecuteNextTransactionFunctionType = interfaceFunctionType(
 
 func emulatorBackendExecuteNextTransactionFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		emulatorBackendExecuteNextTransactionFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			result := testFramework.ExecuteNextTransaction()
 
@@ -1209,7 +1210,6 @@ func emulatorBackendExecuteNextTransactionFunction(testFramework TestFramework) 
 
 			return newTransactionResult(invocation.Interpreter, result)
 		},
-		emulatorBackendExecuteNextTransactionFunctionType,
 	)
 }
 
@@ -1285,6 +1285,7 @@ var emulatorBackendCommitBlockFunctionType = interfaceFunctionType(
 
 func emulatorBackendCommitBlockFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		emulatorBackendCommitBlockFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			err := testFramework.CommitBlock()
 			if err != nil {
@@ -1293,7 +1294,6 @@ func emulatorBackendCommitBlockFunction(testFramework TestFramework) *interprete
 
 			return interpreter.Void
 		},
-		emulatorBackendCommitBlockFunctionType,
 	)
 }
 
@@ -1334,6 +1334,7 @@ var equalMatcherFunctionType = func() *sema.FunctionType {
 }()
 
 var equalMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
+	equalMatcherFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		otherValue, ok := invocation.Arguments[0].(interpreter.EquatableValue)
 		if !ok {
@@ -1344,6 +1345,7 @@ var equalMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 		equalTestFunc := interpreter.NewHostFunctionValue(
 			nil,
+			matcherTestFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
 
 				thisValue, ok := invocation.Arguments[0].(interpreter.EquatableValue)
@@ -1359,12 +1361,10 @@ var equalMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 
 				return interpreter.AsBoolValue(equal)
 			},
-			matcherTestFunctionType,
 		)
 
 		return newMatcherWithGenericTestFunction(invocation, equalTestFunc)
 	},
-	equalMatcherFunctionType,
 )
 
 // 'EmulatorBackend.deployContract' function
@@ -1382,6 +1382,7 @@ var emulatorBackendDeployContractFunctionType = interfaceFunctionType(
 
 func emulatorBackendDeployContractFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		emulatorBackendDeployContractFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			inter := invocation.Interpreter
 
@@ -1421,7 +1422,6 @@ func emulatorBackendDeployContractFunction(testFramework TestFramework) *interpr
 
 			return newErrorValue(inter, err)
 		},
-		emulatorBackendDeployContractFunctionType,
 	)
 }
 
@@ -1438,6 +1438,7 @@ var emulatorBackendUseConfigFunctionType = interfaceFunctionType(
 
 func emulatorBackendUseConfigFunction(testFramework TestFramework) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
+		emulatorBackendUseConfigFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			inter := invocation.Interpreter
 
@@ -1480,7 +1481,6 @@ func emulatorBackendUseConfigFunction(testFramework TestFramework) *interpreter.
 
 			return interpreter.Void
 		},
-		emulatorBackendUseConfigFunctionType,
 	)
 }
 
@@ -1529,6 +1529,7 @@ func newMatcherWithGenericTestFunction(
 	// No need to validate if the matcher is created as a matcher combinator.
 	//
 	matcherTestFunction := interpreter.NewUnmeteredHostFunctionValue(
+		matcherTestFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			inter := invocation.Interpreter
 
@@ -1554,7 +1555,6 @@ func newMatcherWithGenericTestFunction(
 
 			return value
 		},
-		matcherTestFunctionType,
 	)
 
 	matcherConstructor := getNestedTypeConstructorValue(

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -1109,6 +1109,7 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 		Type: checkFunctionType,
 		Value: interpreter.NewHostFunctionValue(
 			nil,
+			checkFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
 				checkCalled = true
 
@@ -1117,7 +1118,6 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
 
 				return interpreter.Void
 			},
-			checkFunctionType,
 		),
 		Kind: common.DeclarationKindConstant,
 	}

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -95,11 +95,11 @@ func TestInterpretVirtualImport(t *testing.T) {
 					value.Functions = map[string]interpreter.FunctionValue{
 						"bar": interpreter.NewHostFunctionValue(
 							inter,
-							func(invocation interpreter.Invocation) interpreter.Value {
-								return interpreter.NewUnmeteredUInt64Value(42)
-							},
 							&sema.FunctionType{
 								ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UIntType),
+							},
+							func(invocation interpreter.Invocation) interpreter.Value {
+								return interpreter.NewUnmeteredUInt64Value(42)
 							},
 						),
 					}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -9085,10 +9085,10 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 func newPanicFunctionValue(gauge common.MemoryGauge) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
+		stdlib.PanicFunction.Type.(*sema.FunctionType),
 		func(invocation interpreter.Invocation) interpreter.Value {
 			panic(errors.NewUnreachableError())
 		},
-		stdlib.PanicFunction.Type.(*sema.FunctionType),
 	)
 }
 

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -4,6 +4,8 @@ rules:
     - go
   message: Host function values must have a static type
   pattern-either:
-    - pattern: NewHostFunctionValue(..., nil)
-    - pattern: interpreter.NewHostFunctionValue(..., nil)
+    - pattern: NewHostFunctionValue($GAUGE, nil, $HOST_FUNC)
+    - pattern: interpreter.NewHostFunctionValue($GAUGE, nil, $HOST_FUNC)
+    - pattern: NewUnmeteredHostFunctionValue(nil, $HOST_FUNC)
+    - pattern: interpreter.NewUnmeteredHostFunctionValue(nil, $HOST_FUNC)
   severity: ERROR


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Almost every invocation of `interpreter.NewHostFunctionValue` and `interpreter.NewUnmeteredHostFunctionValue` uses a function literal, followed by a function type which is defined elsewhere. Having the function block before the type obscures context when function blocks are long. For instance,

```go
fv := interpreter.NewHostFunctionValue(gauge, func(invocation Invocation) Value {
  ... 
  ... // business logic
  ... 
}, AFunctionType) // 
```

Mainly a style preference thing.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
