### PR TITLE
Fix racy tests

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -714,6 +714,8 @@ func TestEncodeArray(t *testing.T) {
         `,
 	}
 
+	fooResourceType := newFooResourceType()
+
 	resourceArray := encodeTest{
 		"Resources",
 		cadence.NewArray([]cadence.Value{
@@ -952,6 +954,8 @@ func TestEncodeDictionary(t *testing.T) {
           }
         `,
 	}
+
+	fooResourceType := newFooResourceType()
 
 	resourceDict := encodeTest{
 		"Resources",
@@ -1323,6 +1327,8 @@ func TestEncodeStruct(t *testing.T) {
         `,
 	}
 
+	fooResourceType := newFooResourceType()
+
 	resourceStructType := &cadence.StructType{
 		Location:            utils.TestLocation,
 		QualifiedIdentifier: "FooStruct",
@@ -1445,6 +1451,8 @@ func TestEncodeEvent(t *testing.T) {
         `,
 	}
 
+	fooResourceType := newFooResourceType()
+
 	resourceEventType := &cadence.EventType{
 		Location:            utils.TestLocation,
 		QualifiedIdentifier: "FooEvent",
@@ -1566,6 +1574,8 @@ func TestEncodeContract(t *testing.T) {
           }
         `,
 	}
+
+	fooResourceType := newFooResourceType()
 
 	resourceContractType := &cadence.ContractType{
 		Location:            utils.TestLocation,
@@ -2995,15 +3005,17 @@ func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value, opti
 	)
 }
 
-var fooResourceType = &cadence.ResourceType{
-	Location:            utils.TestLocation,
-	QualifiedIdentifier: "Foo",
-	Fields: []cadence.Field{
-		{
-			Identifier: "bar",
-			Type:       cadence.IntType{},
+func newFooResourceType() *cadence.ResourceType {
+	return &cadence.ResourceType{
+		Location:            utils.TestLocation,
+		QualifiedIdentifier: "Foo",
+		Fields: []cadence.Field{
+			{
+				Identifier: "bar",
+				Type:       cadence.IntType{},
+			},
 		},
-	},
+	}
 }
 
 func TestNonUTF8StringEncoding(t *testing.T) {

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -54,21 +54,25 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 		assert.IsType(t, expectedError, runtimeErr.Err)
 	}
 
-	fooStruct := cadence.Struct{
-		StructType: &cadence.StructType{
-			Location:            common.ScriptLocation{},
-			QualifiedIdentifier: "Foo",
-			Fields:              []cadence.Field{},
-		},
-		Fields: []cadence.Value{},
+	newFooStruct := func() cadence.Struct {
+		return cadence.Struct{
+			StructType: &cadence.StructType{
+				Location:            common.ScriptLocation{},
+				QualifiedIdentifier: "Foo",
+				Fields:              []cadence.Field{},
+			},
+			Fields: []cadence.Value{},
+		}
 	}
 
-	publicAccountKeys := cadence.Struct{
-		StructType: &cadence.StructType{
-			QualifiedIdentifier: "PublicAccount.Keys",
-			Fields:              []cadence.Field{},
-		},
-		Fields: []cadence.Value{},
+	newPublicAccountKeys := func() cadence.Struct {
+		return cadence.Struct{
+			StructType: &cadence.StructType{
+				QualifiedIdentifier: "PublicAccount.Keys",
+				Fields:              []cadence.Field{},
+			},
+			Fields: []cadence.Value{},
+		}
 	}
 
 	executeScript := func(t *testing.T, script string, arg cadence.Value) (err error) {
@@ -116,7 +120,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
             }
         `
 
-		err := executeScript(t, script, fooStruct)
+		err := executeScript(t, script, newFooStruct())
 		assert.NoError(t, err)
 	})
 
@@ -166,7 +170,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
             }
         `
 
-		err := executeScript(t, script, fooStruct)
+		err := executeScript(t, script, newFooStruct())
 		assert.NoError(t, err)
 	})
 
@@ -436,7 +440,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
                 }
             `
 
-		err := executeScript(t, script, fooStruct)
+		err := executeScript(t, script, newFooStruct())
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
@@ -456,7 +460,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
                 }
             `
 
-		err := executeScript(t, script, fooStruct)
+		err := executeScript(t, script, newFooStruct())
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
@@ -468,7 +472,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
                 }
             `
 
-		err := executeScript(t, script, publicAccountKeys)
+		err := executeScript(t, script, newPublicAccountKeys())
 		RequireError(t, err)
 
 		assert.Contains(t, err.Error(), "cannot import value of type PublicAccount.Keys")
@@ -486,7 +490,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 			t,
 			script,
 			cadence.NewArray([]cadence.Value{
-				publicAccountKeys,
+				newPublicAccountKeys(),
 			}),
 		)
 		RequireError(t, err)
@@ -560,24 +564,28 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 		assert.IsType(t, expectedError, runtimeErr.Err)
 	}
 
-	fooStruct := cadence.Struct{
-		StructType: &cadence.StructType{
-			Location: common.AddressLocation{
-				Address: common.MustBytesToAddress([]byte{0x1}),
-				Name:    "C",
+	newFooStruct := func() cadence.Struct {
+		return cadence.Struct{
+			StructType: &cadence.StructType{
+				Location: common.AddressLocation{
+					Address: common.MustBytesToAddress([]byte{0x1}),
+					Name:    "C",
+				},
+				QualifiedIdentifier: "C.Foo",
+				Fields:              []cadence.Field{},
 			},
-			QualifiedIdentifier: "C.Foo",
-			Fields:              []cadence.Field{},
-		},
-		Fields: []cadence.Value{},
+			Fields: []cadence.Value{},
+		}
 	}
 
-	publicAccountKeys := cadence.Struct{
-		StructType: &cadence.StructType{
-			QualifiedIdentifier: "PublicAccount.Keys",
-			Fields:              []cadence.Field{},
-		},
-		Fields: []cadence.Value{},
+	newPublicAccountKeys := func() cadence.Struct {
+		return cadence.Struct{
+			StructType: &cadence.StructType{
+				QualifiedIdentifier: "PublicAccount.Keys",
+				Fields:              []cadence.Field{},
+			},
+			Fields: []cadence.Value{},
+		}
 	}
 
 	executeTransaction := func(
@@ -645,7 +653,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
           transaction(arg: C.Foo) {}
         `
 
-		err := executeTransaction(t, script, contracts, fooStruct)
+		err := executeTransaction(t, script, contracts, newFooStruct())
 		assert.NoError(t, err)
 	})
 
@@ -715,7 +723,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
           transaction(arg: {C.Bar}) {}
         `
 
-		err := executeTransaction(t, script, contracts, fooStruct)
+		err := executeTransaction(t, script, contracts, newFooStruct())
 		assert.NoError(t, err)
 	})
 
@@ -1030,7 +1038,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
           transaction(arg: AnyStruct?) {}
         `
 
-		err := executeTransaction(t, script, contracts, cadence.NewOptional(fooStruct))
+		err := executeTransaction(t, script, contracts, cadence.NewOptional(newFooStruct()))
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
@@ -1061,7 +1069,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
           transaction(arg: {C.Bar}?) {}
         `
 
-		err := executeTransaction(t, script, contracts, cadence.NewOptional(fooStruct))
+		err := executeTransaction(t, script, contracts, cadence.NewOptional(newFooStruct()))
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
@@ -1072,7 +1080,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
           transaction(arg: AnyStruct) {}
         `
 
-		err := executeTransaction(t, script, nil, publicAccountKeys)
+		err := executeTransaction(t, script, nil, newPublicAccountKeys())
 		RequireError(t, err)
 
 		assert.Contains(t, err.Error(), "cannot import value of type PublicAccount.Keys")
@@ -1089,7 +1097,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 			script,
 			nil,
 			cadence.NewArray([]cadence.Value{
-				publicAccountKeys,
+				newPublicAccountKeys(),
 			}),
 		)
 		RequireError(t, err)


### PR DESCRIPTION
## Description

Discovered in #2344:

`cadence.Type.ID()` might mutate the receiver to cache the computed type ID.

CI runs test with data race detector enabled and reported cases of type values being used in parallel.

Create fresh values/types for each test, instead of reusing shared ones.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
