### PR TITLE
Update docstrings of borrow functions to reflect current behaviour

### DIFF
--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -458,7 +458,8 @@ If there is an object stored, the stored resource or structure is moved out of s
 When the function returns, the storage no longer contains an object under the given path.
 
 The given type must be a supertype of the type of the loaded object.
-If it is not, the function returns nil.
+If it is not, the function panics.
+
 The given type must not necessarily be exactly the same as the type of the loaded object.
 
 The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed
@@ -499,7 +500,8 @@ If there is a structure stored, it is copied.
 The structure stays stored in storage after the function returns.
 
 The given type must be a supertype of the type of the copied structure.
-If it is not, the function returns nil.
+tIf it is not, the function panics.
+
 The given type must not necessarily be exactly the same as the type of the copied structure.
 
 The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed
@@ -539,11 +541,8 @@ const authAccountTypeBorrowFunctionDocString = `
 Returns a reference to an object in storage without removing it from storage.
 
 If no object is stored under the given path, the function returns nil.
-If there is an object stored, a reference is returned as an optional.
-
-The given type must be a reference type.
-It must be possible to create the given reference type for the borrowed object.
-If it is not, the function returns nil.
+If there is an object stored, a reference is returned as an optional, provided it can be borrowed using the given type.
+If the stored object cannot be borrowed using the given type, the function panics.
 
 The given type must not necessarily be exactly the same as the type of the borrowed object.
 

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -500,7 +500,7 @@ If there is a structure stored, it is copied.
 The structure stays stored in storage after the function returns.
 
 The given type must be a supertype of the type of the copied structure.
-tIf it is not, the function panics.
+If it is not, the function panics.
 
 The given type must not necessarily be exactly the same as the type of the copied structure.
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6234,7 +6234,12 @@ func CapabilityTypeCheckFunctionType(borrowType Type) *FunctionType {
 }
 
 const capabilityTypeBorrowFunctionDocString = `
-Returns a reference to the object targeted by the capability, provided it can be borrowed using the given type
+Returns a reference to the object targeted by the capability.
+
+If no object is stored at the target path, the function returns nil.
+
+If there is an object stored, a reference is returned as an optional, provided it can be borrowed using the given type.
+If the stored object cannot be borrowed using the given type, the function panics.
 `
 
 const capabilityTypeCheckFunctionDocString = `


### PR DESCRIPTION
## Description

While responding to https://github.com/onflow/flow/pull/798#issuecomment-1411241981, I checked the current behaviour, and noticed that we changed the behaviour in #1286, but forgot to update the docstrings.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
