### PR TITLE
fixed formating of codeblocks in lists and remove outdated callout 

### DIFF
--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -479,15 +479,18 @@ Both `StoragePath` and `CapabilityPath` are subtypes of `Path`.
 
 #### Path Functions
 
-- `cadence•fun toString(): String`
+ 
+    ```cadence
+    fun toString(): String
+    ````
 
-  Returns the string representation of the path.
+    Returns the string representation of the path.
 
-  ```cadence
-  let storagePath = /storage/path
+    ```cadence
+    let storagePath = /storage/path
 
-  storagePath.toString()  // is "/storage/path"
-  ```
+    storagePath.toString()  // is "/storage/path"
+    ```
 
 There are also utilities to produce paths from strings:
 
@@ -510,61 +513,73 @@ Account storage is accessed through the following functions of `AuthAccount`.
 This means that any code that has access to the authorized account has access
 to all its stored objects.
 
-- `cadence•fun save<T>(_ value: T, to: StoragePath)`
+ 
+    ```cadence
+    fun save<T>(_ value: T, to: StoragePath)
+    ```
 
-  Saves an object to account storage.
-  Resources are moved into storage, and structures are copied.
+    Saves an object to account storage.
+    Resources are moved into storage, and structures are copied.
 
-  `T` is the type parameter for the object type.
-  It can be inferred from the argument's type.
+    `T` is the type parameter for the object type.
+    It can be inferred from the argument's type.
 
-  If there is already an object stored under the given path, the program aborts.
+    If there is already an object stored under the given path, the program aborts.
 
-  The path must be a storage path, i.e., only the domain `storage` is allowed.
+    The path must be a storage path, i.e., only the domain `storage` is allowed.
 
-- `cadence•fun type(at path: StoragePath): Type?`
+ 
+    ```cadence
+    fun type(at path: StoragePath): Type?
+    ```
 
-  Reads the type of an object from the account's storage which is stored under the given path, or nil if no object is stored under the given path.
+    Reads the type of an object from the account's storage which is stored under the given path, or nil if no object is stored under the given path.
 
-  If there is an object stored, the type of the object is returned without modifying the stored object.
+    If there is an object stored, the type of the object is returned without modifying the stored object.
 
-  The path must be a storage path, i.e., only the domain `storage` is allowed
+    The path must be a storage path, i.e., only the domain `storage` is allowed
 
-- `cadence•fun load<T>(from: StoragePath): T?`
+ 
+    ```cadence
+    fun load<T>(from: StoragePath): T?
+    ```
 
-  Loads an object from account storage.
-  If no object is stored under the given path, the function returns `nil`.
-  If there is an object stored, the stored resource or structure is moved
-  out of storage and returned as an optional.
-  When the function returns, the storage no longer contains an object
-  under the given path.
+    Loads an object from account storage.
+    If no object is stored under the given path, the function returns `nil`.
+    If there is an object stored, the stored resource or structure is moved
+    out of storage and returned as an optional.
+    When the function returns, the storage no longer contains an object
+    under the given path.
 
-  `T` is the type parameter for the object type.
-  A type argument for the parameter must be provided explicitly.
+    `T` is the type parameter for the object type.
+    A type argument for the parameter must be provided explicitly.
 
-  The type `T` must be a supertype of the type of the loaded object.
-  If it is not, execution will abort with an error.
-  The given type does not necessarily need to be exactly the same as the type of the loaded object.
+    The type `T` must be a supertype of the type of the loaded object.
+    If it is not, execution will abort with an error.
+    The given type does not necessarily need to be exactly the same as the type of the loaded object.
 
-  The path must be a storage path, i.e., only the domain `storage` is allowed.
+    The path must be a storage path, i.e., only the domain `storage` is allowed.
 
-- `cadence•fun copy<T: AnyStruct>(from: StoragePath): T?`
+ 
+    ```cadence
+    fun copy<T: AnyStruct>(from: StoragePath): T?
+    ```
 
-  Returns a copy of a structure stored in account storage, without removing it from storage.
+    Returns a copy of a structure stored in account storage, without removing it from storage.
 
-  If no structure is stored under the given path, the function returns `nil`.
-  If there is a structure stored, it is copied.
-  The structure stays stored in storage after the function returns.
+    If no structure is stored under the given path, the function returns `nil`.
+    If there is a structure stored, it is copied.
+    The structure stays stored in storage after the function returns.
 
-  `T` is the type parameter for the structure type.
-  A type argument for the parameter must be provided explicitly.
+    `T` is the type parameter for the structure type.
+    A type argument for the parameter must be provided explicitly.
 
-  The type `T` must be a supertype of the type of the copied structure.
-  If it is not, execution will abort with an error.
-  The given type does not necessarily need to be exactly the same as
-  the type of the copied structure.
+    The type `T` must be a supertype of the type of the copied structure.
+    If it is not, execution will abort with an error.
+    The given type does not necessarily need to be exactly the same as
+    the type of the copied structure.
 
-  The path must be a storage path, i.e., only the domain `storage` is allowed.
+    The path must be a storage path, i.e., only the domain `storage` is allowed.
 
 ```cadence
 // Declare a resource named `Counter`.
@@ -655,20 +670,23 @@ as it is necessary for resources,
 it is also possible to create references to objects in storage:
 This is possible using the `borrow` function of an `AuthAccount`:
 
-- `cadence•fun borrow<T: &Any>(from: StoragePath): T?`
+ 
+    ```cadence
+    fun borrow<T: &Any>(from: StoragePath): T?
+    ```
 
-  Returns a reference to an object in storage without removing it from storage.
-  If no object is stored under the given path, the function returns `nil`.
-  If there is an object stored, a reference is returned as an optional.
+    Returns a reference to an object in storage without removing it from storage.
+    If no object is stored under the given path, the function returns `nil`.
+    If there is an object stored, a reference is returned as an optional.
 
-  `T` is the type parameter for the object type.
-  A type argument for the parameter must be provided explicitly.
-  The type argument must be a reference to any type (`&Any`; `Any` is the supertype of all types).
-  It must be possible to create the given reference type `T` for the stored /  borrowed object.
-  If it is not, execution will abort with an error.
-  The given type does not necessarily need to be exactly the same as the type of the borrowed object.
+    `T` is the type parameter for the object type.
+    A type argument for the parameter must be provided explicitly.
+    The type argument must be a reference to any type (`&Any`; `Any` is the supertype of all types).
+    It must be possible to create the given reference type `T` for the stored /  borrowed object.
+    If it is not, execution will abort with an error.
+    The given type does not necessarily need to be exactly the same as the type of the borrowed object.
 
-  The path must be a storage path, i.e., only the domain `storage` is allowed.
+    The path must be a storage path, i.e., only the domain `storage` is allowed.
 
 ```cadence
 // Declare a resource interface named `HasCount`, that has a field `count`

--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -9,61 +9,61 @@ Every account can be accessed through two types, `PublicAccount` and `AuthAccoun
 **Public Account** objects have the type `PublicAccount`,
 which represents the publicly available portion of an account.
 
-  ```cadence
-  struct PublicAccount {
+```cadence
+struct PublicAccount {
 
-      let address: Address
-      // The FLOW balance of the default vault of this account
-      let balance: UFix64
-      // The FLOW balance of the default vault of this account that is available to be moved
-      let availableBalance: UFix64
-      // Amount of storage used by the account, in bytes
-      let storageUsed: UInt64
-      // storage capacity of the account, in bytes
-      let storageCapacity: UInt64
+    let address: Address
+    // The FLOW balance of the default vault of this account
+    let balance: UFix64
+    // The FLOW balance of the default vault of this account that is available to be moved
+    let availableBalance: UFix64
+    // Amount of storage used by the account, in bytes
+    let storageUsed: UInt64
+    // storage capacity of the account, in bytes
+    let storageCapacity: UInt64
 
-      // Contracts deployed to the account
-      let contracts: PublicAccount.Contracts
+    // Contracts deployed to the account
+    let contracts: PublicAccount.Contracts
 
-      // Keys assigned to the account
-      let keys: PublicAccount.Keys
+    // Keys assigned to the account
+    let keys: PublicAccount.Keys
 
-      // The public paths associated with this account
-      let publicPaths: [PublicPath]
+    // The public paths associated with this account
+    let publicPaths: [PublicPath]
 
-      // Storage operations
+    // Storage operations
 
-      fun getCapability<T>(_ path: PublicPath): Capability<T>
-      fun getLinkTarget(_ path: CapabilityPath): Path?
+    fun getCapability<T>(_ path: PublicPath): Capability<T>
+    fun getLinkTarget(_ path: CapabilityPath): Path?
 
-      // Storage iteration  
-      fun forEachPublic(_ function: ((PublicPath, Type): Bool))
+    // Storage iteration  
+    fun forEachPublic(_ function: ((PublicPath, Type): Bool))
 
-      struct Contracts {
+    struct Contracts {
 
-          let names: [String]
+        let names: [String]
 
-          fun get(name: String): DeployedContract?
+        fun get(name: String): DeployedContract?
 
-          fun borrow<T: &Any>(name: String): T?
-      }
+        fun borrow<T: &Any>(name: String): T?
+    }
 
-      struct Keys {
-          // Returns the key at the given index, if it exists.
-          // Revoked keys are always returned, but they have \`isRevoked\` field set to true.
-          fun get(keyIndex: Int): AccountKey?
+    struct Keys {
+        // Returns the key at the given index, if it exists.
+        // Revoked keys are always returned, but they have \`isRevoked\` field set to true.
+        fun get(keyIndex: Int): AccountKey?
 
-          // Iterate over all unrevoked keys in this account,
-          // passing each key in turn to the provided function.
-          // Iteration is stopped early if the function returns `false`.
-          // The order of iteration is undefined.
-          fun forEach(function: ((AccountKey): Bool)): Void
+        // Iterate over all unrevoked keys in this account,
+        // passing each key in turn to the provided function.
+        // Iteration is stopped early if the function returns `false`.
+        // The order of iteration is undefined.
+        fun forEach(function: ((AccountKey): Bool)): Void
 
-          // The total number of unrevoked keys in this account.
-          let count: UInt64
-      }
-  }
-  ```
+        // The total number of unrevoked keys in this account.
+        let count: UInt64
+    }
+}
+```
 
   Any code can get the `PublicAccount` for an account address
   using the built-in `getAccount` function:

--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -668,23 +668,22 @@ as it is necessary for resources,
 it is also possible to create references to objects in storage:
 This is possible using the `borrow` function of an `AuthAccount`:
 
- 
-    ```cadence
-    fun borrow<T: &Any>(from: StoragePath): T?
-    ```
+```cadence
+fun borrow<T: &Any>(from: StoragePath): T?
+```
 
-    Returns a reference to an object in storage without removing it from storage.
-    If no object is stored under the given path, the function returns `nil`.
-    If there is an object stored, a reference is returned as an optional.
+Returns a reference to an object in storage without removing it from storage.
+If no object is stored under the given path, the function returns `nil`.
+If there is an object stored, a reference is returned as an optional.
 
-    `T` is the type parameter for the object type.
-    A type argument for the parameter must be provided explicitly.
-    The type argument must be a reference to any type (`&Any`; `Any` is the supertype of all types).
-    It must be possible to create the given reference type `T` for the stored /  borrowed object.
-    If it is not, execution will abort with an error.
-    The given type does not necessarily need to be exactly the same as the type of the borrowed object.
+`T` is the type parameter for the object type.
+A type argument for the parameter must be provided explicitly.
+The type argument must be a reference to any type (`&Any`; `Any` is the supertype of all types).
+It must be possible to create the given reference type `T` for the stored /  borrowed object.
+If it is not, execution will abort with an error.
+The given type does not necessarily need to be exactly the same as the type of the borrowed object.
 
-    The path must be a storage path, i.e., only the domain `storage` is allowed.
+The path must be a storage path, i.e., only the domain `storage` is allowed.
 
 ```cadence
 // Declare a resource interface named `HasCount`, that has a field `count`

--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -479,18 +479,17 @@ Both `StoragePath` and `CapabilityPath` are subtypes of `Path`.
 
 #### Path Functions
 
- 
-    ```cadence
-    fun toString(): String
-    ````
+```cadence
+fun toString(): String
+````
 
-    Returns the string representation of the path.
+Returns the string representation of the path.
 
-    ```cadence
-    let storagePath = /storage/path
+```cadence
+let storagePath = /storage/path
 
-    storagePath.toString()  // is "/storage/path"
-    ```
+storagePath.toString()  // is "/storage/path"
+```
 
 There are also utilities to produce paths from strings:
 
@@ -512,74 +511,73 @@ let path = PublicPath(identifier: pathID) // is /public/foo
 Account storage is accessed through the following functions of `AuthAccount`.
 This means that any code that has access to the authorized account has access
 to all its stored objects.
-
  
-    ```cadence
-    fun save<T>(_ value: T, to: StoragePath)
-    ```
+```cadence
+fun save<T>(_ value: T, to: StoragePath)
+```
 
-    Saves an object to account storage.
-    Resources are moved into storage, and structures are copied.
+Saves an object to account storage.
+Resources are moved into storage, and structures are copied.
 
-    `T` is the type parameter for the object type.
-    It can be inferred from the argument's type.
+`T` is the type parameter for the object type.
+It can be inferred from the argument's type.
 
-    If there is already an object stored under the given path, the program aborts.
+If there is already an object stored under the given path, the program aborts.
 
-    The path must be a storage path, i.e., only the domain `storage` is allowed.
+The path must be a storage path, i.e., only the domain `storage` is allowed.
 
- 
-    ```cadence
-    fun type(at path: StoragePath): Type?
-    ```
 
-    Reads the type of an object from the account's storage which is stored under the given path, or nil if no object is stored under the given path.
+```cadence
+fun type(at path: StoragePath): Type?
+```
 
-    If there is an object stored, the type of the object is returned without modifying the stored object.
+Reads the type of an object from the account's storage which is stored under the given path, or nil if no object is stored under the given path.
 
-    The path must be a storage path, i.e., only the domain `storage` is allowed
+If there is an object stored, the type of the object is returned without modifying the stored object.
 
- 
-    ```cadence
-    fun load<T>(from: StoragePath): T?
-    ```
+The path must be a storage path, i.e., only the domain `storage` is allowed
 
-    Loads an object from account storage.
-    If no object is stored under the given path, the function returns `nil`.
-    If there is an object stored, the stored resource or structure is moved
-    out of storage and returned as an optional.
-    When the function returns, the storage no longer contains an object
-    under the given path.
 
-    `T` is the type parameter for the object type.
-    A type argument for the parameter must be provided explicitly.
+```cadence
+fun load<T>(from: StoragePath): T?
+```
 
-    The type `T` must be a supertype of the type of the loaded object.
-    If it is not, execution will abort with an error.
-    The given type does not necessarily need to be exactly the same as the type of the loaded object.
+Loads an object from account storage.
+If no object is stored under the given path, the function returns `nil`.
+If there is an object stored, the stored resource or structure is moved
+out of storage and returned as an optional.
+When the function returns, the storage no longer contains an object
+under the given path.
 
-    The path must be a storage path, i.e., only the domain `storage` is allowed.
+`T` is the type parameter for the object type.
+A type argument for the parameter must be provided explicitly.
 
- 
-    ```cadence
-    fun copy<T: AnyStruct>(from: StoragePath): T?
-    ```
+The type `T` must be a supertype of the type of the loaded object.
+If it is not, execution will abort with an error.
+The given type does not necessarily need to be exactly the same as the type of the loaded object.
 
-    Returns a copy of a structure stored in account storage, without removing it from storage.
+The path must be a storage path, i.e., only the domain `storage` is allowed.
 
-    If no structure is stored under the given path, the function returns `nil`.
-    If there is a structure stored, it is copied.
-    The structure stays stored in storage after the function returns.
 
-    `T` is the type parameter for the structure type.
-    A type argument for the parameter must be provided explicitly.
+```cadence
+fun copy<T: AnyStruct>(from: StoragePath): T?
+```
 
-    The type `T` must be a supertype of the type of the copied structure.
-    If it is not, execution will abort with an error.
-    The given type does not necessarily need to be exactly the same as
-    the type of the copied structure.
+Returns a copy of a structure stored in account storage, without removing it from storage.
 
-    The path must be a storage path, i.e., only the domain `storage` is allowed.
+If no structure is stored under the given path, the function returns `nil`.
+If there is a structure stored, it is copied.
+The structure stays stored in storage after the function returns.
+
+`T` is the type parameter for the structure type.
+A type argument for the parameter must be provided explicitly.
+
+The type `T` must be a supertype of the type of the copied structure.
+If it is not, execution will abort with an error.
+The given type does not necessarily need to be exactly the same as
+the type of the copied structure.
+
+The path must be a storage path, i.e., only the domain `storage` is allowed.
 
 ```cadence
 // Declare a resource named `Counter`.

--- a/docs/language/built-in-functions.mdx
+++ b/docs/language/built-in-functions.mdx
@@ -3,7 +3,11 @@ title: Built-in Functions
 ---
 
 ## panic
-`cadence•fun panic(_ message: String): Never`
+#
+
+```cadence
+fun panic(_ message: String): Never
+```
 
   Terminates the program unconditionally
   and reports a message which explains why the unrecoverable error occurred.
@@ -15,7 +19,9 @@ title: Built-in Functions
 
 ## assert
 
-`cadence•fun assert(_ condition: Bool, message: String)`
+```cadence
+fun assert(_ condition: Bool, message: String)
+```
 
   Terminates the program if the given condition is false,
   and reports a message which explains how the condition is false.
@@ -25,7 +31,9 @@ title: Built-in Functions
 
 ## unsafeRandom
 
-`cadence•fun unsafeRandom(): UInt64`
+```cadence
+fun unsafeRandom(): UInt64
+```
 
   Returns a pseudo-random number.
 
@@ -40,16 +48,22 @@ RLP (Recursive Length Prefix) serialization allows the encoding of arbitrarily n
 
 Cadence provides RLP decoding functions in the built-in `RLP` contract, which does not need to be imported.
 
-- `cadence•fun decodeString(_ input: [UInt8]): [UInt8]`
+-
+    ```cadence
+    fun decodeString(_ input: [UInt8]): [UInt8]
+    ```
 
-  Decodes an RLP-encoded byte array (called string in the context of RLP).
-  The byte array should only contain of a single encoded value for a string; if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
-  If any error is encountered while decoding, the program aborts.
+    Decodes an RLP-encoded byte array (called string in the context of RLP).
+    The byte array should only contain of a single encoded value for a string; if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
+    If any error is encountered while decoding, the program aborts.
 
 
-- `cadence•fun decodeList(_ input: [UInt8]): [[UInt8]]`
+ 
+    ```cadence
+    fun decodeList(_ input: [UInt8]): [[UInt8]]`
+    ```
 
-  Decodes an RLP-encoded list into an array of RLP-encoded items.
-  Note that this function does not recursively decode, so each element of the resulting array is RLP-encoded data.
-  The byte array should only contain of a single encoded value for a list; if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
-  If any error is encountered while decoding, the program aborts.
+    Decodes an RLP-encoded list into an array of RLP-encoded items.
+    Note that this function does not recursively decode, so each element of the resulting array is RLP-encoded data.
+    The byte array should only contain of a single encoded value for a list; if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
+    If any error is encountered while decoding, the program aborts.

--- a/docs/language/capability-based-access-control.md
+++ b/docs/language/capability-based-access-control.md
@@ -31,93 +31,112 @@ This allows exposing and hiding certain functionality of a stored object.
 
 Capabilities are created using the `link` function of an authorized account (`AuthAccount`):
 
-- `cadence•fun link<T: &Any>(_ newCapabilityPath: CapabilityPath, target: Path): Capability<T>?`
+-
+    ```cadence
+    fun link<T: &Any>(_ newCapabilityPath: CapabilityPath, target: Path): Capability<T>?
+    ```
 
-  `newCapabilityPath` is the public or private path identifying the new capability.
+    `newCapabilityPath` is the public or private path identifying the new capability.
 
-  `target` is any public, private, or storage path that leads to the object
-  that will provide the functionality defined by this capability.
+    `target` is any public, private, or storage path that leads to the object
+    that will provide the functionality defined by this capability.
 
-  `T` is the type parameter for the capability type.
-  A type argument for the parameter must be provided explicitly.
+    `T` is the type parameter for the capability type.
+    A type argument for the parameter must be provided explicitly.
 
-  The type parameter defines how the capability can be borrowed,
-  i.e., how the stored value can be accessed.
+    The type parameter defines how the capability can be borrowed,
+    i.e., how the stored value can be accessed.
 
-  The link function returns `nil` if a link for the given capability path already exists,
-  or the newly created capability if not.
+    The link function returns `nil` if a link for the given capability path already exists,
+    or the newly created capability if not.
 
-  It is not necessary for the target path to lead to a valid object;
-  the target path could be empty, or could lead to an object
-  which does not provide the necessary type interface:
+    It is not necessary for the target path to lead to a valid object;
+    the target path could be empty, or could lead to an object
+    which does not provide the necessary type interface:
 
-  The link function does **not** check if the target path is valid/exists at the time
-  the capability is created and does **not** check if the target value conforms to the given type.
+    The link function does **not** check if the target path is valid/exists at the time
+    the capability is created and does **not** check if the target value conforms to the given type.
 
-  The link is latent.
-  The target value might be stored after the link is created,
-  and the target value might be moved out after the link has been created.
+    The link is latent.
+    The target value might be stored after the link is created,
+    and the target value might be moved out after the link has been created.
 
 Capabilities can be removed using the `unlink` function of an authorized account (`AuthAccount`):
 
-- `cadence•fun unlink(_ path: CapabilityPath)`
+-
+    ```cadence
+    fun unlink(_ path: CapabilityPath)
+    ```
 
-  `path` is the public or private path identifying the capability that should be removed.
+    `path` is the public or private path identifying the capability that should be removed.
 
 To get the target path for a capability, the `getLinkTarget` function
 of an authorized account (`AuthAccount`) or public account (`PublicAccount`) can be used:
 
-- `cadence•fun getLinkTarget(_ path: CapabilityPath): Path?`
 
-  `path` is the public or private path identifying the capability.
-  The function returns the link target path,
-  if a capability exists at the given path,
-  or `nil` if it does not.
+-
+    ```cadence
+    fun getLinkTarget(_ path: CapabilityPath): Path?
+    ```
+
+    `path` is the public or private path identifying the capability.
+    The function returns the link target path,
+    if a capability exists at the given path,
+    or `nil` if it does not.
 
 Existing capabilities can be obtained by using the `getCapability` function
 of authorized accounts (`AuthAccount`) and public accounts (`PublicAccount`):
 
-- `cadence•fun getCapability<T>(_ at: CapabilityPath): Capability<T>`
+-
+    ```cadence
+    fun getCapability<T>(_ at: CapabilityPath): Capability<T>
+    ```
 
-  For public accounts, the function returns a capability
-  if the given path is public.
-  It is not possible to obtain private capabilities from public accounts.
-  If the path is private or a storage path, the function returns `nil`.
+    For public accounts, the function returns a capability
+    if the given path is public.
+    It is not possible to obtain private capabilities from public accounts.
+    If the path is private or a storage path, the function returns `nil`.
 
-  For authorized accounts, the function returns a capability
-  if the given path is public or private.
-  If the path is a storage path, the function returns `nil`.
+    For authorized accounts, the function returns a capability
+    if the given path is public or private.
+    If the path is a storage path, the function returns `nil`.
 
-  `T` is the type parameter that specifies how the capability can be borrowed.
-  The type argument is optional, i.e. it need not be provided.
+    `T` is the type parameter that specifies how the capability can be borrowed.
+    The type argument is optional, i.e. it need not be provided.
 
 The `getCapability` function does **not** check if the target exists.
 The link is latent.
 The `check` function of the capability can be used to check if the target currently exists and could be borrowed,
 
-- `cadence•fun check<T: &Any>(): Bool`
+-
+    ```cadence
+    fun check<T: &Any>(): Bool
+    ```
 
-  `T` is the type parameter for the reference type.
-  A type argument for the parameter must be provided explicitly.
+    `T` is the type parameter for the reference type.
+    A type argument for the parameter must be provided explicitly.
 
-  The function returns true if the capability currently targets an object
-  that satisfies the given type, i.e. could be borrowed using the given type.
+    The function returns true if the capability currently targets an object
+    that satisfies the given type, i.e. could be borrowed using the given type.
 
 Finally, the capability can be borrowed to get a reference to the stored object.
 This can be done using the `borrow` function of the capability:
 
-- `cadence•fun borrow<T: &Any>(): T?`
+-
+    ```cadence
+    fun borrow<T: &Any>(): T?
+    ```
 
-  The function returns a reference to the object targeted by the capability,
-  provided it can be borrowed using the given type.
+    The function returns a reference to the object targeted by the capability,
+    provided it can be borrowed using the given type.
 
-  `T` is the type parameter for the reference type.
-  If the function is called on a typed capability, the capability's type is used when borrowing.
-  If the capability is untyped, a type argument must be provided explicitly in the call to `borrow`.
+    `T` is the type parameter for the reference type.
+    If the function is called on a typed capability, the capability's type is used when borrowing.
+    If the capability is untyped, a type argument must be provided explicitly in the call to `borrow`.
 
-  The function returns `nil` when the targeted path is empty, i.e. nothing is stored under it.
-  When the requested type exceeds what is allowed by the capability (or any interim capabilities),
-  execution will abort with an error.
+    The function returns `nil` when the targeted path is empty, i.e. nothing is stored under it.
+    When the requested type exceeds what is allowed by the capability (or any interim capabilities),
+    execution will abort with an error.
 
 ```cadence
 // Declare a resource interface named `HasCount`, that has a field `count`
@@ -229,6 +248,9 @@ let counterRef2 = publicAccount.borrow<&Counter>(from: /storage/counter)
 
 The address of a capability can be obtained from the `address` field of the capability:
 
-- `cadence•let address: Address`
+-
+    ```cadence
+    let address: Address
+    ```
 
-  The address of the capability.
+    The address of the capability.

--- a/docs/language/contracts.mdx
+++ b/docs/language/contracts.mdx
@@ -414,15 +414,15 @@ let contract: &TestInterface = signer.contracts.borrow<&TestInterface>(name: "Te
 
 A deployed contract can be removed from an account using the `remove` function:
 
-  ```cadence
-  fun remove(name: String): DeployedContract?
-  ```
+```cadence
+fun remove(name: String): DeployedContract?
+```
 
-  Removes the contract/contract interface from the account which has the given name, if any.
+ Removes the contract/contract interface from the account which has the given name, if any.
 
-  Returns the removed [deployed contract](#deployed-contracts), if any.
+ Returns the removed [deployed contract](#deployed-contracts), if any.
 
-  Returns `nil` if no contract/contract interface with the given name exist in the account.
+ Returns `nil` if no contract/contract interface with the given name exist in the account.
 
 For example, assuming that a contract named `Test` is deployed to an account, the contract can be removed as follows:
 

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -261,7 +261,9 @@ The PoP can only be verified using the `PublicKey` method `verifyPoP`.
 
 ### BLS signature aggregation
 
-`cadence•fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?`
+```cadence
+fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?
+```
 
 Aggregates multiple BLS signatures into one. 
 Signatures could be generated from the same or distinct messages, they
@@ -276,7 +278,9 @@ verfiy multiple signatures of the same message.
 
 ### BLS public key aggregation
 
-`cadence•fun aggregatePublicKeys(_ publicKeys: [PublicKey]): PublicKey?`
+```cadence
+fun aggregatePublicKeys(_ publicKeys: [PublicKey]): PublicKey?
+```
 
 Aggregates multiple BLS public keys into one.
 

--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -19,12 +19,14 @@ To get information about a block, the functions `getCurrentBlock` and `getBlock`
     ```cadence
     fun getCurrentBlock(): Block
     ```
+
   Returns the current block, i.e. the block which contains the currently executed transaction.
 
 -
     ```cadence
     fun getBlock(at height: UInt64): Block?
     ```
+
   Returns the block at the given height.
   If the given block does not exist the function returns `nil`.
 

--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -15,12 +15,16 @@ Please let us know if your use-case demands it by request this feature in an iss
 
 To get information about a block, the functions `getCurrentBlock` and `getBlock` can be used:
 
-- `cadence•fun getCurrentBlock(): Block`
-
+-
+    ```cadence
+    fun getCurrentBlock(): Block
+    ```
   Returns the current block, i.e. the block which contains the currently executed transaction.
 
-- `cadence•fun getBlock(at height: UInt64): Block?`
-
+-
+    ```cadence
+    fun getBlock(at height: UInt64): Block?
+    ```
   Returns the block at the given height.
   If the given block does not exist the function returns `nil`.
 

--- a/docs/language/interfaces.mdx
+++ b/docs/language/interfaces.mdx
@@ -470,10 +470,6 @@ struct SomeInner: OuterInterface.InnerInterface {}
 
 ## Interface Default Functions
 
-<Callout type="info">
-🚧 Status: This feature will be available in a future spork.
-</Callout>
-
 Interfaces can provide default functions:
 If the concrete type implementing the interface does not provide an implementation
 for the function required by the interface,

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -713,101 +713,121 @@ let canadianFlag: Character = "\u{1F1E8}\u{1F1E6}"
 
 Strings have multiple built-in functions you can use:
 
-- `cadence•let length: Int`
+-
+    ```cadence
+    let length: Int
+    ```
 
-  Returns the number of characters in the string as an integer.
+    Returns the number of characters in the string as an integer.
 
-  ```cadence
-  let example = "hello"
+    ```cadence
+    let example = "hello"
 
-  // Find the number of elements of the string.
-  let length = example.length
-  // `length` is `5`
-  ```
+    // Find the number of elements of the string.
+    let length = example.length
+    // `length` is `5`
+    ```
+-
+    ```cadence
+    let utf8: [UInt8]
+    ```
 
-- `cadence•let utf8: [UInt8]`
+    The byte array of the UTF-8 encoding
 
-  The byte array of the UTF-8 encoding
+    ```cadence
+    let flowers = "Flowers \u{1F490}"
+    let bytes = flowers.utf8
+    // `bytes` is `[70, 108, 111, 119, 101, 114, 115, 32, 240, 159, 146, 144]`
+    ```
 
-  ```cadence
-  let flowers = "Flowers \u{1F490}"
-  let bytes = flowers.utf8
-  // `bytes` is `[70, 108, 111, 119, 101, 114, 115, 32, 240, 159, 146, 144]`
-  ```
+-
+    ```cadence
+    fun concat(_ other: String): String
+    ```
 
-- `cadence•fun concat(_ other: String): String`
+    Concatenates the string `other` to the end of the original string,
+    but does not modify the original string.
+    This function creates a new string whose length is the sum of the lengths
+    of the string the function is called on and the string given as a parameter.
 
-  Concatenates the string `other` to the end of the original string,
-  but does not modify the original string.
-  This function creates a new string whose length is the sum of the lengths
-  of the string the function is called on and the string given as a parameter.
+    ```cadence
+    let example = "hello"
+    let new = "world"
 
-  ```cadence
-  let example = "hello"
-  let new = "world"
+    // Concatenate the new string onto the example string and return the new string.
+    let helloWorld = example.concat(new)
+    // `helloWorld` is now `"helloworld"`
+    ```
 
-  // Concatenate the new string onto the example string and return the new string.
-  let helloWorld = example.concat(new)
-  // `helloWorld` is now `"helloworld"`
-  ```
+-
+    ```cadence
+    fun slice(from: Int, upTo: Int): String
+    ```
 
-- `cadence•fun slice(from: Int, upTo: Int): String`
+    Returns a string slice of the characters
+    in the given string from start index `from` up to,
+    but not including, the end index `upTo`.
+    This function creates a new string whose length is `upTo - from`.
+    It does not modify the original string.
+    If either of the parameters are out of the bounds of the string,
+    or the indices are invalid (`from > upTo`), then the function will fail.
 
-  Returns a string slice of the characters
-  in the given string from start index `from` up to,
-  but not including, the end index `upTo`.
-  This function creates a new string whose length is `upTo - from`.
-  It does not modify the original string.
-  If either of the parameters are out of the bounds of the string,
-  or the indices are invalid (`from > upTo`), then the function will fail.
+    ```cadence
+    let example = "helloworld"
 
-  ```cadence
-  let example = "helloworld"
+    // Create a new slice of part of the original string.
+    let slice = example.slice(from: 3, upTo: 6)
+    // `slice` is now `"low"`
 
-  // Create a new slice of part of the original string.
-  let slice = example.slice(from: 3, upTo: 6)
-  // `slice` is now `"low"`
+    // Run-time error: Out of bounds index, the program aborts.
+    let outOfBounds = example.slice(from: 2, upTo: 10)
 
-  // Run-time error: Out of bounds index, the program aborts.
-  let outOfBounds = example.slice(from: 2, upTo: 10)
+    // Run-time error: Invalid indices, the program aborts.
+    let invalidIndices = example.slice(from: 2, upTo: 1)
+    ```
+-
+    ```cadence
+    fun decodeHex(): [UInt8]
+    ```
 
-  // Run-time error: Invalid indices, the program aborts.
-  let invalidIndices = example.slice(from: 2, upTo: 1)
-  ```
+    Returns an array containing the bytes represented by the given hexadecimal string.
 
-- `cadence•fun decodeHex(): [UInt8]`
+    The given string must only contain hexadecimal characters and must have an even length.
+    If the string is malformed, the program aborts
 
-  Returns an array containing the bytes represented by the given hexadecimal string.
+    ```cadence
+    let example = "436164656e636521"
 
-  The given string must only contain hexadecimal characters and must have an even length.
-  If the string is malformed, the program aborts
+    example.decodeHex()  // is `[67, 97, 100, 101, 110, 99, 101, 33]`
+    ```
 
-  ```cadence
-  let example = "436164656e636521"
+-
+    ```cadence
+    fun toLower(): String
+    ```
 
-  example.decodeHex()  // is `[67, 97, 100, 101, 110, 99, 101, 33]`
-  ```
+    Returns a string where all upper case letters are replaced with lowercase characters
 
-- `cadence•fun toLower(): String`
-  Returns a string where all upper case letters are replaced with lowercase characters
+    ```cadence
+    let example = "Flowers"
 
-  ```cadence
-  let example = "Flowers"
-
-  example.toLower()  // is `flowers`
-  ```
+    example.toLower()  // is `flowers`
+    ```
 
 The `String` type also provides the following functions:
 
-- `cadence•fun String.encodeHex(_ data: [UInt8]): String`
+-
+    ```cadence
+    fun String.encodeHex(_ data: [UInt8]): String
+    ```
 
-  Returns a hexadecimal string for the given byte array
+    Returns a hexadecimal string for the given byte array
 
-  ```cadence
-  let data = [1 as UInt8, 2, 3, 0xCA, 0xDE]
+    ```cadence
+    let data = [1 as UInt8, 2, 3, 0xCA, 0xDE]
 
-  String.encodeHex(data)  // is `"010203cade"`
-  ```
+    String.encodeHex(data)  // is `"010203cade"`
+    ```
 
 `String`s are also indexable, returning a `Character` value.
 
@@ -816,35 +836,44 @@ let str = "abc"
 let c = str[0] // is the Character "a"
 ```
 
-- `cadence•fun String.fromUTF8(_ input: [UInt8]): String?`
+-
+    ```cadence
+    fun String.fromUTF8(_ input: [UInt8]): String?
+    ```
 
-  Attempts to convert a UTF-8 encoded byte array into a `String`. This function returns `nil` if the byte array contains invalid UTF-8,
-  such as incomplete codepoint sequences or undefined graphemes.
+    Attempts to convert a UTF-8 encoded byte array into a `String`. This function returns `nil` if the byte array contains invalid UTF-8,
+    such as incomplete codepoint sequences or undefined graphemes.
 
-  For a given string `s`, `String.fromUTF8(s.utf8)` is equivalent to wrapping `s` up in an [optional](#optionals).
+    For a given string `s`, `String.fromUTF8(s.utf8)` is equivalent to wrapping `s` up in an [optional](#optionals).
 
 ### Character Fields and Functions
 
 `Character` values can be converted into `String` values using the `toString` function:
 
-- `cadence•fun toString(): String`
+-
+    ```cadence
+    fun toString(): String`
+    ```
 
-  Returns the string representation of the character.
+    Returns the string representation of the character.
 
-  ```cadence
-  let c: Character = "x"
+    ```cadence
+    let c: Character = "x"
 
-  c.toString()  // is "x"
-  ```
+    c.toString()  // is "x"
+    ```
 
-- `cadence•fun String.fromCharacters(_ characters: [Character]): String`
+-
+    ```cadence
+    fun String.fromCharacters(_ characters: [Character]): String
+    ```
 
-  Builds a new `String` value from an array of `Character`s. Because `String`s are immutable, this operation makes a copy of the input array.
+    Builds a new `String` value from an array of `Character`s. Because `String`s are immutable, this operation makes a copy of the input array.
 
-  ```cadence
-  let rawUwU: [Character] = ["U", "w", "U"]
-  let uwu: String = String.fromCharacters(rawUwU) // "UwU"
-  ```
+    ```cadence
+    let rawUwU: [Character] = ["U", "w", "U"]
+    let uwu: String = String.fromCharacters(rawUwU) // "UwU"
+    ```
 
 ## Arrays
 
@@ -977,259 +1006,293 @@ that can be used to get information about and manipulate the contents of the arr
 The field `length`, and the functions `concat`, and `contains`
 are available for both variable-sized and fixed-sized or variable-sized arrays.
 
-- `cadence•let length: Int`
+-
+    ```cadence
+    let length: Int
+    ```
 
-  The number of elements in the array.
+    The number of elements in the array.
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23, 31, 12]
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23, 31, 12]
 
-  // Find the number of elements of the array.
-  let length = numbers.length
+    // Find the number of elements of the array.
+    let length = numbers.length
 
-  // `length` is `4`
-  ```
+    // `length` is `4`
+    ```
 
-- `cadence•fun concat(_ array: T): T`
 
-  Concatenates the parameter `array` to the end
-  of the array the function is called on,
-  but does not modify that array.
+-
+    ```cadence
+    fun concat(_ array: T): T
+    ```
 
-  Both arrays must be the same type `T`.
+    Concatenates the parameter `array` to the end
+    of the array the function is called on,
+    but does not modify that array.
 
-  This function creates a new array whose length is the sum of the length of the array
-  the function is called on and the length of the array given as the parameter.
+    Both arrays must be the same type `T`.
 
-  ```cadence
-  // Declare two arrays of integers.
-  let numbers = [42, 23, 31, 12]
-  let moreNumbers = [11, 27]
+    This function creates a new array whose length is the sum of the length of the array
+    the function is called on and the length of the array given as the parameter.
 
-  // Concatenate the array `moreNumbers` to the array `numbers`
-  // and declare a new variable for the result.
-  //
-  let allNumbers = numbers.concat(moreNumbers)
+    ```cadence
+    // Declare two arrays of integers.
+    let numbers = [42, 23, 31, 12]
+    let moreNumbers = [11, 27]
 
-  // `allNumbers` is `[42, 23, 31, 12, 11, 27]`
-  // `numbers` is still `[42, 23, 31, 12]`
-  // `moreNumbers` is still `[11, 27]`
-  ```
+    // Concatenate the array `moreNumbers` to the array `numbers`
+    // and declare a new variable for the result.
+    //
+    let allNumbers = numbers.concat(moreNumbers)
 
-- `cadence•fun contains(_ element: T): Bool`
+    // `allNumbers` is `[42, 23, 31, 12, 11, 27]`
+    // `numbers` is still `[42, 23, 31, 12]`
+    // `moreNumbers` is still `[11, 27]`
+    ```
 
-  Returns true if the given element of type `T` is in the array.
+-
+    ```cadence
+    fun contains(_ element: T): Bool
+    ```
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23, 31, 12]
+    Returns true if the given element of type `T` is in the array.
 
-  // Check if the array contains 11.
-  let containsEleven = numbers.contains(11)
-  // `containsEleven` is `false`
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23, 31, 12]
 
-  // Check if the array contains 12.
-  let containsTwelve = numbers.contains(12)
-  // `containsTwelve` is `true`
+    // Check if the array contains 11.
+    let containsEleven = numbers.contains(11)
+    // `containsEleven` is `false`
 
-  // Invalid: Check if the array contains the string "Kitty".
-  // This results in a type error, as the array only contains integers.
-  //
-  let containsKitty = numbers.contains("Kitty")
-  ```
+    // Check if the array contains 12.
+    let containsTwelve = numbers.contains(12)
+    // `containsTwelve` is `true`
 
-- `cadence•fun firstIndex(of: T): Int?`
-  Returns the index of the first element matching the given object in the array, nil if no match.
-  Available if `T` is not resource-kinded and equatable.
+    // Invalid: Check if the array contains the string "Kitty".
+    // This results in a type error, as the array only contains integers.
+    //
+    let containsKitty = numbers.contains("Kitty")
+    ```
 
-```cadence
- // Declare an array of integers.
- let numbers = [42, 23, 31, 12]
+-
+    ```cadence
+    fun firstIndex(of: T): Int?
+    ```
 
- // Check if the array contains 31
- let index = numbers.firstIndex(of: 31)
- // `index` is 2
+    Returns the index of the first element matching the given object in the array, nil if no match.
+    Available if `T` is not resource-kinded and equatable.
 
- // Check if the array contains 22
- let index = numbers.firstIndex(of: 22)
- // `index` is nil
-```
+    ```cadence
+     // Declare an array of integers.
+     let numbers = [42, 23, 31, 12]
 
-- `cadence•fun slice(from: Int, upTo: Int): [T]`
+     // Check if the array contains 31
+     let index = numbers.firstIndex(of: 31)
+     // `index` is 2
 
-  Returns an array slice of the elements
-  in the given array from start index `from` up to,
-  but not including, the end index `upTo`.
-  This function creates a new array whose length is `upTo - from`.
-  It does not modify the original array.
-  If either of the parameters are out of the bounds of the array,
-  or the indices are invalid (`from > upTo`), then the function will fail.
+     // Check if the array contains 22
+     let index = numbers.firstIndex(of: 22)
+     // `index` is nil
+    ```
 
-  ```cadence
-  let example = [1, 2, 3, 4]
+-
+    ```cadence
+    fun slice(from: Int, upTo: Int): [T]
+    ```
 
-  // Create a new slice of part of the original array.
-  let slice = example.slice(from: 1, upTo: 3)
-  // `slice` is now `[2, 3]`
+    Returns an array slice of the elements
+    in the given array from start index `from` up to,
+    but not including, the end index `upTo`.
+    This function creates a new array whose length is `upTo - from`.
+    It does not modify the original array.
+    If either of the parameters are out of the bounds of the array,
+    or the indices are invalid (`from > upTo`), then the function will fail.
 
-  // Run-time error: Out of bounds index, the program aborts.
-  let outOfBounds = example.slice(from: 2, upTo: 10)
+    ```cadence
+    let example = [1, 2, 3, 4]
 
-  // Run-time error: Invalid indices, the program aborts.
-  let invalidIndices = example.slice(from: 2, upTo: 1)
-  ```
+    // Create a new slice of part of the original array.
+    let slice = example.slice(from: 1, upTo: 3)
+    // `slice` is now `[2, 3]`
+
+    // Run-time error: Out of bounds index, the program aborts.
+    let outOfBounds = example.slice(from: 2, upTo: 10)
+
+    // Run-time error: Invalid indices, the program aborts.
+    let invalidIndices = example.slice(from: 2, upTo: 1)
+    ```
 
 #### Variable-size Array Functions
 
 The following functions can only be used on variable-sized arrays.
 It is invalid to use one of these functions on a fixed-sized array.
 
-- `cadence•fun append(_ element: T): Void`
+-
+    ```cadence
+    fun append(_ element: T): Void
+    ```
 
-  Adds the new element `element` of type `T` to the end of the array.
+    Adds the new element `element` of type `T` to the end of the array.
 
-  The new element must be the same type as all the other elements in the array.
+    The new element must be the same type as all the other elements in the array.
 
-  This function [mutates](access-control) the array.
+    This function [mutates](access-control) the array.
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23, 31, 12]
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23, 31, 12]
 
-  // Add a new element to the array.
-  numbers.append(20)
-  // `numbers` is now `[42, 23, 31, 12, 20]`
+    // Add a new element to the array.
+    numbers.append(20)
+    // `numbers` is now `[42, 23, 31, 12, 20]`
 
-  // Invalid: The parameter has the wrong type `String`.
-  numbers.append("SneakyString")
-  ```
+    // Invalid: The parameter has the wrong type `String`.
+    numbers.append("SneakyString")
+    ```
 
-- `cadence•fun appendAll(_ array: T): Void`
+-
+    ```cadence
+    fun appendAll(_ array: T): Void
+    ```
 
-  Adds all the elements from `array` to the end of the array
-  the function is called on.
+    Adds all the elements from `array` to the end of the array
+    the function is called on.
 
-  Both arrays must be the same type `T`.
+    Both arrays must be the same type `T`.
 
-  This function [mutates](access-control) the array.
+    This function [mutates](access-control) the array.
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23]
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23]
 
-  // Add new elements to the array.
-  numbers.appendAll([31, 12, 20])
-  // `numbers` is now `[42, 23, 31, 12, 20]`
+    // Add new elements to the array.
+    numbers.appendAll([31, 12, 20])
+    // `numbers` is now `[42, 23, 31, 12, 20]`
 
-  // Invalid: The parameter has the wrong type `[String]`.
-  numbers.appendAll(["Sneaky", "String"])
-  ```
+    // Invalid: The parameter has the wrong type `[String]`.
+    numbers.appendAll(["Sneaky", "String"])
+    ```
 
-- `cadence•fun insert(at index: Int, _ element: T): Void`
+-
+    ```cadence
+    fun insert(at index: Int, _ element: T): Void
+    ```
 
-  Inserts the new element `element` of type `T`
-  at the given `index` of the array.
+    Inserts the new element `element` of type `T`
+    at the given `index` of the array.
 
-  The new element must be of the same type as the other elements in the array.
+    The new element must be of the same type as the other elements in the array.
 
-  The `index` must be within the bounds of the array.
-  If the index is outside the bounds, the program aborts.
+    The `index` must be within the bounds of the array.
+    If the index is outside the bounds, the program aborts.
 
-  The existing element at the supplied index is not overwritten.
+    The existing element at the supplied index is not overwritten.
 
-  All the elements after the new inserted element
-  are shifted to the right by one.
+    All the elements after the new inserted element
+    are shifted to the right by one.
 
-  This function [mutates](access-control) the array.
+    This function [mutates](access-control) the array.
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23, 31, 12]
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23, 31, 12]
 
-  // Insert a new element at position 1 of the array.
-  numbers.insert(at: 1, 20)
-  // `numbers` is now `[42, 20, 23, 31, 12]`
+    // Insert a new element at position 1 of the array.
+    numbers.insert(at: 1, 20)
+    // `numbers` is now `[42, 20, 23, 31, 12]`
 
-  // Run-time error: Out of bounds index, the program aborts.
-  numbers.insert(at: 12, 39)
-  ```
+    // Run-time error: Out of bounds index, the program aborts.
+    numbers.insert(at: 12, 39)
+    ```
+-
+    ```cadence
+    fun remove(at index: Int): T
+    ```
 
-- `cadence•fun remove(at index: Int): T`
+    Removes the element at the given `index` from the array and returns it.
 
-  Removes the element at the given `index` from the array and returns it.
+    The `index` must be within the bounds of the array.
+    If the index is outside the bounds, the program aborts.
 
-  The `index` must be within the bounds of the array.
-  If the index is outside the bounds, the program aborts.
+    This function [mutates](access-control) the array.
 
-  This function [mutates](access-control) the array.
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23, 31]
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23, 31]
+    // Remove element at position 1 of the array.
+    let twentyThree = numbers.remove(at: 1)
+    // `numbers` is now `[42, 31]`
+    // `twentyThree` is `23`
 
-  // Remove element at position 1 of the array.
-  let twentyThree = numbers.remove(at: 1)
-  // `numbers` is now `[42, 31]`
-  // `twentyThree` is `23`
+    // Run-time error: Out of bounds index, the program aborts.
+    numbers.remove(at: 19)
+    ```
 
-  // Run-time error: Out of bounds index, the program aborts.
-  numbers.remove(at: 19)
-  ```
+-
+    ```cadence
+    fun removeFirst(): T
+    ```
 
-- `cadence•fun removeFirst(): T`
+    Removes the first element from the array and returns it.
 
-  Removes the first element from the array and returns it.
+    The array must not be empty.
+    If the array is empty, the program aborts.
 
-  The array must not be empty.
-  If the array is empty, the program aborts.
+    This function [mutates](access-control) the array.
 
-  This function [mutates](access-control) the array.
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23]
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23]
+    // Remove the first element of the array.
+    let fortytwo = numbers.removeFirst()
+    // `numbers` is now `[23]`
+    // `fortywo` is `42`
 
-  // Remove the first element of the array.
-  let fortytwo = numbers.removeFirst()
-  // `numbers` is now `[23]`
-  // `fortywo` is `42`
+    // Remove the first element of the array.
+    let twentyThree = numbers.removeFirst()
+    // `numbers` is now `[]`
+    // `twentyThree` is `23`
 
-  // Remove the first element of the array.
-  let twentyThree = numbers.removeFirst()
-  // `numbers` is now `[]`
-  // `twentyThree` is `23`
+    // Run-time error: The array is empty, the program aborts.
+    numbers.removeFirst()
+    ```
 
-  // Run-time error: The array is empty, the program aborts.
-  numbers.removeFirst()
-  ```
+-
+    ```cadence
+    fun removeLast(): T
+    ```
 
-- `cadence•fun removeLast(): T`
+    Removes the last element from the array and returns it.
 
-  Removes the last element from the array and returns it.
+    The array must not be empty.
+    If the array is empty, the program aborts.
 
-  The array must not be empty.
-  If the array is empty, the program aborts.
+    This function [mutates](access-control) the array.
 
-  This function [mutates](access-control) the array.
+    ```cadence
+    // Declare an array of integers.
+    let numbers = [42, 23]
 
-  ```cadence
-  // Declare an array of integers.
-  let numbers = [42, 23]
+    // Remove the last element of the array.
+    let twentyThree = numbers.removeLast()
+    // `numbers` is now `[42]`
+    // `twentyThree` is `23`
 
-  // Remove the last element of the array.
-  let twentyThree = numbers.removeLast()
-  // `numbers` is now `[42]`
-  // `twentyThree` is `23`
+    // Remove the last element of the array.
+    let fortyTwo = numbers.removeLast()
+    // `numbers` is now `[]`
+    // `fortyTwo` is `42`
 
-  // Remove the last element of the array.
-  let fortyTwo = numbers.removeLast()
-  // `numbers` is now `[]`
-  // `fortyTwo` is `42`
-
-  // Run-time error: The array is empty, the program aborts.
-  numbers.removeLast()
-  ```
+    // Run-time error: The array is empty, the program aborts.
+    numbers.removeLast()
+    ```
 
 ## Dictionaries
 
@@ -1365,161 +1428,184 @@ booleans[0] = true
 
 ### Dictionary Fields and Functions
 
-- `cadence•let length: Int`
 
-  The number of entries in the dictionary.
+-
+    ```cadence
+    let length: Int
+    ```
 
-  ```cadence
-  // Declare a dictionary mapping strings to integers.
-  let numbers = {"fortyTwo": 42, "twentyThree": 23}
+    The number of entries in the dictionary.
 
-  // Find the number of entries of the dictionary.
-  let length = numbers.length
+    ```cadence
+    // Declare a dictionary mapping strings to integers.
+    let numbers = {"fortyTwo": 42, "twentyThree": 23}
 
-  // `length` is `2`
-  ```
+    // Find the number of entries of the dictionary.
+    let length = numbers.length
 
-- `cadence•fun insert(key: K, _ value: V): V?`
+    // `length` is `2`
+    ```
 
-  Inserts the given value of type `V` into the dictionary under the given `key` of type `K`.
-  
-  The inserted key must have the same type as the dictionary's key type, and the inserted value must have the same type as the dictionary's value type.
+-
+    ```cadence
+    fun insert(key: K, _ value: V): V?
+    ```
 
-  Returns the previous value as an optional
-  if the dictionary contained the key,
-  otherwise `nil`.
-  
-  Updates the value if the dictionary already contained the key.
+    Inserts the given value of type `V` into the dictionary under the given `key` of type `K`.
 
-  This function [mutates](access-control) the dictionary.
+    The inserted key must have the same type as the dictionary's key type, and the inserted value must have the same type as the dictionary's value type.
 
-  ```cadence
-  // Declare a dictionary mapping strings to integers.
-  let numbers = {"twentyThree": 23}
+    Returns the previous value as an optional
+    if the dictionary contained the key,
+    otherwise `nil`.
 
-  // Insert the key `"fortyTwo"` with the value `42` into the dictionary.
-  // The key did not previously exist in the dictionary,
-  // so the result is `nil`
-  //
-  let old = numbers.insert(key: "fortyTwo", 42)
+    Updates the value if the dictionary already contained the key.
 
-  // `old` is `nil`
-  // `numbers` is `{"twentyThree": 23, "fortyTwo": 42}`
-  ```
+    This function [mutates](access-control) the dictionary.
 
-- `cadence•fun remove(key: K): V?`
+    ```cadence
+    // Declare a dictionary mapping strings to integers.
+    let numbers = {"twentyThree": 23}
 
-  Removes the value for the given `key` of type `K` from the dictionary.
+    // Insert the key `"fortyTwo"` with the value `42` into the dictionary.
+    // The key did not previously exist in the dictionary,
+    // so the result is `nil`
+    //
+    let old = numbers.insert(key: "fortyTwo", 42)
 
-  Returns the value of type `V` as an optional
-  if the dictionary contained the key,
-  otherwise `nil`.
+    // `old` is `nil`
+    // `numbers` is `{"twentyThree": 23, "fortyTwo": 42}`
+    ```
 
-  This function [mutates](access-control) the dictionary.
+-
+    ```cadence
+    fun remove(key: K): V?
+    ```
 
-  ```cadence
-  // Declare a dictionary mapping strings to integers.
-  let numbers = {"fortyTwo": 42, "twentyThree": 23}
+    Removes the value for the given `key` of type `K` from the dictionary.
 
-  // Remove the key `"fortyTwo"` from the dictionary.
-  // The key exists in the dictionary,
-  // so the value associated with the key is returned.
-  //
-  let fortyTwo = numbers.remove(key: "fortyTwo")
+    Returns the value of type `V` as an optional
+    if the dictionary contained the key,
+    otherwise `nil`.
 
-  // `fortyTwo` is `42`
-  // `numbers` is `{"twentyThree": 23}`
+    This function [mutates](access-control) the dictionary.
 
-  // Remove the key `"oneHundred"` from the dictionary.
-  // The key does not exist in the dictionary, so `nil` is returned.
-  //
-  let oneHundred = numbers.remove(key: "oneHundred")
+    ```cadence
+    // Declare a dictionary mapping strings to integers.
+    let numbers = {"fortyTwo": 42, "twentyThree": 23}
 
-  // `oneHundred` is `nil`
-  // `numbers` is `{"twentyThree": 23}`
-  ```
+    // Remove the key `"fortyTwo"` from the dictionary.
+    // The key exists in the dictionary,
+    // so the value associated with the key is returned.
+    //
+    let fortyTwo = numbers.remove(key: "fortyTwo")
 
-- `cadence•let keys: [K]`
+    // `fortyTwo` is `42`
+    // `numbers` is `{"twentyThree": 23}`
 
-  Returns an array of the keys of type `K` in the dictionary. This does not
-  modify the dictionary, just returns a copy of the keys as an array.
-  If the dictionary is empty, this returns an empty array. The ordering of the keys is undefined.
+    // Remove the key `"oneHundred"` from the dictionary.
+    // The key does not exist in the dictionary, so `nil` is returned.
+    //
+    let oneHundred = numbers.remove(key: "oneHundred")
 
-  ```cadence
-  // Declare a dictionary mapping strings to integers.
-  let numbers = {"fortyTwo": 42, "twentyThree": 23}
+    // `oneHundred` is `nil`
+    // `numbers` is `{"twentyThree": 23}`
+    ```
 
-  // Find the keys of the dictionary.
-  let keys = numbers.keys
+-
+    ```cadence
+    let keys: [K]
+    ```
 
-  // `keys` has type `[String]` and is `["fortyTwo","twentyThree"]`
-  ```
+    Returns an array of the keys of type `K` in the dictionary. This does not
+    modify the dictionary, just returns a copy of the keys as an array.
+    If the dictionary is empty, this returns an empty array. The ordering of the keys is undefined.
 
-- `cadence•let values: [V]`
+    ```cadence
+    // Declare a dictionary mapping strings to integers.
+    let numbers = {"fortyTwo": 42, "twentyThree": 23}
 
-  Returns an array of the values of type `V` in the dictionary. This does not
-  modify the dictionary, just returns a copy of the values as an array.
-  If the dictionary is empty, this returns an empty array.
+    // Find the keys of the dictionary.
+    let keys = numbers.keys
 
-  This field is not available if `V` is a resource type.
+    // `keys` has type `[String]` and is `["fortyTwo","twentyThree"]`
+    ```
 
-  ```cadence
-  // Declare a dictionary mapping strings to integers.
-  let numbers = {"fortyTwo": 42, "twentyThree": 23}
+-
+    ```cadence
+    let values: [V]
+    ```
 
-  // Find the values of the dictionary.
-  let values = numbers.values
+    Returns an array of the values of type `V` in the dictionary. This does not
+    modify the dictionary, just returns a copy of the values as an array.
+    If the dictionary is empty, this returns an empty array.
 
-  // `values` has type [Int] and is `[42, 23]`
-  ```
+    This field is not available if `V` is a resource type.
 
-- `cadence•fun containsKey(key: K): Bool`
+    ```cadence
+    // Declare a dictionary mapping strings to integers.
+    let numbers = {"fortyTwo": 42, "twentyThree": 23}
 
-  Returns true if the given key of type `K` is in the dictionary.
+    // Find the values of the dictionary.
+    let values = numbers.values
 
-  ```cadence
-  // Declare a dictionary mapping strings to integers.
-  let numbers = {"fortyTwo": 42, "twentyThree": 23}
+    // `values` has type [Int] and is `[42, 23]`
+    ```
 
-  // Check if the dictionary contains the key "twentyFive".
-  let containsKeyTwentyFive = numbers.containsKey("twentyFive")
-  // `containsKeyTwentyFive` is `false`
+-
+    ```cadence
+    fun containsKey(key: K): Bool
+    ```
 
-  // Check if the dictionary contains the key "fortyTwo".
-  let containsKeyFortyTwo = numbers.containsKey("fortyTwo")
-  // `containsKeyFortyTwo` is `true`
+    Returns true if the given key of type `K` is in the dictionary.
 
-  // Invalid: Check if the dictionary contains the key 42.
-  // This results in a type error, as the key type of the dictionary is `String`.
-  //
-  let containsKey42 = numbers.containsKey(42)
-  ```
-- `cadence•fun forEachKey(_ function: ((K): Bool)): Void`
+    ```cadence
+    // Declare a dictionary mapping strings to integers.
+    let numbers = {"fortyTwo": 42, "twentyThree": 23}
 
-  Iterate through all the keys in the dictionary, exiting early if the passed function returns false.
-  This is more efficient than calling `.keys` and iterating over the resulting array, since an intermediate allocation is avoided.
-  The order of key iteration is undefined, similar to `.keys`.
+    // Check if the dictionary contains the key "twentyFive".
+    let containsKeyTwentyFive = numbers.containsKey("twentyFive")
+    // `containsKeyTwentyFive` is `false`
 
-  ```cadence
-  // Take in a targetKey to look for, and a dictionary to iterate through.
-  fun myContainsKey(targetKey: String, dictionary: {String: Int}) {
-    // Declare an accumulator that we'll capture inside a closure.
-    var found = false
+    // Check if the dictionary contains the key "fortyTwo".
+    let containsKeyFortyTwo = numbers.containsKey("fortyTwo")
+    // `containsKeyFortyTwo` is `true`
 
-    // At each step, `key` will be bound to another key from `dictionary`.
-    dictionary.forEachKey(fun (key: String): Bool {
-      found = key == targetKey
+    // Invalid: Check if the dictionary contains the key 42.
+    // This results in a type error, as the key type of the dictionary is `String`.
+    //
+    let containsKey42 = numbers.containsKey(42)
+    ```
 
-      // The returned boolean value, signals whether to continue iterating. 
-      // This allows for control flow during the iteration process:
-      //  true = `continue`
-      //  false = `break`
-      return !found
-    })
+-
+    ```cadence
+    fun forEachKey(_ function: ((K): Bool)): Void
+    ```
 
-    return found
-  }
-  ```
+    Iterate through all the keys in the dictionary, exiting early if the passed function returns false.
+    This is more efficient than calling `.keys` and iterating over the resulting array, since an intermediate allocation is avoided.
+    The order of key iteration is undefined, similar to `.keys`.
+
+    ```cadence
+    // Take in a targetKey to look for, and a dictionary to iterate through.
+    fun myContainsKey(targetKey: String, dictionary: {String: Int}) {
+      // Declare an accumulator that we'll capture inside a closure.
+      var found = false
+
+      // At each step, `key` will be bound to another key from `dictionary`.
+      dictionary.forEachKey(fun (key: String): Bool {
+        found = key == targetKey
+
+        // The returned boolean value, signals whether to continue iterating. 
+        // This allows for control flow during the iteration process:
+        //  true = `continue`
+        //  false = `break`
+        return !found
+      })
+
+      return found
+    }
+    ```
 
 
 ### Dictionary Keys

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -158,53 +158,62 @@ let b = x + 1000000000000000000000000
 
 Integers have multiple built-in functions you can use.
 
-- `cadence•fun toString(): String`
+-
+    ```cadence
+    fun toString(): String
+    ```
 
-  Returns the string representation of the integer.
+    Returns the string representation of the integer.
 
-  ```cadence
-  let answer = 42
+    ```cadence
+    let answer = 42
 
-  answer.toString()  // is "42"
-  ```
+    answer.toString()  // is "42"
+    ```
 
-- `cadence•fun toBigEndianBytes(): [UInt8]`
+-
+    ```cadence
+    fun toBigEndianBytes(): [UInt8]
+    ```
 
-  Returns the byte array representation (`[UInt8]`) in big-endian order of the integer.
+    Returns the byte array representation (`[UInt8]`) in big-endian order of the integer.
 
-  ```cadence
-  let largeNumber = 1234567890
+    ```cadence
+    let largeNumber = 1234567890
 
-  largeNumber.toBigEndianBytes()  // is `[73, 150, 2, 210]`
-  ```
+    largeNumber.toBigEndianBytes()  // is `[73, 150, 2, 210]`
+    ```
 
 All integer types support the following functions:
 
-- `cadence•fun T.fromString(_ input: String): T?`
+-
+    ```cadence
+    fun T.fromString(_ input: String): T?
+    ```
 
-  Attempts to parse an integer value from a base-10 encoded string, returning `nil` if the string is invalid.
+    Attempts to parse an integer value from a base-10 encoded string, returning `nil` if the string is invalid.
 
-  For a given integer `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an [optional](#optionals).
+    For a given integer `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an [optional](#optionals).
 
-  Strings are invalid if:
-    - they contain non-digit characters
-    - they don't fit in the target type
-  
-  For signed integer types like `Int64`, and `Int`, the string may optionally begin with `+` or `-` sign prefix.
+    Strings are invalid if:
+      - they contain non-digit characters
+      - they don't fit in the target type
 
-  For unsigned integer types like `Word64`, `UInt64`, and `UInt`, sign prefices are not allowed.
+    For signed integer types like `Int64`, and `Int`, the string may optionally begin with `+` or `-` sign prefix.
 
-  Examples:
+    For unsigned integer types like `Word64`, `UInt64`, and `UInt`, sign prefices are not allowed.
 
-  ```cadence
-  let fortyTwo: Int64? = Int64.fromString("42") // ok
+    Examples:
 
-  let twenty: UInt? = UInt.fromString("20") // ok
+    ```cadence
+    let fortyTwo: Int64? = Int64.fromString("42") // ok
 
-  let nilWord: Word8? = Word8.fromString("1024") // nil, out of bounds
+    let twenty: UInt? = UInt.fromString("20") // ok
 
-  let negTwenty: Int? = Int.fromString("-20") // ok
-  ```
+    let nilWord: Word8? = Word8.fromString("1024") // nil, out of bounds
+
+    let negTwenty: Int? = Int.fromString("-20") // ok
+    ```
 
 ## Fixed-Point Numbers
 
@@ -240,58 +249,66 @@ have the following factors, and can represent values in the following ranges:
 
 Fixed-Point numbers have multiple built-in functions you can use.
 
-- `cadence•fun toString(): String`
+-
+    ```cadence
+    fun toString(): String
+    ```
 
-  Returns the string representation of the fixed-point number.
+    Returns the string representation of the fixed-point number.
 
-  ```cadence
-  let fix = 1.23
+    ```cadence
+    let fix = 1.23
 
-  fix.toString()  // is "1.23000000"
-  ```
+    fix.toString()  // is "1.23000000"
+    ```
+-
+    ```cadence
+    fun toBigEndianBytes(): [UInt8]
+    ```
 
-- `cadence•fun toBigEndianBytes(): [UInt8]`
+    Returns the byte array representation (`[UInt8]`) in big-endian order of the fixed-point number.
 
-  Returns the byte array representation (`[UInt8]`) in big-endian order of the fixed-point number.
+    ```cadence
+    let fix = 1.23
 
-  ```cadence
-  let fix = 1.23
-
-  fix.toBigEndianBytes()  // is `[0, 0, 0, 0, 7, 84, 212, 192]`
-  ```
+    fix.toBigEndianBytes()  // is `[0, 0, 0, 0, 7, 84, 212, 192]`
+    ```
 
 All fixed-point types support the following functions:
 
-- `cadence•fun T.fromString(_ input: String): T?`
+-
+    ```cadence
+    fun T.fromString(_ input: String): T?
+    ```
 
-  Attempts to parse a fixed-point value from a base-10 encoded string, returning `nil` if the string is invalid.
+    Attempts to parse a fixed-point value from a base-10 encoded string, returning `nil` if the string is invalid.
 
-  For a given fixed-point numeral `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an `optional`.
+    For a given fixed-point numeral `n` of type `T`, `T.fromString(n.toString())` is equivalent to wrapping `n` up in an `optional`.
 
-  Strings are invalid if:
-    - they contain non-digit characters.
-    - they don't fit in the target type.
-    - they're missing a decimal or fractional component. For example, both "0." and ".1" are invalid strings, but "0.1" is accepted.
+    Strings are invalid if:
+      - they contain non-digit characters.
+      - they don't fit in the target type.
+      - they're missing a decimal or fractional component. For example, both "0." and ".1" are invalid strings, but "0.1" is accepted.
 
-  For signed types like `Fix64`, the string may optionally begin with `+` or `-` sign prefix.
+    For signed types like `Fix64`, the string may optionally begin with `+` or `-` sign prefix.
 
-  For unsigned types like `UFix64`, sign prefices are not allowed.
+    For unsigned types like `UFix64`, sign prefices are not allowed.
 
-  Examples:
+    Examples:
 
-  ```cadence
-  let nil1: UFix64? = UFix64.fromString("0.") // nil, fractional part is required
+    ```cadence
+    let nil1: UFix64? = UFix64.fromString("0.") // nil, fractional part is required
 
-  let nil2: UFix64? = UFix64.fromString(".1") // nil, decimal part is required
+    let nil2: UFix64? = UFix64.fromString(".1") // nil, decimal part is required
 
-  let smol: UFix64? = UFix64.fromString("0.1") // ok
+    let smol: UFix64? = UFix64.fromString("0.1") // ok
 
-  let smolString: String = "-0.1"
+    let smolString: String = "-0.1"
 
-  let nil3: UFix64? = UFix64.fromString(smolString) // nil, unsigned types don't allow a sign prefix
+    let nil3: UFix64? = UFix64.fromString(smolString) // nil, unsigned types don't allow a sign prefix
 
-  let smolFix64: Fix64? = Fix64.fromString(smolString) // ok
-  ```
+    let smolFix64: Fix64? = Fix64.fromString(smolString) // ok
+    ```
 
 ## Minimum and maximum values
 
@@ -392,28 +409,34 @@ let aNumber = 0x436164656E636521
 
 Addresses have multiple built-in functions you can use.
 
-- `cadence•fun toString(): String`
+-
+    ```cadence
+    fun toString(): String
+    ```
 
-  Returns the string representation of the address.
-  The result has a `0x` prefix and is zero-padded.
+    Returns the string representation of the address.
+    The result has a `0x` prefix and is zero-padded.
 
-  ```cadence
-  let someAddress: Address = 0x436164656E636521
-  someAddress.toString()   // is "0x436164656E636521"
+    ```cadence
+    let someAddress: Address = 0x436164656E636521
+    someAddress.toString()   // is "0x436164656E636521"
 
-  let shortAddress: Address = 0x1
-  shortAddress.toString()  // is "0x0000000000000001"
-  ```
+    let shortAddress: Address = 0x1
+    shortAddress.toString()  // is "0x0000000000000001"
+    ```
 
-- `cadence•fun toBytes(): [UInt8]`
+-
+    ```cadence
+    fun toBytes(): [UInt8]
+    ```
 
-  Returns the byte array representation (`[UInt8]`) of the address.
+    Returns the byte array representation (`[UInt8]`) of the address.
 
-  ```cadence
-  let someAddress: Address = 0x436164656E636521
+    ```cadence
+    let someAddress: Address = 0x436164656E636521
 
-  someAddress.toBytes()  // is `[67, 97, 100, 101, 110, 99, 101, 33]`
-  ```
+    someAddress.toBytes()  // is `[67, 97, 100, 101, 110, 99, 101, 33]`
+    ```
 
 ## AnyStruct and AnyResource
 


### PR DESCRIPTION

Remove comment that default implementations will be available later. They are here today
