### PR TITLE
If extended elaboration is enabled, record all expression types

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2247,6 +2247,16 @@ func (checker *Checker) visitExpressionWithForceType(
 
 	actualType = ast.AcceptExpression[Type](expr, checker)
 
+	if checker.Config.ExtendedElaborationEnabled {
+		checker.Elaboration.SetExpressionTypes(
+			expr,
+			ExpressionTypes{
+				ActualType:   actualType,
+				ExpectedType: expectedType,
+			},
+		)
+	}
+
 	if forceType &&
 		expectedType != nil &&
 		!expectedType.IsInvalidType() &&

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -101,6 +101,11 @@ type CastingExpressionTypes struct {
 	TargetType      Type
 }
 
+type ExpressionTypes struct {
+	ActualType   Type
+	ExpectedType Type
+}
+
 type Elaboration struct {
 	fixedPointExpressionTypes           map[*ast.FixedPointExpression]Type
 	interfaceTypeDeclarations           map[*InterfaceType]*ast.InterfaceDeclaration
@@ -142,6 +147,7 @@ type Elaboration struct {
 	indexExpressionTypes                map[*ast.IndexExpression]IndexExpressionTypes
 	forceExpressionTypes                map[*ast.ForceExpression]Type
 	staticCastTypes                     map[*ast.CastingExpression]CastTypes
+	expressionTypes                     map[ast.Expression]ExpressionTypes
 	TransactionTypes                    []*TransactionType
 	isChecking                          bool
 }
@@ -843,4 +849,19 @@ func (e *Elaboration) SetNumberConversionArgumentTypes(
 		e.numberConversionArgumentTypes = map[ast.Expression]NumberConversionArgumentTypes{}
 	}
 	e.numberConversionArgumentTypes[expression] = types
+}
+
+func (e *Elaboration) SetExpressionTypes(expression ast.Expression, types ExpressionTypes) {
+	if e.expressionTypes == nil {
+		e.expressionTypes = map[ast.Expression]ExpressionTypes{}
+	}
+	e.expressionTypes[expression] = types
+}
+
+func (e *Elaboration) ExpressionTypes(expression ast.Expression) ExpressionTypes {
+	return e.expressionTypes[expression]
+}
+
+func (e *Elaboration) AllExpressionTypes() map[ast.Expression]ExpressionTypes {
+	return e.expressionTypes
 }


### PR DESCRIPTION
## Description

Analyzers may want to report diagnostics based on the expression types. 

Record all expressions' types (actual and expected) in the elaboration, if extended elaboration is enabled.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
