### PR TITLE
Refactor tests to cache typeIDs during assertions

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -2990,8 +2990,8 @@ func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value, opti
 
 	assert.Equal(
 		t,
-		valueWithCachedTypeID(expectedVal),
-		valueWithCachedTypeID(decodedVal),
+		cadence.ValueWithCachedTypeID(expectedVal),
+		cadence.ValueWithCachedTypeID(decodedVal),
 	)
 }
 
@@ -3220,92 +3220,4 @@ func TestExportFunctionValue(t *testing.T) {
           }
         `,
 	)
-}
-
-// valueWithCachedTypeID recursively caches type ID of value v's type.
-// This is needed because each type ID is lazily cached on
-// its first use in ID() to avoid performance penalty.
-func valueWithCachedTypeID(v cadence.Value) cadence.Value {
-	if v == nil {
-		return v
-	}
-
-	typeWithCachedTypeID(v.Type())
-
-	switch v := v.(type) {
-
-	case cadence.TypeValue:
-		typeWithCachedTypeID(v.StaticType)
-
-	case cadence.Optional:
-		valueWithCachedTypeID(v.Value)
-
-	case cadence.Array:
-		for _, v := range v.Values {
-			valueWithCachedTypeID(v)
-		}
-
-	case cadence.Dictionary:
-		for _, p := range v.Pairs {
-			valueWithCachedTypeID(p.Key)
-			valueWithCachedTypeID(p.Value)
-		}
-
-	case cadence.Struct:
-		for _, f := range v.Fields {
-			valueWithCachedTypeID(f)
-		}
-
-	case cadence.Resource:
-		for _, f := range v.Fields {
-			valueWithCachedTypeID(f)
-		}
-
-	case cadence.Event:
-		for _, f := range v.Fields {
-			valueWithCachedTypeID(f)
-		}
-
-	case cadence.Contract:
-		for _, f := range v.Fields {
-			valueWithCachedTypeID(f)
-		}
-
-	case cadence.Enum:
-		for _, f := range v.Fields {
-			valueWithCachedTypeID(f)
-		}
-	}
-
-	return v
-}
-
-// typeWithCachedTypeID recursively caches type ID of type t.
-// This is needed because each type ID is lazily cached on
-// its first use in ID() to avoid performance penalty.
-func typeWithCachedTypeID(t cadence.Type) cadence.Type {
-	if t == nil {
-		return t
-	}
-
-	// Cache type ID by calling ID()
-	t.ID()
-
-	switch t := t.(type) {
-
-	case cadence.CompositeType:
-		fields := t.CompositeFields()
-		for _, f := range fields {
-			typeWithCachedTypeID(f.Type)
-		}
-
-		initializers := t.CompositeInitializers()
-		for _, params := range initializers {
-			for _, p := range params {
-				typeWithCachedTypeID(p.Type)
-			}
-		}
-	}
-
-	return t
 }

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -1007,7 +1007,13 @@ var SignAlgoType = ExportedBuiltinType(sema.SignatureAlgorithmType).(*cadence.En
 var HashAlgoType = ExportedBuiltinType(sema.HashAlgorithmType).(*cadence.EnumType)
 
 func ExportedBuiltinType(internalType sema.Type) cadence.Type {
-	return ExportType(internalType, map[sema.TypeID]cadence.Type{})
+	typ := ExportType(internalType, map[sema.TypeID]cadence.Type{})
+
+	// These types are re-used across tests.
+	// Hence, cache the ID always to avoid any non-determinism.
+	typ = cadence.TypeWithCachedTypeID(typ)
+
+	return typ
 }
 
 func newBytesValue(bytes []byte) cadence.Array {
@@ -1232,6 +1238,8 @@ func (test accountKeyTestCase) executeScript(
 			Location:  common.ScriptLocation{},
 		},
 	)
+
+	value = cadence.ValueWithCachedTypeID(value)
 	return value, err
 }
 
@@ -1258,7 +1266,7 @@ func TestRuntimePublicKey(t *testing.T) {
 	executeScript := func(code string, runtimeInterface Interface) (cadence.Value, error) {
 		rt := newTestInterpreterRuntime()
 
-		return rt.ExecuteScript(
+		value, err := rt.ExecuteScript(
 			Script{
 				Source: []byte(code),
 			},
@@ -1267,6 +1275,9 @@ func TestRuntimePublicKey(t *testing.T) {
 				Location:  common.ScriptLocation{},
 			},
 		)
+
+		value = cadence.ValueWithCachedTypeID(value)
+		return value, err
 	}
 
 	t.Run("Constructor", func(t *testing.T) {
@@ -1597,6 +1608,7 @@ func TestRuntimePublicKey(t *testing.T) {
 				newSignAlgoValue(sema.SignatureAlgorithmECDSA_P256),
 			},
 		}
+
 		assert.Equal(t, expected, value)
 	})
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -2282,13 +2282,16 @@ func executeTestScript(t *testing.T, script string, arg cadence.Value) (cadence.
 		scriptParam.Arguments = [][]byte{encodedArg}
 	}
 
-	return rt.ExecuteScript(
+	value, err := rt.ExecuteScript(
 		scriptParam,
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
 		},
 	)
+
+	value = cadence.ValueWithCachedTypeID(value)
+	return value, err
 }
 
 func TestRuntimeArgumentPassing(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -118,10 +118,22 @@ func TestType_ID(t *testing.T) {
 		},
 		{
 			&StructType{
+				QualifiedIdentifier: "Foo",
+			},
+			"Foo",
+		},
+		{
+			&StructType{
 				Location:            utils.TestLocation,
 				QualifiedIdentifier: "Foo",
 			},
 			"S.test.Foo",
+		},
+		{
+			&StructInterfaceType{
+				QualifiedIdentifier: "FooI",
+			},
+			"FooI",
 		},
 		{
 			&StructInterfaceType{
@@ -132,21 +144,85 @@ func TestType_ID(t *testing.T) {
 		},
 		{
 			&ResourceType{
-				Location:            utils.TestLocation,
-				QualifiedIdentifier: "Foo",
+				QualifiedIdentifier: "Bar",
 			},
-			"S.test.Foo",
+			"Bar",
+		},
+		{
+			&ResourceType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "Bar",
+			},
+			"S.test.Bar",
+		},
+		{
+			&ResourceInterfaceType{
+				QualifiedIdentifier: "BarI",
+			},
+			"BarI",
 		},
 		{
 			&ResourceInterfaceType{
 				Location:            utils.TestLocation,
-				QualifiedIdentifier: "FooI",
+				QualifiedIdentifier: "BarI",
 			},
-			"S.test.FooI",
+			"S.test.BarI",
 		},
 		{
 			(&RestrictedType{}).WithID("S.test.Foo{S.test.FooI}"),
 			"S.test.Foo{S.test.FooI}",
+		},
+		{
+			&EventType{
+				QualifiedIdentifier: "Event",
+			},
+			"Event",
+		},
+		{
+			&EventType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "Event",
+			},
+			"S.test.Event",
+		},
+		{
+			&EnumType{
+				QualifiedIdentifier: "Enum",
+			},
+			"Enum",
+		},
+		{
+			&EnumType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "Enum",
+			},
+			"S.test.Enum",
+		},
+		{
+			&ContractType{
+				QualifiedIdentifier: "Contract",
+			},
+			"Contract",
+		},
+		{
+			&ContractType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "Contract",
+			},
+			"S.test.Contract",
+		},
+		{
+			&ContractInterfaceType{
+				QualifiedIdentifier: "ContractI",
+			},
+			"ContractI",
+		},
+		{
+			&ContractInterfaceType{
+				Location:            utils.TestLocation,
+				QualifiedIdentifier: "ContractI",
+			},
+			"S.test.ContractI",
 		},
 	}
 

--- a/values.go
+++ b/values.go
@@ -1974,3 +1974,63 @@ func (v Function) String() string {
 	// TODO: include function type
 	return format.Function("(...)")
 }
+
+// ValueWithCachedTypeID recursively caches type ID of value v's type.
+// This is needed because each type ID is lazily cached on
+// its first use in ID() to avoid performance penalty.
+func ValueWithCachedTypeID[T Value](value T) T {
+	var v Value = value
+
+	if v == nil {
+		return value
+	}
+
+	TypeWithCachedTypeID(value.Type())
+
+	switch v := v.(type) {
+
+	case TypeValue:
+		TypeWithCachedTypeID(v.StaticType)
+
+	case Optional:
+		ValueWithCachedTypeID(v.Value)
+
+	case Array:
+		for _, v := range v.Values {
+			ValueWithCachedTypeID(v)
+		}
+
+	case Dictionary:
+		for _, p := range v.Pairs {
+			ValueWithCachedTypeID(p.Key)
+			ValueWithCachedTypeID(p.Value)
+		}
+
+	case Struct:
+		for _, f := range v.Fields {
+			ValueWithCachedTypeID(f)
+		}
+
+	case Resource:
+		for _, f := range v.Fields {
+			ValueWithCachedTypeID(f)
+		}
+
+	case Event:
+		for _, f := range v.Fields {
+			ValueWithCachedTypeID(f)
+		}
+
+	case Contract:
+		for _, f := range v.Fields {
+			ValueWithCachedTypeID(f)
+		}
+
+	case Enum:
+		for _, f := range v.Fields {
+			ValueWithCachedTypeID(f)
+		}
+	}
+
+	return value
+}


### PR DESCRIPTION
Work towards #2325

## Description

Use the utility method introduced in https://github.com/onflow/cadence/pull/2326 in tests to cache the typeID, so the value assertions are not broken by the new cached typeID field.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
