### PR TITLE
lift getLinkTargetFunction into parent scope to cache it

### DIFF
--- a/runtime/interpreter/account.go
+++ b/runtime/interpreter/account.go
@@ -264,6 +264,7 @@ func NewPublicAccountValue(
 	var keys Value
 	var contracts Value
 	var forEachPublicFunction *HostFunctionValue
+	var getLinkTargetFunction *HostFunctionValue
 
 	computeField := func(name string, inter *Interpreter, locationRange LocationRange) Value {
 		switch name {
@@ -305,7 +306,6 @@ func NewPublicAccountValue(
 			return storageCapacityGet(inter)
 
 		case sema.PublicAccountTypeGetTargetLinkFieldName:
-			var getLinkTargetFunction *HostFunctionValue
 			if getLinkTargetFunction == nil {
 				getLinkTargetFunction = inter.accountGetLinkTargetFunction(address)
 			}


### PR DESCRIPTION
## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Noticed that a lazily-instantiated function member wasn't being declared in the right scope, causing it to be reevaluated on each access. 
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
