### PR TITLE
Use pointer receivers for external types with cached typeIDs

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -716,23 +716,23 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonSimpleType{
 			Kind: typ.ID(),
 		}
-	case cadence.OptionalType:
+	case *cadence.OptionalType:
 		return jsonUnaryType{
 			Kind: "Optional",
 			Type: prepareType(typ.Type, results),
 		}
-	case cadence.VariableSizedArrayType:
+	case *cadence.VariableSizedArrayType:
 		return jsonUnaryType{
 			Kind: "VariableSizedArray",
 			Type: prepareType(typ.ElementType, results),
 		}
-	case cadence.ConstantSizedArrayType:
+	case *cadence.ConstantSizedArrayType:
 		return jsonConstantSizedArrayType{
 			Kind: "ConstantSizedArray",
 			Type: prepareType(typ.ElementType, results),
 			Size: typ.Size,
 		}
-	case cadence.DictionaryType:
+	case *cadence.DictionaryType:
 		return jsonDictionaryType{
 			Kind:      "Dictionary",
 			KeyType:   prepareType(typ.KeyType, results),
@@ -801,7 +801,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 			Return:     prepareType(typ.ReturnType, results),
 			Parameters: prepareParameters(typ.Parameters, results),
 		}
-	case cadence.ReferenceType:
+	case *cadence.ReferenceType:
 		return jsonReferenceType{
 			Kind:       "Reference",
 			Authorized: typ.Authorized,
@@ -818,7 +818,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 			Type:         prepareType(typ.Type, results),
 			Restrictions: restrictions,
 		}
-	case cadence.CapabilityType:
+	case *cadence.CapabilityType:
 		return jsonUnaryType{
 			Kind: "Capability",
 			Type: prepareType(typ.BorrowType, results),

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1714,7 +1714,7 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.OptionalType{Type: cadence.IntType{}},
+				StaticType: &cadence.OptionalType{Type: cadence.IntType{}},
 			},
 			// language=json
 			`
@@ -1739,7 +1739,7 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.VariableSizedArrayType{ElementType: cadence.IntType{}},
+				StaticType: &cadence.VariableSizedArrayType{ElementType: cadence.IntType{}},
 			},
 			// language=json
 			`
@@ -1764,7 +1764,7 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.ConstantSizedArrayType{
+				StaticType: &cadence.ConstantSizedArrayType{
 					ElementType: cadence.IntType{},
 					Size:        3,
 				},
@@ -1793,7 +1793,7 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.DictionaryType{
+				StaticType: &cadence.DictionaryType{
 					ElementType: cadence.StringType{},
 					KeyType:     cadence.IntType{},
 				},
@@ -2313,7 +2313,7 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.ReferenceType{
+				StaticType: &cadence.ReferenceType{
 					Authorized: false,
 					Type:       cadence.IntType{},
 				},
@@ -2382,7 +2382,7 @@ func TestEncodeType(t *testing.T) {
 		testEncodeAndDecode(
 			t,
 			cadence.TypeValue{
-				StaticType: cadence.CapabilityType{
+				StaticType: &cadence.CapabilityType{
 					BorrowType: cadence.IntType{},
 				},
 			},
@@ -2726,7 +2726,7 @@ func TestExportRecursiveType(t *testing.T) {
 		},
 	}
 
-	ty.Fields[0].Type = cadence.OptionalType{
+	ty.Fields[0].Type = &cadence.OptionalType{
 		Type: ty,
 	}
 
@@ -2778,7 +2778,7 @@ func TestExportTypeValueRecursiveType(t *testing.T) {
 			Initializers: [][]cadence.Parameter{},
 		}
 
-		ty.Fields[0].Type = cadence.OptionalType{
+		ty.Fields[0].Type = &cadence.OptionalType{
 			Type: ty,
 		}
 
@@ -3191,7 +3191,7 @@ func TestExportFunctionValue(t *testing.T) {
 		},
 	}
 
-	ty.Fields[0].Type = cadence.OptionalType{
+	ty.Fields[0].Type = &cadence.OptionalType{
 		Type: ty,
 	}
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -1022,7 +1022,7 @@ func newBytesValue(bytes []byte) cadence.Array {
 		result[index] = cadence.NewUInt8(value)
 	}
 	return cadence.NewArray(result).
-		WithType(cadence.VariableSizedArrayType{
+		WithType(&cadence.VariableSizedArrayType{
 			ElementType: cadence.UInt8Type{},
 		})
 }
@@ -1047,7 +1047,7 @@ func accountKeyExportedValue(
 		panic(err)
 	}
 
-	return cadence.Struct{
+	value := cadence.Struct{
 		StructType: AccountKeyType,
 		Fields: []cadence.Value{
 			// Key index
@@ -1077,6 +1077,8 @@ func accountKeyExportedValue(
 			cadence.NewBool(isRevoked),
 		},
 	}
+
+	return cadence.ValueWithCachedTypeID(value)
 }
 
 func getAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *testRuntimeInterface {
@@ -1321,6 +1323,7 @@ func TestRuntimePublicKey(t *testing.T) {
 			},
 		}
 
+		expected = cadence.ValueWithCachedTypeID(expected)
 		assert.Equal(t, expected, value)
 	})
 
@@ -1615,6 +1618,7 @@ func TestRuntimePublicKey(t *testing.T) {
 			},
 		}
 
+		expected = cadence.ValueWithCachedTypeID(expected)
 		assert.Equal(t, expected, value)
 	})
 
@@ -2121,7 +2125,7 @@ func TestPublicAccountContracts(t *testing.T) {
 					cadence.UInt8(1),
 					cadence.UInt8(2),
 				},
-			}.WithType(cadence.VariableSizedArrayType{
+			}.WithType(&cadence.VariableSizedArrayType{
 				ElementType: cadence.UInt8Type{},
 			}),
 			array.Values[1],

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -424,7 +424,7 @@ func exportReferenceType(
 	gauge common.MemoryGauge,
 	t *sema.ReferenceType,
 	results map[sema.TypeID]cadence.Type,
-) cadence.ReferenceType {
+) *cadence.ReferenceType {
 	convertedType := ExportMeteredType(gauge, t.Type, results)
 
 	return cadence.NewMeteredReferenceType(
@@ -460,7 +460,7 @@ func exportCapabilityType(
 	gauge common.MemoryGauge,
 	t *sema.CapabilityType,
 	results map[sema.TypeID]cadence.Type,
-) cadence.CapabilityType {
+) *cadence.CapabilityType {
 
 	var borrowType cadence.Type
 	if t.BorrowType != nil {
@@ -498,7 +498,7 @@ func ImportType(memoryGauge common.MemoryGauge, t cadence.Type) interpreter.Stat
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypeAnyStruct)
 	case cadence.AnyResourceType:
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypeAnyResource)
-	case cadence.OptionalType:
+	case *cadence.OptionalType:
 		return interpreter.NewOptionalStaticType(memoryGauge, ImportType(memoryGauge, t.Type))
 	case cadence.MetaType:
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypeMetaType)
@@ -566,15 +566,15 @@ func ImportType(memoryGauge common.MemoryGauge, t cadence.Type) interpreter.Stat
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypeFix64)
 	case cadence.UFix64Type:
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypeUFix64)
-	case cadence.VariableSizedArrayType:
+	case *cadence.VariableSizedArrayType:
 		return interpreter.NewVariableSizedStaticType(memoryGauge, ImportType(memoryGauge, t.ElementType))
-	case cadence.ConstantSizedArrayType:
+	case *cadence.ConstantSizedArrayType:
 		return interpreter.NewConstantSizedStaticType(
 			memoryGauge,
 			ImportType(memoryGauge, t.ElementType),
 			int64(t.Size),
 		)
-	case cadence.DictionaryType:
+	case *cadence.DictionaryType:
 		return interpreter.NewDictionaryStaticType(
 			memoryGauge,
 			ImportType(memoryGauge, t.KeyType),
@@ -590,7 +590,7 @@ func ImportType(memoryGauge common.MemoryGauge, t cadence.Type) interpreter.Stat
 		*cadence.ResourceInterfaceType,
 		*cadence.ContractInterfaceType:
 		return importInterfaceType(memoryGauge, t.(cadence.InterfaceType))
-	case cadence.ReferenceType:
+	case *cadence.ReferenceType:
 		return interpreter.NewReferenceStaticType(
 			memoryGauge,
 			t.Authorized,
@@ -621,7 +621,7 @@ func ImportType(memoryGauge common.MemoryGauge, t cadence.Type) interpreter.Stat
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypePublicPath)
 	case cadence.PrivatePathType:
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypePrivatePath)
-	case cadence.CapabilityType:
+	case *cadence.CapabilityType:
 		return interpreter.NewCapabilityStaticType(memoryGauge, ImportType(memoryGauge, t.BorrowType))
 	case cadence.AccountKeyType:
 		return interpreter.NewPrimitiveStaticType(memoryGauge, interpreter.PrimitiveStaticTypeAccountKey)

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -550,7 +550,7 @@ func exportDictionaryValue(
 		return cadence.Dictionary{}, err
 	}
 
-	exportType := ExportType(v.SemaType(inter), map[sema.TypeID]cadence.Type{}).(cadence.DictionaryType)
+	exportType := ExportType(v.SemaType(inter), map[sema.TypeID]cadence.Type{}).(*cadence.DictionaryType)
 
 	return dictionary.WithType(exportType), err
 }
@@ -1039,7 +1039,7 @@ func (i valueImporter) importStorageCapability(
 	*interpreter.StorageCapabilityValue,
 	error,
 ) {
-	_, ok := borrowType.(cadence.ReferenceType)
+	_, ok := borrowType.(*cadence.ReferenceType)
 	if !ok {
 		return nil, errors.NewDefaultUserError(
 			"cannot import capability: expected reference, got '%s'",

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -97,7 +97,7 @@ func TestExportValue(t *testing.T) {
 		Fields: []cadence.Field{
 			{
 				Identifier: "publicKey",
-				Type: cadence.VariableSizedArrayType{
+				Type: &cadence.VariableSizedArrayType{
 					ElementType: cadence.UInt8Type{},
 				},
 			},
@@ -182,7 +182,7 @@ func TestExportValue(t *testing.T) {
 				)
 			},
 			expected: cadence.NewArray([]cadence.Value{}).
-				WithType(cadence.VariableSizedArrayType{
+				WithType(&cadence.VariableSizedArrayType{
 					ElementType: cadence.AnyStructType{},
 				}),
 		},
@@ -203,7 +203,7 @@ func TestExportValue(t *testing.T) {
 			expected: cadence.NewArray([]cadence.Value{
 				cadence.NewInt(42),
 				cadence.String("foo"),
-			}).WithType(cadence.VariableSizedArrayType{
+			}).WithType(&cadence.VariableSizedArrayType{
 				ElementType: cadence.AnyStructType{},
 			}),
 		},
@@ -220,7 +220,7 @@ func TestExportValue(t *testing.T) {
 				)
 			},
 			expected: cadence.NewDictionary([]cadence.KeyValuePair{}).
-				WithType(cadence.DictionaryType{
+				WithType(&cadence.DictionaryType{
 					KeyType:     cadence.StringType{},
 					ElementType: cadence.AnyStructType{},
 				}),
@@ -251,7 +251,7 @@ func TestExportValue(t *testing.T) {
 					Value: cadence.NewInt(1),
 				},
 			}).
-				WithType(cadence.DictionaryType{
+				WithType(&cadence.DictionaryType{
 					KeyType:     cadence.StringType{},
 					ElementType: cadence.AnyStructType{},
 				}),
@@ -460,7 +460,7 @@ func TestExportValue(t *testing.T) {
 								cadence.NewUInt8(1),
 								cadence.NewUInt8(2),
 								cadence.NewUInt8(3),
-							}).WithType(cadence.VariableSizedArrayType{
+							}).WithType(&cadence.VariableSizedArrayType{
 								ElementType: cadence.UInt8Type{},
 							}),
 							cadence.Enum{
@@ -1104,7 +1104,7 @@ func TestImportRuntimeType(t *testing.T) {
 		},
 		{
 			label: "Optional",
-			actual: cadence.OptionalType{
+			actual: &cadence.OptionalType{
 				Type: cadence.IntType{},
 			},
 			expected: interpreter.OptionalStaticType{
@@ -1113,7 +1113,7 @@ func TestImportRuntimeType(t *testing.T) {
 		},
 		{
 			label: "VariableSizedArray",
-			actual: cadence.VariableSizedArrayType{
+			actual: &cadence.VariableSizedArrayType{
 				ElementType: cadence.IntType{},
 			},
 			expected: interpreter.VariableSizedStaticType{
@@ -1122,7 +1122,7 @@ func TestImportRuntimeType(t *testing.T) {
 		},
 		{
 			label: "ConstantSizedArray",
-			actual: cadence.ConstantSizedArrayType{
+			actual: &cadence.ConstantSizedArrayType{
 				ElementType: cadence.IntType{},
 				Size:        3,
 			},
@@ -1133,7 +1133,7 @@ func TestImportRuntimeType(t *testing.T) {
 		},
 		{
 			label: "Dictionary",
-			actual: cadence.DictionaryType{
+			actual: &cadence.DictionaryType{
 				ElementType: cadence.IntType{},
 				KeyType:     cadence.StringType{},
 			},
@@ -1144,7 +1144,7 @@ func TestImportRuntimeType(t *testing.T) {
 		},
 		{
 			label: "Reference",
-			actual: cadence.ReferenceType{
+			actual: &cadence.ReferenceType{
 				Authorized: false,
 				Type:       cadence.IntType{},
 			},
@@ -1155,7 +1155,7 @@ func TestImportRuntimeType(t *testing.T) {
 		},
 		{
 			label: "Capability",
-			actual: cadence.CapabilityType{
+			actual: &cadence.CapabilityType{
 				BorrowType: cadence.IntType{},
 			},
 			expected: interpreter.CapabilityStaticType{
@@ -1448,7 +1448,7 @@ func TestExportResourceArrayValue(t *testing.T) {
 			cadence.NewUInt64(0),
 			cadence.NewInt(2),
 		}).WithType(fooResourceType),
-	}).WithType(cadence.VariableSizedArrayType{
+	}).WithType(&cadence.VariableSizedArrayType{
 		ElementType: &cadence.ResourceType{
 			Location:            common.ScriptLocation{},
 			QualifiedIdentifier: "Foo",
@@ -1505,7 +1505,7 @@ func TestExportResourceDictionaryValue(t *testing.T) {
 				cadence.NewInt(1),
 			}).WithType(fooResourceType),
 		},
-	}).WithType(cadence.DictionaryType{
+	}).WithType(&cadence.DictionaryType{
 		KeyType: cadence.StringType{},
 		ElementType: &cadence.ResourceType{
 			Location:            common.ScriptLocation{},
@@ -1700,13 +1700,13 @@ func TestExportReferenceValue(t *testing.T) {
 		expected := cadence.NewArray([]cadence.Value{
 			cadence.NewArray([]cadence.Value{
 				nil,
-			}).WithType(cadence.VariableSizedArrayType{
-				ElementType: cadence.ReferenceType{
+			}).WithType(&cadence.VariableSizedArrayType{
+				ElementType: &cadence.ReferenceType{
 					Type: cadence.AnyStructType{},
 				},
 			}),
-		}).WithType(cadence.VariableSizedArrayType{
-			ElementType: cadence.ReferenceType{
+		}).WithType(&cadence.VariableSizedArrayType{
+			ElementType: &cadence.ReferenceType{
 				Type: cadence.AnyStructType{},
 			},
 		})
@@ -2338,7 +2338,7 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 			label:         "Array empty",
 			typeSignature: "[String]",
 			exportedValue: cadence.NewArray([]cadence.Value{}).
-				WithType(cadence.VariableSizedArrayType{
+				WithType(&cadence.VariableSizedArrayType{
 					ElementType: cadence.StringType{},
 				}),
 		},
@@ -2348,7 +2348,7 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 			exportedValue: cadence.NewArray([]cadence.Value{
 				cadence.String("foo"),
 				cadence.String("bar"),
-			}).WithType(cadence.VariableSizedArrayType{
+			}).WithType(&cadence.VariableSizedArrayType{
 				ElementType: cadence.StringType{},
 			}),
 		},
@@ -2360,7 +2360,7 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 					Key:   cadence.String("foo"),
 					Value: cadence.String("bar"),
 				},
-			}).WithType(cadence.DictionaryType{
+			}).WithType(&cadence.DictionaryType{
 				KeyType:     cadence.StringType{},
 				ElementType: cadence.StringType{},
 			}),
@@ -2531,7 +2531,8 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 			require.NoError(t, err)
 
 			if !test.skipExport {
-				assert.Equal(t, test.exportedValue, actual)
+				expected := cadence.ValueWithCachedTypeID(test.exportedValue)
+				assert.Equal(t, expected, actual)
 			}
 		})
 	}
@@ -2553,26 +2554,26 @@ func TestRuntimeComplexStructArgumentPassing(t *testing.T) {
 			Fields: []cadence.Field{
 				{
 					Identifier: "a",
-					Type: cadence.OptionalType{
+					Type: &cadence.OptionalType{
 						Type: cadence.StringType{},
 					},
 				},
 				{
 					Identifier: "b",
-					Type: cadence.DictionaryType{
+					Type: &cadence.DictionaryType{
 						KeyType:     cadence.StringType{},
 						ElementType: cadence.StringType{},
 					},
 				},
 				{
 					Identifier: "c",
-					Type: cadence.VariableSizedArrayType{
+					Type: &cadence.VariableSizedArrayType{
 						ElementType: cadence.StringType{},
 					},
 				},
 				{
 					Identifier: "d",
-					Type: cadence.ConstantSizedArrayType{
+					Type: &cadence.ConstantSizedArrayType{
 						ElementType: cadence.StringType{},
 						Size:        2,
 					},
@@ -2613,20 +2614,20 @@ func TestRuntimeComplexStructArgumentPassing(t *testing.T) {
 					Key:   cadence.String("name"),
 					Value: cadence.String("Doe"),
 				},
-			}).WithType(cadence.DictionaryType{
+			}).WithType(&cadence.DictionaryType{
 				KeyType:     cadence.StringType{},
 				ElementType: cadence.StringType{},
 			}),
 			cadence.NewArray([]cadence.Value{
 				cadence.String("foo"),
 				cadence.String("bar"),
-			}).WithType(cadence.VariableSizedArrayType{
+			}).WithType(&cadence.VariableSizedArrayType{
 				ElementType: cadence.StringType{},
 			}),
 			cadence.NewArray([]cadence.Value{
 				cadence.String("foo"),
 				cadence.String("bar"),
-			}).WithType(cadence.ConstantSizedArrayType{
+			}).WithType(&cadence.ConstantSizedArrayType{
 				ElementType: cadence.StringType{},
 				Size:        2,
 			}),
@@ -2690,7 +2691,9 @@ func TestRuntimeComplexStructArgumentPassing(t *testing.T) {
 
 	actual, err := executeTestScript(t, script, complexStructValue)
 	require.NoError(t, err)
-	assert.Equal(t, complexStructValue, actual)
+
+	expected := cadence.ValueWithCachedTypeID(complexStructValue)
+	assert.Equal(t, expected, actual)
 
 }
 
@@ -2706,26 +2709,26 @@ func TestRuntimeComplexStructWithAnyStructFields(t *testing.T) {
 			Fields: []cadence.Field{
 				{
 					Identifier: "a",
-					Type: cadence.OptionalType{
+					Type: &cadence.OptionalType{
 						Type: cadence.AnyStructType{},
 					},
 				},
 				{
 					Identifier: "b",
-					Type: cadence.DictionaryType{
+					Type: &cadence.DictionaryType{
 						KeyType:     cadence.StringType{},
 						ElementType: cadence.AnyStructType{},
 					},
 				},
 				{
 					Identifier: "c",
-					Type: cadence.VariableSizedArrayType{
+					Type: &cadence.VariableSizedArrayType{
 						ElementType: cadence.AnyStructType{},
 					},
 				},
 				{
 					Identifier: "d",
-					Type: cadence.ConstantSizedArrayType{
+					Type: &cadence.ConstantSizedArrayType{
 						ElementType: cadence.AnyStructType{},
 						Size:        2,
 					},
@@ -2744,20 +2747,20 @@ func TestRuntimeComplexStructWithAnyStructFields(t *testing.T) {
 					Key:   cadence.String("name"),
 					Value: cadence.String("Doe"),
 				},
-			}).WithType(cadence.DictionaryType{
+			}).WithType(&cadence.DictionaryType{
 				KeyType:     cadence.StringType{},
 				ElementType: cadence.AnyStructType{},
 			}),
 			cadence.NewArray([]cadence.Value{
 				cadence.String("foo"),
 				cadence.String("bar"),
-			}).WithType(cadence.VariableSizedArrayType{
+			}).WithType(&cadence.VariableSizedArrayType{
 				ElementType: cadence.AnyStructType{},
 			}),
 			cadence.NewArray([]cadence.Value{
 				cadence.String("foo"),
 				cadence.String("bar"),
-			}).WithType(cadence.ConstantSizedArrayType{
+			}).WithType(&cadence.ConstantSizedArrayType{
 				ElementType: cadence.AnyStructType{},
 				Size:        2,
 			}),
@@ -2800,7 +2803,9 @@ func TestRuntimeComplexStructWithAnyStructFields(t *testing.T) {
 
 	actual, err := executeTestScript(t, script, complexStructValue)
 	require.NoError(t, err)
-	assert.Equal(t, complexStructValue, actual)
+
+	expected := cadence.ValueWithCachedTypeID(complexStructValue)
+	assert.Equal(t, expected, actual)
 }
 
 func TestRuntimeMalformedArgumentPassing(t *testing.T) {
@@ -2853,7 +2858,7 @@ func TestRuntimeMalformedArgumentPassing(t *testing.T) {
 			Fields: []cadence.Field{
 				{
 					Identifier: "a",
-					Type: cadence.VariableSizedArrayType{
+					Type: &cadence.VariableSizedArrayType{
 						ElementType: malformedStructType1,
 					},
 				},
@@ -2874,7 +2879,7 @@ func TestRuntimeMalformedArgumentPassing(t *testing.T) {
 			Fields: []cadence.Field{
 				{
 					Identifier: "a",
-					Type: cadence.DictionaryType{
+					Type: &cadence.DictionaryType{
 						KeyType:     cadence.StringType{},
 						ElementType: malformedStructType1,
 					},
@@ -2899,7 +2904,7 @@ func TestRuntimeMalformedArgumentPassing(t *testing.T) {
 			Fields: []cadence.Field{
 				{
 					Identifier: "a",
-					Type: cadence.VariableSizedArrayType{
+					Type: &cadence.VariableSizedArrayType{
 						ElementType: malformedStructType1,
 					},
 				},
@@ -3121,7 +3126,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		assert.Equal(t,
 			cadence.NewArray([]cadence.Value{}).
-				WithType(cadence.VariableSizedArrayType{
+				WithType(&cadence.VariableSizedArrayType{
 					ElementType: cadence.AnyStructType{},
 				}),
 			actual,
@@ -3189,7 +3194,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			cadence.NewArray([]cadence.Value{
 				cadence.NewInt(42),
 				cadence.String("foo"),
-			}).WithType(cadence.VariableSizedArrayType{
+			}).WithType(&cadence.VariableSizedArrayType{
 				ElementType: cadence.AnyStructType{},
 			}),
 			actual,
@@ -3326,7 +3331,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		assert.Equal(t,
 			cadence.NewDictionary([]cadence.KeyValuePair{}).
-				WithType(cadence.DictionaryType{
+				WithType(&cadence.DictionaryType{
 					KeyType:     cadence.StringType{},
 					ElementType: cadence.IntType{},
 				}),
@@ -3404,7 +3409,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 					Key:   cadence.String("a"),
 					Value: cadence.NewInt(1),
 				},
-			}).WithType(cadence.DictionaryType{
+			}).WithType(&cadence.DictionaryType{
 				KeyType:     cadence.StringType{},
 				ElementType: cadence.IntType{},
 			}),
@@ -3792,7 +3797,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 		t.Parallel()
 
 		capabilityValue := cadence.StorageCapability{
-			BorrowType: cadence.ReferenceType{Type: cadence.IntType{}},
+			BorrowType: &cadence.ReferenceType{Type: cadence.IntType{}},
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
 				Domain:     common.PathDomainPublic.Identifier(),
@@ -3893,7 +3898,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 		t.Parallel()
 
 		capabilityValue := cadence.StorageCapability{
-			BorrowType: cadence.ReferenceType{Type: cadence.IntType{}},
+			BorrowType: &cadence.ReferenceType{Type: cadence.IntType{}},
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
 				Domain:     common.PathDomainPrivate.Identifier(),
@@ -3940,7 +3945,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 		t.Parallel()
 
 		capabilityValue := cadence.StorageCapability{
-			BorrowType: cadence.ReferenceType{Type: cadence.IntType{}},
+			BorrowType: &cadence.ReferenceType{Type: cadence.IntType{}},
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
 				Domain:     common.PathDomainStorage.Identifier(),
@@ -4691,7 +4696,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		Type: interpreter.PrimitiveStaticTypeAnyStruct,
 	}
 
-	externalArrayType := cadence.VariableSizedArrayType{
+	externalArrayType := &cadence.VariableSizedArrayType{
 		ElementType: cadence.AnyStructType{},
 	}
 
@@ -4707,7 +4712,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 	externalArrayValue := cadence.NewArray([]cadence.Value{
 		cadence.NewInt(42),
 		cadence.String("foo"),
-	}).WithType(cadence.VariableSizedArrayType{
+	}).WithType(&cadence.VariableSizedArrayType{
 		ElementType: cadence.AnyStructType{},
 	})
 
@@ -4723,7 +4728,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		ValueType: staticArrayType,
 	}
 
-	externalDictionaryType := cadence.DictionaryType{
+	externalDictionaryType := &cadence.DictionaryType{
 		KeyType:     cadence.StringType{},
 		ElementType: externalArrayType,
 	}
@@ -4740,9 +4745,9 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 			Key:   cadence.String("a"),
 			Value: externalArrayValue,
 		},
-	}).WithType(cadence.DictionaryType{
+	}).WithType(&cadence.DictionaryType{
 		KeyType: cadence.StringType{},
-		ElementType: cadence.VariableSizedArrayType{
+		ElementType: &cadence.VariableSizedArrayType{
 			ElementType: cadence.AnyStructType{},
 		},
 	})

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -590,7 +590,7 @@ func TestBLSAggregateSignatures(t *testing.T) {
 			cadence.UInt8(3),
 			cadence.UInt8(4),
 			cadence.UInt8(5),
-		}).WithType(cadence.VariableSizedArrayType{
+		}).WithType(&cadence.VariableSizedArrayType{
 			ElementType: cadence.UInt8Type{},
 		}),
 		result,
@@ -665,7 +665,7 @@ func TestBLSAggregatePublicKeys(t *testing.T) {
 			cadence.UInt8(2),
 			cadence.UInt8(1),
 			cadence.UInt8(2),
-		}).WithType(cadence.VariableSizedArrayType{
+		}).WithType(&cadence.VariableSizedArrayType{
 			ElementType: cadence.UInt8Type{},
 		}),
 		result.(cadence.Optional).Value.(cadence.Struct).Fields[0],

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -444,7 +444,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 					Identifier: "foobarrington",
 				},
 				Address: cadence.Address{},
-				BorrowType: cadence.ReferenceType{
+				BorrowType: &cadence.ReferenceType{
 					Authorized: true,
 					Type:       cadence.AnyType{},
 				},
@@ -460,7 +460,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 					Identifier: "foobarrington",
 				},
 				Address: cadence.Address{},
-				BorrowType: cadence.ReferenceType{
+				BorrowType: &cadence.ReferenceType{
 					Authorized: true,
 					Type:       cadence.AnyType{},
 				},
@@ -476,7 +476,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 					Identifier: "foobarrington",
 				},
 				Address: cadence.Address{},
-				BorrowType: cadence.ReferenceType{
+				BorrowType: &cadence.ReferenceType{
 					Authorized: true,
 					Type:       cadence.AnyType{},
 				},

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -138,7 +138,7 @@ func TestRLPDecodeString(t *testing.T) {
 					Source: script,
 					Arguments: encodeArgs([]cadence.Value{
 						cadence.Array{
-							ArrayType: cadence.VariableSizedArrayType{
+							ArrayType: &cadence.VariableSizedArrayType{
 								ElementType: cadence.UInt8Type{},
 							},
 							Values: test.input,
@@ -159,7 +159,7 @@ func TestRLPDecodeString(t *testing.T) {
 				assert.Equal(t,
 					cadence.Array{
 						Values: test.output,
-					}.WithType(cadence.VariableSizedArrayType{
+					}.WithType(&cadence.VariableSizedArrayType{
 						ElementType: cadence.UInt8Type{},
 					}),
 					result,
@@ -297,7 +297,7 @@ func TestRLPDecodeList(t *testing.T) {
 					Source: script,
 					Arguments: encodeArgs([]cadence.Value{
 						cadence.Array{
-							ArrayType: cadence.VariableSizedArrayType{
+							ArrayType: &cadence.VariableSizedArrayType{
 								ElementType: cadence.UInt8Type{},
 							},
 							Values: test.input,
@@ -320,7 +320,7 @@ func TestRLPDecodeList(t *testing.T) {
 				for _, values := range test.output {
 					arrays = append(arrays,
 						cadence.Array{Values: values}.
-							WithType(cadence.VariableSizedArrayType{
+							WithType(&cadence.VariableSizedArrayType{
 								ElementType: cadence.UInt8Type{},
 							}))
 				}
@@ -328,8 +328,8 @@ func TestRLPDecodeList(t *testing.T) {
 				assert.Equal(t,
 					cadence.Array{
 						Values: arrays,
-					}.WithType(cadence.VariableSizedArrayType{
-						ElementType: cadence.VariableSizedArrayType{
+					}.WithType(&cadence.VariableSizedArrayType{
+						ElementType: &cadence.VariableSizedArrayType{
 							ElementType: cadence.UInt8Type{},
 						},
 					}),

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2835,13 +2835,13 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
 				expected: cadence.NewArray([]cadence.Value{
 					cadence.NewArray([]cadence.Value{
 						nil,
-					}).WithType(cadence.VariableSizedArrayType{
-						ElementType: cadence.ReferenceType{
+					}).WithType(&cadence.VariableSizedArrayType{
+						ElementType: &cadence.ReferenceType{
 							Type: cadence.AnyStructType{},
 						},
 					}),
-				}).WithType(cadence.VariableSizedArrayType{
-					ElementType: cadence.ReferenceType{
+				}).WithType(&cadence.VariableSizedArrayType{
+					ElementType: &cadence.ReferenceType{
 						Type: cadence.AnyStructType{},
 					},
 				}),

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1428,7 +1428,7 @@ func TestRuntimeStorageSaveStorageCapability(t *testing.T) {
 
 		for typeDescription, ty := range map[string]cadence.Type{
 			"Untyped": nil,
-			"Typed":   cadence.ReferenceType{Authorized: false, Type: cadence.IntType{}},
+			"Typed":   &cadence.ReferenceType{Authorized: false, Type: cadence.IntType{}},
 		} {
 
 			t.Run(fmt.Sprintf("%s %s", domain.Identifier(), typeDescription), func(t *testing.T) {
@@ -1475,17 +1475,17 @@ func TestRuntimeStorageSaveStorageCapability(t *testing.T) {
 				value, err := runtime.ReadStored(signer, storagePath, context)
 				require.NoError(t, err)
 
-				require.Equal(t,
-					cadence.StorageCapability{
-						Path: cadence.Path{
-							Domain:     domain.Identifier(),
-							Identifier: "test",
-						},
-						Address:    cadence.Address(signer),
-						BorrowType: ty,
+				expected := cadence.StorageCapability{
+					Path: cadence.Path{
+						Domain:     domain.Identifier(),
+						Identifier: "test",
 					},
-					value,
-				)
+					Address:    cadence.Address(signer),
+					BorrowType: ty,
+				}
+
+				actual := cadence.ValueWithCachedTypeID(value)
+				require.Equal(t, expected, actual)
 			})
 		}
 	}

--- a/types.go
+++ b/types.go
@@ -114,26 +114,28 @@ type OptionalType struct {
 	typeID string
 }
 
-func NewOptionalType(typ Type) OptionalType {
-	return OptionalType{Type: typ}
+var _ Type = &OptionalType{}
+
+func NewOptionalType(typ Type) *OptionalType {
+	return &OptionalType{Type: typ}
 }
 
-func NewMeteredOptionalType(gauge common.MemoryGauge, typ Type) OptionalType {
+func NewMeteredOptionalType(gauge common.MemoryGauge, typ Type) *OptionalType {
 	common.UseMemory(gauge, common.CadenceOptionalTypeMemoryUsage)
 	return NewOptionalType(typ)
 }
 
-func (OptionalType) isType() {}
+func (*OptionalType) isType() {}
 
-func (t OptionalType) ID() string {
+func (t *OptionalType) ID() string {
 	if len(t.typeID) == 0 {
 		t.typeID = fmt.Sprintf("%s?", t.Type.ID())
 	}
 	return t.typeID
 }
 
-func (t OptionalType) Equal(other Type) bool {
-	otherOptional, ok := other.(OptionalType)
+func (t *OptionalType) Equal(other Type) bool {
+	otherOptional, ok := other.(*OptionalType)
 	if !ok {
 		return false
 	}
@@ -833,35 +835,37 @@ type VariableSizedArrayType struct {
 	typeID      string
 }
 
+var _ Type = &VariableSizedArrayType{}
+
 func NewVariableSizedArrayType(
 	elementType Type,
-) VariableSizedArrayType {
-	return VariableSizedArrayType{ElementType: elementType}
+) *VariableSizedArrayType {
+	return &VariableSizedArrayType{ElementType: elementType}
 }
 
 func NewMeteredVariableSizedArrayType(
 	gauge common.MemoryGauge,
 	elementType Type,
-) VariableSizedArrayType {
+) *VariableSizedArrayType {
 	common.UseMemory(gauge, common.CadenceVariableSizedArrayTypeMemoryUsage)
 	return NewVariableSizedArrayType(elementType)
 }
 
-func (VariableSizedArrayType) isType() {}
+func (*VariableSizedArrayType) isType() {}
 
-func (t VariableSizedArrayType) ID() string {
+func (t *VariableSizedArrayType) ID() string {
 	if len(t.typeID) == 0 {
 		t.typeID = fmt.Sprintf("[%s]", t.ElementType.ID())
 	}
 	return t.typeID
 }
 
-func (t VariableSizedArrayType) Element() Type {
+func (t *VariableSizedArrayType) Element() Type {
 	return t.ElementType
 }
 
-func (t VariableSizedArrayType) Equal(other Type) bool {
-	otherType, ok := other.(VariableSizedArrayType)
+func (t *VariableSizedArrayType) Equal(other Type) bool {
+	otherType, ok := other.(*VariableSizedArrayType)
 	if !ok {
 		return false
 	}
@@ -877,11 +881,13 @@ type ConstantSizedArrayType struct {
 	typeID      string
 }
 
+var _ Type = &ConstantSizedArrayType{}
+
 func NewConstantSizedArrayType(
 	size uint,
 	elementType Type,
-) ConstantSizedArrayType {
-	return ConstantSizedArrayType{
+) *ConstantSizedArrayType {
+	return &ConstantSizedArrayType{
 		Size:        size,
 		ElementType: elementType,
 	}
@@ -891,26 +897,26 @@ func NewMeteredConstantSizedArrayType(
 	gauge common.MemoryGauge,
 	size uint,
 	elementType Type,
-) ConstantSizedArrayType {
+) *ConstantSizedArrayType {
 	common.UseMemory(gauge, common.CadenceConstantSizedArrayTypeMemoryUsage)
 	return NewConstantSizedArrayType(size, elementType)
 }
 
-func (ConstantSizedArrayType) isType() {}
+func (*ConstantSizedArrayType) isType() {}
 
-func (t ConstantSizedArrayType) ID() string {
+func (t *ConstantSizedArrayType) ID() string {
 	if len(t.typeID) == 0 {
 		t.typeID = fmt.Sprintf("[%s;%d]", t.ElementType.ID(), t.Size)
 	}
 	return t.typeID
 }
 
-func (t ConstantSizedArrayType) Element() Type {
+func (t *ConstantSizedArrayType) Element() Type {
 	return t.ElementType
 }
 
-func (t ConstantSizedArrayType) Equal(other Type) bool {
-	otherType, ok := other.(ConstantSizedArrayType)
+func (t *ConstantSizedArrayType) Equal(other Type) bool {
+	otherType, ok := other.(*ConstantSizedArrayType)
 	if !ok {
 		return false
 	}
@@ -927,11 +933,13 @@ type DictionaryType struct {
 	typeID      string
 }
 
+var _ Type = &DictionaryType{}
+
 func NewDictionaryType(
 	keyType Type,
 	elementType Type,
-) DictionaryType {
-	return DictionaryType{
+) *DictionaryType {
+	return &DictionaryType{
 		KeyType:     keyType,
 		ElementType: elementType,
 	}
@@ -941,14 +949,14 @@ func NewMeteredDictionaryType(
 	gauge common.MemoryGauge,
 	keyType Type,
 	elementType Type,
-) DictionaryType {
+) *DictionaryType {
 	common.UseMemory(gauge, common.CadenceDictionaryTypeMemoryUsage)
 	return NewDictionaryType(keyType, elementType)
 }
 
-func (DictionaryType) isType() {}
+func (*DictionaryType) isType() {}
 
-func (t DictionaryType) ID() string {
+func (t *DictionaryType) ID() string {
 	if len(t.typeID) == 0 {
 		t.typeID = fmt.Sprintf(
 			"{%s:%s}",
@@ -959,8 +967,8 @@ func (t DictionaryType) ID() string {
 	return t.typeID
 }
 
-func (t DictionaryType) Equal(other Type) bool {
-	otherType, ok := other.(DictionaryType)
+func (t *DictionaryType) Equal(other Type) bool {
+	otherType, ok := other.(*DictionaryType)
 	if !ok {
 		return false
 	}
@@ -1631,11 +1639,13 @@ type ReferenceType struct {
 	typeID     string
 }
 
+var _ Type = &ReferenceType{}
+
 func NewReferenceType(
 	authorized bool,
 	typ Type,
-) ReferenceType {
-	return ReferenceType{
+) *ReferenceType {
+	return &ReferenceType{
 		Authorized: authorized,
 		Type:       typ,
 	}
@@ -1645,14 +1655,14 @@ func NewMeteredReferenceType(
 	gauge common.MemoryGauge,
 	authorized bool,
 	typ Type,
-) ReferenceType {
+) *ReferenceType {
 	common.UseMemory(gauge, common.CadenceReferenceTypeMemoryUsage)
 	return NewReferenceType(authorized, typ)
 }
 
-func (ReferenceType) isType() {}
+func (*ReferenceType) isType() {}
 
-func (t ReferenceType) ID() string {
+func (t *ReferenceType) ID() string {
 	if len(t.typeID) == 0 {
 		var prefix string
 		if t.Authorized {
@@ -1663,7 +1673,7 @@ func (t ReferenceType) ID() string {
 	return t.typeID
 }
 
-func (t ReferenceType) Equal(other Type) bool {
+func (t *ReferenceType) Equal(other Type) bool {
 	otherType, ok := other.(*ReferenceType)
 	if !ok {
 		return false
@@ -1881,21 +1891,23 @@ type CapabilityType struct {
 	typeID     string
 }
 
-func NewCapabilityType(borrowType Type) CapabilityType {
-	return CapabilityType{BorrowType: borrowType}
+var _ Type = &CapabilityType{}
+
+func NewCapabilityType(borrowType Type) *CapabilityType {
+	return &CapabilityType{BorrowType: borrowType}
 }
 
 func NewMeteredCapabilityType(
 	gauge common.MemoryGauge,
 	borrowType Type,
-) CapabilityType {
+) *CapabilityType {
 	common.UseMemory(gauge, common.CadenceCapabilityTypeMemoryUsage)
 	return NewCapabilityType(borrowType)
 }
 
-func (CapabilityType) isType() {}
+func (*CapabilityType) isType() {}
 
-func (t CapabilityType) ID() string {
+func (t *CapabilityType) ID() string {
 	if len(t.typeID) == 0 {
 		if t.BorrowType != nil {
 			t.typeID = fmt.Sprintf("Capability<%s>", t.BorrowType.ID())
@@ -1906,8 +1918,8 @@ func (t CapabilityType) ID() string {
 	return t.typeID
 }
 
-func (t CapabilityType) Equal(other Type) bool {
-	otherType, ok := other.(CapabilityType)
+func (t *CapabilityType) Equal(other Type) bool {
+	otherType, ok := other.(*CapabilityType)
 	if !ok {
 		return false
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -81,36 +81,36 @@ func TestType_ID(t *testing.T) {
 		{BlockType{}, "Block"},
 		{MetaType{}, "Type"},
 		{
-			CapabilityType{},
+			&CapabilityType{},
 			"Capability",
 		},
 		{
-			CapabilityType{
+			&CapabilityType{
 				BorrowType: IntType{},
 			},
 			"Capability<Int>",
 		},
 		{
-			OptionalType{
+			&OptionalType{
 				Type: StringType{},
 			},
 			"String?",
 		},
 		{
-			VariableSizedArrayType{
+			&VariableSizedArrayType{
 				ElementType: StringType{},
 			},
 			"[String]",
 		},
 		{
-			ConstantSizedArrayType{
+			&ConstantSizedArrayType{
 				ElementType: StringType{},
 				Size:        2,
 			},
 			"[String;2]",
 		},
 		{
-			DictionaryType{
+			&DictionaryType{
 				KeyType:     StringType{},
 				ElementType: IntType{},
 			},
@@ -340,10 +340,10 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("equal with borrow type", func(t *testing.T) {
 			t.Parallel()
 
-			source := CapabilityType{
+			source := &CapabilityType{
 				BorrowType: IntType{},
 			}
-			target := CapabilityType{
+			target := &CapabilityType{
 				BorrowType: IntType{},
 			}
 			assert.True(t, source.Equal(target))
@@ -352,18 +352,18 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("equal without borrow type", func(t *testing.T) {
 			t.Parallel()
 
-			source := CapabilityType{}
-			target := CapabilityType{}
+			source := &CapabilityType{}
+			target := &CapabilityType{}
 			assert.True(t, source.Equal(target))
 		})
 
 		t.Run("not equal", func(t *testing.T) {
 			t.Parallel()
 
-			source := CapabilityType{
+			source := &CapabilityType{
 				BorrowType: IntType{},
 			}
-			target := CapabilityType{
+			target := &CapabilityType{
 				BorrowType: StringType{},
 			}
 			assert.False(t, source.Equal(target))
@@ -372,8 +372,8 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("source missing borrow type", func(t *testing.T) {
 			t.Parallel()
 
-			source := CapabilityType{}
-			target := CapabilityType{
+			source := &CapabilityType{}
+			target := &CapabilityType{
 				BorrowType: StringType{},
 			}
 			assert.False(t, source.Equal(target))
@@ -382,17 +382,17 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("target missing borrow type", func(t *testing.T) {
 			t.Parallel()
 
-			source := CapabilityType{
+			source := &CapabilityType{
 				BorrowType: IntType{},
 			}
-			target := CapabilityType{}
+			target := &CapabilityType{}
 			assert.False(t, source.Equal(target))
 		})
 
 		t.Run("different type", func(t *testing.T) {
 			t.Parallel()
 
-			source := CapabilityType{
+			source := &CapabilityType{
 				BorrowType: IntType{},
 			}
 			target := AnyType{}
@@ -406,10 +406,10 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("equal", func(t *testing.T) {
 			t.Parallel()
 
-			source := OptionalType{
+			source := &OptionalType{
 				Type: IntType{},
 			}
-			target := OptionalType{
+			target := &OptionalType{
 				Type: IntType{},
 			}
 			assert.True(t, source.Equal(target))
@@ -418,10 +418,10 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("not equal", func(t *testing.T) {
 			t.Parallel()
 
-			source := OptionalType{
+			source := &OptionalType{
 				Type: IntType{},
 			}
-			target := OptionalType{
+			target := &OptionalType{
 				Type: StringType{},
 			}
 			assert.False(t, source.Equal(target))
@@ -430,7 +430,7 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different type", func(t *testing.T) {
 			t.Parallel()
 
-			source := OptionalType{
+			source := &OptionalType{
 				Type: IntType{},
 			}
 			target := AnyType{}
@@ -444,10 +444,10 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("equal", func(t *testing.T) {
 			t.Parallel()
 
-			source := VariableSizedArrayType{
+			source := &VariableSizedArrayType{
 				ElementType: IntType{},
 			}
-			target := VariableSizedArrayType{
+			target := &VariableSizedArrayType{
 				ElementType: IntType{},
 			}
 			assert.True(t, source.Equal(target))
@@ -456,10 +456,10 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("not equal", func(t *testing.T) {
 			t.Parallel()
 
-			source := VariableSizedArrayType{
+			source := &VariableSizedArrayType{
 				ElementType: IntType{},
 			}
-			target := VariableSizedArrayType{
+			target := &VariableSizedArrayType{
 				ElementType: StringType{},
 			}
 			assert.False(t, source.Equal(target))
@@ -468,7 +468,7 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different type", func(t *testing.T) {
 			t.Parallel()
 
-			source := VariableSizedArrayType{
+			source := &VariableSizedArrayType{
 				ElementType: IntType{},
 			}
 			target := AnyType{}
@@ -482,11 +482,11 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("equal", func(t *testing.T) {
 			t.Parallel()
 
-			source := ConstantSizedArrayType{
+			source := &ConstantSizedArrayType{
 				ElementType: IntType{},
 				Size:        3,
 			}
-			target := ConstantSizedArrayType{
+			target := &ConstantSizedArrayType{
 				ElementType: IntType{},
 				Size:        3,
 			}
@@ -496,11 +496,11 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different inner types", func(t *testing.T) {
 			t.Parallel()
 
-			source := ConstantSizedArrayType{
+			source := &ConstantSizedArrayType{
 				ElementType: IntType{},
 				Size:        3,
 			}
-			target := ConstantSizedArrayType{
+			target := &ConstantSizedArrayType{
 				ElementType: StringType{},
 				Size:        3,
 			}
@@ -510,11 +510,11 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different sizes", func(t *testing.T) {
 			t.Parallel()
 
-			source := ConstantSizedArrayType{
+			source := &ConstantSizedArrayType{
 				ElementType: IntType{},
 				Size:        3,
 			}
-			target := ConstantSizedArrayType{
+			target := &ConstantSizedArrayType{
 				ElementType: IntType{},
 				Size:        4,
 			}
@@ -524,7 +524,7 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different type", func(t *testing.T) {
 			t.Parallel()
 
-			source := ConstantSizedArrayType{
+			source := &ConstantSizedArrayType{
 				ElementType: IntType{},
 				Size:        3,
 			}
@@ -539,11 +539,11 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("equal", func(t *testing.T) {
 			t.Parallel()
 
-			source := DictionaryType{
+			source := &DictionaryType{
 				KeyType:     IntType{},
 				ElementType: BoolType{},
 			}
-			target := DictionaryType{
+			target := &DictionaryType{
 				KeyType:     IntType{},
 				ElementType: BoolType{},
 			}
@@ -553,11 +553,11 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different key types", func(t *testing.T) {
 			t.Parallel()
 
-			source := DictionaryType{
+			source := &DictionaryType{
 				KeyType:     IntType{},
 				ElementType: BoolType{},
 			}
-			target := DictionaryType{
+			target := &DictionaryType{
 				KeyType:     UIntType{},
 				ElementType: BoolType{},
 			}
@@ -567,11 +567,11 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different element types", func(t *testing.T) {
 			t.Parallel()
 
-			source := DictionaryType{
+			source := &DictionaryType{
 				KeyType:     IntType{},
 				ElementType: BoolType{},
 			}
-			target := DictionaryType{
+			target := &DictionaryType{
 				KeyType:     IntType{},
 				ElementType: StringType{},
 			}
@@ -581,11 +581,11 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different key and element types", func(t *testing.T) {
 			t.Parallel()
 
-			source := DictionaryType{
+			source := &DictionaryType{
 				KeyType:     IntType{},
 				ElementType: BoolType{},
 			}
-			target := DictionaryType{
+			target := &DictionaryType{
 				KeyType:     UIntType{},
 				ElementType: StringType{},
 			}
@@ -595,7 +595,7 @@ func TestTypeEquality(t *testing.T) {
 		t.Run("different type", func(t *testing.T) {
 			t.Parallel()
 
-			source := DictionaryType{
+			source := &DictionaryType{
 				KeyType:     IntType{},
 				ElementType: BoolType{},
 			}

--- a/values.go
+++ b/values.go
@@ -1460,7 +1460,7 @@ func (v Dictionary) MeteredType(common.MemoryGauge) Type {
 	return v.Type()
 }
 
-func (v Dictionary) WithType(dictionaryType DictionaryType) Dictionary {
+func (v Dictionary) WithType(dictionaryType *DictionaryType) Dictionary {
 	v.DictionaryType = dictionaryType
 	return v
 }

--- a/values_test.go
+++ b/values_test.go
@@ -472,7 +472,7 @@ func TestOptional_Type(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
 
 		require.Equal(t,
-			OptionalType{
+			&OptionalType{
 				Type: NeverType{},
 			},
 			Optional{}.Type(),
@@ -482,7 +482,7 @@ func TestOptional_Type(t *testing.T) {
 	t.Run("some", func(t *testing.T) {
 
 		require.Equal(t,
-			OptionalType{
+			&OptionalType{
 				Type: Int8Type{},
 			},
 			Optional{


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/2325

## Description

Some of the Cadence external types that have cached typedIDs doesn't use pointer receivers, resulting in the cached type ID being lost. This PR converts those types to pointers.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
