### PR TITLE
Handle backticks in docstrings when generating code, add surrounding newlines to docstrings

### DIFF
--- a/runtime/sema/block.gen.go
+++ b/runtime/sema/block.gen.go
@@ -28,7 +28,8 @@ const BlockTypeHeightFieldName = "height"
 
 var BlockTypeHeightFieldType = UInt64Type
 
-const BlockTypeHeightFieldDocString = `The height of the block.
+const BlockTypeHeightFieldDocString = `
+The height of the block.
 
 If the blockchain is viewed as a tree with the genesis block at the root,
 the height of a node is the number of edges between the node and the genesis block
@@ -38,7 +39,8 @@ const BlockTypeViewFieldName = "view"
 
 var BlockTypeViewFieldType = UInt64Type
 
-const BlockTypeViewFieldDocString = `The view of the block.
+const BlockTypeViewFieldDocString = `
+The view of the block.
 
 It is a detail of the consensus algorithm. It is a monotonically increasing integer and counts rounds in the consensus algorithm.
 Since not all rounds result in a finalized block, the view number is strictly greater than or equal to the block height
@@ -48,7 +50,8 @@ const BlockTypeTimestampFieldName = "timestamp"
 
 var BlockTypeTimestampFieldType = UFix64Type
 
-const BlockTypeTimestampFieldDocString = `Consider observing blocks' status changes off-chain yourself to get a more reliable value.
+const BlockTypeTimestampFieldDocString = `
+Consider observing blocks' status changes off-chain yourself to get a more reliable value.
 `
 
 const BlockTypeIdFieldName = "id"
@@ -58,7 +61,8 @@ var BlockTypeIdFieldType = &ConstantSizedType{
 	Size: 32,
 }
 
-const BlockTypeIdFieldDocString = `The ID of the block.
+const BlockTypeIdFieldDocString = `
+The ID of the block.
 It is essentially the hash of the block
 `
 

--- a/runtime/sema/gen/testdata/docstrings.cdc
+++ b/runtime/sema/gen/testdata/docstrings.cdc
@@ -1,0 +1,28 @@
+pub struct Docstrings {
+    /// This is a 1-line docstring.
+    pub let owo: Int
+
+    /// This is a 2-line docstring.
+    /// This is the second line.
+    pub let uwu: [Int]
+
+    /// This is a 3-line docstring for a function.
+    /// This is the second line.
+    /// And the third line!
+    pub fun nwn(x: Int): String?
+
+    /// This is a multiline docstring.
+    ///
+    /// There should be two newlines before this line!
+    pub let withBlanks: Int
+
+    /// The function `isSmolBean` has docstrings with backticks.
+    /// These should be handled accordingly.
+    pub fun isSmolBean(): Bool
+
+    /// A function with a docstring.
+    /// This docstring is `cool` because it has inline backticked expressions.
+    /// Look, I did it `again`, wowie!!
+    pub fun runningOutOfIdeas(): UInt64?
+
+}

--- a/runtime/sema/gen/testdata/docstrings.golden.go
+++ b/runtime/sema/gen/testdata/docstrings.golden.go
@@ -1,0 +1,218 @@
+// Code generated from testdata/docstrings.cdc. DO NOT EDIT.
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+const DocstringsTypeOwoFieldName = "owo"
+
+var DocstringsTypeOwoFieldType = IntType
+
+const DocstringsTypeOwoFieldDocString = `
+This is a 1-line docstring.
+`
+
+const DocstringsTypeUwuFieldName = "uwu"
+
+var DocstringsTypeUwuFieldType = &VariableSizedType{
+	Type: IntType,
+}
+
+const DocstringsTypeUwuFieldDocString = `
+This is a 2-line docstring.
+This is the second line.
+`
+
+const DocstringsTypeNwnFunctionName = "nwn"
+
+var DocstringsTypeNwnFunctionType = &FunctionType{
+	Parameters: []Parameter{
+		{
+			TypeAnnotation: NewTypeAnnotation(IntType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: StringType,
+		},
+	),
+}
+
+const DocstringsTypeNwnFunctionDocString = `
+This is a 3-line docstring for a function.
+This is the second line.
+And the third line!
+`
+
+const DocstringsTypeWithBlanksFieldName = "withBlanks"
+
+var DocstringsTypeWithBlanksFieldType = IntType
+
+const DocstringsTypeWithBlanksFieldDocString = `
+This is a multiline docstring.
+
+There should be two newlines before this line!
+`
+
+const DocstringsTypeIsSmolBeanFunctionName = "isSmolBean"
+
+var DocstringsTypeIsSmolBeanFunctionType = &FunctionType{
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		BoolType,
+	),
+}
+
+const DocstringsTypeIsSmolBeanFunctionDocString = `
+The function ` + "`isSmolBean`" + ` has docstrings with backticks.
+These should be handled accordingly.
+`
+
+const DocstringsTypeRunningOutOfIdeasFunctionName = "runningOutOfIdeas"
+
+var DocstringsTypeRunningOutOfIdeasFunctionType = &FunctionType{
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&OptionalType{
+			Type: UInt64Type,
+		},
+	),
+}
+
+const DocstringsTypeRunningOutOfIdeasFunctionDocString = `
+A function with a docstring.
+This docstring is ` + "`cool`" + ` because it has inline backticked expressions.
+Look, I did it ` + "`again`" + `, wowie!!
+`
+
+const DocstringsTypeName = "Docstrings"
+
+var DocstringsType = &SimpleType{
+	Name:          DocstringsTypeName,
+	QualifiedName: DocstringsTypeName,
+	TypeID:        DocstringsTypeName,
+	tag:           DocstringsTypeTag,
+	IsResource:    false,
+	Storable:      false,
+	Equatable:     false,
+	Exportable:    false,
+	Importable:    false,
+	Members: func(t *SimpleType) map[string]MemberResolver {
+		return map[string]MemberResolver{
+			DocstringsTypeOwoFieldName: {
+				Kind: common.DeclarationKindField,
+				Resolve: func(memoryGauge common.MemoryGauge,
+					identifier string,
+					targetRange ast.Range,
+					report func(error)) *Member {
+
+					return NewPublicConstantFieldMember(
+						memoryGauge,
+						t,
+						identifier,
+						DocstringsTypeOwoFieldType,
+						DocstringsTypeOwoFieldDocString,
+					)
+				},
+			},
+			DocstringsTypeUwuFieldName: {
+				Kind: common.DeclarationKindField,
+				Resolve: func(memoryGauge common.MemoryGauge,
+					identifier string,
+					targetRange ast.Range,
+					report func(error)) *Member {
+
+					return NewPublicConstantFieldMember(
+						memoryGauge,
+						t,
+						identifier,
+						DocstringsTypeUwuFieldType,
+						DocstringsTypeUwuFieldDocString,
+					)
+				},
+			},
+			DocstringsTypeNwnFunctionName: {
+				Kind: common.DeclarationKindFunction,
+				Resolve: func(memoryGauge common.MemoryGauge,
+					identifier string,
+					targetRange ast.Range,
+					report func(error)) *Member {
+
+					return NewPublicFunctionMember(
+						memoryGauge,
+						t,
+						identifier,
+						DocstringsTypeNwnFunctionType,
+						DocstringsTypeNwnFunctionDocString,
+					)
+				},
+			},
+			DocstringsTypeWithBlanksFieldName: {
+				Kind: common.DeclarationKindField,
+				Resolve: func(memoryGauge common.MemoryGauge,
+					identifier string,
+					targetRange ast.Range,
+					report func(error)) *Member {
+
+					return NewPublicConstantFieldMember(
+						memoryGauge,
+						t,
+						identifier,
+						DocstringsTypeWithBlanksFieldType,
+						DocstringsTypeWithBlanksFieldDocString,
+					)
+				},
+			},
+			DocstringsTypeIsSmolBeanFunctionName: {
+				Kind: common.DeclarationKindFunction,
+				Resolve: func(memoryGauge common.MemoryGauge,
+					identifier string,
+					targetRange ast.Range,
+					report func(error)) *Member {
+
+					return NewPublicFunctionMember(
+						memoryGauge,
+						t,
+						identifier,
+						DocstringsTypeIsSmolBeanFunctionType,
+						DocstringsTypeIsSmolBeanFunctionDocString,
+					)
+				},
+			},
+			DocstringsTypeRunningOutOfIdeasFunctionName: {
+				Kind: common.DeclarationKindFunction,
+				Resolve: func(memoryGauge common.MemoryGauge,
+					identifier string,
+					targetRange ast.Range,
+					report func(error)) *Member {
+
+					return NewPublicFunctionMember(
+						memoryGauge,
+						t,
+						identifier,
+						DocstringsTypeRunningOutOfIdeasFunctionType,
+						DocstringsTypeRunningOutOfIdeasFunctionDocString,
+					)
+				},
+			},
+		}
+	},
+}

--- a/runtime/sema/gen/testdata/fields.golden.go
+++ b/runtime/sema/gen/testdata/fields.golden.go
@@ -28,7 +28,8 @@ const TestTypeTestIntFieldName = "testInt"
 
 var TestTypeTestIntFieldType = UInt64Type
 
-const TestTypeTestIntFieldDocString = `This is a test integer.
+const TestTypeTestIntFieldDocString = `
+This is a test integer.
 `
 
 const TestTypeTestOptIntFieldName = "testOptInt"
@@ -37,7 +38,8 @@ var TestTypeTestOptIntFieldType = &OptionalType{
 	Type: UInt64Type,
 }
 
-const TestTypeTestOptIntFieldDocString = `This is a test optional integer.
+const TestTypeTestOptIntFieldDocString = `
+This is a test optional integer.
 `
 
 const TestTypeTestRefIntFieldName = "testRefInt"
@@ -46,7 +48,8 @@ var TestTypeTestRefIntFieldType = &ReferenceType{
 	Type: UInt64Type,
 }
 
-const TestTypeTestRefIntFieldDocString = `This is a test integer reference.
+const TestTypeTestRefIntFieldDocString = `
+This is a test integer reference.
 `
 
 const TestTypeTestVarIntsFieldName = "testVarInts"
@@ -55,7 +58,8 @@ var TestTypeTestVarIntsFieldType = &VariableSizedType{
 	Type: UInt64Type,
 }
 
-const TestTypeTestVarIntsFieldDocString = `This is a test variable-sized integer array.
+const TestTypeTestVarIntsFieldDocString = `
+This is a test variable-sized integer array.
 `
 
 const TestTypeTestConstIntsFieldName = "testConstInts"
@@ -65,7 +69,8 @@ var TestTypeTestConstIntsFieldType = &ConstantSizedType{
 	Size: 2,
 }
 
-const TestTypeTestConstIntsFieldDocString = `This is a test constant-sized integer array.
+const TestTypeTestConstIntsFieldDocString = `
+This is a test constant-sized integer array.
 `
 
 const TestTypeTestParamFieldName = "testParam"
@@ -75,28 +80,32 @@ var TestTypeTestParamFieldType = MustInstantiate(
 	BarType,
 )
 
-const TestTypeTestParamFieldDocString = `This is a test parameterized-type field.
+const TestTypeTestParamFieldDocString = `
+This is a test parameterized-type field.
 `
 
 const TestTypeTestAddressFieldName = "testAddress"
 
 var TestTypeTestAddressFieldType = TheAddressType
 
-const TestTypeTestAddressFieldDocString = `This is a test address field.
+const TestTypeTestAddressFieldDocString = `
+This is a test address field.
 `
 
 const TestTypeTestTypeFieldName = "testType"
 
 var TestTypeTestTypeFieldType = MetaType
 
-const TestTypeTestTypeFieldDocString = `This is a test type field.
+const TestTypeTestTypeFieldDocString = `
+This is a test type field.
 `
 
 const TestTypeTestCapFieldName = "testCap"
 
 var TestTypeTestCapFieldType = &CapabilityType{}
 
-const TestTypeTestCapFieldDocString = `This is a test capability field.
+const TestTypeTestCapFieldDocString = `
+This is a test capability field.
 `
 
 const TestTypeTestCapIntFieldName = "testCapInt"
@@ -106,7 +115,8 @@ var TestTypeTestCapIntFieldType = MustInstantiate(
 	IntType,
 )
 
-const TestTypeTestCapIntFieldDocString = `This is a test specific capability field.
+const TestTypeTestCapIntFieldDocString = `
+This is a test specific capability field.
 `
 
 const TestTypeName = "Test"

--- a/runtime/sema/gen/testdata/functions.golden.go
+++ b/runtime/sema/gen/testdata/functions.golden.go
@@ -32,7 +32,8 @@ var TestTypeNothingFunctionType = &FunctionType{
 	),
 }
 
-const TestTypeNothingFunctionDocString = `This is a test function.
+const TestTypeNothingFunctionDocString = `
+This is a test function.
 `
 
 const TestTypeParamsFunctionName = "params"
@@ -51,7 +52,8 @@ var TestTypeParamsFunctionType = &FunctionType{
 	),
 }
 
-const TestTypeParamsFunctionDocString = `This is a test function with parameters.
+const TestTypeParamsFunctionDocString = `
+This is a test function with parameters.
 `
 
 const TestTypeReturnFunctionName = "return"
@@ -62,7 +64,8 @@ var TestTypeReturnFunctionType = &FunctionType{
 	),
 }
 
-const TestTypeReturnFunctionDocString = `This is a test function with a return type.
+const TestTypeReturnFunctionDocString = `
+This is a test function with a return type.
 `
 
 const TestTypeParamsAndReturnFunctionName = "paramsAndReturn"
@@ -81,7 +84,8 @@ var TestTypeParamsAndReturnFunctionType = &FunctionType{
 	),
 }
 
-const TestTypeParamsAndReturnFunctionDocString = `This is a test function with parameters and a return type.
+const TestTypeParamsAndReturnFunctionDocString = `
+This is a test function with parameters and a return type.
 `
 
 const TestTypeTypeParamFunctionName = "typeParam"
@@ -99,7 +103,8 @@ var TestTypeTypeParamFunctionType = &FunctionType{
 	),
 }
 
-const TestTypeTypeParamFunctionDocString = `This is a test function with a type parameter.
+const TestTypeTypeParamFunctionDocString = `
+This is a test function with a type parameter.
 `
 
 const TestTypeTypeParamWithBoundFunctionName = "typeParamWithBound"
@@ -120,7 +125,8 @@ var TestTypeTypeParamWithBoundFunctionType = &FunctionType{
 	),
 }
 
-const TestTypeTypeParamWithBoundFunctionDocString = `This is a test function with a type parameter and a type bound.
+const TestTypeTypeParamWithBoundFunctionDocString = `
+This is a test function with a type parameter and a type bound.
 `
 
 const TestTypeTypeParamWithBoundAndParamFunctionName = "typeParamWithBoundAndParam"
@@ -145,7 +151,8 @@ var TestTypeTypeParamWithBoundAndParamFunctionType = &FunctionType{
 	),
 }
 
-const TestTypeTypeParamWithBoundAndParamFunctionDocString = `This is a test function with a type parameter and a parameter using it.
+const TestTypeTypeParamWithBoundAndParamFunctionDocString = `
+This is a test function with a type parameter and a parameter using it.
 `
 
 const TestTypeName = "Test"


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This fix adds support for backticked expressions in docstrings. This previously resulted in a panic.

The changes are as follows:

1. Backticked sections in docstrings are separated into their own string literals in the generated code, and concatenated. e.g.

```cadence
pub struct Foo {
  /// This is a `backtick`!
  /// Hope you enjoy!
  pub let Bar: Int
}
```

becomes

```go
const FooTypeBarFieldDocString = `
This is a ` + "`backtick`" + `!
Hope you enjoy!
`
```

2. All docstrings are now surrounded with line breaks. This is closer to existing convention for hand-written docstrings. Even for single-line docstrings like

```go
/// This is 1 line.
pub let Bar: Int
```

the result becomes

```go
const FooTypeBarFieldDocString = `
This is 1 line.
`
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
