### PR TITLE
[v0.31]  Require #allowAccountLinking pragma to allow use of account linking function

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -2417,7 +2417,7 @@ func TestRuntimeAccountLink(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("disabled", func(t *testing.T) {
+	t.Run("disabled, missing pragma", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -2488,7 +2488,78 @@ func TestRuntimeAccountLink(t *testing.T) {
 		assert.ErrorContains(t, err, "value of type `AuthAccount` has no member `linkAccount`")
 	})
 
-	t.Run("enabled", func(t *testing.T) {
+	t.Run("enabled, missing pragma", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime(Config{
+			AtreeValidationEnabled: true,
+			AccountLinkingEnabled:  true,
+		})
+
+		address := common.MustBytesToAddress([]byte{0x1})
+
+		accountCodes := map[Location][]byte{}
+		var logs []string
+
+		signerAccount := address
+
+		runtimeInterface := &testRuntimeInterface{
+			getCode: func(location Location) (bytes []byte, err error) {
+				return accountCodes[location], nil
+			},
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{signerAccount}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+				location := common.AddressLocation{
+					Address: address,
+					Name:    name,
+				}
+				return accountCodes[location], nil
+			},
+			updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
+				location := common.AddressLocation{
+					Address: address,
+					Name:    name,
+				}
+				accountCodes[location] = code
+				return nil
+			},
+			log: func(message string) {
+				logs = append(logs, message)
+			},
+		}
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		// Set up account
+
+		setupTransaction := []byte(`
+          transaction {
+              prepare(acct: AuthAccount) {
+                  acct.linkAccount(/public/foo)
+              }
+          }
+        `)
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: setupTransaction,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.Error(t, err)
+
+		assert.ErrorContains(t, err, "value of type `AuthAccount` has no member `linkAccount`")
+	})
+
+	t.Run("enabled, pragma", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -2539,6 +2610,8 @@ func TestRuntimeAccountLink(t *testing.T) {
 		// Set up account
 
 		setupTransaction := []byte(`
+          #allowAccountLinking
+
           transaction {
               prepare(acct: AuthAccount) {
                   acct.linkAccount(/public/foo)
@@ -2647,6 +2720,8 @@ func TestRuntimeAccountLink(t *testing.T) {
 		// Set up account
 
 		setupTransaction := []byte(`
+          #allowAccountLinking
+
           transaction {
               prepare(acct: AuthAccount) {
                   let cap = acct.linkAccount(/private/foo)!

--- a/runtime/common/declarationkind.go
+++ b/runtime/common/declarationkind.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"encoding/json"
+	"math"
 
 	"github.com/onflow/cadence/runtime/errors"
 )
@@ -189,4 +190,27 @@ func (k DeclarationKind) Keywords() string {
 
 func (k DeclarationKind) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.String())
+}
+
+type DeclarationKindSet uint64
+
+const (
+	EmptyDeclarationKindSet DeclarationKindSet = 0
+	AllDeclarationKindsSet  DeclarationKindSet = math.MaxUint64
+)
+
+func NewDeclarationKindSet(declarationKinds ...DeclarationKind) DeclarationKindSet {
+	var set DeclarationKindSet
+	for _, declarationKind := range declarationKinds {
+		set = set.With(declarationKind)
+	}
+	return set
+}
+
+func (s DeclarationKindSet) With(kind DeclarationKind) DeclarationKindSet {
+	return s | DeclarationKindSet(1<<kind)
+}
+
+func (s DeclarationKindSet) Has(kind DeclarationKind) bool {
+	return s&(1<<kind) != 0
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -163,6 +163,7 @@ type Runtime interface {
 type ImportResolver = func(location Location) (program *ast.Program, e error)
 
 var validTopLevelDeclarationsInTransaction = []common.DeclarationKind{
+	common.DeclarationKindPragma,
 	common.DeclarationKindImport,
 	common.DeclarationKindFunction,
 	common.DeclarationKindTransaction,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -162,21 +162,21 @@ type Runtime interface {
 
 type ImportResolver = func(location Location) (program *ast.Program, e error)
 
-var validTopLevelDeclarationsInTransaction = []common.DeclarationKind{
+var validTopLevelDeclarationsInTransaction = common.NewDeclarationKindSet(
 	common.DeclarationKindPragma,
 	common.DeclarationKindImport,
 	common.DeclarationKindFunction,
 	common.DeclarationKindTransaction,
-}
+)
 
-var validTopLevelDeclarationsInAccountCode = []common.DeclarationKind{
+var validTopLevelDeclarationsInAccountCode = common.NewDeclarationKindSet(
 	common.DeclarationKindPragma,
 	common.DeclarationKindImport,
 	common.DeclarationKindContract,
 	common.DeclarationKindContractInterface,
-}
+)
 
-func validTopLevelDeclarations(location Location) []common.DeclarationKind {
+func validTopLevelDeclarations(location Location) common.DeclarationKindSet {
 	switch location.(type) {
 	case common.TransactionLocation:
 		return validTopLevelDeclarationsInTransaction
@@ -184,7 +184,7 @@ func validTopLevelDeclarations(location Location) []common.DeclarationKind {
 		return validTopLevelDeclarationsInAccountCode
 	}
 
-	return nil
+	return common.AllDeclarationKindsSet
 }
 
 func reportMetric(

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -112,6 +112,7 @@ type Checker struct {
 	inInvocation                       bool
 	inCreate                           bool
 	isChecked                          bool
+	allowAccountLinking                bool
 }
 
 var _ ast.DeclarationVisitor[struct{}] = &Checker{}
@@ -329,7 +330,31 @@ func (checker *Checker) CheckProgram(program *ast.Program) {
 
 	checker.checkTopLevelDeclarationValidity(declarations)
 
+	var rejectAllowAccountLinkingPragma bool
+
 	for _, declaration := range declarations {
+
+		// A pragma declaration #allowAccountLinking determines
+		// if the program is allowed to use the account linking.
+		//
+		// It must appear as a top-level declaration (i.e. not nested in the program),
+		// and must appear before all other declarations (i.e. at the top of the program).
+		//
+		// This is a temporary feature, which is planned to get replaced
+		// by capability controllers, a new Account type, and account entitlements.
+
+		if pragmaDeclaration, isPragma := declaration.(*ast.PragmaDeclaration); isPragma {
+			if IsAllowAccountLinkingPragma(pragmaDeclaration) {
+				if rejectAllowAccountLinkingPragma {
+					checker.reportInvalidNonHeaderPragma(pragmaDeclaration)
+				} else {
+					checker.allowAccountLinking = true
+				}
+				continue
+			}
+		}
+
+		rejectAllowAccountLinkingPragma = true
 
 		// Skip import declarations, they are already handled above
 		if _, isImport := declaration.(*ast.ImportDeclaration); isImport {
@@ -360,6 +385,10 @@ func (checker *Checker) checkTopLevelDeclarationValidity(declarations []ast.Decl
 	}
 
 	for _, declaration := range declarations {
+		if _, ok := declaration.(*ast.PragmaDeclaration); ok {
+			continue
+		}
+
 		isValid := validDeclarationKinds[declaration.DeclarationKind()]
 		if isValid {
 			continue
@@ -2386,11 +2415,11 @@ func (checker *Checker) checkNativeModifier(isNative bool, position ast.HasPosit
 }
 
 func (checker *Checker) isAvailableMember(expressionType Type, identifier string) bool {
-	if !checker.Config.AccountLinkingEnabled &&
-		expressionType == AuthAccountType &&
+	if expressionType == AuthAccountType &&
 		identifier == AuthAccountTypeLinkAccountFunctionName {
 
-		return false
+		return checker.Config.AccountLinkingEnabled &&
+			checker.allowAccountLinking
 	}
 
 	return true

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -85,13 +85,18 @@ type InvalidPragmaError struct {
 
 var _ SemanticError = &InvalidPragmaError{}
 var _ errors.UserError = &InvalidPragmaError{}
+var _ errors.SecondaryError = &InvalidPragmaError{}
 
 func (*InvalidPragmaError) isSemanticError() {}
 
 func (*InvalidPragmaError) IsUserError() {}
 
 func (e *InvalidPragmaError) Error() string {
-	return fmt.Sprintf("invalid pragma %s", e.Message)
+	return "invalid pragma"
+}
+
+func (e *InvalidPragmaError) SecondaryError() string {
+	return e.Message
 }
 
 // CheckerError

--- a/runtime/tests/checker/declaration_test.go
+++ b/runtime/tests/checker/declaration_test.go
@@ -473,11 +473,11 @@ func TestCheckTopLevelContractRestriction(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				ValidTopLevelDeclarationsHandler: func(_ common.Location) []common.DeclarationKind {
-					return []common.DeclarationKind{
+				ValidTopLevelDeclarationsHandler: func(_ common.Location) common.DeclarationKindSet {
+					return common.NewDeclarationKindSet(
 						common.DeclarationKindContract,
 						common.DeclarationKindImport,
-					}
+					)
 				},
 			},
 		},
@@ -508,12 +508,12 @@ func TestCheckInvalidTopLevelContractRestriction(t *testing.T) {
 				code,
 				ParseAndCheckOptions{
 					Config: &sema.Config{
-						ValidTopLevelDeclarationsHandler: func(_ common.Location) []common.DeclarationKind {
-							return []common.DeclarationKind{
+						ValidTopLevelDeclarationsHandler: func(_ common.Location) common.DeclarationKindSet {
+							return common.NewDeclarationKindSet(
 								common.DeclarationKindContractInterface,
 								common.DeclarationKindContract,
 								common.DeclarationKindImport,
-							}
+							)
 						},
 					},
 				},

--- a/runtime/tests/checker/pragma_test.go
+++ b/runtime/tests/checker/pragma_test.go
@@ -113,7 +113,7 @@ func TestCheckAllowAccountLinkingPragma(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("top-level, before other declarations", func(t *testing.T) {
+	t.Run("top-level, after other declarations", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := ParseAndCheck(t, `

--- a/runtime/tests/checker/pragma_test.go
+++ b/runtime/tests/checker/pragma_test.go
@@ -32,8 +32,8 @@ func TestCheckPragmaInvalidExpr(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-	  #"string"
-	`)
+      #"string"
+    `)
 
 	errs := RequireCheckerErrors(t, err, 1)
 	assert.IsType(t, &sema.InvalidPragmaError{}, errs[0])
@@ -43,8 +43,8 @@ func TestCheckPragmaValidIdentifierExpr(t *testing.T) {
 
 	t.Parallel()
 	_, err := ParseAndCheck(t, `
-		#pedantic
-	`)
+        #pedantic
+    `)
 
 	require.NoError(t, err)
 }
@@ -54,8 +54,8 @@ func TestCheckPragmaValidInvocationExpr(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-		#version("1.0")
-	`)
+        #version("1.0")
+    `)
 
 	require.NoError(t, err)
 }
@@ -65,10 +65,10 @@ func TestCheckPragmaInvalidLocation(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-	  fun test() {
-		  #version
-	  }
-	`)
+      fun test() {
+          #version
+      }
+    `)
 
 	errs := RequireCheckerErrors(t, err, 1)
 	assert.IsType(t, &sema.InvalidDeclarationError{}, errs[0])
@@ -79,11 +79,11 @@ func TestCheckPragmaInvalidInvocationExprNonStringExprArgument(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-		#version(y)
-	`)
+      #version(y)
+    `)
 
 	errs := RequireCheckerErrors(t, err, 1)
-	assert.IsType(t, &sema.InvalidPragmaError{Message: "invalid arguments"}, errs[0])
+	assert.IsType(t, &sema.InvalidPragmaError{}, errs[0])
 }
 
 func TestCheckPragmaInvalidInvocationExprTypeArgs(t *testing.T) {
@@ -91,9 +91,51 @@ func TestCheckPragmaInvalidInvocationExprTypeArgs(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-		#version<X>()
-	`)
+      #version<X>()
+    `)
 
 	errs := RequireCheckerErrors(t, err, 1)
-	assert.IsType(t, &sema.InvalidPragmaError{Message: "type arguments not supported"}, errs[0])
+	assert.IsType(t, &sema.InvalidPragmaError{}, errs[0])
+}
+
+func TestCheckAllowAccountLinkingPragma(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("top-level, before other declarations", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          #allowAccountLinking
+
+          let x = 1
+        `)
+		require.NoError(t, err)
+	})
+
+	t.Run("top-level, before other declarations", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let x = 1
+
+          #allowAccountLinking
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.InvalidPragmaError{}, errs[0])
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          fun test() {
+              #allowAccountLinking
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.InvalidDeclarationError{}, errs[0])
+	})
 }

--- a/runtime/tests/interpreter/capability_test.go
+++ b/runtime/tests/interpreter/capability_test.go
@@ -471,6 +471,8 @@ func TestInterpretCapability_borrow(t *testing.T) {
 			address,
 			true,
 			`
+              #allowAccountLinking
+
               fun link() {
                   account.linkAccount(/public/acct)
               }
@@ -918,6 +920,8 @@ func TestInterpretCapability_check(t *testing.T) {
 			address,
 			true,
 			`
+              #allowAccountLinking
+
               fun link() {
                   account.linkAccount(/public/acct)
               }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10308,6 +10308,8 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 				true,
 				fmt.Sprintf(
 					`
+                      #allowAccountLinking
+
                       struct S {}
 
                       fun getRef(): &AnyStruct  {
@@ -10344,6 +10346,8 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 				true,
 				fmt.Sprintf(
 					`
+                      #allowAccountLinking
+
                       struct S {}
 
                       fun test(): &%[1]s {
@@ -10370,9 +10374,9 @@ func TestInterpretReferenceUpAndDowncast(t *testing.T) {
 			name:     "account reference",
 			typeName: "AuthAccount",
 			code: `
-		         let cap = account.linkAccount(/private/test)!
-		         let ref = cap.borrow()!
-		       `,
+		      let cap = account.linkAccount(/private/test)!
+		      let ref = cap.borrow()!
+		    `,
 		},
 	}
 

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -7048,11 +7048,14 @@ func TestInterpretAccountLinkValueMetering(t *testing.T) {
 	t.Run("creation", func(t *testing.T) {
 		t.Parallel()
 
-		script := `
-            pub fun main(account: AuthAccount) {
-                account.linkAccount(/public/capo)
-            }
+		const script = `
+          #allowAccountLinking
+
+          pub fun main(account: AuthAccount) {
+              account.linkAccount(/public/capo)
+          }
         `
+
 		meter := newTestMemoryGauge()
 
 		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(


### PR DESCRIPTION
Port #2355 to v0.31

## Description

We would like deploy the feature to all networks. However, the flow-go release branch is on v0.31.
Updating to the latest Cadence version, i.e. porting onflow/flow-go#3884 to the release branch, is not an option, as it depends on other major FVM changes.

Port just the account linking pragma feature to keep changes in the coordinated network update minimal.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
