### PR TITLE
Add defensive check for adding and removing attachments

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -929,3 +929,20 @@ func (e AttachmentIterationMutationError) Error() string {
 		e.Value.QualifiedIdentifier,
 	)
 }
+
+// InvalidAttachmentOperationTargetError
+type InvalidAttachmentOperationTargetError struct {
+	Value Value
+	LocationRange
+}
+
+var _ errors.InternalError = InvalidAttachmentOperationTargetError{}
+
+func (InvalidAttachmentOperationTargetError) IsInternalError() {}
+
+func (e InvalidAttachmentOperationTargetError) Error() string {
+	return fmt.Sprintf(
+		"cannot add or remove attachment with non-owned value %s",
+		e.Value.String(),
+	)
+}

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -942,7 +942,7 @@ func (InvalidAttachmentOperationTargetError) IsInternalError() {}
 
 func (e InvalidAttachmentOperationTargetError) Error() string {
 	return fmt.Sprintf(
-		"cannot add or remove attachment with non-owned value %s",
-		e.Value.String(),
+		"cannot add or remove attachment with non-owned value (%T)",
+		e.Value,
 	)
 }

--- a/runtime/tests/interpreter/attachments_test.go
+++ b/runtime/tests/interpreter/attachments_test.go
@@ -1672,3 +1672,131 @@ func TestInterpretAttachmentsRuntimeType(t *testing.T) {
 		require.Equal(t, "S.test.A", a.(interpreter.TypeValue).Type.String())
 	})
 }
+
+func TestInterpretAttachmentDefensiveCheck(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reference attach", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, _ := parseCheckAndInterpretWithOptions(t, `
+        struct S {}
+        attachment A for S {}
+        fun test() {
+            var s = S()
+            var ref = &s as &S
+            ref = attach A() to ref
+        }
+        `, ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(_ error) {},
+		})
+
+		_, err := inter.Invoke("test")
+		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+	})
+
+	t.Run("reference remove", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, _ := parseCheckAndInterpretWithOptions(t, `
+        struct S {}
+        attachment A for S {}
+        fun test() {
+            var s = S()
+            var ref = &s as &S
+            remove A from S
+        }
+        `, ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(_ error) {},
+		})
+
+		_, err := inter.Invoke("test")
+		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+	})
+
+	t.Run("array attach", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, _ := parseCheckAndInterpretWithOptions(t, `
+        struct S {}
+        attachment A for S {}
+        fun test() {
+            var s = S()
+            var a = attach A() to [s]
+        }
+        `, ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(_ error) {},
+		})
+
+		_, err := inter.Invoke("test")
+		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+	})
+
+	t.Run("array remove", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, _ := parseCheckAndInterpretWithOptions(t, `
+        struct S {}
+        attachment A for S {}
+        fun test() {
+            var s = S()
+            remove A from [s]
+        }
+        `, ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(_ error) {},
+		})
+
+		_, err := inter.Invoke("test")
+		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+	})
+
+	t.Run("enum attach", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, _ := parseCheckAndInterpretWithOptions(t, `
+        struct S {}
+        attachment A for S {}
+        enum E: UInt8 {
+            case a
+        }
+        fun test() {
+            var s = S()
+            var e: E = E.a
+            ref = attach A() to e
+        }
+        `, ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(_ error) {},
+		})
+
+		_, err := inter.Invoke("test")
+		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+	})
+
+	t.Run("enum remove", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, _ := parseCheckAndInterpretWithOptions(t, `
+        struct S {}
+        attachment A for S {}
+        enum E: UInt8 {
+            case a
+        }
+        fun test() {
+            var s = S()
+            var e: E = E.a
+            remove A from e
+        }
+        `, ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(_ error) {},
+		})
+
+		_, err := inter.Invoke("test")
+		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+	})
+}


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2350

We enforce that `attach` and `remove` for attachments can only target owned resource and struct objects statically in the type checker. However, we can also check defensively in the interpreter that this invariant holds. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
