### PR TITLE
Convert reference values

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1744,10 +1744,21 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 			)
 
 		case *StorageReferenceValue:
-			// TODO
+			return NewStorageReferenceValue(
+				interpreter,
+				ref.Authorized,
+				ref.TargetStorageAddress,
+				ref.TargetPath,
+				unwrappedTargetType.Type,
+			)
 
 		case *AccountReferenceValue:
-			// TODO:
+			return NewAccountReferenceValue(
+				interpreter,
+				ref.Address,
+				ref.Path,
+				unwrappedTargetType.Type,
+			)
 
 		default:
 			panic(errors.NewUnexpectedError("unsupported reference value: %T", ref))

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1727,10 +1727,30 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 		}
 	}
 
-	switch unwrappedTargetType.(type) {
+	switch unwrappedTargetType := unwrappedTargetType.(type) {
 	case *sema.AddressType:
 		if !valueType.Equal(unwrappedTargetType) {
 			return ConvertAddress(interpreter, value, locationRange)
+		}
+
+	case *sema.ReferenceType:
+		switch ref := value.(type) {
+		case *EphemeralReferenceValue:
+			return NewEphemeralReferenceValue(
+				interpreter,
+				ref.Authorized,
+				ref.Value,
+				unwrappedTargetType.Type,
+			)
+
+		case *StorageReferenceValue:
+			// TODO
+
+		case *AccountReferenceValue:
+			// TODO:
+
+		default:
+			panic(errors.NewUnexpectedError("unsupported reference value: %T", ref))
 		}
 	}
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1739,7 +1739,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 			case *EphemeralReferenceValue:
 				return NewEphemeralReferenceValue(
 					interpreter,
-					ref.Authorized,
+					unwrappedTargetType.Authorized,
 					ref.Value,
 					unwrappedTargetType.Type,
 				)
@@ -1747,7 +1747,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 			case *StorageReferenceValue:
 				return NewStorageReferenceValue(
 					interpreter,
-					ref.Authorized,
+					unwrappedTargetType.Authorized,
 					ref.TargetStorageAddress,
 					ref.TargetPath,
 					unwrappedTargetType.Type,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1734,34 +1734,36 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 		}
 
 	case *sema.ReferenceType:
-		switch ref := value.(type) {
-		case *EphemeralReferenceValue:
-			return NewEphemeralReferenceValue(
-				interpreter,
-				ref.Authorized,
-				ref.Value,
-				unwrappedTargetType.Type,
-			)
+		if !valueType.Equal(unwrappedTargetType) {
+			switch ref := value.(type) {
+			case *EphemeralReferenceValue:
+				return NewEphemeralReferenceValue(
+					interpreter,
+					ref.Authorized,
+					ref.Value,
+					unwrappedTargetType.Type,
+				)
 
-		case *StorageReferenceValue:
-			return NewStorageReferenceValue(
-				interpreter,
-				ref.Authorized,
-				ref.TargetStorageAddress,
-				ref.TargetPath,
-				unwrappedTargetType.Type,
-			)
+			case *StorageReferenceValue:
+				return NewStorageReferenceValue(
+					interpreter,
+					ref.Authorized,
+					ref.TargetStorageAddress,
+					ref.TargetPath,
+					unwrappedTargetType.Type,
+				)
 
-		case *AccountReferenceValue:
-			return NewAccountReferenceValue(
-				interpreter,
-				ref.Address,
-				ref.Path,
-				unwrappedTargetType.Type,
-			)
+			case *AccountReferenceValue:
+				return NewAccountReferenceValue(
+					interpreter,
+					ref.Address,
+					ref.Path,
+					unwrappedTargetType.Type,
+				)
 
-		default:
-			panic(errors.NewUnexpectedError("unsupported reference value: %T", ref))
+			default:
+				panic(errors.NewUnexpectedError("unsupported reference value: %T", ref))
+			}
 		}
 	}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10282,3 +10282,51 @@ func TestInterpretDictionaryDuplicateKey(t *testing.T) {
 
 	})
 }
+
+func TestInterpretReferenceUpAndDowncast(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("ephemeral reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+
+          struct interface SI {}
+
+          struct S: SI {}
+
+          fun getRef(): &{SI}  {
+              var s = S()
+              return &s as &S
+          }
+
+          fun test(): &S {
+              let ref = getRef()
+              return (ref as AnyStruct) as! &S
+          }
+        `)
+
+		_, err := inter.Invoke("test")
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	})
+
+	t.Run("storage reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		// TODO:
+
+	})
+
+	t.Run("account reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		// TODO:
+
+	})
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10288,7 +10288,13 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		name, code string
+		name     string
+		typeName string
+		code     string
+	}
+
+	checkerConfig := sema.Config{
+		AccountLinkingEnabled: true,
 	}
 
 	testFunctionReturn := func(tc testCase) {
@@ -10302,23 +10308,22 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 				true,
 				fmt.Sprintf(
 					`
-                      struct interface SI {}
+                      struct S {}
 
-                      struct S: SI {}
-
-                      fun getRef(): &{SI}  {
-                         %s
-                         return sRef
+                      fun getRef(): &AnyStruct  {
+                         %[2]s
+                         return ref
                       }
 
-                      fun test(): &S {
-                          let ref = getRef()
-                          return (ref as AnyStruct) as! &S
+                      fun test(): &%[1]s {
+                          let ref2 = getRef()
+                          return (ref2 as AnyStruct) as! &%[1]s
                       }
                     `,
+					tc.typeName,
 					tc.code,
 				),
-				sema.Config{},
+				checkerConfig,
 			)
 
 			_, err := inter.Invoke("test")
@@ -10340,19 +10345,18 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 				true,
 				fmt.Sprintf(
 					`
-                      struct interface SI {}
+                      struct S {}
 
-                      struct S: SI {}
-
-                      fun test(): &S {
-                          %s
-                          let ref: &{SI} = sRef
-                          return (ref as AnyStruct) as! &S
+                      fun test(): &%[1]s {
+                          %[2]s
+                          let ref2: &AnyStruct = ref
+                          return (ref2 as AnyStruct) as! &%[1]s
                       }
                     `,
+					tc.typeName,
 					tc.code,
 				),
-				sema.Config{},
+				checkerConfig,
 			)
 
 			_, err := inter.Invoke("test")
@@ -10365,18 +10369,28 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "ephemeral reference",
+			name:     "ephemeral reference",
+			typeName: "S",
 			code: `
               var s = S()
-              let sRef = &s as &S
+              let ref = &s as &S
             `,
 		},
 		{
-			name: "storage reference",
+			name:     "storage reference",
+			typeName: "S",
 			code: `
               account.save(S(), to: /storage/s)
-              let sRef = account.borrow<&S>(from: /storage/s)!
+              let ref = account.borrow<&S>(from: /storage/s)!
             `,
+		},
+		{
+			name:     "account reference",
+			typeName: "AuthAccount",
+			code: `
+		     let cap = account.linkAccount(/private/test)!
+		     let ref = cap.borrow()!
+		   `,
 		},
 	}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10287,69 +10287,101 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("ephemeral reference", func(t *testing.T) {
+	type testCase struct {
+		name, code string
+	}
 
-		t.Parallel()
+	testFunctionReturn := func(tc testCase) {
 
-		inter := parseCheckAndInterpret(t, `
+		t.Run(fmt.Sprintf("function return: %s", tc.name), func(t *testing.T) {
 
-          struct interface SI {}
+			t.Parallel()
 
-          struct S: SI {}
+			inter, _ := testAccount(t,
+				interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
+				true,
+				fmt.Sprintf(
+					`
+                      struct interface SI {}
 
-          fun getRef(): &{SI}  {
+                      struct S: SI {}
+
+                      fun getRef(): &{SI}  {
+                         %s
+                         return sRef
+                      }
+
+                      fun test(): &S {
+                          let ref = getRef()
+                          return (ref as AnyStruct) as! &S
+                      }
+                    `,
+					tc.code,
+				),
+				sema.Config{},
+			)
+
+			_, err := inter.Invoke("test")
+			RequireError(t, err)
+
+			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+
+		})
+	}
+
+	testVariableDeclaration := func(tc testCase) {
+
+		t.Run(fmt.Sprintf("variable declaration: %s", tc.name), func(t *testing.T) {
+
+			t.Parallel()
+
+			inter, _ := testAccount(t,
+				interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
+				true,
+				fmt.Sprintf(
+					`
+                      struct interface SI {}
+
+                      struct S: SI {}
+
+                      fun test(): &S {
+                          %s
+                          let ref: &{SI} = sRef
+                          return (ref as AnyStruct) as! &S
+                      }
+                    `,
+					tc.code,
+				),
+				sema.Config{},
+			)
+
+			_, err := inter.Invoke("test")
+			RequireError(t, err)
+
+			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+
+		})
+	}
+
+	testCases := []testCase{
+		{
+			name: "ephemeral reference",
+			code: `
               var s = S()
-              return &s as &S
-          }
-
-          fun test(): &S {
-              let ref = getRef()
-              return (ref as AnyStruct) as! &S
-          }
-        `)
-
-		_, err := inter.Invoke("test")
-		RequireError(t, err)
-
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
-	})
-
-	t.Run("storage reference", func(t *testing.T) {
-
-		t.Parallel()
-
-		inter, _ := testAccount(t,
-			interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
-			true,
-			`
-              struct interface SI {}
-
-              struct S: SI {}
-
-              fun getRef(): &{SI}  {
-                  account.save(S(), to: /storage/s)
-                  return account.borrow<&S>(from: /storage/s)!
-              }
-
-              fun test(): &S {
-                  let ref = getRef()
-                  return (ref as AnyStruct) as! &S
-              }
+              let sRef = &s as &S
             `,
-			sema.Config{},
-		)
+		},
+		{
+			name: "storage reference",
+			code: `
+              account.save(S(), to: /storage/s)
+              let sRef = account.borrow<&S>(from: /storage/s)!
+            `,
+		},
+	}
 
-		_, err := inter.Invoke("test")
-		RequireError(t, err)
-
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
-	})
-
-	t.Run("account reference", func(t *testing.T) {
-
-		t.Parallel()
-
-		// TODO:
-
-	})
+	for _, tc := range testCases {
+		testFunctionReturn(tc)
+		testVariableDeclaration(tc)
+	}
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10318,8 +10318,31 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 
 		t.Parallel()
 
-		// TODO:
+		inter, _ := testAccount(t,
+			interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
+			true,
+			`
+              struct interface SI {}
 
+              struct S: SI {}
+
+              fun getRef(): &{SI}  {
+                  account.save(S(), to: /storage/s)
+                  return account.borrow<&S>(from: /storage/s)!
+              }
+
+              fun test(): &S {
+                  let ref = getRef()
+                  return (ref as AnyStruct) as! &S
+              }
+            `,
+			sema.Config{},
+		)
+
+		_, err := inter.Invoke("test")
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
 	})
 
 	t.Run("account reference", func(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10330,7 +10330,6 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 			RequireError(t, err)
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
-
 		})
 	}
 
@@ -10363,35 +10362,50 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 			RequireError(t, err)
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
-
 		})
 	}
 
 	testCases := []testCase{
 		{
-			name:     "ephemeral reference",
-			typeName: "S",
-			code: `
-              var s = S()
-              let ref = &s as &S
-            `,
-		},
-		{
-			name:     "storage reference",
-			typeName: "S",
-			code: `
-              account.save(S(), to: /storage/s)
-              let ref = account.borrow<&S>(from: /storage/s)!
-            `,
-		},
-		{
 			name:     "account reference",
 			typeName: "AuthAccount",
 			code: `
-		     let cap = account.linkAccount(/private/test)!
-		     let ref = cap.borrow()!
-		   `,
+		         let cap = account.linkAccount(/private/test)!
+		         let ref = cap.borrow()!
+		       `,
 		},
+	}
+
+	for _, authorized := range []bool{true, false} {
+
+		var authKeyword, testNameSuffix string
+		if authorized {
+			authKeyword = "auth"
+			testNameSuffix = ", auth"
+		}
+
+		testCases = append(testCases,
+			testCase{
+				name:     fmt.Sprintf("ephemeral reference%s", testNameSuffix),
+				typeName: "S",
+				code: fmt.Sprintf(`
+                      var s = S()
+                      let ref = &s as %s &S
+                    `,
+					authKeyword,
+				),
+			},
+			testCase{
+				name:     fmt.Sprintf("storage reference%s", testNameSuffix),
+				typeName: "S",
+				code: fmt.Sprintf(`
+                      account.save(S(), to: /storage/s)
+                      let ref = account.borrow<%s &S>(from: /storage/s)!
+                    `,
+					authKeyword,
+				),
+			},
+		)
 	}
 
 	for _, tc := range testCases {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -6705,7 +6705,7 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
 	})
 
 	t.Run("creation, optional", func(t *testing.T) {
@@ -6727,7 +6727,7 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
 	})
 }
 

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -6705,7 +6705,7 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
 	})
 
 	t.Run("creation, optional", func(t *testing.T) {
@@ -6727,7 +6727,7 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
 	})
 }
 

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -626,12 +626,35 @@ func TestInterpretGetType(t *testing.T) {
 			// wrapping the ephemeral reference in an optional
 			// ensures getType doesn't dereference the value,
 			// i.e. EphemeralReferenceValue.StaticType is tested
-			name: "optional ephemeral reference",
+			name: "optional ephemeral reference, auth to unauth",
 			code: `
               fun test(): Type {
                   let value = 1
                   let ref = &value as auth &Int
                   let optRef: &Int? = ref
+                  return optRef.getType()
+              }
+            `,
+			result: interpreter.TypeValue{
+				Type: interpreter.OptionalStaticType{
+					Type: interpreter.ReferenceStaticType{
+						// Reference was converted from authorized to unauthorized
+						Authorized:   false,
+						BorrowedType: interpreter.PrimitiveStaticTypeInt,
+					},
+				},
+			},
+		},
+		{
+			// wrapping the ephemeral reference in an optional
+			// ensures getType doesn't dereference the value,
+			// i.e. EphemeralReferenceValue.StaticType is tested
+			name: "optional ephemeral reference, auth to auth",
+			code: `
+              fun test(): Type {
+                  let value = 1
+                  let ref = &value as auth &Int
+                  let optRef: auth &Int? = ref
                   return optRef.getType()
               }
             `,
@@ -648,11 +671,33 @@ func TestInterpretGetType(t *testing.T) {
 			// wrapping the storage reference in an optional
 			// ensures getType doesn't dereference the value,
 			// i.e. StorageReferenceValue.StaticType is tested
-			name: "optional storage reference",
+			name: "optional storage reference, auth to unauth",
 			code: `
               fun test(): Type {
                   let ref = getStorageReference()
                   let optRef: &Int? = ref
+                  return optRef.getType()
+              }
+            `,
+			result: interpreter.TypeValue{
+				Type: interpreter.OptionalStaticType{
+					Type: interpreter.ReferenceStaticType{
+						// Reference was converted from authorized to unauthorized
+						Authorized:   false,
+						BorrowedType: interpreter.PrimitiveStaticTypeInt,
+					},
+				},
+			},
+		},
+		{
+			// wrapping the storage reference in an optional
+			// ensures getType doesn't dereference the value,
+			// i.e. StorageReferenceValue.StaticType is tested
+			name: "optional storage reference, auth to auth",
+			code: `
+              fun test(): Type {
+                  let ref = getStorageReference()
+                  let optRef: auth &Int? = ref
                   return optRef.getType()
               }
             `,

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.31.4"
+const Version = "v0.31.5"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.31.3"
+const Version = "v0.31.4"


### PR DESCRIPTION
Port of https://github.com/dapperlabs/cadence-internal/pull/113 and https://github.com/dapperlabs/cadence-internal/pull/114

Cf: https://github.com/dapperlabs/cadence-internal/compare/v0.31.3...v0.31-internal


## Description

When transferring a reference value, convert it to the target type.

______

<!-- Complete: -->

- [x] Targeted PR against ~`master`~ release branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
