### PR TITLE
Attachments Feature Flag

### DIFF
--- a/runtime/attachments_test.go
+++ b/runtime/attachments_test.go
@@ -28,11 +28,17 @@ import (
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
+func newTestInterpreterRuntimeWithAttachments() testInterpreterRuntime {
+	rt := newTestInterpreterRuntime()
+	rt.interpreterRuntime.defaultConfig.AttachmentsEnabled = true
+	return rt
+}
+
 func TestAccountAttachmentSaveAndLoad(t *testing.T) {
 	t.Parallel()
 
 	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	rt := newTestInterpreterRuntimeWithAttachments()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)
@@ -151,7 +157,7 @@ func TestAccountAttachmentExport(t *testing.T) {
 	t.Parallel()
 
 	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	rt := newTestInterpreterRuntimeWithAttachments()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)
@@ -242,7 +248,7 @@ func TestAccountAttachedExport(t *testing.T) {
 	t.Parallel()
 
 	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	rt := newTestInterpreterRuntimeWithAttachments()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)
@@ -331,7 +337,7 @@ func TestAccountAttachmentSaveAndBorrow(t *testing.T) {
 	t.Parallel()
 
 	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	rt := newTestInterpreterRuntimeWithAttachments()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)
@@ -453,7 +459,7 @@ func TestAccountAttachmentCapability(t *testing.T) {
 	t.Parallel()
 
 	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	rt := newTestInterpreterRuntimeWithAttachments()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -37,4 +37,6 @@ type Config struct {
 	CoverageReportingEnabled bool
 	// AccountLinkingEnabled specifies if account linking is enabled
 	AccountLinkingEnabled bool
+	// AttachmentsEnabled specifies if attachments are enabled
+	AttachmentsEnabled bool
 }

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -159,6 +159,7 @@ func (e *interpreterEnvironment) newCheckerConfig() *sema.Config {
 		ImportHandler:                    e.resolveImport,
 		CheckHandler:                     e.newCheckHandler(),
 		AccountLinkingEnabled:            e.config.AccountLinkingEnabled,
+		AttachmentsEnabled:               e.config.AttachmentsEnabled,
 	}
 }
 

--- a/runtime/sema/check_attach_expression.go
+++ b/runtime/sema/check_attach_expression.go
@@ -24,6 +24,11 @@ import (
 )
 
 func (checker *Checker) VisitAttachExpression(expression *ast.AttachExpression) Type {
+
+	if !checker.Config.AttachmentsEnabled {
+		checker.report(&AttachmentsNotEnabledError{})
+	}
+
 	attachment := expression.Attachment
 	baseExpression := expression.Base
 

--- a/runtime/sema/check_attach_expression.go
+++ b/runtime/sema/check_attach_expression.go
@@ -26,7 +26,9 @@ import (
 func (checker *Checker) VisitAttachExpression(expression *ast.AttachExpression) Type {
 
 	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{})
+		checker.report(&AttachmentsNotEnabledError{
+			Range: ast.NewRangeFromPositioned(checker.memoryGauge, expression),
+		})
 	}
 
 	attachment := expression.Attachment

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -66,6 +66,11 @@ func (checker *Checker) VisitAttachmentDeclaration(declaration *ast.AttachmentDe
 }
 
 func (checker *Checker) visitAttachmentDeclaration(declaration *ast.AttachmentDeclaration, kind ContainerKind) (_ struct{}) {
+
+	if !checker.Config.AttachmentsEnabled {
+		checker.report(&AttachmentsNotEnabledError{})
+	}
+
 	checker.visitCompositeLikeDeclaration(declaration, kind)
 	attachmentType := checker.Elaboration.CompositeDeclarationType(declaration)
 	checker.checkAttachmentBaseType(attachmentType)

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -68,7 +68,9 @@ func (checker *Checker) VisitAttachmentDeclaration(declaration *ast.AttachmentDe
 func (checker *Checker) visitAttachmentDeclaration(declaration *ast.AttachmentDeclaration, kind ContainerKind) (_ struct{}) {
 
 	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{})
+		checker.report(&AttachmentsNotEnabledError{
+			Range: ast.NewRangeFromPositioned(checker.memoryGauge, declaration),
+		})
 	}
 
 	checker.visitCompositeLikeDeclaration(declaration, kind)

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -336,6 +336,10 @@ func (checker *Checker) checkTypeIndexingExpression(
 	indexExpression *ast.IndexExpression,
 ) Type {
 
+	if !checker.Config.AttachmentsEnabled {
+		checker.report(&AttachmentsNotEnabledError{})
+	}
+
 	expressionType := ast.ExpressionAsType(indexExpression.IndexingExpression)
 	if expressionType == nil {
 		return InvalidType

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -337,7 +337,9 @@ func (checker *Checker) checkTypeIndexingExpression(
 ) Type {
 
 	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{})
+		checker.report(&AttachmentsNotEnabledError{
+			Range: ast.NewRangeFromPositioned(checker.memoryGauge, indexExpression),
+		})
 	}
 
 	expressionType := ast.ExpressionAsType(indexExpression.IndexingExpression)

--- a/runtime/sema/check_remove_statement.go
+++ b/runtime/sema/check_remove_statement.go
@@ -24,6 +24,11 @@ import (
 )
 
 func (checker *Checker) VisitRemoveStatement(statement *ast.RemoveStatement) (_ struct{}) {
+
+	if !checker.Config.AttachmentsEnabled {
+		checker.report(&AttachmentsNotEnabledError{})
+	}
+
 	nominalType := checker.convertNominalType(statement.Attachment)
 	base := checker.VisitExpression(statement.Value, nil)
 

--- a/runtime/sema/check_remove_statement.go
+++ b/runtime/sema/check_remove_statement.go
@@ -26,7 +26,9 @@ import (
 func (checker *Checker) VisitRemoveStatement(statement *ast.RemoveStatement) (_ struct{}) {
 
 	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{})
+		checker.report(&AttachmentsNotEnabledError{
+			Range: ast.NewRangeFromPositioned(checker.memoryGauge, statement),
+		})
 	}
 
 	nominalType := checker.convertNominalType(statement.Attachment)

--- a/runtime/sema/config.go
+++ b/runtime/sema/config.go
@@ -55,4 +55,6 @@ type Config struct {
 	AllowStaticDeclarations bool
 	// AccountLinkingEnabled determines if account linking is enabled
 	AccountLinkingEnabled bool
+	// AttachmentsEnabled determines if attachments are enabled
+	AttachmentsEnabled bool
 }

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4001,3 +4001,19 @@ func (e *InvalidTypeIndexingError) Error() string {
 		e.IndexingExpression.String(),
 	)
 }
+
+// AttachmentsNotEnabledError
+type AttachmentsNotEnabledError struct {
+	ast.Range
+}
+
+var _ SemanticError = &AttachmentsNotEnabledError{}
+var _ errors.UserError = &AttachmentsNotEnabledError{}
+
+func (*AttachmentsNotEnabledError) isSemanticError() {}
+
+func (*AttachmentsNotEnabledError) IsUserError() {}
+
+func (e *AttachmentsNotEnabledError) Error() string {
+	return "the attachments feature is not yet enabled and cannot be used"
+}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4015,5 +4015,5 @@ func (*AttachmentsNotEnabledError) isSemanticError() {}
 func (*AttachmentsNotEnabledError) IsUserError() {}
 
 func (e *AttachmentsNotEnabledError) Error() string {
-	return "the attachments feature is not yet enabled and cannot be used"
+	return "attachments are not enabled and cannot be used in this environment"
 }

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -621,7 +621,8 @@ func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
 							),
 							ParseAndCheckOptions{
 								Config: &sema.Config{
-									AccessCheckMode: checkMode,
+									AccessCheckMode:    checkMode,
+									AttachmentsEnabled: true,
 								},
 							},
 						)

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 func TestCheckStorable(t *testing.T) {
@@ -36,7 +37,18 @@ func TestCheckStorable(t *testing.T) {
 
 	test := func(t *testing.T, code string, errorTypes ...error) {
 
-		_, err := ParseAndCheckWithPanic(t, code)
+		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+		baseValueActivation.DeclareValue(stdlib.PanicFunction)
+
+		_, err := ParseAndCheckWithOptions(t,
+			code,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					BaseValueActivation: baseValueActivation,
+					AttachmentsEnabled:  true,
+				},
+			},
+		)
 
 		if len(errorTypes) == 0 {
 			require.NoError(t, err)

--- a/runtime/tests/checker/utils.go
+++ b/runtime/tests/checker/utils.go
@@ -40,7 +40,12 @@ func init() {
 }
 
 func ParseAndCheck(t testing.TB, code string) (*sema.Checker, error) {
-	return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{})
+	return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{
+		// allow attachments is on by default for testing purposes
+		Config: &sema.Config{
+			AttachmentsEnabled: true,
+		},
+	})
 }
 
 type ParseAndCheckOptions struct {

--- a/runtime/tests/interpreter/attachments_test.go
+++ b/runtime/tests/interpreter/attachments_test.go
@@ -1287,7 +1287,9 @@ func TestInterpretAttachmentStorage(t *testing.T) {
                 destroy r3
                 return i
             }
-        `, sema.Config{},
+        `, sema.Config{
+			AttachmentsEnabled: true,
+		},
 		)
 
 		value, err := inter.Invoke("test")
@@ -1315,7 +1317,9 @@ func TestInterpretAttachmentStorage(t *testing.T) {
                 let i = r3[A]?.foo()!
                 return i
             }
-        `, sema.Config{},
+        `, sema.Config{
+			AttachmentsEnabled: true,
+		},
 		)
 
 		value, err := inter.Invoke("test")
@@ -1344,7 +1348,9 @@ func TestInterpretAttachmentStorage(t *testing.T) {
                 let i = cap.borrow()![A]?.foo()!
                 return i
             }
-        `, sema.Config{},
+        `, sema.Config{
+			AttachmentsEnabled: true,
+		},
 		)
 
 		value, err := inter.Invoke("test")
@@ -1374,7 +1380,9 @@ func TestInterpretAttachmentStorage(t *testing.T) {
                 let i = cap.borrow()![A]?.foo()!
                 return i
             }
-        `, sema.Config{},
+        `, sema.Config{
+			AttachmentsEnabled: true,
+		},
 		)
 
 		value, err := inter.Invoke("test")
@@ -1600,7 +1608,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
                 authAccount.save(<-r2, to: /storage/foo)
                 let i = a.foo()
             }
-        `, sema.Config{},
+        `, sema.Config{
+			AttachmentsEnabled: true,
+		},
 		)
 
 		// TODO: in the stable cadence branch, with the new resource reference invalidation,
@@ -1636,7 +1646,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
                 let i = a.foo()
             }
         
-        `, sema.Config{},
+        `, sema.Config{
+			AttachmentsEnabled: true,
+		},
 		)
 
 		// TODO: in the stable cadence branch, with the new resource reference invalidation,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -51,7 +51,12 @@ type ParseCheckAndInterpretOptions struct {
 }
 
 func parseCheckAndInterpret(t testing.TB, code string) *interpreter.Interpreter {
-	inter, err := parseCheckAndInterpretWithOptions(t, code, ParseCheckAndInterpretOptions{})
+	inter, err := parseCheckAndInterpretWithOptions(t, code, ParseCheckAndInterpretOptions{
+		// attachments should be on by default in tests
+		CheckerConfig: &sema.Config{
+			AttachmentsEnabled: true,
+		},
+	})
 	require.NoError(t, err)
 	return inter
 }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2354

To allow us to merge the feature branch to master, put any uses of the attachments features (attachment declarations, attach expressions, remove declarations, and type indexing expressions) behind a feature flag, which will throw an error in the checker if not enabled. 
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
